### PR TITLE
feat: allow wildcard domains for domain-restricted email fields

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -184,7 +184,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
             <Textarea
               autoFocus
               {...register('allowedEmailDomains', emailDomainsValidation)}
-              placeholder={'@data.gov.sg\n@agency.gov.sg'}
+              placeholder={'@agency.gov.sg\n@*.edu.sg'}
             />
             <FormErrorMessage>
               {errors?.allowedEmailDomains?.message}

--- a/shared/utils/__tests__/email-domain-validation.spec.ts
+++ b/shared/utils/__tests__/email-domain-validation.spec.ts
@@ -1,0 +1,31 @@
+import { validateEmailDomains } from '../email-domain-validation'
+
+describe('validateEmailDomains', () => {
+  it('should allow domains with a single asterisk', () => {
+    expect(validateEmailDomains(['@*.tld'])).toBe(true)
+    expect(validateEmailDomains(['@*.gov.sg'])).toBe(true)
+  })
+
+  it('should allow domains without asterisks', () => {
+    expect(validateEmailDomains(['@domain.tld'])).toBe(true)
+    expect(validateEmailDomains(['@sub.domain.sg'])).toBe(true)
+  })
+
+  it('should not allow domains with multiple asterisks', () => {
+    expect(validateEmailDomains(['@*.*.tld'])).toBe(false)
+    expect(validateEmailDomains(['@*.sub.*.sg'])).toBe(false)
+  })
+
+  it('should not allow domains with asterisks not at the start', () => {
+    expect(validateEmailDomains(['@domain.*.tld'])).toBe(false)
+    expect(validateEmailDomains(['@sub.*domain.sg'])).toBe(false)
+  })
+
+  it('should not allow invalid domains', () => {
+    expect(validateEmailDomains(['@*.'])).toBe(false)
+    expect(validateEmailDomains(['@*..tld'])).toBe(false)
+    expect(validateEmailDomains(['@.tld'])).toBe(false)
+    expect(validateEmailDomains(['tld'])).toBe(false)
+    expect(validateEmailDomains(['@domain.tld*'])).toBe(false)
+  })
+})

--- a/shared/utils/email-domain-validation.ts
+++ b/shared/utils/email-domain-validation.ts
@@ -2,14 +2,27 @@ import isEmpty from 'lodash/isEmpty'
 import validator from 'validator'
 
 export const validateEmailDomains = (emailDomains: string[]): boolean => {
+  const isValidAsteriskUsage = (domain: string) => {
+    const parts = domain.split('*');
+    return parts.length <= 2 && !parts.some(part => part.includes('.'));
+  };
+
   return (
+    emailDomains.every(isValidAsteriskUsage) &&
     isEmpty(emailDomains) ||
     (new Set(emailDomains).size === emailDomains.length &&
       emailDomains.every(
-        (emailDomain) =>
+        (emailDomain) => {
           // We need to prepend "bob" to the email domain so that it can form an
           // email address and can be validated by validator.isEmail.
-          emailDomain.startsWith('@') && validator.isEmail('bob' + emailDomain),
+
+          // For wildcards, just replacing them with example to form a domain
+          const domainToCheck = emailDomain.startsWith('@*.')
+            ? 'bob' + emailDomain.replace('*', 'example')
+            : 'bob' + emailDomain;
+
+          return validator.isEmail(domainToCheck);
+        }
       ))
   )
 }

