### PR TITLE
chore: remove mention of data collation tool on landing and email settings results page

### DIFF
--- a/frontend/src/constants/links.ts
+++ b/frontend/src/constants/links.ts
@@ -79,7 +79,6 @@ export const LANDING_PAGE_EXAMPLE_FORMS = [
 
 export const OGP_ALL_PRODUCTS = 'https://www.open.gov.sg/products/overview'
 export const OGP_POSTMAN = 'https://postman.gov.sg'
-export const OGP_FORMSG_COLLATE = 'https://collate.form.gov.sg'
 export const OGP_SGID = 'https://go.gov.sg/sgid-formsg'
 
 export const OGP_FORMSG_REPO = 'https://github.com/opengovsg/formsg'

--- a/frontend/src/features/admin-form/responses/ResponsesPage/email/EmailResponsesTab.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/email/EmailResponsesTab.tsx
@@ -30,12 +30,7 @@ export const EmailResponsesTab = (): JSX.Element => {
           </Text>
         </Skeleton>
         <Text textStyle="body-1">
-          FormSG does not store responses in Email mode. To collate the
-          responses in your Outlook Inbox, use the{' '}
-          <Link isExternal href={OGP_FORMSG_COLLATE}>
-            Data Collation Tool
-          </Link>
-          .
+          FormSG does not store responses in Email mode.
         </Text>
       </Stack>
     </Container>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/email/EmailResponsesTab.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/email/EmailResponsesTab.tsx
@@ -1,9 +1,6 @@
 import { Container, Skeleton, Stack, Text } from '@chakra-ui/react'
 import simplur from 'simplur'
 
-import { OGP_FORMSG_COLLATE } from '~constants/links'
-import Link from '~components/Link'
-
 import { useFormResponsesCount } from '../../queries'
 import { EmptyResponses } from '../common/EmptyResponses'
 

--- a/frontend/src/pages/Landing/Home/LandingPage.tsx
+++ b/frontend/src/pages/Landing/Home/LandingPage.tsx
@@ -36,14 +36,9 @@ import {
   GUIDE_TRANSFER_OWNERSHIP,
   LANDING_PAGE_EXAMPLE_FORMS,
   OGP_ALL_PRODUCTS,
-  OGP_FORMSG_COLLATE,
   OGP_FORMSG_REPO,
 } from '~constants/links'
-import {
-  LANDING_PAYMENTS_ROUTE,
-  LOGIN_ROUTE,
-  TOU_ROUTE,
-} from '~constants/routes'
+import { LOGIN_ROUTE, TOU_ROUTE } from '~constants/routes'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useMdComponents } from '~hooks/useMdComponents'
 import Button from '~components/Button'

--- a/frontend/src/pages/Landing/Home/LandingPage.tsx
+++ b/frontend/src/pages/Landing/Home/LandingPage.tsx
@@ -496,13 +496,6 @@ export const LandingPage = (): JSX.Element => {
                   <OrderedListIcon index={4} />
                   Collect responses at your email address
                 </ListItem>
-                <ListItem textStyle="body-2">
-                  <OrderedListIcon index={5} />
-                  Collate responses with our{' '}
-                  <Link isExternal href={OGP_FORMSG_COLLATE}>
-                    data collation tool
-                  </Link>
-                </ListItem>
               </OrderedList>
             </TabPanel>
           </TabPanels>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We want to deprecate the data collation tool as part of the larger initiative. We are also looking at reducing the maintenance for data collation tool as we have a superior solution (storage mode-webhooks) to manage this.

Closes FRM-1739

## Solution

Removed references to the data collation tool in the email responses tab and landing page.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

