### PR TITLE
chore: add payments by product backend validation

### DIFF
--- a/shared/types/form/__tests__/product.spec.ts
+++ b/shared/types/form/__tests__/product.spec.ts
@@ -1,0 +1,128 @@
+// Unit tests for product.ts, isPaymentsProductt
+
+import { ObjectId } from 'bson'
+import { isPaymentsProducts } from '../product'
+import { Product } from '../product'
+
+describe('Product validation', () => {
+  it('should return false if products is not an array', () => {
+    // Arrange
+    const mockProductNonArray = 'some thing'
+
+    // Assert
+    expect(isPaymentsProducts(mockProductNonArray)).toBe(false)
+  })
+
+  it('should return true if products is an empty array', () => {
+    // Arrange
+    const mockProductEmptyArray: Product[] = []
+
+    // Assert
+    expect(isPaymentsProducts(mockProductEmptyArray)).toBe(false)
+  })
+
+  it('should return false if product has invalid object id', () => {
+    // Arrange
+    const mockProductInvalidId: any = [
+      {
+        name: 'some name',
+        description: 'some description',
+        multi_qty: true,
+        min_qty: 1,
+        max_qty: 1,
+        amount_cents: 1,
+        _id: 'some id',
+      },
+    ]
+
+    // Assert
+    expect(isPaymentsProducts(mockProductInvalidId)).toBe(false)
+  })
+
+  it('should return false if product has no name', () => {
+    // Arrange
+    const mockProductWrongName = [
+      {
+        description: 'some description',
+        multi_qty: true,
+        min_qty: 1,
+        max_qty: 1,
+        amount_cents: 1,
+        _id: new ObjectId(),
+      },
+    ] as unknown as Product[]
+
+    // Assert
+    expect(isPaymentsProducts(mockProductWrongName)).toBe(false)
+  })
+
+  it('should return false if there are multiple products and at least one has no name', () => {
+    // Arrange
+    const mockMultipleProductOneNoName = [
+      {
+        description: 'some description',
+        multi_qty: true,
+        min_qty: 1,
+        max_qty: 1,
+        amount_cents: 1,
+        _id: new ObjectId(),
+      },
+      {
+        name: 'has name',
+        multi_qty: true,
+        min_qty: 1,
+        max_qty: 1,
+        amount_cents: 1,
+        _id: new ObjectId(),
+      },
+    ] as unknown as Product[]
+
+    // Assert
+    expect(isPaymentsProducts(mockMultipleProductOneNoName)).toBe(false)
+  })
+
+  it('should return true if product has valid object id and name', () => {
+    // Arrange
+    const mockProductsCorrectShape = [
+      {
+        name: 'some name',
+        description: 'some description',
+        multi_qty: true,
+        min_qty: 1,
+        max_qty: 1,
+        amount_cents: 1,
+        _id: new ObjectId(),
+      },
+    ] as unknown as Product[]
+
+    // Assert
+    expect(isPaymentsProducts(mockProductsCorrectShape)).toBe(true)
+  })
+
+  it('should return true if multiple products have valid object id and name', () => {
+    // Arrange
+    const mockProductsCorrectShapeMultiple = [
+      {
+        name: 'some name',
+        description: 'some description',
+        multi_qty: true,
+        min_qty: 1,
+        max_qty: 1,
+        amount_cents: 1,
+        _id: new ObjectId(),
+      },
+      {
+        name: 'another name',
+        description: 'another description',
+        multi_qty: true,
+        min_qty: 1,
+        max_qty: 1,
+        amount_cents: 1,
+        _id: new ObjectId(),
+      },
+    ] as unknown as Product[]
+
+    // Assert
+    expect(isPaymentsProducts(mockProductsCorrectShapeMultiple)).toBe(true)
+  })
+})

--- a/shared/types/form/__tests__/product.spec.ts
+++ b/shared/types/form/__tests__/product.spec.ts
@@ -1,5 +1,3 @@
-// Unit tests for product.ts, isPaymentsProductt
-
 import { ObjectId } from 'bson'
 import { isPaymentsProducts } from '../product'
 import { Product } from '../product'

