### PR TITLE
fix(mrf): design review results page

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -72,9 +72,7 @@ const StackRow = ({
           {label}:
         </Text>
       </Box>
-      <Skeleton isLoaded={!isLoading && !isError}>
-        <Box>{children}</Box>
-      </Skeleton>
+      <Skeleton isLoaded={!isLoading && !isError}>{children}</Skeleton>
     </Stack>
   )
 }

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -57,7 +57,7 @@ const StackRow = ({
   isError,
 }: {
   label: string
-  children: string | ReactNode
+  children: ReactNode
   isLoading: boolean
   isError: boolean
 }) => {

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react'
+import { memo, ReactNode, useCallback, useMemo } from 'react'
 import { BiDownload } from 'react-icons/bi'
 import { useParams } from 'react-router-dom'
 import {
@@ -52,12 +52,12 @@ const LoadingDecryption = memo(() => {
 
 const StackRow = ({
   label,
-  value,
+  children,
   isLoading,
   isError,
 }: {
   label: string
-  value: string
+  children: string | ReactNode
   isLoading: boolean
   isError: boolean
 }) => {
@@ -65,11 +65,16 @@ const StackRow = ({
     <Stack
       spacing={{ base: '0', md: '0.5rem' }}
       direction={{ base: 'column', md: 'row' }}
+      alignItems="center"
     >
-      <Text as="span" textStyle="subhead-1" whiteSpace="nowrap">
-        {label}:
-      </Text>
-      <Skeleton isLoaded={!isLoading && !isError}>{value}</Skeleton>
+      <Box minW="8rem">
+        <Text as="span" textStyle="subhead-1" whiteSpace="nowrap">
+          {label}:
+        </Text>
+      </Box>
+      <Skeleton isLoaded={!isLoading && !isError}>
+        <Box>{children}</Box>
+      </Skeleton>
     </Stack>
   )
 }
@@ -135,32 +140,21 @@ export const IndividualResponsePage = (): JSX.Element => {
         spacing={{ base: '1.5rem', md: '2.5rem' }}
       >
         <Stack bg="primary.100" p="1.5rem" textStyle="monospace">
-          <StackRow
-            label="Response ID"
-            value={submissionId}
-            isLoading={isLoading}
-            isError={isError}
-          />
-          <StackRow
-            label="Timestamp"
-            value={data?.submissionTime ?? 'Loading...'}
-            isLoading={isLoading}
-            isError={isError}
-          />
+          <StackRow label="Response ID" isLoading={isLoading} isError={isError}>
+            {submissionId}
+          </StackRow>
+          <StackRow label="Timestamp" isLoading={isLoading} isError={isError}>
+            {data?.submissionTime ?? 'Loading...'}
+          </StackRow>
           {attachmentDownloadUrls.size > 0 && (
-            <Stack
-              spacing={{ base: '0', md: '0.5rem' }}
-              direction={{ base: 'column', md: 'row' }}
-            >
-              <Text
-                as="span"
-                textStyle="subhead-1"
-                py={{ base: '0', md: '0.25rem' }}
+            <>
+              <StackRow
+                label="Attachments"
+                isLoading={isLoading}
+                isError={isError}
               >
-                Attachments:
-              </Text>
-              <Skeleton isLoaded={!isLoading && !isError}>
                 <Button
+                  pl="0"
                   variant="link"
                   isDisabled={downloadAttachmentsAsZipMutation.isLoading}
                   onClick={handleDownload}
@@ -174,16 +168,17 @@ export const IndividualResponsePage = (): JSX.Element => {
                 >
                   {simplur`Download ${attachmentDownloadUrls.size} attachment[|s] as .zip`}
                 </Button>
-              </Skeleton>
-            </Stack>
+              </StackRow>
+            </>
           )}
           {form?.responseMode === FormResponseMode.Multirespondent && (
             <StackRow
               label="Response link"
-              value={responseLinkWithKey}
               isLoading={isLoading}
               isError={isError}
-            />
+            >
+              {responseLinkWithKey}
+            </StackRow>
           )}
         </Stack>
         {isLoading || isError ? (

--- a/src/app/models/__tests__/multirespondent-submission.server.model.spec.ts
+++ b/src/app/models/__tests__/multirespondent-submission.server.model.spec.ts
@@ -42,6 +42,7 @@ describe('Multirespondent Submission Model', () => {
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 3,
           created: createdDate,
+          lastModified: createdDate,
           workflowStep: 0,
         })
 
@@ -105,8 +106,13 @@ describe('Multirespondent Submission Model', () => {
       const VALID_FORM_ID = new ObjectId().toHexString()
       const MOCK_CREATED_DATES_ASC = [
         new Date('2020-01-01'),
+        new Date('2020-01-02'),
+        new Date('2020-01-03'),
+      ]
+      const MOCK_MODIFIED_DATES_ASC = [
+        new Date('2020-02-01'),
         new Date('2020-02-02'),
-        new Date('2020-03-03'),
+        new Date('2020-02-03'),
       ]
 
       it('should return all metadata and count successfully when params are not provided', async () => {
@@ -125,6 +131,7 @@ describe('Multirespondent Submission Model', () => {
             version: 3,
             created: MOCK_CREATED_DATES_ASC[idx],
             workflowStep: 0,
+            lastModified: MOCK_MODIFIED_DATES_ASC[idx],
           }),
         )
         const validSubmissions: IMultirespondentSubmissionSchema[] =
@@ -144,7 +151,7 @@ describe('Multirespondent Submission Model', () => {
               number: idx + 1,
               payments: null,
               refNo: data._id,
-              submissionTime: moment(data.created)
+              submissionTime: moment(data.lastModified)
                 .tz('Asia/Singapore')
                 .format('Do MMM YYYY, h:mm:ss a'),
             }))
@@ -169,6 +176,7 @@ describe('Multirespondent Submission Model', () => {
             version: 3,
             created: MOCK_CREATED_DATES_ASC[idx],
             workflowStep: 0,
+            lastModified: MOCK_MODIFIED_DATES_ASC[idx],
           }),
         )
         const validSubmissions: IMultirespondentSubmissionSchema[] =
@@ -192,7 +200,7 @@ describe('Multirespondent Submission Model', () => {
               number: 2,
               payments: null,
               refNo: secondSubmission._id,
-              submissionTime: moment(secondSubmission.created)
+              submissionTime: moment(secondSubmission.lastModified)
                 .tz('Asia/Singapore')
                 .format('Do MMM YYYY, h:mm:ss a'),
             },
@@ -217,6 +225,7 @@ describe('Multirespondent Submission Model', () => {
             version: 3,
             created: MOCK_CREATED_DATES_ASC[idx],
             workflowStep: 0,
+            lastModified: MOCK_MODIFIED_DATES_ASC[idx],
           }),
         )
         const validSubmissions: IMultirespondentSubmissionSchema[] =
@@ -240,7 +249,7 @@ describe('Multirespondent Submission Model', () => {
               number: 3,
               payments: null,
               refNo: latestSubmission._id,
-              submissionTime: moment(latestSubmission.created)
+              submissionTime: moment(latestSubmission.lastModified)
                 .tz('Asia/Singapore')
                 .format('Do MMM YYYY, h:mm:ss a'),
             },
@@ -265,6 +274,7 @@ describe('Multirespondent Submission Model', () => {
             version: 1,
             created: MOCK_CREATED_DATES_ASC[idx],
             workflowStep: 0,
+            lastModified: MOCK_MODIFIED_DATES_ASC[idx],
           }),
         )
         const validSubmissions: IMultirespondentSubmissionSchema[] =
@@ -333,6 +343,7 @@ describe('Multirespondent Submission Model', () => {
           'encryptedContent',
           'submissionType',
           'version',
+          'lastModified',
         )
         // Native-ify arrays as mongoose documents contain a mongoose-specific array type.
         expectedSubmission.form_fields = JSON.parse(
@@ -418,6 +429,7 @@ describe('Multirespondent Submission Model', () => {
           'submissionType',
           'version',
           'workflowStep',
+          'lastModified',
         )
         expect(actual).not.toBeNull()
         expect(actual?.toJSON()).toEqual(expected)

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -615,6 +615,7 @@ MultirespondentSubmissionSchema.statics.getSubmissionCursorByFormId = function (
         created: 1,
         version: 1,
         id: 1,
+        lastModified: 1,
       })
       .batchSize(2000)
       .read('secondary')

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -23,7 +23,7 @@ export const createMultirespondentSubmissionDto = (
   return {
     submissionType: SubmissionType.Multirespondent,
     refNo: submissionData._id,
-    submissionTime: moment(submissionData.created)
+    submissionTime: moment(submissionData.lastModified)
       .tz('Asia/Singapore')
       .format('ddd, D MMM YYYY, hh:mm:ss A'),
 

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -56,6 +56,7 @@ export interface ISubmissionSchema extends SubmissionBase, Document {
   paymentId: any
 
   created?: Date
+  lastModified?: Date
 }
 
 export type IPendingSubmissionSchema = ISubmissionSchema
@@ -148,6 +149,7 @@ export type MultirespondentSubmissionData = {
   | 'encryptedContent'
   | 'attachmentMetadata'
   | 'created'
+  | 'lastModified'
   | 'version'
   | 'workflowStep'
 > &

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -118,6 +118,7 @@ export type MultirespondentSubmissionCursorData = Pick<
   | 'created'
   | 'id'
   | 'version'
+  | 'lastModified'
 > & { attachmentMetadata?: Record<string, string> } & Document
 
 export type SubmissionCursorData =


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Results Page
- align the values in the box
- Date & time displayed on thank you page and results should use last submission timing

**Breaking Changes** 
- No - this PR is backwards compatible  

## Before & After Screenshots
| Item | Before | After |
|--------|--------|--------|
| Results Metadata | <img width="1173" alt="Screenshot 2024-04-02 at 1 37 16 AM" src="https://github.com/opengovsg/FormSG/assets/12391617/570ad3be-3fde-4c93-b4d4-87c31506b062"> | <img width="990" alt="Screenshot 2024-04-02 at 12 41 37 AM" src="https://github.com/opengovsg/FormSG/assets/12391617/4bc1496d-8995-4bf9-92f3-df9344e565fc"> |

## Tests
<!-- What tests should be run to confirm functionality? -->
