### PR TITLE
feat(mrf): frontend field locking

### DIFF
--- a/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
+++ b/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
@@ -81,12 +81,14 @@ const workflow_step_1: FormWorkflowStepDto = {
   _id: '61e6857c9c794b0012f1c6f8',
   workflow_type: WorkflowType.Static,
   emails: [],
+  edit: [form_field_1._id, form_field_2._id],
 }
 
 const workflow_step_2: FormWorkflowStepDto = {
   _id: '61e6857c9c794b0012f1c6f9',
   workflow_type: WorkflowType.Static,
   emails: ['test_1@tech.gov.sg', 'test_2@tech.gov.sg'],
+  edit: [form_field_3._id, form_field_4._id],
 }
 
 const FORM_WITH_WORKFLOW: Partial<AdminFormDto> = {

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -14,6 +14,7 @@ import { EditStepInputs } from '../../../types'
 import { StepLabel } from '../StepLabel'
 import { isFirstStepByStepNumber } from '../utils/isFirstStepByStepNumber'
 
+import { QuestionsBlock } from './QuestionsBlock'
 import { RespondentBlock } from './RespondentBlock'
 
 export interface EditLogicBlockProps {
@@ -60,6 +61,8 @@ export const EditStepBlock = ({
     switch (inputs.workflow_type) {
       case WorkflowType.Static: {
         step = {
+          ...inputs,
+          // Need to explicitly set workflow_type in this object to help with typechecking.
           workflow_type: WorkflowType.Static,
           emails: inputs.emails ? [inputs.emails] : [],
         }
@@ -68,6 +71,7 @@ export const EditStepBlock = ({
       case WorkflowType.Dynamic: {
         if (!inputs.field) return
         step = {
+          ...inputs,
           workflow_type: WorkflowType.Dynamic,
           field: inputs.field,
         }
@@ -108,6 +112,7 @@ export const EditStepBlock = ({
         formMethods={formMethods}
         isLoading={isLoading}
       />
+      <QuestionsBlock formMethods={formMethods} isLoading={isLoading} />
       <SaveActionGroup
         isLoading={isLoading}
         handleSubmit={handleSubmit}

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
@@ -1,0 +1,83 @@
+import { Controller, UseFormReturn } from 'react-hook-form'
+import { Flex, FormControl, Icon, Stack, Text } from '@chakra-ui/react'
+
+import { BxsInfoCircle } from '~assets/icons'
+import { MultiSelect } from '~components/Dropdown'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import Tooltip from '~components/Tooltip'
+
+import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
+import { getLogicFieldLabel } from '~features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel'
+import { EditStepInputs } from '~features/admin-form/create/workflow/types'
+import { NON_RESPONSE_FIELD_SET } from '~features/form/constants'
+
+import { useAdminFormWorkflow } from '../../../hooks/useAdminFormWorkflow'
+
+interface QuestionsBlockProps {
+  isLoading: boolean
+  formMethods: UseFormReturn<EditStepInputs>
+}
+
+export const QuestionsBlock = ({
+  isLoading,
+  formMethods,
+}: QuestionsBlockProps): JSX.Element => {
+  const { formFields = [], mapIdToField } = useAdminFormWorkflow()
+  const {
+    formState: { errors },
+    control,
+  } = formMethods
+
+  const items = formFields
+    .filter(
+      (f) =>
+        // Only retain actual inputs (exclude header, statement, image)
+        !NON_RESPONSE_FIELD_SET.has(f.fieldType),
+    )
+    .map((f) => ({
+      value: f._id,
+      label: getLogicFieldLabel(mapIdToField[f._id]),
+      icon: BASICFIELD_TO_DRAWER_META[f.fieldType].icon,
+    }))
+
+  return (
+    <Stack
+      direction="column"
+      spacing="0.75rem"
+      py="1.5rem"
+      px={{ base: '1.5rem', md: '2rem' }}
+      borderTopWidth="1px"
+      borderTopColor="secondary.200"
+    >
+      <Flex alignItems="center" gap="0.5rem">
+        <Text textStyle="subhead-3">Questions to fill</Text>
+        <Tooltip label="Respondent will only be able to fill the questions you have selected">
+          <Icon as={BxsInfoCircle} />
+        </Tooltip>
+      </Flex>
+
+      <FormControl
+        isReadOnly={isLoading}
+        id="edit"
+        isRequired
+        isInvalid={!!errors.edit}
+      >
+        <Controller
+          control={control}
+          name="edit"
+          render={({ field: { value, ...field } }) => (
+            <MultiSelect
+              isDisabled={isLoading}
+              placeholder="Select questions from your form"
+              items={items}
+              isSelectedItemFullWidth
+              values={value}
+              {...field}
+            />
+          )}
+        />
+        <FormErrorMessage>{errors.workflow_type?.message}</FormErrorMessage>
+      </FormControl>
+    </Stack>
+  )
+}

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
@@ -59,6 +59,45 @@ export const InactiveStepBlock = ({
     }
   }, [mapIdToField, step])
 
+  const questionBadges = useMemo(() => {
+    const allInvalid = step.edit.every((fieldId) => !(fieldId in mapIdToField))
+
+    if (step.edit.length === 0) {
+      return (
+        <FieldLogicBadge
+          defaults={{
+            variant: 'info',
+            message: 'No fields selected',
+          }}
+        />
+      )
+    }
+
+    if (allInvalid) {
+      return (
+        <FieldLogicBadge
+          defaults={{
+            variant: 'error',
+            message:
+              'All fields were deleted, please select at least one field',
+          }}
+        />
+      )
+    }
+
+    return step.edit.map((fieldId, index) => (
+      <FieldLogicBadge
+        key={index}
+        field={mapIdToField[fieldId]}
+        defaults={{
+          variant: 'info',
+          message:
+            'This field was deleted and has been removed from your workflow',
+        }}
+      />
+    ))
+  }, [mapIdToField, step.edit])
+
   return (
     <Box pos="relative">
       <chakra.button
@@ -87,6 +126,7 @@ export const InactiveStepBlock = ({
       >
         <Stack spacing="1.5rem" p={{ base: '1.5rem', md: '2rem' }}>
           <StepLabel stepNumber={stepNumber} />
+
           <Stack>
             <Text textStyle="subhead-3">Respondent in this step</Text>
             {isFirstStep ? (
@@ -101,6 +141,13 @@ export const InactiveStepBlock = ({
                 {respondentBadges}
               </Flex>
             )}
+          </Stack>
+
+          <Stack>
+            <Text textStyle="subhead-3">Questions to fill</Text>
+            <Stack direction="column" spacing="0.25rem">
+              {questionBadges}
+            </Stack>
           </Stack>
         </Stack>
       </chakra.button>

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
@@ -60,8 +60,6 @@ export const InactiveStepBlock = ({
   }, [mapIdToField, step])
 
   const questionBadges = useMemo(() => {
-    const allInvalid = step.edit.every((fieldId) => !(fieldId in mapIdToField))
-
     if (step.edit.length === 0) {
       return (
         <FieldLogicBadge
@@ -72,6 +70,8 @@ export const InactiveStepBlock = ({
         />
       )
     }
+
+    const allInvalid = step.edit.every((fieldId) => !(fieldId in mapIdToField))
 
     if (allInvalid) {
       return (

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/NewStepBlock/NewStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/NewStepBlock/NewStepBlock.tsx
@@ -38,7 +38,7 @@ export const NewStepBlock = () => {
       stepNumber={formWorkflow.length}
       isLoading={createStepMutation.isLoading}
       onSubmit={handleSubmit}
-      defaultValues={{ workflow_type: WorkflowType.Static }}
+      defaultValues={{ workflow_type: WorkflowType.Static, edit: [] }}
       submitButtonLabel="Add step"
     />
   ) : (

--- a/frontend/src/features/form/utils/augmentWithWorkflowDisabling.ts
+++ b/frontend/src/features/form/utils/augmentWithWorkflowDisabling.ts
@@ -1,0 +1,23 @@
+import { FormFieldDto, FormWorkflowStep } from '~shared/types'
+
+import { NON_RESPONSE_FIELD_SET } from '../constants'
+
+export const isFieldEnabledByWorkflow = (
+  workflowStep: FormWorkflowStep | undefined,
+  field: FormFieldDto,
+) =>
+  // Field is enabled if:
+  // 1. there is no workflow OR
+  // 2. it is a non-response field OR
+  // 3. (by this point it is workflow + response field) has been explicitly set to be editable in the workflow
+  !workflowStep ||
+  NON_RESPONSE_FIELD_SET.has(field.fieldType) ||
+  workflowStep.edit.includes(field._id)
+
+export const augmentWithWorkflowDisabling = (
+  workflowStep: FormWorkflowStep | undefined,
+  field: FormFieldDto,
+) => ({
+  ...field,
+  disabled: field.disabled || !isFieldEnabledByWorkflow(workflowStep, field),
+})

--- a/frontend/src/features/form/utils/augmentWithWorkflowDisabling.ts
+++ b/frontend/src/features/form/utils/augmentWithWorkflowDisabling.ts
@@ -5,14 +5,17 @@ import { NON_RESPONSE_FIELD_SET } from '../constants'
 export const isFieldEnabledByWorkflow = (
   workflowStep: FormWorkflowStep | undefined,
   field: FormFieldDto,
-) =>
-  // Field is enabled if:
-  // 1. there is no workflow OR
-  // 2. it is a non-response field OR
-  // 3. (by this point it is workflow + response field) has been explicitly set to be editable in the workflow
-  !workflowStep ||
-  NON_RESPONSE_FIELD_SET.has(field.fieldType) ||
-  workflowStep.edit.includes(field._id)
+) => {
+  // If no workflow, default to enabled
+  if (!workflowStep) return true
+
+  // There is a workflow, but enable if it's a non-response field
+  if (NON_RESPONSE_FIELD_SET.has(field.fieldType)) return true
+
+  // (By this point a workflow exists and it is a response field, so check if it
+  // has been explicitly set to be editable in the workflow
+  return workflowStep.edit.includes(field._id)
+}
 
 export const augmentWithWorkflowDisabling = (
   workflowStep: FormWorkflowStep | undefined,

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -8,13 +8,19 @@ import { PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID } from '~shared/constants'
 import { CountryRegion } from '~shared/constants/countryRegion'
 import { FieldResponsesV3 } from '~shared/types'
 import { BasicField, FormFieldDto } from '~shared/types/field'
-import { FormColorTheme, FormResponseMode, LogicDto } from '~shared/types/form'
+import {
+  FormColorTheme,
+  FormResponseMode,
+  FormWorkflowStepDto,
+  LogicDto,
+} from '~shared/types/form'
 import { centsToDollars } from '~shared/utils/payments'
 
 import InlineMessage from '~components/InlineMessage'
 import { FormFieldValue, FormFieldValues } from '~templates/Field'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
 
+import { augmentWithWorkflowDisabling } from '~features/form/utils/augmentWithWorkflowDisabling'
 import {
   augmentWithMyInfo,
   extractPreviewValue,
@@ -31,9 +37,9 @@ import { VisibleFormFields } from './VisibleFormFields'
 
 export interface FormFieldsProps {
   previousResponses?: FieldResponsesV3
-  responseMode: FormResponseMode
   formFields: FormFieldDto[]
   formLogics: LogicDto[]
+  workflowStep?: FormWorkflowStepDto
   colorTheme: FormColorTheme
   onSubmit: SubmitHandler<FormFieldValues> | undefined
 }
@@ -47,9 +53,9 @@ export type PrefillMap = {
 
 export const FormFields = ({
   previousResponses,
-  responseMode,
   formFields,
   formLogics,
+  workflowStep,
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
@@ -74,8 +80,11 @@ export const FormFields = ({
   }, [formFields, searchParams])
 
   const augmentedFormFields = useMemo(
-    () => formFields.map(augmentWithMyInfo),
-    [formFields],
+    () =>
+      formFields
+        .map(augmentWithMyInfo)
+        .map(augmentWithWorkflowDisabling.bind(this, workflowStep)),
+    [formFields, workflowStep],
   )
 
   const defaultFormValues = useMemo(() => {
@@ -198,9 +207,9 @@ export const FormFields = ({
               <VisibleFormFields
                 colorTheme={colorTheme}
                 control={formMethods.control}
-                responseMode={responseMode}
                 formFields={augmentedFormFields}
                 formLogics={formLogics}
+                workflowStep={workflowStep}
                 fieldPrefillMap={fieldPrefillMap}
               />
             </Stack>

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -83,7 +83,7 @@ export const FormFields = ({
     () =>
       formFields
         .map(augmentWithMyInfo)
-        .map(augmentWithWorkflowDisabling.bind(this, workflowStep)),
+        .map((fields) => augmentWithWorkflowDisabling(workflowStep, fields)),
     [formFields, workflowStep],
   )
 

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Box } from '@chakra-ui/react'
 
-import { FormAuthType } from '~shared/types'
+import { FormAuthType, FormResponseMode } from '~shared/types'
 
 import { isKeypairValid } from '~utils/secretKeyValidation'
 
@@ -29,7 +29,8 @@ export const FormFieldsContainer = (): JSX.Element | null => {
   const [previousSubmission, setPreviousSubmission] =
     useState<ReturnType<typeof decryptSubmission>>()
 
-  const { submissionPublicKey = null } = encryptedPreviousSubmission ?? {}
+  const { submissionPublicKey = null, workflowStep } =
+    encryptedPreviousSubmission ?? {}
   const [searchParams] = useSearchParams()
   const queryParams = Object.fromEntries([...searchParams])
 
@@ -94,9 +95,17 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     return (
       <FormFields
         previousResponses={previousSubmission?.responses}
-        responseMode={form.responseMode}
         formFields={form.form_fields}
         formLogics={form.form_logics}
+        workflowStep={
+          form.responseMode === FormResponseMode.Multirespondent
+            ? form.workflow[
+                // If no submission, then the workflowStep will be undefined.
+                // Require explicit undefined check here since both 0 and undefined are falsy but mean different things here.
+                workflowStep === undefined ? 0 : workflowStep + 1
+              ]
+            : undefined
+        }
         colorTheme={form.startPage.colorTheme}
         onSubmit={handleSubmitForm}
       />
@@ -107,9 +116,10 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     isAuthRequired,
     previousSubmissionId,
     previousSubmission,
+    workflowStep,
     handleSubmitForm,
-    queryParams.key,
     submissionPublicKey,
+    queryParams.key,
     encryptedPreviousSubmission,
   ])
 

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -1,12 +1,17 @@
 import { useEffect, useState } from 'react'
 import { Control, useWatch } from 'react-hook-form'
 
-import { FormColorTheme, FormResponseMode, LogicDto } from '~shared/types/form'
+import {
+  FormColorTheme,
+  FormWorkflowStepDto,
+  LogicDto,
+} from '~shared/types/form'
 
 import { FormFieldValues } from '~templates/Field'
 
 import { FormFieldWithQuestionNo } from '~features/form/types'
 import { augmentWithQuestionNo } from '~features/form/utils'
+import { isFieldEnabledByWorkflow } from '~features/form/utils/augmentWithWorkflowDisabling'
 import { getVisibleFieldIds } from '~features/logic/utils'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
@@ -16,9 +21,9 @@ import { useFormSections } from './FormSectionsContext'
 
 interface VisibleFormFieldsProps {
   control: Control<FormFieldValues>
-  responseMode: FormResponseMode
   formFields: FormFieldWithQuestionNo[]
   formLogics: LogicDto[]
+  workflowStep?: FormWorkflowStepDto
   colorTheme: FormColorTheme
   fieldPrefillMap: PrefillMap
 }
@@ -29,9 +34,9 @@ interface VisibleFormFieldsProps {
  */
 export const VisibleFormFields = ({
   control,
-  responseMode,
   formFields,
   formLogics,
+  workflowStep,
   colorTheme,
   fieldPrefillMap,
 }: VisibleFormFieldsProps) => {
@@ -71,7 +76,7 @@ export const VisibleFormFields = ({
           colorTheme={colorTheme}
           field={field}
           disableRequiredValidation={
-            responseMode === FormResponseMode.Multirespondent
+            !isFieldEnabledByWorkflow(workflowStep, field)
           }
           key={field._id}
           prefill={fieldPrefillMap[field._id]}

--- a/frontend/src/features/verifiable-fields/components/VerifiableFieldContainer/VerifiableFieldContainer.tsx
+++ b/frontend/src/features/verifiable-fields/components/VerifiableFieldContainer/VerifiableFieldContainer.tsx
@@ -63,7 +63,7 @@ export const VerifiableFieldContainer = ({
               // are removed from DOM if the button is disabled.
               // Instead, we allow users to click the button to trigger verification
               name={`${schema._id}-verify`}
-              isDisabled={isVfnBoxOpen || hasSignature}
+              isDisabled={schema.disabled || isVfnBoxOpen || hasSignature}
               isLoading={isSendingOtp}
               onClick={handleVfnButtonClick}
               colorScheme={`theme-${colorTheme}`}

--- a/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
+++ b/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
@@ -35,6 +35,9 @@ export const HomeNoField = ({
             autoComplete="tel"
             allowInternational={schema.allowIntlNumbers}
             examples={landlineExamples}
+            // Remove placeholder when field is disabled, to avoid confusion if
+            // the field is prefilled or not (placeholder and prefill look similar)
+            examplePlaceholder={schema.disabled ? 'off' : undefined}
             {...field}
           />
         )}

--- a/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
+++ b/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
@@ -53,6 +53,9 @@ export const MobileFieldInput = ({
               ? handleInputChange(onChange)
               : (value) => onChange({ value })
           }
+          // Remove placeholder when field is disabled, to avoid confusion if
+          // the field is prefilled or not (placeholder and prefill look similar)
+          examplePlaceholder={schema.disabled ? 'off' : undefined}
           {...field}
           {...phoneNumberInputProps}
         />

--- a/frontend/src/templates/Field/Table/AddRowFooter.tsx
+++ b/frontend/src/templates/Field/Table/AddRowFooter.tsx
@@ -6,12 +6,14 @@ import simplur from 'simplur'
 import Button from '~components/Button'
 
 interface AddRowFooterProps {
+  isDisabled?: boolean
   handleAddRow: () => void
   currentRows: number
   maxRows: number | ''
 }
 
 export const AddRowFooter = ({
+  isDisabled,
   currentRows,
   maxRows,
   handleAddRow: handleAddRowProp,
@@ -44,7 +46,7 @@ export const AddRowFooter = ({
       spacing="0.75rem"
     >
       <Button
-        isDisabled={!!maxRows && currentRows >= maxRows}
+        isDisabled={isDisabled || (!!maxRows && currentRows >= maxRows)}
         leftIcon={<BiPlus fontSize="1.5rem" />}
         type="button"
         onClick={handleAddRow}

--- a/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -29,6 +29,7 @@ import { TableFieldInputs } from '../types'
 export interface ColumnCellProps
   extends UseTableCellProps<TableFieldInputs, string> {
   schemaId: string
+  isDisabled?: boolean
   disableRequiredValidation: boolean
   columnSchema: ColumnDto
   colorTheme: FormColorTheme
@@ -36,6 +37,7 @@ export interface ColumnCellProps
 
 export interface FieldColumnCellProps<T extends Column = Column> {
   schema: ColumnDto<T>
+  isDisabled?: boolean
   disableRequiredValidation: boolean
   /** Represents `{schemaId}.{rowIndex}.{columnId}` */
   inputName: `${string}.${number}.${string}`
@@ -44,6 +46,7 @@ export interface FieldColumnCellProps<T extends Column = Column> {
 
 const ShortTextColumnCell = ({
   schema,
+  isDisabled,
   disableRequiredValidation,
   inputName,
   colorTheme,
@@ -62,6 +65,7 @@ const ShortTextColumnCell = ({
       rules={rules}
       render={({ field }) => (
         <Input
+          isDisabled={isDisabled}
           colorScheme={`theme-${colorTheme}`}
           aria-labelledby={schema._id}
           {...field}
@@ -73,6 +77,7 @@ const ShortTextColumnCell = ({
 
 const DropdownColumnCell = ({
   schema,
+  isDisabled,
   disableRequiredValidation,
   inputName,
   colorTheme,
@@ -91,6 +96,7 @@ const DropdownColumnCell = ({
       defaultValue=""
       render={({ field }) => (
         <SingleSelect
+          isDisabled={isDisabled}
           colorScheme={`theme-${colorTheme}`}
           // Possibility of fieldOptions being undefined during table field creation.
           items={schema.fieldOptions ?? []}
@@ -106,6 +112,7 @@ const DropdownColumnCell = ({
  */
 export const ColumnCell = ({
   schemaId,
+  isDisabled,
   disableRequiredValidation,
   row,
   column,
@@ -128,6 +135,7 @@ export const ColumnCell = ({
           <ShortTextColumnCell
             colorTheme={colorTheme}
             schema={columnSchema}
+            isDisabled={isDisabled}
             disableRequiredValidation={disableRequiredValidation}
             inputName={inputName}
           />
@@ -137,6 +145,7 @@ export const ColumnCell = ({
           <DropdownColumnCell
             colorTheme={colorTheme}
             schema={columnSchema}
+            isDisabled={isDisabled}
             disableRequiredValidation={disableRequiredValidation}
             inputName={inputName}
           />
@@ -144,7 +153,13 @@ export const ColumnCell = ({
       default:
         return null
     }
-  }, [colorTheme, columnSchema, disableRequiredValidation, inputName])
+  }, [
+    colorTheme,
+    columnSchema,
+    disableRequiredValidation,
+    inputName,
+    isDisabled,
+  ])
 
   return (
     <FormControl

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -212,6 +212,7 @@ export const TableField = ({
                     >
                       {cell.render('Cell', {
                         schemaId: schema._id,
+                        isDisabled: schema.disabled,
                         disableRequiredValidation,
                         columnSchema: schema.columns[j],
                         colorTheme,
@@ -226,7 +227,9 @@ export const TableField = ({
                       display={{ base: 'block', md: 'table-cell' }}
                     >
                       <IconButton
-                        isDisabled={fields.length <= schema.minimumRows}
+                        isDisabled={
+                          schema.disabled || fields.length <= schema.minimumRows
+                        }
                         variant="clear"
                         colorScheme="danger"
                         aria-label="Remove row"
@@ -248,6 +251,7 @@ export const TableField = ({
       ) : null}
       {schema.addMoreRows && schema.maximumRows !== undefined ? (
         <AddRowFooter
+          isDisabled={schema.disabled}
           currentRows={fields.length}
           maxRows={schema.maximumRows}
           handleAddRow={handleAddRow}

--- a/scripts/20240214_mrf-workflow-field-locking/mrf-workflow-field-locking.js
+++ b/scripts/20240214_mrf-workflow-field-locking/mrf-workflow-field-locking.js
@@ -1,0 +1,46 @@
+/* eslint-disable */
+
+// This script migrates the existing workflow options for multirespondent forms
+// to include a new field "edit", which will contain the list of field IDs to be
+// edited by the respondent at each stage.
+
+// BEFORE
+// COUNT existing number of forms with non-empty workflows in total
+db.forms.countDocuments({
+  responseMode: 'multirespondent',
+  workflow: { $exists: true, $type: 'array', $gt: { $size: 0 } },
+})
+
+// UPDATE
+// modifiedCount should match COUNT in BEFORE
+db.forms.updateMany(
+  {
+    responseMode: 'multirespondent',
+    workflow: { $exists: true, $type: 'array' },
+  },
+  [
+    {
+      $addFields: {
+        'workflow.edit': {
+          $map: {
+            input: {
+              $filter: {
+                input: '$form_fields',
+                as: 'field',
+                cond: {
+                  $and: [
+                    { $ne: ['$$field.fieldType', 'section'] },
+                    { $ne: ['$$field.fieldType', 'statement'] },
+                    { $ne: ['$$field.fieldType', 'image'] },
+                  ],
+                },
+              },
+            },
+            as: 'field',
+            in: '$$field._id',
+          },
+        },
+      },
+    },
+  ],
+)

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -23,6 +23,7 @@ export const STORAGE_PUBLIC_FORM_FIELDS = <const>[
 export const MULTIRESPONDENT_PUBLIC_FORM_FIELDS = <const>[
   ...PUBLIC_FORM_FIELDS,
   'publicKey',
+  'workflow',
 ]
 
 const FORM_SETTINGS_FIELDS = <const>[

--- a/shared/types/form/workflow.ts
+++ b/shared/types/form/workflow.ts
@@ -7,6 +7,7 @@ export enum WorkflowType {
 
 export interface FormWorkflowStepBase {
   workflow_type: WorkflowType
+  edit: FormFieldDto['_id'][]
 }
 
 export interface FormWorkflowStepStatic extends FormWorkflowStepBase {

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -881,6 +881,7 @@ describe('Form Model', () => {
 
       it('should create and save successfully with a workflow', async () => {
         // Arrange
+        const emailFieldObjectId = new ObjectId()
         const validFormObj = {
           ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
           workflow: [
@@ -888,11 +889,13 @@ describe('Form Model', () => {
               _id: new ObjectId(),
               workflow_type: WorkflowType.Static,
               emails: ['test@open.gov.sg'],
+              edit: [new ObjectId(), emailFieldObjectId],
             },
             {
               _id: new ObjectId(),
               workflow_type: WorkflowType.Dynamic,
-              field: new ObjectId(),
+              field: emailFieldObjectId,
+              edit: [new ObjectId()],
             },
           ],
         }

--- a/src/app/models/form_workflow_step.server.schema.ts
+++ b/src/app/models/form_workflow_step.server.schema.ts
@@ -17,6 +17,10 @@ const WorkflowStepSchema = new Schema<IWorkflowStepSchema>(
       default: WorkflowType.Static,
       required: true,
     },
+    edit: {
+      type: [{ type: Schema.Types.ObjectId }],
+      required: true,
+    },
   },
   {
     discriminatorKey: 'workflow_type',

--- a/src/app/modules/form/admin-form/admin-form.middlewares.ts
+++ b/src/app/modules/form/admin-form/admin-form.middlewares.ts
@@ -47,10 +47,12 @@ export const updateSettingsValidator = celebrate({
             is: WorkflowType.Static,
             then: Joi.array().items(Joi.string().email()).required(),
           }),
+          // TODO: Add regex validation that these are valid mongo IDs
           field: Joi.when('workflow_type', {
             is: WorkflowType.Dynamic,
             then: Joi.string().required(),
           }),
+          edit: Joi.array().items(Joi.string()).required(),
         }),
       )
       .optional(),

--- a/src/types/form_workflow_step.ts
+++ b/src/types/form_workflow_step.ts
@@ -9,7 +9,10 @@ import {
 
 import { IFieldSchema } from './field'
 
-export interface IWorkflowStepSchema extends FormWorkflowStepBase, Document {}
+export interface IWorkflowStepSchema extends FormWorkflowStepBase, Document {
+  // overwriting field id type to reflect mongoose Id type
+  edit: IFieldSchema['_id'][]
+}
 
 export interface IWorkflowStepStaticSchema
   extends IWorkflowStepSchema,
@@ -17,6 +20,7 @@ export interface IWorkflowStepStaticSchema
     Document {
   workflow_type: WorkflowType.Static
   emails: string[]
+  edit: IFieldSchema['_id'][]
 }
 
 export interface IWorkflowStepDynamicSchema
@@ -25,6 +29,8 @@ export interface IWorkflowStepDynamicSchema
     Document {
   workflow_type: WorkflowType.Dynamic
   field: IFieldSchema['_id']
+  // overwriting field id type to reflect mongoose Id type
+  edit: IFieldSchema['_id'][]
 }
 
 export type FormWorkflowStepSchema =


### PR DESCRIPTION
## Problem

We want to implement field locking for MRF. This PR does this for frontend locking. Backend locking validation will be implemented in a separate PR.

Closes FRM-1639

## Solution

**Admin-side**
- Update workflow builder frontend
  - For active state (`EditStepBlock`), add a new component, `QuestionsBlock` which contains the multiselect dropdown for admins to choose questions to edit.
  - Also, update inactive state (`InactiveStepBlock`) with new section to display field labels for selected questions to be edited by each step.
- Add `edit` key to 
  - workflow step schemas in `shared/*`, 
  - backend types, and 
  - API middlewares for workflow settings, which is where the workflow object still gets `PATCH`ed 😢.

**Public-side**
- Frontend disabling of fields. There are two things that need to be done.
  - Visually, the fields are in a disabled state.
    - A new augmentation `augmentWithWorkflowDisabling` is added, which disables the field only if the field is in the workflow step, and it's an input field (i.e. not header, paragraph or image). This uses the `disabled` key in the `FormFieldDto` type.
    - Some field UI updates had to be done to support this, as not all fields fully supported the `disabled` key. In particular, phone numbers and the table field were updated.
  - Required validation should be turned off for these fields.
    - Achieved through similar means as before, using the `disableRequiredValidation` key in the `FieldFactory` component. However this time instead of checking if the form is MRF and disabling the validation universally, we implement a field-level check using the same util as `augmentWithWorkflowDisabling` so that the logic is always consistent.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

![image](https://github.com/opengovsg/FormSG/assets/25571626/e00610f2-cfb8-4f84-8b63-500c4a876648)

![image](https://github.com/opengovsg/FormSG/assets/25571626/832065b1-c61a-45f3-94c3-1389ca0f310d)

![image](https://github.com/opengovsg/FormSG/assets/25571626/32a19fad-5971-4b58-a9c3-4ef99dbf1b98)

![image](https://github.com/opengovsg/FormSG/assets/25571626/a6be6f68-dbc6-45c2-a56f-d7bd3c29c843)

![image](https://github.com/opengovsg/FormSG/assets/25571626/439d54d4-727d-4a14-9434-b0b1df9e5aec)

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes

**New scripts**:

- `20240214_mrf-workflow-field-locking` : This DB migration script adds the `edit` key for all workflow steps, which allows users to choose the fields each respondent is allowed to edit. To preserve existing behavior, all respondents must be allowed to edit all fields. Therefore, a copy of the form fields (excl non-input fields `section`, `statement` and `image`) are copied into every `edit` key. 