### PR TITLE
fix(btn): remove admin sms toggle check

### DIFF
--- a/__tests__/unit/backend/helpers/jest-db.ts
+++ b/__tests__/unit/backend/helpers/jest-db.ts
@@ -116,7 +116,7 @@ const insertFormCollectionReqs = async ({
   betaFlags,
   apiToken,
 }: {
-  userId?: Schema.Types.ObjectId
+  userId?: Types.ObjectId
   mailName?: string
   mailDomain?: string
   shortName?: string

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -255,7 +255,7 @@ describe('Form Model', () => {
         expect(saved.created).toBeInstanceOf(Date)
         expect(saved.lastModified).toBeInstanceOf(Date)
         // Retrieve object and compare to params, remove indeterministic keys
-        const actualSavedObject = omit(saved.toObject(), [
+        const actualSavedObject = omit(saved.toObject<IFormDocument>(), [
           '_id',
           'created',
           'lastModified',
@@ -1252,7 +1252,7 @@ describe('Form Model', () => {
         const form = await Form.create(formParams)
         await Form.deactivateById(form._id)
         const updated = await Form.findById(form._id)
-        expect(updated!.status).toBe('PRIVATE')
+        expect(updated?.status).toBe('PRIVATE')
       })
 
       it('should not deactivate archived form', async () => {
@@ -1263,7 +1263,7 @@ describe('Form Model', () => {
         const form = await Form.create(formParams)
         await Form.deactivateById(form._id)
         const updated = await Form.findById(form._id)
-        expect(updated!.status).toBe('ARCHIVED')
+        expect(updated?.status).toBe('ARCHIVED')
       })
 
       it('should return null for invalid form ID', async () => {
@@ -1290,7 +1290,9 @@ describe('Form Model', () => {
           admin: populatedAdmin,
         })
         // Create a form
-        const form = (await Form.create(emailFormParams)).toObject()
+        const form = (
+          await Form.create(emailFormParams)
+        ).toObject<IFormDocument>()
 
         // Act
         const actualForm = (await Form.getFullFormById(form._id))?.toObject()
@@ -1321,7 +1323,9 @@ describe('Form Model', () => {
           admin: populatedAdmin,
         })
         // Create a form
-        const form = (await Form.create(encryptFormParams)).toObject()
+        const form = (
+          await Form.create(encryptFormParams)
+        ).toObject<IFormDocument>()
 
         // Act
         const actualForm = (await Form.getFullFormById(form._id))?.toObject()
@@ -1555,7 +1559,7 @@ describe('Form Model', () => {
         // Check that form logic has been added
         expect(modifiedForm?.form_logics).toBeDefined()
         expect(modifiedForm?.form_logics).toHaveLength(1)
-        expect(modifiedForm!.form_logics![0].logicType).toEqual(
+        expect(modifiedForm?.form_logics[0].logicType).toEqual(
           LogicType.PreventSubmit,
         )
       })
@@ -1591,10 +1595,10 @@ describe('Form Model', () => {
         // Check that form logic has been added
         expect(modifiedFormRepeat?.form_logics).toBeDefined()
         expect(modifiedFormRepeat?.form_logics).toHaveLength(2)
-        expect(modifiedFormRepeat!.form_logics![0].logicType).toEqual(
+        expect(modifiedFormRepeat?.form_logics[0].logicType).toEqual(
           LogicType.PreventSubmit,
         )
-        expect(modifiedFormRepeat!.form_logics![1].logicType).toEqual(
+        expect(modifiedFormRepeat?.form_logics[1].logicType).toEqual(
           LogicType.PreventSubmit,
         )
       })
@@ -1628,10 +1632,10 @@ describe('Form Model', () => {
         // Check that form logic has been added
         expect(modifiedForm?.form_logics).toBeDefined()
         expect(modifiedForm?.form_logics).toHaveLength(2)
-        expect(modifiedForm!.form_logics![0].logicType).toEqual(
+        expect(modifiedForm?.form_logics[0].logicType).toEqual(
           LogicType.ShowFields,
         )
-        expect(modifiedForm!.form_logics![1].logicType).toEqual(
+        expect(modifiedForm?.form_logics[1].logicType).toEqual(
           LogicType.PreventSubmit,
         )
       })
@@ -1733,7 +1737,7 @@ describe('Form Model', () => {
         expect(modifiedForm?.form_logics).toBeDefined()
         expect(modifiedForm?.form_logics).toHaveLength(1)
         const logic = modifiedForm?.form_logics || ['some logic']
-        expect((logic[0] as any)['_id'].toString()).toEqual(logicId2)
+        expect((logic[0] as unknown as any)['_id'].toString()).toEqual(logicId2)
       })
 
       it('should return null if formId is invalid', async () => {
@@ -1768,7 +1772,9 @@ describe('Form Model', () => {
 
         // Assert
         // Only non-deleted form field remains
-        const expectedFormFields = [form.toObject().form_fields![1]]
+        const expectedFormFields = [
+          form.toObject<IFormDocument>().form_fields[1],
+        ]
         const retrievedForm = await Form.findById(form._id).lean()
         // Check return shape.
         expect(actual?.toObject().form_fields).toEqual(expectedFormFields)
@@ -1810,7 +1816,7 @@ describe('Form Model', () => {
             title: 'old title',
           },
         })
-        const form = (await Form.create(formParams)).toObject()
+        const form = (await Form.create(formParams)).toObject<IFormDocument>()
         const updatedEndPage: FormEndPage = {
           title: 'some new title',
           paragraph: 'some description paragraph',
@@ -1948,7 +1954,7 @@ describe('Form Model', () => {
         // Check that form logic has been updated
         expect(modifiedForm?.form_logics).toBeDefined()
         expect(modifiedForm?.form_logics).toHaveLength(1)
-        expect(modifiedForm!.form_logics![0].logicType).toEqual(
+        expect(modifiedForm?.form_logics?.[0].logicType).toEqual(
           LogicType.PreventSubmit,
         )
       })
@@ -1983,10 +1989,10 @@ describe('Form Model', () => {
         // Check that first form logic has been updated but second is unchanges
         expect(modifiedForm?.form_logics).toBeDefined()
         expect(modifiedForm?.form_logics).toHaveLength(2)
-        expect(modifiedForm!.form_logics![0].logicType).toEqual(
+        expect(modifiedForm?.form_logics?.[0].logicType).toEqual(
           LogicType.PreventSubmit,
         )
-        expect(modifiedForm!.form_logics![1].logicType).toEqual(
+        expect(modifiedForm?.form_logics?.[1].logicType).toEqual(
           LogicType.ShowFields,
         )
       })
@@ -2047,7 +2053,7 @@ describe('Form Model', () => {
         // Check that form logic has not been updated and there are no new form logics introduced
         expect(modifiedForm?.form_logics).toBeDefined()
         expect(modifiedForm?.form_logics).toHaveLength(1)
-        expect(modifiedForm!.form_logics![0].logicType).toEqual(
+        expect(modifiedForm?.form_logics?.[0].logicType).toEqual(
           LogicType.ShowFields,
         )
       })
@@ -2062,7 +2068,7 @@ describe('Form Model', () => {
             title: 'old title',
           },
         })
-        const form = (await Form.create(formParams)).toObject()
+        const form = (await Form.create(formParams)).toObject<IFormDocument>()
         const prevModifiedDate = form.lastModified
         const updatedStartPage: FormStartPage = {
           paragraph: 'some description paragraph',
@@ -2095,7 +2101,7 @@ describe('Form Model', () => {
         const formParams = merge({}, MOCK_EMAIL_FORM_PARAMS, {
           admin: MOCK_ADMIN_OBJ_ID,
         })
-        const form = (await Form.create(formParams)).toObject()
+        const form = (await Form.create(formParams)).toObject<IFormDocument>()
         const updatedStartPage: FormStartPage = {
           paragraph: 'some description paragraph',
           colorTheme: FormColorTheme.Blue,
@@ -2146,161 +2152,6 @@ describe('Form Model', () => {
         // Assert
         expect(actual).toEqual(null)
         await expect(Form.countDocuments()).resolves.toEqual(0)
-      })
-    })
-
-    describe('disableSmsVerificationsForUser', () => {
-      const MOCK_MSG_SRVC_NAME = 'mockTwilioId'
-      it('should disable sms verifications for all forms belonging to a user that are not onboarded successfully', async () => {
-        // Arrange
-        const mockFormPromises = range(3).map((_, idx) => {
-          const isOnboarded = !!(idx % 2)
-          return Form.create({
-            admin: populatedAdmin._id,
-            responseMode: FormResponseMode.Email,
-            title: 'mock mobile form',
-            emails: [populatedAdmin.email],
-            ...(isOnboarded && { msgSrvcName: MOCK_MSG_SRVC_NAME }),
-            form_fields: [
-              generateDefaultField(BasicField.Mobile, { isVerifiable: true }),
-            ],
-          })
-        })
-        await Promise.all(mockFormPromises)
-
-        // Act
-        await Form.disableSmsVerificationsForUser(populatedAdmin._id)
-
-        // Assert
-        // Find all forms that match admin id
-        // All forms with msgSrvcName have been using their own credentials
-        // They should not have verifications disabled.
-        const onboardedForms = await Form.find({
-          admin: populatedAdmin._id,
-          msgSrvcName: {
-            $exists: true,
-          },
-        })
-        onboardedForms.map(({ form_fields }) =>
-          form_fields!.map((field) => {
-            expect(field.isVerifiable).toBe(true)
-          }),
-        )
-
-        // Conversely, forms without msgSrvcName are using our credentials
-        // And should have their verifications disabled.
-        const notOnboardedForms = await Form.find({
-          admin: populatedAdmin._id,
-          msgSrvcName: {
-            $exists: false,
-          },
-        })
-
-        notOnboardedForms.map(({ form_fields }) =>
-          form_fields!.map((field) => {
-            expect(field.isVerifiable).toBe(false)
-          }),
-        )
-      })
-
-      it('should not disable non mobile fields for a user', async () => {
-        // Arrange
-        const mockFormPromises = range(3).map(() => {
-          return Form.create({
-            admin: populatedAdmin._id,
-            responseMode: FormResponseMode.Email,
-            title: 'mock email form',
-            emails: [populatedAdmin.email],
-            form_fields: [
-              generateDefaultField(BasicField.Email, { isVerifiable: true }),
-            ],
-          })
-        })
-        await Promise.all(mockFormPromises)
-
-        // Act
-        await Form.disableSmsVerificationsForUser(populatedAdmin._id)
-
-        // Assert
-        // Find all forms that match admin id
-        const updatedForms = await Form.find({ admin: populatedAdmin._id })
-        updatedForms.map(({ form_fields }) =>
-          form_fields!.map((field) => {
-            expect(field.isVerifiable).toBe(true)
-          }),
-        )
-      })
-
-      it('should only disable sms verifications for a particular user', async () => {
-        // Arrange
-        const MOCK_USER_ID = new ObjectId()
-        await dbHandler.insertFormCollectionReqs({
-          userId: MOCK_USER_ID,
-          mailDomain: 'something.com',
-        })
-        await Form.create({
-          admin: populatedAdmin._id,
-          responseMode: FormResponseMode.Email,
-          title: 'mock email form',
-          emails: [populatedAdmin.email],
-          form_fields: [
-            generateDefaultField(BasicField.Mobile, { isVerifiable: true }),
-          ],
-        })
-        await Form.create({
-          admin: MOCK_USER_ID,
-          responseMode: FormResponseMode.Email,
-          title: 'mock email form',
-          emails: [populatedAdmin.email],
-          form_fields: [
-            generateDefaultField(BasicField.Email, { isVerifiable: true }),
-          ],
-        })
-
-        // Act
-        await Form.disableSmsVerificationsForUser(populatedAdmin._id)
-
-        // Assert
-        // Find all forms that match admin id
-        const updatedMobileForms = (await Form.find({
-          admin: populatedAdmin._id,
-        })) as IFormDocument[]
-        expect(updatedMobileForms[0].form_fields[0].isVerifiable).toBe(false)
-        const updatedEmailForm = (await Form.find({
-          admin: MOCK_USER_ID,
-        })) as IFormDocument[]
-        expect(updatedEmailForm[0].form_fields[0].isVerifiable).toBe(true)
-      })
-
-      it('should not update when a db error occurs', async () => {
-        // Arrange
-        const disableSpy = jest.spyOn(Form, 'disableSmsVerificationsForUser')
-        // @ts-ignore
-        disableSpy.mockResolvedValueOnce(new Error('tee hee db crashed'))
-        const mockFormPromises = range(3).map(() => {
-          return Form.create({
-            admin: populatedAdmin._id,
-            responseMode: FormResponseMode.Email,
-            title: 'mock mobile form',
-            emails: [populatedAdmin.email],
-            form_fields: [
-              generateDefaultField(BasicField.Mobile, { isVerifiable: true }),
-            ],
-          })
-        })
-        await Promise.all(mockFormPromises)
-
-        // Act
-        await Form.disableSmsVerificationsForUser(populatedAdmin._id)
-
-        // Assert
-        // Find all forms that match admin id
-        const updatedForms = await Form.find({ admin: populatedAdmin._id })
-        updatedForms.map(({ form_fields }) =>
-          form_fields!.map((field) => {
-            expect(field.isVerifiable).toBe(true)
-          }),
-        )
       })
     })
 
@@ -3065,7 +2916,7 @@ describe('Form Model', () => {
         // Act
         const updatedForm = await form.updateMsgSrvcName(MOCK_MSG_SRVC_NAME)
         // Assert
-        expect(updatedForm!.msgSrvcName).toBe(MOCK_MSG_SRVC_NAME)
+        expect(updatedForm?.msgSrvcName).toBe(MOCK_MSG_SRVC_NAME)
       })
     })
 
@@ -3083,7 +2934,7 @@ describe('Form Model', () => {
         const updatedForm = await form.deleteMsgSrvcName()
 
         // Assert
-        expect(updatedForm!.msgSrvcName).toBeUndefined()
+        expect(updatedForm?.msgSrvcName).toBeUndefined()
       })
     })
   })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1127,31 +1127,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     ).exec()
   }
 
-  FormSchema.statics.disableSmsVerificationsForUser = async function (
-    userId: IUserSchema['_id'],
-  ) {
-    return this.updateMany(
-      // Filter the collection so that only specified user is selected
-      // Only update forms without message service name
-      // As it implies that those forms are using default (our) credentials
-      {
-        admin: userId,
-        msgSrvcName: {
-          $exists: false,
-        },
-      },
-      // Next, set the isVerifiable property for each field in form_fields
-      // Refer here for $[identifier] syntax: https://docs.mongodb.com/manual/reference/operator/update/positional-filtered/
-      { $set: { 'form_fields.$[field].isVerifiable': false } },
-      {
-        // Only set if the field has fieldType equal to mobile
-        arrayFilters: [{ 'field.fieldType': 'mobile' }],
-        // NOTE: Not updating the timestamp because we should preserve ordering due to user-level modifications
-        timestamps: false,
-      },
-    ).exec()
-  }
-
   /**
    * Retrieves all the public forms for a user which has sms verifications enabled
    * This only retrieves forms that are using FormSG credentials

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -36,7 +36,6 @@ import {
 import * as SubmissionService from 'src/app/modules/submission/submission.service'
 import * as SubmissionUtils from 'src/app/modules/submission/submission.utils'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
-import { SmsLimitExceededError } from 'src/app/modules/verification/verification.errors'
 import * as WorkspaceService from 'src/app/modules/workspace/workspace.service'
 import {
   MailGenerationError,
@@ -6937,9 +6936,6 @@ describe('admin-form.controller', () => {
       MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
         okAsync(MOCK_FORM),
       )
-      MockAdminFormService.shouldUpdateFormField.mockReturnValue(
-        okAsync(MOCK_FORM),
-      )
       MockAdminFormService.updateFormField.mockReturnValue(
         okAsync(MOCK_UPDATED_FIELD as FormFieldSchema),
       )
@@ -7036,29 +7032,6 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(MockAdminFormService.updateFormField).not.toHaveBeenCalled()
-    })
-
-    it('should return 409 when the field could not be updated due to a sms limit exceeded error', async () => {
-      // Arrange
-      MockAdminFormService.shouldUpdateFormField.mockReturnValueOnce(
-        errAsync(new SmsLimitExceededError()),
-      )
-      const expected = {
-        message:
-          'You have exceeded the free sms limit. Please refresh and try again.',
-      }
-      const mockRes = expressHandler.mockResponse()
-
-      // Act
-      await AdminFormController._handleUpdateFormField(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
-
-      // Assert
-      expect(mockRes.status).toHaveBeenCalledWith(409)
-      expect(mockRes.json).toHaveBeenCalledWith(expected)
     })
 
     it('should return 410 when form to update form field for is already archived', async () => {
@@ -7233,9 +7206,6 @@ describe('admin-form.controller', () => {
       MockAuthService.getFormAfterPermissionChecks.mockReturnValue(
         okAsync(MOCK_FORM),
       )
-      MockAdminFormService.shouldUpdateFormField.mockReturnValue(
-        okAsync(MOCK_FORM),
-      )
       MockAdminFormService.createFormField.mockReturnValue(
         okAsync(MOCK_RETURNED_FIELD),
       )
@@ -7343,29 +7313,6 @@ describe('admin-form.controller', () => {
         message: expectedErrorString,
       })
       expect(MockAdminFormService.createFormField).not.toHaveBeenCalled()
-    })
-
-    it('should return 409 when the field could not be created due to a sms limit exceeded error', async () => {
-      // Arrange
-      MockAdminFormService.shouldUpdateFormField.mockReturnValueOnce(
-        errAsync(new SmsLimitExceededError()),
-      )
-      const expected = {
-        message:
-          'You have exceeded the free sms limit. Please refresh and try again.',
-      }
-      const mockRes = expressHandler.mockResponse()
-
-      // Act
-      await AdminFormController._handleCreateFormField(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
-
-      // Assert
-      expect(mockRes.status).toHaveBeenCalledWith(409)
-      expect(mockRes.json).toHaveBeenCalledWith(expected)
     })
 
     it('should return 410 when attempting to create a form field for an archived form', async () => {
@@ -7594,9 +7541,6 @@ describe('admin-form.controller', () => {
         okAsync(MOCK_FORM),
       )
       MockAdminFormService.getFormField.mockReturnValue(ok(MOCK_FIELDS[0]))
-      MockAdminFormService.shouldUpdateFormField.mockReturnValue(
-        okAsync(MOCK_FORM),
-      )
       MockAdminFormService.duplicateFormField.mockReturnValue(
         okAsync(MOCK_DUPLICATED_FIELD),
       )
@@ -7734,28 +7678,6 @@ describe('admin-form.controller', () => {
       )
     })
 
-    it('should return 409 when the field could not be duplicated due to a sms limit exceeded error', async () => {
-      // Arrange
-      MockAdminFormService.shouldUpdateFormField.mockReturnValueOnce(
-        errAsync(new SmsLimitExceededError()),
-      )
-      const expected = {
-        message:
-          'You have exceeded the free sms limit. Please refresh and try again.',
-      }
-      const mockRes = expressHandler.mockResponse()
-
-      // Act
-      await AdminFormController.handleDuplicateFormField(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
-
-      // Assert
-      expect(mockRes.status).toHaveBeenCalledWith(409)
-      expect(mockRes.json).toHaveBeenCalledWith(expected)
-    })
     it('should return 410 when form to duplicate form field for is already archived', async () => {
       // Arrange
       const mockRes = expressHandler.mockResponse()

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -24,7 +24,6 @@ import {
 } from 'src/app/modules/core/core.errors'
 import { MissingUserError } from 'src/app/modules/user/user.errors'
 import * as UserService from 'src/app/modules/user/user.service'
-import { SmsLimitExceededError } from 'src/app/modules/verification/verification.errors'
 import { TwilioCredentials } from 'src/app/services/sms/sms.types'
 import { CreatePresignedPostError } from 'src/app/utils/aws-s3'
 import { formatErrorRecoveryMessage } from 'src/app/utils/handle-mongo-error'
@@ -60,7 +59,6 @@ import {
   LogicType,
   SettingsUpdateDto,
 } from '../../../../../../shared/types'
-import { smsConfig } from '../../../../config/features/sms.config'
 import * as SmsService from '../../../../services/sms/sms.service'
 import {
   FormNotFoundError,
@@ -2317,6 +2315,8 @@ describe('admin-form.service', () => {
       buttonLink: 'https://some-button-link.example.com',
       buttonText: 'expected button text',
       paragraph: 'some paragraph',
+      paymentTitle: '',
+      paymentParagraph: '',
     }
 
     it('should return updated end page when update is successful', async () => {
@@ -2609,113 +2609,6 @@ describe('admin-form.service', () => {
     })
   })
 
-  describe('shouldUpdateFormField', () => {
-    const MOCK_FORM = {
-      admin: {
-        _id: new ObjectId(),
-      },
-    } as unknown as IPopulatedForm
-
-    const countSpy = jest.spyOn(SmsService, 'retrieveFreeSmsCounts')
-
-    describe('when update form field is not a BasicField.Mobile type', () => {
-      const MOCK_RATING_FIELD = generateDefaultField(BasicField.Rating)
-      it('should return the form without doing anything', async () => {
-        // Act
-        const actual = await AdminFormService.shouldUpdateFormField(
-          MOCK_FORM,
-          MOCK_RATING_FIELD,
-        )
-
-        // Assert
-        expect(actual._unsafeUnwrap()).toEqual(MOCK_FORM)
-        expect(countSpy).not.toHaveBeenCalled()
-      })
-    })
-
-    describe('when update form field is a BasicField.Mobile type', () => {
-      const MOCK_UNVERIFIABLE_MOBILE_FIELD = generateDefaultField(
-        BasicField.Mobile,
-      )
-      const MOCK_VERIFIABLE_MOBILE_FIELD = generateDefaultField(
-        BasicField.Mobile,
-        { isVerifiable: true },
-      )
-
-      it('should return the given form when the admin is under the free sms limit', async () => {
-        // Arrange
-        countSpy.mockReturnValueOnce(okAsync(smsConfig.smsVerificationLimit))
-
-        // Act
-        const actual = await AdminFormService.shouldUpdateFormField(
-          MOCK_FORM,
-          MOCK_VERIFIABLE_MOBILE_FIELD,
-        )
-
-        // Assert
-        expect(actual._unsafeUnwrap()).toBe(MOCK_FORM)
-      })
-
-      it('should return the given form when the form is onboarded with its own credentials', async () => {
-        // Arrange
-        const MOCK_ONBOARDED_FORM = { ...MOCK_FORM, msgSrvcName: 'form a form' }
-
-        // Act
-        const actual = await AdminFormService.shouldUpdateFormField(
-          MOCK_ONBOARDED_FORM,
-          MOCK_VERIFIABLE_MOBILE_FIELD,
-        )
-
-        // Assert
-        expect(countSpy).not.toHaveBeenCalled()
-        expect(actual._unsafeUnwrap()).toEqual(MOCK_ONBOARDED_FORM)
-      })
-
-      it('should return the given form when mobile field is not verifiable', async () => {
-        // Act
-        const actual = await AdminFormService.shouldUpdateFormField(
-          MOCK_FORM,
-          MOCK_UNVERIFIABLE_MOBILE_FIELD,
-        )
-
-        // Assert
-        expect(countSpy).not.toHaveBeenCalled()
-        expect(actual._unsafeUnwrap()).toEqual(MOCK_FORM)
-      })
-
-      it('should return sms retrieval error when sms limit exceeded and the given form has not been onboarded', async () => {
-        // Arrange
-        countSpy.mockReturnValueOnce(
-          okAsync(smsConfig.smsVerificationLimit + 1),
-        )
-
-        // Act
-        const actual = await AdminFormService.shouldUpdateFormField(
-          MOCK_FORM,
-          MOCK_VERIFIABLE_MOBILE_FIELD,
-        )
-
-        // Assert
-        expect(actual._unsafeUnwrapErr()).toEqual(new SmsLimitExceededError())
-      })
-
-      it('should propagate any database errors encountered during retrieval', async () => {
-        // Arrange
-        const MOCK_ERROR_STRING = 'something went oopsie'
-        const expectedError = new DatabaseError(MOCK_ERROR_STRING)
-        countSpy.mockReturnValueOnce(errAsync(expectedError))
-
-        // Act
-        const actual = await AdminFormService.shouldUpdateFormField(
-          MOCK_FORM,
-          MOCK_VERIFIABLE_MOBILE_FIELD,
-        )
-
-        // Assert
-        expect(actual._unsafeUnwrapErr()).toBe(expectedError)
-      })
-    })
-  })
   describe('createTwilioCredentials', () => {
     const MOCK_FORM_ID = new mongoose.Types.ObjectId()
     const MOCK_ADMIN_ID = new mongoose.Types.ObjectId()

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -2609,40 +2609,6 @@ describe('admin-form.service', () => {
     })
   })
 
-  describe('disableSmsVerificationsForUser', () => {
-    it('should return true when the forms are updated successfully', async () => {
-      // Arrange
-      const MOCK_ADMIN_ID = new ObjectId().toHexString()
-      const disableSpy = jest.spyOn(FormModel, 'disableSmsVerificationsForUser')
-      disableSpy.mockResolvedValueOnce({ n: 0, nModified: 0, ok: 0 })
-
-      // Act
-      const expected = await AdminFormService.disableSmsVerificationsForUser(
-        MOCK_ADMIN_ID,
-      )
-
-      // Assert
-      expect(disableSpy).toHaveBeenCalledWith(MOCK_ADMIN_ID)
-      expect(expected._unsafeUnwrap()).toEqual(true)
-    })
-
-    it('should return a database error when the operation fails', async () => {
-      // Arrange
-      const MOCK_ADMIN_ID = new ObjectId().toHexString()
-      const disableSpy = jest.spyOn(FormModel, 'disableSmsVerificationsForUser')
-      disableSpy.mockRejectedValueOnce('whoops')
-
-      // Act
-      const expected = await AdminFormService.disableSmsVerificationsForUser(
-        MOCK_ADMIN_ID,
-      )
-
-      // Assert
-      expect(disableSpy).toHaveBeenCalledWith(MOCK_ADMIN_ID)
-      expect(expected._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
-    })
-  })
-
   describe('shouldUpdateFormField', () => {
     const MOCK_FORM = {
       admin: {

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1320,12 +1320,6 @@ export const handleDuplicateFormField: ControllerHandler<
         level: PermissionLevel.Write,
       }),
     )
-    .andThen((form) => {
-      return AdminFormService.getFormField(form, fieldId).asyncAndThen(
-        (formFieldToDuplicate) =>
-          AdminFormService.shouldUpdateFormField(form, formFieldToDuplicate),
-      )
-    })
     .andThen((form) => AdminFormService.duplicateFormField(form, fieldId))
     .map((duplicatedField) =>
       res.status(StatusCodes.OK).json(duplicatedField as FormFieldDto),
@@ -1512,11 +1506,7 @@ export const _handleUpdateFormField: ControllerHandler<
           level: PermissionLevel.Write,
         }),
       )
-      // Step 3: Check if the user has exceeded the allowable limit for sms if the fieldType is mobile
-      .andThen((form) =>
-        AdminFormService.shouldUpdateFormField(form, updatedFormField),
-      )
-      // Step 4: User has permissions, update form field of retrieved form.
+      // Step 3: User has permissions, update form field of retrieved form.
       .andThen((form) =>
         AdminFormService.updateFormField(form, fieldId, updatedFormField),
       )
@@ -1958,11 +1948,7 @@ export const _handleCreateFormField: ControllerHandler<
           level: PermissionLevel.Write,
         }),
       )
-      // Step 3: Check if the user has exceeded the allowable limit for sms if the fieldType is mobile
-      .andThen((form) =>
-        AdminFormService.shouldUpdateFormField(form, formFieldToCreate),
-      )
-      // Step 4: User has permissions, proceed to create form field with provided body.
+      // Step 3: User has permissions, proceed to create form field with provided body.
       .andThen((form) =>
         AdminFormService.createFormField(form, formFieldToCreate, to),
       )

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -17,19 +17,16 @@ import {
 import { MYINFO_ATTRIBUTE_MAP } from '../../../../../shared/constants/field/myinfo'
 import {
   AdminDashboardFormMetaDto,
-  BasicField,
   DuplicateFormOverwriteDto,
   EndPageUpdateDto,
   FieldCreateDto,
   FieldUpdateDto,
   FormAuthType,
-  FormField,
   FormLogoState,
   FormPermission,
   FormResponseMode,
   FormSettings,
   LogicDto,
-  MobileFieldBase,
   SettingsUpdateDto,
   StartPageUpdateDto,
 } from '../../../../../shared/types'
@@ -49,14 +46,12 @@ import { createLoggerWithLabel } from '../../../config/logger'
 import getAgencyModel from '../../../models/agency.server.model'
 import getFormModel from '../../../models/form.server.model'
 import { getWorkspaceModel } from '../../../models/workspace.server.model'
-import * as SmsService from '../../../services/sms/sms.service'
 import { twilioClientCache } from '../../../services/sms/sms.service'
 import {
   createPresignedPostDataPromise,
   CreatePresignedPostError,
 } from '../../../utils/aws-s3'
 import { dotifyObject } from '../../../utils/dotify-object'
-import { isVerifiableMobileField } from '../../../utils/field-validation/field-validation.guards'
 import {
   getMongoErrorMessage,
   transformMongoError,
@@ -74,8 +69,6 @@ import {
 } from '../../core/core.errors'
 import { MissingUserError } from '../../user/user.errors'
 import * as UserService from '../../user/user.service'
-import { SmsLimitExceededError } from '../../verification/verification.errors'
-import { hasAdminExceededFreeSmsLimit } from '../../verification/verification.util'
 import { removeFormsFromAllWorkspaces } from '../../workspace/workspace.service'
 import {
   FormNotFoundError,
@@ -87,7 +80,6 @@ import {
   getFormFieldById,
   getFormFieldIndexById,
   getLogicById,
-  isFormOnboarded,
 } from '../form.utils'
 
 import {
@@ -1388,66 +1380,6 @@ export const updateStartPage = (
     }
     return okAsync(updatedForm.startPage)
   })
-}
-
-/**
- * Checks if the given form field should be updated.
- * This currently checks if the admin has exceeded their free sms limit.
- * @param form The form which the specified field belongs to
- * @param formField The field which we should perform the update for
- * @returns ok(form) If the field can be updated
- * @return err(PossibleDatabaseError) if an error occurred while performing the required checks
- * @return err(SmsLimitExceededError) if the form admin went over the free sms limit
- * while attempting to toggle verification on for a mobile form field
- */
-export const shouldUpdateFormField = (
-  form: IPopulatedForm,
-  formField: FormField,
-): ResultAsync<
-  IPopulatedForm,
-  PossibleDatabaseError | SmsLimitExceededError
-> => {
-  switch (formField.fieldType) {
-    case BasicField.Mobile: {
-      return isMobileFieldUpdateAllowed(formField, form)
-    }
-    default:
-      return okAsync(form)
-  }
-}
-
-/**
- * Checks whether the mobile update should be allowed based on whether the mobile field is verified
- * and (if verified), the admin's free sms counts
- * @param mobileField The mobile field to check
- * @param form The form that the field belongs to
- * @returns ok(form) if the update is valid
- * @returns err(PossibleDatabaseError) if an error occurred while retrieving counts from database
- * @returns err(SmsLimitExceededError) if the admin of the form has exceeded their free sms quota
- */
-const isMobileFieldUpdateAllowed = (
-  mobileField: MobileFieldBase,
-  form: IPopulatedForm,
-): ResultAsync<
-  IPopulatedForm,
-  PossibleDatabaseError | SmsLimitExceededError
-> => {
-  // Field can always update if it's not a verifiable field or if the form has been onboarded
-  if (!isVerifiableMobileField(mobileField) || isFormOnboarded(form)) {
-    return okAsync(form)
-  }
-
-  const formAdminId = String(form.admin._id)
-
-  // If the form admin has exceeded the sms limit
-  // And the form is not onboarded, refuse to update the field
-  return SmsService.retrieveFreeSmsCounts(formAdminId).andThen(
-    (freeSmsSent) => {
-      return hasAdminExceededFreeSmsLimit(freeSmsSent)
-        ? errAsync(new SmsLimitExceededError())
-        : okAsync(form)
-    },
-  )
 }
 
 /**

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1391,31 +1391,6 @@ export const updateStartPage = (
 }
 
 /**
- * Disables sms verifications for all forms belonging to the specified user
- * @param userId the id of the user whose sms verifications should be disabled
- * @returns ok(true) when the forms have been successfully disabled
- * @returns err(PossibleDatabaseError) when an error occurred while attempting to disable sms verifications
- */
-export const disableSmsVerificationsForUser = (
-  userId: string,
-): ResultAsync<true, PossibleDatabaseError> =>
-  ResultAsync.fromPromise(
-    FormModel.disableSmsVerificationsForUser(userId),
-    (error) => {
-      logger.error({
-        message:
-          'Error occurred when attempting to disable sms verifications for user',
-        meta: {
-          action: 'disableSmsVerificationsForUser',
-          userId,
-        },
-        error,
-      })
-      return transformMongoError(error)
-    },
-  ).map(() => true)
-
-/**
  * Checks if the given form field should be updated.
  * This currently checks if the admin has exceeded their free sms limit.
  * @param form The form which the specified field belongs to

--- a/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -303,9 +303,6 @@ describe('Verification controller', () => {
 
     it('should return 201 when params are valid and form has no SPCP/MyInfo authentication required', async () => {
       // Arrange
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
-      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -332,13 +329,6 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_FORM_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_FORM,
-        mockTransaction,
-        MOCK_FORM_REQ.params.fieldId,
-      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
@@ -358,9 +348,6 @@ describe('Verification controller', () => {
       mockSpOidcServiceClass.extractJwt.mockReturnValueOnce(ok(MOCK_JWT))
       mockSpOidcServiceClass.extractJwtPayload.mockReturnValueOnce(
         okAsync(MOCK_SP_SESSION),
-      )
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
       )
 
       // Act
@@ -384,13 +371,6 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_FORM_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_SP_FORM,
-        mockTransaction,
-        MOCK_FORM_REQ.params.fieldId,
-      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
@@ -407,10 +387,6 @@ describe('Verification controller', () => {
       MockFormService.retrieveFullFormById.mockReturnValueOnce(
         okAsync(MOCK_CP_FORM),
       )
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
-      )
-
       mockCpOidcServiceClass.extractJwt.mockReturnValueOnce(ok(MOCK_JWT))
       mockCpOidcServiceClass.extractJwtPayload.mockReturnValueOnce(
         okAsync(MOCK_CP_SESSION),
@@ -437,19 +413,15 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_FORM_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_CP_FORM,
-        mockTransaction,
-        MOCK_FORM_REQ.params.fieldId,
-      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
     it('should return 201 when SGID authentication is enabled and sgid jwt token is valid', async () => {
       // Arrange
-      const MOCK_VALID_SGID_PAYLOAD = { userName: MOCK_JWT_PAYLOAD.userName }
+      const MOCK_VALID_SGID_PAYLOAD = {
+        userName: MOCK_JWT_PAYLOAD.userName,
+        rememberMe: false,
+      }
       const MOCK_SGID_REQ = expressHandler.mockRequest({
         body: { answer: MOCK_ANSWER },
         params: {
@@ -463,9 +435,6 @@ describe('Verification controller', () => {
 
       MockFormService.retrieveFullFormById.mockReturnValueOnce(
         okAsync(MOCK_SGID_FORM),
-      )
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
       )
       MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
         ok(MOCK_VALID_SGID_PAYLOAD),
@@ -489,13 +458,6 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_FORM_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_SGID_FORM,
-        mockTransaction,
-        MOCK_FORM_REQ.params.fieldId,
-      )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
@@ -510,10 +472,6 @@ describe('Verification controller', () => {
       MockMyInfoService.verifyLoginJwt.mockReturnValueOnce(
         ok(MOCK_MYINFO_LOGIN_COOKIE),
       )
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
-      )
-
       // Act
       await VerificationController._handleGenerateOtp(
         MOCK_FORM_REQ,
@@ -535,13 +493,6 @@ describe('Verification controller', () => {
       expect(MockOtpUtils.generateOtpWithHash).toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_FORM_OTP,
-      )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_MYINFO_FORM,
-        mockTransaction,
-        MOCK_FORM_REQ.params.fieldId,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
@@ -1205,9 +1156,6 @@ describe('Verification controller', () => {
 
     it('should return 201 when params are valid and form has no SPCP/MyInfo authentication required for payment otp', async () => {
       // Arrange
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
-      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -1234,13 +1182,7 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_PAYMENT_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_FORM,
-        mockTransaction,
-        MOCK_PAYMENT_REQ.params.fieldId,
-      )
+
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
@@ -1260,9 +1202,6 @@ describe('Verification controller', () => {
       mockSpOidcServiceClass.extractJwt.mockReturnValueOnce(ok(MOCK_JWT))
       mockSpOidcServiceClass.extractJwtPayload.mockReturnValueOnce(
         okAsync(MOCK_SP_SESSION),
-      )
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
       )
 
       // Act
@@ -1286,13 +1225,7 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_PAYMENT_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_SP_FORM,
-        mockTransaction,
-        MOCK_PAYMENT_REQ.params.fieldId,
-      )
+
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
@@ -1308,9 +1241,6 @@ describe('Verification controller', () => {
 
       MockFormService.retrieveFullFormById.mockReturnValueOnce(
         okAsync(MOCK_CP_FORM),
-      )
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
       )
 
       mockCpOidcServiceClass.extractJwt.mockReturnValueOnce(ok(MOCK_JWT))
@@ -1339,19 +1269,16 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_PAYMENT_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_CP_FORM,
-        mockTransaction,
-        MOCK_PAYMENT_REQ.params.fieldId,
-      )
+
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
     it('should return 201 when SGID authentication is enabled and sgid jwt token is valid for payment otp', async () => {
       // Arrange
-      const MOCK_VALID_SGID_PAYLOAD = { userName: MOCK_JWT_PAYLOAD.userName }
+      const MOCK_VALID_SGID_PAYLOAD = {
+        userName: MOCK_JWT_PAYLOAD.userName,
+        rememberMe: false,
+      }
       const MOCK_SGID_REQ = expressHandler.mockRequest({
         body: { answer: MOCK_ANSWER },
         params: {
@@ -1366,9 +1293,7 @@ describe('Verification controller', () => {
       MockFormService.retrieveFullFormById.mockReturnValueOnce(
         okAsync(MOCK_SGID_FORM),
       )
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
-      )
+
       MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
         ok(MOCK_VALID_SGID_PAYLOAD),
       )
@@ -1391,13 +1316,7 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_PAYMENT_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_SGID_FORM,
-        mockTransaction,
-        MOCK_PAYMENT_REQ.params.fieldId,
-      )
+
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 
@@ -1411,9 +1330,6 @@ describe('Verification controller', () => {
       )
       MockMyInfoService.verifyLoginJwt.mockReturnValueOnce(
         ok(MOCK_MYINFO_LOGIN_COOKIE),
-      )
-      MockVerificationService.disableVerifiedFieldsIfRequired.mockReturnValueOnce(
-        okAsync(true),
       )
 
       // Act
@@ -1438,13 +1354,7 @@ describe('Verification controller', () => {
       expect(MockVerificationService.sendNewOtp).toHaveBeenCalledWith(
         EXPECTED_PARAMS_FOR_SENDING_PAYMENT_OTP,
       )
-      expect(
-        MockVerificationService.disableVerifiedFieldsIfRequired,
-      ).toHaveBeenCalledWith(
-        MOCK_MYINFO_FORM,
-        mockTransaction,
-        MOCK_PAYMENT_REQ.params.fieldId,
-      )
+
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.CREATED)
     })
 

--- a/src/app/modules/verification/verification.controller.ts
+++ b/src/app/modules/verification/verification.controller.ts
@@ -194,15 +194,8 @@ export const _handleGenerateOtp: ControllerHandler<
             },
         ),
       )
-      .map(({ updatedTransaction, form, otpPrefix }) => {
-        res.status(StatusCodes.CREATED).json({ otpPrefix })
-        // NOTE: This is returned because tests require this to avoid async mocks interfering with each other.
-        // However, this is not an issue in reality because express does not require awaiting on the sendStatus call.
-        return VerificationService.disableVerifiedFieldsIfRequired(
-          form,
-          updatedTransaction,
-          fieldId,
-        )
+      .map(({ otpPrefix }) => {
+        return res.status(StatusCodes.CREATED).json({ otpPrefix })
       })
       .mapErr((error) => {
         logger.error({

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -7,7 +7,6 @@ import { startsWithSgPrefix } from '../../../../shared/utils/phone-num-validatio
 import { NUM_OTP_RETRIES } from '../../../../shared/utils/verification'
 import {
   IFormSchema,
-  IPopulatedForm,
   IVerificationFieldSchema,
   IVerificationSchema,
 } from '../../../types'
@@ -317,32 +316,6 @@ export const sendNewOtp = ({
         return okAsync(newTransaction)
       })
   })
-}
-
-export const disableVerifiedFieldsIfRequired = (
-  form: IPopulatedForm,
-  transaction: IVerificationSchema,
-  fieldId: string,
-): ResultAsync<boolean, void> => {
-  return getFieldFromTransaction(
-    transaction,
-    fieldId === PAYMENT_CONTACT_FIELD_ID,
-    fieldId,
-  )
-    .asyncAndThen(() => okAsync(false))
-    .mapErr((error) => {
-      logger.error({
-        message:
-          'Error checking sms counts or deactivating OTP verification for admin',
-        meta: {
-          action: 'checkShouldDisabledVerifiedMobileFields',
-          transactionId: transaction._id,
-          fieldId,
-          formId: transaction.formId,
-        },
-        error,
-      })
-    })
 }
 
 /**

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -4,10 +4,7 @@ import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { PAYMENT_CONTACT_FIELD_ID } from '../../../../shared/constants'
 import { BasicField } from '../../../../shared/types'
 import { startsWithSgPrefix } from '../../../../shared/utils/phone-num-validation'
-import {
-  NUM_OTP_RETRIES,
-  SMS_WARNING_TIERS,
-} from '../../../../shared/utils/verification'
+import { NUM_OTP_RETRIES } from '../../../../shared/utils/verification'
 import {
   IFormSchema,
   IPopulatedForm,
@@ -16,15 +13,10 @@ import {
 } from '../../../types'
 import formsgSdk from '../../config/formsg-sdk'
 import { createLoggerWithLabel } from '../../config/logger'
-import * as AdminFormService from '../../modules/form/admin-form/admin-form.service'
-import {
-  MailGenerationError,
-  MailSendError,
-} from '../../services/mail/mail.errors'
+import { MailSendError } from '../../services/mail/mail.errors'
 import MailService from '../../services/mail/mail.service'
 import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
 import { SmsFactory } from '../../services/sms/sms.factory'
-import * as SmsService from '../../services/sms/sms.service'
 import { transformMongoError } from '../../utils/handle-mongo-error'
 import { compareHash, HashingError } from '../../utils/hash'
 import {
@@ -34,7 +26,6 @@ import {
 } from '../core/core.errors'
 import { FormNotFoundError } from '../form/form.errors'
 import * as FormService from '../form/form.service'
-import { isFormOnboarded } from '../form/form.utils'
 
 import {
   FieldNotFoundInTransactionError,
@@ -57,7 +48,6 @@ import {
 } from './verification.types'
 import {
   getFieldFromTransaction,
-  hasAdminExceededFreeSmsLimit,
   isOtpExpired,
   isOtpRequestCountExceeded,
   isOtpWaitTimeElapsed,
@@ -339,14 +329,7 @@ export const disableVerifiedFieldsIfRequired = (
     fieldId === PAYMENT_CONTACT_FIELD_ID,
     fieldId,
   )
-    .asyncAndThen((field) => {
-      switch (field.fieldType) {
-        case BasicField.Mobile:
-          return processAdminSmsCounts(form)
-        default:
-          return okAsync(false)
-      }
-    })
+    .asyncAndThen(() => okAsync(false))
     .mapErr((error) => {
       logger.error({
         message:
@@ -516,67 +499,6 @@ const sendOtpForField = (
     default:
       return errAsync(new NonVerifiedFieldTypeError(fieldType))
   }
-}
-
-/**
- * Checks the number of free smses sent by the admin of the form and deactivates verification or sends mail as required
- * @param form The form whose admin's sms counts needs to be checked
- * @returns ok(true) when the verification has been deactivated successfully
- * @returns ok(false) when no action is required
- * @returns err(MailGenerationError) when an error occurred on creating the HTML template for the email
- * @returns err(MailSendError) when an error occurred on sending the email
- * @returns err(PossibleDatabaseError) when an error occurred while retrieving the counts from the database
- */
-const processAdminSmsCounts = (
-  form: IPopulatedForm,
-): ResultAsync<
-  boolean,
-  MailGenerationError | MailSendError | PossibleDatabaseError
-> => {
-  if (isFormOnboarded(form)) {
-    return okAsync(false)
-  }
-
-  // Convert to string because it's typed as any
-  const formAdminId = String(form.admin._id)
-
-  return SmsService.retrieveFreeSmsCounts(formAdminId).andThen((freeSmsSent) =>
-    checkSmsCountAndPerformAction(form, freeSmsSent),
-  )
-}
-
-/**
- * Checks the number of free smses sent by the admin of a form and performs the appropriate action
- * @param form The form whose admin's sms counts needs to be checked
- * @returns ok(true) when the action has been performed successfully
- * @returns ok(false) when no action is required
- * @returns err(MailGenerationError) when an error occurred on creating the HTML template for the email
- * @returns err(MailSendError) when an error occurred on sending the email
- * @returns err(PossibleDatabaseError) when an error occurred while retrieving the counts from the database
- */
-const checkSmsCountAndPerformAction = (
-  form: Pick<IPopulatedForm, 'admin' | 'title' | '_id' | 'permissionList'>,
-  freeSmsSent: number,
-): ResultAsync<
-  boolean,
-  MailGenerationError | MailSendError | PossibleDatabaseError
-> => {
-  // Convert to string because it's typed as any
-  const formAdminId = String(form.admin._id)
-
-  // NOTE: Because the admin has exceeded their allowable limit of free sms,
-  // the sms verifications for their forms also need to be disabled.
-  if (hasAdminExceededFreeSmsLimit(freeSmsSent)) {
-    return MailService.sendSmsVerificationDisabledEmail(form).andThen(() =>
-      AdminFormService.disableSmsVerificationsForUser(formAdminId),
-    )
-  }
-
-  if (freeSmsSent in SMS_WARNING_TIERS) {
-    return MailService.sendSmsVerificationWarningEmail(form, freeSmsSent)
-  }
-
-  return okAsync(false)
 }
 
 /**

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -4,7 +4,6 @@ import {
   LeanDocument,
   Model,
   ToObjectOptions,
-  UpdateWriteOpResult,
 } from 'mongoose'
 import { DeepRequired } from 'ts-essentials'
 import type { Merge, SetOptional } from 'type-fest'
@@ -358,10 +357,6 @@ export interface IFormModel extends Model<IFormSchema> {
   retrieveFormsOwnedByUserId(
     userId: IUserSchema['_id'],
   ): Promise<AdminDashboardFormMetaDto[]>
-
-  disableSmsVerificationsForUser(
-    userId: IUserSchema['_id'],
-  ): Promise<UpdateWriteOpResult>
 
   /**
    * Retrieves all the public forms for a user which has sms verifications enabled


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Missed out the whole backend changes for #7257.

Also took the chance to update backend tests.

Closes FRM-1716

## Solution
<!-- How did you solve the problem? -->

Key logic changes were the removal of checks that will:
1. Disable SMS (`processAdminSmsCounts`, `disableVerifiedFieldsIfRequired`)
2. Block OTP Verification toggle on updates from FormFE (`shouldUpdateFormField`)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
#### Regression
**Admins can update twilio credentials**
- [x] Create a new storage form
- [x] Go to Form Twilio Settings page
- [x] Enter `ACC`, `SKK`, `SKK`, `MGG` for the respective fields
- [x] Ensure that clicking on save credentials isn't blocked

**Admins can update OTP fields**
- [x] Ensure that clicking on "Remove and re-enter credentials" isn't blocked

**Respondent OTP verification still works**
- [x] Add Mobile field 
- [x] Enable OTP verification
- [x] Open up the admin form
- [x] Ensure that verify sends an SMS to you

**New feature test**
- [x] Update on SSM `SMS_VERIFICATION_LIMIT` to 10
- [x] Send 10 SMS
- [x] Ensure that the 11th SMS is still received by respondent
- [x] Ensure that admin can still toggle on and off OTP verification field