### PR TITLE
fix: correct alignment issues in preview mode

### DIFF
--- a/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -47,7 +47,7 @@ interface PreviewFormBannerProps {
 const textProps: TextProps = {
   textStyle: 'body-2',
   color: 'white',
-  ml: '2rem',
+  mx: '2rem',
   mt: '0.5rem',
   mb: '0.5rem',
 }

--- a/frontend/src/features/admin-form/create/end-page/PaymentEndPageBlock.tsx
+++ b/frontend/src/features/admin-form/create/end-page/PaymentEndPageBlock.tsx
@@ -57,7 +57,7 @@ export const PaymentEndPageBlock = ({
   )
 
   return (
-    <Box mx={{ base: '1rem', md: '4rem' }}>
+    <Box>
       <Box ref={focusRef} bg="white">
         <VisuallyHidden aria-live="assertive">
           {submittedAriaText}

--- a/frontend/src/features/admin-form/create/end-page/PaymentEndPageBlock.tsx
+++ b/frontend/src/features/admin-form/create/end-page/PaymentEndPageBlock.tsx
@@ -57,7 +57,7 @@ export const PaymentEndPageBlock = ({
   )
 
   return (
-    <Box>
+    <Box mx={{ base: '1rem', md: '4rem' }}>
       <Box ref={focusRef} bg="white">
         <VisuallyHidden aria-live="assertive">
           {submittedAriaText}

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
@@ -33,18 +33,21 @@ export const PaymentEndPagePreview = ({
           pt={{ base: '1rem', md: '1.5rem' }}
           mx={{ base: '1rem', md: '2rem' }}
           bg="transparent"
+          width="100%"
         >
-          <PaymentEndPageBlock focusOnMount {...endPageProps} />
-          {isFeedbackSubmitted ? null : (
-            <Box
-              backgroundColor="white"
-              p="2rem"
-              py={{ base: '1.5rem', md: '2rem' }}
-              px={{ base: '1rem', md: '2rem' }}
-            >
-              <FeedbackBlock onSubmit={handleSubmitFeedback} />
-            </Box>
-          )}
+          <PaymentEndPageBlock {...endPageProps} />
+          <Stack px={{ base: '1rem', md: '4rem' }} bg="transparent">
+            {isFeedbackSubmitted ? null : (
+              <Box
+                backgroundColor="white"
+                p="2rem"
+                py={{ base: '1.5rem', md: '2rem' }}
+                px={{ base: '1rem', md: '2rem' }}
+              >
+                <FeedbackBlock onSubmit={handleSubmitFeedback} />
+              </Box>
+            )}
+          </Stack>
         </Stack>
       </Flex>
     </>

--- a/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/PaymentEndPagePreview.tsx
@@ -31,23 +31,21 @@ export const PaymentEndPagePreview = ({
         </Box>
         <Stack
           pt={{ base: '1rem', md: '1.5rem' }}
-          mx={{ base: '1rem', md: '2rem' }}
+          px={{ base: '1rem', md: '4rem' }}
           bg="transparent"
-          width="100%"
+          w="100%"
         >
-          <PaymentEndPageBlock {...endPageProps} />
-          <Stack px={{ base: '1rem', md: '4rem' }} bg="transparent">
-            {isFeedbackSubmitted ? null : (
-              <Box
-                backgroundColor="white"
-                p="2rem"
-                py={{ base: '1.5rem', md: '2rem' }}
-                px={{ base: '1rem', md: '2rem' }}
-              >
-                <FeedbackBlock onSubmit={handleSubmitFeedback} />
-              </Box>
-            )}
-          </Stack>
+          <PaymentEndPageBlock focusOnMount {...endPageProps} />
+          {isFeedbackSubmitted ? null : (
+            <Box
+              backgroundColor="white"
+              p="2rem"
+              py={{ base: '1.5rem', md: '2rem' }}
+              px={{ base: '1rem', md: '2rem' }}
+            >
+              <FeedbackBlock onSubmit={handleSubmitFeedback} />
+            </Box>
+          )}
         </Stack>
       </Flex>
     </>


### PR DESCRIPTION
## Problem
There were alignment issues found where the text would bleed out of the page and container if the text is too long.

**Root cause**: Originally, the width of the Stack component in `PaymentEndPagePreview.tsx` was not indicated to be 100%, which might have caused the text to bleed since no width was defined. In the Edit mode and the actual Thank You Page (which worked as intended and the text did not bleed), the widths were defined as 100%.

![image](https://github.com/opengovsg/FormSG/assets/89055608/e970c144-bd37-4a3a-9312-fa225073e7e3)

Closes FRM-1656

## Solution
- Fixed alignment and width of the component such that the text does not bleed beyond the page
- Fixed padding of components in mobile view
- Fixed padding of preview banner warning

**Breaking Changes** 

- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:

#### Mobile View
<img width="296" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/0f7dae3c-e68a-489a-aaa7-e3bb596cdf80">



**AFTER**:

#### Desktop View
<img width="1245" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/c130cd9d-4303-412f-ab4e-69e8e96a701f">

#### Mobile View
<img width="293" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/fede703a-6ecf-4ab1-ba84-83826c6a8fd6">


## Tests

- [ ] Add a payment variable to a form
- [ ] Edit the Thank You page such that the title and follow-up instructions are very long
- [ ] Click on the Preview (eye) button of the form in admin mode to enter Preview mode
- [ ] The title and follow up instructions text (which are very long) should still be within the Summary table
- [ ] In mobile view, the preview banner instructions and components should have sufficient padding

