### PR TITLE
feat: Disabling MRF for Forms with SingPass

### DIFF
--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -22,7 +22,7 @@ export const useUseTemplateWizardContext = (
       /* enabled= */ !!formId,
     )
 
-  const hasSingpass = !!templateFormData?.spcpSession
+  const isSingpass = !!templateFormData?.spcpSession
 
   const { formMethods, currentStep, direction, keypair, setCurrentStep } =
     useCommonFormWizardProvider()
@@ -93,7 +93,7 @@ export const useUseTemplateWizardContext = (
     formMethods,
     handleDetailsSubmit,
     handleCreateStorageModeOrMultirespondentForm,
-    hasSingpass,
+    isSingpass,
     modalHeader: 'Duplicate form',
   }
 }

--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -22,6 +22,8 @@ export const useUseTemplateWizardContext = (
       /* enabled= */ !!formId,
     )
 
+  const hasSingpass = !!templateFormData?.spcpSession
+
   const { formMethods, currentStep, direction, keypair, setCurrentStep } =
     useCommonFormWizardProvider()
 
@@ -91,6 +93,7 @@ export const useUseTemplateWizardContext = (
     formMethods,
     handleDetailsSubmit,
     handleCreateStorageModeOrMultirespondentForm,
+    hasSingpass,
     modalHeader: 'Duplicate form',
   }
 }

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -38,7 +38,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     isLoading,
     isFetching,
     modalHeader,
-    hasSingpass,
+    isSingpass,
   } = useCreateFormWizard()
   const {
     register,
@@ -90,7 +90,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
                     <FormResponseOptions
                       {...field}
                       showMrf={showMrf}
-                      hasSingpass={hasSingpass}
+                      isSingpass={isSingpass}
                     />
                   </WorkspaceRowsProvider>
                 )}
@@ -98,11 +98,10 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
               />
             </Skeleton>
             <FormErrorMessage>{errors.responseMode?.message}</FormErrorMessage>
