### PR TITLE
fix(encrypt-submission): add missing ndi response fields

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,8 @@ jobs:
   test:
     timeout-minutes: 40
     runs-on: ubuntu-latest
+    env:
+      AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE: 1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Build
         env:
           NODE_OPTIONS: '--max-old-space-size=4096 --openssl-legacy-provider'
+          AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE: 1
           REACT_APP_FORMSG_SDK_MODE: 'test'
         run: npm run build
       - name: Run Playwright tests (login)

--- a/__tests__/e2e/email-submission.spec.ts
+++ b/__tests__/e2e/email-submission.spec.ts
@@ -28,7 +28,7 @@ import {
   createMyInfoField,
   createOptionalVersion,
   deleteDocById,
-  getSettings,
+  getEmailSettings,
   makeModel,
   makeMongooseFixtures,
 } from './utils'
@@ -58,7 +58,7 @@ test.describe('Email form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -76,7 +76,7 @@ test.describe('Email form submission', () => {
       createBlankVersion(createOptionalVersion(ff)),
     )
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -98,10 +98,10 @@ test.describe('Email form submission', () => {
           title: `Attachment ${i}`,
           path: `__tests__/e2e/files/att-folder-${i}/test-att.txt`,
           val: `${i === 2 ? '' : `${2 - i}-`}test-att.txt`,
-        } as E2eFieldMetadata),
+        }) as E2eFieldMetadata,
     )
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -135,7 +135,7 @@ test.describe('Email form submission', () => {
       } as E2eFieldMetadata,
     ]
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -151,7 +151,7 @@ test.describe('Email form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEmailSettings({
       authType: FormAuthType.SP,
     })
 
@@ -169,7 +169,7 @@ test.describe('Email form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEmailSettings({
       authType: FormAuthType.CP,
     })
 
@@ -187,7 +187,7 @@ test.describe('Email form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEmailSettings({
       authType: FormAuthType.SGID,
     })
 
