### PR TITLE
fix(tests): fix e2e testing for email notifications on encrypt-forms

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Build
         env:
           NODE_OPTIONS: '--max-old-space-size=4096 --openssl-legacy-provider'
+          AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE: 1
           REACT_APP_FORMSG_SDK_MODE: 'test'
         run: npm run build
       - name: Run Playwright tests (login)

--- a/__tests__/e2e/email-submission.spec.ts
+++ b/__tests__/e2e/email-submission.spec.ts
@@ -28,7 +28,7 @@ import {
   createMyInfoField,
   createOptionalVersion,
   deleteDocById,
-  getSettings,
+  getEmailSettings,
   makeModel,
   makeMongooseFixtures,
 } from './utils'
@@ -58,7 +58,7 @@ test.describe('Email form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -76,7 +76,7 @@ test.describe('Email form submission', () => {
       createBlankVersion(createOptionalVersion(ff)),
     )
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -98,10 +98,10 @@ test.describe('Email form submission', () => {
           title: `Attachment ${i}`,
           path: `__tests__/e2e/files/att-folder-${i}/test-att.txt`,
           val: `${i === 2 ? '' : `${2 - i}-`}test-att.txt`,
-        } as E2eFieldMetadata),
+        }) as E2eFieldMetadata,
     )
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -135,7 +135,7 @@ test.describe('Email form submission', () => {
       } as E2eFieldMetadata,
     ]
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -151,7 +151,7 @@ test.describe('Email form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEmailSettings({
       authType: FormAuthType.SP,
     })
 
@@ -169,7 +169,7 @@ test.describe('Email form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEmailSettings({
       authType: FormAuthType.CP,
     })
 
@@ -187,7 +187,7 @@ test.describe('Email form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEmailSettings({
       authType: FormAuthType.SGID,
     })
 
@@ -216,7 +216,7 @@ test.describe('Email form submission', () => {
       createMyInfoField(MyInfoAttribute.WorkpassStatus, 'Live', false),
     ]
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEmailSettings({
       authType: FormAuthType.MyInfo,
     })
 
@@ -233,7 +233,7 @@ test.describe('Email form submission', () => {
   }) => {
     // Define
     const { formFields, formLogics } = TEST_ALL_FIELDS_SHOWN_BY_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -248,7 +248,7 @@ test.describe('Email form submission', () => {
   }) => {
     // Define
     const { formFields, formLogics } = TEST_FIELD_HIDDEN_BY_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     await runEmailSubmissionTest(page, Form, {
@@ -264,7 +264,7 @@ test.describe('Email form submission', () => {
     // Define
     const { formFields, formLogics, preventSubmitMessage } =
       TEST_SUBMISSION_DISABLED_BY_CHAINED_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEmailSettings()
 
     // Test
     const { form } = await createForm(page, Form, FormResponseMode.Email, {

--- a/__tests__/e2e/encrypt-submission.spec.ts
+++ b/__tests__/e2e/encrypt-submission.spec.ts
@@ -26,7 +26,7 @@ import {
   createMyInfoField,
   createOptionalVersion,
   deleteDocById,
-  getSettings,
+  getEncryptSettings,
   makeModel,
   makeMongooseFixtures,
 } from './utils'
@@ -61,7 +61,7 @@ test.describe('Storage form submission', () => {
     // Define
     const formFields = ALL_FIELDS
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     await runEncryptSubmissionTest(page, Form, {
@@ -79,7 +79,7 @@ test.describe('Storage form submission', () => {
       createBlankVersion(createOptionalVersion(ff)),
     )
     const formLogics = NO_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     await runEncryptSubmissionTest(page, Form, {
@@ -94,7 +94,7 @@ test.describe('Storage form submission', () => {
   }) => {
     // Define
     const { formFields, formLogics } = TEST_ALL_FIELDS_SHOWN_BY_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     await runEncryptSubmissionTest(page, Form, {
@@ -109,7 +109,7 @@ test.describe('Storage form submission', () => {
   }) => {
     // Define
     const { formFields, formLogics } = TEST_FIELD_HIDDEN_BY_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     await runEncryptSubmissionTest(page, Form, {
@@ -125,7 +125,7 @@ test.describe('Storage form submission', () => {
     // Define
     const { formFields, formLogics, preventSubmitMessage } =
       TEST_SUBMISSION_DISABLED_BY_CHAINED_LOGIC
-    const formSettings = getSettings()
+    const formSettings = getEncryptSettings()
 
     // Test
     const { form } = await createForm(page, Form, FormResponseMode.Encrypt, {
@@ -158,7 +158,7 @@ test.describe('Storage form submission', () => {
       createMyInfoField(MyInfoAttribute.WorkpassStatus, 'Live', false),
     ]
     const formLogics = NO_LOGIC
-    const formSettings = getSettings({
+    const formSettings = getEncryptSettings({
       authType: FormAuthType.MyInfo,
     })
 

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -171,10 +171,7 @@ const addSettings = async (
   await expect(page).toHaveURL(ADMIN_FORM_PAGE_SETTINGS(formId))
 
   await addGeneralSettings(page, formSettings)
-  // Encrypt mode forms don't have an email
-  if (formResponseMode.responseMode === FormResponseMode.Encrypt) {
-    await addAdminEmails(page, formSettings)
-  }
+  await addAdminEmails(page, formSettings)
   await addAuthSettings(page, formSettings)
   await addCollaborators(page, formSettings)
 
@@ -384,6 +381,8 @@ const addAdminEmails = async (
     await page.keyboard.press('Backspace')
 
     await emailInput.fill(formSettings.emails.join(', '))
+
+    await page.keyboard.press('Tab')
 
     await expectToast(page, /emails successfully updated/i)
   }

--- a/__tests__/e2e/utils/settings.ts
+++ b/__tests__/e2e/utils/settings.ts
@@ -1,8 +1,21 @@
-import { FormAuthType, FormStatus } from 'shared/types'
+import { FormAuthType, FormResponseMode, FormStatus } from 'shared/types'
 
+import { ADMIN_EMAIL } from '../constants'
 import { E2eSettingsOptions } from '../constants/settings'
 
-export const getSettings = (
+export const getEncryptSettings = (
+  custom?: Partial<E2eSettingsOptions>,
+): E2eSettingsOptions => {
+  return _getSettings(FormResponseMode.Encrypt, custom)
+}
+
+export const getEmailSettings = (
+  custom?: Partial<E2eSettingsOptions>,
+): E2eSettingsOptions => {
+  return _getSettings(FormResponseMode.Email, custom)
+}
+const _getSettings = (
+  responseMode: FormResponseMode,
   custom?: Partial<E2eSettingsOptions>,
 ): E2eSettingsOptions => {
   // Inject form auth settings
@@ -24,11 +37,18 @@ export const getSettings = (
     }
   }
 
-  return {
+  // Create
+  const settings: E2eSettingsOptions = {
     status: FormStatus.Public,
     collaborators: [],
     authType: FormAuthType.NIL,
     // By default, if emails is undefined, only the admin (current user) will receive.
     ...custom,
   }
+
+  if (responseMode === FormResponseMode.Encrypt) {
+    settings.emails = [ADMIN_EMAIL]
+  }
+
+  return settings
 }


### PR DESCRIPTION
## Problem
Now that #7350 is merged, we need to check for email notifications in MailDev for encrypt submissions. This PR fixes that. There are changes to email mode e2e since the email notifications input is moved to its own page. Note that running `npx playwright test` does NOT hot reload backend code, only the test code. You have to close playwright, rerun the build and re open playwright for your changes to take effect.  

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

