### PR TITLE
feat(btn): phase 2 - add growthbook toggle to control adding twilio creds

### DIFF
--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
@@ -15,6 +15,7 @@ import {
 } from '@chakra-ui/react'
 import { useToggle } from 'rooks'
 
+import { featureFlags } from '~shared/constants'
 import { TwilioCredentials } from '~shared/types/twilio'
 
 import { trimStringsInObject } from '~utils/trimStringsInObject'
@@ -25,6 +26,7 @@ import IconButton from '~components/IconButton'
 import Input, { InputProps } from '~components/Input'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { useIsFeatureEnabled } from '~features/feature-flags/queries'
 
 import { useMutateTwilioCreds } from '../../mutations'
 
@@ -61,11 +63,15 @@ const TWILIO_INPUT_RULES: Record<keyof TwilioCredentials, RegisterOptions> = {
     },
   },
 }
-
 export const TwilioDetailsInputs = (): JSX.Element => {
   const { data: form, isLoading } = useAdminForm()
 
   const [isApiSecretShown, toggleIsApiSecretShown] = useToggle(false)
+
+  const isAddingTwilioDisabled = useIsFeatureEnabled(
+    featureFlags.addingTwilioDisabled,
+    false,
+  )
 
   const hasExistingTwilioCreds = useMemo(
     () => !!form?.msgSrvcName,
@@ -93,6 +99,7 @@ export const TwilioDetailsInputs = (): JSX.Element => {
 
   const handleUpdateTwilioDetails = handleSubmit((credentials) => {
     if (!form) return
+    if (isAddingTwilioDisabled) return
     return mutateFormTwilioDetails.mutate(trimStringsInObject(credentials), {
       onSuccess: () => reset(),
     })
@@ -129,6 +136,7 @@ export const TwilioDetailsInputs = (): JSX.Element => {
         <FormControl
           isReadOnly={mutateFormTwilioDetails.isLoading}
           isInvalid={!!errors.accountSid}
+          isDisabled={isAddingTwilioDisabled}
         >
           <FormLabel isRequired>Account SID</FormLabel>
           <Skeleton isLoaded={!isLoading}>
@@ -139,6 +147,7 @@ export const TwilioDetailsInputs = (): JSX.Element => {
         <FormControl
           isReadOnly={mutateFormTwilioDetails.isLoading}
           isInvalid={!!errors.apiKey}
+          isDisabled={isAddingTwilioDisabled}
         >
           <FormLabel isRequired>API Key SID</FormLabel>
           <Skeleton isLoaded={!isLoading}>
@@ -149,6 +158,7 @@ export const TwilioDetailsInputs = (): JSX.Element => {
         <FormControl
           isReadOnly={mutateFormTwilioDetails.isLoading}
           isInvalid={!!errors.apiSecret}
+          isDisabled={isAddingTwilioDisabled}
         >
           <FormLabel isRequired>API key secret</FormLabel>
           <Skeleton isLoaded={!isLoading}>
@@ -179,6 +189,7 @@ export const TwilioDetailsInputs = (): JSX.Element => {
         <FormControl
           isReadOnly={mutateFormTwilioDetails.isLoading}
           isInvalid={!!errors.messagingServiceSid}
+          isDisabled={isAddingTwilioDisabled}
         >
           <FormLabel isRequired>Messaging service SID</FormLabel>
           <Skeleton isLoaded={!isLoading}>
@@ -198,6 +209,7 @@ export const TwilioDetailsInputs = (): JSX.Element => {
           <Button
             isLoading={mutateFormTwilioDetails.isLoading}
             onClick={handleUpdateTwilioDetails}
+            isDisabled={isAddingTwilioDisabled}
           >
             Save credentials
           </Button>

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioSettingsSection.tsx
@@ -1,10 +1,21 @@
 import { ListItem, Text, UnorderedList } from '@chakra-ui/react'
 
+import { featureFlags } from '~shared/constants'
+
 import InlineMessage from '~components/InlineMessage'
+
+import { useIsFeatureEnabled } from '~features/feature-flags/queries'
 
 import { TwilioDetailsInputs } from './TwilioDetailsInputs'
 
 export const TwilioSettingsSection = (): JSX.Element => {
+  const isAddingTwilioDisabled = useIsFeatureEnabled(
+    featureFlags.addingTwilioDisabled,
+    false,
+  )
+
+  const verbTense = isAddingTwilioDisabled ? 'has been' : 'will be'
+
   return (
     <>
       <InlineMessage mb="1rem" variant="warning">
@@ -15,8 +26,8 @@ export const TwilioSettingsSection = (): JSX.Element => {
           <UnorderedList spacing="0.5rem" mt="1rem">
             <ListItem>
               There is no longer a limit of 10,000 SMSes per form admin. Given
-              this change, the capability of adding new Twilio credentials will
-              be disabled from 30 April.
+              this change, the capability of adding new Twilio credentials{' '}
+              {verbTense} disabled from 30 April.
             </ListItem>
 
             <ListItem>

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -5,4 +5,5 @@ export const featureFlags = {
   validateStripeEmailDomain: 'validateStripeEmailDomain' as const,
   myinfoSgid: 'myinfo-sgid' as const,
   chartsMaxResponseCount: 'charts-max-response-count' as const,
+  addingTwilioDisabled: 'adding-twilio-disabled' as const,
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes frm-1718

## Solution
<!-- How did you solve the problem? -->

Add growthbook toggle to toggle between enabling and disabling adding of Twilio Credentials on the Frontend.

Backend is not disabled as we will be:
1. removing the whole endpoint in June
2. forcefully disconnecting the endpoint
3. does not impact our service 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Component | Before | After |
|--------|--------|--------|
| Twilio Credentials Tab | <img width="713" alt="Screenshot 2024-04-28 at 5 41 17 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/536b2072-8a72-4366-8dc7-107eace808a0"> | <img width="761" alt="Screenshot 2024-04-28 at 5 41 41 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/01c6e89b-ff0b-4fe0-8ddd-940c9071c773"> |

## Tests
<!-- What tests should be run to confirm functionality? -->
Regression
Feature toggle is off, user should still see `will be`, and able to add twilio credentials
- [ ] Go to Form Settings > Twilio Credentials page
- [ ] Ensure that the infobox text reads `will be disabled from 30 April`
- [ ] Ensure that "Save Credentials" button is enabled


New feature test
- [ ] Enable toggle on `staging` env from growthbook
- [ ] Go to Form Settings > Twilio Credentials page
- [ ] Ensure that the infobox text reads `will be disabled from 30 April`
- [ ] Ensure that "Save Credentials" button is disabled


## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

Ensure that `adding-twilio-disabled` is added on growthbook (with `value: True`, but not toggled on `production`) . It should be disabled before April 30 or enabled if it is after April 30.
- April 30 is the transition window to enable this on production

**New environment variables**:

- `adding-twilio-disabled` : on growth book to control text message and button.
