### PR TITLE
fix(mrf): skip verifying OTP signatures on decryption for export

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -139,12 +139,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     }
   }, [isPdfResponseEnabled])
 
-  // vfn is not supported on MRF
-  const isToggleVfnDisabled = useMemo(
-    () => form?.responseMode === FormResponseMode.Multirespondent,
-    [form],
-  )
-
   // email confirmation is not supported on MRF
   const isToggleEmailConfirmationDisabled = useMemo(
     () => form?.responseMode === FormResponseMode.Multirespondent,
@@ -170,7 +164,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
       <FormControl isReadOnly={isLoading}>
         <Toggle {...register('required')} label="Required" />
       </FormControl>
-      <FormControl isReadOnly={isLoading} isDisabled={isToggleVfnDisabled}>
+      <FormControl isReadOnly={isLoading}>
         <Toggle
           {...register('isVerifiable')}
           label="OTP verification"

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import { Box, FormControl, useDisclosure } from '@chakra-ui/react'
 import { extend, pick } from 'lodash'
 
-import { FormResponseMode } from '~shared/types'
 import { MobileFieldBase } from '~shared/types/field'
 
 import { createBaseValidationRules } from '~utils/fieldValidation'
@@ -63,20 +62,13 @@ export const EditMobile = ({ field }: EditMobileProps): JSX.Element => {
 
   const { data: freeSmsCount } = useFreeSmsQuota()
   const isToggleVfnDisabled = useMemo(() => {
-    // vfn is not supported on MRF
-    if (form?.responseMode === FormResponseMode.Multirespondent) return true
     if (!freeSmsCount) return true
     return (
       !field.isVerifiable &&
       !hasTwilioCredentials &&
       freeSmsCount.freeSmsCounts >= freeSmsCount.quota
     )
-  }, [
-    field.isVerifiable,
-    freeSmsCount,
-    hasTwilioCredentials,
-    form?.responseMode,
-  ])
+  }, [field.isVerifiable, freeSmsCount, hasTwilioCredentials])
 
   const smsCountsDisclosure = useDisclosure()
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -138,7 +138,11 @@ async function decryptIntoCsv(data: LineData): Promise<MaterializedCsvRecord> {
         }
       }
 
-      if (verifySignature(decryptedSubmission, submission.created)) {
+      if (
+        // Short-circuit signature verification for multirespondent submission
+        submission.submissionType === SubmissionType.Multirespondent ||
+        verifySignature(decryptedSubmission, submission.created)
+      ) {
         csvRecord.setStatus(CsvRecordStatus.Ok, 'Success')
         csvRecord.setRecord(decryptedSubmission)
       } else {


### PR DESCRIPTION
## Problem

On MRFs, verified fields are currently not available (email and mobile OTP verification). The primary reason is that while the verification flows all work, exporting fails due to the signatures being matched with the `createdAt` time of the submission.

Closes FRM-1615

## Solution

This PR skips the verification check for MRFs so that it is only conducted on storage mode responses. 

At the same time, the OTP verification toggles for email and mobile are re-enabled (ref: #7106).

Potential TODO: Open another ticket to investigate if re-enabling this is required.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

- [ ] Create an MRF form with email and mobile otp for respondent 1 and another email and mobile otp for respondent 2. Fill the form for both respondents, then attempt to export the results as CSV. This should work.