### PR TITLE
fix: prefill myinfo dropdown field options when faking sample submission data

### DIFF
--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -35,6 +35,7 @@ import {
   PossibleDatabaseError,
 } from '../core/core.errors'
 import { IntranetService } from '../intranet/intranet.service'
+import { getMyInfoFieldOptions } from '../myinfo/myinfo.util'
 
 import {
   FormDeletedError,
@@ -358,6 +359,11 @@ export const retrievePublicFormsWithSmsVerification = (
 }
 
 export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
+  // Prefill dropdown MyInfo field options for faking
+  if (field.fieldType === BasicField.Dropdown && field.myInfo) {
+    field.fieldOptions = getMyInfoFieldOptions(field.myInfo.attr)
+  }
+
   let sampleValue = null
   let noOfTableRows
   let noOfTableCols
@@ -371,7 +377,10 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       break
     case BasicField.Radio:
     case BasicField.Dropdown:
-      sampleValue = faker.helpers.arrayElement(field.fieldOptions)
+      sampleValue =
+        field.fieldOptions.length === 0
+          ? ''
+          : faker.helpers.arrayElement(field.fieldOptions)
       break
     case BasicField.Email:
       sampleValue = faker.internet.email()
@@ -412,7 +421,10 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       sampleValue = tableSampleValue
       break
     case BasicField.Checkbox:
-      sampleValue = faker.helpers.arrayElements(field.fieldOptions)
+      sampleValue =
+        field.fieldOptions.length === 0
+          ? ''
+          : faker.helpers.arrayElements(field.fieldOptions)
       break
     case BasicField.Date:
       sampleValue = faker.date.anytime().toLocaleDateString('en-SG', {

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -424,6 +424,7 @@ export const handleGetPublicFormSampleSubmission: ControllerHandler<
       meta: logMeta,
       error,
     })
+    return res.sendStatus(HttpStatusCode.InternalServerError)
   }
 
   return res.json({ responses: sampleData })


### PR DESCRIPTION
## Problem
Sample submission endpoint is causing server to crash for myinfo dropdown fields due to no field options being available to fake.

## Solution
Pre-populate myinfo dropdowns with the right fieldOptions. Additionally, add more logging upon failures.

**Breaking Changes** 
- No - this PR is backwards compatible  