### PR TITLE
fix: add localhost domain into cors, used by attachment uploads

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,7 @@ services:
     environment:
       - SERVICES=s3,sqs,secretsmanager
       - DNS_ADDRESS=0
+      - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:3000
     volumes:
       - ./.localstack/volume:/var/lib/localstack
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When submitting a form with attachment on local, it will fail with CORS error. 
`
65fa903a375c0de6e5362ee2:1 Access to XMLHttpRequest at 'http://localhost:4566/local-virus-scanner-quarantine-bucket' from origin 'http://localhost:3000' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
`

## Solution
<!-- How did you solve the problem? -->

Add localhost into allowed origin
