### PR TITLE
fix(chromium, puppeteer): old version pin

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -23,13 +23,6 @@ RUN apk update && apk upgrade && \
     # Python version must be specified starting in alpine3.12
     g++ gcc libgcc libstdc++ linux-headers autoconf automake make nasm python3 git curl \
     # Runtime dependencies
-    # Note that each alpine version supports a specific version of chromium
-    # Note that chromium and puppeteer-core are released together and it is the only version
-    # that is guaranteed to work. Upgrades must be done in lockstep.
-    # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
-    # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
-    # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=124.0.6367.78-r0 \
     nss \
     freetype \
     freetype-dev \
@@ -45,6 +38,15 @@ RUN apk update && apk upgrade && \
     # [ver1] ensures that the underlying AWS CLI version is also installed
     pip install awscli-local[ver1] --break-system-packages
 
+
+# Note that each alpine version supports a specific version of chromium
+# Note that chromium and puppeteer-core are released together and it is the only version
+# that is guaranteed to work. Upgrades must be done in lockstep.
+# https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
+# https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
+# Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
+# Pinning to an older version of node to avoid regular breakage due to version chromium being bumped on latest alpine
+RUN apk add chromium=119.0.6045.159-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community/
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -45,8 +45,8 @@ RUN apk update && apk upgrade && \
 # https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
-# Pinning to an older version of node to avoid regular breakage due to version chromium being bumped on latest alpine
-RUN apk add chromium=119.0.6045.159-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community/
+# Pinning to an older version of node:alpine3.18 to avoid regular breakage due to version chromium being bumped on current alpine of 3.19
+RUN apk add chromium=119.0.6045.159-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -46,7 +46,7 @@ RUN apk update && apk upgrade && \
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
 # Pinning to an older version of node:alpine3.18 to avoid regular breakage due to version chromium being bumped on current alpine of 3.19
-RUN apk add chromium=119.0.6045.159-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community
+RUN apk add chromium --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -90,7 +90,7 @@ RUN apk add --no-cache \
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
 # Pinning to an older version of node to avoid regular breakage due to version chromium being bumped on latest alpine
-RUN apk add chromium=119.0.6045.159-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community
+RUN apk add chromium --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -73,16 +73,7 @@ COPY --from=build /build/dist /opt/formsg/dist
 RUN mv /opt/formsg/dist/backend/src /opt/formsg/
 RUN mv /opt/formsg/dist/backend/shared /opt/formsg/
 
-# Install chromium from official docs
-# https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
-# Note that each alpine version supports a specific version of chromium
-# Note that chromium and puppeteer-core are released together and it is the only version
-# that is guaranteed to work. Upgrades must be done in lockstep.
-# https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
-
 RUN apk add --no-cache \
-    # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.19&repo=&arch=&maintainer=
-    chromium=124.0.6367.78-r0 \
     nss \
     freetype \
     freetype-dev \
@@ -90,6 +81,16 @@ RUN apk add --no-cache \
     ca-certificates \
     ttf-freefont \
     tini
+
+
+# Note that each alpine version supports a specific version of chromium
+# Note that chromium and puppeteer-core are released together and it is the only version
+# that is guaranteed to work. Upgrades must be done in lockstep.
+# https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
+# https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
+# Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
+# Pinning to an older version of node to avoid regular breakage due to version chromium being bumped on latest alpine
+RUN apk add chromium=119.0.6045.159-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community/
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -90,7 +90,7 @@ RUN apk add --no-cache \
 # https://www.npmjs.com/package/puppeteer-core?activeTab=versions for corresponding versions
 # Compatible chromium versions can be found here https://pkgs.alpinelinux.org/packages?name=chromium&branch=v3.18&repo=&arch=&maintainer=
 # Pinning to an older version of node to avoid regular breakage due to version chromium being bumped on latest alpine
-RUN apk add chromium=119.0.6045.159-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community/
+RUN apk add chromium=119.0.6045.159-r0 --repository https://dl-cdn.alpinelinux.org/alpine/v3.18/community
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "p-queue": "^6.6.2",
         "promise-retry": "^2.0.1",
         "promise-timeout": "^1.3.0",
-        "puppeteer-core": "22.6.3",
+        "puppeteer-core": "21.5.0",
         "selectize": "0.12.6",
         "slick-carousel": "1.8.1",
         "sns-validator": "^0.3.5",
@@ -5807,16 +5807,15 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.1.tgz",
-      "integrity": "sha512-QSXujx4d4ogDamQA8ckkkRieFzDgZEuZuGiey9G7CuDcbnX4iINKWxTPC5Br2AEzY9ICAvcndqgAUFMMKnS/Tw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
+      "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
         "progress": "2.0.3",
-        "proxy-agent": "6.4.0",
-        "semver": "7.6.0",
-        "tar-fs": "3.0.5",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.2"
       },
@@ -5824,21 +5823,7 @@
         "browsers": "lib/cjs/main-cli.js"
       },
       "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">=16.3.0"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -9936,38 +9921,6 @@
       "version": "1.0.0",
       "license": "MIT"
     },
