### PR TITLE
chore: reduce output, check gh login auth status only if not logged in

### DIFF
--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
+set +x
 
-set -x
 
 # pre-requisites: install github CLI
 # - github documentation: https://github.com/cli/cli#installation
 # - github is remote 'origin'
 # - PRs use test section LAST with heading "## Tests"
 # - ALL build and release PRs start with "build: "
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "Install gh first"
+    exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "You need to login: gh auth login"
+    exit 1
+fi
 
 has_local_changes=$(git status --porcelain --untracked-files=no --ignored=no)
 if [[ ${has_local_changes} ]]; then
@@ -69,8 +79,6 @@ echo "" >> ${pr_body_file_groupped}
 echo "## Dev-Dependencies" >> ${pr_body_file_groupped}
 echo "" >> ${pr_body_file_groupped}
 grep -E -- '- [a-z]+\(deps-dev\)' ${pr_body_file} >> ${pr_body_file_groupped}
-
-gh auth login
 
 ## Extract test procedures for feature PRs
 echo "" >> ${pr_body_file_groupped}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When releasing:
1.  output is very noisy
2. `gh auth login` executes every time even if we've just logged in

## Solution
<!-- How did you solve the problem? -->
Ideally we should use commander or something high-tech for our release scripts...

1. Hide output with `+e`
2. Test for login through `gh auth status` instead

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