--- a/shared/types/form/product.ts
+++ b/shared/types/form/product.ts
@@ -16,3 +16,23 @@ export type ProductItem = {
   selected: boolean
   quantity: number
 }
+
+// Typeguard for Product
+export const isPaymentsProducts = (
+  products: unknown,
+): products is Product[] => {
+  if (!Array.isArray(products)) {
+    return false
+  }
+  return products.every((product) => {
+    return (
+      typeof product._id === 'string' &&
+      typeof product.name === 'string' &&
+      typeof product.description === 'string' &&
+      typeof product.multi_qty === 'boolean' &&
+      typeof product.min_qty === 'number' &&
+      typeof product.max_qty === 'number' &&
+      typeof product.amount_cents === 'number'
+    )
+  })
+}

--- a/shared/types/form/product.ts
+++ b/shared/types/form/product.ts
@@ -24,15 +24,15 @@ export const isPaymentsProducts = (
   if (!Array.isArray(products)) {
     return false
   }
-  return products.every((product) => {
-    return (
-      typeof product._id === 'string' &&
-      typeof product.name === 'string' &&
-      typeof product.description === 'string' &&
-      typeof product.multi_qty === 'boolean' &&
-      typeof product.min_qty === 'number' &&
-      typeof product.max_qty === 'number' &&
-      typeof product.amount_cents === 'number'
-    )
-  })
+  return (
+    products.length > 0 &&
+    products.every((product) => {
+      return (
+        product._id &&
+        String(product._id).match(/^[0-9a-fA-F]{24}$/) &&
+        product.name &&
+        typeof product.name === 'string'
+      )
+    })
+  )
 }

--- a/src/app/modules/payments/__tests__/payments.service.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.service.spec.ts
@@ -2,7 +2,7 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
 import moment from 'moment-timezone'
 import mongoose, { Query } from 'mongoose'
-import { PaymentStatus, Product, ProductItem } from 'shared/types'
+import { PaymentStatus, Product, ProductId, ProductItem } from 'shared/types'
 
 import getAgencyModel from 'src/app/models/agency.server.model'
 import getPaymentModel from 'src/app/models/payment.server.model'
