### PR TITLE
chore: update mrf copy on create-page

### DIFF
--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -90,12 +90,13 @@ export const FormResponseOptions = forwardRef<
         >
           <Tile.Title>Multi-respondent form</Tile.Title>
           <Tile.Subtitle>
-            Create a workflow to collect responses from multiple respondents
+            Create a workflow to collect responses from multiple respondents in
+            the same form submission
           </Tile.Subtitle>
           <OptionDescription
             listItems={[
               'Route form to respondents according to a sequence',
-              'Specify up to two respondents to route form to for filling',
+              'Assign fields and specify respondents to route form to for filling',
             ]}
           />
         </Tile>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Create page
- Change subheader copy on MRF tile to - ‘Create a workflow to collect responses from multiple respondents in the same form submission’
- Change second bullet point copy on MRF tile to - ‘Assign fields and specify respondents to route form to for filling’

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  


## Before & After Screenshots

| Item | Before | After |
|--------|--------|--------|
| CreateFormModalContent | ![Screenshot 2024-03-28 at 4 34 21 PM](https://github.com/opengovsg/FormSG/assets/12391617/c3c23246-837a-4305-8be7-3399d746cbd6) | ![Screenshot 2024-03-28 at 4 36 01 PM](https://github.com/opengovsg/FormSG/assets/12391617/fea8d344-6bd3-46ac-b143-f28c98be8f2c) |
