### PR TITLE
fix: remove number and decimal scrolling

### DIFF
--- a/frontend/src/templates/Field/Decimal/DecimalField.tsx
+++ b/frontend/src/templates/Field/Decimal/DecimalField.tsx
@@ -37,7 +37,6 @@ export const DecimalField = ({
           <NumberInput
             inputMode="decimal"
             aria-label={`${schema.questionNumber}. ${schema.title}`}
-            allowMouseWheel
             preventDefaultOnEnter
             {...field}
           />

--- a/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.tsx
@@ -39,7 +39,6 @@ export const NumberField = ({
             inputMode="numeric"
             colorScheme={`theme-${colorTheme}`}
             aria-label={`${schema.questionNumber}. ${schema.title}`}
-            allowMouseWheel
             precision={0}
             value={value}
             preventDefaultOnEnter


### PR DESCRIPTION
## Problem
We want to remove the scrolling behavior on number and decimal fields.

## Solution

Remove the `allowMouseWheel` prop from number and decimal fields. See https://chakra-ui.com/docs/components/number-input/usage#increment-value-using-mouse-wheel for more info

**Breaking Changes** 
- No - this PR is backwards compatible  