--- a/shared/utils/email-domain-validation.ts
+++ b/shared/utils/email-domain-validation.ts
@@ -3,24 +3,21 @@ import validator from 'validator'
 
 export const validateEmailDomains = (emailDomains: string[]): boolean => {
   const isValidAsteriskUsage = (domain: string) => {
-    const parts = domain.split('*');
-    return parts.length <= 2 && !parts.some(part => part.includes('.'));
-  };
+    const parts = domain.split('*')
+    return parts.length <= 2 && !parts.some((part) => part.includes('.'))
+  }
 
   return (
-    emailDomains.every(isValidAsteriskUsage) &&
-    isEmpty(emailDomains) ||
+    (emailDomains.every(isValidAsteriskUsage) && isEmpty(emailDomains)) ||
     (new Set(emailDomains).size === emailDomains.length &&
-      emailDomains.every(
-        (emailDomain) => {
-          // We need to prepend "bob" to the email domain so that it can form an
-          // email address and can be validated by validator.isEmail.
+      emailDomains.every((emailDomain) => {
+        // We need to prepend "bob" to the email domain so that it can form an
+        // email address and can be validated by validator.isEmail.
 
-          // For wildcards, just replacing them with example to form a domain
-          const domainToCheck = 'bob' + emailDomain.replace(/\*\./g, 'example.');
-
-          return validator.isEmail('bob' + emailDomain.replace(/\*\./g, 'example.'));
-        }
-      ))
+        // For wildcards, just replacing them with example to form a domain
+        return validator.isEmail(
+          'bob' + emailDomain.replace(/\*\./g, 'example.'),
+        )
+      }))
   )
 }

--- a/shared/utils/email-domain-validation.ts
+++ b/shared/utils/email-domain-validation.ts
@@ -3,21 +3,23 @@ import validator from 'validator'
 
 export const validateEmailDomains = (emailDomains: string[]): boolean => {
   const isValidAsteriskUsage = (domain: string) => {
-    const parts = domain.split('*')
-    return parts.length <= 2 && !parts.some((part) => part.includes('.'))
+    const asteriskOccurrences = (domain.match(/\*/g) || []).length
+    return (
+      asteriskOccurrences === 0 ||
+      (asteriskOccurrences === 1 && domain.indexOf('*') === 1)
+    )
   }
 
   return (
-    (emailDomains.every(isValidAsteriskUsage) && isEmpty(emailDomains)) ||
-    (new Set(emailDomains).size === emailDomains.length &&
-      emailDomains.every((emailDomain) => {
-        // We need to prepend "bob" to the email domain so that it can form an
-        // email address and can be validated by validator.isEmail.
-
-        // For wildcards, just replacing them with example to form a domain
-        return validator.isEmail(
-          'bob' + emailDomain.replace(/\*\./g, 'example.'),
-        )
-      }))
+    isEmpty(emailDomains) ||
+    (emailDomains.every(isValidAsteriskUsage) &&
+      new Set(emailDomains).size === emailDomains.length &&
+      emailDomains.every(
+        (emailDomain) =>
+          // We need to prepend "bob" to the email domain so that it can form an
+          // email address and can be validated by validator.isEmail.
+          emailDomain.startsWith('@') &&
+          validator.isEmail('bob' + emailDomain.replace(/\*/g, 'example')),
+      ))
   )
 }

--- a/shared/utils/email-domain-validation.ts
+++ b/shared/utils/email-domain-validation.ts
@@ -17,11 +17,9 @@ export const validateEmailDomains = (emailDomains: string[]): boolean => {
           // email address and can be validated by validator.isEmail.
 
           // For wildcards, just replacing them with example to form a domain
-          const domainToCheck = emailDomain.startsWith('@*.')
-            ? 'bob' + emailDomain.replace('*', 'example')
-            : 'bob' + emailDomain;
+          const domainToCheck = 'bob' + emailDomain.replace(/\*\./g, 'example.');
 
-          return validator.isEmail(domainToCheck);
+          return validator.isEmail('bob' + emailDomain.replace(/\*\./g, 'example.'));
         }
       ))
   )

--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -176,6 +176,25 @@ describe('Form Field Schema', () => {
         expect(fieldObj).toHaveProperty('hasAllowedEmailDomains', true)
         expect(fieldObj).toHaveProperty('allowedEmailDomains', ['@example.com'])
       })
