### PR TITLE
feat: disabling submit another response button (MRF)

### DIFF
--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -86,9 +86,7 @@ export const EndPageBlock = ({
           </Text>
         </Box>
         <Box mt="2.25rem">
-          {disableSubmitResponseButton ? (
-            <></>
-          ) : (
+          {disableSubmitResponseButton || (
             <Button
               as="a"
               href={endPage.buttonLink || window.location.href}

--- a/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/EndPageBlock.tsx
@@ -8,7 +8,10 @@ import { useMdComponents } from '~hooks/useMdComponents'
 import Button from '~components/Button'
 import { MarkdownText } from '~components/MarkdownText'
 
-import { SubmissionData } from '~features/public-form/PublicFormContext'
+import {
+  SubmissionData,
+  usePublicFormContext,
+} from '~features/public-form/PublicFormContext'
 
 export interface EndPageBlockProps {
   formTitle: FormDto['title'] | undefined
@@ -53,6 +56,9 @@ export const EndPageBlock = ({
     return 'You have successfully submitted your response.'
   }, [formTitle])
 
+  const { previousSubmissionId } = usePublicFormContext()
+  const disableSubmitResponseButton = !!previousSubmissionId //disable for MRF 2nd respondent onwards
+
   return (
     <>
       <Box ref={focusRef}>
@@ -80,14 +86,18 @@ export const EndPageBlock = ({
           </Text>
         </Box>
         <Box mt="2.25rem">
-          <Button
-            as="a"
-            href={endPage.buttonLink || window.location.href}
-            variant="solid"
-            colorScheme={`theme-${colorTheme}`}
-          >
-            {endPage.buttonText || 'Submit another response'}
-          </Button>
+          {disableSubmitResponseButton ? (
+            <></>
+          ) : (
+            <Button
+              as="a"
+              href={endPage.buttonLink || window.location.href}
+              variant="solid"
+              colorScheme={`theme-${colorTheme}`}
+            >
+              {endPage.buttonText || 'Submit another response'}
+            </Button>
+          )}
         </Box>
       </Box>
     </>


### PR DESCRIPTION
## Problem
The `Submit Another Response` button should be disabled for MRF forms' 2nd respondent onwards because the link used by the 2nd respondent onwards is meant to be a one-time link, and should not be re-accessed anymore. Hence, users who are 2nd respondents onwards should not be able to submit another response (and hence should not be accessing that link anymore after submitting).

This can be allowed for 1st respondents since the link is a public URL and is mean to be accessed by anyone with the link (use case: many applicants can access the link to submit an application, but backend, the approver should be approving the unique applications one by one) 

To note: look into editing approvals in applications in the future?

Closes FRM-1694

## Solution
The user should not be able to see the `Submit another response` button after submitting the form if they are Respondent 2 onwards so that it is clear that the process is meant for the respondents to only access the form once if they are not the first respondent.

**Breaking Changes** 

- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="737" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/f4e05eb1-07f6-42d2-8bd5-5944f436b5ef">

**AFTER**:
<img width="747" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/b9a18c56-c273-476b-8d3b-825fd04d9e37">

## Manual Tests

**Check MRF forms**
- [ ] Create an MRF form
- [ ] Create a workflow for multiple respondents under `Add Workflow`
- [ ] Make a first submission as a first respondent 
- [ ] Check that the `Submit another response` button should be visible in the Thank you page
- [ ] Make a submission as a second respondent
- [ ] Check that the `Submit another response` button should be hidden/ not visible in the Thank you page

**Check non-MRF forms**
- [ ] Create a normal non-MRF form
- [ ]  Make a submission
- [ ] Check that the `Submit another response` button should be visible in the Thank you page
