### PR TITLE
chore: update dockerfile casing

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:hydrogen-alpine3.19 as build
+FROM node:hydrogen-alpine3.19 AS build
 
 # node-modules-builder stage installs/compiles the node_modules folder
 # Python version must be specified starting in alpine3.12


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Received new warning when pushing to `staging`. Doesn't break our builds, but we shouldn't have too many ignored warnings.
```
 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
 ```

## Solution
<!-- How did you solve the problem? -->

Likely due to github actions deps updating, https://docs.docker.com/reference/build-checks/from-as-casing/

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
