### PR TITLE
feat(payments): add min global payment limit override

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/VariablePaymentAmountField.tsx
@@ -33,16 +33,21 @@ export const VariablePaymentAmountField = ({
 }) => {
   const {
     data: {
-      maxPaymentAmountCents = Number.MAX_SAFE_INTEGER,
-      minPaymentAmountCents = Number.MIN_SAFE_INTEGER,
+      maxPaymentAmountCents: envMaxPaymentAmountCents = Number.MAX_SAFE_INTEGER,
+      minPaymentAmountCents: envMinPaymentAmountCents = Number.MIN_SAFE_INTEGER,
     } = {},
   } = useEnv()
 
+  const minAmountCents =
+    input.global_min_amount_override || envMinPaymentAmountCents
+
+  const maxAmountCents = envMaxPaymentAmountCents
+
   const minAmountInDollars = `S${formatCurrency(
-    Number(centsToDollars(minPaymentAmountCents)),
+    Number(centsToDollars(minAmountCents)),
   )}`
   const maxAmountInDollars = `S${formatCurrency(
-    Number(centsToDollars(maxPaymentAmountCents)),
+    Number(centsToDollars(maxAmountCents)),
   )}`
 
   const minAmountValidation: RegisterOptions<
@@ -51,6 +56,7 @@ export const VariablePaymentAmountField = ({
   > = usePaymentFieldValidation<FormPaymentsInput, typeof MIN_FIELD_KEY>({
     lesserThanCents: dollarsToCents(input[MAX_FIELD_KEY] || ''),
     msgWhenEmpty: `The minimum amount is ${minAmountInDollars}`,
+    overrideMinAmount: input.global_min_amount_override,
   })
   const maxAmountValidation: RegisterOptions<
     FormPaymentsInput,

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailsBlock.tsx
@@ -20,6 +20,7 @@ export const VariablePaymentItemDetailsBlock = ({
   paymentItemName,
   paymentMin: _paymentMin,
   paymentMax: _paymentMax,
+  globalMinAmountOverride,
 }: VariableItemDetailProps): JSX.Element => {
   const {
     control,
@@ -39,7 +40,11 @@ export const VariablePaymentItemDetailsBlock = ({
       [PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID]: string
     },
     typeof PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID
-  >({ lesserThanCents: paymentMax, greaterThanCents: paymentMin })
+  >({
+    lesserThanCents: paymentMax,
+    greaterThanCents: paymentMin,
+    overrideMinAmount: globalMinAmountOverride,
+  })
 
   const amountHint = `Enter an amount between ${centsToDollarString(
     paymentMin,

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/types.ts
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/types.ts
@@ -9,6 +9,7 @@ type PaymentItemDetailsProps = PaymentItemNameDescriptionProps
 export interface VariableItemDetailProps extends PaymentItemDetailsProps {
   paymentMin: number
   paymentMax: number
+  globalMinAmountOverride: number | undefined
 }
 
 export interface FixedItemDetailProps extends PaymentItemDetailsProps {

--- a/frontend/src/hooks/usePaymentFieldValidation.ts
+++ b/frontend/src/hooks/usePaymentFieldValidation.ts
@@ -8,28 +8,40 @@ import {
 
 import { useEnv } from '~features/env/queries'
 
+/**
+ *
+ * @param options.greaterThanCents The minimum amount in cents
+ * @param options.lesserThanCents The maximum amount in cents
+ * @param options.overrideMinAmount The minimum amount in cents that overrides the global minimum amount
+ * @param options.msgWhenEmpty The message to display when the field is empty
+ * @returns
+ */
 export const usePaymentFieldValidation = <
   T extends FieldValues,
   V extends FieldPath<T>,
 >(options?: {
   greaterThanCents?: number
   lesserThanCents?: number
+  overrideMinAmount?: number
   msgWhenEmpty?: string
 }) => {
   const {
     data: {
-      maxPaymentAmountCents = Number.MAX_SAFE_INTEGER,
-      minPaymentAmountCents = Number.MIN_SAFE_INTEGER,
+      maxPaymentAmountCents: envMaxPaymentAmountCents = Number.MAX_SAFE_INTEGER,
+      minPaymentAmountCents: envMinPaymentAmountCents = Number.MIN_SAFE_INTEGER,
     } = {},
   } = useEnv()
+
+  const maxAmountCents = envMaxPaymentAmountCents
+  const minAmountCents = options?.overrideMinAmount || envMinPaymentAmountCents
 
   const {
     lesserThanCents: maxCents = Number.MAX_SAFE_INTEGER,
     greaterThanCents: minCents = Number.MIN_SAFE_INTEGER,
     msgWhenEmpty = '',
   } = options || {}
-  const maxCentsLimit = Math.min(maxCents, maxPaymentAmountCents)
-  const minCentsLimit = Math.max(minCents, minPaymentAmountCents)
+  const maxCentsLimit = Math.min(maxCents, maxAmountCents)
+  const minCentsLimit = Math.max(minCents, minAmountCents)
 
   const amountValidation: RegisterOptions<T, V> = {
     validate: (val) => {

--- a/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
+++ b/frontend/src/templates/Field/PaymentPreview/PaymentPreview.tsx
@@ -47,6 +47,7 @@ const PaymentItemDetailsElement = ({
           paymentDescription={paymentDetails.description}
           paymentMin={paymentDetails.min_amount}
           paymentMax={paymentDetails.max_amount}
+          globalMinAmountOverride={paymentDetails.global_min_amount_override}
         />
       )
     }

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -122,6 +122,9 @@ export type FormPaymentsField =
       description?: string
       name?: string
       gst_enabled?: boolean
+      // This amount overrides global minimum value
+      // https://linear.app/ogp/issue/FRM-1720/add-feature-flag-to-allow-10-cents-as-minimum-value-on-form-level
+      global_min_amount_override?: number
     } & (VariablePaymentsField | FixedPaymentField | ProductsPaymentField)
 
 export type FormBusinessField = {

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -116,6 +116,7 @@ const PAYMENTS_DEFAULTS = {
     min_amount: 0,
     max_amount: 0,
     payment_type: PaymentType.Products,
+    global_min_amount_override: 0,
     gst_enabled: true,
     products: [],
     products_meta: {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -186,6 +186,10 @@ export const formPaymentsFieldSchema = {
     type: Boolean,
     default: true,
   },
+  global_min_amount_override: {
+    type: Number,
+    default: 0,
+  },
 }
 
 const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({

--- a/src/app/modules/form/admin-form/__tests__/admin-form.payments.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.payments.service.spec.ts
@@ -271,6 +271,63 @@ describe('admin-form.payment.service', () => {
           InvalidPaymentAmountError,
         )
       })
+
+      it('should return OK if min_amount is greater than global_min_amount_override', async () => {
+        const updatedPaymentSettingsMaxAboveMin = {
+          ...defaultVariablePaymentSettings,
+          min_amount: 10,
+          max_amount: 1500,
+          global_min_amount_override: 10,
+        }
+
+        const mockUpdatedForm = {
+          _id: mockFormId,
+          payments_field: updatedPaymentSettingsMaxAboveMin,
+        }
+        const putSpy = jest
+          .spyOn(EncryptFormModel, 'updatePaymentsById')
+          .mockResolvedValueOnce(
+            mockUpdatedForm as unknown as IEncryptedFormDocument,
+          )
+        // Act
+        const actualResult = await AdminFormPaymentService.updatePayments(
+          mockFormId,
+          updatedPaymentSettingsMaxAboveMin,
+        )
+
+        // Assert
+        expect(putSpy).toHaveBeenCalledWith(
+          mockFormId,
+          updatedPaymentSettingsMaxAboveMin,
+        )
+        expect(actualResult.isOk()).toBeTrue()
+        expect(actualResult._unsafeUnwrap()).toEqual(
+          updatedPaymentSettingsMaxAboveMin,
+        )
+      })
+
+      it('should return error if min_amount is lower than global_min_amount_override', async () => {
+        const updatedPaymentSettingsMaxAboveMin = {
+          ...defaultVariablePaymentSettings,
+          min_amount: 9,
+          max_amount: 1500,
+          global_min_amount_override: 10,
+        }
+
+        const putSpy = jest.spyOn(EncryptFormModel, 'updatePaymentsById')
+        // Act
+        const actualResult = await AdminFormPaymentService.updatePayments(
+          mockFormId,
+          updatedPaymentSettingsMaxAboveMin,
+        )
+
+        // Assert
+        expect(putSpy).not.toHaveBeenCalled()
+        expect(actualResult.isErr()).toBeTrue()
+        expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
+          InvalidPaymentAmountError,
+        )
+      })
     })
   })
 

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -297,7 +297,14 @@ const _handleUpdatePayments: ControllerHandler<
           : ok(form),
       )
       // Step 4: User has permissions, proceed to allow updating of start page
-      .andThen(() => AdminFormPaymentService.updatePayments(formId, req.body))
+      .andThen((form) => {
+        return AdminFormPaymentService.updatePayments(formId, {
+          ...req.body,
+          // prevent APIs from updating global_min_amount_override
+          global_min_amount_override:
+            form.payments_field.global_min_amount_override,
+        })
+      })
       .map((updatedPayments) =>
         res.status(StatusCodes.OK).json(updatedPayments),
       )
@@ -380,9 +387,7 @@ const updatePaymentsValidator = celebrate({
       is: Joi.equal(true),
       then: Joi.when('payment_type', {
         is: Joi.equal(PaymentType.Fixed),
-        then: JoiInt.min(paymentConfig.minPaymentAmountCents)
-          .max(paymentConfig.maxPaymentAmountCents)
-          .required(),
+        then: JoiInt.max(paymentConfig.maxPaymentAmountCents).required(),
         otherwise: JoiInt,
       }),
       otherwise: JoiInt,
@@ -392,9 +397,7 @@ const updatePaymentsValidator = celebrate({
       is: Joi.equal(true),
       then: Joi.when('payment_type', {
         is: Joi.equal(PaymentType.Variable),
-        then: JoiInt.positive()
-          .min(paymentConfig.minPaymentAmountCents)
-          .required(),
+        then: JoiInt.positive().required(),
         otherwise: JoiInt,
       }),
       otherwise: JoiInt,
@@ -452,6 +455,8 @@ const updatePaymentsValidator = celebrate({
       is: Joi.equal(true),
       then: Joi.boolean().required(),
     }),
+
+    global_min_amount_override: JoiInt.positive().optional(),
   },
 })
 

--- a/src/app/modules/form/admin-form/admin-form.payments.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.service.ts
@@ -52,7 +52,10 @@ export const updatePayments = (
     if (min_amount > max_amount) {
       return errAsync(new InvalidPaymentAmountError())
     }
-    if (min_amount < paymentConfig.minPaymentAmountCents) {
+    const minAmountCents =
+      newPayments.global_min_amount_override ||
+      paymentConfig.minPaymentAmountCents
+    if (min_amount < minAmountCents) {
       return errAsync(new InvalidPaymentAmountError())
     }
     if (max_amount > paymentConfig.maxPaymentAmountCents) {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -373,9 +373,23 @@ const _createPaymentSubmission = async ({
   })
 
   // Step 0: Perform validation checks
+  if (!amount) {
+    logger.error({
+      message: 'Error when creating payment: amount is missing',
+      meta: logMeta,
+    })
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message:
+        "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+    })
+  }
+
+  const paymentMinAmount =
+    form.payments_field.global_min_amount_override ||
+    paymentConfig.minPaymentAmountCents
+
   if (
-    !amount ||
-    amount < paymentConfig.minPaymentAmountCents ||
+    amount < paymentMinAmount ||
     amount > paymentConfig.maxPaymentAmountCents
   ) {
     logger.error({

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -153,7 +153,6 @@ export const validateStorageSubmissionParams = celebrate({
       amount_cents: Joi.number()
         .integer()
         .positive()
-        .min(paymentConfig.minPaymentAmountCents)
         .max(paymentConfig.maxPaymentAmountCents),
     }),
     version: Joi.number().required(),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes frm-1720

## Solution
<!-- How did you solve the problem? -->



**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Header | Header | Header |
|--------|--------|--------|
| Cell | Cell | Cell |
| Cell | Cell | Cell |
| Cell | Cell | Cell | 

## Tests
<!-- What tests should be run to confirm functionality? -->
Approach for testing should be largely regressive in nature, as we do not have an account has this capability enabled from the 3rd party side (stripe).

Regression
Variable Payment - Admin
- [ ] Create a variable payment form
- [ ] Ensure that $0.49 cannot be set as the lower limit
- [ ] Ensure that error message and placeholder should reflect $0.50 as the minimum amount
- [ ] Ensure that $0.50 can be set as the lower limit and saved
- [ ] Ensure that $10 can be set as the upper limit and saved

Variable Payment - Respondent
- [ ] Load the variable payment form
- [ ] Ensure that the lower limit cannot be lower than $0.50
- [ ] Ensure that the lower limit prompt show `Enter an amount between S$0.50 and S$10.00.`
- [ ] Ensure that a successful payment can be made with $0.50
- [ ] Ensure that the upper limit cannot be higher than $10
- [ ] Ensure that a successful payment can be made with $10

Payment By Products - Admin
- [ ] Create a payment by products form
- [ ] Create a product priced at $10 
- [ ] Ensure that product can be saved
- [ ] Create a product priced at $25 
- [ ] Ensure that product can be saved

Payment By Products - Respondent
- [ ] Load the payment form
- [ ] Make a payment with both items selected
- [ ] Ensure that a successful payment can be made

New feature test
Variable Payment - Admin
- [ ] Create a variable payment form
- [ ] On the DB set `payments_field.global_min_amount_override` to be 10 (`Int32`)
- [ ] Ensure that $0.09 cannot be set as the lower limit
- [ ] Ensure that error message and placeholder should reflect $0.10 as the minimum amount
- [ ] Ensure that $0.10 can be set as the lower limit and saved
- [ ] Ensure that $10 can be set as the upper limit and saved

Variable Payment - Respondent
- [ ] Load the variable payment form
- [ ] Ensure that the lower limit cannot be lower than $0.09
- [ ] Ensure that the lower limit prompt show `Enter an amount between S$0.10 and S$10.00.`
- [ ] Ensure that a successful payment can be made with $0.10
- [ ] Ensure that the upper limit cannot be higher than $10
- [ ] Ensure that a successful payment can be made with $10
