### PR TITLE
chore: add minor changes to sample form submission api

### DIFF
--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -499,10 +499,14 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       }
     }
     case BasicField.Checkbox: {
+      const sampleValue =
+        field.fieldOptions.length === 0
+          ? []
+          : faker.helpers.arrayElements(field.fieldOptions)
       return {
         id: field._id,
         question: field.title,
-        answerArray: field.fieldOptions.length === 0 ? [] : field.fieldOptions,
+        answerArray: sampleValue,
         fieldType: field.fieldType,
       }
     }

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -499,21 +499,17 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       }
     }
     case BasicField.Checkbox: {
-      const sampleValue =
-        field.fieldOptions.length === 0
-          ? []
-          : faker.helpers.arrayElements(field.fieldOptions)
       return {
         id: field._id,
         question: field.title,
-        answerArray: sampleValue,
+        answerArray: field.fieldOptions.length === 0 ? [] : field.fieldOptions,
         fieldType: field.fieldType,
       }
     }
     case BasicField.Date: {
       const sampleValue = faker.date.anytime().toLocaleDateString('en-SG', {
         day: 'numeric',
-        month: 'long',
+        month: 'short',
         year: 'numeric',
       })
       return {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Data from the sample form submission API are not in the correct format.
- Checkbox field, should return the same `fieldOptions` to allow users to use every option possible
- Date field, should return month in `short` format

## Solution
<!-- How did you solve the problem? -->
- Checkbox field to return all fields options
- Date field to return months as `short`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible 