### PR TITLE
fix(btn): use different growthbook api

### DIFF
--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioDetailsInputs.tsx
@@ -13,6 +13,7 @@ import {
   Stack,
   useDisclosure,
 } from '@chakra-ui/react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 import { useToggle } from 'rooks'
 
 import { featureFlags } from '~shared/constants'
@@ -26,7 +27,6 @@ import IconButton from '~components/IconButton'
 import Input, { InputProps } from '~components/Input'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
-import { useIsFeatureEnabled } from '~features/feature-flags/queries'
 
 import { useMutateTwilioCreds } from '../../mutations'
 
@@ -68,7 +68,7 @@ export const TwilioDetailsInputs = (): JSX.Element => {
 
   const [isApiSecretShown, toggleIsApiSecretShown] = useToggle(false)
 
-  const isAddingTwilioDisabled = useIsFeatureEnabled(
+  const isAddingTwilioDisabled = useFeatureValue(
     featureFlags.addingTwilioDisabled,
     false,
   )

--- a/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/TwilioSettingsSection/TwilioSettingsSection.tsx
@@ -1,15 +1,14 @@
 import { ListItem, Text, UnorderedList } from '@chakra-ui/react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants'
 
 import InlineMessage from '~components/InlineMessage'
 
-import { useIsFeatureEnabled } from '~features/feature-flags/queries'
-
 import { TwilioDetailsInputs } from './TwilioDetailsInputs'
 
 export const TwilioSettingsSection = (): JSX.Element => {
-  const isAddingTwilioDisabled = useIsFeatureEnabled(
+  const isAddingTwilioDisabled = useFeatureValue(
     featureFlags.addingTwilioDisabled,
     false,
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Used incorrect feature toggle endpoint. 

`useIsFeatureEnabled` is our BE Feature flag service, while `useFeatureValue` is our growthbook feature toggle.

## Solution
<!-- How did you solve the problem? -->

Switch to use `useFeatureValue`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
