### PR TITLE
chore: add logs for virus scanning duration

### DIFF
--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -385,11 +385,20 @@ export const downloadCleanFile = (cleanFileKey: string, versionId: string) => {
     })
     .createReadStream()
 
+  logger.info({
+    message: 'File download from S3 has started',
+    meta: logMeta,
+  })
+
   readStream.pipe(writeStream)
 
   return ResultAsync.fromPromise(
     new Promise<Buffer>((resolve, reject) => {
       readStream.on('end', () => {
+        logger.info({
+          message: 'Successfully downloaded file from S3',
+          meta: logMeta,
+        })
         resolve(buffer)
       })
 


### PR DESCRIPTION
## Problem
Currently we do not keep track of how long it will take for files to be downloaded from S3 - this arose from an [alarm](https://www.notion.so/opengov/Storage-Form-Submission-taking-too-long-ab0b0e1f97d04833a25d67d617461b64?pvs=4) due to a spike in time taken for scanning and downloading clean attachments


## Solution
Added logs in `src/app/modules/submission/submission.service.ts` to track the start and end of the download from S3

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Manual tests

- [ ] Create a form
- [ ] Complete a submission of the form
- [ ] In datadog, search for "Successfully downloaded file from S3"
- [ ] Copy the Clean File Key
- [ ] Search for the clean file key in datadog or cloudwatch and check that there will be 2 logs with the messages of "File download from S3 has started" and "Successfully downloaded file from S3".

Datadog:
<img width="1326" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/a121ffc2-e1e1-4d32-b47f-1681072ae3c2">


Cloudwatch:
<img width="1069" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/6a81d333-d4f3-4a71-b396-c5b0b63692ea">

Searching by clean file ID of form submitted:
<img width="1065" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/e781a7bf-e6eb-475a-b525-71f6fd887249">

