### PR TITLE
fix(payments): allow 0 cents

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -456,7 +456,7 @@ const updatePaymentsValidator = celebrate({
       then: Joi.boolean().required(),
     }),
 
-    global_min_amount_override: JoiInt.positive().optional(),
+    global_min_amount_override: JoiInt.positive().allow(0).optional(),
   },
 })
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Admins cannot save when `global_min_amount_override` is initialized with `0` as `0` is not positive.

## Solution
<!-- How did you solve the problem? -->

Allow `0` in addition to positive.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
