### PR TITLE
feat(mrf): disable unsupported features

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -139,6 +139,12 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     }
   }, [isPdfResponseEnabled])
 
+  // vfn is not supported on MRF
+  const isToggleVfnDisabled = useMemo(
+    () => form?.responseMode === FormResponseMode.Multirespondent,
+    [form],
+  )
+
   return (
     <CreatePageDrawerContentContainer>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
@@ -158,7 +164,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
       <FormControl isReadOnly={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
+      <FormControl isReadOnly={isLoading} isDisabled={isToggleVfnDisabled}>
         <Toggle
           {...register('isVerifiable')}
           label="OTP verification"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -145,6 +145,12 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     [form],
   )
 
+  // email confirmation is not supported on MRF
+  const isToggleEmailConfirmationDisabled = useMemo(
+    () => form?.responseMode === FormResponseMode.Multirespondent,
+    [form],
+  )
+
   return (
     <CreatePageDrawerContentContainer>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
@@ -199,7 +205,10 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         )}
       </Box>
       <Box>
-        <FormControl isReadOnly={isLoading}>
+        <FormControl
+          isReadOnly={isLoading}
+          isDisabled={isToggleEmailConfirmationDisabled}
+        >
           <Toggle
             {...register('autoReplyOptions.hasAutoReply')}
             description="Customise an email acknowledgement to respondents"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { Box, FormControl, useDisclosure } from '@chakra-ui/react'
 import { extend, pick } from 'lodash'
 
+import { FormResponseMode } from '~shared/types'
 import { MobileFieldBase } from '~shared/types/field'
 
 import { createBaseValidationRules } from '~utils/fieldValidation'
@@ -62,13 +63,20 @@ export const EditMobile = ({ field }: EditMobileProps): JSX.Element => {
 
   const { data: freeSmsCount } = useFreeSmsQuota()
   const isToggleVfnDisabled = useMemo(() => {
+    // vfn is not supported on MRF
+    if (form?.responseMode === FormResponseMode.Multirespondent) return true
     if (!freeSmsCount) return true
     return (
       !field.isVerifiable &&
       !hasTwilioCredentials &&
       freeSmsCount.freeSmsCounts >= freeSmsCount.quota
     )
-  }, [field.isVerifiable, freeSmsCount, hasTwilioCredentials])
+  }, [
+    field.isVerifiable,
+    freeSmsCount,
+    hasTwilioCredentials,
+    form?.responseMode,
+  ])
 
   const smsCountsDisclosure = useDisclosure()
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -1,6 +1,9 @@
 import { Droppable } from 'react-beautiful-dnd'
 import { Box } from '@chakra-ui/react'
 