-    "node_modules/bare-events": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-      "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
-      "optional": true
-    },
-    "node_modules/bare-fs": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.3.tgz",
-      "integrity": "sha512-amG72llr9pstfXOBOHve1WjiuKKAMnebcmMbPWDZ7BCevAoJLpugjuAPRsDINEyjT0a6tbaVx3DctkXIRbLuJw==",
-      "optional": true,
-      "dependencies": {
-        "bare-events": "^2.0.0",
-        "bare-path": "^2.0.0",
-        "streamx": "^2.13.0"
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.1.tgz",
-      "integrity": "sha512-OwPyHgBBMkhC29Hl3O4/YfxW9n7mdTr2+SsO29XBWKKJsbgj3mnorDB80r5TiCQgQstgE5ga1qNYrpes6NvX2w==",
-      "optional": true
-    },
-    "node_modules/bare-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.1.tgz",
-      "integrity": "sha512-OHM+iwRDRMDBsSW7kl3dO62JyHdBKO3B25FB9vNQBPcGHMo4+eA8Yj41Lfbk3pS/seDY+siNge0LdRTulAau/A==",
-      "optional": true,
-      "dependencies": {
-        "bare-os": "^2.1.0"
-      }
-    },
     "node_modules/base": {
       "version": "0.11.2",
       "dev": true,
@@ -10659,13 +10612,12 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.16.tgz",
-      "integrity": "sha512-IT5lnR44h/qZQ4GaCHvBxYIl4cQL2i9UvFyYeRyVdcpY04hx5H720HQfe/7Oz7ndxaYVLQFGpCO71J4X2Ye/Gw==",
+      "version": "0.4.33",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.33.tgz",
+      "integrity": "sha512-IxoFM5WGQOIAd95qrSXzJUv4eXIrh+RvU3rwwqIiwYuvfE7U/Llj4fejbsJnjJMUYCuGtVQsY2gv7oGl4aTNSQ==",
       "dependencies": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0",
-        "zod": "3.22.4"
+        "urlpattern-polyfill": "9.0.0"
       },
       "peerDependencies": {
         "devtools-protocol": "*"
@@ -12081,9 +12033,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1262051",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
-      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g=="
+      "version": "0.0.1203626",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
+      "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g=="
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -20869,6 +20821,11 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "node_modules/mockdate": {
       "version": "3.0.5",
       "dev": true,
@@ -22745,14 +22702,14 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
         "lru-cache": "^7.14.1",
         "pac-proxy-agent": "^7.0.1",
         "proxy-from-env": "^1.1.0",
@@ -22855,24 +22812,33 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.3.tgz",
-      "integrity": "sha512-YrTAak5zCTWVTnVaCK1b7FD1qFCCT9bSvQhLzamnIsJ57/tfuXiT8ZvPJR2SBfahyFTYFCcaZAd/Npow3lmDGA==",
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.0.tgz",
+      "integrity": "sha512-qG0RJ6qKgFz09UUZxDB9IcyTJGypQXMuE8WmEoHk7kgjutmRiOVv5RgsyUkY67AxDdBWx21bn1PHHRJnO/6b4A==",
       "dependencies": {
-        "@puppeteer/browsers": "2.2.1",
-        "chromium-bidi": "0.5.16",
+        "@puppeteer/browsers": "1.8.0",
+        "chromium-bidi": "0.4.33",
+        "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1262051",
-        "ws": "8.16.0"
+        "devtools-protocol": "0.0.1203626",
+        "ws": "8.14.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16.3.0"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -24865,16 +24831,13 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
       "dependencies": {
+        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0"
       }
     },
     "node_modules/tar-stream": {
@@ -26010,9 +25973,9 @@
       "license": "MIT"
     },
     "node_modules/urlpattern-polyfill": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
     },
     "node_modules/use": {
       "version": "3.1.1",
@@ -31704,28 +31667,17 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@puppeteer/browsers": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.1.tgz",
-      "integrity": "sha512-QSXujx4d4ogDamQA8ckkkRieFzDgZEuZuGiey9G7CuDcbnX4iINKWxTPC5Br2AEzY9ICAvcndqgAUFMMKnS/Tw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
+      "integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
       "requires": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
         "progress": "2.0.3",
-        "proxy-agent": "6.4.0",
-        "semver": "7.6.0",
-        "tar-fs": "3.0.5",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@radix-ui/react-compose-refs": {
@@ -34937,38 +34889,6 @@
     "balanced-match": {
       "version": "1.0.0"
     },
-    "bare-events": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-      "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
-      "optional": true
-    },
-    "bare-fs": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.3.tgz",
-      "integrity": "sha512-amG72llr9pstfXOBOHve1WjiuKKAMnebcmMbPWDZ7BCevAoJLpugjuAPRsDINEyjT0a6tbaVx3DctkXIRbLuJw==",
-      "optional": true,
-      "requires": {
-        "bare-events": "^2.0.0",
-        "bare-path": "^2.0.0",
-        "streamx": "^2.13.0"
-      }
-    },
-    "bare-os": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.1.tgz",
-      "integrity": "sha512-OwPyHgBBMkhC29Hl3O4/YfxW9n7mdTr2+SsO29XBWKKJsbgj3mnorDB80r5TiCQgQstgE5ga1qNYrpes6NvX2w==",
-      "optional": true
-    },
-    "bare-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.1.tgz",
-      "integrity": "sha512-OHM+iwRDRMDBsSW7kl3dO62JyHdBKO3B25FB9vNQBPcGHMo4+eA8Yj41Lfbk3pS/seDY+siNge0LdRTulAau/A==",
-      "optional": true,
-      "requires": {
-        "bare-os": "^2.1.0"
-      }
-    },
     "base": {
       "version": "0.11.2",
       "dev": true,
@@ -35469,13 +35389,12 @@
       }
     },
     "chromium-bidi": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.16.tgz",
