### PR TITLE
fix: remove phantom fields

### DIFF
--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -183,7 +183,6 @@ export const MultirespondentSubmissionStreamDto =
     form_logics: true,
     encryptedSubmissionSecretKey: true,
     encryptedContent: true,
-    verifiedContent: true,
     version: true,
   }).extend({
     attachmentMetadata: z.record(z.string()),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Build is blocked after some dependencies were upgraded. 
```
Error: [backend] shared/types/submission.ts(186,5): error TS2322: Type 'boolean' is not assignable to type 'never'.
```

Traced back to https://github.com/opengovsg/FormSG/actions/runs/8790136379 [#7273] as the first commit that failed.

## Solution
<!-- How did you solve the problem? -->

`verifiedContent` is not part of `MultirespondentSubmissionBase`. Removed it.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
