### PR TITLE
chore: update chromium to latest published version

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -29,7 +29,7 @@ RUN apk update && apk upgrade && \
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
     # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=123.0.6312.122-r0 \
+    chromium=124.0.6367.60-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -82,7 +82,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 
 RUN apk add --no-cache \
     # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=123.0.6312.122-r0 \
+    chromium=124.0.6367.60-r0 \
     nss \
     freetype \
     freetype-dev \


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

New version [published](https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=), old version is no longer reachable.

## Solution
<!-- How did you solve the problem? -->
![Screenshot 2024-04-18 at 8 24 49 PM](https://github.com/opengovsg/FormSG/assets/12391617/1cdab631-ac46-4a38-827f-14188ee96b5e)

Update to latest supported version.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
