### PR TITLE
feat: disabling response limit toggle for MRF

### DIFF
--- a/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -109,7 +109,7 @@ export const FormLimitToggle = (): JSX.Element => {
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
-  const isMRF = settings?.responseMode === FormResponseMode.Multirespondent
+  const isMrf = settings?.responseMode === FormResponseMode.Multirespondent
 
   const { data: responseCount, isLoading: isLoadingCount } =
     useFormResponsesCount()
@@ -154,13 +154,13 @@ export const FormLimitToggle = (): JSX.Element => {
   return (
     <Skeleton isLoaded={!isLoadingSettings && !!settings} mt="2rem">
       <Toggle
-        isDisabled={isMRF}
+        isDisabled={isMrf}
         isLoading={mutateFormLimit.isLoading}
         isChecked={isLimit}
         label="Set a response limit"
         onChange={() => handleToggleLimit()}
       />
-      {isMRF ? (
+      {isMrf ? (
         <InlineMessage variant="warning" mt="0.5rem">
           Response limits cannot be applied for multi-respondent forms.
         </InlineMessage>

--- a/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -7,8 +7,11 @@ import {
 } from 'react'
 import { FormControl, Skeleton } from '@chakra-ui/react'
 
+import { FormResponseMode } from '~shared/types'
+
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
+import InlineMessage from '~components/InlineMessage'
 import NumberInput from '~components/NumberInput'
 import Toggle from '~components/Toggle'
 
@@ -106,6 +109,8 @@ export const FormLimitToggle = (): JSX.Element => {
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
+  const isMRF = settings?.responseMode === FormResponseMode.Multirespondent
+
   const { data: responseCount, isLoading: isLoadingCount } =
     useFormResponsesCount()
 
@@ -149,11 +154,17 @@ export const FormLimitToggle = (): JSX.Element => {
   return (
     <Skeleton isLoaded={!isLoadingSettings && !!settings} mt="2rem">
       <Toggle
+        isDisabled={isMRF}
         isLoading={mutateFormLimit.isLoading}
         isChecked={isLimit}
         label="Set a response limit"
         onChange={() => handleToggleLimit()}
       />
+      {isMRF ? (
+        <InlineMessage variant="warning" mt="0.5rem">
+          Response limits cannot be applied for multi-respondent forms.
+        </InlineMessage>
+      ) : null}
       {settings && settings?.submissionLimit !== null && (
         <Skeleton isLoaded={!isLoadingCount}>
           <FormLimitBlock


### PR DESCRIPTION
## Problem
Imposing a response limit is only applicable for forms in email or storage mode and not for MRF (because response tracking works differently in the context of MRF). Hence the response limit toggle should be disabled for MRF forms.

Closes FRM-1693

## Solution
As a user, the response limit toggle should be disabled when using an MRF so that it is clear this feature is not intended for MRFs (and reduce potential confusion and errors if a response limit were to be set for MRFs)

**Breaking Changes** 

- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="736" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/c9d593f3-a763-4565-8b5f-9481f0c6b190">

**AFTER**:
<img width="722" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/7cfb862d-1ed1-41d6-a9f3-e70c7bd5b2b5">


## Manual Tests

- [ ] Create a multi-respondent form
- [ ] Proceed to Settings >> General
- [ ] Response limit toggle should be disabled

