### PR TITLE
fix: add default values for postman env variables to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,9 +133,9 @@ services:
       - WOGAA_START_ENDPOINT
       - WOGAA_SUBMIT_ENDPOINT
       - WOGAA_FEEDBACK_ENDPOINT
-      - POSTMAN_MOP_CAMPAIGN_ID
-      - POSTMAN_MOP_CAMPAIGN_API_KEY
-      - POSTMAN_BASE_URL
+      - POSTMAN_MOP_CAMPAIGN_ID=campaign_test
+      - POSTMAN_MOP_CAMPAIGN_API_KEY=key_test_123
+      - POSTMAN_BASE_URL=https://test.postman.gov.sg/api/v2
 
   mockpass:
     build: https://github.com/opengovsg/mockpass.git#v4.3.1


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Due to the new postman service env variables added, local dev is expecting env variables for
`POSTMAN_MOP_CAMPAIGN_ID`,  `POSTMAN_MOP_CAMPAIGN_API_KEY` and `POSTMAN_BASE_URL`. 

however, during local dev env run with `docker compose up`, these variables are not defined and hence cannot be found, leading to var not found error. seen in 'before' screenshot below. 

## Solution
<!-- How did you solve the problem? -->

Add default values for these 3 env variables in `docker.compose.yml`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

![image](https://github.com/opengovsg/FormSG/assets/55353265/e8da1d18-16fc-4d13-960e-6803f3f58fdf)
Error message seen when backend is serving requests due to no env variables found. 

**AFTER**:
<!-- [insert screenshot here] -->

No error should occur. 

## Tests
<!-- What tests should be run to confirm functionality? -->

- [x] Go to the /dashboard page on local dev, there should not be any error seen in the server logs and page should be served without any error. 
