### PR TITLE
fix(mrf): remove any response limits for MRF

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -600,7 +600,8 @@ export const duplicateForm = (
     overrideProps.endPage = omit(originalForm.endPage, 'buttonLink')
   }
 
-  // if MRF, set submissionLimit (i.e. response limit) = null
+  // if MRF, set submissionLimit = null
+  // this is because MRF does not support submission limit (i.e. response limit)
 
   if (overrideProps.responseMode === FormResponseMode.Multirespondent) {
     overrideProps.submissionLimit = null

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -600,6 +600,12 @@ export const duplicateForm = (
     overrideProps.endPage = omit(originalForm.endPage, 'buttonLink')
   }
 
+  // if MRF, set submissionLimit (i.e. response limit) = null
+
+  if (overrideProps.responseMode === FormResponseMode.Multirespondent) {
+    overrideProps.submissionLimit = null
+  }
+
   const duplicateParams = originalForm.getDuplicateParams(overrideProps)
 
   if (workspaceId)

--- a/src/app/modules/form/admin-form/admin-form.types.ts
+++ b/src/app/modules/form/admin-form/admin-form.types.ts
@@ -30,6 +30,7 @@ export type OverrideProps = {
   responseMode: FormResponseMode
   emails?: string | string[]
   publicKey?: string
+  submissionLimit?: number | null
 }
 
 export type EditFormFieldResult = Result<FormFieldSchema[], EditFieldError>


### PR DESCRIPTION
## Problem
If a user already sets a response limit and duplicates the form as an MRF, the response limit would be set but is disabled and the user will not be able to turn off the response limit:

![image](https://github.com/opengovsg/FormSG/assets/89055608/8fda29da-bbe3-4fa0-b3f0-0ba82cf4704c)

Closes FRM-1698

## Solution
If a user duplicates a form to MRF that was originally on email/storage mode, and a response limit has been set, the new MRF form should have it's response limit switched off.

**Breaking Changes** 

- No - this PR is backwards compatible  

## Before & After Screenshots

**AFTER**:
![image](https://github.com/opengovsg/FormSG/assets/89055608/9b9f6fe0-f16a-4f56-b820-00737c11ffc2)


## Manual Tests

- [ ] Create a form on email or storage mode
- [ ] Switch on the response limit (using the toggle) under Settings
- [ ] Duplicate the form which has a response limit set to an MRF
- [ ] Check that within the duplicated MRF, the response limit under Settings is switched off and the toggle disabled (hence there is no way for the response limit to be on for MRFs)
