### PR TITLE
feat(btn): frm 1717 mop flow to postman

### DIFF
--- a/.template-env
+++ b/.template-env
@@ -117,3 +117,4 @@ FORMSG_SDK_MODE=
 # Used to check if BE Server is currently running on local development environment
 # One of boolean: "true" | "false"
 # USE_MOCK_TWILIO=
+# USE_MOCK_POSTMAN_SMS=

--- a/__tests__/setup/.test-env
+++ b/__tests__/setup/.test-env
@@ -91,3 +91,6 @@ SSM_ENV_SITE_NAME=test
 
 # Public API env vars
 API_KEY_VERSION=v1
+POSTMAN_MOP_CAMPAIGN_ID=campaign_tesst
+POSTMAN_MOP_CAMPAIGN_API_KEY=key_test_123
+POSTMAN_BASE_URL=https://test.postman.gov.sg/api/v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,9 @@ services:
       - WOGAA_START_ENDPOINT
       - WOGAA_SUBMIT_ENDPOINT
       - WOGAA_FEEDBACK_ENDPOINT
-
+      - POSTMAN_MOP_CAMPAIGN_ID
+      - POSTMAN_MOP_CAMPAIGN_API_KEY
+      - POSTMAN_BASE_URL
 
   mockpass:
     build: https://github.com/opengovsg/mockpass.git#v4.3.1

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -6,4 +6,5 @@ export const featureFlags = {
   myinfoSgid: 'myinfo-sgid' as const,
   chartsMaxResponseCount: 'charts-max-response-count' as const,
   addingTwilioDisabled: 'adding-twilio-disabled' as const,
+  postmanSms: 'postmanSms' as const,
 }

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -15,6 +15,7 @@ export const UserBase = z.object({
     .object({
       payment: z.boolean().optional(),
       children: z.boolean().optional(),
+      postmanSms: z.boolean().optional(),
     })
     .optional(),
   flags: z

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -42,8 +42,6 @@ const isDev =
   basicVars.core.nodeEnv === Environment.Dev ||
   basicVars.core.nodeEnv === Environment.Test
 const nodeEnv = isDev ? basicVars.core.nodeEnv : Environment.Prod
-const useMockTwilio = basicVars.core.useMockTwilio
-const useMockPostmanSms = basicVars.core.useMockPostmanSms
 
 // Load and validate configuration values which are compulsory only in production
 // If environment variables are not present, an error will be thrown
@@ -235,8 +233,8 @@ const config: Config = {
   mail: mailConfig,
   cookieSettings,
   isDev,
-  useMockTwilio,
-  useMockPostmanSms,
+  useMockTwilio: basicVars.core.useMockTwilio,
+  useMockPostmanSms: basicVars.core.useMockPostmanSms,
   nodeEnv,
   formsgSdkMode: basicVars.formsgSdkMode,
   customCloudWatchGroup: basicVars.awsConfig.customCloudWatchGroup,

--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -43,6 +43,7 @@ const isDev =
   basicVars.core.nodeEnv === Environment.Test
 const nodeEnv = isDev ? basicVars.core.nodeEnv : Environment.Prod
 const useMockTwilio = basicVars.core.useMockTwilio
+const useMockPostmanSms = basicVars.core.useMockPostmanSms
 
 // Load and validate configuration values which are compulsory only in production
 // If environment variables are not present, an error will be thrown
@@ -235,6 +236,7 @@ const config: Config = {
   cookieSettings,
   isDev,
   useMockTwilio,
+  useMockPostmanSms,
   nodeEnv,
   formsgSdkMode: basicVars.formsgSdkMode,
   customCloudWatchGroup: basicVars.awsConfig.customCloudWatchGroup,

--- a/src/app/config/features/postman-sms.config.ts
+++ b/src/app/config/features/postman-sms.config.ts
@@ -1,0 +1,32 @@
+import convict, { Schema } from 'convict'
+
+export interface ISms {
+  mopCampaignId: string
+  mopCampaignApiKey: string
+  postmanBaseUrl: string
+}
+
+const postmanSmsSchema: Schema<ISms> = {
+  mopCampaignId: {
+    doc: 'Postman SMS messaging campaign ID',
+    format: String,
+    default: null,
+    env: 'POSTMAN_MOP_CAMPAIGN_ID',
+  },
+  mopCampaignApiKey: {
+    doc: 'Postman SMS messaging campaign ID',
+    format: String,
+    default: null,
+    env: 'POSTMAN_MOP_CAMPAIGN_API_KEY',
+  },
+  postmanBaseUrl: {
+    doc: 'Postman base URL',
+    format: String,
+    default: null,
+    env: 'POSTMAN_BASE_URL',
+  },
+}
+
+export const postmanSmsConfig = convict(postmanSmsSchema)
+  .validate({ allowed: 'strict' })
+  .getProperties()

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -329,11 +329,18 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: Environment.Prod,
       env: 'NODE_ENV',
     },
+    // TODO(ken): to remove after twilio is no longer used
     useMockTwilio: {
       doc: 'Enables twilio API mocking and directs SMS body over to maildev',
       format: 'Boolean',
       default: false,
       env: 'USE_MOCK_TWILIO',
+    },
+    useMockPostmanSms: {
+      doc: 'Enables Postman SMS API mocking and directs SMS body over to maildev',
+      format: 'Boolean',
+      default: false,
+      env: 'USE_MOCK_POSTMAN_SMS',
     },
   },
   rateLimit: {

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -74,6 +74,7 @@ const compileUserModel = (db: Mongoose) => {
       betaFlags: {
         payment: Boolean,
         children: Boolean,
+        postmanSms: Boolean,
       },
       flags: {
         lastSeenFeatureUpdateVersion: Number,

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -365,7 +365,7 @@ describe('Verification service', () => {
         expect(postmanSpy).toHaveBeenCalledOnce()
       })
 
-      it('should send OTP with twilio if admin has feature flag on', async () => {
+      it('should send OTP with twilio if admin has feature flag off', async () => {
         const postmanSpy = jest
           .spyOn(PostmanSmsService, 'sendVerificationOtp')
           .mockResolvedValueOnce(okAsync(true))

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -3,7 +3,7 @@ import getMockLogger from '__tests__/unit/backend/helpers/jest-logger'
 import { ObjectId } from 'bson'
 import { addHours, subHours, subMinutes, subSeconds } from 'date-fns'
 import mongoose from 'mongoose'
-import { errAsync, okAsync } from 'neverthrow'
+import { err, errAsync, ok, okAsync } from 'neverthrow'
 
 // These need to be mocked first before the rest of the test
 import * as LoggerModule from 'src/app/config/logger'
@@ -30,14 +30,21 @@ import {
 } from 'src/app/modules/verification/verification.errors'
 import { MailSendError } from 'src/app/services/mail/mail.errors'
 import MailService from 'src/app/services/mail/mail.service'
+import PostmanSmsService from 'src/app/services/postman-sms/postman-sms.service'
 import { SmsSendError } from 'src/app/services/sms/sms.errors'
 import { SmsFactory } from 'src/app/services/sms/sms.factory'
 import * as HashUtils from 'src/app/utils/hash'
-import { IFormSchema, IVerificationSchema, UpdateFieldData } from 'src/types'
+import {
+  IFormSchema,
+  IUserSchema,
+  IVerificationSchema,
+  UpdateFieldData,
+} from 'src/types'
 
 import { BasicField } from '../../../../../shared/types'
 import { DatabaseError } from '../../core/core.errors'
-import { FormNotFoundError } from '../../form/form.errors'
+import * as AdminFormUtils from '../../form/admin-form/admin-form.utils'
+import { ForbiddenFormError, FormNotFoundError } from '../../form/form.errors'
 import {
   FieldNotFoundInTransactionError,
   TransactionExpiredError,
@@ -311,6 +318,10 @@ describe('Verification service', () => {
           .spyOn(VerificationModel, 'updateHashForField')
           .mockResolvedValue(mockTransactionSuccessful)
         MockFormService.retrieveFormById.mockReturnValue(okAsync(mockForm))
+
+        jest
+          .spyOn(AdminFormUtils, 'verifyUserBetaflag')
+          .mockReturnValue(err(new ForbiddenFormError('ForbiddenFormError')))
       })
 
       it('should send OTP and update hashes when parameters are valid', async () => {
@@ -335,6 +346,45 @@ describe('Verification service', () => {
           answer: MOCK_LOCAL_RECIPIENT,
         })
         expect(result._unsafeUnwrap()).toEqual(mockTransactionSuccessful)
+      })
+
+      it('should send OTP with postman if admin has feature flag on', async () => {
+        jest
+          .spyOn(AdminFormUtils, 'verifyUserBetaflag')
+          .mockReturnValue(ok(true as unknown as IUserSchema))
+
+        const postmanSpy = jest
+          .spyOn(PostmanSmsService, 'sendVerificationOtp')
+          .mockResolvedValueOnce(okAsync(true))
+
+        await VerificationService.sendNewOtp(mockSendNewFormOtpValidInput)
+
+        // Default mock params has fieldType: 'mobile'
+        expect(MockSmsFactory.sendVerificationOtp).not.toHaveBeenCalled()
+
+        expect(postmanSpy).toHaveBeenCalledOnce()
+      })
+
+      it('should send OTP with twilio if admin has feature flag on', async () => {
+        const postmanSpy = jest
+          .spyOn(PostmanSmsService, 'sendVerificationOtp')
+          .mockResolvedValueOnce(okAsync(true))
+
+        await VerificationService.sendNewOtp(mockSendNewFormOtpValidInput)
+
+        // Default mock params has fieldType: 'mobile'
+        expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalledWith(
+          MOCK_LOCAL_RECIPIENT,
+          MOCK_OTP,
+          MOCK_OTP_PREFIX,
+          mockTransaction.formId,
+          MOCK_SENDER_IP,
+        )
+
+        // Default mock params has fieldType: 'mobile'
+        expect(MockSmsFactory.sendVerificationOtp).toHaveBeenCalled()
+
+        expect(postmanSpy).not.toHaveBeenCalled()
       })
 
       it('should return TransactionNotFoundError when transaction ID does not exist', async () => {

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -14,8 +14,9 @@ import formsgSdk from '../../config/formsg-sdk'
 import { createLoggerWithLabel } from '../../config/logger'
 import { MailSendError } from '../../services/mail/mail.errors'
 import MailService from '../../services/mail/mail.service'
+import PostmanSmsService from '../../services/postman-sms/postman-sms.service'
 import { InvalidNumberError, SmsSendError } from '../../services/sms/sms.errors'
-import { SmsFactory } from '../../services/sms/sms.factory'
+// import { SmsFactory } from '../../services/sms/sms.factory'
 import { transformMongoError } from '../../utils/handle-mongo-error'
 import { compareHash, HashingError } from '../../utils/hash'
 import {
@@ -456,14 +457,22 @@ const sendOtpForField = (
               shouldGenerateMobileOtp(form, fieldId, recipient),
             )
             // call sms - it should validate the recipient
-            .andThen(() =>
-              SmsFactory.sendVerificationOtp(
-                recipient,
-                otp,
-                otpPrefix,
-                formId,
-                senderIp,
-              ),
+            .andThen(
+              () =>
+                PostmanSmsService.sendVerificationOtp(
+                  recipient,
+                  otp,
+                  otpPrefix,
+                  formId,
+                  senderIp,
+                ),
+              // SmsFactory.sendVerificationOtp(
+              //   recipient,
+              //   otp,
+              //   otpPrefix,
+              //   formId,
+              //   senderIp,
+              // ),
             )
         : errAsync(new MalformedParametersError('Field id not present'))
     case BasicField.Email:

--- a/src/app/services/postman-sms/__tests__/postman-sms.service.spec.ts
+++ b/src/app/services/postman-sms/__tests__/postman-sms.service.spec.ts
@@ -249,7 +249,7 @@ describe('postman-sms.service', () => {
       expect(postmanSendSpy).not.toHaveBeenCalled()
     })
 
-    it('should log and send verification OTP when sending has no errors', async () => {
+    it('should log and send verification OTP through MOP channel when sending has no errors', async () => {
       // Arrange
       jest.spyOn(FormModel, 'getOtpData').mockResolvedValueOnce(mockOtpData)
 
@@ -271,7 +271,7 @@ describe('postman-sms.service', () => {
       expect(postmanSendSpy).toHaveBeenCalledOnce()
     })
 
-    it('should log failure and return InvalidNumberError when verification OTP fails to send due to invalid number', async () => {
+    it('should return InvalidNumberError when verification OTP fails to send due to invalid number', async () => {
       // Arrange
       jest.spyOn(FormModel, 'getOtpData').mockResolvedValueOnce(mockOtpData)
       const postmanSendSpy = jest

--- a/src/app/services/postman-sms/__tests__/postman-sms.service.spec.ts
+++ b/src/app/services/postman-sms/__tests__/postman-sms.service.spec.ts
@@ -1,0 +1,386 @@
+import dbHandler from '__tests__/unit/backend/helpers/jest-db'
+import mongoose from 'mongoose'
+import { okAsync } from 'neverthrow'
+
+import getFormModel from 'src/app/models/form.server.model'
+import { MalformedParametersError } from 'src/app/modules/core/core.errors'
+import { FormOtpData, IFormSchema, IUserSchema } from 'src/types'
+
+import { FormResponseMode } from '../../../../../shared/types'
+import { InvalidNumberError } from '../postman-sms.errors'
+import PostmanSmsService from '../postman-sms.service'
+
+const FormModel = getFormModel(mongoose)
+
+const TEST_NUMBER = '+15005550006'
+
+const MOCK_SENDER_IP = '200.000.000.000'
+
+describe('postman-sms.service', () => {
+  let testUser: IUserSchema
+
+  beforeAll(async () => await dbHandler.connect())
+  beforeEach(async () => {
+    const { user } = await dbHandler.insertFormCollectionReqs()
+    testUser = user
+    jest.clearAllMocks()
+  })
+  afterEach(async () => await dbHandler.clearDatabase())
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  //   describe('sendFormDeactivatedSms', () => {
+  //     it('should send SMS and log success when sending is successful', async () => {
+  //       const expectedMessage = renderFormDeactivatedSms(MOCK_FORM_TITLE)
+
+  //       await PostmanSmsService.sendFormDeactivatedSms(
+  //         {
+  //           recipient: TWILIO_TEST_NUMBER,
+  //           adminEmail: MOCK_ADMIN_EMAIL,
+  //           adminId: MOCK_ADMIN_ID,
+  //           formId: MOCK_FORM_ID,
+  //           formTitle: MOCK_FORM_TITLE,
+  //           recipientEmail: MOCK_RECIPIENT_EMAIL,
+  //         },
+  //         MOCK_VALID_CONFIG,
+  //       )
+
+  //       expect(twilioSuccessSpy).toHaveBeenCalledWith({
+  //         to: TWILIO_TEST_NUMBER,
+  //         body: expectedMessage,
+  //         from: MOCK_VALID_CONFIG.msgSrvcSid,
+  //         forceDelivery: true,
+  //         statusCallback: expect.stringContaining(MOCK_TWILIO_WEBHOOK_ROUTE),
+  //       })
+
+  //       expect(twilioSuccessSpy.mock.calls[0][0].statusCallback).toEqual(
+  //         expect.not.stringContaining('?senderIp'),
+  //       )
+
+  //       expect(smsCountSpy).toHaveBeenCalledWith({
+  //         smsData: {
+  //           form: MOCK_FORM_ID,
+  //           collaboratorEmail: MOCK_RECIPIENT_EMAIL,
+  //           recipientNumber: TWILIO_TEST_NUMBER,
+  //           formAdmin: {
+  //             email: MOCK_ADMIN_EMAIL,
+  //             userId: MOCK_ADMIN_ID,
+  //           },
+  //         },
+  //         smsType: SmsType.DeactivatedForm,
+  //         msgSrvcSid: MOCK_VALID_CONFIG.msgSrvcSid,
+  //         logType: LogType.success,
+  //       })
+  //     })
+
+  //     it('should log failure when sending fails', async () => {
+  //       // Arrange
+  //       const expectedMessage = renderFormDeactivatedSms(MOCK_FORM_TITLE)
+
+  //       // Act
+  //       const actualResult = await SmsService.sendFormDeactivatedSms(
+  //         {
+  //           recipient: TWILIO_TEST_NUMBER,
+  //           adminEmail: MOCK_ADMIN_EMAIL,
+  //           adminId: MOCK_ADMIN_ID,
+  //           formId: MOCK_FORM_ID,
+  //           formTitle: MOCK_FORM_TITLE,
+  //           recipientEmail: MOCK_RECIPIENT_EMAIL,
+  //         },
+  //         MOCK_INVALID_CONFIG,
+  //       )
+
+  //       // Assert
+  //       expect(actualResult._unsafeUnwrapErr()).toEqual(new InvalidNumberError())
+  //       expect(twilioFailureSpy).toHaveBeenCalledWith({
+  //         to: TWILIO_TEST_NUMBER,
+  //         body: expectedMessage,
+  //         from: MOCK_INVALID_CONFIG.msgSrvcSid,
+  //         forceDelivery: true,
+  //         statusCallback: expect.stringContaining(MOCK_TWILIO_WEBHOOK_ROUTE),
+  //       })
+  //       expect(smsCountSpy).toHaveBeenCalledWith({
+  //         smsData: {
+  //           form: MOCK_FORM_ID,
+  //           collaboratorEmail: MOCK_RECIPIENT_EMAIL,
+  //           recipientNumber: TWILIO_TEST_NUMBER,
+  //           formAdmin: {
+  //             email: MOCK_ADMIN_EMAIL,
+  //             userId: MOCK_ADMIN_ID,
+  //           },
+  //         },
+  //         smsType: SmsType.DeactivatedForm,
+  //         msgSrvcSid: MOCK_INVALID_CONFIG.msgSrvcSid,
+  //         logType: LogType.failure,
+  //       })
+  //     })
+  //   })
+
+  //   describe('sendBouncedSubmissionSms', () => {
+  //     it('should send SMS and log success when sending is successful', async () => {
+  //       const expectedMessage = renderBouncedSubmissionSms(MOCK_FORM_TITLE)
+
+  //       await SmsService.sendBouncedSubmissionSms(
+  //         {
+  //           recipient: TWILIO_TEST_NUMBER,
+  //           adminEmail: MOCK_ADMIN_EMAIL,
+  //           adminId: MOCK_ADMIN_ID,
+  //           formId: MOCK_FORM_ID,
+  //           formTitle: MOCK_FORM_TITLE,
+  //           recipientEmail: MOCK_RECIPIENT_EMAIL,
+  //         },
+  //         MOCK_VALID_CONFIG,
+  //       )
+
+  //       expect(twilioSuccessSpy).toHaveBeenCalledWith({
+  //         to: TWILIO_TEST_NUMBER,
+  //         body: expectedMessage,
+  //         from: MOCK_VALID_CONFIG.msgSrvcSid,
+  //         forceDelivery: true,
+  //         statusCallback: expect.stringContaining(MOCK_TWILIO_WEBHOOK_ROUTE),
+  //       })
+
+  //       expect(twilioSuccessSpy.mock.calls[0][0].statusCallback).toEqual(
+  //         expect.not.stringContaining('?senderIp'),
+  //       )
+
+  //       expect(smsCountSpy).toHaveBeenCalledWith({
+  //         smsData: {
+  //           form: MOCK_FORM_ID,
+  //           collaboratorEmail: MOCK_RECIPIENT_EMAIL,
+  //           recipientNumber: TWILIO_TEST_NUMBER,
+  //           formAdmin: {
+  //             email: MOCK_ADMIN_EMAIL,
+  //             userId: MOCK_ADMIN_ID,
+  //           },
+  //         },
+  //         smsType: SmsType.BouncedSubmission,
+  //         msgSrvcSid: MOCK_VALID_CONFIG.msgSrvcSid,
+  //         logType: LogType.success,
+  //       })
+  //     })
+
+  //     it('should log failure when sending fails', async () => {
+  //       // Arrange
+  //       const expectedMessage = renderBouncedSubmissionSms(MOCK_FORM_TITLE)
+
+  //       // Act
+  //       const actualResult = await SmsService.sendBouncedSubmissionSms(
+  //         {
+  //           recipient: TWILIO_TEST_NUMBER,
+  //           adminEmail: MOCK_ADMIN_EMAIL,
+  //           adminId: MOCK_ADMIN_ID,
+  //           formId: MOCK_FORM_ID,
+  //           formTitle: MOCK_FORM_TITLE,
+  //           recipientEmail: MOCK_RECIPIENT_EMAIL,
+  //         },
+  //         MOCK_INVALID_CONFIG,
+  //       )
+
+  //       // Assert
+  //       expect(actualResult._unsafeUnwrapErr()).toEqual(new InvalidNumberError())
+  //       expect(twilioFailureSpy).toHaveBeenCalledWith({
+  //         to: TWILIO_TEST_NUMBER,
+  //         body: expectedMessage,
+  //         from: MOCK_INVALID_CONFIG.msgSrvcSid,
+  //         forceDelivery: true,
+  //         statusCallback: expect.stringContaining(MOCK_TWILIO_WEBHOOK_ROUTE),
+  //       })
+  //       expect(smsCountSpy).toHaveBeenCalledWith({
+  //         smsData: {
+  //           form: MOCK_FORM_ID,
+  //           collaboratorEmail: MOCK_RECIPIENT_EMAIL,
+  //           recipientNumber: TWILIO_TEST_NUMBER,
+  //           formAdmin: {
+  //             email: MOCK_ADMIN_EMAIL,
+  //             userId: MOCK_ADMIN_ID,
+  //           },
+  //         },
+  //         smsType: SmsType.BouncedSubmission,
+  //         msgSrvcSid: MOCK_INVALID_CONFIG.msgSrvcSid,
+  //         logType: LogType.failure,
+  //       })
+  //     })
+  //   })
+
+  describe('sendVerificationOtp', () => {
+    let mockOtpData: FormOtpData
+    let testForm: IFormSchema
+
+    beforeEach(async () => {
+      testForm = await FormModel.create({
+        title: 'Test Form',
+        emails: [testUser.email],
+        admin: testUser._id,
+        responseMode: FormResponseMode.Email,
+      })
+
+      mockOtpData = {
+        form: testForm._id,
+        formAdmin: {
+          email: testUser.email,
+          userId: testUser._id,
+        },
+      }
+    })
+
+    it('should return MalformedParametersError error when retrieved otpData is null', async () => {
+      // Arrange
+      // Return null on Form method
+      jest.spyOn(FormModel, 'getOtpData').mockResolvedValueOnce(null)
+      const postmanSendSpy = jest
+        .spyOn(PostmanSmsService, 'sendMopSms')
+        .mockResolvedValueOnce(okAsync(true))
+
+      // Act
+      const actualResult = await PostmanSmsService.sendVerificationOtp(
+        TEST_NUMBER,
+        '111111',
+        'ABC',
+        testForm._id,
+        MOCK_SENDER_IP,
+      )
+
+      // Assert
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new MalformedParametersError(
+          `Unable to retrieve otpData from ${testForm._id}`,
+        ),
+      )
+      expect(postmanSendSpy).not.toHaveBeenCalled()
+    })
+
+    it('should log and send verification OTP when sending has no errors', async () => {
+      // Arrange
+      jest.spyOn(FormModel, 'getOtpData').mockResolvedValueOnce(mockOtpData)
+
+      const postmanSendSpy = jest
+        .spyOn(PostmanSmsService, 'sendMopSms')
+        .mockResolvedValueOnce(okAsync(true))
+
+      // Act
+      const actualResult = await PostmanSmsService.sendVerificationOtp(
+        TEST_NUMBER,
+        '111111',
+        'ABC',
+        testForm._id,
+        MOCK_SENDER_IP,
+      )
+
+      // Assert
+      expect(actualResult._unsafeUnwrap()).toEqual(true)
+      expect(postmanSendSpy).toHaveBeenCalledOnce()
+    })
+
+    it('should log failure and return InvalidNumberError when verification OTP fails to send due to invalid number', async () => {
+      // Arrange
+      jest.spyOn(FormModel, 'getOtpData').mockResolvedValueOnce(mockOtpData)
+      const postmanSendSpy = jest
+        .spyOn(PostmanSmsService, 'sendMopSms')
+        .mockResolvedValueOnce(okAsync(true))
+
+      const invalidNumber = '1+11123'
+      // Act
+      const actualResult = await PostmanSmsService.sendVerificationOtp(
+        invalidNumber,
+        '111111',
+        'ABC',
+        testForm._id,
+        MOCK_SENDER_IP,
+      )
+
+      // Assert
+      expect(actualResult._unsafeUnwrapErr()).toEqual(new InvalidNumberError())
+      expect(postmanSendSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  //   describe('sendAdminContactOtp', () => {
+  //     it('should log and send contact OTP when sending has no errors', async () => {
+  //       // Act
+  //       const actualResult = await SmsService.sendAdminContactOtp(
+  //         /* recipient= */ TWILIO_TEST_NUMBER,
+  //         /* otp= */ '111111',
+  //         /* userId= */ testUser._id,
+  //         /* senderIp= */ MOCK_SENDER_IP,
+  //         /* defaultConfig= */ MOCK_VALID_CONFIG,
+  //       )
+
+  //       // Assert
+  //       expect(twilioSuccessSpy.mock.calls[0][0].statusCallback).toEqual(
+  //         expect.stringContaining('?senderIp'),
+  //       )
+
+  //       // Should resolve to true
+  //       expect(actualResult.isOk()).toEqual(true)
+  //       expect(actualResult._unsafeUnwrap()).toEqual(true)
+  //       // Logging should also have happened.
+  //       const expectedLogParams = {
+  //         smsData: {
+  //           admin: testUser._id,
+  //         },
+  //         msgSrvcSid: MOCK_MSG_SRVC_SID,
+  //         smsType: SmsType.AdminContact,
+  //         logType: LogType.success,
+  //       }
+  //       expect(smsCountSpy).toHaveBeenCalledWith(expectedLogParams)
+  //     })
+  //   })
+
+  //   describe('retrieveFreeSmsCounts', () => {
+  //     const VERIFICATION_SMS_COUNT = 3
+
+  //     it('should retrieve sms counts correctly for a specified user', async () => {
+  //       // Arrange
+  //       const retrieveSpy = jest.spyOn(SmsCountModel, 'retrieveFreeSmsCounts')
+  //       retrieveSpy.mockResolvedValueOnce(VERIFICATION_SMS_COUNT)
+
+  //       // Act
+  //       const actual = await SmsService.retrieveFreeSmsCounts(testUser._id)
+
+  //       // Assert
+  //       expect(actual._unsafeUnwrap()).toBe(VERIFICATION_SMS_COUNT)
+  //     })
+
+  //     it('should return a database error when retrieval fails', async () => {
+  //       // Arrange
+  //       const retrieveSpy = jest.spyOn(SmsCountModel, 'retrieveFreeSmsCounts')
+  //       retrieveSpy.mockRejectedValueOnce('ohno')
+
+  //       // Act
+  //       const actual = await SmsService.retrieveFreeSmsCounts(testUser._id)
+
+  //       // Assert
+  //       expect(actual._unsafeUnwrapErr()).toEqual(
+  //         new DatabaseError(getMongoErrorMessage('ohno')),
+  //       )
+  //     })
+  //   })
+
+  //   it('should log failure and throw error when contact OTP fails to send', async () => {
+  //     // Act
+  //     const actualResult = await SmsService.sendAdminContactOtp(
+  //       /* recipient= */ TWILIO_TEST_NUMBER,
+  //       /* otp= */ '111111',
+  //       /* userId= */ testUser._id,
+  //       /* senderIp= */ MOCK_SENDER_IP,
+  //       /* defaultConfig= */ MOCK_INVALID_CONFIG,
+  //     )
+
+  //     // Assert
+  //     const expectedError = new Error(VfnErrors.InvalidMobileNumber)
+  //     expectedError.name = VfnErrors.SendOtpFailed
+
+  //     expect(actualResult.isErr()).toEqual(true)
+
+  //     // Logging should also have happened.
+  //     const expectedLogParams = {
+  //       smsData: {
+  //         admin: testUser._id,
+  //       },
+  //       msgSrvcSid: MOCK_MSG_SRVC_SID,
+  //       smsType: SmsType.AdminContact,
+  //       logType: LogType.failure,
+  //     }
+  //     expect(smsCountSpy).toHaveBeenCalledWith(expectedLogParams)
+  //   })
+})

--- a/src/app/services/postman-sms/postman-sms.errors.ts
+++ b/src/app/services/postman-sms/postman-sms.errors.ts
@@ -1,0 +1,16 @@
+import { ApplicationError } from '../../modules/core/core.errors'
+
+export class SmsSendError extends ApplicationError {
+  constructor(
+    message = 'Error sending OTP. Please try again later and if the problem persists, contact us.',
+    meta?: unknown,
+  ) {
+    super(message, meta)
+  }
+}
+
+export class InvalidNumberError extends ApplicationError {
+  constructor(message = 'Please enter a valid phone number') {
+    super(message)
+  }
+}

--- a/src/app/services/postman-sms/postman-sms.service.ts
+++ b/src/app/services/postman-sms/postman-sms.service.ts
@@ -3,7 +3,7 @@ import mongoose from 'mongoose'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 
 import { isPhoneNumber } from '../../../../shared/utils/phone-num-validation'
-import { AdminContactOtpData, FormOtpData } from '../../../types'
+import { FormOtpData } from '../../../types'
 import { useMockPostmanSms } from '../../config/config'
 import { postmanSmsConfig } from '../../config/features/postman-sms.config'
 import { createLoggerWithLabel } from '../../config/logger'

--- a/src/app/services/postman-sms/postman-sms.service.ts
+++ b/src/app/services/postman-sms/postman-sms.service.ts
@@ -29,12 +29,12 @@ class PostmanSmsService {
    * Messages to any member of public MUST be sent using this method.
    */
   sendMopSms(
-    smsData: FormOtpData | AdminContactOtpData,
+    smsData: FormOtpData,
     recipient: string,
     message: string,
     smsType: SmsType,
     senderIp?: string,
-  ): ResultAsync<true, SmsSendError | InvalidNumberError> {
+  ): ResultAsync<true, SmsSendError> {
     const logMeta = {
       action: 'sendMopSms',
       recipient,

--- a/src/app/services/postman-sms/postman-sms.service.ts
+++ b/src/app/services/postman-sms/postman-sms.service.ts
@@ -50,7 +50,10 @@ class PostmanSmsService {
     }
 
     if (useMockPostmanSms) {
-      return MailService.sendLocalDevMail('[mocktwilio] Captured SMS', message)
+      return MailService.sendLocalDevMail(
+        '[Mock Postman SMS] Captured SMS',
+        message,
+      )
     }
 
     const campaignUrl =

--- a/src/app/services/postman-sms/postman-sms.service.ts
+++ b/src/app/services/postman-sms/postman-sms.service.ts
@@ -1,0 +1,158 @@
+import axios, { AxiosError } from 'axios'
+import mongoose from 'mongoose'
+import { errAsync, okAsync, ResultAsync } from 'neverthrow'
+
+import { isPhoneNumber } from '../../../../shared/utils/phone-num-validation'
+import { AdminContactOtpData, FormOtpData } from '../../../types'
+import { useMockPostmanSms } from '../../config/config'
+import { postmanSmsConfig } from '../../config/features/postman-sms.config'
+import { createLoggerWithLabel } from '../../config/logger'
+import getFormModel from '../../models/form.server.model'
+import {
+  DatabaseError,
+  MalformedParametersError,
+} from '../../modules/core/core.errors'
+import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
+import MailService from '../mail/mail.service'
+import { InvalidNumberError, SmsSendError } from '../sms/sms.errors'
+
+import { SmsType } from './postman-sms.types'
+import { renderVerificationSms } from './postman-sms.util'
+
+const logger = createLoggerWithLabel(module)
+const Form = getFormModel(mongoose)
+class PostmanSmsService {
+  /**
+   * Send SMS using Postman API to Member of public
+   *
+   * SMSes will be sent using govsg sender id.
+   * Messages to any member of public MUST be sent using this method.
+   */
+  private sendMopSms(
+    smsData: FormOtpData | AdminContactOtpData,
+    recipient: string,
+    message: string,
+    smsType: SmsType,
+    senderIp?: string,
+  ): ResultAsync<true, SmsSendError | InvalidNumberError> {
+    const logMeta = {
+      action: 'sendMopSms',
+      recipient,
+      smsType,
+      smsData,
+      senderIp,
+    }
+
+    const body = {
+      recipient: recipient.replace('+', ''),
+      language: 'english',
+      values: { body: message },
+    }
+
+    if (useMockPostmanSms) {
+      return MailService.sendLocalDevMail('[mocktwilio] Captured SMS', message)
+    }
+
+    const campaignUrl =
+      postmanSmsConfig.postmanBaseUrl +
+      `/campaigns/${postmanSmsConfig.mopCampaignId}/messages`
+
+    return ResultAsync.fromPromise(
+      axios.post(campaignUrl, body, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${postmanSmsConfig.mopCampaignApiKey}`,
+        },
+      }),
+      (error) => {
+        logger.warn({
+          message: 'Error sending SMS using Postman API',
+          meta: {
+            ...logMeta,
+            postmanError: (error as AxiosError).response?.data,
+          },
+        })
+
+        return new SmsSendError()
+      },
+    ).andThen(() => {
+      return okAsync(true as const)
+    })
+  }
+
+  /**
+   * Send SMS using Postman API to Internal users
+   *
+   * SMSes will be sent using FormSG sender id.
+   */
+  private sendInternalSms() {
+    // stub
+  }
+
+  /**
+   * Sends an otp to a valid phonenumber through the MOP SMS flow
+   * @param recipient The phone number to send to
+   * @param otp The OTP to send
+   * @param otpPrefix The OTP Prefix to send
+   * @param formId Form id for retrieving otp data.
+   * @param senderIp The ip address of the person triggering the SMS
+   */
+  public sendVerificationOtp(
+    recipient: string,
+    otp: string,
+    otpPrefix: string,
+    formId: string,
+    senderIp: string,
+  ): ResultAsync<
+    true,
+    DatabaseError | MalformedParametersError | SmsSendError | InvalidNumberError
+  > {
+    const logMeta = {
+      action: 'sendVerificationOtp',
+      formId,
+    }
+    logger.info({
+      message: `Sending verification OTP for ${formId}`,
+      meta: logMeta,
+    })
+
+    if (!isPhoneNumber(recipient)) {
+      logger.warn({
+        message: `${recipient} is not a valid phone number`,
+        meta: logMeta,
+      })
+      return errAsync(new InvalidNumberError())
+    }
+
+    return ResultAsync.fromPromise(Form.getOtpData(formId), (error) => {
+      logger.error({
+        message: `Database error occurred whilst retrieving form otp data`,
+        meta: logMeta,
+        error,
+      })
+
+      return new DatabaseError(getMongoErrorMessage(error))
+    }).andThen((otpData) => {
+      if (!otpData) {
+        const errMsg = `Unable to retrieve otpData from ${formId}`
+        logger.error({
+          message: errMsg,
+          meta: logMeta,
+        })
+
+        return errAsync(new MalformedParametersError(errMsg))
+      }
+
+      const message = renderVerificationSms(otp, otpPrefix)
+      return this.sendMopSms(
+        otpData,
+        recipient,
+        message,
+        SmsType.Verification,
+        senderIp,
+      )
+    })
+  }
+}
+
+export default new PostmanSmsService()

--- a/src/app/services/postman-sms/postman-sms.service.ts
+++ b/src/app/services/postman-sms/postman-sms.service.ts
@@ -14,8 +14,8 @@ import {
 } from '../../modules/core/core.errors'
 import { getMongoErrorMessage } from '../../utils/handle-mongo-error'
 import MailService from '../mail/mail.service'
-import { InvalidNumberError, SmsSendError } from '../sms/sms.errors'
 
+import { InvalidNumberError, SmsSendError } from './postman-sms.errors'
 import { SmsType } from './postman-sms.types'
 import { renderVerificationSms } from './postman-sms.util'
 
@@ -28,7 +28,7 @@ class PostmanSmsService {
    * SMSes will be sent using govsg sender id.
    * Messages to any member of public MUST be sent using this method.
    */
-  private sendMopSms(
+  sendMopSms(
     smsData: FormOtpData | AdminContactOtpData,
     recipient: string,
     message: string,

--- a/src/app/services/postman-sms/postman-sms.types.ts
+++ b/src/app/services/postman-sms/postman-sms.types.ts
@@ -1,0 +1,6 @@
+export enum SmsType {
+  Verification = 'VERIFICATION',
+  AdminContact = 'ADMIN_CONTACT',
+  DeactivatedForm = 'DEACTIVATED_FORM',
+  BouncedSubmission = 'BOUNCED_SUBMISSION',
+}

--- a/src/app/services/postman-sms/postman-sms.util.ts
+++ b/src/app/services/postman-sms/postman-sms.util.ts
@@ -1,0 +1,20 @@
+import dedent from 'dedent-js'
+
+export const renderFormDeactivatedSms = (formTitle: string): string => dedent`
+  Due to responses bouncing from all recipient inboxes, your form "${formTitle}" has been automatically deactivated to prevent further response loss.
+
+  Please ensure your recipient email addresses (Settings tab) have the ability to receive emailed responses from us. Invalid email addresses should be deleted, and full inboxes should be cleared.
+
+  If a systemic email issue is affecting email delivery, consider temporarily deactivating your form until email delivery is stable, or switching the form to Storage mode to continue receiving responses.
+`
+
+export const renderBouncedSubmissionSms = (formTitle: string): string => dedent`
+  A response to your form "${formTitle}" has bounced from all recipient inboxes. Bounced responses cannot be recovered. To prevent more bounces, please ensure recipient email addresses are correct, and clear any full inboxes.
+`
+
+export const renderVerificationSms = (
+  otp: string,
+  otpPrefix: string,
+): string => dedent`Use the OTP ${otpPrefix}-${otp} to submit on FormSG.
+
+  Never share your OTP with anyone else. If you did not request this OTP, you can safely ignore this SMS.`

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -84,6 +84,7 @@ export type Config = {
   isDev: boolean
   nodeEnv: Environment
   useMockTwilio: boolean
+  useMockPostmanSms: boolean
   port: number
   sessionSecret: string
   chromiumBin: string
@@ -157,6 +158,7 @@ export interface IOptionalVarsSchema {
     submissionsTopUp: number
     nodeEnv: Environment
     useMockTwilio: boolean
+    useMockPostmanSms: boolean
   }
   banner: {
     isGeneralMaintenance: string


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1717

## Solution
<!-- How did you solve the problem? -->

Migration of our SMS service from Twilio to Postman. We will want to remove `Twilio` completely and utilize specific Postman campaign IDs that's clearly segregated by (1) `MOP` and (2) `INTERNAL` at the SmsService level. This switches our SMS decisions to be determined by the targetted demographics[1] as opposed to sending an SMS out from the FormSG.

A new Service, `PostmanSmsService`, is created to allow us to control the roll outs before enabling it for all admins.

[1] This is necessary as we have a WOG mandate to ensure that ALL SMSes to MOPs must be from Postman.

#7343 implements the `INTERNAL` flow of this new SMS service.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `POSTMAN_MOP_CAMPAIGN_ID`
- `POSTMAN_MOP_CAMPAIGN_API_KEY`
-  `POSTMAN_BASE_URL`
