### PR TITLE
fix: silence aws-sdk deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       - run: npm run build
         env:
           NODE_OPTIONS: '--max-old-space-size=4096 --openssl-legacy-provider'
+          AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE: 1
       - name: Upload build files
         uses: actions/upload-artifact@v2
         if: always()
@@ -98,6 +99,7 @@ jobs:
       - name: Run frontend test
         env:
           NODE_OPTIONS: --max-old-space-size=4096
+          AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE: 1
         run: npm run test:frontend
 
   frontend_lint:
@@ -157,6 +159,7 @@ jobs:
       - run: npm run test:backend:ci
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
+          AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE: 1
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
## Problem
The aws-sdk v2 for Javascript is deprecated end of next year but we get the error message on every single test ran, which gets very very cluttered and reduces the noise to signal ratio. It's also painful to sift through the messages to see what the actual error was with thousands of these messages.

This PR silences them during the workflow runs

![Screenshot 2024-06-26 at 2.21.00 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/3mgCW7CChSJl2tqAMOXs/414b7f65-e3c2-4568-8fb7-c698025e0d62.png)

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

**New environment variables**:
- `AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE` : Silences the aws-sdk deprecation warnings
