### PR TITLE
feat: add reddot to mrf workflow

### DIFF
--- a/frontend/src/features/admin-form/create/common/CreatePageSidebar/DrawerTabIcon.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebar/DrawerTabIcon.tsx
@@ -1,3 +1,6 @@
+import { GoPrimitiveDot } from 'react-icons/go'
+import { Box, Icon } from '@chakra-ui/react'
+
 import IconButton from '~components/IconButton'
 import Tooltip from '~components/Tooltip'
 
@@ -7,6 +10,7 @@ interface DrawerTabIconProps {
   label: string
   isActive: boolean
   id?: string
+  showRedDot?: boolean
 }
 
 export const DrawerTabIcon = ({
@@ -15,17 +19,28 @@ export const DrawerTabIcon = ({
   label,
   isActive,
   id,
+  showRedDot,
 }: DrawerTabIconProps): JSX.Element => {
   return (
     <Tooltip label={label} placement="right">
-      <IconButton
-        variant="reverse"
-        aria-label={label}
-        isActive={isActive}
-        icon={icon}
-        onClick={onClick}
-        id={id}
-      />
+      <Box>
+        <IconButton
+          variant="reverse"
+          aria-label={label}
+          isActive={isActive}
+          icon={icon}
+          onClick={onClick}
+          id={id}
+        />
+        {showRedDot ? (
+          <Icon
+            as={GoPrimitiveDot}
+            color="danger.500"
+            position="absolute"
+            ml="-15px"
+          />
+        ) : null}
+      </Box>
     </Tooltip>
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1748

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Component  | Before  | After|
|---|---|---|
|  Workflow Button | ![Screenshot 2024-07-02 at 7.24.39 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/1pRrlAd2KXkLRBeP0wKD/b8b443d8-a14f-4603-8101-6aa225ff18c0.png)  |  ![Screenshot 2024-07-02 at 7.25.03 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/1pRrlAd2KXkLRBeP0wKD/d488ab2c-4f41-41b1-8971-5562f784fda4.png) |

## Tests
<!-- What tests should be run to confirm functionality? -->
MRF reddot should show if not seen, and removed on click
- [ ] Create a new MRF
- [ ] Go to MRF Builder Page
- [ ] Ensure that red dot is shown on Workflow Button
- [ ] Click on Workflow Button
- [ ] Ensure that red dot is not shown
- [ ] Reload the page
- [ ] Ensure that red dot is still not shown