### PR TITLE
fix: add secret key input mask

### DIFF
--- a/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
+++ b/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
@@ -128,6 +128,7 @@ export const SecretKeyVerificationInput = ({
         <Stack direction="row" spacing="0.5rem">
           <Skeleton isLoaded={!isLoading} w="100%">
             <Input
+              type="password"
               isDisabled={isLoading}
               {...register(SECRET_KEY_NAME, secretKeyValidationRules)}
             />

--- a/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
+++ b/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
@@ -128,6 +128,7 @@ export const SecretKeyVerificationInput = ({
         <Stack direction="row" spacing="0.5rem">
           <Skeleton isLoaded={!isLoading} w="100%">
             <Input
+              data-testid="secretKey"
               type="password"
               isDisabled={isLoading}
               {...register(SECRET_KEY_NAME, secretKeyValidationRules)}

--- a/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
@@ -135,25 +135,14 @@ export const StorageFormUnlocked = Template.bind({})
 StorageFormUnlocked.parameters = StorageForm.parameters
 StorageFormUnlocked.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement)
-  const inputName =
-    /enter or upload secret key your secret key was downloaded when you created your form/i
 
   await waitFor(
     async () => {
-      expect(
-        canvas.getByRole('textbox', {
-          name: inputName,
-        }),
-      ).not.toBeDisabled()
+      expect(canvas.getByTestId('secretKey')).not.toBeDisabled()
     },
     { timeout: 5000 },
   )
-  await userEvent.type(
-    canvas.getByRole('textbox', {
-      name: inputName,
-    }),
-    MOCK_KEYPAIR.secretKey,
-  )
+  await userEvent.type(canvas.getByTestId('secretKey'), MOCK_KEYPAIR.secretKey)
 
   await userEvent.click(
     canvas.getByRole('button', { name: /unlock responses/i }),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Secret key input on Admin Response Results Tab is not masked.

## Solution
<!-- How did you solve the problem? -->

Add `type=password` to mask it.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | Before | After |
|--------|--------|--------|
| Input Field | ![Screenshot 2024-04-02 at 3 10 36 PM](https://github.com/opengovsg/FormSG/assets/12391617/28579829-87e9-42c3-a5b2-593520c7244c) | ![Screenshot 2024-04-02 at 3 10 27 PM](https://github.com/opengovsg/FormSG/assets/12391617/a973c2d1-35a0-427c-97b3-8c892530821c) | 
