### PR TITLE
fix(mrf): attachment v2

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -29,7 +29,7 @@ RUN apk update && apk upgrade && \
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
     # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=124.0.6367.60-r0 \
+    chromium=124.0.6367.78-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -82,7 +82,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 
 RUN apk add --no-cache \
     # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=124.0.6367.60-r0 \
+    chromium=124.0.6367.78-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,6 +169,7 @@ services:
     environment:
       - SERVICES=s3,sqs,secretsmanager
       - DNS_ADDRESS=0
+      - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:3000
     volumes:
       - ./.localstack/volume:/var/lib/localstack
       - /var/run/docker.sock:/var/run/docker.sock

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -91,7 +91,7 @@ export const getDecryptedSubmissionById = async ({
     submissionId,
   })
 
-  let processedContent, submissionSecretKey
+  let processedContent, submissionSecretKey, mrfVersion
   switch (encryptedSubmission.submissionType) {
     case SubmissionType.Encrypt: {
       const decryptedContent = formsgSdk.crypto.decrypt(secretKey, {
@@ -119,6 +119,7 @@ export const getDecryptedSubmissionById = async ({
         decryptedContent,
       )
       submissionSecretKey = decryptedContent.submissionSecretKey
+      mrfVersion = encryptedSubmission.mrfVersion
       break
     }
   }
@@ -138,6 +139,7 @@ export const getDecryptedSubmissionById = async ({
         ? encryptedSubmission.payment
         : undefined,
     responses,
+    mrfVersion,
   }
 }
 

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
@@ -16,7 +16,7 @@ export interface DecryptedRowBaseProps {
   row: AugmentedDecryptedResponse
 }
 type DecryptedRowProps = DecryptedRowBaseProps & {
-  secretKey: string
+  attachmentDecryptionKey: string
 }
 
 const DecryptedQuestionLabel = ({ row }: DecryptedRowBaseProps) => {
@@ -62,17 +62,20 @@ const DecryptedTableRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
   )
 }
 
-const DecryptedAttachmentRow = ({ row, secretKey }: DecryptedRowProps) => {
+const DecryptedAttachmentRow = ({
+  row,
+  attachmentDecryptionKey,
+}: DecryptedRowProps) => {
   const { downloadAttachmentMutation } = useMutateDownloadAttachments()
 
   const handleDownload = useCallback(() => {
     if (!row.downloadUrl || !row.answer) return
     return downloadAttachmentMutation.mutate({
       url: row.downloadUrl,
-      secretKey,
+      secretKey: attachmentDecryptionKey,
       fileName: row.answer,
     })
-  }, [downloadAttachmentMutation, row, secretKey])
+  }, [downloadAttachmentMutation, row, attachmentDecryptionKey])
 
   return (
     <Stack>
@@ -102,12 +105,17 @@ const DecryptedAttachmentRow = ({ row, secretKey }: DecryptedRowProps) => {
 }
 
 export const DecryptedRow = memo(
-  ({ row, secretKey }: DecryptedRowProps): JSX.Element => {
+  ({ row, attachmentDecryptionKey }: DecryptedRowProps): JSX.Element => {
     switch (row.fieldType) {
       case BasicField.Section:
         return <DecryptedHeaderRow row={row} />
       case BasicField.Attachment:
-        return <DecryptedAttachmentRow row={row} secretKey={secretKey} />
+        return (
+          <DecryptedAttachmentRow
+            row={row}
+            attachmentDecryptionKey={attachmentDecryptionKey}
+          />
+        )
       case BasicField.Table:
         return <DecryptedTableRow row={row} />
       default:

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -68,7 +68,8 @@ export interface PublicFormContextProps
 
   encryptedPreviousSubmission?: MultirespondentSubmissionDto
   previousSubmission?: ReturnType<typeof decryptSubmission>
-  setPreviousSubmission: (
+  previousAttachments?: Record<string, ArrayBuffer>
+  setPreviousSubmission?: (
     previousSubmission: ReturnType<typeof decryptSubmission>,
   ) => void
 }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -223,9 +223,11 @@ export const PublicFormProvider = ({
         Object.keys(previousSubmission.responses).forEach((id) => {
           const response = previousSubmission.responses[id]
           if (response.fieldType === BasicField.Attachment) {
-            //@ts-expect-error 'content' required for backward compatibility,
-            // but does not exist on type AttachmentResponseV3
-            previousAttachments[id] = Uint8Array.from(response.content.data)
+            previousAttachments[id] = Uint8Array.from(
+              //@ts-expect-error 'content' required for backward compatibility, but
+              // does not exist on AttachmentFieldResponseV3 in mrfVersion === 1 versions
+              response.answer.content.data,
+            )
           }
         })
         setPreviousAttachments(previousAttachments)

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -38,6 +38,7 @@ import { VisibleFormFields } from './VisibleFormFields'
 
 export interface FormFieldsProps {
   previousResponses?: FieldResponsesV3
+  previousAttachments?: Record<string, ArrayBuffer>
   formFields: FormFieldDto[]
   formLogics: LogicDto[]
   workflowStep?: FormWorkflowStepDto
@@ -54,6 +55,7 @@ export type PrefillMap = {
 
 export const FormFields = ({
   previousResponses,
+  previousAttachments,
   formFields,
   formLogics,
   workflowStep,
@@ -106,9 +108,12 @@ export const FormFields = ({
           case BasicField.Attachment: {
             const attachmentData =
               previousResponse.answer as AttachmentFieldResponseV3
-            const fileData = attachmentData.content.data
             const fileName = attachmentData.answer
-            acc[field._id] = bufferToFile(fileData, fileName)
+            const fileData = previousAttachments?.[field._id]
+            if (fileData) {
+              acc[field._id] = bufferToFile(fileData, fileName)
+            }
+
             break
           }
           default:
@@ -140,7 +145,12 @@ export const FormFields = ({
       }
       return acc
     }, {})
-  }, [augmentedFormFields, previousResponses, fieldPrefillMap])
+  }, [
+    augmentedFormFields,
+    previousResponses,
+    fieldPrefillMap,
+    previousAttachments,
+  ])
 
   // payment prefills - only for variable payments
   if (searchParams.has(PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID)) {

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -19,6 +19,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     submissionData,
     encryptedPreviousSubmission,
     previousSubmission,
+    previousAttachments,
   } = usePublicFormContext()
 
   const { workflowStep } = encryptedPreviousSubmission ?? {}
@@ -42,6 +43,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     return (
       <FormFields
         previousResponses={previousSubmission?.responses}
+        previousAttachments={previousAttachments}
         formFields={form.form_fields}
         formLogics={form.form_logics}
         workflowStep={
@@ -61,7 +63,8 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     isLoading,
     form,
     isAuthRequired,
-    previousSubmission,
+    previousSubmission?.responses,
+    previousAttachments,
     workflowStep,
     handleSubmitForm,
   ])

--- a/frontend/src/features/public-form/queries.ts
+++ b/frontend/src/features/public-form/queries.ts
@@ -1,6 +1,5 @@
 import { useQuery, UseQueryResult } from 'react-query'
 
-import { MultirespondentSubmissionDto } from '~shared/types'
 import { PublicFormViewDto } from '~shared/types/form/form'
 
 import { ApiError } from '~typings/core'
@@ -11,6 +10,7 @@ import {
   getMultirespondentSubmissionById,
   getPublicFormView,
 } from './PublicFormService'
+import { MultirespondentSubmissionDtoWithAttachments } from './types'
 
 export const publicFormKeys = {
   // All keys map to either an array or function returning an array for
@@ -45,7 +45,7 @@ export const useEncryptedSubmission = (
   submissionId?: string,
   /** Extra override to determine whether query is enabled */
   enabled = true,
-): UseQueryResult<MultirespondentSubmissionDto, ApiError> => {
+): UseQueryResult<MultirespondentSubmissionDtoWithAttachments, ApiError> => {
   return useQuery(
     publicFormKeys.submission(formId, submissionId),
     () =>

--- a/frontend/src/features/public-form/types.ts
+++ b/frontend/src/features/public-form/types.ts
@@ -1,0 +1,8 @@
+import { EncryptedFileContent } from '@opengovsg/formsg-sdk/dist/types'
+
+import { MultirespondentSubmissionDto } from '~shared/types'
+
+export type MultirespondentSubmissionDtoWithAttachments =
+  MultirespondentSubmissionDto & {
+    encryptedAttachments: Record<string, EncryptedFileContent>
+  }

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -33,7 +33,7 @@ import { validateResponses } from './validateResponses'
 
 /**
  * @returns StorageModeSubmissionContentDto
- * @throw Error if form inputs are invalid.
+ * @throws Error if form inputs are invalid.
  */
 export const createEncryptedSubmissionData = async ({
   formFields,

--- a/frontend/src/utils/bufferToFile.ts
+++ b/frontend/src/utils/bufferToFile.ts
@@ -4,9 +4,8 @@
  * @param filename
  * @returns
  */
-const bufferToFile = (data: Iterable<number>, filename: string): File => {
-  const bufferArray = Uint8Array.from(data)
-  const blob = new Blob([bufferArray])
+const bufferToFile = (data: ArrayBuffer, filename: string): File => {
+  const blob = new Blob([data])
   const file = new File([blob], filename)
 
   return file

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -1,7 +1,6 @@
 import type { Opaque, RequireAtLeastOne } from 'type-fest'
 import { z } from 'zod'
 
-import { EncryptedFileContent } from '@opengovsg/formsg-sdk/dist/types'
 import { ErrorDto } from './core'
 import { FormFieldDto, MyInfoAttribute, PaymentFieldsDto } from './field'
 import { FormAuthType } from './form/form'
@@ -93,6 +92,7 @@ export const MultirespondentSubmissionBase = SubmissionBase.extend({
   attachmentMetadata: z.map(z.string(), z.string()).optional(),
   version: z.number(),
   workflowStep: z.number(),
+  mrfVersion: z.number().optional(),
 })
 
 export type MultirespondentSubmissionBase = z.infer<
@@ -151,13 +151,11 @@ export type MultirespondentSubmissionDto = SubmissionDtoBase & {
   submissionPublicKey: string
   encryptedSubmissionSecretKey: string
   encryptedContent: string
-  //verified?: string
   attachmentMetadata: Record<string, string>
-  // Populated by FE during upon loading of the submission dto
-  encryptedAttachments: Record<string, EncryptedFileContent>
+  workflowStep: number
 
   version: number
-  workflowStep: number
+  mrfVersion: number
 }
 
 export type SubmissionDto =
@@ -188,6 +186,7 @@ export const MultirespondentSubmissionStreamDto =
     encryptedSubmissionSecretKey: true,
     encryptedContent: true,
     version: true,
+    mrfVersion: true,
   }).extend({
     attachmentMetadata: z.record(z.string()),
     _id: SubmissionId,

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -1,6 +1,7 @@
 import type { Opaque, RequireAtLeastOne } from 'type-fest'
 import { z } from 'zod'
 
+import { EncryptedFileContent } from '@opengovsg/formsg-sdk/dist/types'
 import { ErrorDto } from './core'
 import { FormFieldDto, MyInfoAttribute, PaymentFieldsDto } from './field'
 import { FormAuthType } from './form/form'
@@ -152,6 +153,9 @@ export type MultirespondentSubmissionDto = SubmissionDtoBase & {
   encryptedContent: string
   //verified?: string
   attachmentMetadata: Record<string, string>
+  // Populated by FE during upon loading of the submission dto
+  encryptedAttachments: Record<string, EncryptedFileContent>
+
   version: number
   workflowStep: number
 }

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -498,6 +498,9 @@ export const MultirespondentSubmissionSchema = new Schema<
     type: Number,
     required: true,
   },
+  mrfVersion: {
+    type: Number,
+  },
 })
 
 MultirespondentSubmissionSchema.statics.findSingleMetadata = function (
@@ -611,6 +614,7 @@ MultirespondentSubmissionSchema.statics.getSubmissionCursorByFormId = function (
         attachmentMetadata: 1,
         created: 1,
         version: 1,
+        mrfVersion: 1,
         id: 1,
       })
       .batchSize(2000)
@@ -645,6 +649,7 @@ MultirespondentSubmissionSchema.statics.findEncryptedSubmissionById = function (
       created: 1,
       version: 1,
       workflowStep: 1,
+      mrfVersion: 1,
     })
     .exec()
 }

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -149,6 +149,7 @@ const submitMultirespondentForm = async (
     encryptedContent,
     responseMetadata,
     version,
+    mrfVersion,
   } = encryptedPayload
 
   const submissionContent = {
@@ -164,6 +165,7 @@ const submitMultirespondentForm = async (
     attachmentMetadata,
     version,
     workflowStep: 0,
+    mrfVersion,
   }
 
   return _createSubmission({
@@ -382,6 +384,7 @@ const updateMultirespondentSubmission = async (
     version,
     workflowStep,
     responses,
+    mrfVersion,
   } = encryptedPayload
 
   // Save Responses to Database
@@ -419,6 +422,7 @@ const updateMultirespondentSubmission = async (
   submission.version = version
   submission.workflowStep = workflowStep
   submission.attachmentMetadata = attachmentMetadata
+  submission.mrfVersion = mrfVersion
 
   try {
     await submission.save()

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -603,19 +603,19 @@ export const encryptSubmission = async (
     }
   }
 
-  const encryptedAttachments =
-    await getEncryptedAttachmentsMapFromAttachmentsMap(
-      attachmentsMap,
-      formPublicKey,
-      req.body.version,
-    )
-
   const {
     encryptedContent,
     encryptedSubmissionSecretKey,
     submissionSecretKey,
     submissionPublicKey,
-  } = formsgSdk.cryptoV3.encrypt(responses, formPublicKey)
+  } = formsgSdk.cryptoV3.encrypt(strippedAttachmentResponses, formPublicKey)
+
+  const encryptedAttachments =
+    await getEncryptedAttachmentsMapFromAttachmentsMap(
+      attachmentsMap,
+      submissionPublicKey,
+      req.body.version,
+    )
 
   req.formsg.encryptedPayload = {
     attachments: encryptedAttachments,
@@ -627,6 +627,13 @@ export const encryptSubmission = async (
     version: req.body.version,
     workflowStep: req.body.workflowStep,
     responses,
+    /**
+     * MRF Version: 1
+     * ====================
+     * - Encrypted payload does not contain attachment contents
+     * - Encrypted Attachment now encrypted by mrf / submission Public Key instead of Form Public Key
+     */
+    mrfVersion: 1,
   }
 
   return next()

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -13,7 +13,7 @@ import { MultirespondentSubmissionData } from '../../../../types'
 import { InvalidWorkflowTypeError } from '../submission.errors'
 
 /**
- * Creates and returns a StorageModeSubmissionDto object from submissionData and
+ * Creates and returns a MultirespondentSubmissionDto object from submissionData and
  * attachment presigned urls.
  */
 export const createMultirespondentSubmissionDto = (
@@ -37,6 +37,7 @@ export const createMultirespondentSubmissionDto = (
     attachmentMetadata: attachmentPresignedUrls,
     version: submissionData.version,
     workflowStep: submissionData.workflowStep,
+    mrfVersion: submissionData.mrfVersion,
   }
 }
 

--- a/src/types/api/multirespondent_submission.ts
+++ b/src/types/api/multirespondent_submission.ts
@@ -37,4 +37,5 @@ export type MultirespondentSubmissionDto = {
   responseMetadata?: ResponseMetadata
   workflowStep: number
   responses: FieldResponsesV3
+  mrfVersion: number
 }

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -91,6 +91,7 @@ export interface IMultirespondentSubmissionSchema
   form: any
   submissionType: SubmissionType.Multirespondent
   getWebhookView(): Promise<null>
+  mrfVersion: number
 }
 
 // When retrieving from database, the attachmentMetadata type becomes an object
@@ -117,6 +118,7 @@ export type MultirespondentSubmissionCursorData = Pick<
   | 'created'
   | 'id'
   | 'version'
+  | 'mrfVersion'
 > & { attachmentMetadata?: Record<string, string> } & Document
 
 export type SubmissionCursorData =
@@ -150,6 +152,7 @@ export type MultirespondentSubmissionData = {
   | 'created'
   | 'version'
   | 'workflowStep'
+  | 'mrfVersion'
 > &
   Document
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Encrypted content of MRF with attachments is huge as it contains the attachments contents. 

## Solution
<!-- How did you solve the problem? -->

### Overview

First, we introduce a new backward-compatibility key `mrfVersion` in the multirespondent submission object. This is initialized as 1 for all new MRF submissions. Here are the differences between the two values.

Old version: `mrfVersion === undefined`
- On submission
  - Response + attachments is saved to DB encrypted with submission key. 
  - Attachment is also saved to S3 encrypted with form key.  
- On retrieval
  - Respondent flow (R2 onwards): response + attachment is retrieved from DB and decrypted with submission key.
  - Admin flow (individual response page, csv download): attachment is retrieved from S3 and decrypted with form key.

New version: `mrfVersion === 1`
- On submission
  - Response is saved to DB encrypted with submission key.
  - Attachment is saved to S3 encrypted with submission key.
- On retrieval
  - Respondent flow (R2 onwards): response is retrieved from DB and decrypted with submission key. attachment is  retrieved from S3 and decrypted with submission key.
  - Admin flow (individual response page, csv download): attachment is retrieved from S3 and decrypted with form key (via encrypted submission key).

### Changelog

Therefore, this PR does the following changes.
- On submission
  1. Exclude attachment contents in the saved response `encryptedContent`
  2. Encrypt attachments using the submission key instead.
- On retrieval (all of these must be backward compatible, thus gated by `mrfVersion === 1` check)
  - Respondent flow
    1. a new type `MultirespondentSubmissionDtoWithAttachments` is created to allow for rehydration of the encrypted attachments 
    2. Add rehydration of attachments during `getMultirespondentSubmissionById`. _(This will slow down the initial load, but provides compatibility quickly. If the UX is slow, it might make sense for us to provide a loading screen to handle this.)_
    3. evaluation of which attachment to attach as defaults to the existing form is streamlined into the `useEffect` in `PublicFormProvider`, via the `previousAttachments` variable, based on whether `mrfVersion === 1` 
  - Admin flow
    1. Change Admin Response Page to use Submission Key to decrypt files for `mrfVersion === 1` responses, since attachments are now encrypted with a different key

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
  - Backwards compatibility is handled through `mrfVersion: 1` on the encryptedContent.

## Tests
<!-- What tests should be run to confirm functionality? -->

### Before deployment tests

**Prepare for backward compatibility tests**

- [ ] Create an MRF with an attachment field (of less than 4MB).
- [ ] Make a new submission with an attachment. This should be successful.
- [ ] Run the following attachment loading tests:
  - [ ] In the admin individual response page, download the attachment. This should be successful.
  - [ ] In the admin individual response page, download all attachments as ZIP. This should be successful.
  - [ ] In the admin panel, export all form responses as CSV with attachments. This should be successful.
  - [ ] As respondent 2, load the public form. Download the attachment from the form page. This should be successful.

### After deployment tests

**Backward compatibility tests**

For the submission that was made earlier, 
- [ ] Run the attachment loading tests defined above

**End-to-end tests for the new protocol**

- [ ] Now, make a new submission with an attachment. This should be successful.
- [ ] Run the attachment loading tests defined above
- [ ] As respondent 2, submit the form with the default attachment. This should be successful.
- [ ] Run the attachment loading tests defined above again


**Ensure that attachments up to 20MB are supported** 
_(note: this is not testable on staging as a result of infra-level limitations. test this on production as a manual test once the new version is released)_

- [ ] Adjust the form to allow two attachments of up to 10MB each
- [ ] Submit two 9MB attachments. This should be successful.
- [ ] Run the attachment loading tests defined above again