### PR TITLE
feat(mrf): backend validation for field locking

### DIFF
--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -11,6 +11,8 @@ import { UseQueryResult } from 'react-query'
 import { MultirespondentSubmissionDto } from '~shared/types'
 import { PublicFormViewDto } from '~shared/types/form'
 
+import { decryptSubmission } from './utils/decryptSubmission'
+
 export type SubmissionData = {
   /** Submission id */
   id: string | undefined
@@ -65,6 +67,10 @@ export interface PublicFormContextProps
   setNumVisibleFields?: Dispatch<SetStateAction<number>>
 
   encryptedPreviousSubmission?: MultirespondentSubmissionDto
+  previousSubmission?: ReturnType<typeof decryptSubmission>
+  setPreviousSubmission: (
+    previousSubmission: ReturnType<typeof decryptSubmission>,
+  ) => void
 }
 
 export const PublicFormContext = createContext<

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -61,6 +61,7 @@ import {
 } from '~features/verifiable-fields'
 
 import { FormNotFound } from './components/FormNotFound'
+import { decryptSubmission } from './utils/decryptSubmission'
 import { usePublicAuthMutations, usePublicFormMutations } from './mutations'
 import { PublicFormContext, SubmissionData } from './PublicFormContext'
 import { useEncryptedSubmission, usePublicFormView } from './queries'
