### PR TITLE
chore: allow pip to install packages globally

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -43,7 +43,7 @@ RUN apk update && apk upgrade && \
     py-pip && \
     npm install --quiet node-gyp -g && \
     # [ver1] ensures that the underlying AWS CLI version is also installed
-    pip install awscli-local[ver1]
+    pip install awscli-local[ver1] --break-system-packages
 
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Podman Desktop is unable to run `pip install awscli-local[ver1]` as it pip doesn't allow packages to be installed globally as per [PEP-668](https://peps.python.org/pep-0668/). However, we're installing the packages in a container, the problem of package ownership not a concern for us.

## Solution
<!-- How did you solve the problem? -->

Add `--break-system-packages` to override the error.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests

[Skip this test during release. This is a local-dev only, change.]
#### Regression
Ensure that local dev through `docker` is not impacted
- [ ] Run `docker compose up`
- [ ] Ensure that formsg runs

#### New feature test
Ensure that local dev through `podman` works
- [x] Run `podman compose up`
- [x] Ensure that formsg runs