### PR TITLE
feat(virus-scanner): allow endpoint to be specified

### DIFF
--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -97,10 +97,16 @@ const s3 = new aws.S3({
 // using aws-sdk v3 (FRM-993)
 const virusScannerLambda = new Lambda({
   region: basicVars.awsConfig.region,
-  // Endpoint is set for development mode to point to the separate docker container running the lambda function.
+  // For dev mode or where specified, endpoint is set to point to the separate docker container running the lambda function.
   // host.docker.internal is a special DNS name which resolves to the internal IP address used by the host.
   // Reference: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
-  ...(isDev ? { endpoint: 'http://host.docker.internal:9999' } : undefined),
+  ...(isDev || basicVars.awsConfig.virusScannerLambdaEndpoint
+    ? {
+        endpoint:
+          basicVars.awsConfig.virusScannerLambdaEndpoint ||
+          'http://host.docker.internal:9999',
+      }
+    : undefined),
 })
 
 const awsConfig: AwsConfig = {

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -297,6 +297,12 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: '',
       env: 'VIRUS_SCANNER_LAMBDA_FUNCTION_NAME',
     },
+    virusScannerLambdaEndpoint: {
+      doc: 'Endpoint address for virus scanner lambda function. Specify this if the lambda is hosted neither on AWS nor your local dev environment.',
+      format: String,
+      default: '',
+      env: 'VIRUS_SCANNER_LAMBDA_ENDPOINT',
+    },
   },
   core: {
     port: {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -168,6 +168,7 @@ export interface IOptionalVarsSchema {
     region: string
     customCloudWatchGroup: string
     virusScannerLambdaFunctionName: string
+    virusScannerLambdaEndpoint: string
   }
   mail: {
     from: string


### PR DESCRIPTION
## Problem
For environments that are neither AWS nor local dev, the virus scanner lambda might be hosted elsewhere, eg, on a host running an emulated environment.

## Solution
Grant the flexibility to specify the endpoint address to reach the virus scanner, and thus the discretion to use AWS or some other environment.

## Tests
<!-- What tests should be run to confirm functionality? -->
##### Regression on non-local development env
Virus scanner rejects test virus file
- [x] Create a form with attachments
- [x] Submit a [test virus file](https://docs.trendmicro.com/all/ent/de/v1.5/en-us/de_1.5_olh/ctm_ag/ctm1_ag_ch8/t_test_eicar_file.htm)
- [x] Observe that submission fails

Virus scanner passes virus-safe file
- [x] Create a form with attachments
- [x] Submit a plain text file
- [x] Observe that submission passes