### PR TITLE
fix(mrf): attachment equality validation

### DIFF
--- a/frontend/src/features/public-form/mutations.ts
+++ b/frontend/src/features/public-form/mutations.ts
@@ -87,7 +87,7 @@ export const usePublicFormMutations = (
     },
   )
 
-  const useSubmitStorageModeFormMutation = (
+  const useSubmitMutationWithAttachmentVirusScanning = (
     f: (
       args: SubmitStorageFormClearArgs & {
         fieldIdToQuarantineKeyMap: FieldIdToQuarantineKeyType[]
@@ -164,20 +164,17 @@ export const usePublicFormMutations = (
       )
     })
 
-  const submitStorageModeFormMutation = useSubmitStorageModeFormMutation(
-    submitStorageModeForm,
-  )
+  const submitStorageModeFormMutation =
+    useSubmitMutationWithAttachmentVirusScanning(submitStorageModeForm)
 
-  const submitStorageModeFormFetchMutation = useSubmitStorageModeFormMutation(
-    submitStorageModeFormWithFetch,
-  )
+  const submitStorageModeFormFetchMutation =
+    useSubmitMutationWithAttachmentVirusScanning(submitStorageModeFormWithFetch)
 
-  const submitMultirespondentFormMutation = useSubmitStorageModeFormMutation(
-    submitMultirespondentForm,
-  )
+  const submitMultirespondentFormMutation =
+    useSubmitMutationWithAttachmentVirusScanning(submitMultirespondentForm)
 
   const updateMultirespondentSubmissionMutation =
-    useSubmitStorageModeFormMutation((args) =>
+    useSubmitMutationWithAttachmentVirusScanning((args) =>
       updateMultirespondentSubmission({ ...args, submissionSecretKey }),
     )
 

--- a/shared/types/response-v3.ts
+++ b/shared/types/response-v3.ts
@@ -114,4 +114,5 @@ export type ChildrenCompoundFieldResponsesV3 = {
 export type AttachmentFieldResponseV3 = {
   hasBeenScanned: boolean
   answer: string
+  md5Hash?: string
 }

--- a/src/app/utils/response-v3.ts
+++ b/src/app/utils/response-v3.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 
 import { BasicField, FieldResponseV3 } from '../../../shared/types'
+import { ParsedClearAttachmentResponseV3 } from '../../types/api'
 
 export const isFieldResponseV3Equal = (
   l: FieldResponseV3,
@@ -29,26 +30,16 @@ export const isFieldResponseV3Equal = (
     case BasicField.Children:
       return _.isEqual(l.answer, r.answer)
     case BasicField.Attachment: {
-      return true
-      // TODO(FRM-1724): Re-enable this validation
-      /**
       const lAnswer = l.answer as ParsedClearAttachmentResponseV3['answer']
       const rAnswer = r.answer as ParsedClearAttachmentResponseV3['answer']
 
-      const lMd5 = crypto
-        .createHash('md5')
-        .update(Buffer.from(lAnswer.content))
-        .digest()
-
-      const rMd5 = crypto
-        .createHash('md5')
-        .update(Buffer.from(rAnswer.content))
-        .digest()
+      const lMd5 = lAnswer.md5Hash
+      const rMd5 = rAnswer.md5Hash
 
       return (
-        lMd5.equals(rMd5) && l.answer.hasBeenScanned === rAnswer.hasBeenScanned
+        (!lMd5 || !rMd5 || lMd5 === rMd5) &&
+        l.answer.hasBeenScanned === rAnswer.hasBeenScanned
       )
-      */
     }
     case BasicField.Section:
       return true


### PR DESCRIPTION
## Problem
Attachment equality validation had to be removed previously due to backward compatibility issues in v6.119.1. This PR restores it.

## Solution

Inject a new `md5Hash` key in the database for attachment answers. 
- The key is populated with the attachment MD5 hash after virus scanning has been completed.
- The incoming attachment's MD5 is compared with the existing attachment's MD5 in order to determine equality.

At the same time, I also made a change to the frontend mutation name that was bothering me. paiseh

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests

- [x] Create an MRF with two attachment fields. Respondent 1 can edit question 1. Respondent 2 can edit question 2.

**Backward-compatibility tests**

- [x] Submit an MRF with an attachment 1 on the old application version as respondent 1.
- [x] Now, submit the same form with an attachment 2 on the new application version as respondent 2. This should succeed.

**Tests**

- [x] Submit an MRF with an attachment 1 on the new application version as respondent 1.
- [x] Now, submit the same form with an attachment 2 on the new application version as respondent 2. This should succeed.