@@ -131,8 +131,8 @@ describe('payments.service', () => {
         {
           data: {
             ...mockValidProduct,
-            _id: new ObjectId(),
-          } as unknown as Product,
+            _id: new ObjectId() as unknown as ProductId,
+          },
           quantity: 1,
           selected: true,
         },
@@ -166,13 +166,7 @@ describe('payments.service', () => {
           data: {
             ...mockValidProduct,
             description: 'some other description',
-            _id: new ObjectId(),
-          } as unknown as Product,
-          quantity: 1,
-          selected: true,
-        },
-        {
-          data: mockValidProduct,
+          },
           quantity: 1,
           selected: true,
         },
@@ -201,13 +195,7 @@ describe('payments.service', () => {
           data: {
             ...mockValidProduct,
             name: 'some other name',
-            _id: new ObjectId(),
-          } as unknown as Product,
-          quantity: 1,
-          selected: true,
-        },
-        {
-          data: mockValidProduct,
+          },
           quantity: 1,
           selected: true,
         },
@@ -236,13 +224,7 @@ describe('payments.service', () => {
           data: {
             ...mockValidProduct,
             multi_qty: true,
-            _id: new ObjectId(),
-          } as unknown as Product,
-          quantity: 1,
-          selected: true,
-        },
-        {
-          data: mockValidProduct,
+          },
           quantity: 1,
           selected: true,
         },
@@ -271,13 +253,7 @@ describe('payments.service', () => {
           data: {
             ...mockValidProduct,
             max_qty: 5,
-            _id: new ObjectId(),
-          } as unknown as Product,
-          quantity: 1,
-          selected: true,
-        },
-        {
-          data: mockValidProduct,
+          },
           quantity: 1,
           selected: true,
         },

--- a/src/app/modules/payments/__tests__/payments.service.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.service.spec.ts
@@ -155,7 +155,147 @@ describe('payments.service', () => {
         InvalidPaymentProductsError,
       )
       expect(result._unsafeUnwrapErr().message).toContain(
-        'Invalid product selected.',
+        'There has been a change in the products available.',
+      )
+    })
+
+    it('should return with error if the description has changed', () => {
+      // Arrange
+      const mockInvalidProductSubmission: ProductItem[] = [
+        {
+          data: {
+            ...mockValidProduct,
+            description: 'some other description',
+            _id: new ObjectId(),
+          } as unknown as Product,
+          quantity: 1,
+          selected: true,
+        },
+        {
+          data: mockValidProduct,
+          quantity: 1,
+          selected: true,
+        },
+      ]
+
+      // Act
+      const result = PaymentsService.validatePaymentProducts(
+        mockValidProductsDefinition,
+        mockInvalidProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'There has been a change in the products available.',
+      )
+    })
+
+    it('should return with error if the name has changed', () => {
+      // Arrange
+      const mockInvalidProductSubmission: ProductItem[] = [
+        {
+          data: {
+            ...mockValidProduct,
+            name: 'some other name',
+            _id: new ObjectId(),
+          } as unknown as Product,
+          quantity: 1,
+          selected: true,
+        },
+        {
+          data: mockValidProduct,
+          quantity: 1,
+          selected: true,
+        },
+      ]
+
+      // Act
+      const result = PaymentsService.validatePaymentProducts(
+        mockValidProductsDefinition,
+        mockInvalidProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'There has been a change in the products available.',
+      )
+    })
+
+    it('should return with error if multi_qty has changed', () => {
+      // Arrange
+      const mockInvalidProductSubmission: ProductItem[] = [
+        {
+          data: {
+            ...mockValidProduct,
+            multi_qty: true,
+            _id: new ObjectId(),
+          } as unknown as Product,
+          quantity: 1,
+          selected: true,
+        },
+        {
+          data: mockValidProduct,
+          quantity: 1,
+          selected: true,
+        },
+      ]
+
+      // Act
+      const result = PaymentsService.validatePaymentProducts(
+        mockValidProductsDefinition,
+        mockInvalidProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'There has been a change in the products available.',
+      )
+    })
+
+    it('should return with error if the max_qty has changed', () => {
+      // Arrange
+      const mockInvalidProductSubmission: ProductItem[] = [
+        {
+          data: {
+            ...mockValidProduct,
+            max_qty: 5,
+            _id: new ObjectId(),
+          } as unknown as Product,
+          quantity: 1,
+          selected: true,
+        },
+        {
+          data: mockValidProduct,
+          quantity: 1,
+          selected: true,
+        },
+      ]
+
+      // Act
+      const result = PaymentsService.validatePaymentProducts(
+        mockValidProductsDefinition,
+        mockInvalidProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'There has been a change in the products available.',
       )
     })
 
@@ -264,7 +404,7 @@ describe('payments.service', () => {
       )
     })
 
