### PR TITLE
chore(vscode): update code actions value options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": ["javascript", "typescript"],
   "editor.formatOnSave": true,
@@ -12,7 +12,7 @@
   },
   "[html]": {
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": false
+      "source.fixAll.eslint": "never"
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Our vscode config automatically introduces changes on two config statements of `source.fixAll.eslint`.


Since Nov23, the boolean values are deprecated, and the new options are:

> The options are:
> - explicit - Triggers Code Actions when explicitly saved. Same as true.
> - always - Triggers Code Actions when explicitly saved and on Auto Saves from window or focus changes.
> - never - Never triggers Code Actions on save. Same as false.

Ref: https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto

## Solution
<!-- How did you solve the problem? -->

Update the values to `"explicit"` as we were using `true` previously.