### PR TITLE
chore(mrf): prevent form activation if email confirmation is present

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -147,8 +147,10 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
 
   // email confirmation is not supported on MRF
   const isToggleEmailConfirmationDisabled = useMemo(
-    () => form?.responseMode === FormResponseMode.Multirespondent,
-    [form],
+    () =>
+      form?.responseMode === FormResponseMode.Multirespondent &&
+      !field.autoReplyOptions.hasAutoReply,
+    [field.autoReplyOptions.hasAutoReply, form?.responseMode],
   )
 
   return (


### PR DESCRIPTION
## Problem
When users duplicate their forms from email/storage mode to MRF, they may have email confirmations present. We want to prevent them from opening the form with this setting enabled. This is purely a frontend block.

Closes FRM-1677

## Solution

Perform a check on the activation toggle, pre-activation. Also, enable users to un-toggle the email confirmation in the email field themselves (i.e., only disable the toggle if email confirmations is already off).

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots

<img width="834" alt="image" src="https://github.com/opengovsg/FormSG/assets/25571626/3b43ef95-9400-4698-a03b-c0f91df98184">
