### PR TITLE
fix: storybook folder to use base dir

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -61,7 +61,7 @@ jobs:
           autoAcceptChanges: develop
           exitOnceUploaded: true
           onlyChanged: true
-          storybookBaseDir: frontend/.storybook
+          storybookBaseDir: frontend
           # Skip running Chromatic on dependabot PRs
           skip: dependabot/**
           # Only run when the frontend directory has changes

--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -194,7 +194,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
           if (file.size === 0) {
             return {
               code: 'file-empty',
-              message: `You have uploaded an empty file, please upload a valid attachment`,
+              message: `You have uploaded an empty file, please upload another valid attachment`,
             }
           }
         }

--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -194,7 +194,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
           if (file.size === 0) {
             return {
               code: 'file-empty',
-              message: `You have uploaded an empty file, please upload another valid attachment`,
+              message: `You have uploaded an empty file, please upload a valid attachment`,
             }
           }
         }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Our publication to chromatic is still failing due to improper `storybookBaseDir`.

## Solution
<!-- How did you solve the problem? -->

Chromatic requires us to specify the specific frontend folder instead of `.storybook` folder.

See successful [action](https://github.com/opengovsg/FormSG/actions/runs/9095607708/job/24999192888?pr=7328)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
