### PR TITLE
Feat/encryption boundary shift preview mode

### DIFF
--- a/frontend/src/features/admin-form/common/AdminViewFormService.ts
+++ b/frontend/src/features/admin-form/common/AdminViewFormService.ts
@@ -181,26 +181,15 @@ export const submitEmailModeFormPreview = async ({
  * Submit a storage mode form in preview mode
  */
 export const submitStorageModeFormPreview = async ({
-  formFields,
-  formLogics,
-  formInputs,
   formId,
-  publicKey,
-}: SubmitStorageFormArgs) => {
-  const filteredInputs = filterHiddenInputs({
-    formFields,
-    formInputs,
-    formLogics,
-  })
-  const submissionContent = await createEncryptedSubmissionData({
-    formFields,
-    formInputs: filteredInputs,
-    publicKey,
-  })
+}: {
+  formId: string
+}) => {
+  const formData = {}
 
   return ApiService.post<SubmissionResponseDto>(
-    `${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/encrypt`,
-    submissionContent,
+    `${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/storage`,
+    formData,
   ).then(({ data }) => data)
 }
 
@@ -242,28 +231,17 @@ export const submitEmailModeFormPreviewWithFetch = async ({
  * TODO(#5826): Fallback using Fetch. Remove once network error is resolved
  */
 export const submitStorageModeFormPreviewWithFetch = async ({
-  formFields,
-  formLogics,
-  formInputs,
   formId,
-  publicKey,
-}: SubmitStorageFormArgs): Promise<SubmissionResponseDto> => {
-  const filteredInputs = filterHiddenInputs({
-    formFields,
-    formInputs,
-    formLogics,
-  })
-  const submissionContent = await createEncryptedSubmissionData({
-    formFields,
-    formInputs: filteredInputs,
-    publicKey,
-  })
+}: {
+  formId: string
+}): Promise<SubmissionResponseDto> => {
+  const formData = {}
 
   const response = await fetch(
-    `${API_BASE_URL}${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/encrypt`,
+    `${API_BASE_URL}${ADMIN_FORM_ENDPOINT}/${formId}/preview/submissions/storage`,
     {
       method: 'POST',
-      body: JSON.stringify(submissionContent),
+      body: JSON.stringify(formData),
       headers: {
         'Content-Type': 'application/json',
         Accept: 'application/json',

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -469,7 +469,7 @@ export const usePreviewFormMutations = (formId: string) => {
 
   const submitStorageModeFormMutation = useMutation(
     (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
-      return submitStorageModeFormPreview({ ...args, formId })
+      return submitStorageModeFormPreview({ formId })
     },
   )
 
@@ -482,7 +482,7 @@ export const usePreviewFormMutations = (formId: string) => {
 
   const submitStorageModeFormFetchMutation = useMutation(
     (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
-      return submitStorageModeFormPreviewWithFetch({ ...args, formId })
+      return submitStorageModeFormPreviewWithFetch({ formId })
     },
   )
 

--- a/frontend/src/features/admin-form/create/end-page/EndPageContent.tsx
+++ b/frontend/src/features/admin-form/create/end-page/EndPageContent.tsx
@@ -1,18 +1,26 @@
 import { useMemo } from 'react'
 import { Box, Flex, Stack } from '@chakra-ui/react'
 
-import { FormAuthType, FormColorTheme, FormLogoState } from '~shared/types'
+import {
+  FormAuthType,
+  FormColorTheme,
+  FormLogoState,
+  FormResponseMode,
+} from '~shared/types'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 import { PREVIEW_MOCK_UINFIN } from '~features/admin-form/preview/constants'
 import { useEnv } from '~features/env/queries'
 import { EndPageBlock } from '~features/public-form/components/FormEndPage/components/EndPageBlock'
-import { ThankYouSvgr } from '~features/public-form/components/FormEndPage/components/ThankYouSvgr'
+import { PaymentEndPageBlock } from '~features/public-form/components/FormEndPage/components/PaymentEndPageBlock'
+import {
+  PaymentsThankYouSvgr,
+  ThankYouSvgr,
+} from '~features/public-form/components/FormEndPage/components/ThankYouSvgr'
 import {
   FormBannerLogo,
   useFormBannerLogo,
 } from '~features/public-form/components/FormLogo'
-import { useBgColor } from '~features/public-form/components/PublicFormWrapper'
 
 import { useDesignColorTheme } from '../builder-and-design/utils/useDesignColorTheme'
 
@@ -42,7 +50,21 @@ export const EndPageContent = (): JSX.Element => {
     showDefaultLogoIfNoLogo: true,
   })
 
-  const backgroundColor = useBgColor({ colorTheme })
+  const isPaymentEnabled =
+    form?.responseMode === FormResponseMode.Encrypt && //TOCHECK: what does this mean?
+    form.payments_field.enabled
+
+  const backgroundColor = isPaymentEnabled ? 'transparent' : 'white'
+
+  const thankYouSvg = isPaymentEnabled ? (
+    <Flex backgroundColor="primary.100" justifyContent="center" py="1rem">
+      <PaymentsThankYouSvgr h="100%" pt="2.5rem" />
+    </Flex>
+  ) : (
+    <Flex backgroundColor="primary.100" justifyContent="center">
+      <ThankYouSvgr h="100%" pt="2.5rem" />
+    </Flex>
+  )
 
   return (
     <Flex
@@ -55,7 +77,7 @@ export const EndPageContent = (): JSX.Element => {
       justify="center"
       overflow="auto"
     >
-      <Stack w="100%" h="fit-content" bg="white">
+      <Stack w="100%" h="fit-content" bg="primary.100">
         <FormBannerLogo
           isLoading={isLoading}
           {...formBannerLogoProps}
@@ -66,25 +88,49 @@ export const EndPageContent = (): JSX.Element => {
               : undefined
           }
         />
-        <Flex backgroundColor={backgroundColor} justifyContent="center">
-          <ThankYouSvgr h="100%" pt="2.5rem" />
-        </Flex>
-
-        <Box
-          py={{ base: '1.5rem', md: '3rem' }}
-          px={{ base: '1.5rem', md: '4rem' }}
-          w="100%"
-        >
-          <EndPageBlock
-            formTitle={form?.title}
-            endPage={endPage ?? { title: '', buttonText: '' }}
-            submissionData={{
-              id: form?._id ?? 'Submission ID',
-              timestamp: Date.now(),
-            }}
-            colorTheme={colorTheme ?? FormColorTheme.Blue}
-          />
-        </Box>
+        {thankYouSvg}
+        <Stack>
+          <Box px={{ base: '1.5rem', md: '4rem' }} bg={backgroundColor}>
+            {isPaymentEnabled ? (
+              <PaymentEndPageBlock
+                formTitle={form?.title}
+                submissionData={{
+                  id: form?._id ?? 'Submission ID',
+                  timestamp: Date.now(),
+                }}
+                endPage={
+                  endPage ?? {
+                    title: '',
+                    buttonText: '',
+                    paymentTitle: '',
+                    paymentParagraph: '',
+                  }
+                }
+                isPaymentEnabled
+                products={[]}
+                name={''}
+              />
+            ) : (
+              <EndPageBlock
+                formTitle={form?.title}
+                isPaymentEnabled={isPaymentEnabled}
+                endPage={
+                  endPage ?? {
+                    title: '',
+                    buttonText: '',
+                    paymentTitle: '',
+                    paymentParagraph: '',
+                  }
+                }
+                submissionData={{
+                  id: form?._id ?? 'Submission ID',
+                  timestamp: Date.now(),
+                }}
+                colorTheme={colorTheme ?? FormColorTheme.Blue}
+              />
+            )}
+          </Box>
+        </Stack>
       </Stack>
     </Flex>
   )

--- a/frontend/src/features/admin-form/create/end-page/EndPageContent.tsx
+++ b/frontend/src/features/admin-form/create/end-page/EndPageContent.tsx
@@ -105,12 +105,10 @@ export const EndPageContent = (): JSX.Element => {
                   timestamp: Date.now(),
                 }}
                 endPage={endPageContent}
-                isPaymentEnabled
               />
             ) : (
               <EndPageBlock
                 formTitle={form?.title}
-                isPaymentEnabled={isPaymentEnabled}
                 endPage={endPageContent}
                 submissionData={{
                   id: form?._id ?? 'Submission ID',

--- a/frontend/src/features/admin-form/create/end-page/EndPageContent.tsx
+++ b/frontend/src/features/admin-form/create/end-page/EndPageContent.tsx
@@ -6,8 +6,6 @@ import {
   FormColorTheme,
   FormLogoState,
   FormResponseMode,
-  PaymentType,
-  ProductItemForReceipt,
 } from '~shared/types'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
@@ -56,72 +54,14 @@ export const EndPageContent = (): JSX.Element => {
     form?.responseMode === FormResponseMode.Encrypt &&
     form.payments_field.enabled
 
-  const isMultiProduct =
-    form?.responseMode === FormResponseMode.Encrypt &&
-    form.payments_field.products_meta?.multi_product
-
-  let paymentProducts: ProductItemForReceipt[] = []
-  let totalAmount = 0
-
-  if (isPaymentEnabled) {
-    switch (form?.payments_field?.payment_type) {
-      case PaymentType.Products:
-        if (isMultiProduct) {
-          paymentProducts = form?.payments_field?.products?.map((product) => {
-            totalAmount += product.amount_cents * product.min_qty
-            return {
-              name: product.name,
-              quantity: product.min_qty,
-              amount_cents: product.amount_cents,
-            }
-          }) as ProductItemForReceipt[]
-        } else {
-          paymentProducts = [
-            {
-              name:
-                isPaymentEnabled && form?.payments_field?.products
-                  ? form?.payments_field?.products[0].name
-                  : 'Product/Service',
-              quantity: form?.payments_field?.products[0].min_qty,
-              amount_cents: form?.payments_field?.products[0].amount_cents,
-            },
-          ] as ProductItemForReceipt[]
-          totalAmount =
-            paymentProducts[0].quantity * paymentProducts[0].amount_cents
-        }
-        break
-
-      case PaymentType.Variable:
-        paymentProducts = [
-          {
-            name: form?.payments_field?.name,
-            quantity: 1,
-            amount_cents: form?.payments_field?.min_amount,
-          },
-        ] as ProductItemForReceipt[]
-        totalAmount = form?.payments_field?.min_amount
-        break
-
-      case PaymentType.Fixed:
-      default:
-        paymentProducts = [
-          {
-            name:
-              isPaymentEnabled && form?.payments_field?.products
-                ? form?.payments_field?.products[0].name
-                : 'Product/Service',
-            quantity: 1,
-            amount_cents:
-              isPaymentEnabled && form?.payments_field?.products
-                ? form?.payments_field?.products[0].amount_cents
-                : '0',
-          },
-        ] as ProductItemForReceipt[]
-        totalAmount = paymentProducts[0].amount_cents
-    }
-  }
-
   const backgroundColor = isPaymentEnabled ? 'transparent' : 'white'
+
+  const endPageContent = endPage ?? {
+    title: '',
+    buttonText: '',
+    paymentTitle: '',
+    paymentParagraph: '',
+  }
 
   const thankYouSvg = isPaymentEnabled ? (
     <Flex backgroundColor="primary.100" justifyContent="center" py="1rem">
@@ -160,36 +100,18 @@ export const EndPageContent = (): JSX.Element => {
           <Box px={{ base: '1.5rem', md: '4rem' }} bg={backgroundColor}>
             {isPaymentEnabled ? (
               <PaymentEndPageBlock
-                formTitle={form?.title}
                 submissionData={{
                   id: form?._id ?? 'Submission ID',
                   timestamp: Date.now(),
                 }}
-                endPage={
-                  endPage ?? {
-                    title: '',
-                    buttonText: '',
-                    paymentTitle: '',
-                    paymentParagraph: '',
-                  }
-                }
+                endPage={endPageContent}
                 isPaymentEnabled
-                products={paymentProducts}
-                name={''}
-                totalAmount={totalAmount}
               />
             ) : (
               <EndPageBlock
                 formTitle={form?.title}
                 isPaymentEnabled={isPaymentEnabled}
-                endPage={
-                  endPage ?? {
-                    title: '',
-                    buttonText: '',
-                    paymentTitle: '',
-                    paymentParagraph: '',
-                  }
-                }
+                endPage={endPageContent}
                 submissionData={{
                   id: form?._id ?? 'Submission ID',
                   timestamp: Date.now(),

--- a/frontend/src/features/admin-form/create/end-page/EndPageDrawer.tsx
+++ b/frontend/src/features/admin-form/create/end-page/EndPageDrawer.tsx
@@ -78,9 +78,8 @@ export const EndPageInput = ({
   const { handleClose } = useCreatePageSidebar()
 
   const paymentDefaults = {
-    title: 'Your payment has been made successfully.',
-    paragraph: 'Your form has been submitted and payment has been made.',
-    buttonLink: 'Default proof of payment link',
+    paymentTitle: endPageData?.paymentTitle,
+    paymentParagraph: endPageData?.paymentParagraph,
     buttonText: 'Save proof of payment',
   }
 
@@ -93,6 +92,10 @@ export const EndPageInput = ({
     mode: 'onBlur',
     defaultValues: isPayment ? paymentDefaults : endPageData,
   })
+
+  const formPlaceholder = isPayment
+    ? 'Default proof of payment'
+    : 'Default form link'
 
   // Update dirty state of builder so confirmation modal can be shown
   useEffect(() => {
@@ -125,14 +128,17 @@ export const EndPageInput = ({
 
   const handleCloseDrawer = useCallback(() => handleClose(false), [handleClose])
 
-  const handleUpdateEndPage = handleSubmit((endPage) =>
-    endPageMutation.mutate(endPage, {
+  const handleUpdateEndPage = handleSubmit((endPage) => {
+    return endPageMutation.mutate(endPage, {
       onSuccess: () => {
         setToInactive()
         handleCloseDrawer()
       },
-    }),
-  )
+    })
+  })
+
+  const paymentTitle = isPayment ? 'paymentTitle' : 'title'
+  const paymentParagraph = isPayment ? 'paymentParagraph' : 'paragraph'
 
   return (
     <CreatePageDrawerContentContainer>
@@ -140,22 +146,20 @@ export const EndPageInput = ({
         <FormControl
           isReadOnly={endPageMutation.isLoading}
           isInvalid={!!errors.title}
-          isDisabled={isPayment}
         >
           <FormLabel isRequired>Title</FormLabel>
           <Input
             autoFocus
-            {...register('title', { required: REQUIRED_ERROR })}
+            {...register(paymentTitle, { required: REQUIRED_ERROR })}
           />
           <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
         </FormControl>
         <FormControl
           isReadOnly={endPageMutation.isLoading}
           isInvalid={!!errors.paragraph}
-          isDisabled={isPayment}
         >
           <FormLabel isRequired>Follow-up instructions</FormLabel>
-          <Textarea {...register('paragraph')} />
+          <Textarea {...register(paymentParagraph)} />
           <FormErrorMessage>{errors.paragraph?.message}</FormErrorMessage>
         </FormControl>
         <Stack direction={['column', 'row']} gap={['2rem', '1rem']}>
@@ -178,7 +182,7 @@ export const EndPageInput = ({
           >
             <FormLabel isRequired>Button redirect link</FormLabel>
             <Input
-              placeholder="Default form link"
+              placeholder={formPlaceholder}
               {...register('buttonLink', buttonLinkRules)}
             />
             <FormErrorMessage>{errors.buttonLink?.message}</FormErrorMessage>

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.tsx
@@ -1,6 +1,8 @@
 import { useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
+import { FormResponseMode } from '~shared/types'
+
 import FormIssueFeedback from '~/features/public-form/components/FormIssueFeedback'
 
 import { fillHeightCss } from '~utils/fillHeightCss'

--- a/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.tsx
@@ -39,7 +39,6 @@ export const PublicFormPage = (): JSX.Element => {
             <FormFields />
             <FormIssueFeedback />
             <FormEndPage />
-
             <FormFooter />
           </PublicFormWrapper>
         </Flex>

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
@@ -2,7 +2,10 @@ import { Container, Flex, Stack, StackDivider } from '@chakra-ui/react'
 
 import { FormColorTheme, FormDto } from '~shared/types/form'
 
-import { SubmissionData } from '~features/public-form/PublicFormContext'
+import {
+  SubmissionData,
+  usePublicFormContext,
+} from '~features/public-form/PublicFormContext'
 
 import { EndPageBlock } from './components/EndPageBlock'
 import { FeedbackBlock, FeedbackFormInput } from './components/FeedbackBlock'
@@ -23,6 +26,7 @@ export const FormEndPage = ({
   colorTheme,
   ...endPageProps
 }: FormEndPageProps): JSX.Element => {
+  const { isPaymentEnabled } = usePublicFormContext()
   return (
     <Container w="42.5rem" maxW="100%" p={0}>
       <Flex flexDir="column" align="center">
@@ -39,6 +43,7 @@ export const FormEndPage = ({
             focusOnMount
             {...endPageProps}
             colorTheme={colorTheme}
+            isPaymentEnabled={isPaymentEnabled}
           />
           {isFeedbackSubmitted ? null : (
             <FeedbackBlock

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useState } from 'react'
 import { Box } from '@chakra-ui/react'
 
+import { FormResponseMode } from '~shared/types'
+
 import { useToast } from '~hooks/useToast'
 
 import { useSubmitFormFeedbackMutation } from '~features/public-form/mutations'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { FeedbackFormInput } from './components/FeedbackBlock'
+import { PaymentEndPagePreview } from './components/PaymentEndPagePreview'
 import { FormEndPage } from './FormEndPage'
 
 export const FormEndPageContainer = (): JSX.Element | null => {
@@ -17,6 +20,10 @@ export const FormEndPageContainer = (): JSX.Element | null => {
   )
   const toast = useToast()
   const [isFeedbackSubmitted, setIsFeedbackSubmitted] = useState(false)
+
+  const isPaymentEnabled =
+    form?.responseMode === FormResponseMode.Encrypt &&
+    form.payments_field.enabled
 
   /**
    * Handles feedback submission
@@ -54,16 +61,27 @@ export const FormEndPageContainer = (): JSX.Element | null => {
 
   if (!form || !submissionData) return null
 
-  return (
-    <Box py={{ base: '1.5rem', md: '2.5rem' }} w="100%">
-      <FormEndPage
-        colorTheme={form.startPage.colorTheme}
+  if (isPaymentEnabled) {
+    return (
+      <PaymentEndPagePreview
         submissionData={submissionData}
-        formTitle={form.title}
         endPage={form.endPage}
-        isFeedbackSubmitted={isFeedbackSubmitted}
         handleSubmitFeedback={handleSubmitFeedback}
+        isFeedbackSubmitted={isFeedbackSubmitted}
+        colorTheme={form.startPage.colorTheme}
       />
-    </Box>
-  )
+    )
+  } else
+    return (
+      <Box py={{ base: '1.5rem', md: '2.5rem' }} w="100%">
+        <FormEndPage
+          colorTheme={form.startPage.colorTheme}
+          submissionData={submissionData}
+          formTitle={form.title}
+          endPage={form.endPage}
+          isFeedbackSubmitted={isFeedbackSubmitted}
+          handleSubmitFeedback={handleSubmitFeedback}
+        />
+      </Box>
+    )
 }

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react'
-import { Box, Flex, Text, VisuallyHidden } from '@chakra-ui/react'
+import { Box, Container, Text, VisuallyHidden } from '@chakra-ui/react'
 import { format } from 'date-fns'
 
 import { FormColorTheme, FormDto } from '~shared/types/form'
@@ -16,6 +16,7 @@ export interface EndPageBlockProps {
   submissionData: SubmissionData
   colorTheme?: FormColorTheme
   focusOnMount?: boolean
+  isPaymentEnabled: boolean
 }
 
 export const EndPageBlock = ({
@@ -24,6 +25,7 @@ export const EndPageBlock = ({
   submissionData,
   colorTheme = FormColorTheme.Blue,
   focusOnMount,
+  isPaymentEnabled,
 }: EndPageBlockProps): JSX.Element => {
   const focusRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -54,7 +56,7 @@ export const EndPageBlock = ({
   }, [formTitle])
 
   return (
-    <Flex flexDir="column">
+    <Container py={{ base: '1.5rem', md: '3rem' }}>
       <Box ref={focusRef}>
         <VisuallyHidden aria-live="assertive">
           {submittedAriaText}
@@ -70,24 +72,26 @@ export const EndPageBlock = ({
           </Box>
         ) : null}
       </Box>
-      <Box mt="2rem">
-        <Text textColor="secondary.300" textStyle="caption-2">
-          Response ID: {submissionData.id}
-        </Text>
-        <Text mt="0.25rem" textColor="secondary.300" textStyle="caption-2">
-          {submissionTimestamp}
-        </Text>
+      <Box mt="1.5rem">
+        <Box>
+          <Text textColor="secondary.300" textStyle="caption-2">
+            Response ID: {submissionData.id}
+          </Text>
+          <Text mt="0.25rem" textColor="secondary.300" textStyle="caption-2">
+            {submissionTimestamp}
+          </Text>
+        </Box>
+        <Box mt="2.25rem">
+          <Button
+            as="a"
+            href={endPage.buttonLink || window.location.href}
+            variant="solid"
+            colorScheme={`theme-${colorTheme}`}
+          >
+            {endPage.buttonText || 'Submit another response'}
+          </Button>
+        </Box>
       </Box>
-      <Box mt="2.25rem">
-        <Button
-          as="a"
-          href={endPage.buttonLink || window.location.href}
-          variant="solid"
-          colorScheme={`theme-${colorTheme}`}
-        >
-          {endPage.buttonText || 'Submit another response'}
-        </Button>
-      </Box>
-    </Flex>
+    </Container>
   )
 }

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -25,7 +25,6 @@ export const EndPageBlock = ({
   submissionData,
   colorTheme = FormColorTheme.Blue,
   focusOnMount,
-  isPaymentEnabled,
 }: EndPageBlockProps): JSX.Element => {
   const focusRef = useRef<HTMLDivElement>(null)
   useEffect(() => {

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -16,7 +16,6 @@ export interface EndPageBlockProps {
   submissionData: SubmissionData
   colorTheme?: FormColorTheme
   focusOnMount?: boolean
-  isPaymentEnabled: boolean
 }
 
 export const EndPageBlock = ({

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPageBlock.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { Box, Container, VisuallyHidden } from '@chakra-ui/react'
+import { format } from 'date-fns'
+
+import { FormColorTheme, FormDto, ProductItem } from '~shared/types/form'
+
+import { SubmissionData } from '~features/public-form/PublicFormContext'
+
+import { DownloadReceiptBlock } from '../../FormPaymentPage/stripe/components'
+
+export interface PaymentEndPageBlockProps {
+  formTitle: FormDto['title'] | undefined
+  endPage: FormDto['endPage']
+  submissionData: SubmissionData
+  colorTheme?: FormColorTheme
+  focusOnMount?: boolean
+  isPaymentEnabled: boolean
+  products: ProductItem[]
+  name: string
+}
+
+export const PaymentEndPageBlock = ({
+  formTitle,
+  endPage,
+  submissionData,
+  colorTheme = FormColorTheme.Blue,
+  focusOnMount,
+  products,
+  name,
+}: PaymentEndPageBlockProps): JSX.Element => {
+  const focusRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (focusOnMount) {
+      focusRef.current?.focus()
+    }
+  }, [focusOnMount])
+
+  const submittedAriaText = useMemo(() => {
+    if (formTitle) {
+      return `You have successfully submitted your response for ${formTitle}.`
+    }
+    return 'You have successfully submitted your response.'
+  }, [formTitle])
+
+  return (
+    <Container pb={{ base: '1.5rem', md: '3rem' }}>
+      <Box ref={focusRef} bg="white">
+        <VisuallyHidden aria-live="assertive">
+          {submittedAriaText}
+        </VisuallyHidden>
+      </Box>
+      <DownloadReceiptBlock
+        formId={''}
+        submissionId={submissionData.id as string}
+        paymentId={''}
+        endPage={endPage}
+        amount={1000}
+        products={products}
+        name={'Product/ Service'}
+        paymentDate={new Date()}
+      />
+    </Container>
+  )
+}

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPageBlock.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react'
-import { Box, Container, VisuallyHidden } from '@chakra-ui/react'
+import { Box, VisuallyHidden } from '@chakra-ui/react'
 
 import {
   AdminStorageFormDto,
@@ -53,7 +53,7 @@ export const PaymentEndPageBlock = ({
   )
 
   return (
-    <Container pb={{ base: '1.5rem', md: '3rem' }}>
+    <Box>
       <Box ref={focusRef} bg="white">
         <VisuallyHidden aria-live="assertive">
           {submittedAriaText}
@@ -69,6 +69,6 @@ export const PaymentEndPageBlock = ({
         name={'Product/ Service'}
         paymentDate={new Date()}
       />
-    </Container>
+    </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPageBlock.tsx
@@ -1,38 +1,31 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { Box, Container, VisuallyHidden } from '@chakra-ui/react'
 
+import { PaymentType } from '~shared/types'
 import {
-  FormColorTheme,
   FormDto,
+  FormResponseMode,
   ProductItemForReceipt,
 } from '~shared/types/form'
 
+import { useAdminForm } from '~features/admin-form/common/queries'
 import { SubmissionData } from '~features/public-form/PublicFormContext'
 
 import { DownloadReceiptBlock } from '../../FormPaymentPage/stripe/components'
 
 export interface PaymentEndPageBlockProps {
-  formTitle: FormDto['title'] | undefined
   endPage: FormDto['endPage']
   submissionData: SubmissionData
-  colorTheme?: FormColorTheme
   focusOnMount?: boolean
   isPaymentEnabled: boolean
-  products: ProductItemForReceipt[]
-  totalAmount: number
-  name: string
 }
 
 export const PaymentEndPageBlock = ({
-  formTitle,
   endPage,
   submissionData,
-  colorTheme = FormColorTheme.Blue,
   focusOnMount,
-  products,
-  totalAmount,
-  name,
 }: PaymentEndPageBlockProps): JSX.Element => {
+  const { data: form } = useAdminForm()
   const focusRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
     if (focusOnMount) {
@@ -40,12 +33,81 @@ export const PaymentEndPageBlock = ({
     }
   }, [focusOnMount])
 
+  const isPaymentEnabled =
+    form?.responseMode === FormResponseMode.Encrypt &&
+    form.payments_field.enabled
+
+  const isMultiProduct =
+    form?.responseMode === FormResponseMode.Encrypt &&
+    form.payments_field.products_meta?.multi_product
+
+  let paymentProducts: ProductItemForReceipt[] = []
+  let totalAmount = 0
+
+  if (isPaymentEnabled) {
+    switch (form?.payments_field?.payment_type) {
+      case PaymentType.Products:
+        if (isMultiProduct) {
+          paymentProducts = form?.payments_field?.products?.map((product) => {
+            totalAmount += product.amount_cents * product.min_qty
+            return {
+              name: product.name,
+              quantity: product.min_qty,
+              amount_cents: product.amount_cents,
+            }
+          }) as ProductItemForReceipt[]
+        } else {
+          paymentProducts = [
+            {
+              name:
+                isPaymentEnabled && form?.payments_field?.products
+                  ? form?.payments_field?.products[0].name
+                  : 'Product/Service',
+              quantity: form?.payments_field?.products[0].min_qty,
+              amount_cents: form?.payments_field?.products[0].amount_cents,
+            },
+          ] as ProductItemForReceipt[]
+          totalAmount =
+            paymentProducts[0].quantity * paymentProducts[0].amount_cents
+        }
+        break
+
+      case PaymentType.Variable:
+        paymentProducts = [
+          {
+            name: form?.payments_field?.name,
+            quantity: 1,
+            amount_cents: form?.payments_field?.min_amount,
+          },
+        ] as ProductItemForReceipt[]
+        totalAmount = form?.payments_field?.min_amount
+        break
+
+      case PaymentType.Fixed:
+      default:
+        paymentProducts = [
+          {
+            name:
+              isPaymentEnabled && form?.payments_field?.products
+                ? form?.payments_field?.products[0].name
+                : 'Product/Service',
+            quantity: 1,
+            amount_cents:
+              isPaymentEnabled && form?.payments_field?.products
+                ? form?.payments_field?.products[0].amount_cents
+                : '0',
+          },
+        ] as ProductItemForReceipt[]
+        totalAmount = paymentProducts[0].amount_cents
+    }
+  }
+
   const submittedAriaText = useMemo(() => {
-    if (formTitle) {
-      return `You have successfully submitted your response for ${formTitle}.`
+    if (form?.title) {
+      return `You have successfully submitted your response for ${form?.title}.`
     }
     return 'You have successfully submitted your response.'
-  }, [formTitle])
+  }, [form?.title])
 
   return (
     <Container pb={{ base: '1.5rem', md: '3rem' }}>
@@ -60,7 +122,7 @@ export const PaymentEndPageBlock = ({
         paymentId={''}
         endPage={endPage}
         amount={totalAmount}
-        products={products}
+        products={paymentProducts}
         name={'Product/ Service'}
         paymentDate={new Date()}
       />

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPageBlock.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useRef } from 'react'
 import { Box, Container, VisuallyHidden } from '@chakra-ui/react'
-import { format } from 'date-fns'
 
-import { FormColorTheme, FormDto, ProductItem } from '~shared/types/form'
+import {
+  FormColorTheme,
+  FormDto,
+  ProductItemForReceipt,
+} from '~shared/types/form'
 
 import { SubmissionData } from '~features/public-form/PublicFormContext'
 
@@ -15,7 +18,8 @@ export interface PaymentEndPageBlockProps {
   colorTheme?: FormColorTheme
   focusOnMount?: boolean
   isPaymentEnabled: boolean
-  products: ProductItem[]
+  products: ProductItemForReceipt[]
+  totalAmount: number
   name: string
 }
 
@@ -26,6 +30,7 @@ export const PaymentEndPageBlock = ({
   colorTheme = FormColorTheme.Blue,
   focusOnMount,
   products,
+  totalAmount,
   name,
 }: PaymentEndPageBlockProps): JSX.Element => {
   const focusRef = useRef<HTMLDivElement>(null)
@@ -54,7 +59,7 @@ export const PaymentEndPageBlock = ({
         submissionId={submissionData.id as string}
         paymentId={''}
         endPage={endPage}
-        amount={1000}
+        amount={totalAmount}
         products={products}
         name={'Product/ Service'}
         paymentDate={new Date()}

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
@@ -1,11 +1,8 @@
-import { Box, Container, Flex, Stack, StackDivider } from '@chakra-ui/react'
+import { Box, Flex, Stack } from '@chakra-ui/react'
 
 import { FormColorTheme, FormDto } from '~shared/types/form'
 
-import {
-  SubmissionData,
-  usePublicFormContext,
-} from '~features/public-form/PublicFormContext'
+import { SubmissionData } from '~features/public-form/PublicFormContext'
 
 import { FeedbackBlock, FeedbackFormInput } from './FeedbackBlock'
 import { PaymentEndPageBlock } from './PaymentEndPageBlock'
@@ -25,22 +22,16 @@ export const PaymentEndPagePreview = ({
   colorTheme,
   ...endPageProps
 }: PaymentEndPagePreviewProps): JSX.Element => {
-  const { isPaymentEnabled } = usePublicFormContext()
   return (
     <>
       <Flex flexDir="column" align="center">
         <PaymentsThankYouSvgr h="100%" pt="2.5rem" />
         <Stack
-          //   spacing={{ base: '1.5rem', md: '3rem' }}
-          py={{ base: '1rem', md: '1.5rem' }}
+          pt={{ base: '1rem', md: '1.5rem' }}
           mx={{ base: '1.5rem', md: '2rem' }}
           bg="transparent"
         >
-          <PaymentEndPageBlock
-            focusOnMount
-            {...endPageProps}
-            isPaymentEnabled={isPaymentEnabled}
-          />
+          <PaymentEndPageBlock focusOnMount {...endPageProps} />
           {isFeedbackSubmitted ? null : (
             <Box backgroundColor="white" p="2rem">
               <FeedbackBlock onSubmit={handleSubmitFeedback} />

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
@@ -27,16 +27,14 @@ export const PaymentEndPagePreview = ({
 }: PaymentEndPagePreviewProps): JSX.Element => {
   const { isPaymentEnabled } = usePublicFormContext()
   return (
-    <Container>
+    <>
       <Flex flexDir="column" align="center">
         <PaymentsThankYouSvgr h="100%" pt="2.5rem" />
         <Stack
           //   spacing={{ base: '1.5rem', md: '3rem' }}
           py={{ base: '1rem', md: '1.5rem' }}
-          //   px={{ base: '1.5rem', md: '2rem' }}
+          mx={{ base: '1.5rem', md: '2rem' }}
           bg="transparent"
-          //   w="100%"
-          divider={<StackDivider />}
         >
           <PaymentEndPageBlock
             focusOnMount
@@ -50,6 +48,6 @@ export const PaymentEndPagePreview = ({
           )}
         </Stack>
       </Flex>
-    </Container>
+    </>
   )
 }

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
@@ -1,0 +1,55 @@
+import { Box, Container, Flex, Stack, StackDivider } from '@chakra-ui/react'
+
+import { FormColorTheme, FormDto } from '~shared/types/form'
+
+import {
+  SubmissionData,
+  usePublicFormContext,
+} from '~features/public-form/PublicFormContext'
+
+import { FeedbackBlock, FeedbackFormInput } from './FeedbackBlock'
+import { PaymentEndPageBlock } from './PaymentEndPageBlock'
+import { PaymentsThankYouSvgr } from './ThankYouSvgr'
+
+export interface PaymentEndPagePreviewProps {
+  endPage: FormDto['endPage']
+  submissionData: SubmissionData
+  handleSubmitFeedback: (inputs: FeedbackFormInput) => void
+  isFeedbackSubmitted: boolean
+  colorTheme: FormColorTheme
+}
+
+export const PaymentEndPagePreview = ({
+  handleSubmitFeedback,
+  isFeedbackSubmitted,
+  colorTheme,
+  ...endPageProps
+}: PaymentEndPagePreviewProps): JSX.Element => {
+  const { isPaymentEnabled } = usePublicFormContext()
+  return (
+    <Container>
+      <Flex flexDir="column" align="center">
+        <PaymentsThankYouSvgr h="100%" pt="2.5rem" />
+        <Stack
+          //   spacing={{ base: '1.5rem', md: '3rem' }}
+          py={{ base: '1rem', md: '1.5rem' }}
+          //   px={{ base: '1.5rem', md: '2rem' }}
+          bg="transparent"
+          //   w="100%"
+          divider={<StackDivider />}
+        >
+          <PaymentEndPageBlock
+            focusOnMount
+            {...endPageProps}
+            isPaymentEnabled={isPaymentEnabled}
+          />
+          {isFeedbackSubmitted ? null : (
+            <Box backgroundColor="white" p="2rem">
+              <FeedbackBlock onSubmit={handleSubmitFeedback} />
+            </Box>
+          )}
+        </Stack>
+      </Flex>
+    </Container>
+  )
+}

--- a/frontend/src/features/public-form/components/FormEndPage/components/ThankYouSvgr.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/ThankYouSvgr.tsx
@@ -75,3 +75,21 @@ export const ThankYouSvgr = chakra((props: SVGProps<SVGSVGElement>) => (
     />
   </svg>
 ))
+
+export const PaymentsThankYouSvgr = chakra((props: SVGProps<SVGSVGElement>) => (
+  <svg
+    width="64"
+    height="64"
+    viewBox="0 0 64 64"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g id="Icon/check-circle-solid">
+      <path
+        id="Vector"
+        d="M32.0006 5.33203C17.2967 5.33203 5.33398 17.2947 5.33398 31.9987C5.33398 46.7027 17.2967 58.6654 32.0006 58.6654C46.7046 58.6654 58.6673 46.7027 58.6673 31.9987C58.6673 17.2947 46.7046 5.33203 32.0006 5.33203ZM26.67 43.7667L16.7687 33.8867L20.534 30.1107L26.6646 36.2307L40.782 22.1134L44.5527 25.884L26.67 43.7667Z"
+        fill="#05CC9A"
+      />
+    </g>
+  </svg>
+))

--- a/frontend/src/features/public-form/components/FormEndPage/components/payment.utils.ts
+++ b/frontend/src/features/public-form/components/FormEndPage/components/payment.utils.ts
@@ -1,0 +1,78 @@
+import {
+  AdminStorageFormDto,
+  FormResponseMode,
+  PaymentType,
+  ProductItemForReceipt,
+} from '~shared/types'
+
+export const paymentTypeSelection = (
+  form: AdminStorageFormDto,
+): { paymentProducts: ProductItemForReceipt[]; totalAmount: number } => {
+  let paymentProducts: ProductItemForReceipt[] = []
+  let totalAmount = 0
+
+  const { payments_field } = form
+  switch (payments_field.payment_type) {
+    case PaymentType.Products: {
+      const isMultiProduct =
+        form.responseMode === FormResponseMode.Encrypt &&
+        payments_field.products_meta?.multi_product
+      if (isMultiProduct) {
+        paymentProducts = payments_field.products?.map((product) => {
+          return {
+            name: product.name,
+            quantity: product.min_qty,
+            amount_cents: product.amount_cents,
+          }
+        }) as ProductItemForReceipt[]
+        // add up total amount
+        totalAmount = paymentProducts.reduce((accum, cur) => {
+          return accum + cur.amount_cents * cur.quantity
+        }, 0)
+      } else {
+        paymentProducts = [
+          {
+            name: payments_field.products
+              ? payments_field.products[0].name
+              : 'Product/Service',
+            quantity: payments_field.products[0].min_qty,
+            amount_cents: payments_field.products[0].amount_cents,
+          },
+        ] as ProductItemForReceipt[]
+        totalAmount =
+          paymentProducts[0].quantity * paymentProducts[0].amount_cents
+      }
+      break
+    }
+
+    case PaymentType.Fixed: {
+      paymentProducts = [
+        {
+          name: payments_field.name,
+          quantity: 1,
+          amount_cents: payments_field.amount_cents,
+        },
+      ] as ProductItemForReceipt[]
+      totalAmount = payments_field.amount_cents
+      break
+    }
+
+    case PaymentType.Variable: {
+      paymentProducts = [
+        {
+          name: payments_field.name,
+          quantity: 1,
+          amount_cents: payments_field.min_amount,
+        },
+      ] as ProductItemForReceipt[]
+      totalAmount = payments_field.min_amount
+      break
+    }
+
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _: never = payments_field
+    }
+  }
+  return { paymentProducts, totalAmount }
+}

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentStack.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentStack.tsx
@@ -14,8 +14,7 @@ export const PaymentStack = ({
   const backgroundColour = noBg ? 'transparent' : 'white'
   return (
     <Stack
-      spacing={{ base: '1.5rem', md: '2.25rem' }}
-      py={{ base: '1.5rem', md: '3rem' }}
+      pt="1.5rem"
       px={{ base: '1.5rem', md: '4rem' }}
       bg={backgroundColour}
       w="100%"

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
@@ -4,7 +4,11 @@ import { Flex } from '@chakra-ui/react'
 import { Elements, useStripe } from '@stripe/react-stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
 
-import { GetPaymentInfoDto } from '~shared/types'
+import {
+  GetPaymentInfoDto,
+  PaymentType,
+  ProductItemForReceipt,
+} from '~shared/types'
 
 import InlineMessage from '~components/InlineMessage'
 
@@ -69,6 +73,28 @@ const StripePaymentContainer = ({
     stripe,
     refetchKey,
   })
+
+  const productsProductsType = paymentInfoData?.products?.map((product) => {
+    return {
+      name: product.data.name,
+      quantity: product.quantity,
+      amount_cents: product.data.amount_cents,
+    }
+  }) as ProductItemForReceipt[]
+
+  const productsVariableType = [
+    {
+      name: paymentInfoData?.payment_fields_snapshot?.name,
+      quantity: 1,
+      amount_cents: paymentInfoData?.amount,
+    },
+  ] as ProductItemForReceipt[]
+
+  const paymentProducts =
+    paymentInfoData?.payment_fields_snapshot?.payment_type ===
+    PaymentType.Variable
+      ? productsVariableType
+      : productsProductsType
 
   const viewStates = getPaymentViewStates(
     stripePaymentStatusResponse?.paymentIntent?.status,
@@ -138,7 +164,7 @@ const StripePaymentContainer = ({
               paymentId={paymentId}
               submissionId={paymentInfoData.submissionId}
               amount={paymentInfoData.amount}
-              products={paymentInfoData.products || []}
+              products={paymentProducts || []}
               paymentFieldsSnapshot={paymentInfoData.payment_fields_snapshot}
             />
           </>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -1,12 +1,9 @@
 import { useCallback, useState } from 'react'
 import { Box, Stack, useToast } from '@chakra-ui/react'
 
-import { FormPaymentsField, ProductItem } from '~shared/types'
+import { FormPaymentsField, ProductItemForReceipt } from '~shared/types'
 
-import {
-  usePublicFormMutations,
-  useSubmitFormFeedbackMutation,
-} from '~features/public-form/mutations'
+import { useSubmitFormFeedbackMutation } from '~features/public-form/mutations'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import {
@@ -30,7 +27,7 @@ export const StripeReceiptContainer = ({
   submissionId: string
   paymentId: string
   amount: number
-  products: ProductItem[]
+  products: ProductItemForReceipt[]
   paymentFieldsSnapshot: FormPaymentsField
 }) => {
   const {

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -3,7 +3,11 @@ import { Box, Stack, useToast } from '@chakra-ui/react'
 
 import { FormPaymentsField, ProductItem } from '~shared/types'
 
-import { useSubmitFormFeedbackMutation } from '~features/public-form/mutations'
+import {
+  usePublicFormMutations,
+  useSubmitFormFeedbackMutation,
+} from '~features/public-form/mutations'
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import {
   FeedbackBlock,
@@ -35,6 +39,7 @@ export const StripeReceiptContainer = ({
     error,
   } = useGetPaymentReceiptStatus(formId, paymentId)
 
+  const { form } = usePublicFormContext()
   const toast = useToast()
   const [isFeedbackSubmitted, setIsFeedbackSubmitted] = useState(false)
 
@@ -59,7 +64,7 @@ export const StripeReceiptContainer = ({
     [submitFormFeedbackMutation, toast],
   )
 
-  if (isLoading || error || !paymentReceiptStatus?.isReady) {
+  if (isLoading || error || !paymentReceiptStatus?.isReady || !form) {
     return (
       <PaymentStack>
         <GenericMessageBlock
@@ -85,6 +90,7 @@ export const StripeReceiptContainer = ({
           paymentType={paymentFieldsSnapshot.payment_type}
           name={paymentFieldsSnapshot.name || ''}
           paymentDate={paymentReceiptStatus.paymentDate}
+          endPage={form?.endPage}
         />
       </PaymentStack>
       <PaymentStack noBg>

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripeReceiptContainer.tsx
@@ -90,13 +90,13 @@ export const StripeReceiptContainer = ({
           endPage={form?.endPage}
         />
       </PaymentStack>
-      <PaymentStack noBg>
+      <Stack px={{ base: '1.5rem', md: '4rem' }} bg="transparent">
         {!isFeedbackSubmitted && (
           <Box backgroundColor="white" p="2rem">
             <FeedbackBlock onSubmit={handleSubmitFeedback} />
           </Box>
         )}
-      </PaymentStack>
+      </Stack>
     </Stack>
   )
 }

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -99,8 +99,6 @@ export const DownloadReceiptBlock = ({
   paymentId,
   amount,
   products,
-  paymentType,
-  name,
   paymentDate,
   endPage,
 }: DownloadReceiptBlockProps) => {
@@ -157,8 +155,9 @@ export const DownloadReceiptBlock = ({
               Summary
             </Text>
             <Stack spacing="0.75rem" my="1rem">
-              {products.map((product) => (
+              {products.map((product, index) => (
                 <LineItem
+                  key={index}
                   name={product.name}
                   quantity={product.quantity}
                   amount_cents={product.amount_cents}

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -124,7 +124,7 @@ export const DownloadReceiptBlock = ({
     <>
       <Box bg="white" p="2rem">
         <Stack tabIndex={-1} spacing="0.75rem">
-          <Text textStyle="h2" color="content.strong">
+          <Text textStyle="h2" color="secondary.500">
             {endPage.paymentTitle ||
               'Thank you, your payment has been made successfully.'}
           </Text>
@@ -134,7 +134,7 @@ export const DownloadReceiptBlock = ({
           </Text>
         </Stack>
       </Box>
-      <Box mt="2rem" px="1rem" py="2rem" bgColor="white">
+      <Box my="1.5rem" px="1rem" py="2rem" bgColor="white">
         <Stack>
           <Box mb="1.5rem" px="1.5rem">
             <Text textStyle="h2" mb="0.5rem" color="secondary.500">

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -3,13 +3,7 @@ import { BiDownload } from 'react-icons/bi'
 import { Box, Divider, Flex, Stack, Text } from '@chakra-ui/react'
 import { format } from 'date-fns'
 
-import {
-  ExtractTypeFromArray,
-  FormDto,
-  GetPaymentInfoDto,
-  PaymentType,
-  ProductItem,
-} from '~shared/types'
+import { FormDto, PaymentType, ProductItemForReceipt } from '~shared/types'
 import { centsToDollars } from '~shared/utils/payments'
 
 import { useToast } from '~hooks/useToast'
@@ -22,7 +16,7 @@ type DownloadReceiptBlockProps = {
   submissionId: string
   paymentId: string
   amount: number
-  products: ProductItem[]
+  products: ProductItemForReceipt[]
   paymentType?: PaymentType
   name: string
   paymentDate: Date | null
@@ -80,17 +74,21 @@ const PaymentSummaryRow = ({
 }
 
 const LineItem = ({
-  productItem,
+  name,
+  quantity,
+  amount_cents,
 }: {
-  productItem: ExtractTypeFromArray<NonNullable<GetPaymentInfoDto['products']>>
+  name: string
+  quantity: number
+  amount_cents: number
 }) => {
   return (
     <Flex textStyle="body-1" mb="1rem" justifyContent="space-between">
       <Text fontWeight="400" color="secondary.700">
-        {productItem.data.name} x {productItem.quantity}
+        {name} x {quantity}
       </Text>
       <Text fontWeight="500" color="secondary.700">
-        S${centsToDollars(productItem.quantity * productItem.data.amount_cents)}
+        S${centsToDollars(quantity * amount_cents)}
       </Text>
     </Flex>
   )
@@ -160,21 +158,12 @@ export const DownloadReceiptBlock = ({
             </Text>
             <Stack spacing="0.75rem" my="1rem">
               {products.map((product) => (
-                <LineItem productItem={product} />
+                <LineItem
+                  name={product.name}
+                  quantity={product.quantity}
+                  amount_cents={product.amount_cents}
+                />
               ))}
-              <Flex
-                textStyle={'body-1'}
-                mb="1rem"
-                justifyContent={'space-between'}
-              >
-                <Text fontWeight="400" color="secondary.700">
-                  {name}
-                </Text>
-                <Text fontWeight="500" color="secondary.700">
-                  S$
-                  {centsToDollars(amount)}
-                </Text>
-              </Flex>
             </Stack>
             <Divider />
             <Stack my="1rem">

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/DownloadReceiptBlock.tsx
@@ -5,6 +5,7 @@ import { format } from 'date-fns'
 
 import {
   ExtractTypeFromArray,
+  FormDto,
   GetPaymentInfoDto,
   PaymentType,
   ProductItem,
@@ -25,6 +26,7 @@ type DownloadReceiptBlockProps = {
   paymentType?: PaymentType
   name: string
   paymentDate: Date | null
+  endPage: FormDto['endPage']
 }
 
 const PaymentDetailsRow = ({
@@ -93,7 +95,6 @@ const LineItem = ({
     </Flex>
   )
 }
-
 export const DownloadReceiptBlock = ({
   formId,
   submissionId,
@@ -103,10 +104,12 @@ export const DownloadReceiptBlock = ({
   paymentType,
   name,
   paymentDate,
+  endPage,
 }: DownloadReceiptBlockProps) => {
   const toast = useToast({ status: 'success', isClosable: true })
 
   const totalAmount = useMemo(() => `S$${centsToDollars(amount)}`, [amount])
+
   const paymentTimestamp = useMemo(
     () =>
       paymentDate
@@ -125,11 +128,13 @@ export const DownloadReceiptBlock = ({
     <>
       <Box bg="white" p="2rem">
         <Stack tabIndex={-1} spacing="0.75rem">
-          <Text textStyle="h2" color="secondary.500">
-            Thank you, your payment has been made successfully.
+          <Text textStyle="h2" color="content.strong">
+            {endPage.paymentTitle ||
+              'Thank you, your payment has been made successfully.'}
           </Text>
           <Text textStyle="subhead-1" color="secondary.500">
-            Your form has been submitted and payment has been made.
+            {endPage.paymentParagraph ||
+              'Your form has been submitted and payment has been made.'}
           </Text>
         </Stack>
       </Box>
@@ -157,6 +162,19 @@ export const DownloadReceiptBlock = ({
               {products.map((product) => (
                 <LineItem productItem={product} />
               ))}
+              <Flex
+                textStyle={'body-1'}
+                mb="1rem"
+                justifyContent={'space-between'}
+              >
+                <Text fontWeight="400" color="secondary.700">
+                  {name}
+                </Text>
+                <Text fontWeight="500" color="secondary.700">
+                  S$
+                  {centsToDollars(amount)}
+                </Text>
+              </Flex>
             </Stack>
             <Divider />
             <Stack my="1rem">

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -46,6 +46,8 @@ export type FormEndPage = {
   paragraph?: string
   buttonLink?: string
   buttonText: string
+  paymentTitle: string
+  paymentParagraph: string
 }
 
 export enum FormAuthType {

--- a/shared/types/form/product.ts
+++ b/shared/types/form/product.ts
@@ -16,3 +16,9 @@ export type ProductItem = {
   selected: boolean
   quantity: number
 }
+
+export type ProductItemForReceipt = {
+  name: string
+  quantity: number
+  amount_cents: number
+}

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -76,6 +76,8 @@ const FORM_DEFAULTS = {
   endPage: {
     title: 'Thank you for filling out the form.',
     buttonText: 'Submit another response',
+    paymentTitle: 'Thank you, your payment has been made successfully.',
+    paymentParagraph: 'Your form has been submitted and payment has been made.',
   },
   hasCaptcha: true,
   hasIssueNotification: true,
@@ -1730,6 +1732,9 @@ describe('Form Model', () => {
           title: 'some new title',
           paragraph: 'some description paragraph',
           buttonText: 'custom button text',
+          paymentParagraph:
+            'Your form has been submitted and payment has been made.',
+          paymentTitle: 'Thank you, your payment has been made successfully.',
         }
 
         // Act
@@ -1768,6 +1773,9 @@ describe('Form Model', () => {
             // Defaults should be populated and returned
             buttonText: 'Submit another response',
             title: 'Thank you for filling out the form.',
+            paymentParagraph:
+              'Your form has been submitted and payment has been made.',
+            paymentTitle: 'Thank you, your payment has been made successfully.',
           },
         })
       })
@@ -1779,6 +1787,9 @@ describe('Form Model', () => {
           buttonText: 'custom button text',
           title: 'some new title',
           paragraph: 'does not really matter',
+          paymentParagraph:
+            'Your form has been submitted and payment has been made.',
+          paymentTitle: 'Thank you, your payment has been made successfully.',
         }
 
         // Act

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -464,6 +464,14 @@ const compileFormModel = (db: Mongoose): IFormModel => {
           type: String,
           default: 'Submit another response',
         },
+        paymentTitle: {
+          type: String,
+          default: 'Thank you, your payment has been made successfully',
+        },
+        paymentParagraph: {
+          type: String,
+          default: 'Your form has been submitted and payment has been made.',
+        },
       },
 
       hasCaptcha: {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -466,7 +466,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         },
         paymentTitle: {
           type: String,
-          default: 'Thank you, your payment has been made successfully',
+          default: 'Thank you, your payment has been made successfully.',
         },
         paymentParagraph: {
           type: String,

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1,6 +1,6 @@
 import JoiDate from '@joi/date'
 import axios from 'axios'
-import { ObjectId } from 'bson'
+import { ObjectID, ObjectId } from 'bson'
 import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
 import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
@@ -72,9 +72,7 @@ import {
   mapRouteError as mapEmailSubmissionError,
   SubmissionEmailObj,
 } from '../../submission/email-submission/email-submission.util'
-import * as EncryptSubmissionMiddleware from '../../submission/encrypt-submission/encrypt-submission.middleware'
 import * as EncryptSubmissionService from '../../submission/encrypt-submission/encrypt-submission.service'
-import IncomingEncryptSubmission from '../../submission/encrypt-submission/IncomingEncryptSubmission.class'
 import ParsedResponsesObject from '../../submission/ParsedResponsesObject.class'
 import * as ReceiverMiddleware from '../../submission/receiver/receiver.middleware'
 import * as SubmissionService from '../../submission/submission.service'
@@ -1692,7 +1690,6 @@ export const submitEncryptPreview: ControllerHandler<
   const { formId } = req.params
   const sessionUserId = (req.session as AuthedSessionData).user._id
   // No need to process attachments as we don't do anything with them
-  const { encryptedContent, responses, version } = req.body
   const logMeta = {
     action: 'submitEncryptPreview',
     formId,
@@ -1718,41 +1715,12 @@ export const submitEncryptPreview: ControllerHandler<
         return error
       }),
     )
-    .andThen((form) =>
-      IncomingEncryptSubmission.init(form, responses, encryptedContent)
-        .map((incomingSubmission) => ({ incomingSubmission, form }))
-        .mapErr((error) => {
-          logger.error({
-            message: 'Error while processing incoming preview submission.',
-            meta: logMeta,
-            error,
-          })
-          return error
-        }),
-    )
-    .map(({ incomingSubmission, form }) => {
-      const submission =
-        EncryptSubmissionService.createEncryptSubmissionWithoutSave({
-          form,
-          encryptedContent: incomingSubmission.encryptedContent,
-          // Don't bother encrypting and signing mock variables for previews
-          verifiedContent: '',
-          version,
-        })
-
-      void SubmissionService.sendEmailConfirmations({
-        form,
-        submission,
-        recipientData: extractEmailConfirmationData(
-          incomingSubmission.responses,
-          form.form_fields,
-        ),
-      })
-
+    .map(() => {
+      const fakeSubmissionId = new ObjectID().toString()
       // Return the reply early to the submitter
       return res.json({
         message: 'Form submission successful.',
-        submissionId: submission._id,
+        submissionId: fakeSubmissionId,
       })
     })
     .mapErr((error) => {
@@ -1762,7 +1730,6 @@ export const submitEncryptPreview: ControllerHandler<
 }
 
 export const handleEncryptPreviewSubmission = [
-  EncryptSubmissionMiddleware.validateEncryptSubmissionParams,
   submitEncryptPreview,
 ] as ControllerHandler[]
 

--- a/src/app/routes/api/v3/admin/forms/admin-forms.preview.routes.ts
+++ b/src/app/routes/api/v3/admin/forms/admin-forms.preview.routes.ts
@@ -42,7 +42,7 @@ AdminFormsPreviewRouter.post(
 
 /**
  * Submit an encrypt mode form in preview mode
- * @route POST api/v3/admin/forms/:formId([a-fA-F0-9]{24})/preview/submissions/encrypt
+ * @route POST api/v3/admin/forms/:formId([a-fA-F0-9]{24})/preview/submissions/storage
  * @security session
  *
  * @returns 200 if submission was valid
@@ -54,7 +54,7 @@ AdminFormsPreviewRouter.post(
  * @returns 500 when database error occurs
  */
 AdminFormsPreviewRouter.post(
-  '/:formId([a-fA-F0-9]{24})/preview/submissions/encrypt',
+  '/:formId([a-fA-F0-9]{24})/preview/submissions/storage',
   AdminFormController.handleEncryptPreviewSubmission,
 )
 


### PR DESCRIPTION
## Problem
Adding encryption boundary shift for storage mode form submissions previews.

Closes FRM-1506

## Solution
added encryption shift to preview mode - also reducing the complexity of implementing encryption within preview mode by no longer saving any answers or attachments uploaded in preview mode. This decision was made because:
- use of preview mode, let alone uploading attachment functionality or sending of answers to users' emails via preview mode is low
- main value/ usage of preview mode is primarily used for testing what the look and feel of the form would look like, rather than viewing the answers/ attachments saved in the preview mode after submitting a form

**Breaking Changes** 
- [ X] No - this PR is backwards compatible  