-    it('should return with error if submitted price is not the same as in form defintion', () => {
+    it('should return with error if submitted price is not the same as in form definition', () => {
       // Arrange
       const mockProductWithCorrectPrice = {
         name: 'some name',
@@ -303,7 +443,9 @@ describe('payments.service', () => {
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(
         InvalidPaymentProductsError,
       )
-      expect(result._unsafeUnwrapErr().message).toContain('Price has changed')
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'There has been a change in the products available',
+      )
     })
   })
 

--- a/src/app/modules/payments/__tests__/payments.service.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.service.spec.ts
@@ -2,13 +2,14 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
 import moment from 'moment-timezone'
 import mongoose, { Query } from 'mongoose'
-import { PaymentStatus } from 'shared/types'
+import { PaymentStatus, Product, ProductItem } from 'shared/types'
 
 import getAgencyModel from 'src/app/models/agency.server.model'
 import getPaymentModel from 'src/app/models/payment.server.model'
 
 import { InvalidDomainError } from '../../auth/auth.errors'
 import { DatabaseError } from '../../core/core.errors'
+import { InvalidPaymentProductsError } from '../payments.errors'
 import * as PaymentsService from '../payments.service'
 
 const Payment = getPaymentModel(mongoose)
@@ -70,6 +71,239 @@ describe('payments.service', () => {
         new ObjectId().toHexString(),
       )
       expect(result.isErr()).toBeTrue()
+    })
+  })
+
+  describe('validatePaymentProducts', () => {
+    const mockValidProduct = {
+      name: 'some name',
+      description: 'some description',
+      multi_qty: false,
+      min_qty: 1,
+      max_qty: 1,
+      amount_cents: 1000,
+      _id: new ObjectId(),
+    } as unknown as Product
+
+    const mockValidProductsDefinition = [mockValidProduct]
+
+    const mockValidProductSubmission: ProductItem[] = [
+      { data: mockValidProduct, quantity: 1, selected: true },
+    ]
+
+    it('should return without error if payment products are valid', () => {
+      // Act
+      const result = PaymentsService.validatePaymentProducts(
+        mockValidProductsDefinition,
+        mockValidProductSubmission,
+      )
+
+      // Assert
+      expect(result.isOk()).toBeTrue()
+    })
+
+    it('should return with error if there are duplicate payment products', () => {
+      // Arrange
+      const mockDuplicatedProductSubmission: ProductItem[] = [
+        { data: mockValidProduct, quantity: 1, selected: true },
+        { data: mockValidProduct, quantity: 1, selected: true },
+      ]
+
+      // Act
+      const result = PaymentsService.validatePaymentProducts(
+        mockValidProductsDefinition,
+        mockDuplicatedProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'You have selected a duplicate product.',
+      )
+    })
+
+    it('should return with error if the payment product id cannot be found', () => {
+      // Arrange
+      const mockInvalidProductSubmission: ProductItem[] = [
+        {
+          data: {
+            ...mockValidProduct,
+            _id: new ObjectId(),
+          } as unknown as Product,
+          quantity: 1,
+          selected: true,
+        },
+        {
+          data: mockValidProduct,
+          quantity: 1,
+          selected: true,
+        },
+      ]
+
+      // Act
+      const result = PaymentsService.validatePaymentProducts(
+        mockValidProductsDefinition,
+        mockInvalidProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'Invalid product selected.',
+      )
+    })
+
+    it('should return with error if more than 1 quantity selected when multi_qty is disabled', () => {
+      // Arrange
+      const mockSingleQuantityProduct = {
+        name: 'some name',
+        description: 'some description',
+        multi_qty: false,
+        min_qty: 1,
+        max_qty: 5,
+        amount_cents: 1000,
+        _id: new ObjectId(),
+      } as unknown as Product
+
+      const mockProductSubmission = [
+        { data: mockSingleQuantityProduct, quantity: 2, selected: true },
+      ]
+
+      const mockProductDefinition = [mockSingleQuantityProduct]
+
+      // Act
+
+      const result = PaymentsService.validatePaymentProducts(
+        mockProductDefinition,
+        mockProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'Selected more than 1 quantity when it is not allowed',
+      )
+    })
+
+    it('should return with error if less than min quantity selected when multi_qty is enabled', () => {
+      // Arrange
+      const mockMultiQuantityProduct = {
+        name: 'some name',
+        description: 'some description',
+        multi_qty: true,
+        min_qty: 3,
+        max_qty: 5,
+        amount_cents: 1000,
+        _id: new ObjectId(),
+      } as unknown as Product
+
+      const mockProductSubmission = [
+        { data: mockMultiQuantityProduct, quantity: 1, selected: true },
+      ]
+
+      const mockProductDefinition = [mockMultiQuantityProduct]
+
+      // Act
+
+      const result = PaymentsService.validatePaymentProducts(
+        mockProductDefinition,
+        mockProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'Selected an invalid quantity below the limit',
+      )
+    })
+
+    it('should return with error if more than max quantity selected when multi_qty is enabled', () => {
+      // Arrange
+      const mockMultiQuantityProduct = {
+        name: 'some name',
+        description: 'some description',
+        multi_qty: true,
+        min_qty: 3,
+        max_qty: 5,
+        amount_cents: 1000,
+        _id: new ObjectId(),
+      } as unknown as Product
+
+      const mockProductSubmission = [
+        { data: mockMultiQuantityProduct, quantity: 10, selected: true },
+      ]
+
+      const mockProductDefinition = [mockMultiQuantityProduct]
+
+      // Act
+
+      const result = PaymentsService.validatePaymentProducts(
+        mockProductDefinition,
+        mockProductSubmission,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain(
+        'Selected an invalid quantity above the limit',
+      )
+    })
+
+    it('should return with error if submitted price is not the same as in form defintion', () => {
+      // Arrange
+      const mockProductWithCorrectPrice = {
+        name: 'some name',
+        description: 'some description',
+        multi_qty: true,
+        min_qty: 3,
+        max_qty: 5,
+        amount_cents: 1000,
+        _id: new ObjectId(),
+      } as unknown as Product
+
+      const mockProductWithIncorrectPrice = {
+        ...mockProductWithCorrectPrice,
+        amount_cents: 500,
+      }
+
+      const mockProductSubmissionWithIncorrectPrice = [
+        {
+          data: mockProductWithIncorrectPrice,
+          quantity: 3,
+          selected: true,
+        },
+      ]
+
+      const mockProductDefinition = [mockProductWithCorrectPrice]
+
+      // Act
+
+      const result = PaymentsService.validatePaymentProducts(
+        mockProductDefinition,
+        mockProductSubmissionWithIncorrectPrice,
+      )
+
+      // Assert
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        InvalidPaymentProductsError,
+      )
+      expect(result._unsafeUnwrapErr().message).toContain('Price has changed')
     })
   })
 