-            {!hasSingpass || (
+            {isSingpass && (
               <InlineMessage mt="2rem">
-                {
-                  'The form you are trying to duplicate has Singpass authentication which is not supported for Multi-respondent forms.'
-                }
+                The form you are trying to duplicate has Singpass authentication
+                which is not supported for Multi-respondent forms.
               </InlineMessage>
             )}
           </FormControl>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -98,14 +98,12 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
               />
             </Skeleton>
             <FormErrorMessage>{errors.responseMode?.message}</FormErrorMessage>
-            {hasSingpass ? (
+            {!hasSingpass || (
               <InlineMessage mt="2rem">
                 {
                   'The form you are trying to duplicate has Singpass authentication which is not supported for Multi-respondent forms.'
                 }
               </InlineMessage>
-            ) : (
-              <></>
             )}
           </FormControl>
           {responseModeValue === FormResponseMode.Email && (

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -17,10 +17,12 @@ import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormFieldMessage from '~components/FormControl/FormFieldMessage'
 import FormLabel from '~components/FormControl/FormLabel'
+import InlineMessage from '~components/InlineMessage'
 import Input from '~components/Input'
 
 import { useUser } from '~features/user/queries'
 
+import { WorkspaceRowsProvider } from '../../WorkspaceFormRow/WorkspaceRowsContext'
 import { useCreateFormWizard } from '../CreateFormWizardContext'
 
 import { EmailFormRecipientsInput } from './EmailFormRecipientsInput'
@@ -36,6 +38,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     isLoading,
     isFetching,
     modalHeader,
+    hasSingpass,
   } = useCreateFormWizard()
   const {
     register,
@@ -83,12 +86,27 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
                 name="responseMode"
                 control={control}
                 render={({ field }) => (
-                  <FormResponseOptions {...field} showMrf={showMrf} />
+                  <WorkspaceRowsProvider>
+                    <FormResponseOptions
+                      {...field}
+                      showMrf={showMrf}
+                      hasSingpass={hasSingpass}
+                    />
+                  </WorkspaceRowsProvider>
                 )}
                 rules={{ required: 'Please select a form response mode' }}
               />
             </Skeleton>
             <FormErrorMessage>{errors.responseMode?.message}</FormErrorMessage>
+            {hasSingpass ? (
+              <InlineMessage mt="2rem">
+                {
+                  'The form you are trying to duplicate has Singpass authentication which is not supported for Multi-respondent forms.'
+                }
+              </InlineMessage>
+            ) : (
+              <></>
+            )}
           </FormControl>
           {responseModeValue === FormResponseMode.Email && (
             <FormControl isRequired isInvalid={!!errors.emails} mb="2.25rem">

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -11,6 +11,7 @@ export interface FormResponseOptionsProps {
   onChange: (option: FormResponseMode) => void
   value: FormResponseMode
   showMrf: boolean
+  hasSingpass: boolean
 }
 
 const OptionDescription = ({ listItems = [] }: { listItems: string[] }) => {
@@ -30,7 +31,7 @@ const OptionDescription = ({ listItems = [] }: { listItems: string[] }) => {
 export const FormResponseOptions = forwardRef<
   FormResponseOptionsProps,
   'button'
->(({ value, onChange, showMrf }, ref) => {
+>(({ value, onChange, showMrf, hasSingpass }, ref) => {
   return (
     <Stack spacing="1rem" w="100%" direction={{ base: 'column', md: 'row' }}>
       <Tile
@@ -86,6 +87,7 @@ export const FormResponseOptions = forwardRef<
           onClick={() => onChange(FormResponseMode.Multirespondent)}
           isFullWidth
           flex={1}
+          isDisabled={hasSingpass}
         >
           <Tile.Title>Multi-respondent form</Tile.Title>
           <Tile.Subtitle>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -11,7 +11,7 @@ export interface FormResponseOptionsProps {
   onChange: (option: FormResponseMode) => void
   value: FormResponseMode
   showMrf: boolean
-  hasSingpass: boolean
+  isSingpass: boolean
 }
 
 const OptionDescription = ({ listItems = [] }: { listItems: string[] }) => {
@@ -31,7 +31,7 @@ const OptionDescription = ({ listItems = [] }: { listItems: string[] }) => {
 export const FormResponseOptions = forwardRef<
   FormResponseOptionsProps,
   'button'
->(({ value, onChange, showMrf, hasSingpass }, ref) => {
+>(({ value, onChange, showMrf, isSingpass }, ref) => {
   return (
     <Stack spacing="1rem" w="100%" direction={{ base: 'column', md: 'row' }}>
       <Tile
@@ -87,7 +87,7 @@ export const FormResponseOptions = forwardRef<
           onClick={() => onChange(FormResponseMode.Multirespondent)}
           isFullWidth
           flex={1}
-          isDisabled={hasSingpass}
+          isDisabled={isSingpass}
         >
           <Tile.Title>Multi-respondent form</Tile.Title>
           <Tile.Subtitle>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -34,7 +34,7 @@ export type CreateFormWizardContextReturn = {
   isFetching: boolean
   isLoading: boolean
   modalHeader: string
-  hasSingpass: boolean
+  isSingpass: boolean
 }
 
 export const CreateFormWizardContext = createContext<

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -34,6 +34,7 @@ export type CreateFormWizardContextReturn = {
   isFetching: boolean
   isLoading: boolean
   modalHeader: string
+  hasSingpass: boolean
 }
 
 export const CreateFormWizardContext = createContext<

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -114,7 +114,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
     formMethods,
     handleDetailsSubmit,
     handleCreateStorageModeOrMultirespondentForm,
-    hasSingpass: false,
+    isSingpass: false,
     modalHeader: 'Set up your form',
   }
 }

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -114,6 +114,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
     formMethods,
     handleDetailsSubmit,
     handleCreateStorageModeOrMultirespondentForm,
+    hasSingpass: false,
     modalHeader: 'Set up your form',
   }
 }

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -31,7 +31,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
 
   const { reset, getValues } = formMethods
 
-  const hasSingpass = !!previewFormData?.spcpSession
+  const isSingpass = !!previewFormData?.spcpSession
 
   // Async set defaultValues onto modal inputs.
   useEffect(() => {
@@ -117,7 +117,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
     formMethods,
     handleDetailsSubmit,
     handleCreateStorageModeOrMultirespondentForm,
-    hasSingpass,
+    isSingpass,
     modalHeader: 'Duplicate form',
   }
 }

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -31,6 +31,8 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
 
   const { reset, getValues } = formMethods
 
+  const hasSingpass = !!previewFormData?.spcpSession
+
   // Async set defaultValues onto modal inputs.
   useEffect(() => {
     if (
@@ -115,6 +117,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
     formMethods,
     handleDetailsSubmit,
     handleCreateStorageModeOrMultirespondentForm,
+    hasSingpass,
     modalHeader: 'Duplicate form',
   }
 }


### PR DESCRIPTION
## Problem
Currently Singpass is not compatible with MRF, and if someone shares a form that is SingPass enabled, it could cause the form to break when someone submits the MRF form. We should prevent users from duplicating forms that are singpass enabled to MRF to prevent errors that could occur downstream (at least until singpass features are built for MRF)

Closes FRM-1676

## Solution
If a user duplicates an email/ storage-mode form that is SingPass enabled to an MRF, the option for MRF should be disabled to prevent the user from duplicating the form until the SingPass settings are disabled.

**Breaking Changes** 

- No - this PR is backwards compatible  

## Before & After Screenshots

**Without SingPass or creating a new form**:
<img width="1160" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/62ec8e07-aaae-402e-9ef5-9f9907aac239">

**If SingPass is enabled**:

<img width="1158" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/53fdc3a2-e2c4-44d9-9dac-088d2ac82012">

## Manual Tests
**Creating a new form**

- [ ] Create a new form
- [ ] All 3 options for Storage mode, email mode and MRF should be selectable

**Duplicating a form without SingPass**

- [ ] Duplicate a form without SingPass
- [ ] All 3 options for Storage mode, email mode and MRF should be selectable

**Duplicating a form with SingPass**

- [ ] Duplicate a form with SingPass enabled
- [ ] The option for MRF should be disabled, and not be able to be selected to proceed with the form duplication
