### PR TITLE
chore: remove unused jwt-decode package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
         "jsonwebtoken": "^9.0.2",
         "jszip": "^3.10.1",
         "jwk-to-pem": "^2.0.5",
-        "jwt-decode": "^3.1.2",
         "libphonenumber-js": "^1.10.59",
         "lodash": "^4.17.21",
         "moment-timezone": "0.5.41",
@@ -19484,10 +19483,6 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "license": "MIT"
     },
     "node_modules/kareem": {
       "version": "2.5.1",
@@ -41564,9 +41559,6 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
-    },
-    "jwt-decode": {
-      "version": "3.1.2"
     },
     "kareem": {
       "version": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "jsonwebtoken": "^9.0.2",
     "jszip": "^3.10.1",
     "jwk-to-pem": "^2.0.5",
-    "jwt-decode": "^3.1.2",
     "libphonenumber-js": "^1.10.59",
     "lodash": "^4.17.21",
     "moment-timezone": "0.5.41",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Unused package. Reduces noise from dependabot / snyk.

Closes #7187

## Solution
<!-- How did you solve the problem? -->

- `jwt-decode` is no longer [used](https://github.com/opengovsg/FormSG/blob/v4.45.0/src/public/modules/forms/services/spcp-session.client.factory.js#L3)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