@@ -147,6 +148,9 @@ export const PublicFormProvider = ({
     // Stop querying once submissionData is present.
     /* enabled= */ !submissionData,
   )
+
+  const [previousSubmission, setPreviousSubmission] =
+    useState<ReturnType<typeof decryptSubmission>>()
 
   // Replace form fields, logic, and workflow with the previous version for MRF consistency.
   if (data && encryptedPreviousSubmission) {
@@ -300,7 +304,11 @@ export const PublicFormProvider = ({
     submitStorageModeFormFetchMutation,
     submitMultirespondentFormMutation,
     updateMultirespondentSubmissionMutation,
-  } = usePublicFormMutations(formId, previousSubmissionId)
+  } = usePublicFormMutations(
+    formId,
+    previousSubmissionId,
+    previousSubmission?.submissionSecretKey,
+  )
 
   const { handleLogoutMutation } = usePublicAuthMutations(formId)
 
@@ -694,6 +702,8 @@ export const PublicFormProvider = ({
         isPreview: false,
         setNumVisibleFields,
         encryptedPreviousSubmission,
+        previousSubmission,
+        setPreviousSubmission,
         ...commonFormValues,
         ...data,
         ...rest,

--- a/frontend/src/features/public-form/PublicFormService.ts
+++ b/frontend/src/features/public-form/PublicFormService.ts
@@ -144,7 +144,7 @@ export type SubmitStorageFormWithVirusScanningArgs =
 
 export type SubmitMultirespondentFormWithVirusScanningArgs =
   SubmitEmailFormArgs & {
-    // publicKey: string
+    submissionSecretKey?: string
     fieldIdToQuarantineKeyMap: FieldIdToQuarantineKeyType[]
   }
 
@@ -369,6 +369,7 @@ export const updateMultirespondentSubmission = async ({
   captchaType = '',
   responseMetadata,
   fieldIdToQuarantineKeyMap,
+  submissionSecretKey,
 }: SubmitMultirespondentFormWithVirusScanningArgs & {
   submissionId?: string
 }) => {
@@ -383,6 +384,7 @@ export const updateMultirespondentSubmission = async ({
       formFields,
       formInputs: filteredInputs,
       responseMetadata,
+      submissionSecretKey,
       version: MULTIRESPONDENT_FORM_SUBMISSION_VERSION,
     },
     fieldIdToQuarantineKeyMap,

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { Box } from '@chakra-ui/react'
 
@@ -24,10 +24,9 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     handleSubmitForm,
     submissionData,
     encryptedPreviousSubmission,
+    previousSubmission,
+    setPreviousSubmission,
   } = usePublicFormContext()
-
-  const [previousSubmission, setPreviousSubmission] =
-    useState<ReturnType<typeof decryptSubmission>>()
 
   const { submissionPublicKey = null, workflowStep } =
     encryptedPreviousSubmission ?? {}
@@ -120,6 +119,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     handleSubmitForm,
     submissionPublicKey,
     queryParams.key,
+    setPreviousSubmission,
     encryptedPreviousSubmission,
   ])
 

--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -72,6 +72,7 @@ export const usePublicAuthMutations = (formId: string) => {
 export const usePublicFormMutations = (
   formId: string,
   submissionId?: string,
+  submissionSecretKey?: string,
 ) => {
   const submitEmailModeFormMutation = useMutation(
     (args: Omit<SubmitEmailFormArgs, 'formId'>) => {
@@ -176,7 +177,9 @@ export const usePublicFormMutations = (
   )
 
   const updateMultirespondentSubmissionMutation =
-    useSubmitStorageModeFormMutation(updateMultirespondentSubmission)
+    useSubmitStorageModeFormMutation((args) =>
+      updateMultirespondentSubmission({ ...args, submissionSecretKey }),
+    )
 
   return {
     submitEmailModeFormMutation,

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -270,8 +270,10 @@ const createResponsesV3 = (
       case BasicField.Date:
       case BasicField.CountryRegion:
       case BasicField.YesNo: {
-        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
-        if (!input) continue
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input) break
         returnedInputs[ff._id] = {
           fieldType: ff.fieldType,
           answer: input,
@@ -280,8 +282,10 @@ const createResponsesV3 = (
       }
       case BasicField.Email:
       case BasicField.Mobile: {
-        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
-        if (!input || !input.value) continue
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input?.value) break
         returnedInputs[ff._id] = {
           fieldType: ff.fieldType,
           answer: input,
@@ -289,10 +293,12 @@ const createResponsesV3 = (
         break
       }
       case BasicField.Table: {
-        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
-        if (!input) continue
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input) break
         if (input.every((row) => Object.values(row).every((value) => !value))) {
-          continue
+          break
         }
         returnedInputs[ff._id] = {
           fieldType: ff.fieldType,
@@ -301,10 +307,14 @@ const createResponsesV3 = (
         break
       }
       case BasicField.Checkbox: {
-        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
-        if (!input) continue
-        if ((!input.value || input.value.length === 0) && !input.othersInput) {
-          continue
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (
+          (!input?.value || input?.value.length === 0) &&
+          !input?.othersInput
+        ) {
+          break
         }
         returnedInputs[ff._id] = {
           fieldType: ff.fieldType,
@@ -313,10 +323,14 @@ const createResponsesV3 = (
         break
       }
       case BasicField.Children: {
-        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
-        if (!input) continue
-        if (input.child.every((child) => child.every((value) => !value))) {
-          continue
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (
+          !input ||
+          input.child.every((child) => child.every((value) => !value))
+        ) {
+          break
         }
         returnedInputs[ff._id] = {
           fieldType: ff.fieldType,
@@ -325,8 +339,10 @@ const createResponsesV3 = (
         break
       }
       case BasicField.Attachment: {
-        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
-        if (!input) continue
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input) break
         // for each attachment response, find the corresponding quarantine bucket key
         const fieldIdToQuarantineKeyEntry = fieldIdToQuarantineKeyMap.find(
           (v) => v.fieldId === ff._id,
@@ -345,9 +361,10 @@ const createResponsesV3 = (
         break
       }
       case BasicField.Radio: {
-        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
-        if (!input) continue
-        if (!input.value && !input.othersInput) continue
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input?.value && !input?.othersInput) break
         returnedInputs[ff._id] = {
           fieldType: ff.fieldType,
           answer: input.othersInput

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -94,6 +94,7 @@ type CreateStorageSubmissionFormDataArgs = CreateEmailSubmissionFormDataArgs & {
 
 type CreateMultirespondentSubmissionFormDataArgs =
   CreateEmailSubmissionFormDataArgs & {
+    submissionSecretKey?: string
     version: number
   }
 
@@ -268,14 +269,55 @@ const createResponsesV3 = (
       case BasicField.Uen:
       case BasicField.Date:
       case BasicField.CountryRegion:
-      case BasicField.YesNo:
+      case BasicField.YesNo: {
+        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
+        if (!input) continue
+        returnedInputs[ff._id] = {
+          fieldType: ff.fieldType,
+          answer: input,
+        } as FieldResponseV3
+        break
+      }
       case BasicField.Email:
-      case BasicField.Mobile:
-      case BasicField.Table:
-      case BasicField.Checkbox:
+      case BasicField.Mobile: {
+        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
+        if (!input || !input.value) continue
+        returnedInputs[ff._id] = {
+          fieldType: ff.fieldType,
+          answer: input,
+        } as FieldResponseV3
+        break
+      }
+      case BasicField.Table: {
+        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
+        if (!input) continue
+        if (input.every((row) => Object.values(row).every((value) => !value))) {
+          continue
+        }
+        returnedInputs[ff._id] = {
+          fieldType: ff.fieldType,
+          answer: input,
+        } as FieldResponseV3
+        break
+      }
+      case BasicField.Checkbox: {
+        const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
+        if (!input) continue
+        if ((!input.value || input.value.length === 0) && !input.othersInput) {
+          continue
+        }
+        returnedInputs[ff._id] = {
+          fieldType: ff.fieldType,
+          answer: input,
+        } as FieldResponseV3
+        break
+      }
       case BasicField.Children: {
         const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
         if (!input) continue
+        if (input.child.every((child) => child.every((value) => !value))) {
+          continue
+        }
         returnedInputs[ff._id] = {
           fieldType: ff.fieldType,
           answer: input,
@@ -305,6 +347,7 @@ const createResponsesV3 = (
       case BasicField.Radio: {
         const input = formInputs[ff._id] as FormFieldValue<typeof ff.fieldType>
         if (!input) continue
+        if (!input.value && !input.othersInput) continue
         returnedInputs[ff._id] = {
           fieldType: ff.fieldType,
           answer: input.othersInput

--- a/frontend/src/features/public-form/utils/decryptSubmission.ts
+++ b/frontend/src/features/public-form/utils/decryptSubmission.ts
@@ -11,6 +11,7 @@ export const decryptSubmission = ({
 }):
   | (Omit<MultirespondentSubmissionDto, 'encryptedContent' | 'version'> & {
       responses: FieldResponsesV3
+      submissionSecretKey: string
     })
   | undefined => {
   if (!submission) throw Error('Encrypted submission undefined')
@@ -28,5 +29,6 @@ export const decryptSubmission = ({
   return {
     ...rest,
     responses: decryptedContent.responses as FieldResponsesV3,
+    submissionSecretKey: secretKey,
   }
 }

--- a/shared/utils/response-v3.ts
+++ b/shared/utils/response-v3.ts
@@ -1,0 +1,106 @@
+import { BasicField, FieldResponseV3 } from '../types'
+
+const areArraysEqual = <T>(
+  array1: T[],
+  array2: T[],
+  eq: (value1: T, value2: T) => boolean,
+): boolean =>
+  array1.length === array2.length &&
+  array1.every((value1, i) => eq(value1, array2[i]))
+
+export const areFieldResponseV3sEqual = (
+  response1: FieldResponseV3,
+  response2: FieldResponseV3,
+): boolean => {
+  if (response1.fieldType !== response2.fieldType) return false
+
+  switch (response1.fieldType) {
+    case BasicField.Number:
+    case BasicField.Decimal:
+    case BasicField.ShortText:
+    case BasicField.LongText:
+    case BasicField.HomeNo:
+    case BasicField.Dropdown:
+    case BasicField.Rating:
+    case BasicField.Nric:
+    case BasicField.Uen:
+    case BasicField.Date:
+    case BasicField.CountryRegion:
+    case BasicField.YesNo:
+      return response1.answer === response2.answer
+
+    case BasicField.Attachment: {
+      const response2Answer = response2.answer as typeof response1.answer
+      return (
+        response1.answer.answer === response2Answer.answer &&
+        response1.answer.hasBeenScanned === response2Answer.hasBeenScanned
+      )
+    }
+    case BasicField.Email:
+    case BasicField.Mobile: {
+      const response2Answer = response2.answer as typeof response1.answer
+      return (
+        response1.answer.value === response2Answer.value &&
+        response1.answer.signature === response2Answer.signature
+      )
+    }
+    case BasicField.Table: {
+      const response2Answer = response2.answer as typeof response1.answer
+      return areArraysEqual(
+        response1.answer,
+        response2Answer,
+        (row1, row2) =>
+          Object.keys(row1).length === Object.keys(row2).length &&
+          Object.keys(row1).every(
+            (columnId) => row1[columnId] === row2[columnId],
+          ),
+      )
+    }
+    case BasicField.Radio: {
+      if ('value' in response1.answer) {
+        const response2Answer = response2.answer as typeof response1.answer
+        return response1.answer.value === response2Answer.value
+      } else {
+        const response2Answer = response2.answer as typeof response1.answer
+        return response1.answer.othersInput === response2Answer.othersInput
+      }
+    }
+    case BasicField.Checkbox: {
+      const response2Answer = response2.answer as typeof response1.answer
+      return (
+        areArraysEqual(
+          response1.answer.value,
+          response2Answer.value,
+          (value1, value2) => value1 === value2,
+        ) && response1.answer.othersInput === response2Answer.othersInput
+      )
+    }
+    case BasicField.Children: {
+      const response2Answer = response2.answer as typeof response1.answer
+      return (
+        areArraysEqual(
+          response1.answer.child,
+          response2Answer.child,
+          (child1, child2) =>
+            areArraysEqual(
+              child1,
+              child2,
+              (value1, value2) => value1 === value2,
+            ),
+        ) &&
+        areArraysEqual(
+          response1.answer.childFields,
+          response2Answer.childFields,
+          (attr1, attr2) => attr1 === attr2,
+        )
+      )
+    }
+    case BasicField.Section:
+      return true
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _: never = response1
+      return false
+    }
+  }
+}

--- a/shared/utils/response-v3.ts
+++ b/shared/utils/response-v3.ts
@@ -1,20 +1,13 @@
+import _ from 'lodash'
 import { BasicField, FieldResponseV3 } from '../types'
 
-const areArraysEqual = <T>(
-  array1: T[],
-  array2: T[],
-  eq: (value1: T, value2: T) => boolean,
-): boolean =>
-  array1.length === array2.length &&
-  array1.every((value1, i) => eq(value1, array2[i]))
-
-export const areFieldResponseV3sEqual = (
-  response1: FieldResponseV3,
-  response2: FieldResponseV3,
+export const isFieldResponseV3Equal = (
+  l: FieldResponseV3,
+  r: FieldResponseV3,
 ): boolean => {
-  if (response1.fieldType !== response2.fieldType) return false
+  if (l.fieldType !== r.fieldType) return false
 
-  switch (response1.fieldType) {
+  switch (l.fieldType) {
     case BasicField.Number:
     case BasicField.Decimal:
     case BasicField.ShortText:
@@ -27,79 +20,25 @@ export const areFieldResponseV3sEqual = (
     case BasicField.Date:
     case BasicField.CountryRegion:
     case BasicField.YesNo:
-      return response1.answer === response2.answer
-
-    case BasicField.Attachment: {
-      const response2Answer = response2.answer as typeof response1.answer
-      return (
-        response1.answer.answer === response2Answer.answer &&
-        response1.answer.hasBeenScanned === response2Answer.hasBeenScanned
-      )
-    }
     case BasicField.Email:
-    case BasicField.Mobile: {
-      const response2Answer = response2.answer as typeof response1.answer
+    case BasicField.Mobile:
+    case BasicField.Table:
+    case BasicField.Radio:
+    case BasicField.Checkbox:
+    case BasicField.Children:
+      return _.isEqual(l.answer, r.answer)
+    case BasicField.Attachment: {
+      const rAnswer = r.answer as typeof l.answer
       return (
-        response1.answer.value === response2Answer.value &&
-        response1.answer.signature === response2Answer.signature
-      )
-    }
-    case BasicField.Table: {
-      const response2Answer = response2.answer as typeof response1.answer
-      return areArraysEqual(
-        response1.answer,
-        response2Answer,
-        (row1, row2) =>
-          Object.keys(row1).length === Object.keys(row2).length &&
-          Object.keys(row1).every(
-            (columnId) => row1[columnId] === row2[columnId],
-          ),
-      )
-    }
-    case BasicField.Radio: {
-      if ('value' in response1.answer) {
-        const response2Answer = response2.answer as typeof response1.answer
-        return response1.answer.value === response2Answer.value
-      } else {
-        const response2Answer = response2.answer as typeof response1.answer
-        return response1.answer.othersInput === response2Answer.othersInput
-      }
-    }
-    case BasicField.Checkbox: {
-      const response2Answer = response2.answer as typeof response1.answer
-      return (
-        areArraysEqual(
-          response1.answer.value,
-          response2Answer.value,
-          (value1, value2) => value1 === value2,
-        ) && response1.answer.othersInput === response2Answer.othersInput
-      )
-    }
-    case BasicField.Children: {
-      const response2Answer = response2.answer as typeof response1.answer
-      return (
-        areArraysEqual(
-          response1.answer.child,
-          response2Answer.child,
-          (child1, child2) =>
-            areArraysEqual(
-              child1,
-              child2,
-              (value1, value2) => value1 === value2,
-            ),
-        ) &&
-        areArraysEqual(
-          response1.answer.childFields,
-          response2Answer.childFields,
-          (attr1, attr2) => attr1 === attr2,
-        )
+        l.answer.answer === rAnswer.answer &&
+        l.answer.hasBeenScanned === rAnswer.hasBeenScanned
       )
     }
     case BasicField.Section:
       return true
     default: {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const _: never = response1
+      const _: never = l
       return false
     }
   }

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -424,9 +424,9 @@ const updateMultirespondentSubmission = async (
     await submission.save()
   } catch (err) {
     logger.error({
-      message: 'Encrypt submission save error',
+      message: 'Multirespondent submission save error',
       meta: {
-        action: 'onEncryptSubmissionFailure',
+        action: 'onMultirespondentSubmissionFailure',
         ...createReqMeta(req),
       },
       error: err,
@@ -491,8 +491,7 @@ export const handleMultirespondentSubmission = [
   MultirespondentSubmissionMiddleware.validateMultirespondentSubmissionParams,
   MultirespondentSubmissionMiddleware.createFormsgAndRetrieveForm,
   MultirespondentSubmissionMiddleware.scanAndRetrieveAttachments,
-  // TODO(MRF/FRM-1592): Add validation for FieldResponsesV3
-  // EncryptSubmissionMiddleware.validateStorageSubmission,
+  MultirespondentSubmissionMiddleware.validateMultirespondentSubmission,
   MultirespondentSubmissionMiddleware.encryptSubmission,
   submitMultirespondentForm,
 ] as ControllerHandler[]
@@ -501,10 +500,10 @@ export const handleUpdateMultirespondentSubmission = [
   CaptchaMiddleware.validateCaptchaParams,
   TurnstileMiddleware.validateTurnstileParams,
   ReceiverMiddleware.receiveMultirespondentSubmission,
-  MultirespondentSubmissionMiddleware.validateMultirespondentSubmissionParams,
+  MultirespondentSubmissionMiddleware.validateUpdateMultirespondentSubmissionParams,
   MultirespondentSubmissionMiddleware.createFormsgAndRetrieveForm,
   MultirespondentSubmissionMiddleware.scanAndRetrieveAttachments,
-  // EncryptSubmissionMiddleware.validateStorageSubmission,
+  MultirespondentSubmissionMiddleware.validateMultirespondentSubmission,
   MultirespondentSubmissionMiddleware.setCurrentWorkflowStep,
   MultirespondentSubmissionMiddleware.encryptSubmission,
   updateMultirespondentSubmission,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -10,7 +10,7 @@ import {
   FormResponseMode,
   SubmissionType,
 } from '../../../../../shared/types'
-import { areFieldResponseV3sEqual } from '../../../../../shared/utils/response-v3'
+import { isFieldResponseV3Equal } from '../../../../../shared/utils/response-v3'
 import { isDev } from '../../../../app/config/config'
 import { ParsedClearAttachmentResponseV3 } from '../../../../types/api'
 import { MultirespondentFormLoadedDto } from '../../../../types/api/multirespondent_submission'
@@ -447,7 +447,7 @@ export const validateMultirespondentSubmission = async (
 
                 return Result.combine(
                   nonEditableFieldIdsWithResponses.map((fieldId) =>
-                    areFieldResponseV3sEqual(
+                    isFieldResponseV3Equal(
                       req.body.responses[fieldId],
                       previousResponses[fieldId],
                     )

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -320,9 +320,9 @@ export const validateMultirespondentSubmission = async (
    * 2. Defined editable fields from workflow[0].edit.
    *     a. If no workflow, all fields are editable.
    * 3. Get visible fields by logic
-   * 4. CHECK: no preventing submit
-   * 5. CHECK: response fields C visible fields
-   * 6. CHECK: response fields C editable fields
+   * 4. CHECK: no logic block preventing submit
+   * 5. CHECK: response fields subset of visible fields
+   * 6. CHECK: response fields subset of editable fields
    * 7. CHECK: for each field, validate by its rules
    *
    * Subsequent submissions:
@@ -365,7 +365,7 @@ export const validateMultirespondentSubmission = async (
         }) => {
           // Step 0b: Determine editable fields based on the workflow step, if it exists.
           const editableFieldIds = (
-            workflow && !!workflow[workflowStep]
+            workflow[workflowStep]
               ? workflow[workflowStep].edit
               : form_fields.map((ff) => ff._id)
           ).map(String)

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -1,18 +1,25 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { NextFunction } from 'express'
 import { StatusCodes } from 'http-status-codes'
-import { err, errAsync, ok, Result, ResultAsync } from 'neverthrow'
+import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
 import {
   BasicField,
+  FieldResponsesV3,
+  FormDto,
   FormResponseMode,
   SubmissionType,
 } from '../../../../../shared/types'
+import { areFieldResponseV3sEqual } from '../../../../../shared/utils/response-v3'
 import { isDev } from '../../../../app/config/config'
 import { ParsedClearAttachmentResponseV3 } from '../../../../types/api'
 import { MultirespondentFormLoadedDto } from '../../../../types/api/multirespondent_submission'
 import formsgSdk from '../../../config/formsg-sdk'
 import { createLoggerWithLabel } from '../../../config/logger'
+import {
+  getLogicUnitPreventingSubmitV3,
+  getVisibleFieldIdsV3,
+} from '../../../utils/logic-adaptor'
 import { createReqMeta } from '../../../utils/request'
 import * as FeatureFlagService from '../../feature-flags/feature-flags.service'
 import { assertFormAvailable } from '../../form/admin-form/admin-form.utils'
@@ -23,6 +30,7 @@ import {
   DownloadCleanFileFailedError,
   InvalidSubmissionTypeError,
   MaliciousFileDetectedError,
+  ProcessingError,
   VirusScanFailedError,
 } from '../submission.errors'
 import {
@@ -34,7 +42,10 @@ import {
   mapRouteError,
 } from '../submission.utils'
 
-import { checkFormIsMultirespondent } from './multirespondent-submission.service'
+import {
+  checkFormIsMultirespondent,
+  getMultirespondentSubmission,
+} from './multirespondent-submission.service'
 import {
   CreateFormsgAndRetrieveFormMiddlewareHandlerRequest,
   MultirespondentSubmissionMiddlewareHandlerRequest,
@@ -45,74 +56,35 @@ import {
 
 const logger = createLoggerWithLabel(module)
 
-export const validateMultirespondentSubmissionParams = celebrate({
-  [Segments.BODY]: Joi.object({
-    responses: Joi.object().pattern(
-      /^[a-fA-F0-9]{24}$/,
-      Joi.object({
-        fieldType: Joi.string().valid(...Object.values(BasicField)),
-        //TODO(MRF/FRM-1592): Improve this validation, should match ParsedClearFormFieldResponseV3
-        answer: Joi.required(),
-      }),
-    ),
-    responseMetadata: Joi.object({
-      responseTimeMs: Joi.number(),
-      numVisibleFields: Joi.number(),
+const multirespondentSubmissionBodySchema = Joi.object({
+  responses: Joi.object().pattern(
+    /^[a-fA-F0-9]{24}$/,
+    Joi.object({
+      fieldType: Joi.string().valid(...Object.values(BasicField)),
+      //TODO(MRF/FRM-1592): Improve this validation, should match ParsedClearFormFieldResponseV3
+      answer: Joi.required(),
     }),
-    version: Joi.number().required(),
+  ),
+  responseMetadata: Joi.object({
+    responseTimeMs: Joi.number(),
+    numVisibleFields: Joi.number(),
   }),
+  version: Joi.number().required(),
 })
 
-export const setCurrentWorkflowStep = async (
-  req: ProcessedMultirespondentSubmissionHandlerRequest,
-  res: Parameters<MultirespondentSubmissionMiddlewareHandlerType>[1],
-  next: NextFunction,
-) => {
-  const { formId, submissionId } = req.params
-  if (!submissionId) {
-    return errAsync(new InvalidSubmissionTypeError())
-  }
-  const logMeta = {
-    action: 'setCurrentWorkflowStep',
-    submissionId,
-    formId,
-    ...createReqMeta(req),
-  }
+export const validateMultirespondentSubmissionParams = celebrate({
+  [Segments.BODY]: multirespondentSubmissionBodySchema,
+})
 
-  return (
-    // Step 1: Retrieve the full form object.
-    FormService.retrieveFullFormById(formId)
-      //Step 2: Check whether form is archived.
-      .andThen((form) => assertFormAvailable(form).map(() => form))
-      // Step 3: Check whether form is multirespondent mode.
-      .andThen(checkFormIsMultirespondent)
-      // Step 4: Is multirespondent mode form, retrieve submission data.
-      .andThen((form) =>
-        getEncryptedSubmissionData(form.responseMode, formId, submissionId),
-      )
-      // Step 6: Retrieve presigned URLs for attachments.
-      .map((submissionData) => {
-        if (submissionData.submissionType !== SubmissionType.Multirespondent) {
-          return errAsync(new InvalidSubmissionTypeError())
-        }
-        // Increment previous submission's workflow step by 1 to get workflow step of current submission
-        req.body.workflowStep = submissionData.workflowStep + 1
-        return next()
-      })
-      .mapErr((error) => {
-        logger.error({
-          message: 'Failure retrieving encrypted submission response',
-          meta: logMeta,
-          error,
-        })
+const updateMultirespondentSubmissionBodySchema =
+  multirespondentSubmissionBodySchema.append({
+    submissionSecretKey: Joi.string().required(),
+  })
 
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({
-          message: errorMessage,
-        })
-      })
-  )
-}
+export const validateUpdateMultirespondentSubmissionParams = celebrate({
+  [Segments.BODY]: updateMultirespondentSubmissionBodySchema,
+})
+
 /**
  * Creates formsg namespace in req.body and populates it with featureFlags, formDef and encryptedFormDef.
  */
@@ -322,6 +294,244 @@ export const scanAndRetrieveAttachments = async (
   }
 
   return next()
+}
+
+export const validateMultirespondentSubmission = async (
+  req: ProcessedMultirespondentSubmissionHandlerRequest,
+  res: Parameters<MultirespondentSubmissionMiddlewareHandlerType>[1],
+  next: NextFunction,
+) => {
+  const { formId, submissionId } = req.params
+
+  const logMeta = {
+    action: 'validateMultirespondentSubmission',
+    submissionId,
+    formId,
+    ...createReqMeta(req),
+  }
+  /**
+   * What types of fields are there?
+   *                Visible                     Not visible
+   * Editable       Regular field validation    Not allowed
+   * Non-editable   Not allowed / prev submiss  Not allowed
+   *
+   * Initial submission:
+   * 1. Retrieve form object
+   * 2. Defined editable fields from workflow[0].edit.
+   *     a. If no workflow, all fields are editable.
+   * 3. Get visible fields by logic
+   * 4. CHECK: no preventing submit
+   * 5. CHECK: response fields C visible fields
+   * 6. CHECK: response fields C editable fields
+   * 7. CHECK: for each field, validate by its rules
+   *
+   * Subsequent submissions:
+   * Identical to initial except in step 6, check that any response fields that
+   * were non-editable were indeed not edited (i.e. equality with previous submission)
+   */
+
+  return (
+    // Step 0: Prepare by retrieving relevant reference data
+    okAsync(submissionId)
+      .andThen((submissionId) =>
+        // Step 0a: If its an existing submission, use the reference data from
+        // the submission rather than the form
+        submissionId
+          ? getMultirespondentSubmission(submissionId).map((submission) => ({
+              previousSubmission: {
+                encryptedContent: submission.encryptedContent,
+                version: submission.version,
+              },
+              workflowStep: submission.workflowStep + 1,
+              workflow: submission.workflow,
+              form_fields: submission.form_fields,
+              form_logics: submission.form_logics,
+            }))
+          : okAsync({
+              previousSubmission: undefined,
+              workflowStep: 0,
+              workflow: req.formsg.formDef.workflow,
+              form_fields: req.formsg.formDef.form_fields,
+              form_logics: req.formsg.formDef.form_logics,
+            }),
+      )
+      .andThen(
+        ({
+          previousSubmission,
+          workflowStep,
+          workflow,
+          form_fields,
+          form_logics,
+        }) => {
+          // Step 0b: Determine editable fields based on the workflow step, if it exists.
+          const editableFieldIds = (
+            workflow && !!workflow[workflowStep]
+              ? workflow[workflowStep].edit
+              : form_fields.map((ff) => ff._id)
+          ).map(String)
+
+          const formPropertiesForLogicComputation = {
+            _id: formId,
+            form_fields,
+            form_logics,
+          } as Pick<FormDto, '_id' | 'form_fields' | 'form_logics'>
+
+          // Step 0c: Get visible fields based on evaluation of logic
+          return getVisibleFieldIdsV3(
+            req.body.responses,
+            formPropertiesForLogicComputation,
+          ).andThen((visibleFieldIds) =>
+            // Step 1: Check prevent submission logic
+            getLogicUnitPreventingSubmitV3(
+              req.body.responses,
+              formPropertiesForLogicComputation,
+              visibleFieldIds,
+            )
+              .andThen((logicUnitPreventingSubmit) =>
+                logicUnitPreventingSubmit
+                  ? err(
+                      new ProcessingError('Submission prevented by form logic'),
+                    )
+                  : ok(undefined),
+              )
+              .andThen(() =>
+                // Step 2: Check that response fields C visible fields
+                Object.keys(req.body.responses).every((fieldId) =>
+                  visibleFieldIds.has(fieldId),
+                )
+                  ? ok(undefined)
+                  : err(
+                      new ProcessingError(
+                        'Attempted to submit response on a hidden field',
+                      ),
+                    ),
+              )
+              .andThen(() => {
+                // Step 3: Match non-editable response fields to previous version
+                const nonEditableFieldIdsWithResponses = Object.keys(
+                  req.body.responses,
+                ).filter((fieldId) => !editableFieldIds.includes(fieldId))
+
+                // If it's the first submission, just check that response fields C editable fields
+                if (!previousSubmission) {
+                  return nonEditableFieldIdsWithResponses.length === 0
+                    ? ok(undefined)
+                    : err(
+                        new ProcessingError(
+                          'Attempted to submit response on a non-editable field',
+                        ),
+                      )
+                }
+
+                // If it's not the first submission, need to check that the responses match existing values from the DB
+                if (!req.body.submissionSecretKey) {
+                  return err(
+                    new ProcessingError('Submission secret key is required'),
+                  )
+                }
+
+                const previousSubmissionDecryptedContent =
+                  formsgSdk.cryptoV3.decryptFromSubmissionKey(
+                    req.body.submissionSecretKey,
+                    previousSubmission,
+                  )
+
+                if (!previousSubmissionDecryptedContent) {
+                  return err(
+                    new ProcessingError('Unable to decrypt previous response'),
+                  )
+                }
+
+                const previousResponses =
+                  previousSubmissionDecryptedContent.responses as FieldResponsesV3
+
+                return Result.combine(
+                  nonEditableFieldIdsWithResponses.map((fieldId) =>
+                    areFieldResponseV3sEqual(
+                      req.body.responses[fieldId],
+                      previousResponses[fieldId],
+                    )
+                      ? ok(undefined)
+                      : err(
+                          new ProcessingError(
+                            'Submitted response on a non-editable field which did not match previous response',
+                          ),
+                        ),
+                  ),
+                ).map(() => undefined)
+              })
+              .andThen(() =>
+                // TODO: Step 4: Validate each field content individually.
+                ok(undefined),
+              ),
+          )
+        },
+      )
+      .map(() => next())
+      .mapErr((error) => {
+        logger.error({
+          message: 'Validation failed on incoming multirespondent submission',
+          meta: logMeta,
+          error,
+        })
+
+        const { statusCode, errorMessage } = mapRouteError(error)
+        return res.status(statusCode).json({
+          message: errorMessage,
+        })
+      })
+  )
+}
+
+export const setCurrentWorkflowStep = async (
+  req: ProcessedMultirespondentSubmissionHandlerRequest,
+  res: Parameters<MultirespondentSubmissionMiddlewareHandlerType>[1],
+  next: NextFunction,
+) => {
+  const { formId, submissionId } = req.params
+  if (!submissionId) {
+    return errAsync(new InvalidSubmissionTypeError())
+  }
+  const logMeta = {
+    action: 'setCurrentWorkflowStep',
+    submissionId,
+    formId,
+    ...createReqMeta(req),
+  }
+
+  return (
+    // Step 1: Retrieve the full form object.
+    FormService.retrieveFullFormById(formId)
+      //Step 2: Check whether form is archived.
+      .andThen((form) => assertFormAvailable(form).map(() => form))
+      // Step 3: Check whether form is multirespondent mode.
+      .andThen(checkFormIsMultirespondent)
+      // Step 4: Is multirespondent mode form, retrieve submission data.
+      .andThen((form) =>
+        getEncryptedSubmissionData(form.responseMode, formId, submissionId),
+      )
+      // Step 6: Retrieve presigned URLs for attachments.
+      .map((submissionData) => {
+        if (submissionData.submissionType !== SubmissionType.Multirespondent) {
+          return errAsync(new InvalidSubmissionTypeError())
+        }
+        // Increment previous submission's workflow step by 1 to get workflow step of current submission
+        req.body.workflowStep = submissionData.workflowStep + 1
+        return next()
+      })
+      .mapErr((error) => {
+        logger.error({
+          message: 'Failure retrieving encrypted submission response',
+          meta: logMeta,
+          error,
+        })
+
+        const { statusCode, errorMessage } = mapRouteError(error)
+        return res.status(statusCode).json({
+          message: errorMessage,
+        })
+      })
+  )
 }
 
 /**

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1,12 +1,25 @@
-import { err, ok, Result } from 'neverthrow'
+import mongoose from 'mongoose'
+import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
 import { FormResponseMode } from '../../../../../shared/types'
 import {
+  IMultirespondentSubmissionSchema,
   IPopulatedForm,
   IPopulatedMultirespondentForm,
 } from '../../../../types'
+import { createLoggerWithLabel } from '../../../config/logger'
+import { getMultirespondentSubmissionModel } from '../../../models/submission.server.model'
+import { transformMongoError } from '../../../utils/handle-mongo-error'
+import { DatabaseError } from '../../core/core.errors'
 import { isFormMultirespondent } from '../../form/form.utils'
-import { ResponseModeError } from '../submission.errors'
+import {
+  ResponseModeError,
+  SubmissionNotFoundError,
+} from '../submission.errors'
+
+const logger = createLoggerWithLabel(module)
+
+const MultirespondentSubmission = getMultirespondentSubmissionModel(mongoose)
 
 export const checkFormIsMultirespondent = (
   form: IPopulatedForm,
@@ -20,3 +33,30 @@ export const checkFormIsMultirespondent = (
         ),
       )
 }
+
+export const getMultirespondentSubmission = (
+  submissionId: string,
+): ResultAsync<
+  IMultirespondentSubmissionSchema,
+  DatabaseError | SubmissionNotFoundError
+> =>
+  ResultAsync.fromPromise(
+    MultirespondentSubmission.findById(submissionId).exec(),
+    (error) => {
+      logger.error({
+        message:
+          'Error encountered while retrieving multirespondent submission',
+        meta: {
+          action: 'getMultirespondentSubmission',
+          submissionId,
+        },
+        error,
+      })
+      return transformMongoError(error)
+    },
+  ).andThen((submission) => {
+    if (!submission) {
+      return errAsync(new SubmissionNotFoundError())
+    }
+    return okAsync(submission)
+  })

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.types.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.types.ts
@@ -40,6 +40,7 @@ export type ProcessedMultirespondentSubmissionHandlerType = ControllerHandler<
   { formId: string; submissionId?: string },
   SubmissionResponseDto | SubmissionErrorDto,
   Omit<ParsedMultirespondentSubmissionBody, 'responses'> & {
+    submissionSecretKey?: string
     responses: ParsedClearFormFieldResponsesV3
   },
   { captchaResponse?: unknown; captchaType?: unknown }

--- a/src/app/utils/logic-adaptor.ts
+++ b/src/app/utils/logic-adaptor.ts
@@ -1,15 +1,9 @@
 import { err, ok, Result } from 'neverthrow'
 
-import { LOGIC_MAP } from '../../../shared/modules/logic'
 import {
-  BasicField,
-  FieldResponseAnswerMapV3,
   FieldResponsesV3,
   FormDto,
-  LogicableField,
   PreventSubmitLogicDto,
-  RadioFieldResponsesV3,
-  SingleAnswerResponseV3,
 } from '../../../shared/types'
 import { isNonEmpty } from '../../../shared/utils/isNonEmpty'
 import {
@@ -20,6 +14,8 @@ import {
 } from '../../../shared/utils/logic'
 import { FieldResponse, IFormDocument } from '../../types'
 import { ProcessingError } from '../modules/submission/submission.errors'
+
+import { isLogicableField, isNotLogicableField } from './typeguards'
 
 export { FieldIdSet } from '../../../shared/utils/logic'
 
@@ -68,30 +64,6 @@ export const getLogicUnitPreventingSubmitV3 = (
   )
 
 // Transformer functions
-
-type SingleAnswerLogicableField = Exclude<LogicableField, BasicField.Radio>
-
-const isLogicableField = (args: {
-  fieldType: BasicField
-  input: FieldResponseAnswerMapV3<BasicField>
-}): args is
-  | {
-      fieldType: SingleAnswerLogicableField
-      input: SingleAnswerResponseV3
-    }
-  | {
-      fieldType: BasicField.Radio
-      input: RadioFieldResponsesV3
-    } => [...LOGIC_MAP.keys()].includes(args.fieldType)
-
-const isNotLogicableField = (args: {
-  fieldType: BasicField
-  input: FieldResponseAnswerMapV3<BasicField>
-}): args is {
-  fieldType: Exclude<BasicField, LogicableField>
-  input: FieldResponseAnswerMapV3<BasicField>
-} => !isLogicableField(args)
-
 const fieldResponsesV3ToLogicFieldResponseTransformer = (
   submission: FieldResponsesV3,
   form_fields: FormDto['form_fields'],

--- a/src/app/utils/logic-adaptor.ts
+++ b/src/app/utils/logic-adaptor.ts
@@ -1,10 +1,22 @@
-import { ok, Result } from 'neverthrow'
+import { err, ok, Result } from 'neverthrow'
 
-import { FormDto, PreventSubmitLogicDto } from '../../../shared/types'
+import { LOGIC_MAP } from '../../../shared/modules/logic'
+import {
+  BasicField,
+  FieldResponseAnswerMapV3,
+  FieldResponsesV3,
+  FormDto,
+  LogicableField,
+  PreventSubmitLogicDto,
+  RadioFieldResponsesV3,
+  SingleAnswerResponseV3,
+} from '../../../shared/types'
+import { isNonEmpty } from '../../../shared/utils/isNonEmpty'
 import {
   FieldIdSet,
   getLogicUnitPreventingSubmit as logicGetLogicUnitPreventingSubmit,
   getVisibleFieldIds as logicGetVisibleFieldIds,
+  type LogicFieldResponse,
 } from '../../../shared/utils/logic'
 import { FieldResponse, IFormDocument } from '../../types'
 import { ProcessingError } from '../modules/submission/submission.errors'
@@ -31,3 +43,78 @@ export const getLogicUnitPreventingSubmit = (
     ),
   )
 }
+
+export const getVisibleFieldIdsV3 = (
+  submission: FieldResponsesV3,
+  form: Pick<FormDto, '_id' | 'form_fields' | 'form_logics'>,
+): Result<FieldIdSet, ProcessingError> =>
+  // Convert submission into a form understood by the shared function
+  fieldResponsesV3ToLogicFieldResponseTransformer(submission, form.form_fields)
+    // Call the shared logic evaluator
+    .map((responseData) =>
+      logicGetVisibleFieldIds(responseData, form as unknown as FormDto),
+    )
+
+export const getLogicUnitPreventingSubmitV3 = (
+  submission: FieldResponsesV3,
+  form: Pick<FormDto, '_id' | 'form_fields' | 'form_logics'>,
+  visibleFieldIds: FieldIdSet,
+): Result<PreventSubmitLogicDto | undefined, ProcessingError> =>
+  fieldResponsesV3ToLogicFieldResponseTransformer(
+    submission,
+    form.form_fields,
+  ).map((responseData) =>
+    logicGetLogicUnitPreventingSubmit(responseData, form, visibleFieldIds),
+  )
+
+// Transformer functions
+
+type SingleAnswerLogicableField = Exclude<LogicableField, BasicField.Radio>
+
+const isLogicableField = (args: {
+  fieldType: BasicField
+  input: FieldResponseAnswerMapV3<BasicField>
+}): args is
+  | {
+      fieldType: SingleAnswerLogicableField
+      input: SingleAnswerResponseV3
+    }
+  | {
+      fieldType: BasicField.Radio
+      input: RadioFieldResponsesV3
+    } => [...LOGIC_MAP.keys()].includes(args.fieldType)
+
+const isNotLogicableField = (args: {
+  fieldType: BasicField
+  input: FieldResponseAnswerMapV3<BasicField>
+}): args is {
+  fieldType: Exclude<BasicField, LogicableField>
+  input: FieldResponseAnswerMapV3<BasicField>
+} => !isLogicableField(args)
+
+const fieldResponsesV3ToLogicFieldResponseTransformer = (
+  submission: FieldResponsesV3,
+  form_fields: FormDto['form_fields'],
+): Result<LogicFieldResponse[], ProcessingError> =>
+  Result.combine(
+    form_fields.map((ff) => {
+      const input = submission[ff._id]?.answer
+      if (!input) return ok(null)
+      const fieldTypeAndInput = {
+        fieldType: ff.fieldType,
+        input,
+      }
+      // Type narrowing to help the typechecker along with complex if-else types
+      // Unfortunately, this requires the runtime check where isNotLogicableField
+      // is defined as !isLogicableField, allowing the final "else" case to be
+      // an unreachable code path.
+      if (isNotLogicableField(fieldTypeAndInput)) {
+        return ok({ _id: ff._id, fieldType: fieldTypeAndInput.fieldType })
+      } else if (isLogicableField(fieldTypeAndInput)) {
+        return ok({ _id: ff._id, ...fieldTypeAndInput })
+      } else {
+        // Unreachable branch
+        return err(new ProcessingError())
+      }
+    }),
+  ).map((responseData) => responseData.filter(isNonEmpty))

--- a/src/app/utils/logic-adaptor.ts
+++ b/src/app/utils/logic-adaptor.ts
@@ -8,8 +8,8 @@ import {
 import { isNonEmpty } from '../../../shared/utils/isNonEmpty'
 import {
   FieldIdSet,
-  getLogicUnitPreventingSubmit as logicGetLogicUnitPreventingSubmit,
-  getVisibleFieldIds as logicGetVisibleFieldIds,
+  getLogicUnitPreventingSubmit as sharedGetLogicUnitPreventingSubmit,
+  getVisibleFieldIds as sharedGetVisibleFieldIds,
   type LogicFieldResponse,
 } from '../../../shared/utils/logic'
 import { FieldResponse, IFormDocument } from '../../types'
@@ -23,7 +23,7 @@ export const getVisibleFieldIds = (
   submission: FieldResponse[],
   form: IFormDocument,
 ): Result<FieldIdSet, ProcessingError> => {
-  return ok(logicGetVisibleFieldIds(submission, form as unknown as FormDto))
+  return ok(sharedGetVisibleFieldIds(submission, form as unknown as FormDto))
 }
 
 export const getLogicUnitPreventingSubmit = (
@@ -32,7 +32,7 @@ export const getLogicUnitPreventingSubmit = (
   visibleFieldIds: FieldIdSet,
 ): Result<PreventSubmitLogicDto | undefined, ProcessingError> => {
   return ok(
-    logicGetLogicUnitPreventingSubmit(
+    sharedGetLogicUnitPreventingSubmit(
       submission,
       form as unknown as FormDto,
       visibleFieldIds,
@@ -48,7 +48,7 @@ export const getVisibleFieldIdsV3 = (
   fieldResponsesV3ToLogicFieldResponseTransformer(submission, form.form_fields)
     // Call the shared logic evaluator
     .map((responseData) =>
-      logicGetVisibleFieldIds(responseData, form as unknown as FormDto),
+      sharedGetVisibleFieldIds(responseData, form as unknown as FormDto),
     )
 
 export const getLogicUnitPreventingSubmitV3 = (
@@ -60,7 +60,7 @@ export const getLogicUnitPreventingSubmitV3 = (
     submission,
     form.form_fields,
   ).map((responseData) =>
-    logicGetLogicUnitPreventingSubmit(responseData, form, visibleFieldIds),
+    sharedGetLogicUnitPreventingSubmit(responseData, form, visibleFieldIds),
   )
 
 // Transformer functions

--- a/src/app/utils/typeguards.ts
+++ b/src/app/utils/typeguards.ts
@@ -1,0 +1,35 @@
+import { LOGIC_MAP } from '../../../shared/modules/logic'
+import {
+  BasicField,
+  FieldResponseAnswerMapV3,
+  LogicableField,
+  RadioFieldResponsesV3,
+  SingleAnswerResponseV3,
+} from '../../../shared/types'
+
+type SingleAnswerLogicableField = Exclude<LogicableField, BasicField.Radio>
+
+export const isLogicableField = (args: {
+  fieldType: BasicField
+  input: FieldResponseAnswerMapV3<BasicField>
+}): args is
+  | {
+      fieldType: SingleAnswerLogicableField
+      input: SingleAnswerResponseV3
+    }
+  | {
+      fieldType: BasicField.Radio
+      input: RadioFieldResponsesV3
+    } => {
+  return [...LOGIC_MAP.keys()].includes(args.fieldType)
+}
+
+export const isNotLogicableField = (args: {
+  fieldType: BasicField
+  input: FieldResponseAnswerMapV3<BasicField>
+}): args is {
+  fieldType: Exclude<BasicField, LogicableField>
+  input: FieldResponseAnswerMapV3<BasicField>
+} => {
+  return !isLogicableField(args)
+}


### PR DESCRIPTION
## Problem

Field locking currently only has frontend validation, but we need to implement backend validation for this as well.

Closes FRM-1640

## Solution

This PR implements the `MultirespondentSubmissionMiddleware.validateMultirespondentSubmission` function as it's main focus. Everything else is auxiliary and enables this function to be defined.

Shared logic functions are used to replicate evaluation of submission logic. A logic adaptor is built for the backend to make use of these shared functions. It uses the client version of the schema since `FieldResponseV3` is more similar to frontend `FormFieldValues` than they are to the older backend `FieldResponse`.

Additionally, most notably, as a result of needing to validate that non-editable fields are untouched, a notion of "response equality" is defined in `shared/utils/response-v3.ts`. Additionally, as the submission secret key is required for the backend to decrypt the existing submission in the database, the submission secret key is now sent to the backend from the frontend. This accounts for the frontend modifications seen in this PR.

Note that this PR does not account for field-level validation. This has been marked as a TODO in code, where each visible and editable field itself needs to be validated with it's own validation rules (e.g. required/optional, etc).

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

Create a multirespondent form with a simple workflow (e.g. two respondents). Make sure there are a mix of shared and unshared fields (in this case "shared" means editable by both respondent 1 and respondent 2). In this example, I created a Q1 radio, Q2 dropdown, Q3 email, Q4 checkbox, Q5 yes/no, Q6 short answer. Respondent 1 is assigned Q1-4 and respondent 2 is assigned Q3-6, so that Q3 and Q4 are shared.

Initial submission
- [ ] Send a valid submission via cURL. This should succeed.

```
curl 'http://localhost:3000/api/v3/forms/65680f30df564e005e446e2d/submissions/multirespondent?captchaResponse=null' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundarygrSB7FoxtaZ5Ycg7' \
  -H 'DNT: 1' \
  -H 'Origin: http://localhost:3000' \
  -H 'Referer: http://localhost:3000/65680f30df564e005e446e2d' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Not(A:Brand";v="24", "Chromium";v="122"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw $'------WebKitFormBoundarygrSB7FoxtaZ5Ycg7\r\nContent-Disposition: form-data; name="body"\r\n\r\n{"responses":{"6571f03219eb850112ae990e":{"fieldType":"radiobutton","answer":{"value":"Radio 1"}},"65d4238b1230effbfd6f74cb":{"fieldType":"dropdown","answer":"Dropdown 1"},"65f9257217e471530f22bcd9":{"fieldType":"email","answer":{"value":"justyn@open.gov.sg"}},"65d423891230effbfd6f74b7":{"fieldType":"checkbox","answer":{"value":["Checkbox 1"]}}},"responseMetadata":{"responseTimeMs":33230,"numVisibleFields":6},"version":3}\r\n------WebKitFormBoundarygrSB7FoxtaZ5Ycg7--\r\n'
{"message":"Form submission successful.","submissionId":"65f926ca17e471530f22bea5","timestamp":1710827210246}
```

- [ ] Send a submission where a respondent 2-only field (e.g. Q5/6) is filled. This should be rejected by the server.

```
curl 'http://localhost:3000/api/v3/forms/65680f30df564e005e446e2d/submissions/multirespondent?captchaResponse=null' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundarygrSB7FoxtaZ5Ycg7' \
  -H 'DNT: 1' \
  -H 'Origin: http://localhost:3000' \
  -H 'Referer: http://localhost:3000/65680f30df564e005e446e2d' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Not(A:Brand";v="24", "Chromium";v="122"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw $'------WebKitFormBoundarygrSB7FoxtaZ5Ycg7\r\nContent-Disposition: form-data; name="body"\r\n\r\n{"responses":{"6571f03219eb850112ae990e":{"fieldType":"radiobutton","answer":{"value":"Radio 1"}},"65d4238b1230effbfd6f74cb":{"fieldType":"dropdown","answer":"Dropdown 1"},"65f9257217e471530f22bcd9":{"fieldType":"email","answer":{"value":"justyn@open.gov.sg"}},"65d423891230effbfd6f74b7":{"fieldType":"checkbox","answer":{"value":["Checkbox 1"]}},"65f9258417e471530f22bd46":{"fieldType":"yes_no","answer":"Yes"}},"responseMetadata":{"responseTimeMs":33230,"numVisibleFields":6},"version":3}\r\n------WebKitFormBoundarygrSB7FoxtaZ5Ycg7--\r\n'
{"message":"There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page."}
```

Respondent 2 submission 
_(if you're copying cURL from a browser network tab, don't forget to change the submissionId in the URL, the response itself, and the submission secret key in the data section)_
- [ ] Send a valid submission via cURL. This should succeed.
- [ ] Send a submission where a shared field (e.g. Q3/4) is modified. This should succeed.

```
curl 'http://localhost:3000/api/v3/forms/65680f30df564e005e446e2d/submissions/65f926ca17e471530f22bea5?captchaResponse=null' \
  -X 'PUT' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryMAkuNxQsfBvsmprX' \
  -H 'DNT: 1' \
  -H 'Origin: http://localhost:3000' \
  -H 'Referer: http://localhost:3000/65680f30df564e005e446e2d/edit/65f9265b17e471530f22be96?key=o2QsH57uSqkqdkHelkoJt2UboIwb7alecrA7IOLlsJE%3D' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Not(A:Brand";v="24", "Chromium";v="122"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw $'------WebKitFormBoundaryMAkuNxQsfBvsmprX\r\nContent-Disposition: form-data; name="body"\r\n\r\n{"responses":{"6571f03219eb850112ae990e":{"fieldType":"radiobutton","answer":{"value":"Radio 1"}},"65d4238b1230effbfd6f74cb":{"fieldType":"dropdown","answer":"Dropdown 1"},"65f9257217e471530f22bcd9":{"fieldType":"email","answer":{"value":"justyn@open.gov.sg"}},"65d423891230effbfd6f74b7":{"fieldType":"checkbox","answer":{"value":["Checkbox 1","Checkbox 2"]}},"65f9258417e471530f22bd46":{"fieldType":"yes_no","answer":"No"},"65d423821230effbfd6f7464":{"fieldType":"textfield","answer":"abcde"}},"responseMetadata":{"responseTimeMs":7236,"numVisibleFields":6},"submissionSecretKey":"Z2T/aqbaHECMe+JX1Wpwlz0weEA9xm/m8PoSUCvR60U=","version":3}\r\n------WebKitFormBoundaryMAkuNxQsfBvsmprX--\r\n'
{"message":"Form submission successful.","submissionId":"65f926ca17e471530f22bea5","timestamp":1710827210246}
```

- [ ] Send a submission where a respondent 1-only field is modified. This should be rejected by the server.

```
curl 'http://localhost:3000/api/v3/forms/65680f30df564e005e446e2d/submissions/65f926ca17e471530f22bea5?captchaResponse=null' \
  -X 'PUT' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryMAkuNxQsfBvsmprX' \
  -H 'DNT: 1' \
  -H 'Origin: http://localhost:3000' \
  -H 'Referer: http://localhost:3000/65680f30df564e005e446e2d/edit/65f9265b17e471530f22be96?key=o2QsH57uSqkqdkHelkoJt2UboIwb7alecrA7IOLlsJE%3D' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36' \
  -H 'sec-ch-ua: "Not(A:Brand";v="24", "Chromium";v="122"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw $'------WebKitFormBoundaryMAkuNxQsfBvsmprX\r\nContent-Disposition: form-data; name="body"\r\n\r\n{"responses":{"6571f03219eb850112ae990e":{"fieldType":"radiobutton","answer":{"value":"Radio 2"}},"65d4238b1230effbfd6f74cb":{"fieldType":"dropdown","answer":"Dropdown 1"},"65f9257217e471530f22bcd9":{"fieldType":"email","answer":{"value":"justyn@open.gov.sg"}},"65d423891230effbfd6f74b7":{"fieldType":"checkbox","answer":{"value":["Checkbox 1"]}},"65f9258417e471530f22bd46":{"fieldType":"yes_no","answer":"No"},"65d423821230effbfd6f7464":{"fieldType":"textfield","answer":"abcde"}},"responseMetadata":{"responseTimeMs":7236,"numVisibleFields":6},"submissionSecretKey":"Z2T/aqbaHECMe+JX1Wpwlz0weEA9xm/m8PoSUCvR60U=","version":3}\r\n------WebKitFormBoundaryMAkuNxQsfBvsmprX--\r\n'
{"message":"There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page."}
```

Now, add logic to the form and make some fields optional.

Initial submission
- [ ] With prevent submit logic, send a valid submission via cURL. This should succeed.
- [ ] With prevent submit logic, send a submission via cURL such that submission should have been prevented. This should be rejected by the server.
- [ ] With show fields logic, send a valid submission via cURL. This should succeed.
- [ ] With show fields logic, send a submission via cURL such that a value is provided for a field that should have been hidden. This should be rejected by the server.

Respondent 2 submission 
_(take note that form fields and logic are saved with a submission lifetime, so you if you change the form logics you will need to make a new initial submission to generate a new edit link)_
- [ ] With prevent submit logic, send a valid submission via cURL. This should succeed.
- [ ] With prevent submit logic, send a submission via cURL such that submission should have been prevented. This should be rejected by the server.
- [ ] With show fields logic, send a valid submission via cURL. This should succeed.
- [ ] With show fields logic, send a submission via cURL such that a value is provided for a field that should have been hidden. This should be rejected by the server.