--- a/src/app/modules/payments/payments.errors.ts
+++ b/src/app/modules/payments/payments.errors.ts
@@ -29,3 +29,9 @@ export class PaymentAccountInformationError extends ApplicationError {
     super(message)
   }
 }
+
+export class InvalidPaymentProductsError extends ApplicationError {
+  constructor(message = 'Invalid payment submission') {
+    super(message)
+  }
+}

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -370,6 +370,9 @@ export const sendOnboardingEmailIfEligible = (
   )
 }
 
+/**
+ * Validates that payment by product is valid
+ */
 export const validatePaymentProducts = (
   formProductsDefinition: Product[],
   submittedPaymentProducts: ProductItem[],
@@ -378,7 +381,7 @@ export const validatePaymentProducts = (
     action: 'validatePayments',
   }
 
-  // Check that no duplicate payment products are selected
+  // Check that no duplicate payment products (by id) are selected
   const selectedProducts = submittedPaymentProducts.filter(
     (product) => product.selected,
   )
@@ -412,7 +415,11 @@ export const validatePaymentProducts = (
         message: 'Invalid payment product selected.',
         meta: logMeta,
       })
-      return err(new InvalidPaymentProductsError('Invalid product selected.'))
+      return err(
+        new InvalidPaymentProductsError(
+          'Invalid product selected. Please refresh and try again.',
+        ),
+      )
     }
 
     // Check that the quantity of the product is valid
@@ -424,7 +431,7 @@ export const validatePaymentProducts = (
       })
       return err(
         new InvalidPaymentProductsError(
-          'Selected more than 1 quantity when it is not allowed.',
+          'Selected more than 1 quantity when it is not allowed. Please refresh and try again.',
         ),
       )
     }
@@ -439,7 +446,7 @@ export const validatePaymentProducts = (
 
         return err(
           new InvalidPaymentProductsError(
-            `Selected an invalid quantity below the liimt.`,
+            `Selected an invalid quantity below the limit. Please refresh and try again.`,
           ),
         )
       }
@@ -452,11 +459,20 @@ export const validatePaymentProducts = (
 
         return err(
           new InvalidPaymentProductsError(
-            `Selected an invalid quantity above the limit.`,
+            `Selected an invalid quantity above the limit. Please refresh and try again.`,
           ),
         )
       }
     }
+
+    if (product.data.amount_cents !== productDefinition.amount_cents) {
+      return err(
+        new InvalidPaymentProductsError(
+          `Price has changed. Please refresh and try again.`,
+        ),
+      )
+    }
   }
+
   return ok(true)
 }

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash'
+import { isEqual, omit } from 'lodash'
 import moment from 'moment-timezone'
 import mongoose, { Types } from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
