### PR TITLE
fix: correct date validation for disabled fields

### DIFF
--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
+import { useParams } from 'react-router-dom'
 
 import { DATE_DISPLAY_FORMAT, DATE_PARSE_FORMAT } from '~shared/constants/dates'
 import { FormColorTheme } from '~shared/types'
@@ -32,10 +33,15 @@ export const DateField = ({
   colorTheme = FormColorTheme.Blue,
   ...fieldContainerProps
 }: DateFieldProps): JSX.Element => {
+  console.log('disable validaton', disableRequiredValidation)
   const validationRules = useMemo(
     () => createDateValidationRules(schema, disableRequiredValidation),
     [schema, disableRequiredValidation],
   )
+
+  console.log('validation rules', validationRules)
+  const { submissionId } = useParams()
+  console.log('submission id', submissionId)
 
   const isDateUnavailable = useCallback(
     (date: Date) => {
@@ -77,7 +83,7 @@ export const DateField = ({
       <Controller
         control={control}
         name={schema._id}
-        rules={validationRules}
+        rules={disableRequiredValidation ? undefined : validationRules}
         defaultValue=""
         render={({ field: { value, onChange, ...field } }) => (
           <DatePicker

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
-import { useParams } from 'react-router-dom'
 
 import { DATE_DISPLAY_FORMAT, DATE_PARSE_FORMAT } from '~shared/constants/dates'
 import { FormColorTheme } from '~shared/types'
@@ -33,15 +32,10 @@ export const DateField = ({
   colorTheme = FormColorTheme.Blue,
   ...fieldContainerProps
 }: DateFieldProps): JSX.Element => {
-  console.log('disable validaton', disableRequiredValidation)
   const validationRules = useMemo(
     () => createDateValidationRules(schema, disableRequiredValidation),
     [schema, disableRequiredValidation],
   )
-
-  console.log('validation rules', validationRules)
-  const { submissionId } = useParams()
-  console.log('submission id', submissionId)
 
   const isDateUnavailable = useCallback(
     (date: Date) => {


### PR DESCRIPTION
## Problem
There is a bug in the validation for dates where if a date field had been input by Respondent 1, and the date violates the validation when it reaches Respondent 2+ (and the fields are disabled), there is still a validation in place that could prevent Respondent 2 onwards from submitting the form

<img width="941" alt="image" src="https://github.com/opengovsg/FormSG/assets/89055608/f64d8aed-16dc-4c19-8cc0-ecfe67202acb">


Closes FRM-1706

## Solution
To remove the validation for disabled fields for Respondent 2 onwards

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

- [ ] Create an MRF form and add a date field with a validation (eg. prevent past dates)
- [ ] Go to Workflow to create multiple workflows
- [ ] Add the date fields for Workflow 1
- [ ] Add more fields for Workflow 2 onwards
- [ ] Share the form and select a future date - submit the form
- [ ] Open the form for Respondent 2
- [ ] Copy the Submission ID, proceed to the DB and search for the submission ID - change the selected date validation to "selectedDateValidation" : "Disallow future dates"
- [ ] Refresh the page for the MRF form for Respondent 2
- [ ] Fill up the remaining fields in the form and submit as Respondent 2 - you should be able to submit the form