### PR TITLE
feat(fe): update copy, copy btn

### DIFF
--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
@@ -32,7 +32,7 @@ import { getPaymentViewStates, PaymentViewStates } from './utils'
 const PaymentFormWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
     <PublicFormWrapper>
-      <Flex
+      <Box
         pt={{ base: '2.5rem', md: '0' }}
         mb={{ base: '1.5rem', md: '0' }}
         w="100%"
@@ -40,7 +40,7 @@ const PaymentFormWrapper = ({ children }: { children: React.ReactNode }) => {
         <Container w="100%" maxW="57rem" p={0}>
           {children}
         </Container>
-      </Flex>
+      </Box>
     </PublicFormWrapper>
   )
 }

--- a/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/stripe/StripePaymentElement.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Box, Center, Container } from '@chakra-ui/react'
+import { Box, Center, Container, Flex, Stack, Text } from '@chakra-ui/react'
 import { Elements, useStripe } from '@stripe/react-stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
 
@@ -11,6 +11,7 @@ import {
 } from '~shared/types'
 
 import InlineMessage from '~components/InlineMessage'
+import { CopyButton } from '~templates/CopyButton'
 
 import { useEnv } from '~features/env/queries'
 
@@ -31,7 +32,7 @@ import { getPaymentViewStates, PaymentViewStates } from './utils'
 const PaymentFormWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
     <PublicFormWrapper>
-      <Box
+      <Flex
         pt={{ base: '2.5rem', md: '0' }}
         mb={{ base: '1.5rem', md: '0' }}
         w="100%"
@@ -39,7 +40,7 @@ const PaymentFormWrapper = ({ children }: { children: React.ReactNode }) => {
         <Container w="100%" maxW="57rem" p={0}>
           {children}
         </Container>
-      </Box>
+      </Flex>
     </PublicFormWrapper>
   )
 }
@@ -155,9 +156,22 @@ const StripePaymentContainer = ({
             <PaymentFormWrapper>
               {secretEnv === 'production' ? null : (
                 <InlineMessage variant="warning" mb="1rem">
-                  Use '4242 4242 4242 4242' as your card number to test payments
-                  on this form. Payments made on this form will only show in
-                  test mode in Stripe.
+                  <Stack>
+                    <Text>
+                      Make a test payment with the card number below! Payments
+                      made on this form will only show in test mode in Stripe.
+                    </Text>
+                    <Flex align="center">
+                      <Text mr="0.25rem">4242 4242 4242 4242</Text>
+                      <Flex boxSize="1.5rem" align="center" justify="center">
+                        <CopyButton
+                          colorScheme="secondary"
+                          stringToCopy={`4242424242424242`}
+                          aria-label="Copy test card number"
+                        />
+                      </Flex>
+                    </Flex>
+                  </Stack>
                 </InlineMessage>
               )}
               <PaymentStack>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There's a better test card filling UX in Airwallex, and found that we are lacking behind.

<img width="438" alt="Screenshot 2024-03-01 at 2 32 15 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/769f4b19-b12b-4c23-9e4e-7b3e2f15a57e">

## Solution
<!-- How did you solve the problem? -->

- Update card filling copy
- Add copy button that copies test card number over to user's clipboard

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
<img width="404" alt="Screenshot 2024-03-01 at 7 02 53 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/6ec94509-1ef3-4855-a602-8260d4e3aafc">
<img width="372" alt="Screenshot 2024-03-01 at 7 02 48 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/c1b6f826-dcbd-4baf-95f8-0a97ad1e2b23">
<img width="886" alt="Screenshot 2024-03-01 at 7 02 43 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/4c2c2440-a55d-460e-884f-8178fd496696">
