### PR TITLE
fix(payment): add joi validation on POST body for payment onboarding

### DIFF
--- a/src/app/modules/payments/__tests__/payments.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/payments.controller.spec.ts
@@ -280,7 +280,7 @@ describe('payments.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await PaymentsController.handleSendOnboardingEmail(
+      await PaymentsController._handleSendOnboardingEmail(
         mockReq,
         mockRes,
         jest.fn(),
@@ -297,7 +297,7 @@ describe('payments.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await PaymentsController.handleSendOnboardingEmail(
+      await PaymentsController._handleSendOnboardingEmail(
         mockReq,
         mockRes,
         jest.fn(),
@@ -315,7 +315,7 @@ describe('payments.controller', () => {
       const mockRes = expressHandler.mockResponse()
 
       // Act
-      await PaymentsController.handleSendOnboardingEmail(
+      await PaymentsController._handleSendOnboardingEmail(
         mockReq,
         mockRes,
         jest.fn(),
@@ -335,7 +335,7 @@ describe('payments.controller', () => {
       await dbHandler.closeDatabase()
 
       // Act
-      await PaymentsController.handleSendOnboardingEmail(
+      await PaymentsController._handleSendOnboardingEmail(
         mockReq,
         mockRes,
         jest.fn(),

--- a/src/app/modules/payments/payments.controller.ts
+++ b/src/app/modules/payments/payments.controller.ts
@@ -1,3 +1,4 @@
+import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 
 import { createLoggerWithLabel } from '../../config/logger'
@@ -72,7 +73,7 @@ export const handleGetPreviousPaymentId: ControllerHandler<
   )
 }
 
-export const handleSendOnboardingEmail: ControllerHandler<
+export const _handleSendOnboardingEmail: ControllerHandler<
   unknown,
   unknown,
   { email: string }
@@ -114,3 +115,12 @@ export const handleSendOnboardingEmail: ControllerHandler<
       }
     })
 }
+
+export const handleSendOnboardingEmail = [
+  celebrate({
+    [Segments.BODY]: Joi.object({
+      email: Joi.string(),
+    }),
+  }),
+  _handleSendOnboardingEmail,
+] as ControllerHandler[]

--- a/src/app/modules/payments/payments.controller.ts
+++ b/src/app/modules/payments/payments.controller.ts
@@ -119,7 +119,7 @@ export const _handleSendOnboardingEmail: ControllerHandler<
 export const handleSendOnboardingEmail = [
   celebrate({
     [Segments.BODY]: Joi.object({
-      email: Joi.string(),
+      email: Joi.string().email().required(),
     }),
   }),
   _handleSendOnboardingEmail,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Our `payment/onboarding` url doesn't strictly validates that the email field exists. This in turn causes some parts of the email validator to fail.

Notes: this was from a tester trying to inject a malicious request into our DB query.

## Solution
<!-- How did you solve the problem? -->

Require `email` to be a valid string.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
#### Regression
- [ ] Visit form.gov.sg/payments 
- [ ] Enter your whitelisted email
- [ ] Ensure that the message "An email has been sent to this email address." is displayed
- [ ] Ensure that the email is received in your inbox