+import { BasicField, FormResponseMode } from '~shared/types'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
 import {
   BASIC_FIELDS_ORDERED,
   CREATE_FIELD_DROP_ID,
@@ -13,20 +16,33 @@ import { FieldSection } from './FieldSection'
 
 export const BasicFieldPanel = () => {
   const { isLoading } = useCreateTabForm()
+  const { data: form } = useAdminForm()
 
   return (
     <Droppable isDropDisabled droppableId={CREATE_FIELD_DROP_ID}>
       {(provided) => (
         <Box ref={provided.innerRef} {...provided.droppableProps}>
           <FieldSection>
-            {BASIC_FIELDS_ORDERED.map((fieldType, index) => (
-              <DraggableBasicFieldListOption
-                index={index}
-                isDisabled={isLoading}
-                key={index}
-                fieldType={fieldType}
-              />
-            ))}
+            {BASIC_FIELDS_ORDERED.map((fieldType, index) => {
+              let shouldDisableField = isLoading
+
+              // Attachment is not supported on MRF
+              if (
+                fieldType === BasicField.Attachment &&
+                form?.responseMode === FormResponseMode.Multirespondent
+              ) {
+                shouldDisableField = true
+              }
+
+              return (
+                <DraggableBasicFieldListOption
+                  index={index}
+                  isDisabled={shouldDisableField}
+                  key={index}
+                  fieldType={fieldType}
+                />
+              )
+            })}
             <Box display="none">{provided.placeholder}</Box>
           </FieldSection>
         </Box>

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
@@ -43,6 +43,8 @@ Default.args = {
     title:
       'Thank you for your submission with some super long backstory about how important the submission is to them',
     paragraph: 'We will get back to you shortly.\n\nOnce again,\r\nthank you.',
+    paymentTitle: '',
+    paymentParagraph: '',
   },
   submissionData: {
     id: 'mockSubmissionId',
@@ -84,7 +86,7 @@ ColorThemeOrange.args = {
 export const FeedbackSubmitted = Template.bind({})
 FeedbackSubmitted.args = {
   ...Default.args,
-  isFeedbackSubmitted: true,
+  hideFeedbackSection: true,
 }
 
 export const Mobile = Template.bind({})

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
@@ -86,7 +86,7 @@ ColorThemeOrange.args = {
 export const FeedbackSubmitted = Template.bind({})
 FeedbackSubmitted.args = {
   ...Default.args,
-  hideFeedbackSection: true,
+  isFeedbackSectionHidden: true,
 }
 
 export const Mobile = Template.bind({})

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
@@ -13,13 +13,13 @@ export interface FormEndPageProps {
   endPage: FormDto['endPage']
   submissionData: SubmissionData
   handleSubmitFeedback: (inputs: FeedbackFormInput) => void
-  isFeedbackSubmitted: boolean
+  hideFeedbackSection: boolean
   colorTheme: FormColorTheme
 }
 
 export const FormEndPage = ({
   handleSubmitFeedback,
-  isFeedbackSubmitted,
+  hideFeedbackSection,
   colorTheme,
   ...endPageProps
 }: FormEndPageProps): JSX.Element => {
@@ -40,7 +40,7 @@ export const FormEndPage = ({
             {...endPageProps}
             colorTheme={colorTheme}
           />
-          {isFeedbackSubmitted ? null : (
+          {hideFeedbackSection ? null : (
             <FeedbackBlock
               colorTheme={colorTheme}
               onSubmit={handleSubmitFeedback}

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPage.tsx
@@ -13,13 +13,13 @@ export interface FormEndPageProps {
   endPage: FormDto['endPage']
   submissionData: SubmissionData
   handleSubmitFeedback: (inputs: FeedbackFormInput) => void
-  hideFeedbackSection: boolean
+  isFeedbackSectionHidden: boolean
   colorTheme: FormColorTheme
 }
 
 export const FormEndPage = ({
   handleSubmitFeedback,
-  hideFeedbackSection,
+  isFeedbackSectionHidden,
   colorTheme,
   ...endPageProps
 }: FormEndPageProps): JSX.Element => {
@@ -40,7 +40,7 @@ export const FormEndPage = ({
             {...endPageProps}
             colorTheme={colorTheme}
           />
-          {hideFeedbackSection ? null : (
+          {isFeedbackSectionHidden ? null : (
             <FeedbackBlock
               colorTheme={colorTheme}
               onSubmit={handleSubmitFeedback}

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -73,9 +73,11 @@ export const FormEndPageContainer = (): JSX.Element | null => {
     )
   }
 
-  // Feedback is not supported on MRF
   const isFeedbackHidden =
-    form.responseMode === FormResponseMode.Multirespondent
+    // Feedback is not supported on MRF
+    form.responseMode === FormResponseMode.Multirespondent ||
+    isFeedbackSubmitted
+
   return (
     <Box py={{ base: '1.5rem', md: '2.5rem' }} w="100%">
       <FormEndPage
@@ -83,7 +85,7 @@ export const FormEndPageContainer = (): JSX.Element | null => {
         submissionData={submissionData}
         formTitle={form.title}
         endPage={form.endPage}
-        hideFeedbackSection={isFeedbackSubmitted || isFeedbackHidden}
+        isFeedbackSectionHidden={isFeedbackHidden}
         handleSubmitFeedback={handleSubmitFeedback}
       />
     </Box>

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -74,8 +74,8 @@ export const FormEndPageContainer = (): JSX.Element | null => {
   }
 
   // Feedback is not supported on MRF
-  const isHideFeedback = form.responseMode === FormResponseMode.Multirespondent
-  console.log(isHideFeedback)
+  const isFeedbackHidden =
+    form.responseMode === FormResponseMode.Multirespondent
   return (
     <Box py={{ base: '1.5rem', md: '2.5rem' }} w="100%">
       <FormEndPage
@@ -83,7 +83,7 @@ export const FormEndPageContainer = (): JSX.Element | null => {
         submissionData={submissionData}
         formTitle={form.title}
         endPage={form.endPage}
-        hideFeedbackSection={isFeedbackSubmitted || isHideFeedback}
+        hideFeedbackSection={isFeedbackSubmitted || isFeedbackHidden}
         handleSubmitFeedback={handleSubmitFeedback}
       />
     </Box>

--- a/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -72,6 +72,10 @@ export const FormEndPageContainer = (): JSX.Element | null => {
       />
     )
   }
+
+  // Feedback is not supported on MRF
+  const isHideFeedback = form.responseMode === FormResponseMode.Multirespondent
+  console.log(isHideFeedback)
   return (
     <Box py={{ base: '1.5rem', md: '2.5rem' }} w="100%">
       <FormEndPage
@@ -79,7 +83,7 @@ export const FormEndPageContainer = (): JSX.Element | null => {
         submissionData={submissionData}
         formTitle={form.title}
         endPage={form.endPage}
-        isFeedbackSubmitted={isFeedbackSubmitted}
+        hideFeedbackSection={isFeedbackSubmitted || isHideFeedback}
         handleSubmitFeedback={handleSubmitFeedback}
       />
     </Box>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The users should not be able to use the features that do not work for the beta release
Closes FRM-1663

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Screenshots
### Attachments are disabled
<img width="601" alt="disable attachments" src="https://github.com/opengovsg/FormSG/assets/12391617/14f43395-3bfb-452e-8d6c-170eb3307cb7">

### Mobile OTP is disabled
<img width="609" alt="disable mobile otp" src="https://github.com/opengovsg/FormSG/assets/12391617/d42d8455-4f26-41a6-84ef-eb3c4317a558">

### Email OTP + Confirmation is disabled
![email-mrf](https://github.com/opengovsg/FormSG/assets/12391617/66acbd78-ec0e-46e2-8a1b-5eea2c270786)


## Tests
<!-- What tests should be run to confirm functionality? -->
##### New feature tests
Admin MRF Forms - Unsupported fields are disabled
- [ ] As an Admin create a non-MRF form
- [ ] Ensure that Attachment Field is disabled
  - [ ] Ensure that Attachment Field **cannot** be added as a form field
- [ ] Ensure that on Mobile Field, the OTP toggle is disabled
- [ ] Ensure that on Email Field, the OTP toggle is disabled
- [ ] Ensure that on Email Field, the OTP and email confirmation toggles are disabled

Respondent MRF Forms - Feedback section is not shown
- [ ] As a respondent, submit an MRF form
- [ ] Ensure that form feedback section is not shown

##### Regression
Non-MRF Forms - fields that are disabled on MRF should not affect non-MRF forms
- [ ] As an Admin create a non-MRF form
- [ ] Ensure that Attachment Field is **not** disabled
- [ ] Ensure that Attachment Field **can** be added as a form field 
- [ ] Ensure that on Mobile Field, the OTP toggle is not disabled
- [ ] Ensure that on Email Field, the OTP and email confirmation toggles are **not** disabled

Respondent Non-MRF Forms - Feedback section is shown
- [ ] As a respondent, submit a form
- [ ] Ensure that form feedback section is shown
