### PR TITLE
chore: remove Anguilla from country listing

### DIFF
--- a/shared/constants/countryRegion.ts
+++ b/shared/constants/countryRegion.ts
@@ -5,7 +5,6 @@ export enum CountryRegion {
   American_Samoa = 'American Samoa',
   Andorra = 'Andorra',
   Angola = 'Angola',
-  Anguilla = 'Anguilla',
   Antigua = 'Antigua',
   Argentina = 'Argentina',
   Armenia = 'Armenia',

--- a/shared/constants/field/myinfo/myinfo-countries.ts
+++ b/shared/constants/field/myinfo/myinfo-countries.ts
@@ -5,7 +5,6 @@ export const myInfoCountries = [
   'AMERICAN SAMOA',
   'ANDORRA',
   'ANGOLA',
-  'ANGUILLA',
   'ANTIGUA',
   'ARGENTINA',
   'ARMENIA',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->


The country/region code list should be the same for both MyInfo and FormSG if the nature of the data collected is the same (i.e. if there is any issue in the list, this is not OGP's problem to manage but MyInfo team's).

Closes FRM-1665

## Solution
<!-- How did you solve the problem? -->

Remove `Anguilla` from country list

Note: `Anguilla` can still be selected as a prefix on Mobile Number Fields that accepts international numbers. The value is ultimately stored as a string, thus not removed.