@@ -411,7 +411,11 @@ export const validatePaymentProducts = (
     const productDefinition = formProductsDefinition.find(
       (product) => String(product._id) === String(productIdSubmitted),
     )
-    if (!productDefinition || !isEqual(productDefinition, product.data)) {
+
+    if (
+      !productDefinition ||
+      !isEqual(omit(productDefinition, '_id'), omit(product.data, '_id'))
+    ) {
       logger.error({
         message: 'Invalid payment product selected.',
         meta: logMeta,

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -1,8 +1,8 @@
 import moment from 'moment-timezone'
 import mongoose, { Types } from 'mongoose'
-import { errAsync, okAsync, ResultAsync } from 'neverthrow'
+import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
-import { PaymentStatus } from '../../../../shared/types'
+import { PaymentStatus, Product, ProductItem } from '../../../../shared/types'
 import { IPaymentSchema } from '../../../types'
 import { createLoggerWithLabel } from '../../config/logger'
 import getPaymentModel from '../../models/payment.server.model'
@@ -25,6 +25,7 @@ import { findSubmissionById } from '../submission/submission.service'
 
 import {
   ConfirmedPaymentNotFoundError,
+  InvalidPaymentProductsError,
   PaymentAlreadyConfirmedError,
   PaymentNotFoundError,
 } from './payments.errors'
@@ -367,4 +368,95 @@ export const sendOnboardingEmailIfEligible = (
   return AuthService.validateEmailDomain(email).andThen(() =>
     MailService.sendPaymentOnboardingEmail({ email }),
   )
+}
+
+export const validatePaymentProducts = (
+  formProductsDefinition: Product[],
+  submittedPaymentProducts: ProductItem[],
+): Result<true, InvalidPaymentProductsError> => {
+  const logMeta = {
+    action: 'validatePayments',
+  }
+
+  // Check that no duplicate payment products are selected
+  const selectedProducts = submittedPaymentProducts.filter(
+    (product) => product.selected,
+  )
+
+  const selectedProductIds = new Set(
+    selectedProducts.map((product) => product.data._id),
+  )
+
+  if (selectedProductIds.size !== selectedProducts.length) {
+    logger.error({
+      message: 'Duplicate payment products selected',
+      meta: logMeta,
+    })
+
+    return err(
+      new InvalidPaymentProductsError(
+        'You have selected a duplicate product. Please refresh and try again.',
+      ),
+    )
+  }
+
+  for (const product of submittedPaymentProducts) {
+    // Check that every selected product is in the form definition
+    const productIdSubmitted = product.data._id
+    const productDefinition = formProductsDefinition.find(
+      (product) => String(product._id) === String(productIdSubmitted),
+    )
+
+    if (!productDefinition) {
+      logger.error({
+        message: 'Invalid payment product selected.',
+        meta: logMeta,
+      })
+      return err(new InvalidPaymentProductsError('Invalid product selected.'))
+    }
+
+    // Check that the quantity of the product is valid
+
+    if (!productDefinition.multi_qty && product.quantity > 1) {
+      logger.error({
+        message: 'Invalid payment product quantity',
+        meta: logMeta,
+      })
+      return err(
+        new InvalidPaymentProductsError(
+          'Selected more than 1 quantity when it is not allowed.',
+        ),
+      )
+    }
+
+    if (productDefinition.multi_qty) {
+      if (product.quantity < productDefinition.min_qty) {
+        logger.error({
+          message:
+            'Selected an invalid payment product quantity below the limit',
+          meta: logMeta,
+        })
+
+        return err(
+          new InvalidPaymentProductsError(
+            `Selected an invalid quantity below the liimt.`,
+          ),
+        )
+      }
+      if (product.quantity > productDefinition.max_qty) {
+        logger.error({
+          message:
+            'Selected an invalid payment product quantity above the limit.',
+          meta: logMeta,
+        })
+
+        return err(
+          new InvalidPaymentProductsError(
+            `Selected an invalid quantity above the limit.`,
+          ),
+        )
+      }
+    }
+  }
+  return ok(true)
 }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -630,6 +630,7 @@ export const handleStorageSubmission = [
   EncryptSubmissionMiddleware.createFormsgAndRetrieveForm,
   EncryptSubmissionMiddleware.scanAndRetrieveAttachments,
   EncryptSubmissionMiddleware.validateStorageSubmission,
+  EncryptSubmissionMiddleware.validatePaymentSubmission,
   EncryptSubmissionMiddleware.encryptSubmission,
   submitEncryptModeForm,
 ] as ControllerHandler[]

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -294,7 +294,17 @@ export const validatePaymentSubmission = async (
 
   const formDefProducts = formDef?.payments_field?.products
   const submittedPaymentProducts = req.body.paymentProducts
-  if (isPaymentsProducts(formDefProducts) && submittedPaymentProducts) {
+  if (submittedPaymentProducts) {
+    if (!isPaymentsProducts(formDefProducts)) {
+      logger.error({
+        message: 'Invalid form definition for payment by product',
+        meta: logMeta,
+      })
+
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        message: 'This form has an invalid payment setting.',
+      })
+    }
     return PaymentsService.validatePaymentProducts(
       formDefProducts,
       submittedPaymentProducts,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -9,6 +9,7 @@ import {
   FormResponseMode,
   isPaymentsProducts,
 } from '../../../../../shared/types'
+import { IPopulatedForm } from '../../../../types'
 import {
   EncryptAttachmentResponse,
   EncryptFormFieldResponse,
@@ -284,11 +285,13 @@ export const validatePaymentSubmission = async (
   res: Parameters<EncryptSubmissionMiddlewareHandlerType>[1],
   next: NextFunction,
 ) => {
-  const formDef = req.formsg.formDef
+  const formDefDoc = req.formsg.formDef as IPopulatedForm
+
+  const formDef = formDefDoc.toObject() // Convert to POJO
 
   const logMeta = {
     action: 'validatePaymentSubmission',
-    formId: formDef._id.toString(),
+    formId: String(formDef._id),
     ...createReqMeta(req),
   }
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -296,13 +296,16 @@ export const validatePaymentSubmission = async (
   const submittedPaymentProducts = req.body.paymentProducts
   if (submittedPaymentProducts) {
     if (!isPaymentsProducts(formDefProducts)) {
+      // Payment definition does not allow for payment by product
+
       logger.error({
         message: 'Invalid form definition for payment by product',
         meta: logMeta,
       })
 
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: 'This form has an invalid payment setting.',
+      return res.status(StatusCodes.BAD_REQUEST).json({
+        message:
+          'The payment settings in this form have been updated. Please refresh and try again.',
       })
     }
     return PaymentsService.validatePaymentProducts(

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -90,7 +90,10 @@ import {
 } from '../myinfo/myinfo.errors'
 import { MyInfoKey } from '../myinfo/myinfo.types'
 import { getMyInfoChildHashKey } from '../myinfo/myinfo.util'
-import { PaymentNotFoundError } from '../payments/payments.errors'
+import {
+  InvalidPaymentProductsError,
+  PaymentNotFoundError,
+} from '../payments/payments.errors'
 import {
   SgidInvalidJwtError,
   SgidMissingJwtError,
@@ -207,6 +210,7 @@ const errorMapper: MapRouteError = (
         errorMessage: error.message,
       }
     case ResponseModeError:
+    case InvalidPaymentProductsError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,


### PR DESCRIPTION
## Problem
- There is currently no backend validation for payments by product.
## Solution

**Bug Fixes**:
- Adds backend validation for payments by product

## Tests
- [ ] Create payments by product. Can submit normally.
  - [ ] Load the form. Change the payment amount in form definition. Submission should fail.
  - [ ] Load the form. Delete the product in form definition and add another product. Submission should fail.
  - [ ] Load the form. Change to multi quantity of 2 to 5. Submission with qty 1 should fail.
  - [ ] Load the form. Submission with Qty 6 should fail
  - [ ] Load the form. Now disable multi quantity. Submission with qty 4 should fail.
- [ ] Create payments by amount form. Can submit normally.

<!-- What tests should be run to confirm functionality? -->
