### PR TITLE
refactor: move override code closer to other overrides

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
@@ -298,6 +298,7 @@ describe('admin-form.utils', () => {
         title: params.title,
         admin: newAdminId,
         publicKey: params.publicKey,
+        submissionLimit: null,
       }
       expect(actual).toEqual(expected)
     })

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -600,13 +600,6 @@ export const duplicateForm = (
     overrideProps.endPage = omit(originalForm.endPage, 'buttonLink')
   }
 
-  // if MRF, set submissionLimit = null
-  // this is because MRF does not support submission limit (i.e. response limit)
-
-  if (overrideProps.responseMode === FormResponseMode.Multirespondent) {
-    overrideProps.submissionLimit = null
-  }
-
   const duplicateParams = originalForm.getDuplicateParams(overrideProps)
 
   if (workspaceId)

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -349,6 +349,7 @@ export const processDuplicateOverrideProps = (
     case FormResponseMode.Encrypt:
     case FormResponseMode.Multirespondent:
       overrideProps.publicKey = params.publicKey
+      overrideProps.submissionLimit = null
       break
     case FormResponseMode.Email:
       overrideProps.emails = params.emails


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
There's already a function that keeps all the duplication exclusion rules. We should use that.

Thanks @justynoh for highlighting an even better way.


## Solution
<!-- How did you solve the problem? -->

Move override statement into `processDuplicateOverrideProps` function.
