### PR TITLE
fix: added validation for empty attachments

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -61,6 +61,7 @@ jobs:
           autoAcceptChanges: develop
           exitOnceUploaded: true
           onlyChanged: true
+          storybookBaseDir: frontend/.storybook
           # Skip running Chromatic on dependabot PRs
           skip: dependabot/**
           # Only run when the frontend directory has changes

--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -184,14 +184,18 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
 
     const fileValidator = useCallback<NonNullable<DropzoneProps['validator']>>(
       (file) => {
-        if (
-          !IMAGE_UPLOAD_TYPES_TO_COMPRESS.includes(file.type) &&
-          maxSize &&
-          file.size > maxSize
-        ) {
-          return {
-            code: 'file-too-large',
-            message: `You have exceeded the limit, please upload a file below ${readableMaxSize}`,
+        if (!IMAGE_UPLOAD_TYPES_TO_COMPRESS.includes(file.type)) {
+          if (maxSize && file.size > maxSize) {
+            return {
+              code: 'file-too-large',
+              message: `You have exceeded the limit, please upload a file below ${readableMaxSize}`,
+            }
+          }
+          if (file.size === 0) {
+            return {
+              code: 'file-empty',
+              message: `You have uploaded an empty file, please upload a valid attachment`,
+            }
           }
         }
         return null

--- a/src/app/utils/field-validation/validators/attachmentValidator.ts
+++ b/src/app/utils/field-validation/validators/attachmentValidator.ts
@@ -44,6 +44,12 @@ const makeAttachmentSizeValidator: AttachmentValidatorConstructor =
   (attachmentField) => (response) => {
     const { attachmentSize } = attachmentField
     const byteSizeLimit = parseInt(attachmentSize) * MB
+
+    // Check if the attachment content is empty
+    if (response.content.byteLength === 0) {
+      return left(`AttachmentValidator:\t File is empty.`)
+    }
+
     return response.content.byteLength <= byteSizeLimit
       ? right(response)
       : left(`AttachmentValidator:\t File size more than limit`)


### PR DESCRIPTION
## Problem
Users can upload empty files on FormSG

Closes FRM-1726

## Solution
Implement validation to prevent uploading of empty files

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  


## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->
<img width="884" alt="Screenshot 2024-05-07 at 4 29 01 PM" src="https://github.com/opengovsg/FormSG/assets/136435307/62bc3fcc-17b5-4782-9fe1-46cf34625117">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Upload an empty file as an attachment.
- [ ] Should encounter error preventing submission