-      "integrity": "sha512-IT5lnR44h/qZQ4GaCHvBxYIl4cQL2i9UvFyYeRyVdcpY04hx5H720HQfe/7Oz7ndxaYVLQFGpCO71J4X2Ye/Gw==",
+      "version": "0.4.33",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.33.tgz",
+      "integrity": "sha512-IxoFM5WGQOIAd95qrSXzJUv4eXIrh+RvU3rwwqIiwYuvfE7U/Llj4fejbsJnjJMUYCuGtVQsY2gv7oGl4aTNSQ==",
       "requires": {
         "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0",
-        "zod": "3.22.4"
+        "urlpattern-polyfill": "9.0.0"
       }
     },
     "ci-info": {
@@ -36489,9 +36408,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.1262051",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1262051.tgz",
-      "integrity": "sha512-YJe4CT5SA8on3Spa+UDtNhEqtuV6Epwz3OZ4HQVLhlRccpZ9/PAYk0/cy/oKxFKRrZPBUPyxympQci4yWNWZ9g=="
+      "version": "0.0.1203626",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1203626.tgz",
+      "integrity": "sha512-nEzHZteIUZfGCZtTiS1fRpC8UZmsfD1SiyPvaUNvS13dvKf666OAm8YTi0+Ca3n1nLEyu49Cy4+dPWpaHFJk9g=="
     },
     "dezalgo": {
       "version": "1.0.4",
@@ -42613,6 +42532,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "mockdate": {
       "version": "3.0.5",
       "dev": true
@@ -43931,14 +43855,14 @@
       }
     },
     "proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
       "requires": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
         "lru-cache": "^7.14.1",
         "pac-proxy-agent": "^7.0.1",
         "proxy-from-env": "^1.1.0",
@@ -44023,21 +43947,30 @@
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
     },
     "puppeteer-core": {
-      "version": "22.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.6.3.tgz",
-      "integrity": "sha512-YrTAak5zCTWVTnVaCK1b7FD1qFCCT9bSvQhLzamnIsJ57/tfuXiT8ZvPJR2SBfahyFTYFCcaZAd/Npow3lmDGA==",
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.0.tgz",
+      "integrity": "sha512-qG0RJ6qKgFz09UUZxDB9IcyTJGypQXMuE8WmEoHk7kgjutmRiOVv5RgsyUkY67AxDdBWx21bn1PHHRJnO/6b4A==",
       "requires": {
-        "@puppeteer/browsers": "2.2.1",
-        "chromium-bidi": "0.5.16",
+        "@puppeteer/browsers": "1.8.0",
+        "chromium-bidi": "0.4.33",
+        "cross-fetch": "4.0.0",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1262051",
-        "ws": "8.16.0"
+        "devtools-protocol": "0.0.1203626",
+        "ws": "8.14.2"
       },
       "dependencies": {
+        "cross-fetch": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+          "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+          "requires": {
+            "node-fetch": "^2.6.12"
+          }
+        },
         "ws": {
-          "version": "8.16.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-          "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ=="
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g=="
         }
       }
     },
@@ -45501,12 +45434,11 @@
       }
     },
     "tar-fs": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
       "requires": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0",
+        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
       }
@@ -46237,9 +46169,9 @@
       }
     },
     "urlpattern-polyfill": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
-      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
     },
     "use": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "p-queue": "^6.6.2",
     "promise-retry": "^2.0.1",
     "promise-timeout": "^1.3.0",
-    "puppeteer-core": "22.6.3",
+    "puppeteer-core": "21.5.0",
     "selectize": "0.12.6",
     "slick-carousel": "1.8.1",
     "sns-validator": "^0.3.5",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We have to regularly update our chromium on node:alpine to unblock our builds. This makes our release very flakey.

## Solution
<!-- How did you solve the problem? -->

Pin chromium download to an older and less updated version of alpine.
Downgrade `puppeteer-core` to compatible version.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  