### PR TITLE
feat(i18n): replace hardcoded text in PublicFormSubmitButton

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,5 +1,6 @@
 import { MouseEventHandler, useMemo, useState } from 'react'
 import { useFormState, UseFormTrigger, useWatch } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Stack, useDisclosure, VisuallyHidden } from '@chakra-ui/react'
 
 import { PAYMENT_CONTACT_FIELD_ID } from '~shared/constants'
@@ -37,6 +38,7 @@ export const PublicFormSubmitButton = ({
   onSubmit,
   trigger,
 }: PublicFormSubmitButtonProps): JSX.Element => {
+  const { t } = useTranslation()
   const [prevPaymentId, setPrevPaymentId] = useState('')
 
   const isMobile = useIsMobile()
@@ -103,15 +105,27 @@ export const PublicFormSubmitButton = ({
         type="button"
         isLoading={isSubmitting}
         isDisabled={!!preventSubmissionLogic || !onSubmit}
-        loadingText="Submitting"
+        loadingText={t(
+          'features.publicForm.components.PublicFormSubmitButton.loadingText',
+        )}
         onClick={isPaymentEnabled && !isPreview ? checkBeforeOpen : onSubmit}
       >
-        <VisuallyHidden>End of form.</VisuallyHidden>
+        <VisuallyHidden>
+          {t(
+            'features.publicForm.components.PublicFormSubmitButton.visuallyHidden',
+          )}
+        </VisuallyHidden>
         {preventSubmissionLogic
-          ? 'Submission disabled'
+          ? t(
+              'features.publicForm.components.PublicFormSubmitButton.preventSubmission',
+            )
           : isPaymentEnabled
-            ? 'Proceed to pay'
-            : 'Submit now'}
+            ? t(
+                'features.publicForm.components.PublicFormSubmitButton.proceedToPay',
+              )
+            : t(
+                'features.publicForm.components.PublicFormSubmitButton.submitNow',
+              )}
       </Button>
       {preventSubmissionLogic ? (
         <InlineMessage variant="warning">

--- a/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -24,4 +24,13 @@ export const enSG: PublicForm = {
     verifiedFieldExpired_other:
       'Your verified fields {{count}} have expired. Please verify those {{count}} fields again.',
   },
+  components: {
+    PublicFormSubmitButton: {
+      loadingText: 'Submitting',
+      visuallyHidden: 'End of form.',
+      preventSubmission: 'Submission disabled',
+      proceedToPay: 'Proceed to pay',
+      submitNow: 'Submit now',
+    },
+  },
 }

--- a/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/frontend/src/i18n/locales/features/public-form/index.ts
@@ -17,4 +17,13 @@ export interface PublicForm {
     verifiedFieldExpired_one: string
     verifiedFieldExpired_other: string
   }
+  components: {
+    PublicFormSubmitButton: {
+      loadingText: string
+      visuallyHidden: string
+      preventSubmission: string
+      proceedToPay: string
+      submitNow: string
+    }
+  }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

As discussed with @LoneRifle in person, I would like to help solve the lack of i18n support in formsg, by refactoring hardcoded string into locale files. The starting scope of work focuses on `frontend/src/features/public-form`.

Since this is my first PR for the repo, I am intentionally keeping the scope small.

## Solution

This PR replaces all hardcoded string in `PublicFormSubmitButton`.

I will use this PR as a reference for other components in `frontend/src/features/public-form` in future PRs.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

**Improvements**:

- i18n locale in `frontend/src/features/public-form/PublicFormSubmitButton` refactored

## Before & After Screenshots

**BEFORE**:

<img width="866" alt="Screenshot 2024-06-23 at 4 06 41 PM" src="https://github.com/opengovsg/FormSG/assets/1209810/358b983e-2505-4ece-978a-c2998be28657">

<img width="867" alt="Screenshot 2024-06-23 at 4 06 36 PM" src="https://github.com/opengovsg/FormSG/assets/1209810/789e6759-dabf-46f8-b6dc-dc36f8055a32">


**AFTER**:

<img width="867" alt="Screenshot 2024-06-23 at 4 07 35 PM" src="https://github.com/opengovsg/FormSG/assets/1209810/9abd0f8d-3205-4e1a-a7a1-7d4d8f6cf237">

<img width="859" alt="Screenshot 2024-06-23 at 4 07 40 PM" src="https://github.com/opengovsg/FormSG/assets/1209810/45ae7bc4-a57e-4aae-8702-383a11ca47fc">
