### PR TITLE
chore: replace outdated esrv id link

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcHelperText.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcHelperText.tsx
@@ -1,0 +1,31 @@
+import { Text } from '@chakra-ui/react'
+
+import { SINGPASS_PARTNER_SUPPORT_LINK } from '~shared/constants/links'
+import { FormAuthType } from '~shared/types/form'
+
+import Link from '~components/Link'
+
+interface EsrvcHelperTextProps {
+  authType: FormAuthType
+}
+
+export const EsrvcHelperText = ({
+  authType,
+}: EsrvcHelperTextProps): JSX.Element => {
+  switch (authType) {
+    case FormAuthType.SP:
+    case FormAuthType.CP:
+    case FormAuthType.MyInfo:
+      return (
+        <Text textStyle="body-2" color="secondary.400">
+          Contact{' '}
+          <Link isExternal href={SINGPASS_PARTNER_SUPPORT_LINK}>
+            Singpass partner support
+          </Link>{' '}
+          for your e-Service ID
+        </Text>
+      )
+    default:
+      return <></>
+  }
+}

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
@@ -61,7 +61,7 @@ export const EsrvcIdBox = ({
     return errors.esrvcId ? reset() : onSubmit()
   }, [errors, onSubmit, reset])
 
-  const renderedHelperText = useMemo(() => {
+  const renderHelperTextComponent = () => {
     switch (settings.authType) {
       case FormAuthType.SP:
       case FormAuthType.CP:
@@ -78,7 +78,7 @@ export const EsrvcIdBox = ({
       default:
         return null
     }
-  }, [settings.authType])
+  }
 
   const placeHolder = useMemo(
     () =>
@@ -90,7 +90,7 @@ export const EsrvcIdBox = ({
   return (
     <form onSubmit={onSubmit} onBlur={handleBlur}>
       <Stack ml="2.75rem" mb="1.25rem">
-        {renderedHelperText}
+        {renderHelperTextComponent()}
         <VisuallyHidden>
           <FormLabel htmlFor="esrvcId">e-service ID:</FormLabel>
         </VisuallyHidden>

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
@@ -7,7 +7,6 @@ import {
   InputGroup,
   InputRightElement,
   Stack,
-  Text,
   VisuallyHidden,
 } from '@chakra-ui/react'
 
@@ -15,10 +14,11 @@ import { FormAuthType, FormSettings } from '~shared/types/form'
 
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Input from '~components/Input'
-import Link from '~components/Link'
 import Spinner from '~components/Spinner'
 
 import { useMutateFormSettings } from '../../mutations'
+
+import { EsrvcHelperText } from './EsrvcHelperText'
 
 interface EsrvcIdBoxProps {
   settings: FormSettings
@@ -61,25 +61,6 @@ export const EsrvcIdBox = ({
     return errors.esrvcId ? reset() : onSubmit()
   }, [errors, onSubmit, reset])
 
-  const renderHelperTextComponent = () => {
-    switch (settings.authType) {
-      case FormAuthType.SP:
-      case FormAuthType.CP:
-      case FormAuthType.MyInfo:
-        return (
-          <Text textStyle="body-2" color="secondary.400">
-            Contact{' '}
-            <Link isExternal href="https://go.gov.sg/formsg-singpass-contact">
-              Singpass partner support
-            </Link>{' '}
-            for your e-Service ID
-          </Text>
-        )
-      default:
-        return null
-    }
-  }
-
   const placeHolder = useMemo(
     () =>
       `Enter ${
@@ -90,7 +71,7 @@ export const EsrvcIdBox = ({
   return (
     <form onSubmit={onSubmit} onBlur={handleBlur}>
       <Stack ml="2.75rem" mb="1.25rem">
-        {renderHelperTextComponent()}
+        <EsrvcHelperText authType={settings.authType} />
         <VisuallyHidden>
           <FormLabel htmlFor="esrvcId">e-service ID:</FormLabel>
         </VisuallyHidden>

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcIdBox.tsx
@@ -15,6 +15,7 @@ import { FormAuthType, FormSettings } from '~shared/types/form'
 
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Input from '~components/Input'
+import Link from '~components/Link'
 import Spinner from '~components/Spinner'
 
 import { useMutateFormSettings } from '../../mutations'
@@ -65,9 +66,17 @@ export const EsrvcIdBox = ({
       case FormAuthType.SP:
       case FormAuthType.CP:
       case FormAuthType.MyInfo:
-        return 'Contact askNDI@tech.gov.sg for your e-service ID'
+        return (
+          <Text textStyle="body-2" color="secondary.400">
+            Contact{' '}
+            <Link isExternal href="https://go.gov.sg/formsg-singpass-contact">
+              Singpass partner support
+            </Link>{' '}
+            for your e-Service ID
+          </Text>
+        )
       default:
-        return ''
+        return null
     }
   }, [settings.authType])
 
@@ -81,9 +90,7 @@ export const EsrvcIdBox = ({
   return (
     <form onSubmit={onSubmit} onBlur={handleBlur}>
       <Stack ml="2.75rem" mb="1.25rem">
-        <Text textStyle="body-2" color="secondary.400">
-          {renderedHelperText}
-        </Text>
+        {renderedHelperText}
         <VisuallyHidden>
           <FormLabel htmlFor="esrvcId">e-service ID:</FormLabel>
         </VisuallyHidden>

--- a/shared/constants/links.ts
+++ b/shared/constants/links.ts
@@ -2,5 +2,7 @@ export const SUPPORT_FORM_LINK = 'https://go.gov.sg/formsg-support'
 export const PUBLIC_PAYMENTS_GUIDE_LINK =
   'https://go.gov.sg/formsg-guide-payments'
 
+export const SINGPASS_PARTNER_SUPPORT_LINK =
+  'https://go.gov.sg/formsg-singpass-contact'
 export const SGID_VALID_ORG_PAGE =
   'https://docs.id.gov.sg/faq-users#as-a-government-officer-why-am-i-not-able-to-login-to-my-work-tool-using-sgid'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, for admin to get their eservice id, it says to email askNDI@tech.gov.sg but it should be http://partnersupport.singpass.gov.sg/ instead. 

Closes FRM-1754

## Solution
<!-- How did you solve the problem? -->
Update the text to the correct website link.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Topic | Before | After | 
| --- | --- | --- |
| eSrvIdBox help message | <img width="402" alt="image" src="https://github.com/opengovsg/FormSG/assets/55353265/0d58a385-45b6-4827-b505-5ad69eae62e6"> | <img width="377" alt="image" src="https://github.com/opengovsg/FormSG/assets/55353265/36a0a2b4-1d68-482b-8e59-c7f0035cdc5e"> | 

## Tests
### helper text displays message as intended
- [ ] Create form and go to admin auth settings page 
- [ ] Select singpass authtype
- [ ] Check that the new message is as shown as screenshot. (Ie. Singpass support partner...)
- [ ] Repeat for SP with Myinfo & Corppass 