### PR TITLE
feat(config): allow R2 bucket URLs

### DIFF
--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -81,13 +81,17 @@ const s3BucketUrlVars = convict(s3BucketUrlSchema)
   .validate({ allowed: 'strict' })
   .getProperties()
 
+const hasR2Buckets = Object.values(s3BucketUrlVars).some((url) =>
+  /https:\/\/\w+\.r2\.cloudflarestorage\.com/i.test(url),
+)
+
 const s3 = new aws.S3({
   region: basicVars.awsConfig.region,
   // Unset and use default if not in development mode
-  // Endpoint and path style overrides are needed only in development mode for
-  // localstack to work.
-  endpoint: isDev ? s3BucketUrlVars.endPoint : undefined,
-  s3ForcePathStyle: isDev ? true : undefined,
+  // Endpoint and path style overrides are needed only in development mode
+  // for localstack to work, or for Cloudflare R2.
+  endpoint: isDev || hasR2Buckets ? s3BucketUrlVars.endPoint : undefined,
+  s3ForcePathStyle: isDev || hasR2Buckets ? true : undefined,
 })
 
 // using aws-sdk v3 (FRM-993)

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -58,9 +58,15 @@ const validateS3BucketUrl = (
     }
   }
   // Region should be specified correctly in production
-  const isRegionCorrect = new RegExp(`^https://s3.${region}.amazonaws.com`, 'i')
-  if (!isDev && !isRegionCorrect.test(val)) {
-    throw new Error(`region should be ${region}`)
+  const isS3RegionCorrect = new RegExp(
+    `^https://s3.${region}.amazonaws.com`,
+    'i',
+  )
+  const isR2 = new RegExp(`^https://\\w+.r2.cloudflarestorage.com`, 'i')
+  if (!isDev && !isS3RegionCorrect.test(val) && !isR2.test(val)) {
+    throw new Error(
+      `region should be ${region}, or url should be for Cloudflare R2`,
+    )
   }
   /* eslint-enable typesafe/no-throw-sync-func */
 }


### PR DESCRIPTION
## Problem
FormSG assumes in production environments that S3 buckets are hosted by AWS and use URLs that take after a certain pattern. This is not necessarily the case for eg, Cloudflare R2, which use a different pattern

## Solution
- Allow config to accept URLs to R2 buckets, in addition to S3 buckets
- Force path-style S3 URLs for R2 buckets, not just for dev mode

