### PR TITLE
chore(dockerfile): bump chromium version to work with alpine-3.19

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -29,7 +29,7 @@ RUN apk update && apk upgrade && \
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
     # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=123.0.6312.105-r0 \
+    chromium=123.0.6312.122-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -82,7 +82,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 
 RUN apk add --no-cache \
     # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=123.0.6312.105-r0 \
+    chromium=123.0.6312.122-r0 \
     nss \
     freetype \
     freetype-dev \


### PR DESCRIPTION
## Problem and Solution
Alpine bumped the version of Chromium that works with 3.19, so tweak Dockerfiles to reflect this
