### PR TITLE
feat(mrf): multiple static emails

### DIFF
--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
@@ -27,15 +27,6 @@ export const ActiveStepBlock = ({
   const { updateStepMutation } = useWorkflowMutations()
   const setToInactive = useAdminWorkflowStore(setToInactiveSelector)
 
-  const defaultValues =
-    // A bit of instrumentation to convert the emails array to a single email
-    step.workflow_type === WorkflowType.Static
-      ? {
-          ...step,
-          emails: step.emails[0],
-        }
-      : step
-
   const handleSubmit = useCallback(
     (step: FormWorkflowStep) =>
       updateStepMutation.mutate(
@@ -56,7 +47,7 @@ export const ActiveStepBlock = ({
       isLoading={updateStepMutation.isLoading}
       handleOpenDeleteModal={handleOpenDeleteModal}
       onSubmit={handleSubmit}
-      defaultValues={defaultValues}
+      defaultValues={step}
       submitButtonLabel="Save step"
     />
   )

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -64,7 +64,7 @@ export const EditStepBlock = ({
           ...inputs,
           // Need to explicitly set workflow_type in this object to help with typechecking.
           workflow_type: WorkflowType.Static,
-          emails: inputs.emails ? [inputs.emails] : [],
+          emails: inputs.emails ?? [],
         }
         break
       }

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock.tsx
@@ -152,7 +152,7 @@ const RespondentInput = ({ isLoading, formMethods }: RespondentInputProps) => {
           {staticTagInputErrorMessage ? (
             <FormErrorMessage>{staticTagInputErrorMessage}</FormErrorMessage>
           ) : (
-            <Text textStyle="body-2" my="8px" py="2px">
+            <Text textStyle="body-2" my="0.5rem" py="0.125rem">
               Separate multiple emails with a comma
             </Text>
           )}

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock.tsx
@@ -1,13 +1,14 @@
 import { Controller, UseFormReturn } from 'react-hook-form'
 import { Flex, FormControl, Stack, Text } from '@chakra-ui/react'
+import { get } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 
 import { WorkflowType } from '~shared/types'
 
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
-import Input from '~components/Input'
 import Radio from '~components/Radio'
+import { TagInput } from '~components/TagInput'
 
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { EditStepInputs } from '~features/admin-form/create/workflow/types'
@@ -56,23 +57,29 @@ export const RespondentBlock = ({
             isInvalid={!!errors.workflow_type}
           >
             <Radio.RadioGroup defaultValue={defaultWorkflowType}>
-              <Flex flexDir="row">
-                <Radio
-                  isDisabled={isLoading}
-                  allowDeselect={false}
-                  value={WorkflowType.Static}
-                  {...register('workflow_type')}
-                >
-                  Assign by a specific email
-                </Radio>
-                <Radio
-                  isDisabled={isLoading}
-                  allowDeselect={false}
-                  value={WorkflowType.Dynamic}
-                  {...register('workflow_type')}
-                >
-                  Assign from email field on form
-                </Radio>
+              <Flex flexDir="row" justifyContent="space-between">
+                <Flex>
+                  <Radio
+                    isDisabled={isLoading}
+                    allowDeselect={false}
+                    value={WorkflowType.Static}
+                    {...register('workflow_type')}
+                    px="8px"
+                  >
+                    Enter specific email(s)
+                  </Radio>
+                </Flex>
+                <Flex>
+                  <Radio
+                    isDisabled={isLoading}
+                    allowDeselect={false}
+                    value={WorkflowType.Dynamic}
+                    {...register('workflow_type')}
+                    px="8px"
+                  >
+                    Select an email field from your form
+                  </Radio>
+                </Flex>
               </Flex>
             </Radio.RadioGroup>
             <FormErrorMessage>{errors.workflow_type?.message}</FormErrorMessage>
@@ -106,6 +113,8 @@ const RespondentInput = ({ isLoading, formMethods }: RespondentInputProps) => {
 
   const watchedWorkflowType = watch('workflow_type')
 
+  const staticTagInputErrorMessage = get(errors, 'emails.message')
+
   switch (watchedWorkflowType) {
     case WorkflowType.Static:
       return (
@@ -120,21 +129,33 @@ const RespondentInput = ({ isLoading, formMethods }: RespondentInputProps) => {
             name="emails"
             control={control}
             rules={{
-              required: 'Please add an email',
               validate: {
-                isEmails: (email) =>
-                  !email || isEmail(email) || 'Please enter a valid email',
+                required: (emails) =>
+                  !emails || emails.length === 0
+                    ? 'You must enter at least one email to receive responses'
+                    : true,
+                isEmails: (emails) =>
+                  !emails ||
+                  emails.every((email) => isEmail(email)) ||
+                  'Please enter valid email(s) (e.g. me@example.com) separated by commas, as invalid emails will not be saved',
               },
             }}
             render={({ field }) => (
-              <Input
+              <TagInput
                 isDisabled={isLoading}
                 placeholder="me@example.com"
+                tagValidation={isEmail}
                 {...field}
               />
             )}
           />
-          <FormErrorMessage>{errors.emails?.message}</FormErrorMessage>
+          {staticTagInputErrorMessage ? (
+            <FormErrorMessage>{staticTagInputErrorMessage}</FormErrorMessage>
+          ) : (
+            <Text textStyle="body-2" my="8px" py="2px">
+              Separate multiple emails with a comma
+            </Text>
+          )}
         </FormControl>
       )
     case WorkflowType.Dynamic:

--- a/frontend/src/features/admin-form/create/workflow/types.ts
+++ b/frontend/src/features/admin-form/create/workflow/types.ts
@@ -12,9 +12,6 @@ export enum AdminEditWorkflowState {
 
 export type EditStepInputs = Omit<FormWorkflowStep, 'emails'> & {
   workflow_type: WorkflowType
-  // Should be FormWorkflowStepStatic['emails'], but the model accomodates an
-  // array of strings while on the frontend, we only want to show one email input
-  // for now.
-  emails?: FormWorkflowStepStatic['emails'][number]
+  emails?: FormWorkflowStepStatic['emails']
   field?: FormWorkflowStepDynamic['field']
 }


### PR DESCRIPTION
## Problem
We want to implement multiple static emails

Closes FRM-1735

## Solution

Enable multiple emails to be added on the frontend. Backend, everything has already been set up previously.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Screenshots
<img width="563" alt="Screenshot 2024-06-24 at 12 04 45 PM" src="https://github.com/opengovsg/FormSG/assets/25571626/f7f4ca5b-cc36-4f43-9355-843c51fdbf29">

<img width="567" alt="Screenshot 2024-06-24 at 12 04 18 PM" src="https://github.com/opengovsg/FormSG/assets/25571626/8b2a95b2-d314-443b-b696-161f3fffae2e">

<img width="559" alt="Screenshot 2024-06-24 at 12 05 00 PM" src="https://github.com/opengovsg/FormSG/assets/25571626/beac582c-917f-4bd1-9ecb-8b761e835231">

<img width="843" alt="Screenshot 2024-06-24 at 12 05 29 PM" src="https://github.com/opengovsg/FormSG/assets/25571626/cbd63b8b-da9d-49b9-a80c-ce465eb68bba">


## Tests
<!-- What tests should be run to confirm functionality? -->
Multiple emails are able to be added and received
- [ ] Create an MRF Form
- [ ] Add multiple emails in the first workflow step (`<your_email>@open.gov.sg`, `<your_email>+2@open.gov.sg`)
- [ ] Observe that emails are added and pilled
- [ ] Add an invalid email `asd`
- [ ] Observe that `asd` is flagged as an invalid email and not saved
- [ ] Delete `asd`
- [ ] As a respondent, make a submission
- [ ] Ensure that emails are sent and received in your inbox