+
+      it('should allow email field with wildcard domains', async () => {
+        // Arrange
+        const field = await createAndReturnFormField({
+          fieldType: BasicField.Email,
+          isVerifiable: true,
+          hasAllowedEmailDomains: true,
+          allowedEmailDomains: ['@*.gov.sg', '@*.example.com'],
+        })
+
+        // Assert
+        const fieldObj = field.toObject()
+        expect(fieldObj).toHaveProperty('isVerifiable', true)
+        expect(fieldObj).toHaveProperty('hasAllowedEmailDomains', true)
+        expect(fieldObj).toHaveProperty('allowedEmailDomains', [
+          '@*.gov.sg',
+          '@*.asia',
+        ])
+      })
     })
   })
 

--- a/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -183,7 +183,7 @@ describe('Form Field Schema', () => {
           fieldType: BasicField.Email,
           isVerifiable: true,
           hasAllowedEmailDomains: true,
-          allowedEmailDomains: ['@*.gov.sg', '@*.example.com'],
+          allowedEmailDomains: ['@*.gov.sg', '@*.asia'],
         })
 
         // Assert

--- a/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
@@ -477,6 +477,7 @@ describe('Email field validation', () => {
       question: 'random',
       isVisible: true,
       answer: 'user@agency.gov.sg',
+      signature: 'some signature',
     } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',
@@ -504,6 +505,7 @@ describe('Email field validation', () => {
       question: 'random',
       isVisible: true,
       answer: 'user@company.com.sg',
+      signature: 'some signature',
     } as SingleAnswerFieldResponse
     const validateResult = validateField(
       'formId',

--- a/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
@@ -459,6 +459,63 @@ describe('Email field validation', () => {
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
+
+  it('should allow email addresses with wildcard domains when allowedEmailDomains includes a wildcard domain', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: false,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: ['@*.gov.sg'],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'user@agency.gov.sg',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should not allow email addresses with domains not matching the wildcard when allowedEmailDomains includes a wildcard domain', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: false,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: ['@*.gov.sg'],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'user@company.com.sg',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
   it('should disallow responses submitted for hidden fields', () => {
     const formField = {
       _id: 'abc123',

--- a/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
@@ -460,64 +460,6 @@ describe('Email field validation', () => {
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
 
-  it('should allow email addresses with wildcard domains when allowedEmailDomains includes a wildcard domain', () => {
-    const formField = {
-      _id: 'abc123',
-      fieldType: BasicField.Email,
-      globalId: 'random',
-      title: 'random',
-      required: true,
-      isVerifiable: false,
-      hasAllowedEmailDomains: true,
-      allowedEmailDomains: ['@*.gov.sg'],
-    } as OmitUnusedValidatorProps<IEmailFieldSchema>
-    const response = {
-      _id: 'abc123',
-      fieldType: BasicField.Email,
-      question: 'random',
-      isVisible: true,
-      answer: 'user@agency.gov.sg',
-      signature: 'some signature',
-    } as SingleAnswerFieldResponse
-    const validateResult = validateField(
-      'formId',
-      formField,
-      response as ProcessedFieldResponse,
-    )
-    expect(validateResult.isOk()).toBe(true)
-    expect(validateResult._unsafeUnwrap()).toEqual(true)
-  })
-
-  it('should not allow email addresses with domains not matching the wildcard when allowedEmailDomains includes a wildcard domain', () => {
-    const formField = {
-      _id: 'abc123',
-      fieldType: BasicField.Email,
-      globalId: 'random',
-      title: 'random',
-      required: true,
-      isVerifiable: false,
-      hasAllowedEmailDomains: true,
-      allowedEmailDomains: ['@*.gov.sg'],
-    } as OmitUnusedValidatorProps<IEmailFieldSchema>
-    const response = {
-      _id: 'abc123',
-      fieldType: BasicField.Email,
-      question: 'random',
-      isVisible: true,
-      answer: 'user@company.com.sg',
-      signature: 'some signature',
-    } as SingleAnswerFieldResponse
-    const validateResult = validateField(
-      'formId',
-      formField,
-      response as ProcessedFieldResponse,
-    )
-    expect(validateResult.isErr()).toBe(true)
-    expect(validateResult._unsafeUnwrapErr()).toEqual(
-      new ValidateFieldError('Invalid answer submitted'),
-    )
-  })
-
   it('should disallow responses submitted for hidden fields', () => {
     const formField = {
       _id: 'abc123',
@@ -607,5 +549,140 @@ describe('Email field validation', () => {
     expect(validateResult._unsafeUnwrapErr()).toEqual(
       new ValidateFieldError('Invalid answer submitted'),
     )
+  })
+
+  describe('Wildcard domain validation', () => {
+    const formFieldBase = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: false,
+      hasAllowedEmailDomains: true,
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+
+    const responseBase = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+    } as SingleAnswerFieldResponse
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should allow email addresses with wildcard domains when allowedEmailDomains includes a wildcard domain', () => {
+      const formField = {
+        ...formFieldBase,
+        allowedEmailDomains: ['@*.gov.sg'],
+      }
+      const response = {
+        ...responseBase,
+        answer: 'user@agency.gov.sg',
+      }
+      const validateResult = validateField(
+        'formId',
+        formField,
+        response as ProcessedFieldResponse,
+      )
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should not allow email addresses with domains not matching the wildcard when allowedEmailDomains includes a wildcard domain', () => {
+      const formField = {
+        ...formFieldBase,
+        allowedEmailDomains: ['@*.gov.sg'],
+      }
+      const response = {
+        ...responseBase,
+        answer: 'user@company.com.sg',
+      }
+      const validateResult = validateField(
+        'formId',
+        formField,
+        response as ProcessedFieldResponse,
+      )
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should allow email addresses with exact domain match even when wildcard is present', () => {
+      const formField = {
+        ...formFieldBase,
+        allowedEmailDomains: ['@*.gov.sg', '@agency.gov.sg'],
+      }
+      const response = {
+        ...responseBase,
+        answer: 'user@agency.gov.sg',
+      }
+      const validateResult = validateField(
+        'formId',
+        formField,
+        response as ProcessedFieldResponse,
+      )
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should allow email addresses with subdomains not explicitly specified in wildcard', () => {
+      const formField = {
+        ...formFieldBase,
+        allowedEmailDomains: ['@*.gov.sg'],
+      }
+      const response = {
+        ...responseBase,
+        answer: 'user@sub.agency.gov.sg',
+      }
+      const validateResult = validateField(
+        'formId',
+        formField,
+        response as ProcessedFieldResponse,
+      )
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should allow email addresses with multiple wildcard domains', () => {
+      const formField = {
+        ...formFieldBase,
+        allowedEmailDomains: ['@*.gov.sg', '@*.agency.gov.sg'],
+      }
+      const response = {
+        ...responseBase,
+        answer: 'user@sub.agency.gov.sg',
+      }
+      const validateResult = validateField(
+        'formId',
+        formField,
+        response as ProcessedFieldResponse,
+      )
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should not allow email addresses with invalid wildcard domains', () => {
+      const formField = {
+        ...formFieldBase,
+        allowedEmailDomains: ['@*.invalid.gov.sg'],
+      }
+      const response = {
+        ...responseBase,
+        answer: 'user@agency.gov.sg',
+      }
+      const validateResult = validateField(
+        'formId',
+        formField,
+        response as ProcessedFieldResponse,
+      )
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
   })
 })

--- a/src/app/utils/field-validation/validators/emailValidator.ts
+++ b/src/app/utils/field-validation/validators/emailValidator.ts
@@ -40,10 +40,9 @@ const makeEmailDomainValidator: EmailValidatorConstructor =
     const emailDomain = ('@' + emailAddress.split('@').pop()).toLowerCase()
     const domainMatches = (domainPattern: string) => {
       if (domainPattern.startsWith('*.')) {
-        const domainRegex = new RegExp(
-          domainPattern.replace('*', '[a-z0-9-]+') + '$',
-          'i',
-        )
+        const domainRegexPattern =
+          domainPattern.replace(/\*/g, '[a-z0-9-]+') + '$'
+        const domainRegex = new RegExp(domainRegexPattern, 'i')
         return domainRegex.test(emailDomain)
       }
       return domainPattern.toLowerCase() === emailDomain

--- a/src/app/utils/field-validation/validators/emailValidator.ts
+++ b/src/app/utils/field-validation/validators/emailValidator.ts
@@ -38,17 +38,18 @@ const makeEmailDomainValidator: EmailValidatorConstructor =
     if (!(hasAllowedEmailDomains && allowedEmailDomains.length))
       return right(response)
     const emailDomain = ('@' + emailAddress.split('@').pop()).toLowerCase()
-    const domainMatches = (domainPattern: string) => {
-      if (domainPattern.startsWith('*.')) {
-        const domainRegexPattern =
-          domainPattern.replace(/\*/g, '[a-z0-9-]+') + '$'
-        const domainRegex = new RegExp(domainRegexPattern, 'i')
-        return domainRegex.test(emailDomain)
+
+    const domainMatches = (domainPattern: string, emailDomain: string) => {
+      if (domainPattern.startsWith('@*.')) {
+        const wildcardDomain = domainPattern.slice(3).toLowerCase()
+        return emailDomain.endsWith(wildcardDomain)
       }
       return domainPattern.toLowerCase() === emailDomain
     }
 
-    return allowedEmailDomains.some(domainMatches)
+    return allowedEmailDomains.some((domain) =>
+      domainMatches(domain, emailDomain),
+    )
       ? right(response)
       : left(`EmailValidator:\t answer is not a valid email domain`)
   }

--- a/src/app/utils/field-validation/validators/emailValidator.ts
+++ b/src/app/utils/field-validation/validators/emailValidator.ts
@@ -38,10 +38,18 @@ const makeEmailDomainValidator: EmailValidatorConstructor =
     if (!(hasAllowedEmailDomains && allowedEmailDomains.length))
       return right(response)
     const emailDomain = ('@' + emailAddress.split('@').pop()).toLowerCase()
+    const domainMatches = (domainPattern: string) => {
+      if (domainPattern.startsWith('*.')) {
+        const domainRegex = new RegExp(
+          domainPattern.replace('*', '[a-z0-9-]+') + '$',
+          'i',
+        )
+        return domainRegex.test(emailDomain)
+      }
+      return domainPattern.toLowerCase() === emailDomain
+    }
 
-    return allowedEmailDomains.some(
-      (domain) => domain.toLowerCase() === emailDomain,
-    )
+    return allowedEmailDomains.some(domainMatches)
       ? right(response)
       : left(`EmailValidator:\t answer is not a valid email domain`)
   }


### PR DESCRIPTION
## Problem
Public officers often face the challenge of whitelisting email domains for form submissions, requiring them to manually list each .gov.sg, .edu.sg... domain. This process is not only time-consuming but also prone to errors, as it might exclude newer agency domains unintentionally.

Closes #7084

> Note: 🚨 I may have jumped the gun not waiting for a discussion on #7084.

## Solution
To address this issue, implemented a pattern-based email domain whitelisting feature. This allows form creators to use wildcard patterns such as `@*.gov.sg` and `@*.edu.sg` to automatically whitelist all subdomains under these TLDs or Suffixes.

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Features**:
- Implemented pattern-based email domain whitelisting to allow using wildcards for domain names.

**Improvements**:
- Updated the email field validation logic to support wildcard domains, ensuring that email addresses matching the specified patterns are accepted.
- Enhanced the user interface to clearly indicate the support for wildcard domains in the email domain whitelist feature.

## Before & After Screenshots

**BEFORE**:
<img width="546" alt="Screenshot 2024-02-14 at 12 20 22" src="https://github.com/opengovsg/FormSG/assets/932949/de7fb36f-ef98-4b0e-ae6d-529560b52f3e">

**AFTER**:
(Ah need to shoot one)