@@ -216,7 +216,7 @@ test.describe('Email form submission', () => {
       createMyInfoField(MyInfoAttribute.WorkpassStatus, 'Live', false),
     ]
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEmailSettings({
       authType: FormAuthType.MyInfo,
     })
 
@@ -233,7 +233,7 @@ test.describe('Email form submission', () => {
   }) => {
     // Define
     const { formFields, formLogics } = TEST_ALL_FIELDS_SHOWN_BY_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -248,7 +248,7 @@ test.describe('Email form submission', () => {
   }) => {
     // Define
     const { formFields, formLogics } = TEST_FIELD_HIDDEN_BY_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -264,7 +264,7 @@ test.describe('Email form submission', () => {
     // Define
     const { formFields, formLogics, preventSubmitMessage } =
       TEST_SUBMISSION_DISABLED_BY_CHAINED_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     const { form } = await createForm(page, Form, FormResponseMode.Email, {

--- a/__tests__/e2e/encrypt-submission.spec.ts
+++ b/__tests__/e2e/encrypt-submission.spec.ts
@@ -26,7 +26,7 @@ import {
   createMyInfoField,
   createOptionalVersion,
   deleteDocById,
-  getSettings,
+  getEncryptSettings,
   makeModel,
   makeMongooseFixtures,
 } from './utils'
@@ -61,7 +61,7 @@ test.describe('Storage form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     await runEncryptSubmissionTest(page, Form, {
@@ -79,7 +79,7 @@ test.describe('Storage form submission', () => {
       createBlankVersion(createOptionalVersion(ff)),
     )
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     await runEncryptSubmissionTest(page, Form, {
@@ -94,7 +94,7 @@ test.describe('Storage form submission', () => {
   }) => {
     // Define
     const { formFields, formLogics } = TEST_ALL_FIELDS_SHOWN_BY_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     await runEncryptSubmissionTest(page, Form, {
@@ -109,7 +109,7 @@ test.describe('Storage form submission', () => {
   }) => {
     // Define
     const { formFields, formLogics } = TEST_FIELD_HIDDEN_BY_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     await runEncryptSubmissionTest(page, Form, {
@@ -125,7 +125,7 @@ test.describe('Storage form submission', () => {
     // Define
     const { formFields, formLogics, preventSubmitMessage } =
       TEST_SUBMISSION_DISABLED_BY_CHAINED_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     const { form } = await createForm(page, Form, FormResponseMode.Encrypt, {
@@ -158,7 +158,7 @@ test.describe('Storage form submission', () => {
       createMyInfoField(MyInfoAttribute.WorkpassStatus, 'Live', false),
     ]
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEncryptSettings({
       authType: FormAuthType.MyInfo,
     })
 

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -171,10 +171,7 @@ const addSettings = async (
   await expect(page).toHaveURL(ADMIN_FORM_PAGE_SETTINGS(formId))
 
   await addGeneralSettings(page, formSettings)
-  // Encrypt mode forms don't have an email
-  if (formResponseMode.responseMode === FormResponseMode.Encrypt) {
-    await addAdminEmails(page, formSettings)
-  }
+  await addAdminEmails(page, formSettings)
   await addAuthSettings(page, formSettings)
   await addCollaborators(page, formSettings)
 
@@ -384,6 +381,8 @@ const addAdminEmails = async (
     await page.keyboard.press('Backspace')
 
     await emailInput.fill(formSettings.emails.join(', '))
+
+    await page.keyboard.press('Tab')
 
     await expectToast(page, /emails successfully updated/i)
   }

--- a/__tests__/e2e/helpers/verifySubmission.ts
+++ b/__tests__/e2e/helpers/verifySubmission.ts
@@ -204,11 +204,12 @@ export const verifyEncryptSubmission = async (
     // Verify form responses in email
     for (const field of formFields) {
       const responseArray = getResponseArray(field, {
-        mode: FormResponseMode.Email,
+        mode: FormResponseMode.Encrypt,
+        csv: false,
       })
       if (!responseArray) continue
       expectSubmissionContains([
-        getResponseTitle(field, { mode: FormResponseMode.Email }),
+        getResponseTitle(field, { mode: FormResponseMode.Encrypt, csv: false }),
         ...responseArray,
       ])
       if (!submission.attachments) continue

--- a/__tests__/e2e/helpers/verifySubmission.ts
+++ b/__tests__/e2e/helpers/verifySubmission.ts
@@ -1,5 +1,5 @@
 import { expect, Page } from '@playwright/test'
-import { readFileSync } from 'fs'
+// import { readFileSync } from 'fs'
 import { BasicField, FormAuthType, FormResponseMode } from 'shared/types'
 
 import { IFormSchema, SgidFieldTitle, SPCPFieldTitle } from 'src/types'
@@ -7,7 +7,7 @@ import { IFormSchema, SgidFieldTitle, SPCPFieldTitle } from 'src/types'
 import {
   ADMIN_EMAIL,
   ADMIN_FORM_PAGE_RESPONSES,
-  ADMIN_FORM_PAGE_RESPONSES_INDIVIDUAL,
+  // ADMIN_FORM_PAGE_RESPONSES_INDIVIDUAL,
   E2eFieldMetadata,
   E2eFormResponseMode,
   E2eSettingsOptions,
@@ -15,7 +15,7 @@ import {
 import {
   expectAttachment,
   expectContains,
-  expectToast,
+  // expectToast,
   getAutoreplyEmail,
   getResponseArray,
   getResponseTitle,
@@ -198,6 +198,7 @@ export const verifyEncryptSubmission = async (
     }
 
     // Subject need not be verified, since we got the email via the subject.
+
     const expectSubmissionContains = expectContains(submission.html)
 
     // Verify form responses in email
@@ -245,13 +246,12 @@ export const verifyEncryptSubmission = async (
   //   [responseId, form.title],
   // )
 
-  // // Go to the responses summary page and enter the secret key
-  // await page.goto(ADMIN_FORM_PAGE_RESPONSES(form._id))
-  // await page.getByLabel(/Enter or upload Secret Key/).fill(secretKey)
-  // await page.getByRole('button', { name: 'Unlock responses' }).click()
+  // Go to the responses summary page and enter the secret key
+  await page.goto(ADMIN_FORM_PAGE_RESPONSES(form._id))
+  await page.getByLabel(/Enter or upload Secret Key/).fill(secretKey)
+  await page.getByRole('button', { name: 'Unlock responses' }).click()
 
   // // Try downloading CSV and checking contents
-  // // Start waiting for download before clicking. Note no await.
   // const downloadPromise = page.waitForEvent('download')
   // await page.getByRole('button', { name: 'Download' }).click()
   // await page.getByRole('menuitem', { name: 'CSV only' }).click()

--- a/__tests__/e2e/utils/settings.ts
+++ b/__tests__/e2e/utils/settings.ts
@@ -1,8 +1,21 @@
-import { FormAuthType, FormStatus } from 'shared/types'
+import { FormAuthType, FormResponseMode, FormStatus } from 'shared/types'
 
+import { ADMIN_EMAIL } from '../constants'
 import { E2eSettingsOptions } from '../constants/settings'
 
-export const getSettings = (
+export const getEncryptSettings = (
+  custom?: Partial<E2eSettingsOptions>,
+): E2eSettingsOptions => {
+  return _getSettings(FormResponseMode.Encrypt, custom)
+}
+
+export const getEmailSettings = (
+  custom?: Partial<E2eSettingsOptions>,
+): E2eSettingsOptions => {
+  return _getSettings(FormResponseMode.Email, custom)
+}
+const _getSettings = (
+  responseMode: FormResponseMode,
   custom?: Partial<E2eSettingsOptions>,
 ): E2eSettingsOptions => {
   // Inject form auth settings
@@ -24,11 +37,18 @@ export const getSettings = (
     }
   }
 
-  return {
+  // Create
+  const settings: E2eSettingsOptions = {
     status: FormStatus.Public,
     collaborators: [],
     authType: FormAuthType.NIL,
     // By default, if emails is undefined, only the admin (current user) will receive.
     ...custom,
   }
+
+  if (responseMode === FormResponseMode.Encrypt) {
+    settings.emails = [ADMIN_EMAIL]
+  }
+
+  return settings
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,4 @@
-import type { PlaywrightTestConfig } from '@playwright/test'
-import { devices } from '@playwright/test'
+import { defineConfig, devices } from '@playwright/test'
 import dotenv from 'dotenv'
 import path from 'path'
 
@@ -10,7 +9,7 @@ dotenv.config({
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
-const config: PlaywrightTestConfig = {
+export default defineConfig({
   testDir: './__tests__/e2e',
   /* Maximum time one test can run for. */
   timeout: 120 * 1000,
@@ -107,6 +106,4 @@ const config: PlaywrightTestConfig = {
       reuseExistingServer: !process.env.CI,
     },
   ],
-}
-
-export default config
+})

--- a/src/app/modules/submission/ParsedResponsesObject.class.ts
+++ b/src/app/modules/submission/ParsedResponsesObject.class.ts
@@ -41,7 +41,7 @@ type NdiUserInfo =
 
 export default class ParsedResponsesObject {
   public ndiResponses: ProcessedFieldResponse[] = []
-  private constructor(public responses: ProcessedFieldResponse[]) {}
+  constructor(public responses: ProcessedFieldResponse[]) {}
 
   addNdiResponses(info: NdiUserInfo): ParsedResponsesObject {
     /**

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.controller.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.controller.spec.ts
@@ -163,7 +163,7 @@ describe('email-submission.controller', () => {
       expect(
         MockSubmissionService.sendEmailConfirmations,
       ).toHaveBeenCalledTimes(1)
-      // Assert nric is masked
+      // Assert nric is not masked
       expect(
         MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
           .answer,

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -59,7 +59,10 @@ const EncryptSubmission = getEncryptSubmissionModel(mongoose)
 describe('encrypt-submission.controller', () => {
   describe('nricMask', () => {
     beforeAll(async () => await dbHandler.connect())
-    afterEach(async () => await dbHandler.clearDatabase())
+    afterEach(async () => {
+      await dbHandler.clearDatabase()
+      jest.clearAllMocks()
+    })
     afterAll(async () => await dbHandler.closeDatabase())
 
     beforeEach(() => {
@@ -189,5 +192,101 @@ describe('encrypt-submission.controller', () => {
       expect(savedSubmission).toBeDefined()
       expect(savedSubmission!.verifiedContent).toEqual(MOCK_NRIC)
     })
+
+    // it('should not mask nric in email notification if form isNricMaskEnabled is false', async () => {
+    //   // Arrange
+    //   const mockFormId = new ObjectId()
+    //   const mockSpAuthTypeAndNricMaskingDisabledForm = {
+    //     _id: mockFormId,
+    //     title: 'some form',
+    //     authType: FormAuthType.SP,
+    //     isNricMaskEnabled: false,
+    //     form_fields: [] as FormFieldSchema[],
+    //     emails: ['test@example.com'],
+    //     getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+    //   } as IPopulatedEncryptedForm
+
+    //   const MOCK_REQ = merge(
+    //     expressHandler.mockRequest({
+    //       params: { formId: 'some id' },
+    //       body: {
+    //         responses: [],
+    //       },
+    //     }),
+    //     {
+    //       formsg: {
+    //         encryptedPayload: {
+    //           encryptedContent: 'encryptedContent',
+    //           version: 1,
+    //         },
+    //         formDef: {
+    //           authType: FormAuthType.SP,
+    //         },
+    //         encryptedFormDef: mockSpAuthTypeAndNricMaskingDisabledForm,
+    //       } as unknown as EncryptSubmissionDto,
+    //     } as unknown as FormCompleteDto,
+    //   ) as unknown as SubmitEncryptModeFormHandlerRequest
+    //   const mockRes = expressHandler.mockResponse()
+
+    //   // Act
+    //   await submitEncryptModeFormForTest(MOCK_REQ, mockRes)
+
+    //   // Assert
+    //   // email notification should be sent with the unmasked nric
+    //   expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+    //   // Assert nric is not masked
+    //   expect(
+    //     MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
+    //       .answer,
+    //   ).toEqual(MOCK_NRIC)
+    // })
+
+    // it('should mask nric in email notification if form isNricMaskEnabled is true', async () => {
+    //   // Arrange
+    //   const mockFormId = new ObjectId()
+    //   const mockSpAuthTypeAndNricMaskingEnabledForm = {
+    //     _id: mockFormId,
+    //     title: 'some form',
+    //     authType: FormAuthType.SP,
+    //     isNricMaskEnabled: true,
+    //     form_fields: [] as FormFieldSchema[],
+    //     emails: ['test@example.com'],
+    //     getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+    //   } as IPopulatedEncryptedForm
+
+    //   const MOCK_REQ = merge(
+    //     expressHandler.mockRequest({
+    //       params: { formId: 'some id' },
+    //       body: {
+    //         responses: [],
+    //       },
+    //     }),
+    //     {
+    //       formsg: {
+    //         encryptedPayload: {
+    //           encryptedContent: 'encryptedContent',
+    //           version: 1,
+    //         },
+    //         formDef: {
+    //           authType: FormAuthType.SP,
+    //         },
+    //         encryptedFormDef: mockSpAuthTypeAndNricMaskingEnabledForm,
+    //       } as unknown as EncryptSubmissionDto,
+    //     } as unknown as FormCompleteDto,
+    //   ) as unknown as SubmitEncryptModeFormHandlerRequest
+    //   const mockRes = expressHandler.mockResponse()
+
+    //   // Act
+    //   await submitEncryptModeFormForTest(MOCK_REQ, mockRes)
+
+    //   // Assert
+    //   // email notification should be sent with the masked nric
+    //   expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+    //   // Assert nric is not masked
+    //   expect(
+    //     MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
+    //       .answer,
+    //   ).toEqual(MOCK_MASKED_NRIC)
+    // })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -193,100 +193,100 @@ describe('encrypt-submission.controller', () => {
       expect(savedSubmission!.verifiedContent).toEqual(MOCK_NRIC)
     })
 
-    // it('should not mask nric in email notification if form isNricMaskEnabled is false', async () => {
-    //   // Arrange
-    //   const mockFormId = new ObjectId()
-    //   const mockSpAuthTypeAndNricMaskingDisabledForm = {
-    //     _id: mockFormId,
-    //     title: 'some form',
-    //     authType: FormAuthType.SP,
-    //     isNricMaskEnabled: false,
-    //     form_fields: [] as FormFieldSchema[],
-    //     emails: ['test@example.com'],
-    //     getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
-    //   } as IPopulatedEncryptedForm
+    it('should not mask nric in email notification if form isNricMaskEnabled is false', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockSpAuthTypeAndNricMaskingDisabledForm = {
+        _id: mockFormId,
+        title: 'some form',
+        authType: FormAuthType.SP,
+        isNricMaskEnabled: false,
+        form_fields: [] as FormFieldSchema[],
+        emails: ['test@example.com'],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
 
-    //   const MOCK_REQ = merge(
-    //     expressHandler.mockRequest({
-    //       params: { formId: 'some id' },
-    //       body: {
-    //         responses: [],
-    //       },
-    //     }),
-    //     {
-    //       formsg: {
-    //         encryptedPayload: {
-    //           encryptedContent: 'encryptedContent',
-    //           version: 1,
-    //         },
-    //         formDef: {
-    //           authType: FormAuthType.SP,
-    //         },
-    //         encryptedFormDef: mockSpAuthTypeAndNricMaskingDisabledForm,
-    //       } as unknown as EncryptSubmissionDto,
-    //     } as unknown as FormCompleteDto,
-    //   ) as unknown as SubmitEncryptModeFormHandlerRequest
-    //   const mockRes = expressHandler.mockResponse()
+      const MOCK_REQ = merge(
+        expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+            },
+            formDef: {
+              authType: FormAuthType.SP,
+            },
+            encryptedFormDef: mockSpAuthTypeAndNricMaskingDisabledForm,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+      const mockRes = expressHandler.mockResponse()
 
-    //   // Act
-    //   await submitEncryptModeFormForTest(MOCK_REQ, mockRes)
+      // Act
+      await submitEncryptModeFormForTest(MOCK_REQ, mockRes)
 
-    //   // Assert
-    //   // email notification should be sent with the unmasked nric
-    //   expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
-    //   // Assert nric is not masked
-    //   expect(
-    //     MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
-    //       .answer,
-    //   ).toEqual(MOCK_NRIC)
-    // })
+      // Assert
+      // email notification should be sent with the unmasked nric
+      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+      // Assert nric is not masked
+      expect(
+        MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
+          .answer,
+      ).toEqual(MOCK_NRIC)
+    })
 
-    // it('should mask nric in email notification if form isNricMaskEnabled is true', async () => {
-    //   // Arrange
-    //   const mockFormId = new ObjectId()
-    //   const mockSpAuthTypeAndNricMaskingEnabledForm = {
-    //     _id: mockFormId,
-    //     title: 'some form',
-    //     authType: FormAuthType.SP,
-    //     isNricMaskEnabled: true,
-    //     form_fields: [] as FormFieldSchema[],
-    //     emails: ['test@example.com'],
-    //     getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
-    //   } as IPopulatedEncryptedForm
+    it('should mask nric in email notification if form isNricMaskEnabled is true', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockSpAuthTypeAndNricMaskingEnabledForm = {
+        _id: mockFormId,
+        title: 'some form',
+        authType: FormAuthType.SP,
+        isNricMaskEnabled: true,
+        form_fields: [] as FormFieldSchema[],
+        emails: ['test@example.com'],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
 
-    //   const MOCK_REQ = merge(
-    //     expressHandler.mockRequest({
-    //       params: { formId: 'some id' },
-    //       body: {
-    //         responses: [],
-    //       },
-    //     }),
-    //     {
-    //       formsg: {
-    //         encryptedPayload: {
-    //           encryptedContent: 'encryptedContent',
-    //           version: 1,
-    //         },
-    //         formDef: {
-    //           authType: FormAuthType.SP,
-    //         },
-    //         encryptedFormDef: mockSpAuthTypeAndNricMaskingEnabledForm,
-    //       } as unknown as EncryptSubmissionDto,
-    //     } as unknown as FormCompleteDto,
-    //   ) as unknown as SubmitEncryptModeFormHandlerRequest
-    //   const mockRes = expressHandler.mockResponse()
+      const MOCK_REQ = merge(
+        expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+            },
+            formDef: {
+              authType: FormAuthType.SP,
+            },
+            encryptedFormDef: mockSpAuthTypeAndNricMaskingEnabledForm,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+      const mockRes = expressHandler.mockResponse()
 
-    //   // Act
-    //   await submitEncryptModeFormForTest(MOCK_REQ, mockRes)
+      // Act
+      await submitEncryptModeFormForTest(MOCK_REQ, mockRes)
 
-    //   // Assert
-    //   // email notification should be sent with the masked nric
-    //   expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
-    //   // Assert nric is not masked
-    //   expect(
-    //     MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
-    //       .answer,
-    //   ).toEqual(MOCK_MASKED_NRIC)
-    // })
+      // Assert
+      // email notification should be sent with the masked nric
+      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+      // Assert nric is not masked
+      expect(
+        MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
+          .answer,
+      ).toEqual(MOCK_MASKED_NRIC)
+    })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -282,7 +282,7 @@ describe('encrypt-submission.controller', () => {
       // Assert
       // email notification should be sent with the masked nric
       expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
-      // Assert nric is not masked
+      // Assert nric is masked
       expect(
         MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
           .answer,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -163,11 +163,6 @@ const submitEncryptModeForm = async (
         })
       }
       uinFin = jwtPayloadResult.value.userName
-      uinFin = form.isNricMaskEnabled ? maskNric(uinFin) : uinFin
-      parsedResponses.addNdiResponses({
-        authType,
-        uinFin,
-      })
       break
     }
     case FormAuthType.CP: {
@@ -190,13 +185,7 @@ const submitEncryptModeForm = async (
         })
       }
       uinFin = jwtPayloadResult.value.userName
-      uinFin = form.isNricMaskEnabled ? maskNric(uinFin) : uinFin
       userInfo = jwtPayloadResult.value.userInfo
-      parsedResponses.addNdiResponses({
-        authType,
-        uinFin,
-        userInfo,
-      })
       break
     }
     case FormAuthType.SGID_MyInfo:
@@ -236,11 +225,6 @@ const submitEncryptModeForm = async (
         })
       }
       uinFin = jwtPayloadResult.value
-      uinFin = form.isNricMaskEnabled ? maskNric(uinFin) : uinFin
-      parsedResponses.addNdiResponses({
-        authType,
-        uinFin,
-      })
       break
     }
     case FormAuthType.SGID: {
@@ -262,9 +246,41 @@ const submitEncryptModeForm = async (
         })
       }
       uinFin = jwtPayloadResult.value.userName
-      uinFin = form.isNricMaskEnabled ? maskNric(uinFin) : uinFin
+      break
+    }
+  }
+
+  // Mask if Nric masking is enabled
+  if (
+    uinFin &&
+    form.isNricMaskEnabled &&
+    (form.authType === FormAuthType.SP ||
+      form.authType === FormAuthType.CP ||
+      form.authType === FormAuthType.SGID ||
+      form.authType === FormAuthType.MyInfo ||
+      form.authType === FormAuthType.SGID_MyInfo)
+  ) {
+    uinFin = maskNric(uinFin)
+  }
+
+  // Add NDI responses
+  switch (form.authType) {
+    case FormAuthType.CP: {
+      if (!uinFin || !userInfo) break
       parsedResponses.addNdiResponses({
         authType,
+        uinFin,
+        userInfo,
+      })
+      break
+    }
+    case FormAuthType.SP:
+    case FormAuthType.SGID:
+    case FormAuthType.MyInfo:
+    case FormAuthType.SGID_MyInfo: {
+      if (!uinFin) break
+      parsedResponses.addNdiResponses({
+        authType: form.authType,
         uinFin,
       })
       break


### PR DESCRIPTION
## Problem
Previously for email notifications for storage mode forms, for MyInfo fields, only the [MyInfo] Name gets added, and not the "sgID Validate NRIC". This PR adds them. 

Closes FRM-1752

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

![Screenshot 2024-06-21 at 3.50.31 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/3mgCW7CChSJl2tqAMOXs/8a634e1b-1f65-4581-b7c1-d5505c0efeaf.png)


## Tests
**Without NRIC Masking**
- [ ] 1. Create storage mode form, and add admin emails. 
- [ ] 2. Add my info fields and make form public
- [ ] 3. Fill in a form and submit
- [ ] 4. Receive email and observe that the sgID Validated NRIC field exists. The NRIC must be **unmasked**

**With NRIC Masking**
- [ ] 1. Create storage mode form, and add admin emails. 
- [ ] 2. Enable NRIC Masking
- [ ] 3. Add my info fields and make form public
- [ ] 4. Fill in a form and submit
- [ ] 5. Receive email and observe that the sgID Validated NRIC field exists. The NRIC in the email must be **masked**