### PR TITLE
fix(mrf): use undefined as default for response display

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processDecryptedContent.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processDecryptedContent.ts
@@ -129,7 +129,7 @@ export const processDecryptedContentV3 = async (
     .map((ff) => {
       const response = responses[ff._id]
       if (!response) {
-        return transformInputsToOutputs(ff, '')
+        return transformInputsToOutputs(ff)
       }
       if (response.fieldType === BasicField.Attachment) {
         const answer = response.answer as AttachmentFieldResponseV3

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -134,7 +134,7 @@ const transformToAttachmentOutput = (
 
 const transformToCheckboxOutput = (
   schema: CheckboxFieldSchema,
-  input: CheckboxFieldValues,
+  input?: CheckboxFieldValues,
 ): CheckboxResponse => {
   let answerArray: string[] = []
   if (input !== undefined && input.value) {
@@ -158,7 +158,7 @@ const transformToCheckboxOutput = (
 
 const transformToRadioOutput = (
   schema: RadioFieldSchema,
-  input: RadioFieldValues,
+  input?: RadioFieldValues,
 ): RadioResponse => {
   let answer = ''
   if (input !== undefined) {
@@ -210,7 +210,7 @@ const transformToChildOutput = (
  */
 export const transformInputsToOutputs = (
   field: FormFieldDto,
-  input: FormFieldValue,
+  input?: FormFieldValue,
 ): FieldResponse | null => {
   switch (field.fieldType) {
     case BasicField.Section:


### PR DESCRIPTION
## Problem

User reported an issue with MRF pilot where they got an error message `a.map is not a function`. 

![image](https://github.com/opengovsg/FormSG/assets/25571626/c4692109-83ea-491f-9826-f317f3302236)

After identification, this was identified to only occur as a result of a frontend bug. The form contains a table field hidden by logic, and all hidden fields are removed from the field payload upon submission. This means that the table field did not exist in the stored data payload.

Upon retrieval, the payload was decrypted and displayed to the user on the individual response page. Therefore, when retrieved, the data object keyed by the table's field id would result in `undefined`. To deal with these undefined keys, the code used `''` as a default, in `inputTransformation`. This works in most cases, but due to the expected type of table field answers being arrays, a type with `.map` was expected, but `''` did not have this method. Therefore, the transformation process failed.

Closes FRM-1629

## Solution

We change the transformation to use `undefined` as a default. This involves changing the type signature for `transformInputsToOutputs` to accept an optional `input`, but this is okay because most sub-functions allow for an optional input. The exceptions are checkbox and radio, but even then, the functions themselves are actually already written to accommodate the case where `input` is undefined, even though the type signature doesn't specify that it's allowed. Therefore we also modify these function to allow `input` to be undefined.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

- [ ] Ensure that visible fields can be displayed on the MRF individual response page.
- [ ] Ensure that hidden fields can be displayed on the MRF individual response page.
