### PR TITLE
fix(mrf): input transformation types for decrypting radio others

### DIFF
--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -3,11 +3,10 @@ import { times } from 'lodash'
 
 import { DATE_PARSE_FORMAT } from '~shared/constants/dates'
 import {
-  AttachmentResponseV3,
+  AttachmentFieldResponseV3,
   CheckboxFieldResponsesV3,
   ChildrenCompoundFieldResponsesV3,
   FieldResponseAnswerMapV3,
-  FieldResponseV3,
   RadioFieldResponsesV3,
   TableFieldResponsesV3,
   VerifiableFieldResponsesV3,
@@ -230,7 +229,10 @@ type FormFieldValueOrFieldResponseAnswerV3<T extends BasicField> =
  */
 export const transformInputsToOutputs = (
   field: FormFieldDto,
-  input?: Exclude<FormFieldValue | FieldResponseV3, AttachmentResponseV3>,
+  input?: Exclude<
+    FormFieldValue | FieldResponseAnswerMapV3,
+    AttachmentFieldResponseV3
+  >,
 ): FieldResponse | null => {
   switch (field.fieldType) {
     case BasicField.Section:


### PR DESCRIPTION
## Problem
A user reported an issue decrypting the radio "Others" response on MRF. This PR fixes this.

## Solution

The root cause is usage of `transformInputsToOutputs` on the wrong input type. This PR corrects the type of `transformInputsToOutputs` to unblock this decryption.

**Breaking Changes** 
- No - this PR is backwards compatible  
