### PR TITLE
fix: update chromium version

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -29,7 +29,7 @@ RUN apk update && apk upgrade && \
     # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
     # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
     # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=124.0.6367.60-r0 \
+    chromium=124.0.6367.78-r0 \
     nss \
     freetype \
     freetype-dev \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -82,7 +82,7 @@ RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 
 RUN apk add --no-cache \
     # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=124.0.6367.60-r0 \
+    chromium=124.0.6367.78-r0 \
     nss \
     freetype \
     freetype-dev \


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Blocks release build.
Out of sync again. Perhaps we could load from the previous LTS repository instead (i.e., v3.18)

## Solution

Upgrade to latest version.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
