### PR TITLE
feat: single submission per nric

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
@@ -150,6 +150,25 @@ PrivateEmailMyInfoFormNricMaskingEnabled.parameters = {
   ],
 }
 
+export const PrivateEmailSingpassFormSingleSubmissionEnabled = Template.bind({})
+PrivateEmailSingpassFormSingleSubmissionEnabled.parameters = {
+  msw: buildMswRoutes({
+    status: FormStatus.Private,
+    authType: FormAuthType.SGID,
+    isSingleSubmission: true,
+  }),
+}
+
+export const PrivateEmailSingpassFormAllTogglesEnabled = Template.bind({})
+PrivateEmailSingpassFormAllTogglesEnabled.parameters = {
+  msw: buildMswRoutes({
+    status: FormStatus.Private,
+    authType: FormAuthType.SGID,
+    isSingleSubmission: true,
+    isNricMaskEnabled: true,
+  }),
+}
+
 export const Loading = Template.bind({})
 Loading.parameters = {
   msw: [getAdminFormSettings({ delay: 'infinite' })],

--- a/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, Story } from '@storybook/react'
 
+import { PaymentChannel } from '~shared/types'
 import {
   FormAuthType,
   FormResponseMode,
@@ -14,13 +15,24 @@ import {
   patchAdminFormSettings,
 } from '~/mocks/msw/handlers/admin-form'
 
-import { StoryRouter } from '~utils/storybook'
+import { StoryRouter, viewports } from '~utils/storybook'
 
 import { SettingsAuthPage } from './SettingsAuthPage'
 
-const buildMswRoutes = (overrides?: Partial<FormSettings>) => [
+const DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE = {
+  channel: PaymentChannel.Stripe,
+  target_account_id: 'dummy',
+  publishable_key: 'dummy',
+}
+
+const buildEmailModeMswRoutes = (overrides?: Partial<FormSettings>) => [
   getAdminFormSettings({ overrides }),
   patchAdminFormSettings({ overrides }),
+]
+
+const buildEncryptModeMswRoutes = (overrides: Partial<FormSettings>) => [
+  getAdminFormSettings({ overrides, mode: FormResponseMode.Encrypt }),
+  patchAdminFormSettings({ overrides, mode: FormResponseMode.Encrypt }),
 ]
 
 export default {
@@ -30,19 +42,19 @@ export default {
   parameters: {
     // Required so skeleton "animation" does not hide content.
     chromatic: { pauseAnimationAtEnd: true },
-    msw: buildMswRoutes(),
+    msw: buildEmailModeMswRoutes(),
   },
 } as Meta
 
 const Template: Story = () => <SettingsAuthPage />
 export const PrivateEmailNilAuthForm = Template.bind({})
 PrivateEmailNilAuthForm.parameters = {
-  msw: buildMswRoutes({ status: FormStatus.Private }),
+  msw: buildEmailModeMswRoutes({ status: FormStatus.Private }),
 }
 
 export const PrivateStorageNilAuthForm = Template.bind({})
 PrivateStorageNilAuthForm.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEncryptModeMswRoutes({
     responseMode: FormResponseMode.Encrypt,
     status: FormStatus.Private,
   }),
@@ -50,7 +62,7 @@ PrivateStorageNilAuthForm.parameters = {
 
 export const PublicEmailNilAuthForm = Template.bind({})
 PublicEmailNilAuthForm.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEmailModeMswRoutes({
     responseMode: FormResponseMode.Email,
     status: FormStatus.Public,
   }),
@@ -58,7 +70,7 @@ PublicEmailNilAuthForm.parameters = {
 
 export const PublicStorageNilAuthForm = Template.bind({})
 PublicStorageNilAuthForm.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEncryptModeMswRoutes({
     responseMode: FormResponseMode.Encrypt,
     status: FormStatus.Public,
   }),
@@ -67,7 +79,7 @@ PublicStorageNilAuthForm.parameters = {
 // purpose: tests that isNricMaskEnabled should not affect setting options available
 export const PublicStorageNilAuthFormNricMaskingEnabled = Template.bind({})
 PublicStorageNilAuthFormNricMaskingEnabled.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEncryptModeMswRoutes({
     responseMode: FormResponseMode.Encrypt,
     status: FormStatus.Public,
     isNricMaskEnabled: true,
@@ -76,27 +88,28 @@ PublicStorageNilAuthFormNricMaskingEnabled.parameters = {
 
 export const PrivateStorageCorppassForm = Template.bind({})
 PrivateStorageCorppassForm.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEncryptModeMswRoutes({
     status: FormStatus.Private,
     authType: FormAuthType.CP,
-    responseMode: FormResponseMode.Encrypt,
     esrvcId: 'STORYBOOK-TEST',
+    responseMode: FormResponseMode.Encrypt,
   }),
 }
 
 export const PublicEmailSingpassForm = Template.bind({})
 PublicEmailSingpassForm.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEmailModeMswRoutes({
     status: FormStatus.Public,
     authType: FormAuthType.SP,
     esrvcId: 'STORYBOOK-TEST',
+    responseMode: FormResponseMode.Email,
   }),
 }
 
 export const PrivateEmailMyInfoWithoutMyInfoFieldsForm = Template.bind({})
 PrivateEmailMyInfoWithoutMyInfoFieldsForm.parameters = {
   msw: [
-    ...buildMswRoutes({
+    ...buildEmailModeMswRoutes({
       status: FormStatus.Private,
       authType: FormAuthType.MyInfo,
       esrvcId: 'STORYBOOK-TEST',
@@ -108,7 +121,7 @@ PrivateEmailMyInfoWithoutMyInfoFieldsForm.parameters = {
 export const PrivateEmailMyinfoForm = Template.bind({})
 PrivateEmailMyinfoForm.parameters = {
   msw: [
-    ...buildMswRoutes({
+    ...buildEmailModeMswRoutes({
       status: FormStatus.Private,
       authType: FormAuthType.MyInfo,
       esrvcId: 'STORYBOOK-TEST',
@@ -120,7 +133,7 @@ PrivateEmailMyinfoForm.parameters = {
 export const PublicEmailMyInfoForm = Template.bind({})
 PublicEmailMyInfoForm.parameters = {
   msw: [
-    ...buildMswRoutes({
+    ...buildEmailModeMswRoutes({
       status: FormStatus.Public,
       authType: FormAuthType.MyInfo,
       esrvcId: 'STORYBOOK-TEST',
@@ -131,7 +144,7 @@ PublicEmailMyInfoForm.parameters = {
 
 export const PrivateEmailSingpassFormNricMaskingEnabled = Template.bind({})
 PrivateEmailSingpassFormNricMaskingEnabled.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEmailModeMswRoutes({
     status: FormStatus.Private,
     authType: FormAuthType.SGID,
     isNricMaskEnabled: true,
@@ -140,7 +153,7 @@ PrivateEmailSingpassFormNricMaskingEnabled.parameters = {
 export const PrivateEmailMyInfoFormNricMaskingEnabled = Template.bind({})
 PrivateEmailMyInfoFormNricMaskingEnabled.parameters = {
   msw: [
-    ...buildMswRoutes({
+    ...buildEmailModeMswRoutes({
       status: FormStatus.Private,
       authType: FormAuthType.MyInfo,
       esrvcId: 'STORYBOOK-TEST',
@@ -152,21 +165,89 @@ PrivateEmailMyInfoFormNricMaskingEnabled.parameters = {
 
 export const PrivateEmailSingpassFormSingleSubmissionEnabled = Template.bind({})
 PrivateEmailSingpassFormSingleSubmissionEnabled.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEmailModeMswRoutes({
     status: FormStatus.Private,
     authType: FormAuthType.SGID,
     isSingleSubmission: true,
   }),
 }
 
+// purpose: displays all available singpass settings in an enabled state
 export const PrivateEmailSingpassFormAllTogglesEnabled = Template.bind({})
 PrivateEmailSingpassFormAllTogglesEnabled.parameters = {
-  msw: buildMswRoutes({
+  msw: buildEmailModeMswRoutes({
     status: FormStatus.Private,
     authType: FormAuthType.SGID,
     isSingleSubmission: true,
     isNricMaskEnabled: true,
   }),
+}
+
+export const PublicStorageCorppassAllTogglesEnabledForm = Template.bind({})
+PublicStorageCorppassAllTogglesEnabledForm.parameters = {
+  msw: buildEncryptModeMswRoutes({
+    status: FormStatus.Public,
+    authType: FormAuthType.CP,
+    isSingleSubmission: true,
+  }),
+}
+
+export const PrivateStorageMyInfoPaymentEnabledForm = Template.bind({})
+PrivateStorageMyInfoPaymentEnabledForm.parameters = {
+  msw: [
+    ...buildEncryptModeMswRoutes({
+      status: FormStatus.Private,
+      authType: FormAuthType.MyInfo,
+      esrvcId: 'STORYBOOK-TEST',
+      responseMode: FormResponseMode.Encrypt,
+      payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
+    }),
+    ...createFormBuilderMocks({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
+  ],
+}
+
+export const PublicStorageMyInfoPaymentEnabledForm = Template.bind({})
+PublicStorageMyInfoPaymentEnabledForm.parameters = {
+  msw: [
+    ...buildEncryptModeMswRoutes({
+      status: FormStatus.Public,
+      authType: FormAuthType.MyInfo,
+      esrvcId: 'STORYBOOK-TEST',
+      responseMode: FormResponseMode.Encrypt,
+      payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
+    }),
+    ...createFormBuilderMocks({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
+  ],
+}
+
+export const PrivateStorageSgidPaymentEnabledForm = Template.bind({})
+PrivateStorageSgidPaymentEnabledForm.parameters = {
+  msw: [
+    ...buildEncryptModeMswRoutes({
+      status: FormStatus.Private,
+      authType: FormAuthType.SGID,
+      responseMode: FormResponseMode.Encrypt,
+      payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
+    }),
+  ],
+}
+
+export const Tablet = Template.bind({})
+Tablet.parameters = {
+  viewport: {
+    defaultViewport: 'tablet',
+  },
+  chromatic: { viewports: [viewports.md] },
+  msw: PrivateEmailSingpassFormAllTogglesEnabled.parameters.msw,
+}
+
+export const Mobile = Template.bind({})
+Mobile.parameters = {
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
+  msw: PrivateEmailSingpassFormAllTogglesEnabled.parameters.msw,
 }
 
 export const Loading = Template.bind({})

--- a/frontend/src/features/admin-form/settings/SettingsPaymentsPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPaymentsPage.stories.tsx
@@ -1,0 +1,48 @@
+import { Meta, Story } from '@storybook/react'
+
+import { FormResponseMode, FormSettings } from '~shared/types'
+
+import {
+  getAdminFormSettings,
+  patchAdminFormSettings,
+} from '~/mocks/msw/handlers/admin-form'
+
+import { StoryRouter } from '~utils/storybook'
+
+import { SettingsPaymentsPage } from './SettingsPaymentsPage'
+
+const buildEncryptModeMswRoutes = (overrides?: Partial<FormSettings>) => [
+  getAdminFormSettings({ overrides, mode: FormResponseMode.Encrypt }),
+  patchAdminFormSettings({ overrides, mode: FormResponseMode.Encrypt }),
+]
+
+export default {
+  title: 'Pages/AdminFormPage/Settings/PaymentsTab',
+  component: SettingsPaymentsPage,
+  decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
+  parameters: {
+    msw: buildEncryptModeMswRoutes(),
+  },
+} as Meta
+
+const Template: Story = () => <SettingsPaymentsPage />
+export const IsSingleSubmissionEnabledWithoutEmailNotifications = Template.bind(
+  {},
+)
+IsSingleSubmissionEnabledWithoutEmailNotifications.parameters = {
+  msw: buildEncryptModeMswRoutes({ isSingleSubmission: true, emails: [] }),
+}
+
+export const IsSingleSubmissionEnabledWithEmailNotifications = Template.bind({})
+IsSingleSubmissionEnabledWithEmailNotifications.parameters = {
+  msw: buildEncryptModeMswRoutes({
+    isSingleSubmission: true,
+    emails: ['dummy@dummy.com'],
+  }),
+}
+
+export const IsSingleSubmissionDisabledWithoutEmailNotifications =
+  Template.bind({})
+IsSingleSubmissionDisabledWithoutEmailNotifications.parameters = {
+  msw: buildEncryptModeMswRoutes({ isSingleSubmission: false, emails: [] }),
+}

--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -100,6 +100,14 @@ export const updateFormNricMask: UpdateFormFn<'isNricMaskEnabled'> = async (
   })
 }
 
+export const updateIsSingleSubmission: UpdateFormFn<
+  'isSingleSubmission'
+> = async (formId, newIsSingleSubmission) => {
+  return updateFormSettings(formId, {
+    isSingleSubmission: newIsSingleSubmission,
+  })
+}
+
 export const updateFormEsrvcId: UpdateFormFn<'esrvcId'> = async (
   formId,
   newEsrvcId,

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDescriptionText.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDescriptionText.tsx
@@ -6,7 +6,7 @@ import Link from '~components/Link'
 export const AuthSettingsDescriptionText = () => {
   return (
     <Text textStyle="subhead-1" color="secondary.500" mb="2.5rem" mt="2.5rem">
-      Authenticate respondents by NRIC/FIN.{' '}
+      Authenticate respondents via Singpass.{' '}
       <Link
         textStyle="subhead-1"
         href={GUIDE_SPCP_ESRVCID}

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
@@ -8,7 +8,7 @@ interface AuthSettingsDisabledExplanationTextProps {
 }
 
 const CONTAINS_MYINFO_FIELDS_DISABLED_EXPLANATION_TEXT =
-  'To change Singpass settings, close your form to new responses. For Singpass authentication changes, remove all existing MyInfo fields.'
+  'To change Singpass settings, close your form to new responses. For Singpass authentication changes, remove all existing Myinfo fields.'
 const FORM_IS_PUBLIC_DISABLED_EXPLANATION_TEXT =
   'To change Singpass settings, close your form to new responses.'
 

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
@@ -8,7 +8,7 @@ interface AuthSettingsDisabledExplanationTextProps {
 }
 
 const CONTAINS_MYINFO_FIELDS_DISABLED_EXPLANATION_TEXT =
-  'To change Singpass settings, close your form to new responses. For Singpass authentication mode changes, additionally remove all existing MyInfo fields. '
+  'To change Singpass settings, close your form to new responses. For Singpass authentication mode changes, additionally remove all existing MyInfo fields.'
 const FORM_IS_PUBLIC_DISABLED_EXPLANATION_TEXT =
   'To change Singpass settings, close your form to new responses.'
 

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
@@ -8,9 +8,9 @@ interface AuthSettingsDisabledExplanationTextProps {
 }
 
 const CONTAINS_MYINFO_FIELDS_DISABLED_EXPLANATION_TEXT =
-  'To change Singpass authentication settings, close your form to new responses and remove all existing Myinfo fields.'
+  'To change Singpass settings, close your form to new responses. For Singpass authentication mode changes, additionally remove all existing MyInfo fields. '
 const FORM_IS_PUBLIC_DISABLED_EXPLANATION_TEXT =
-  'To change Singpass authentication settings, close your form to new responses.'
+  'To change Singpass settings, close your form to new responses.'
 
 export const AuthSettingsDisabledExplanationText = ({
   isFormPublic,

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
@@ -8,7 +8,7 @@ interface AuthSettingsDisabledExplanationTextProps {
 }
 
 const CONTAINS_MYINFO_FIELDS_DISABLED_EXPLANATION_TEXT =
-  'To change Singpass settings, close your form to new responses. For Singpass authentication mode changes, additionally remove all existing MyInfo fields.'
+  'To change Singpass settings, close your form to new responses. For Singpass authentication changes, remove all existing MyInfo fields.'
 const FORM_IS_PUBLIC_DISABLED_EXPLANATION_TEXT =
   'To change Singpass settings, close your form to new responses.'
 

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSingpassSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSingpassSection.tsx
@@ -3,6 +3,7 @@ import { Divider } from '@chakra-ui/react'
 import { FormSettings } from '~shared/types/form'
 
 import { FormNricMaskToggle } from './FormNricMaskToggle'
+import { FormSingleSubmissionToggle } from './FormSingleSubmissionToggle'
 import { SingpassAuthOptionsRadio } from './SingpassAuthOptionsRadio'
 
 export interface AuthSettingsSingpassSectionProps {
@@ -22,7 +23,6 @@ export const AuthSettingsSingpassSection = ({
         settings={settings}
         isDisabled={isFormPublic || containsMyInfoFields}
       />
-
       {/* Hide the NRIC mask toggle if they have not yet enabled it as part of
       PMO circular */}
       {settings.isNricMaskEnabled ? (
@@ -31,6 +31,11 @@ export const AuthSettingsSingpassSection = ({
           <FormNricMaskToggle settings={settings} isDisabled={isFormPublic} />
         </>
       ) : null}
+      <Divider my="2.5rem" />
+      <FormSingleSubmissionToggle
+        settings={settings}
+        isDisabled={isFormPublic}
+      />
     </>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormNricMaskToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormNricMaskToggle.tsx
@@ -15,7 +15,7 @@ export const FormNricMaskToggle = ({
   settings,
   isDisabled,
 }: FormNricMaskToggleProps): JSX.Element => {
-  const isNricMaskEnabled = settings?.isNricMaskEnabled
+  const isNricMaskEnabled = !!settings?.isNricMaskEnabled
 
   const { mutateNricMask } = useMutateFormSettings()
 

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
@@ -1,0 +1,38 @@
+import { useCallback } from 'react'
+
+import { FormSettings } from '~shared/types/form'
+
+import Toggle from '~components/Toggle'
+
+import { useMutateFormSettings } from '../../mutations'
+
+interface FormSingleSubmissionPerNricToggleProps {
+  settings: FormSettings
+  isDisabled: boolean
+}
+
+export const FormSingleSubmissionToggle = ({
+  settings,
+  isDisabled,
+}: FormSingleSubmissionPerNricToggleProps): JSX.Element => {
+  const { mutateIsSingleSubmission } = useMutateFormSettings()
+  const isSingleSubmission = !!settings?.isSingleSubmission
+  const isLoading = !settings || mutateIsSingleSubmission.isLoading
+
+  const handleToggleIsSingleSubmission = useCallback(() => {
+    if (isLoading) return
+    const nextIsSingleSubmission = !settings.isSingleSubmission
+    return mutateIsSingleSubmission.mutate(nextIsSingleSubmission)
+  }, [settings, isLoading, mutateIsSingleSubmission])
+
+  return (
+    <Toggle
+      containerStyles={{ opacity: isDisabled ? 0.3 : 1 }}
+      isDisabled={isDisabled}
+      isLoading={isLoading}
+      isChecked={isSingleSubmission}
+      label="Limit each unique NRIC/FIN to one response"
+      onChange={handleToggleIsSingleSubmission}
+    />
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
@@ -44,13 +44,13 @@ export const FormSingleSubmissionToggle = ({
         isDisabled={isDisabled || isPaymentsEnabled}
         isLoading={isLoading}
         isChecked={isSingleSubmission}
-        label="Limit each unique NRIC/FIN to one response"
+        label="Limit each unique NRIC/FIN/UEN to one response"
         onChange={handleToggleIsSingleSubmission}
       />
       {isPaymentsEnabled ? (
         <InlineMessage mt="1rem">
           <Text>
-            To allow only one submission per NRIC/FIN,{' '}
+            To allow only one submission per NRIC/FIN/UEN,{' '}
             <Link as={ReactLink} to={'payments'}>
               disconnect your stripe account
             </Link>

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
@@ -27,8 +27,9 @@ export const FormSingleSubmissionToggle = ({
   const isPaymentsEnabled =
     settings &&
     settings.responseMode === FormResponseMode.Encrypt &&
-    (settings.payments_channel.channel !== PaymentChannel.Unconnected ||
-      settings.payments_field.enabled)
+    ((settings?.payments_channel?.channel &&
+      settings.payments_channel.channel !== PaymentChannel.Unconnected) ||
+      settings?.payments_field?.enabled)
 
   const handleToggleIsSingleSubmission = useCallback(() => {
     if (isLoading) return

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
@@ -27,9 +27,8 @@ export const FormSingleSubmissionToggle = ({
   const isPaymentsEnabled =
     settings &&
     settings.responseMode === FormResponseMode.Encrypt &&
-    ((settings?.payments_channel?.channel &&
-      settings.payments_channel.channel !== PaymentChannel.Unconnected) ||
-      settings?.payments_field?.enabled)
+    (settings.payments_channel.channel !== PaymentChannel.Unconnected ||
+      settings.payments_field.enabled)
 
   const handleToggleIsSingleSubmission = useCallback(() => {
     if (isLoading) return

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingleSubmissionToggle.tsx
@@ -1,7 +1,12 @@
 import { useCallback } from 'react'
+import { Link as ReactLink } from 'react-router-dom'
+import { Text } from '@chakra-ui/react'
 
-import { FormSettings } from '~shared/types/form'
+import { PaymentChannel } from '~shared/types'
+import { FormResponseMode, FormSettings } from '~shared/types/form'
 
+import InlineMessage from '~components/InlineMessage'
+import Link from '~components/Link'
 import Toggle from '~components/Toggle'
 
 import { useMutateFormSettings } from '../../mutations'
@@ -19,6 +24,12 @@ export const FormSingleSubmissionToggle = ({
   const isSingleSubmission = !!settings?.isSingleSubmission
   const isLoading = !settings || mutateIsSingleSubmission.isLoading
 
+  const isPaymentsEnabled =
+    settings &&
+    settings.responseMode === FormResponseMode.Encrypt &&
+    (settings.payments_channel.channel !== PaymentChannel.Unconnected ||
+      settings.payments_field.enabled)
+
   const handleToggleIsSingleSubmission = useCallback(() => {
     if (isLoading) return
     const nextIsSingleSubmission = !settings.isSingleSubmission
@@ -26,13 +37,26 @@ export const FormSingleSubmissionToggle = ({
   }, [settings, isLoading, mutateIsSingleSubmission])
 
   return (
-    <Toggle
-      containerStyles={{ opacity: isDisabled ? 0.3 : 1 }}
-      isDisabled={isDisabled}
-      isLoading={isLoading}
-      isChecked={isSingleSubmission}
-      label="Limit each unique NRIC/FIN to one response"
-      onChange={handleToggleIsSingleSubmission}
-    />
+    <>
+      <Toggle
+        containerStyles={{ opacity: isDisabled ? 0.3 : 1 }}
+        isDisabled={isDisabled || isPaymentsEnabled}
+        isLoading={isLoading}
+        isChecked={isSingleSubmission}
+        label="Limit each unique NRIC/FIN to one response"
+        onChange={handleToggleIsSingleSubmission}
+      />
+      {isPaymentsEnabled ? (
+        <InlineMessage mt="1rem">
+          <Text>
+            To allow only one submission per NRIC/FIN,{' '}
+            <Link as={ReactLink} to={'payments'}>
+              disconnect your stripe account
+            </Link>
+            . Doing this will also remove all payment fields from your form.
+          </Text>
+        </InlineMessage>
+      ) : null}
+    </>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -63,7 +63,7 @@ const getPaymentsNotAllowedMessageText = (
         To enable payment fields, remove all recipients from{' '}
         <Link as={ReactLink} to={'email-notifications'}>
           email notifications
-        </Link>{' '}
+        </Link>
         .
       </Text>
     )
@@ -73,7 +73,7 @@ const getPaymentsNotAllowedMessageText = (
         To enable payment fields, disable{' '}
         <Link as={ReactLink} to={'singpass'}>
           only one submission per NRIC/FIN
-        </Link>{' '}
+        </Link>
         .
       </Text>
     )

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -39,48 +39,44 @@ import {
   StripeConnectButtonStates,
 } from './StripeConnectButton'
 
-const getPaymentsNotAllowedMessageText = (
-  isEmailsPresent: boolean,
-  isSingleSubmission: boolean,
-) => {
-  if (isEmailsPresent && isSingleSubmission) {
-    return (
-      <Text>
-        To enable payment fields, remove all recipients from{' '}
-        <Link as={ReactLink} to={'email-notifications'}>
-          email notifications
-        </Link>{' '}
-        and disable{' '}
-        <Link as={ReactLink} to={'singpass'}>
-          only one submission per NRIC/FIN/UEN
-        </Link>
-        .
-      </Text>
-    )
-  }
-  if (isEmailsPresent) {
-    return (
-      <Text>
-        To enable payment fields, remove all recipients from{' '}
-        <Link as={ReactLink} to={'email-notifications'}>
-          email notifications
-        </Link>
-        .
-      </Text>
-    )
-  }
-  if (isSingleSubmission) {
-    return (
-      <Text>
-        To enable payment fields, disable{' '}
-        <Link as={ReactLink} to={'singpass'}>
-          only one submission per NRIC/FIN/UEN
-        </Link>
-        .
-      </Text>
-    )
-  }
-  return null
+const PaymentsNotAllowedMessageText = ({
+  isEmailsPresent,
+  isSingleSubmission,
+}: {
+  isEmailsPresent: boolean
+  isSingleSubmission: boolean
+}): JSX.Element => {
+  return isEmailsPresent && isSingleSubmission ? (
+    <Text>
+      To enable payment fields, remove all recipients from{' '}
+      <Link as={ReactLink} to={'email-notifications'}>
+        email notifications
+      </Link>{' '}
+      and disable{' '}
+      <Link as={ReactLink} to={'singpass'}>
+        only one submission per NRIC/FIN/UEN
+      </Link>
+      .
+    </Text>
+  ) : isEmailsPresent ? (
+    <Text>
+      To enable payment fields, remove all recipients from{' '}
+      <Link as={ReactLink} to={'email-notifications'}>
+        email notifications
+      </Link>
+      .
+    </Text>
+  ) : isSingleSubmission ? (
+    <Text>
+      To enable payment fields, disable{' '}
+      <Link as={ReactLink} to={'singpass'}>
+        only one submission per NRIC/FIN/UEN
+      </Link>
+      .
+    </Text>
+  ) : (
+    <></>
+  )
 }
 
 const BeforeConnectionInstructions = ({
@@ -110,11 +106,6 @@ const BeforeConnectionInstructions = ({
 
   const isPaymentsDisabled = isEmailsPresent || isSingleSubmission
 
-  const PaymentsNotAllowedMessageText = getPaymentsNotAllowedMessageText(
-    isEmailsPresent,
-    isSingleSubmission,
-  )
-
   if (isInvalidDomain) {
     return (
       <>
@@ -132,9 +123,14 @@ const BeforeConnectionInstructions = ({
   if (isProductionEnv) {
     return (
       <VStack spacing="2.5rem" alignItems="start">
-        {PaymentsNotAllowedMessageText ? (
+        {isPaymentsDisabled ? (
           <Box w="100%">
-            <InlineMessage>{PaymentsNotAllowedMessageText}</InlineMessage>
+            <InlineMessage>
+              <PaymentsNotAllowedMessageText
+                isEmailsPresent={isEmailsPresent}
+                isSingleSubmission={isSingleSubmission}
+              />
+            </InlineMessage>
           </Box>
         ) : (
           <InlineMessage useMarkdown>
@@ -179,9 +175,14 @@ const BeforeConnectionInstructions = ({
   return (
     <>
       <VStack spacing="2.5rem" alignItems="start">
-        {PaymentsNotAllowedMessageText ? (
+        {isPaymentsDisabled ? (
           <Box w="100%">
-            <InlineMessage>{PaymentsNotAllowedMessageText}</InlineMessage>
+            <InlineMessage>
+              <PaymentsNotAllowedMessageText
+                isEmailsPresent={isEmailsPresent}
+                isSingleSubmission={isSingleSubmission}
+              />
+            </InlineMessage>
           </Box>
         ) : (
           <InlineMessage variant="info">

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -46,37 +46,44 @@ const PaymentsDisabledRationaleText = ({
   isEmailsPresent: boolean
   isSingleSubmission: boolean
 }): JSX.Element => {
-  return isEmailsPresent && isSingleSubmission ? (
-    <Text>
-      To enable payment fields, remove all recipients from{' '}
-      <Link as={ReactLink} to={'email-notifications'}>
-        email notifications
-      </Link>{' '}
-      and disable{' '}
-      <Link as={ReactLink} to={'singpass'}>
-        only one submission per NRIC/FIN/UEN
-      </Link>
-      .
-    </Text>
-  ) : isEmailsPresent ? (
-    <Text>
-      To enable payment fields, remove all recipients from{' '}
-      <Link as={ReactLink} to={'email-notifications'}>
-        email notifications
-      </Link>
-      .
-    </Text>
-  ) : isSingleSubmission ? (
-    <Text>
-      To enable payment fields, disable{' '}
-      <Link as={ReactLink} to={'singpass'}>
-        only one submission per NRIC/FIN/UEN
-      </Link>
-      .
-    </Text>
-  ) : (
-    <></>
-  )
+  if (isEmailsPresent && isSingleSubmission) {
+    return (
+      <Text>
+        To enable payment fields, remove all recipients from{' '}
+        <Link as={ReactLink} to={'email-notifications'}>
+          email notifications
+        </Link>{' '}
+        and disable{' '}
+        <Link as={ReactLink} to={'singpass'}>
+          only one submission per NRIC/FIN/UEN
+        </Link>
+        .
+      </Text>
+    )
+  }
+  if (isEmailsPresent) {
+    return (
+      <Text>
+        To enable payment fields, remove all recipients from{' '}
+        <Link as={ReactLink} to={'email-notifications'}>
+          email notifications
+        </Link>
+        .
+      </Text>
+    )
+  }
+  if (isSingleSubmission) {
+    return (
+      <Text>
+        To enable payment fields, disable{' '}
+        <Link as={ReactLink} to={'singpass'}>
+          only one submission per NRIC/FIN/UEN
+        </Link>
+        .
+      </Text>
+    )
+  }
+  return <></>
 }
 
 const BeforeConnectionInstructions = ({

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -57,7 +57,8 @@ const getPaymentsNotAllowedMessageText = (
         .
       </Text>
     )
-  } else if (isEmailsPresent) {
+  }
+  if (isEmailsPresent) {
     return (
       <Text>
         To enable payment fields, remove all recipients from{' '}
@@ -67,7 +68,8 @@ const getPaymentsNotAllowedMessageText = (
         .
       </Text>
     )
-  } else if (isSingleSubmission) {
+  }
+  if (isSingleSubmission) {
     return (
       <Text>
         To enable payment fields, disable{' '}
@@ -77,9 +79,8 @@ const getPaymentsNotAllowedMessageText = (
         .
       </Text>
     )
-  } else {
-    return null
   }
+  return null
 }
 
 const BeforeConnectionInstructions = ({

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -39,20 +39,47 @@ import {
   StripeConnectButtonStates,
 } from './StripeConnectButton'
 
-const PaymentsNotAllowedMessage = () => {
-  return (
-    <Box w="100%">
-      <InlineMessage>
-        <Text>
-          To enable payment fields, remove all recipients from{' '}
-          <Link as={ReactLink} to={'email-notifications'}>
-            email notifications
-          </Link>
-          .
-        </Text>
-      </InlineMessage>
-    </Box>
-  )
+const getPaymentsNotAllowedMessageText = (
+  isEmailsPresent: boolean,
+  isSingleSubmission: boolean,
+) => {
+  if (isEmailsPresent && isSingleSubmission) {
+    return (
+      <Text>
+        To enable payment fields, remove all recipients from{' '}
+        <Link as={ReactLink} to={'email-notifications'}>
+          email notifications
+        </Link>{' '}
+        and disable{' '}
+        <Link as={ReactLink} to={'singpass'}>
+          only one submission per NRIC/FIN
+        </Link>
+        .
+      </Text>
+    )
+  } else if (isEmailsPresent) {
+    return (
+      <Text>
+        To enable payment fields, remove all recipients from{' '}
+        <Link as={ReactLink} to={'email-notifications'}>
+          email notifications
+        </Link>{' '}
+        .
+      </Text>
+    )
+  } else if (isSingleSubmission) {
+    return (
+      <Text>
+        To enable payment fields, disable{' '}
+        <Link as={ReactLink} to={'singpass'}>
+          only one submission per NRIC/FIN
+        </Link>{' '}
+        .
+      </Text>
+    )
+  } else {
+    return null
+  }
 }
 
 const BeforeConnectionInstructions = ({
@@ -78,6 +105,15 @@ const BeforeConnectionInstructions = ({
     )
   }, [settings])
 
+  const isSingleSubmission = !!settings?.isSingleSubmission
+
+  const isPaymentsDisabled = isEmailsPresent || isSingleSubmission
+
+  const PaymentsNotAllowedMessageText = getPaymentsNotAllowedMessageText(
+    isEmailsPresent,
+    isSingleSubmission,
+  )
+
   if (isInvalidDomain) {
     return (
       <>
@@ -95,8 +131,10 @@ const BeforeConnectionInstructions = ({
   if (isProductionEnv) {
     return (
       <VStack spacing="2.5rem" alignItems="start">
-        {isEmailsPresent ? (
-          <PaymentsNotAllowedMessage />
+        {PaymentsNotAllowedMessageText ? (
+          <Box w="100%">
+            <InlineMessage>{PaymentsNotAllowedMessageText}</InlineMessage>
+          </Box>
         ) : (
           <InlineMessage useMarkdown>
             {`Read [our guide](${paymentGuideLink}) to set up a Stripe account. If your agency already has a Stripe account, you can connect it to this form.`}
@@ -128,7 +166,7 @@ const BeforeConnectionInstructions = ({
         </Checkbox>
         <StripeConnectButton
           connectState={
-            allowConnect && !isEmailsPresent
+            allowConnect && !isPaymentsDisabled
               ? StripeConnectButtonStates.ENABLED
               : StripeConnectButtonStates.DISABLED
           }
@@ -140,8 +178,10 @@ const BeforeConnectionInstructions = ({
   return (
     <>
       <VStack spacing="2.5rem" alignItems="start">
-        {isEmailsPresent ? (
-          <PaymentsNotAllowedMessage />
+        {PaymentsNotAllowedMessageText ? (
+          <Box w="100%">
+            <InlineMessage>{PaymentsNotAllowedMessageText}</InlineMessage>
+          </Box>
         ) : (
           <InlineMessage variant="info">
             <Text>
@@ -152,9 +192,9 @@ const BeforeConnectionInstructions = ({
         )}
         <StripeConnectButton
           connectState={
-            isEmailsPresent
-              ? StripeConnectButtonStates.DISABLED
-              : StripeConnectButtonStates.ENABLED
+            !isPaymentsDisabled
+              ? StripeConnectButtonStates.ENABLED
+              : StripeConnectButtonStates.DISABLED
           }
         />
       </VStack>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -52,7 +52,7 @@ const getPaymentsNotAllowedMessageText = (
         </Link>{' '}
         and disable{' '}
         <Link as={ReactLink} to={'singpass'}>
-          only one submission per NRIC/FIN
+          only one submission per NRIC/FIN/UEN
         </Link>
         .
       </Text>
@@ -72,7 +72,7 @@ const getPaymentsNotAllowedMessageText = (
       <Text>
         To enable payment fields, disable{' '}
         <Link as={ReactLink} to={'singpass'}>
-          only one submission per NRIC/FIN
+          only one submission per NRIC/FIN/UEN
         </Link>
         .
       </Text>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -39,7 +39,7 @@ import {
   StripeConnectButtonStates,
 } from './StripeConnectButton'
 
-const PaymentsNotAllowedMessageText = ({
+const PaymentsDisabledRationaleText = ({
   isEmailsPresent,
   isSingleSubmission,
 }: {
@@ -126,7 +126,7 @@ const BeforeConnectionInstructions = ({
         {isPaymentsDisabled ? (
           <Box w="100%">
             <InlineMessage>
-              <PaymentsNotAllowedMessageText
+              <PaymentsDisabledRationaleText
                 isEmailsPresent={isEmailsPresent}
                 isSingleSubmission={isSingleSubmission}
               />
@@ -178,7 +178,7 @@ const BeforeConnectionInstructions = ({
         {isPaymentsDisabled ? (
           <Box w="100%">
             <InlineMessage>
-              <PaymentsNotAllowedMessageText
+              <PaymentsDisabledRationaleText
                 isEmailsPresent={isEmailsPresent}
                 isSingleSubmission={isSingleSubmission}
               />

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -324,7 +324,6 @@ export const useMutateFormSettings = () => {
 
   const mutateIsSingleSubmission = useMutation(
     (nextIsSingleSubmissionPerNricEnabled: boolean) => {
-      console.log('mutating')
       return updateIsSingleSubmission(
         formId,
         nextIsSingleSubmissionPerNricEnabled,

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -42,6 +42,7 @@ import {
   updateFormWebhookRetries,
   updateFormWebhookUrl,
   updateGstEnabledFlag,
+  updateIsSingleSubmission,
   updateTwilioCredentials,
 } from './SettingsService'
 
@@ -321,6 +322,27 @@ export const useMutateFormSettings = () => {
     },
   )
 
+  const mutateIsSingleSubmission = useMutation(
+    (nextIsSingleSubmissionPerNricEnabled: boolean) => {
+      console.log('mutating')
+      return updateIsSingleSubmission(
+        formId,
+        nextIsSingleSubmissionPerNricEnabled,
+      )
+    },
+    {
+      onSuccess: (newData) => {
+        handleSuccess({
+          newData,
+          toastDescription: newData.isSingleSubmission
+            ? 'Single submission per NRIC/FIN is now enabled on your form.'
+            : 'Single submission per NRIC/FIN is now disabled on your form.',
+        })
+      },
+      onError: handleError,
+    },
+  )
+
   const mutateFormWebhookUrl = useMutation(
     (nextUrl?: string) => updateFormWebhookUrl(formId, nextUrl),
     {
@@ -391,6 +413,7 @@ export const useMutateFormSettings = () => {
     mutateFormTitle,
     mutateFormAuthType,
     mutateNricMask,
+    mutateIsSingleSubmission,
     mutateFormEsrvcId,
     mutateFormBusiness,
     mutateGST,

--- a/frontend/src/features/admin-form/settings/mutations.ts
+++ b/frontend/src/features/admin-form/settings/mutations.ts
@@ -335,8 +335,8 @@ export const useMutateFormSettings = () => {
         handleSuccess({
           newData,
           toastDescription: newData.isSingleSubmission
-            ? 'Single submission per NRIC/FIN is now enabled on your form.'
-            : 'Single submission per NRIC/FIN is now disabled on your form.',
+            ? 'Single submission per NRIC/FIN/UEN is now enabled on your form.'
+            : 'Single submission per NRIC/FIN/UEN is now disabled on your form.',
         })
       },
       onError: handleError,

--- a/frontend/src/features/public-form/PublicFormContext.tsx
+++ b/frontend/src/features/public-form/PublicFormContext.tsx
@@ -66,6 +66,9 @@ export interface PublicFormContextProps
   /** Sets the current number of visible fields in the form in public forms only*/
   setNumVisibleFields?: Dispatch<SetStateAction<number>>
 
+  hasSingleSubmissionValidationError: boolean
+  setHasSingleSubmissionValidationError: Dispatch<SetStateAction<boolean>>
+
   encryptedPreviousSubmission?: MultirespondentSubmissionDto
   previousSubmission?: ReturnType<typeof decryptSubmission>
   previousAttachments?: Record<string, ArrayBuffer>

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -383,6 +383,66 @@ SgidAuthorized.parameters = {
   ],
 }
 
+export const SgIdSingleSubmissionFailureMessage = Template.bind({})
+SgIdSingleSubmissionFailureMessage.storyName =
+  'SGID/Single Submission Per NRIC/FIN/UEN Failure Sign In Screen Message'
+SgIdSingleSubmissionFailureMessage.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'SGID login form',
+          authType: FormAuthType.SGID,
+          isSingleSubmission: true,
+        },
+        hasSingleSubmissionValidationFailure: true,
+      },
+    }),
+  ],
+}
+
+export const SingpassSingleSubmissionFailureMessage = Template.bind({})
+SingpassSingleSubmissionFailureMessage.storyName =
+  'Singpass/Single Submission Per NRIC/FIN/UEN Failure Sign In Screen Message'
+SingpassSingleSubmissionFailureMessage.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'SP login form',
+          authType: FormAuthType.SP,
+          isSingleSubmission: true,
+        },
+        hasSingleSubmissionValidationFailure: true,
+      },
+    }),
+  ],
+}
+
+export const CorppassSingleSubmissionFailuredMessage = Template.bind({})
+CorppassSingleSubmissionFailuredMessage.storyName =
+  'Corppass/Single Submission Per NRIC/FIN/UEN Failure Sign In Screen Message'
+CorppassSingleSubmissionFailuredMessage.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'CP login form',
+          authType: FormAuthType.CP,
+          isSingleSubmission: true,
+        },
+        hasSingleSubmissionValidationFailure: true,
+      },
+    }),
+  ],
+}
+
 export const VerifiedFieldsExpiry = Template.bind({})
 VerifiedFieldsExpiry.parameters = {
   msw: [

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -443,6 +443,52 @@ CorppassSingleSubmissionFailuredMessage.parameters = {
   ],
 }
 
+export const SgIdSingleSubmissionFailureModalAfterSubmit = Template.bind({})
+SgIdSingleSubmissionFailureModalAfterSubmit.storyName =
+  'SGID/Single Submission Per NRIC/FIN/UEN Failure Modal After Submit'
+SgIdSingleSubmissionFailureModalAfterSubmit.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'SGID login form',
+          authType: FormAuthType.SGID,
+          isSingleSubmission: true,
+        },
+        spcpSession: {
+          userName: 'S1234567A',
+        },
+        hasSingleSubmissionValidationFailure: true,
+      },
+    }),
+  ],
+}
+
+export const CpSingleSubmissionFailureModalAfterSubmit = Template.bind({})
+CpSingleSubmissionFailureModalAfterSubmit.storyName =
+  'CP/Single Submission Per NRIC/FIN/UEN Failure Modal After Submit'
+CpSingleSubmissionFailureModalAfterSubmit.parameters = {
+  msw: [
+    ...envHandlers,
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          title: 'CP login form',
+          authType: FormAuthType.CP,
+          isSingleSubmission: true,
+        },
+        spcpSession: {
+          userName: 'uen-123456789A',
+        },
+        hasSingleSubmissionValidationFailure: true,
+      },
+    }),
+  ],
+}
+
 export const VerifiedFieldsExpiry = Template.bind({})
 VerifiedFieldsExpiry.parameters = {
   msw: [

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -155,6 +155,18 @@ export const PublicFormProvider = ({
     data.spcpSession.userName = maskNric(data.spcpSession.userName)
   }
 
+  useEffect(() => {
+    if (
+      data?.form.isSingleSubmission &&
+      data.hasSingleSubmissionValidationFailure
+    ) {
+      setHasSingleSubmissionValidationError(true)
+    }
+  }, [
+    data?.form.isSingleSubmission,
+    data?.hasSingleSubmissionValidationFailure,
+  ])
+
   const { isNotFormId, toast, vfnToastIdRef, expiryInMs, ...commonFormValues } =
     useCommonFormProvider(formId)
 
@@ -444,6 +456,11 @@ export const PublicFormProvider = ({
   )
 
   const { handleLogoutMutation } = usePublicAuthMutations(formId)
+
+  const handleLogout = useCallback(() => {
+    if (!data?.form || data.form.authType === FormAuthType.NIL) return
+    return handleLogoutMutation.mutate(data.form.authType)
+  }, [data?.form, handleLogoutMutation])
 
   const navigate = useNavigate()
   const [, storePaymentMemory] = useBrowserStm(formId)
@@ -813,11 +830,6 @@ export const PublicFormProvider = ({
   )
 
   useTimeout(generateVfnExpiryToast, expiryInMs)
-
-  const handleLogout = useCallback(() => {
-    if (!data?.form || data.form.authType === FormAuthType.NIL) return
-    return handleLogoutMutation.mutate(data.form.authType)
-  }, [data?.form, handleLogoutMutation])
 
   const isAuthRequired = useMemo(
     () =>

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -38,7 +38,10 @@ import { useBrowserStm } from '~hooks/payments'
 import { useTimeout } from '~hooks/useTimeout'
 import { useToast } from '~hooks/useToast'
 import { isKeypairValid } from '~utils/secretKeyValidation'
-import { HttpError } from '~services/ApiService'
+import {
+  HttpError,
+  SingleSubmissionValidationError,
+} from '~services/ApiService'
 import { FormFieldValues } from '~templates/Field'
 
 import NotFoundErrorPage from '~pages/NotFoundError'
@@ -131,6 +134,10 @@ export const PublicFormProvider = ({
   // Once form has been submitted, submission data will be set here.
   const [submissionData, setSubmissionData] = useState<SubmissionData>()
   const [numVisibleFields, setNumVisibleFields] = useState(0)
+  const [
+    hasSingleSubmissionValidationError,
+    setHasSingleSubmissionValidationError,
+  ] = useState(false)
 
   const {
     data,
@@ -520,11 +527,20 @@ export const PublicFormProvider = ({
         submissionId: string
         timestamp: number
       }) => {
+        setHasSingleSubmissionValidationError(false)
         setSubmissionData({
           id: submissionId,
           timestamp,
         })
         trackSubmitForm(form)
+      }
+
+      const handleError = (error: Error, form: PublicFormDto) => {
+        if (error instanceof SingleSubmissionValidationError) {
+          setHasSingleSubmissionValidationError(true)
+        } else {
+          showErrorToast(error, form)
+        }
       }
 
       switch (form.responseMode) {
@@ -561,7 +577,7 @@ export const PublicFormProvider = ({
                     },
                   },
                 })
-                showErrorToast(error, form)
+                handleError(error, form)
               })
           }
 
@@ -607,7 +623,7 @@ export const PublicFormProvider = ({
                     axiosDebugFlow()
                     return submitEmailFormWithFetch()
                   } else {
-                    showErrorToast(error, form)
+                    handleError(error, form)
                   }
                 })
             )
@@ -686,7 +702,7 @@ export const PublicFormProvider = ({
                     },
                   },
                 })
-                showErrorToast(error, form)
+                handleError(error, form)
               })
           }
 
@@ -748,7 +764,7 @@ export const PublicFormProvider = ({
                 // defaults to the safest option of storage submission without virus scanning
                 return submitStorageFormWithFetch()
               } else {
-                showErrorToast(error, form)
+                handleError(error, form)
               }
             })
         }
@@ -831,6 +847,8 @@ export const PublicFormProvider = ({
         isPaymentEnabled,
         isPreview: false,
         setNumVisibleFields,
+        hasSingleSubmissionValidationError,
+        setHasSingleSubmissionValidationError,
         encryptedPreviousSubmission,
         previousSubmission,
         previousAttachments,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -547,7 +547,7 @@ export const PublicFormProvider = ({
         if (
           data &&
           form.isSingleSubmission &&
-          form.authType != FormAuthType.NIL
+          form.authType !== FormAuthType.NIL
         ) {
           data.spcpSession = undefined
         }
@@ -709,7 +709,7 @@ export const PublicFormProvider = ({
                     if (
                       data &&
                       form.isSingleSubmission &&
-                      form.authType != FormAuthType.NIL
+                      form.authType !== FormAuthType.NIL
                     ) {
                       data.spcpSession = undefined
                     }
@@ -772,7 +772,7 @@ export const PublicFormProvider = ({
                   if (
                     data &&
                     form.isSingleSubmission &&
-                    form.authType != FormAuthType.NIL
+                    form.authType !== FormAuthType.NIL
                   ) {
                     data.spcpSession = undefined
                   }

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -544,6 +544,13 @@ export const PublicFormProvider = ({
         submissionId: string
         timestamp: number
       }) => {
+        if (
+          data &&
+          form.isSingleSubmission &&
+          form.authType != FormAuthType.NIL
+        ) {
+          data.spcpSession = undefined
+        }
         setHasSingleSubmissionValidationError(false)
         setSubmissionData({
           id: submissionId,
@@ -699,6 +706,14 @@ export const PublicFormProvider = ({
                       storePaymentMemory(paymentData.paymentId)
                       return
                     }
+                    if (
+                      data &&
+                      form.isSingleSubmission &&
+                      form.authType != FormAuthType.NIL
+                    ) {
+                      data.spcpSession = undefined
+                    }
+                    setHasSingleSubmissionValidationError(false)
                     setSubmissionData({
                       id: submissionId,
                       timestamp,
@@ -749,12 +764,19 @@ export const PublicFormProvider = ({
                   paymentData,
                 }) => {
                   trackSubmitForm(form)
-
                   if (paymentData) {
                     navigate(getPaymentPageUrl(formId, paymentData.paymentId))
                     storePaymentMemory(paymentData.paymentId)
                     return
                   }
+                  if (
+                    data &&
+                    form.isSingleSubmission &&
+                    form.authType != FormAuthType.NIL
+                  ) {
+                    data.spcpSession = undefined
+                  }
+                  setHasSingleSubmissionValidationError(false)
                   setSubmissionData({
                     id: submissionId,
                     timestamp,

--- a/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
+++ b/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
@@ -2,7 +2,10 @@ import { useMemo } from 'react'
 import { BiLogInCircle } from 'react-icons/bi'
 import { Box, Stack, Text } from '@chakra-ui/react'
 
+import { FORM_SINGLE_SUBMISSION_VALIDATION_ERROR_MESSAGE } from '~shared/constants'
 import { FormAuthType } from '~shared/types/form'
+
+import InlineMessage from '~/components/InlineMessage'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
@@ -14,9 +17,13 @@ import { AuthImageSvgr } from './AuthImageSvgr'
 
 export interface FormAuthProps {
   authType: Exclude<FormAuthType, FormAuthType.NIL>
+  hasSingleSubmissionValidationError: boolean
 }
 
-export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
+export const FormAuth = ({
+  authType,
+  hasSingleSubmissionValidationError,
+}: FormAuthProps): JSX.Element => {
   const { formId, form } = usePublicFormContext()
 
   const buttonColorScheme = useMemo(() => {
@@ -80,6 +87,11 @@ export const FormAuth = ({ authType }: FormAuthProps): JSX.Element => {
         >
           {displayedInfo.helpText}
         </Text>
+        {hasSingleSubmissionValidationError ? (
+          <InlineMessage variant="error">
+            {FORM_SINGLE_SUBMISSION_VALIDATION_ERROR_MESSAGE}
+          </InlineMessage>
+        ) : null}
       </Stack>
     </Box>
   )

--- a/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -14,6 +14,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
   const {
     form,
     isAuthRequired,
+    hasSingleSubmissionValidationError,
     isLoading,
     handleSubmitForm,
     submissionData,
@@ -35,9 +36,15 @@ export const FormFieldsContainer = (): JSX.Element | null => {
       return <div>Something went wrong</div>
     }
 
-    // Redundant conditional for type narrowing
     if (isAuthRequired && form.authType !== FormAuthType.NIL) {
-      return <FormAuth authType={form.authType} />
+      return (
+        <FormAuth
+          authType={form.authType}
+          hasSingleSubmissionValidationError={
+            hasSingleSubmissionValidationError
+          }
+        />
+      )
     }
 
     return (
@@ -67,6 +74,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     previousAttachments,
     workflowStep,
     handleSubmitForm,
+    hasSingleSubmissionValidationError,
   ])
 
   if (submissionData) return null

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -97,7 +97,7 @@ export const PublicFormSubmitButton = ({
 
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
-      {isPaymentsModalOpen && !isSingleSubmissionOnlyModalOpen ? (
+      {isPaymentsModalOpen ? (
         prevPaymentId ? (
           <DuplicatePaymentModal
             onSubmit={onSubmit}

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -18,6 +18,7 @@ import { usePublicFormContext } from '../../PublicFormContext'
 import { DuplicatePaymentModal } from '../DuplicatePaymentModal/DuplicatePaymentModal'
 import { FormPaymentModal } from '../FormPaymentModal/FormPaymentModal'
 import { getPreviousPaymentId } from '../FormPaymentPage/FormPaymentService'
+import { SingleSubmissionModal } from '../SingleSubmissionModal/SingleSubmissionModal'
 
 interface PublicFormSubmitButtonProps {
   formFields: MyInfoFormField<FormField>[]
@@ -44,7 +45,13 @@ export const PublicFormSubmitButton = ({
   const isMobile = useIsMobile()
   const { isSubmitting } = useFormState()
   const formInputs = useWatch<FormFieldValues>({}) as FormFieldValues
-  const { formId, isPaymentEnabled, isPreview } = usePublicFormContext()
+  const {
+    formId,
+    isPaymentEnabled,
+    isPreview,
+    hasSingleSubmissionValidationError,
+    setHasSingleSubmissionValidationError,
+  } = usePublicFormContext()
 
   const paymentEmailField = formInputs[
     PAYMENT_CONTACT_FIELD_ID
@@ -79,9 +86,15 @@ export const PublicFormSubmitButton = ({
     }
   }
 
+  const isSingleSubmissionOnlyModalOpen = hasSingleSubmissionValidationError
+  const onSingleSubmissionModalClose = () => {
+    setHasSingleSubmissionValidationError(false)
+  }
+
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
-      {isOpen ? (
+      // Prevent opening of multiple modals
+      {isOpen && !isSingleSubmissionOnlyModalOpen ? (
         prevPaymentId ? (
           <DuplicatePaymentModal
             onSubmit={onSubmit}
@@ -98,6 +111,11 @@ export const PublicFormSubmitButton = ({
           />
         )
       ) : null}
+      <SingleSubmissionModal
+        formId={formId}
+        isOpen={isSingleSubmissionOnlyModalOpen}
+        onClose={onSingleSubmissionModalClose}
+      />
       <Button
         isFullWidth={isMobile}
         w="100%"

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -66,7 +66,11 @@ export const PublicFormSubmitButton = ({
   }, [formInputs, formFields, formLogics])
 
   // For payments submit and pay modal
-  const { isOpen, onOpen, onClose } = useDisclosure({ defaultIsOpen: false })
+  const {
+    isOpen: isPaymentsModalOpen,
+    onOpen: onPaymentsModalOpen,
+    onClose: onPaymentsModalClose,
+  } = useDisclosure({ defaultIsOpen: false })
 
   const checkBeforeOpen = async () => {
     const result = await trigger()
@@ -82,7 +86,7 @@ export const PublicFormSubmitButton = ({
       } catch (err) {
         setPrevPaymentId('')
       }
-      onOpen()
+      onPaymentsModalOpen()
     }
   }
 
@@ -93,12 +97,11 @@ export const PublicFormSubmitButton = ({
 
   return (
     <Stack px={{ base: '1rem', md: 0 }} pt="2.5rem" pb="4rem">
-      // Prevent opening of multiple modals
-      {isOpen && !isSingleSubmissionOnlyModalOpen ? (
+      {isPaymentsModalOpen && !isSingleSubmissionOnlyModalOpen ? (
         prevPaymentId ? (
           <DuplicatePaymentModal
             onSubmit={onSubmit}
-            onClose={onClose}
+            onClose={onPaymentsModalClose}
             isSubmitting={isSubmitting}
             formId={formId}
             paymentId={prevPaymentId}
@@ -106,7 +109,7 @@ export const PublicFormSubmitButton = ({
         ) : (
           <FormPaymentModal
             onSubmit={onSubmit}
-            onClose={onClose}
+            onClose={onPaymentsModalClose}
             isSubmitting={isSubmitting}
           />
         )

--- a/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
+++ b/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
@@ -18,7 +18,7 @@ import { useIsMobile } from '~hooks/useIsMobile'
 import ButtonGroup from '~components/ButtonGroup'
 
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
-import { getPublicFormResponseSingpassLoginUrl } from '~features/public-form/utils/urls'
+import { getPublicFormUrl } from '~features/public-form/utils/urls'
 
 interface SingleSubmissionModalProps {
   formId: string
@@ -39,7 +39,7 @@ export const SingleSubmissionModal = ({
   const singpassLogoutAndRedirectToFormLogin = () => {
     if (!handleLogout) return
     handleLogout()
-    navigate(getPublicFormResponseSingpassLoginUrl(formId))
+    navigate(getPublicFormUrl(formId))
   }
 
   return (

--- a/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
+++ b/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
@@ -26,7 +26,6 @@ interface SingleSubmissionModalProps {
   isOpen: boolean
 }
 
-// TODO: check if need to handle preview behavior
 export const SingleSubmissionModal = ({
   formId,
   isOpen,

--- a/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
+++ b/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
@@ -53,7 +53,7 @@ export const SingleSubmissionModal = ({
       <ModalContent>
         <ModalCloseButton />
         <ModalHeader pb={'2rem'} w="90%">
-          Only one submission per NRIC/FIN allowed
+          Only one submission per NRIC/FIN/UEN allowed
         </ModalHeader>
         <ModalBody flexGrow={0}>
           <Stack>

--- a/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
+++ b/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
@@ -12,6 +12,8 @@ import {
   Text,
 } from '@chakra-ui/react'
 
+import { FORM_SINGLE_SUBMISSION_VALIDATION_ERROR_MESSAGE } from '~shared/constants/'
+
 import { useIsMobile } from '~hooks/useIsMobile'
 import ButtonGroup from '~components/ButtonGroup'
 
@@ -55,11 +57,7 @@ export const SingleSubmissionModal = ({
         </ModalHeader>
         <ModalBody flexGrow={0}>
           <Stack>
-            <Text>
-              You have already submitted a response using this NRIC/FIN. If you
-              think this is a mistake, please contact the agency that gave you
-              the form link.
-            </Text>
+            <Text>{FORM_SINGLE_SUBMISSION_VALIDATION_ERROR_MESSAGE}</Text>
           </Stack>
         </ModalBody>
         <ModalFooter>

--- a/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
+++ b/frontend/src/features/public-form/components/SingleSubmissionModal/SingleSubmissionModal.tsx
@@ -1,0 +1,79 @@
+import { useNavigate } from 'react-router-dom'
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
+
+import { useIsMobile } from '~hooks/useIsMobile'
+import ButtonGroup from '~components/ButtonGroup'
+
+import { usePublicFormContext } from '~features/public-form/PublicFormContext'
+import { getPublicFormResponseSingpassLoginUrl } from '~features/public-form/utils/urls'
+
+interface SingleSubmissionModalProps {
+  formId: string
+  onClose: () => void
+  isOpen: boolean
+}
+
+// TODO: check if need to handle preview behavior
+export const SingleSubmissionModal = ({
+  formId,
+  isOpen,
+  onClose,
+}: SingleSubmissionModalProps) => {
+  const isMobile = useIsMobile()
+  const navigate = useNavigate()
+
+  const { handleLogout } = usePublicFormContext()
+
+  const singpassLogoutAndRedirectToFormLogin = () => {
+    if (!handleLogout) return
+    handleLogout()
+    navigate(getPublicFormResponseSingpassLoginUrl(formId))
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen && !!handleLogout}
+      onClose={onClose}
+      size={isMobile ? 'full' : undefined}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton />
+        <ModalHeader pb={'2rem'} w="90%">
+          Only one submission per NRIC/FIN allowed
+        </ModalHeader>
+        <ModalBody flexGrow={0}>
+          <Stack>
+            <Text>
+              You have already submitted a response using this NRIC/FIN. If you
+              think this is a mistake, please contact the agency that gave you
+              the form link.
+            </Text>
+          </Stack>
+        </ModalBody>
+        <ModalFooter>
+          <ButtonGroup isFullWidth={isMobile}>
+            <Button
+              loadingText="Logging out"
+              isDisabled={!handleLogout}
+              onClick={singpassLogoutAndRedirectToFormLogin}
+            >
+              Back to Singpass log in
+            </Button>
+          </ButtonGroup>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/frontend/src/features/public-form/utils/urls.ts
+++ b/frontend/src/features/public-form/utils/urls.ts
@@ -15,3 +15,7 @@ export const getPaymentInvoiceDownloadUrl = (
     paymentId,
   )}` as const
 }
+
+export const getPublicFormResponseSingpassLoginUrl = (formId: string) => {
+  return `/${formId}` as const
+}

--- a/frontend/src/features/public-form/utils/urls.ts
+++ b/frontend/src/features/public-form/utils/urls.ts
@@ -16,6 +16,6 @@ export const getPaymentInvoiceDownloadUrl = (
   )}` as const
 }
 
-export const getPublicFormResponseSingpassLoginUrl = (formId: string) => {
+export const getPublicFormUrl = (formId: string) => {
   return `/${formId}` as const
 }

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -15,6 +15,12 @@ export class HttpError extends Error {
   }
 }
 
+export class SingleSubmissionValidationError extends HttpError {
+  constructor() {
+    super('Single submission validation failed', StatusCodes.BAD_REQUEST)
+  }
+}
+
 /**
  * Converts possible AxiosError objects to normal Error objects
  *
@@ -24,6 +30,9 @@ export const transformAxiosError = (error: Error): ApiError => {
   if (axios.isAxiosError(error)) {
     if (error.response) {
       const statusCode = error.response.status
+      if (error.response.data?.isSingleSubmissionValidationFailure) {
+        return new SingleSubmissionValidationError()
+      }
       if (statusCode === StatusCodes.TOO_MANY_REQUESTS) {
         return new HttpError('Please try again later.', statusCode)
       }

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -30,7 +30,7 @@ export const transformAxiosError = (error: Error): ApiError => {
   if (axios.isAxiosError(error)) {
     if (error.response) {
       const statusCode = error.response.status
-      if (error.response.data?.isSingleSubmissionValidationFailure) {
+      if (error.response.data?.hasSingleSubmissionValidationFailure) {
         return new SingleSubmissionValidationError()
       }
       if (statusCode === StatusCodes.TOO_MANY_REQUESTS) {

--- a/shared/constants/errors.ts
+++ b/shared/constants/errors.ts
@@ -10,4 +10,4 @@ export const GO_VALIDATION_ERROR_MESSAGE =
 export const GO_ALREADY_EXIST_ERROR_MESSAGE = 'GoGov link already exists'
 
 export const FORM_SINGLE_SUBMISSION_VALIDATION_ERROR_MESSAGE =
-  'You have already submitted a response using this NRIC/FIN. If you think this is a mistake, please contact the agency that gave you the form link.'
+  'You have already submitted a response using this NRIC/FIN/UEN. If you think this is a mistake, please contact the agency that gave you the form link.'

--- a/shared/constants/errors.ts
+++ b/shared/constants/errors.ts
@@ -8,3 +8,6 @@ export const GO_VALIDATION_ERROR_MESSAGE =
   'Validation error when claiming GoGov link'
 
 export const GO_ALREADY_EXIST_ERROR_MESSAGE = 'GoGov link already exists'
+
+export const FORM_SINGLE_SUBMISSION_VALIDATION_ERROR_MESSAGE =
+  'You have already submitted a response using this NRIC/FIN. If you think this is a mistake, please contact the agency that gave you the form link.'

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -2,6 +2,7 @@ const PUBLIC_FORM_FIELDS = <const>[
   'admin',
   'authType',
   'isNricMaskEnabled',
+  'isSingleSubmission',
   'endPage',
   'esrvcId',
   'form_fields',

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -31,6 +31,7 @@ const FORM_SETTINGS_FIELDS = <const>[
   'responseMode',
   'authType',
   'isNricMaskEnabled',
+  'isSingleSubmission',
   'esrvcId',
   'hasCaptcha',
   'hasIssueNotification',

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -304,7 +304,7 @@ export type PublicFormViewDto = {
   isIntranetUser?: boolean
   myInfoError?: true
   myInfoChildrenBirthRecords?: MyInfoChildData
-  hasSingleSubmissionValidationFailure?: boolean
+  hasSingleSubmissionValidationFailure?: true
 }
 
 export type PreviewFormViewDto = Pick<PublicFormViewDto, 'form' | 'spcpSession'>

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -146,6 +146,7 @@ export interface FormBase {
   hasIssueNotification: boolean
   authType: FormAuthType
   isNricMaskEnabled: boolean
+  isSingleSubmission: boolean
 
   status: FormStatus
 

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -304,6 +304,7 @@ export type PublicFormViewDto = {
   isIntranetUser?: boolean
   myInfoError?: true
   myInfoChildrenBirthRecords?: MyInfoChildData
+  hasSingleSubmissionValidationFailure?: boolean
 }
 
 export type PreviewFormViewDto = Pick<PublicFormViewDto, 'form' | 'spcpSession'>

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -1,7 +1,7 @@
 import type { Opaque, RequireAtLeastOne } from 'type-fest'
 import { z } from 'zod'
 
-import { ErrorDto, SingleSubmissionValidationErrorDto } from './core'
+import { ErrorDto } from './core'
 import { FormFieldDto, MyInfoAttribute, PaymentFieldsDto } from './field'
 import { FormAuthType } from './form/form'
 import { DateString } from './generic'
@@ -235,11 +235,10 @@ export type SubmissionResponseDto = {
   paymentData?: PaymentSubmissionData
 }
 
-export type SubmissionErrorDto =
-  | (ErrorDto & {
-      spcpSubmissionFailure?: true
-    })
-  | SingleSubmissionValidationErrorDto
+export type SubmissionErrorDto = ErrorDto & {
+  spcpSubmissionFailure?: true
+  hasSingleSubmissionValidationFailure?: true
+}
 
 export type SubmissionCountQueryDto =
   | {

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -27,7 +27,7 @@ export type ResponseMetadata = z.infer<typeof ResponseMetadata>
 export const SubmissionBase = z.object({
   form: z.string(),
   authType: z.nativeEnum(FormAuthType),
-  submitterSingpassId: z.string().optional(),
+  submitterId: z.string().optional(),
   myInfoFields: z.array(z.nativeEnum(MyInfoAttribute)).optional(),
   submissionType: z.nativeEnum(SubmissionType),
   responseMetadata: ResponseMetadata.optional(),

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -1,7 +1,7 @@
 import type { Opaque, RequireAtLeastOne } from 'type-fest'
 import { z } from 'zod'
 
-import { ErrorDto } from './core'
+import { ErrorDto, SingleSubmissionValidationErrorDto } from './core'
 import { FormFieldDto, MyInfoAttribute, PaymentFieldsDto } from './field'
 import { FormAuthType } from './form/form'
 import { DateString } from './generic'
@@ -235,10 +235,11 @@ export type SubmissionResponseDto = {
   paymentData?: PaymentSubmissionData
 }
 
-export type SubmissionErrorDto = ErrorDto & {
-  spcpSubmissionFailure?: true
-  isSingleSubmissionValidationFailure?: true
-}
+export type SubmissionErrorDto =
+  | (ErrorDto & {
+      spcpSubmissionFailure?: true
+    })
+  | SingleSubmissionValidationErrorDto
 
 export type SubmissionCountQueryDto =
   | {

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -27,6 +27,7 @@ export type ResponseMetadata = z.infer<typeof ResponseMetadata>
 export const SubmissionBase = z.object({
   form: z.string(),
   authType: z.nativeEnum(FormAuthType),
+  submitterSingpassId: z.string().optional(),
   myInfoFields: z.array(z.nativeEnum(MyInfoAttribute)).optional(),
   submissionType: z.nativeEnum(SubmissionType),
   responseMetadata: ResponseMetadata.optional(),

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -235,7 +235,10 @@ export type SubmissionResponseDto = {
   paymentData?: PaymentSubmissionData
 }
 
-export type SubmissionErrorDto = ErrorDto & { spcpSubmissionFailure?: true }
+export type SubmissionErrorDto = ErrorDto & {
+  spcpSubmissionFailure?: true
+  isSingleSubmissionValidationFailure?: true
+}
 
 export type SubmissionCountQueryDto =
   | {

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -73,6 +73,7 @@ const MOCK_MULTIRESPONDENT_FORM_PARAMS = {
 const FORM_DEFAULTS = {
   authType: 'NIL',
   isNricMaskEnabled: false,
+  isSingleSubmission: false,
   inactiveMessage:
     'If you think this is a mistake, please contact the agency that gave you the form link.',
   isListed: true,

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -2635,6 +2635,7 @@ describe('Form Model', () => {
           admin: MOCK_ADMIN_OBJ_ID,
           authType: FormAuthType.SP,
           isNricMaskEnabled: true,
+          isSingleSubmission: true,
           inactiveMessage: 'inactive_test',
           responseMode: FormResponseMode.Encrypt,
           submissionLimit: 1000,
@@ -2662,6 +2663,9 @@ describe('Form Model', () => {
         )
         expect(duplicatedForm.inactiveMessage).toEqual(
           MOCK_ALL_FORM_PARAMS.inactiveMessage,
+        )
+        expect(duplicatedForm.isSingleSubmission).toEqual(
+          MOCK_ALL_FORM_PARAMS.isSingleSubmission,
         )
       })
     })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -522,6 +522,11 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         default: false,
       },
 
+      isSingleSubmission: {
+        type: Boolean,
+        default: false,
+      },
+
       // This must be before `status` since `status` has setters reliant on
       // whether esrvcId is available, and mongoose@v6 now saves objects with keys
       // in the order the keys are specifified in the schema instead of the object.
@@ -706,6 +711,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       'endPage',
       'authType',
       'isNricMaskEnabled',
+      'isSingleSubmission',
       'inactiveMessage',
       'responseMode',
       'submissionLimit',

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -34,7 +34,6 @@ import {
   WebhookData,
   WebhookView,
 } from '../../types'
-import { DatabaseError } from '../modules/core/core.errors'
 import { getPaymentWebhookEventObject } from '../modules/payments/payment.service.utils'
 import { EmailSubmissionContent } from '../modules/submission/email-submission/email-submission.types'
 import { EncryptSubmissionContent } from '../modules/submission/encrypt-submission/encrypt-submission.types'

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -58,7 +58,7 @@ export const SubmissionSchema = new Schema<ISubmissionSchema, ISubmissionModel>(
       enum: Object.values(FormAuthType),
       default: FormAuthType.NIL,
     },
-    submitterSingpassId: {
+    submitterId: {
       type: String,
     },
     myInfoFields: {
@@ -156,33 +156,32 @@ EmailSubmissionSchema.methods.getWebhookView = function (): Promise<null> {
 }
 
 /**
- * Creates a new email submission only if provided submitterSingpassId is unique.
+ * Creates a new email submission only if provided submitterId is unique.
  * This method ensures that isSingleSubmission is enforced.
- * @param submitterSingpassId uniquely identifies the submitter
+ * @param submitterId uniquely identifies the submitter
  * @returns created submission if successful, null otherwise
  */
-EmailSubmissionSchema.statics.saveIfSubmitterSingpassIdIsUnique =
-  async function (
-    formId: string,
-    submitterSingpassId: string,
-    submissionContent: EmailSubmissionContent,
-  ): Promise<IEmailSubmissionSchema | null> {
-    const res = await this.findOneAndUpdate(
-      { form: formId, submitterSingpassId },
-      { $set: {}, $setOnInsert: { ...submissionContent } },
-      { upsert: true, new: true, rawResult: true },
-    ).exec()
+EmailSubmissionSchema.statics.saveIfSubmitterIdIsUnique = async function (
+  formId: string,
+  submitterId: string,
+  submissionContent: EmailSubmissionContent,
+): Promise<IEmailSubmissionSchema | null> {
+  const res = await this.findOneAndUpdate(
+    { form: formId, submitterId },
+    { $set: {}, $setOnInsert: { ...submissionContent } },
+    { upsert: true, new: true, rawResult: true },
+  ).exec()
 
-    if (!res.lastErrorObject) {
-      throw new DatabaseError(
-        "Execution result from findOneAndUpdatedid did not include expected field 'lastErrorObject'",
-      )
-    }
-    if (res.lastErrorObject.updatedExisting) {
-      return null
-    }
-    return res.value
+  if (!res.lastErrorObject) {
+    throw new DatabaseError(
+      "Execution result from findOneAndUpdatedid did not include expected field 'lastErrorObject'",
+    )
   }
+  if (res.lastErrorObject.updatedExisting) {
+    return null
+  }
+  return res.value
+}
 
 const webhookResponseSchema = new Schema<IWebhookResponseSchema>(
   {
@@ -360,33 +359,32 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
 }
 
 /**
- * Creates a new encrypt submission only if provided submitterSingpassId is unique.
+ * Creates a new encrypt submission only if provided submitterId is unique.
  * This method ensures that isSingleSubmission is enforced.
- * @param submitterSingpassId uniquely identifies the submitter
+ * @param submitterId uniquely identifies the submitter
  * @returns created submission if successful, null otherwise
  */
-EncryptSubmissionSchema.statics.saveIfSubmitterSingpassIdIsUnique =
-  async function (
-    formId: string,
-    submitterSingpassId: string,
-    submissionContent: EncryptSubmissionContent,
-  ): Promise<IEncryptedSubmissionSchema | null> {
-    const res = await this.findOneAndUpdate(
-      { form: formId, submitterSingpassId },
-      { $set: {}, $setOnInsert: { ...submissionContent } },
-      { upsert: true, new: true, rawResult: true },
-    ).exec()
+EncryptSubmissionSchema.statics.saveIfSubmitterIdIsUnique = async function (
+  formId: string,
+  submitterId: string,
+  submissionContent: EncryptSubmissionContent,
+): Promise<IEncryptedSubmissionSchema | null> {
+  const res = await this.findOneAndUpdate(
+    { form: formId, submitterId },
+    { $set: {}, $setOnInsert: { ...submissionContent } },
+    { upsert: true, new: true, rawResult: true },
+  ).exec()
 
-    if (!res.lastErrorObject) {
-      throw new DatabaseError(
-        "Execution result from findOneAndUpdatedid did not include expected field 'lastErrorObject'",
-      )
-    }
-    if (res.lastErrorObject.updatedExisting) {
-      return null
-    }
-    return res.value
+  if (!res.lastErrorObject) {
+    throw new DatabaseError(
+      "Execution result from findOneAndUpdatedid did not include expected field 'lastErrorObject'",
+    )
   }
+  if (res.lastErrorObject.updatedExisting) {
+    return null
+  }
+  return res.value
+}
 
 /**
  * Unexported as the type is only used in {@see findAllMetadataByFormId} for

--- a/src/app/modules/form/admin-form/__tests__/admin-form.payments.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.payments.service.spec.ts
@@ -178,9 +178,33 @@ describe('admin-form.payment.service', () => {
 
         // Assert
         expect(actualResult.isErr()).toBeTrue()
-        expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
-          PaymentConfigurationError,
+        actualResult.mapErr((err) => {
+          expect(err).toBeInstanceOf(PaymentConfigurationError)
+        })
+      })
+
+      it('should not allow payment updates for encrypt forms with isSingleSubmission true', async () => {
+        // Arrange
+        const updatedPaymentSettings: PaymentsUpdateDto = {
+          enabled: true,
+          amount_cents: 100,
+          description: 'some description',
+          payment_type: PaymentType.Fixed,
+        }
+        const mockForm = { ...MOCK_FORM, isSingleSubmission: true }
+
+        // Act
+        const actualResult = await AdminFormPaymentService.updatePayments(
+          mockFormId,
+          mockForm,
+          updatedPaymentSettings,
         )
+
+        // Assert
+        expect(actualResult.isErr()).toBeTrue()
+        actualResult.mapErr((err) => {
+          expect(err).toBeInstanceOf(PaymentConfigurationError)
+        })
       })
     })
 

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -1490,7 +1490,13 @@ describe('admin-form.service', () => {
         emails: ['test@example.com', 'test2@example.com'],
       }
 
-      const PAYMENT_ENABLED_FORM = merge({}, MOCK_ENCRYPT_FORM, {
+      const PAYMENT_ENABLED_FORM_TYPE_1 = merge({}, MOCK_ENCRYPT_FORM, {
+        payments_channel: {
+          channel: PaymentChannel.Stripe,
+        },
+      })
+
+      const PAYMENT_ENABLED_FORM_TYPE_2 = merge({}, MOCK_ENCRYPT_FORM, {
         payments_field: {
           enabled: true,
           amount_cents: 54.22,
@@ -1501,12 +1507,69 @@ describe('admin-form.service', () => {
 
       // Act
       const actualResult = await AdminFormService.updateFormSettings(
-        PAYMENT_ENABLED_FORM,
+        PAYMENT_ENABLED_FORM_TYPE_1,
+        settingsToUpdate,
+      )
+
+      const actualResult2 = await AdminFormService.updateFormSettings(
+        PAYMENT_ENABLED_FORM_TYPE_2,
         settingsToUpdate,
       )
 
       // Assert
       expect(actualResult.isErr()).toBeTrue()
+      actualResult.mapErr((err) => {
+        expect(err).toBeInstanceOf(MalformedParametersError)
+      })
+
+      expect(actualResult2.isErr()).toBeTrue()
+      actualResult2.mapErr((err) => {
+        expect(err).toBeInstanceOf(MalformedParametersError)
+      })
+    })
+
+    it('should not allow isSingleSubmission update to true for payment forms', async () => {
+      // Arrange
+      const settingsToUpdate: SettingsUpdateDto = {
+        isSingleSubmission: true,
+      }
+
+      // Act
+      const PAYMENT_ENABLED_FORM_TYPE_1 = merge({}, MOCK_ENCRYPT_FORM, {
+        payments_channel: {
+          channel: PaymentChannel.Stripe,
+        },
+      })
+
+      const PAYMENT_ENABLED_FORM_TYPE_2 = merge({}, MOCK_ENCRYPT_FORM, {
+        payments_field: {
+          enabled: true,
+          amount_cents: 54.22,
+          description: 'some payment',
+          payment_type: null,
+        },
+      })
+
+      // Assert
+      const actualResult = await AdminFormService.updateFormSettings(
+        PAYMENT_ENABLED_FORM_TYPE_1,
+        settingsToUpdate,
+      )
+
+      const actualResult2 = await AdminFormService.updateFormSettings(
+        PAYMENT_ENABLED_FORM_TYPE_2,
+        settingsToUpdate,
+      )
+
+      expect(actualResult.isErr()).toBeTrue()
+      actualResult.mapErr((err) => {
+        expect(err).toBeInstanceOf(MalformedParametersError)
+      })
+
+      expect(actualResult2.isErr()).toBeTrue()
+      actualResult2.mapErr((err) => {
+        expect(err).toBeInstanceOf(MalformedParametersError)
+      })
     })
   })
 

--- a/src/app/modules/form/admin-form/admin-form.middlewares.ts
+++ b/src/app/modules/form/admin-form/admin-form.middlewares.ts
@@ -22,6 +22,7 @@ export const updateSettingsValidator = celebrate({
   [Segments.BODY]: Joi.object<SettingsUpdateDto>({
     authType: Joi.string().valid(...Object.values(FormAuthType)),
     isNricMaskEnabled: Joi.boolean(),
+    isSingleSubmission: Joi.boolean(),
     emails: Joi.alternatives().try(
       Joi.array().items(Joi.string().email()),
       Joi.string().email({ multiple: true }),

--- a/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -23,7 +23,10 @@ import {
   unlinkStripeAccountFromForm,
   validateAccount,
 } from '../../payments/stripe.service'
-import { checkFormIsEncryptMode } from '../../submission/encrypt-submission/encrypt-submission.service'
+import {
+  assertFormIsSingleSubmissionDisabled,
+  checkFormIsEncryptMode,
+} from '../../submission/encrypt-submission/encrypt-submission.service'
 import { getPopulatedUserById } from '../../user/user.service'
 import * as UserService from '../../user/user.service'
 
@@ -70,6 +73,9 @@ export const handleConnectAccount: ControllerHandler<{
           level: PermissionLevel.Write,
         }),
       )
+      // Payments should not be allowed to connect
+      // since single submission forms do not support it currently.
+      .andThen(assertFormIsSingleSubmissionDisabled)
       // Ensure that the form is encrypt mode.
       .andThen(checkFormIsEncryptMode)
       // Get the auth URL and state, and pass the auth URL for redirection.

--- a/src/app/modules/form/admin-form/admin-form.payments.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.payments.service.ts
@@ -83,6 +83,14 @@ export const updatePayments = (
     )
   }
 
+  if (form.isSingleSubmission) {
+    return errAsync(
+      new PaymentConfigurationError(
+        'Cannot enable payment for form with single submission per submitterId enabled',
+      ),
+    )
+  }
+
   return ResultAsync.fromPromise(
     EncryptedFormModel.updatePaymentsById(formId, newPayments),
     (error) => {

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1068,12 +1068,13 @@ export const updateFormSettings = (
     )
   }
 
-  // Don't allow emails updates if payments_field is enabled on the form and vice versa
+  // Don't allow emails updates or single response per submitterId
+  // if payments_field is enabled on the form
   if (isFormEncryptMode(originalForm)) {
     if (
       (originalForm.payments_channel.channel !== PaymentChannel.Unconnected ||
         originalForm.payments_field.enabled) &&
-      (body as StorageFormSettings).emails
+      ((body as StorageFormSettings).emails || body.isSingleSubmission)
     ) {
       return errAsync(
         new MalformedParametersError(

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -38,7 +38,10 @@ import {
 import { ErrorResponseData } from '../../core/core.types'
 import { InvalidPaymentAmountError } from '../../payments/payments.errors'
 import { StripeAccountError } from '../../payments/stripe.errors'
-import { ResponseModeError } from '../../submission/submission.errors'
+import {
+  ResponseModeError,
+  UnsupportedSettingsError,
+} from '../../submission/submission.errors'
 import { MissingUserError } from '../../user/user.errors'
 import { SmsLimitExceededError } from '../../verification/verification.errors'
 import {
@@ -127,6 +130,11 @@ export const mapRouteError = (
         errorMessage: error.message,
       }
     case MalformedParametersError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+      }
+    case UnsupportedSettingsError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -9,6 +9,7 @@ import {
   FormFieldDto,
   FormResponseMode,
   FormStatus,
+  PublicFormDto,
 } from '../../../../shared/types'
 import {
   IEmailFormModel,
@@ -272,6 +273,50 @@ export const checkFormSubmissionLimitAndDeactivateForm = (
       ),
     )
   })
+}
+
+/**
+ * Verify that if the form is a single submission per submitterId form, the submitterId has not responded
+ * @param form the form to check for
+ * @param submitterId submitterId of current submitter
+ * @returns ok(true) if the form is not a single submission per submitterId form or the submitterId has not responded before
+ * @returns ok(false) if the form is a single submission per submitterId form and submitterId has already responded
+ * @returns err(ApplicationError) if the submitterId is not found
+ * @returns err(PossibleDatabaseError) if an error occurred while querying the database to check for previous responses by same submitterId
+ */
+export const checkHasSingleSubmissionValidationFailure = (
+  form: PublicFormDto,
+  submitterId: string,
+): ResultAsync<boolean, ApplicationError | PossibleDatabaseError> => {
+  const logMeta = {
+    action: 'checkHasSingleSubmissionValidationFailure',
+    formId: form._id,
+  }
+  if (form.isSingleSubmission) {
+    if (!submitterId) {
+      return errAsync(
+        new ApplicationError(
+          'Cannot find submitterId which is required for single submission per submitterId form',
+        ),
+      )
+    }
+    const submissionWithSameSubmitterIdExists = SubmissionModel.exists({
+      form: form._id,
+      submitterId,
+    }).then((result) => result != null)
+    return ResultAsync.fromPromise(
+      submissionWithSameSubmitterIdExists,
+      (error) => {
+        logger.error({
+          message: 'Error while counting submissions for form',
+          meta: logMeta,
+          error,
+        })
+        return transformMongoError(error)
+      },
+    )
+  }
+  return okAsync(false)
 }
 
 export const getFormModelByResponseMode = (

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -276,7 +276,7 @@ export const checkFormSubmissionLimitAndDeactivateForm = (
 }
 
 /**
- * Verify that if the form is a single submission per submitterId form, the submitterId has not responded
+ * Verify that if the form is a single submission per submitterId form, the submitterId does not exist.
  * @param form the form to check for
  * @param submitterId submitterId of current submitter
  * @returns ok(true) if the form is not a single submission per submitterId form or the submitterId has not responded before

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -292,31 +292,31 @@ export const checkHasSingleSubmissionValidationFailure = (
     action: 'checkHasSingleSubmissionValidationFailure',
     formId: form._id,
   }
-  if (form.isSingleSubmission) {
-    if (!submitterId) {
-      return errAsync(
-        new ApplicationError(
-          'Cannot find submitterId which is required for single submission per submitterId form',
-        ),
-      )
-    }
-    const submissionWithSameSubmitterIdExists = SubmissionModel.exists({
-      form: form._id,
-      submitterId,
-    }).then((result) => result != null)
-    return ResultAsync.fromPromise(
-      submissionWithSameSubmitterIdExists,
-      (error) => {
-        logger.error({
-          message: 'Error while counting submissions for form',
-          meta: logMeta,
-          error,
-        })
-        return transformMongoError(error)
-      },
+  if (!form.isSingleSubmission) {
+    return okAsync(false)
+  }
+
+  if (!submitterId) {
+    return errAsync(
+      new ApplicationError(
+        'Cannot find submitterId which is required for single submission per submitterId form',
+      ),
     )
   }
-  return okAsync(false)
+  return ResultAsync.fromPromise(
+    SubmissionModel.exists({
+      form: form._id,
+      submitterId,
+    }),
+    (error) => {
+      logger.error({
+        message: 'Error while counting submissions for form',
+        meta: logMeta,
+        error,
+      })
+      return transformMongoError(error)
+    },
+  ).andThen((result) => okAsync(result !== null))
 }
 
 export const getFormModelByResponseMode = (

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -52,6 +52,7 @@ import {
 import * as FormService from '../../form.service'
 import * as PublicFormController from '../public-form.controller'
 import * as PublicFormService from '../public-form.service'
+import { getCookieNameByAuthType } from '../public-form.service'
 
 jest.mock('../public-form.service')
 jest.mock('../../form.service')
@@ -604,6 +605,70 @@ describe('public-form.controller', () => {
           form: MOCK_CP_FORM.getPublicView(),
           isIntranetUser: false,
         })
+      })
+    })
+
+    describe('errors due to single submission per submitterId violation', () => {
+      const MOCK_SP_FORM = {
+        ...BASE_FORM,
+        authType: FormAuthType.SP,
+      } as unknown as IPopulatedForm
+      const MOCK_SPCP_SESSION = {
+        userName: 'submitterId',
+        exp: 1000000000,
+        iat: 100000000,
+        rememberMe: false,
+      }
+      it('should return 200 but with single submission validation failure flag when submitterId already submitted for form id', async () => {
+        MockAuthService.getFormIfPublic.mockReturnValueOnce(
+          okAsync(MOCK_SP_FORM),
+        )
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+          okAsync(MOCK_SP_FORM),
+        )
+        jest
+          .spyOn(SpOidcServiceClass.prototype, 'extractJwtPayloadFromRequest')
+          .mockReturnValueOnce(okAsync(MOCK_SPCP_SESSION))
+
+        const checkHasSingleSubmissionValidationFailureSpy = jest
+          .spyOn(MockFormService, 'checkHasSingleSubmissionValidationFailure')
+          .mockResolvedValueOnce(okAsync(true))
+
+        const mockRes = expressHandler.mockResponse()
+
+        // Act
+        await PublicFormController.handleGetPublicForm(
+          MOCK_REQ,
+          mockRes,
+          jest.fn(),
+        )
+
+        // Assert that the submitterId is hashed when compared
+        expect(
+          checkHasSingleSubmissionValidationFailureSpy.mock.calls[0][1],
+        ).toEqual(
+          '151c329a583a82e4a768f16ab8c9b7ae621fcfdea574e87925dd56d7f73e367d',
+        )
+
+        // Assert that status is not set, which defaults to intended 200 ok
+        expect(mockRes.status).not.toHaveBeenCalled()
+        // Assert that the form details is still returned so that FE can populate the title
+        expect((mockRes.json as jest.Mock).mock.calls[0][0].form).toEqual(
+          MOCK_SP_FORM.getPublicView(),
+        )
+        // Assert that the response contains the single submission validation failure flag
+        expect(
+          (mockRes.json as jest.Mock).mock.calls[0][0]
+            .hasSingleSubmissionValidationFailure,
+        ).toEqual(true)
+
+        // Assert user is logged out
+        expect((mockRes.json as jest.Mock).mock.calls[0][0]).not.toContainKey(
+          'spcpSession',
+        )
+        expect(mockRes.clearCookie).toHaveBeenCalledOnceWith(
+          getCookieNameByAuthType(FormAuthType.SP),
+        )
       })
     })
 

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -133,6 +133,9 @@ describe('public-form.controller', () => {
 
       beforeAll(() => {
         MockFormService.checkIsIntranetFormAccess.mockReturnValue(false)
+        MockFormService.checkHasSingleSubmissionValidationFailure.mockReturnValue(
+          okAsync(false),
+        )
       })
 
       it('should return 200 when there is no FormAuthType on the request', async () => {

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -326,7 +326,7 @@ export const handleGetPublicForm: ControllerHandler<
   const hasSingleSubmissionValidationFailureResult =
     await FormService.checkHasSingleSubmissionValidationFailure(
       publicForm,
-      generateHashedSubmitterId(spcpSession.userName),
+      generateHashedSubmitterId(spcpSession.userName, form.id),
     )
 
   if (hasSingleSubmissionValidationFailureResult.isErr()) {

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -20,6 +20,7 @@ import { createReqMeta, getRequestIp } from '../../../utils/request'
 import { getFormIfPublic } from '../../auth/auth.service'
 import * as BillingService from '../../billing/billing.service'
 import { ControllerHandler } from '../../core/core.types'
+import { MyInfoData } from '../../myinfo/myinfo.adapter'
 import {
   MYINFO_AUTH_CODE_COOKIE_NAME,
   MYINFO_AUTH_CODE_COOKIE_OPTIONS,
@@ -52,6 +53,7 @@ import {
   getRedirectTargetSpcpOidc,
   validateSpcpForm,
 } from '../../spcp/spcp.util'
+import { generateHashedSubmitterId } from '../../submission/submission.utils'
 import { AuthTypeMismatchError, PrivateFormError } from '../form.errors'
 import * as FormService from '../form.service'
 
@@ -120,57 +122,61 @@ export const handleGetPublicForm: ControllerHandler<
     form,
   )
 
+  if (authType === FormAuthType.NIL) {
+    return res.json({ form: publicForm, isIntranetUser })
+  }
+
+  let spcpSession
+  let myInfoFields
+
+  // extract spcpSession and myInfoFields based on authType
   switch (authType) {
-    case FormAuthType.NIL:
-      return res.json({ form: publicForm, isIntranetUser })
-    case FormAuthType.SP:
-      return getOidcService(FormAuthType.SP)
-        .extractJwtPayloadFromRequest(req.cookies)
-        .map((spcpSession) => {
-          return res.json({
-            form: publicForm,
-            isIntranetUser,
-            spcpSession,
+    case FormAuthType.SP: {
+      const oidcService = getOidcService(FormAuthType.SP)
+      const jwtPayloadResult = await oidcService.extractJwtPayloadFromRequest(
+        req.cookies,
+      )
+      if (jwtPayloadResult.isErr()) {
+        const error = jwtPayloadResult.error
+        // Report only relevant errors - verification failed for user here
+        if (
+          error instanceof VerifyJwtError ||
+          error instanceof InvalidJwtError
+        ) {
+          logger.error({
+            message: 'Error getting public form',
+            meta: logMeta,
+            error,
           })
-        })
-        .mapErr((error) => {
-          // Report only relevant errors - verification failed for user here
-          if (
-            error instanceof VerifyJwtError ||
-            error instanceof InvalidJwtError
-          ) {
-            logger.error({
-              message: 'Error getting public form',
-              meta: logMeta,
-              error,
-            })
-          }
-          return res.json({ form: publicForm, isIntranetUser })
-        })
-    case FormAuthType.CP:
-      return getOidcService(FormAuthType.CP)
-        .extractJwtPayloadFromRequest(req.cookies)
-        .map((spcpSession) => {
-          return res.json({
-            form: publicForm,
-            isIntranetUser,
-            spcpSession,
+        }
+        return res.json({ form: publicForm, isIntranetUser })
+      }
+      spcpSession = jwtPayloadResult.value
+      break
+    }
+    case FormAuthType.CP: {
+      const oidcService = getOidcService(FormAuthType.CP)
+      const jwtPayloadResult = await oidcService.extractJwtPayloadFromRequest(
+        req.cookies,
+      )
+      if (jwtPayloadResult.isErr()) {
+        const error = jwtPayloadResult.error
+        // Report only relevant errors - verification failed for user here
+        if (
+          error instanceof VerifyJwtError ||
+          error instanceof InvalidJwtError
+        ) {
+          logger.error({
+            message: 'Error getting public form',
+            meta: logMeta,
+            error,
           })
-        })
-        .mapErr((error) => {
-          // Report only relevant errors - verification failed for user here
-          if (
-            error instanceof VerifyJwtError ||
-            error instanceof InvalidJwtError
-          ) {
-            logger.error({
-              message: 'Error getting public form',
-              meta: logMeta,
-              error,
-            })
-          }
-          return res.json({ form: publicForm, isIntranetUser })
-        })
+        }
+        return res.json({ form: publicForm, isIntranetUser })
+      }
+      spcpSession = jwtPayloadResult.value
+      break
+    }
     case FormAuthType.MyInfo: {
       // We always want to clear existing login cookies because we no longer
       // have the prefilled data
@@ -184,103 +190,60 @@ export const handleGetPublicForm: ControllerHandler<
           isIntranetUser,
         })
       }
-
       // Clear auth code cookie once found, as it can't be reused
       res.clearCookie(
         MYINFO_AUTH_CODE_COOKIE_NAME,
         MYINFO_AUTH_CODE_COOKIE_OPTIONS,
       )
-
-      // Step 1. Fetch required data and fill the form based off data retrieved
-      return extractAuthCode(authCodeCookie)
+      const myInfoFieldsResult = await extractAuthCode(authCodeCookie)
         .asyncAndThen((authCode) => MyInfoService.retrieveAccessToken(authCode))
         .andThen((accessToken) =>
           MyInfoService.getMyInfoDataForForm(form, accessToken),
         )
-        .andThen((myInfoData) =>
-          BillingService.recordLoginByForm(form).map(() => myInfoData),
-        )
-        .andThen((myInfoData) => {
-          return MyInfoService.prefillAndSaveMyInfoFields(
-            form._id,
-            myInfoData,
-            form.toJSON().form_fields,
-          ).map((prefilledFields) => ({
-            prefilledFields,
-            spcpSession: { userName: myInfoData.getUinFin() },
-            myInfoLoginCookie: createMyInfoLoginCookie(myInfoData.getUinFin()),
-            myInfoChildrenBirthRecords: myInfoData.getChildrenBirthRecords(
-              form.getUniqueMyInfoAttrs(),
-            ),
-          }))
+
+      if (myInfoFieldsResult.isErr()) {
+        const error = myInfoFieldsResult.error
+        logger.error({
+          message: 'MyInfo login error',
+          meta: logMeta,
+          error,
         })
-        .map(
-          ({
-            myInfoLoginCookie,
-            prefilledFields,
-            spcpSession,
-            myInfoChildrenBirthRecords,
-          }) => {
-            // Set the updated cookie accordingly and return the form back to the user
-            return res
-              .cookie(
-                MYINFO_LOGIN_COOKIE_NAME,
-                myInfoLoginCookie,
-                MYINFO_LOGIN_COOKIE_OPTIONS,
-              )
-              .json({
-                spcpSession,
-                form: {
-                  ...publicForm,
-                  form_fields: prefilledFields as FormFieldDto[],
-                },
-                isIntranetUser,
-                myInfoChildrenBirthRecords,
-              })
-          },
-        )
-        .mapErr((error) => {
+        // No need for cookie if data could not be retrieved
+        // NOTE: If the user does not have any cookie, clearing the cookie still has the same result
+        return res.json({
+          form: publicForm,
+          myInfoError: true,
+          isIntranetUser,
+        })
+      }
+      myInfoFields = myInfoFieldsResult.value
+      spcpSession = { userName: myInfoFields.getUinFin() }
+      break
+    }
+    case FormAuthType.SGID: {
+      const jwtPayloadResult = await SgidService.extractSgidSingpassJwtPayload(
+        req.cookies[SGID_COOKIE_NAME],
+      )
+      if (jwtPayloadResult.isErr()) {
+        const error = jwtPayloadResult.error
+        // Report only relevant errors - verification failed for user here
+        if (
+          error instanceof SgidVerifyJwtError ||
+          error instanceof SgidInvalidJwtError
+        ) {
           logger.error({
-            message: 'MyInfo login error',
+            message: 'Error getting public form',
             meta: logMeta,
             error,
           })
-          // No need for cookie if data could not be retrieved
-          // NOTE: If the user does not have any cookie, clearing the cookie still has the same result
-          return res.json({
-            form: publicForm,
-            myInfoError: true,
-            isIntranetUser,
-          })
-        })
+        }
+        return res.json({ form: publicForm, isIntranetUser })
+      }
+      spcpSession = jwtPayloadResult.value
+      break
     }
-    case FormAuthType.SGID:
-      return SgidService.extractSgidSingpassJwtPayload(
-        req.cookies[SGID_COOKIE_NAME],
-      )
-        .map((spcpSession) => {
-          return res.json({
-            form: publicForm,
-            isIntranetUser,
-            spcpSession,
-          })
-        })
-        .mapErr((error) => {
-          // Report only relevant errors - verification failed for user here
-          if (
-            error instanceof SgidVerifyJwtError ||
-            error instanceof SgidInvalidJwtError
-          ) {
-            logger.error({
-              message: 'Error getting public form',
-              meta: logMeta,
-              error,
-            })
-          }
-          return res.json({ form: publicForm, isIntranetUser })
-        })
     case FormAuthType.SGID_MyInfo: {
-      const parseSgidMyInfoCookie = Result.fromThrowable(
+      const parseSgidMyInfoCookieResult = Result.fromThrowable(
         () =>
           JSON.parse(req.cookies[SGID_MYINFO_COOKIE_NAME] ?? '{}') as {
             jwt?: string
@@ -294,65 +257,223 @@ export const handleGetPublicForm: ControllerHandler<
           })
           return new SgidMalformedMyInfoCookieError()
         },
-      )
-      return parseSgidMyInfoCookie()
-        .mapErr(() =>
-          res.json({
-            form: publicForm,
-            isIntranetUser,
-          }),
+      )()
+
+      if (parseSgidMyInfoCookieResult.isErr()) {
+        return res.json({
+          form: publicForm,
+          isIntranetUser,
+        })
+      }
+
+      const parseSgidMyInfoCookie = parseSgidMyInfoCookieResult.value
+      const { jwt: accessToken = '', sub = '' } = parseSgidMyInfoCookie
+
+      if (!accessToken) {
+        return res.json({
+          form: publicForm,
+          isIntranetUser,
+        })
+      }
+      res.clearCookie(SGID_MYINFO_COOKIE_NAME)
+      res.clearCookie(SGID_MYINFO_LOGIN_COOKIE_NAME)
+
+      const jwtPayloadResult =
+        await SgidService.extractSgidJwtMyInfoPayload(accessToken)
+      if (jwtPayloadResult.isErr()) {
+        const error = jwtPayloadResult.error
+        logger.error({
+          message: 'sgID: MyInfo login error',
+          meta: logMeta,
+          error,
+        })
+        return res.json({
+          form: publicForm,
+          myInfoError: true,
+          isIntranetUser,
+        })
+      }
+      const jwtPayload = jwtPayloadResult.value
+      const myInfoFieldsResult = await SgidService.retrieveUserInfo({
+        accessToken: jwtPayload.accessToken,
+        sub,
+      })
+
+      if (myInfoFieldsResult.isErr()) {
+        const error = myInfoFieldsResult.error
+        logger.error({
+          message: 'sgID: MyInfo login error',
+          meta: logMeta,
+          error,
+        })
+        return res.json({
+          form: publicForm,
+          myInfoError: true,
+          isIntranetUser,
+        })
+      }
+
+      myInfoFields = new SGIDMyInfoData(myInfoFieldsResult.value.data)
+      spcpSession = { userName: myInfoFields.getUinFin() }
+      break
+    }
+    default: {
+      return new UnreachableCaseError(authType)
+    }
+  }
+
+  // validate for isSingleSubmission
+  const hasSingleSubmissionValidationFailureResult =
+    await FormService.checkHasSingleSubmissionValidationFailure(
+      publicForm,
+      generateHashedSubmitterId(spcpSession.userName),
+    )
+
+  if (hasSingleSubmissionValidationFailureResult.isErr()) {
+    const error = hasSingleSubmissionValidationFailureResult.error
+    logger.error({
+      message: 'Error validating single submission constraint',
+      meta: logMeta,
+      error,
+    })
+    return res.sendStatus(HttpStatusCode.InternalServerError)
+  }
+
+  const hasSingleSubmissionValidationFailure =
+    hasSingleSubmissionValidationFailureResult.value
+
+  // Do not log user in for the form
+  // if there is a single submission validation failure
+  if (hasSingleSubmissionValidationFailure) {
+    spcpSession = undefined
+    const authCookieName = PublicFormService.getCookieNameByAuthType(authType)
+    res.clearCookie(authCookieName)
+  }
+
+  // generate form response based on authType
+  switch (authType) {
+    case FormAuthType.SP:
+    case FormAuthType.CP:
+      return res.json({
+        form: publicForm,
+        isIntranetUser,
+        spcpSession,
+        hasSingleSubmissionValidationFailure,
+      })
+    case FormAuthType.MyInfo: {
+      if (!myInfoFields) {
+        logger.error({
+          message: 'Failed to load MyInfo fields',
+          meta: logMeta,
+        })
+        // No need for cookie if data could not be retrieved
+        // NOTE: If the user does not have any cookie, clearing the cookie still has the same result
+        return res.json({
+          form: publicForm,
+          myInfoError: true,
+          isIntranetUser,
+        })
+      }
+      await BillingService.recordLoginByForm(form)
+      const prefilledFieldsResult =
+        await MyInfoService.prefillAndSaveMyInfoFields(
+          form._id,
+          myInfoFields,
+          form.toJSON().form_fields,
         )
-        .map(({ jwt: accessToken = '', sub = '' }) => {
-          if (!accessToken) {
-            return res.json({
-              form: publicForm,
-              isIntranetUser,
-            })
-          }
-          res.clearCookie(SGID_MYINFO_COOKIE_NAME)
-          res.clearCookie(SGID_MYINFO_LOGIN_COOKIE_NAME)
-          return SgidService.extractSgidJwtMyInfoPayload(accessToken)
-            .asyncAndThen((auth) =>
-              SgidService.retrieveUserInfo({
-                accessToken: auth.accessToken,
-                sub,
-              }),
-            )
-            .andThen((userInfo) => {
-              const data = new SGIDMyInfoData(userInfo.data)
-              return MyInfoService.prefillAndSaveMyInfoFields(
-                form._id,
-                data,
-                form.toJSON().form_fields,
-              ).map((prefilledFields) => {
-                return res
-                  .cookie(
-                    SGID_MYINFO_LOGIN_COOKIE_NAME,
-                    createMyInfoLoginCookie(data.getUinFin()),
-                    MYINFO_LOGIN_COOKIE_OPTIONS,
-                  )
-                  .json({
-                    form: {
-                      ...publicForm,
-                      form_fields: prefilledFields as FormFieldDto[],
-                    },
-                    spcpSession: { userName: data.getUinFin() },
-                    isIntranetUser,
-                  })
-              })
-            })
-            .mapErr((error) => {
-              logger.error({
-                message: 'sgID: MyInfo login error',
-                meta: logMeta,
-                error,
-              })
-              return res.json({
-                form: publicForm,
-                myInfoError: true,
-                isIntranetUser,
-              })
-            })
+
+      if (prefilledFieldsResult.isErr()) {
+        const error = prefilledFieldsResult.error
+        logger.error({
+          message: 'MyInfo: Failed to prefill and save MyInfo fields',
+          meta: logMeta,
+          error,
+        })
+        return res.json({
+          form: publicForm,
+          myInfoError: true,
+          isIntranetUser,
+        })
+      }
+
+      const prefilledFields = prefilledFieldsResult.value
+
+      return res
+        .cookie(
+          MYINFO_LOGIN_COOKIE_NAME,
+          createMyInfoLoginCookie(myInfoFields.getUinFin()),
+          MYINFO_LOGIN_COOKIE_OPTIONS,
+        )
+        .json({
+          spcpSession,
+          form: {
+            ...publicForm,
+            form_fields: prefilledFields as FormFieldDto[],
+          },
+          isIntranetUser,
+          myInfoChildrenBirthRecords: (
+            myInfoFields as MyInfoData
+          ).getChildrenBirthRecords(form.getUniqueMyInfoAttrs()),
+          hasSingleSubmissionValidationFailure,
+        })
+    }
+    case FormAuthType.SGID:
+      return res.json({
+        form: publicForm,
+        isIntranetUser,
+        spcpSession,
+        hasSingleSubmissionValidationFailure,
+      })
+    case FormAuthType.SGID_MyInfo: {
+      if (!myInfoFields) {
+        logger.error({
+          message: 'sgID_MyInfo: Failed to load MyInfo fields',
+          meta: logMeta,
+        })
+        // No need for cookie if data could not be retrieved
+        // NOTE: If the user does not have any cookie, clearing the cookie still has the same result
+        return res.json({
+          form: publicForm,
+          myInfoError: true,
+          isIntranetUser,
+        })
+      }
+      const prefilledFieldsResult =
+        await MyInfoService.prefillAndSaveMyInfoFields(
+          form._id,
+          myInfoFields,
+          form.toJSON().form_fields,
+        )
+
+      if (prefilledFieldsResult.isErr()) {
+        const error = prefilledFieldsResult.error
+        logger.error({
+          message: 'sgID_MyInfo: Failed to prefill and save MyInfo fields',
+          meta: logMeta,
+          error,
+        })
+        return res.json({
+          form: publicForm,
+          myInfoError: true,
+          isIntranetUser,
+        })
+      }
+
+      const prefilledFields = prefilledFieldsResult.value
+      return res
+        .cookie(
+          SGID_MYINFO_LOGIN_COOKIE_NAME,
+          createMyInfoLoginCookie(myInfoFields.getUinFin()),
+          MYINFO_LOGIN_COOKIE_OPTIONS,
+        )
+        .json({
+          form: {
+            ...publicForm,
+            form_fields: prefilledFields as FormFieldDto[],
+          },
+          spcpSession: { userName: myInfoFields.getUinFin() },
+          isIntranetUser,
+          hasSingleSubmissionValidationFailure,
         })
     }
     default:

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -348,6 +348,12 @@ export const handleGetPublicForm: ControllerHandler<
     spcpSession = undefined
     const authCookieName = PublicFormService.getCookieNameByAuthType(authType)
     res.clearCookie(authCookieName)
+
+    return res.json({
+      form: publicForm, // do not need to pre-fill even if MyInfo since user is not logged in
+      isIntranetUser,
+      hasSingleSubmissionValidationFailure: true,
+    })
   }
 
   // generate form response based on authType
@@ -358,7 +364,6 @@ export const handleGetPublicForm: ControllerHandler<
         form: publicForm,
         isIntranetUser,
         spcpSession,
-        hasSingleSubmissionValidationFailure,
       })
     case FormAuthType.MyInfo: {
       if (!myInfoFields) {
@@ -414,7 +419,6 @@ export const handleGetPublicForm: ControllerHandler<
           myInfoChildrenBirthRecords: (
             myInfoFields as MyInfoData
           ).getChildrenBirthRecords(form.getUniqueMyInfoAttrs()),
-          hasSingleSubmissionValidationFailure,
         })
     }
     case FormAuthType.SGID:
@@ -422,7 +426,6 @@ export const handleGetPublicForm: ControllerHandler<
         form: publicForm,
         isIntranetUser,
         spcpSession,
-        hasSingleSubmissionValidationFailure,
       })
     case FormAuthType.SGID_MyInfo: {
       if (!myInfoFields) {
@@ -473,7 +476,6 @@ export const handleGetPublicForm: ControllerHandler<
           },
           spcpSession: { userName: myInfoFields.getUinFin() },
           isIntranetUser,
-          hasSingleSubmissionValidationFailure,
         })
     }
     default:

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.controller.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.controller.spec.ts
@@ -1,10 +1,13 @@
 import expressHandler from '__tests__/unit/backend/helpers/jest-express'
 import { ObjectId } from 'bson'
+import { merge } from 'lodash'
 import { ok, okAsync } from 'neverthrow'
 import { FormAuthType } from 'shared/types'
 
 import * as FormService from 'src/app/modules/form/form.service'
 import { SgidService } from 'src/app/modules/sgid/sgid.service'
+import * as OidcService from 'src/app/modules/spcp/spcp.oidc.service/index'
+import { OidcServiceType } from 'src/app/modules/spcp/spcp.oidc.service/spcp.oidc.service.types'
 import * as EmailSubmissionService from 'src/app/modules/submission/email-submission/email-submission.service'
 import * as SubmissionService from 'src/app/modules/submission/submission.service'
 import MailService from 'src/app/services/mail/mail.service'
@@ -15,13 +18,17 @@ import {
   IPopulatedForm,
 } from 'src/types'
 
-import { getCookieNameByAuthType } from '../../submission.utils'
+import {
+  generateHashedSubmitterId,
+  getCookieNameByAuthType,
+} from '../../submission.utils'
 import { submitEmailModeForm } from '../email-submission.controller'
 
 jest.mock(
   'src/app/modules/submission/email-submission/email-submission.service',
 )
 jest.mock('src/app/modules/form/form.service')
+jest.mock('src/app/modules/spcp/spcp.oidc.service')
 jest.mock('src/app/modules/submission/submission.service')
 jest.mock('src/app/modules/sgid/sgid.service')
 jest.mock('src/app/modules/submission/submissions.statsd-client')
@@ -32,6 +39,7 @@ const MockFormService = jest.mocked(FormService)
 const MockSubmissionService = jest.mocked(SubmissionService)
 const MockSgidService = jest.mocked(SgidService)
 const MockMailService = jest.mocked(MailService)
+const MockOidcService = jest.mocked(OidcService)
 
 describe('email-submission.controller', () => {
   beforeEach(() => {
@@ -39,31 +47,186 @@ describe('email-submission.controller', () => {
       hash: 'some hash',
       salt: 'some salt',
     }
-    MockEmailSubmissionService.hashSubmission.mockReturnValueOnce(
+    MockEmailSubmissionService.hashSubmission.mockReturnValue(
       okAsync(MOCK_SUBMISSION_HASH),
     )
-    MockEmailSubmissionService.saveSubmissionMetadata.mockReturnValueOnce(
+    MockEmailSubmissionService.saveSubmissionMetadata.mockReturnValue(
       okAsync({} as IEmailSubmissionSchema),
     )
-    MockFormService.isFormPublic.mockReturnValueOnce(ok(true))
+    MockFormService.isFormPublic.mockReturnValue(ok(true))
 
-    MockMailService.sendSubmissionToAdmin.mockReturnValueOnce(okAsync(true))
+    MockMailService.sendSubmissionToAdmin.mockReturnValue(okAsync(true))
 
-    MockSubmissionService.validateAttachments.mockReturnValueOnce(okAsync(true))
-    MockSubmissionService.sendEmailConfirmations.mockReturnValueOnce(
-      okAsync(true),
-    )
+    MockSubmissionService.validateAttachments.mockReturnValue(okAsync(true))
+    MockSubmissionService.sendEmailConfirmations.mockReturnValue(okAsync(true))
   })
   afterEach(() => {
     jest.clearAllMocks()
   })
 
   describe('submitterId', () => {
+    const MOCK_COOKIE_TIMESTAMP = {
+      iat: 1,
+      exp: 1,
+    }
+    it('should have same submitterId if same uen but different nric for corppass', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockIsSingleSubmissionEnabledEmailModeForm = {
+        _id: mockFormId,
+        id: mockFormId.toHexString(),
+        title: 'some form',
+        authType: FormAuthType.CP,
+        form_fields: [] as FormFieldSchema[],
+      } as IPopulatedForm
+
+      const UEN = 'uen'
+      const NRIC_1 = 'S1234567A'
+      const NRIC_2 = 'S1234567B'
+      const MOCK_JWT_PAYLOAD_1 = {
+        userName: UEN,
+        userInfo: NRIC_1,
+        rememberMe: false,
+      }
+      const MOCK_JWT_PAYLOAD_2 = {
+        userName: UEN,
+        userInfo: NRIC_2,
+        rememberMe: false,
+      }
+
+      MockOidcService.getOidcService
+        .mockReturnValueOnce({
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          extractJwt: (_arg1) => ok('jwt'),
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          extractJwtPayload: (_arg1) =>
+            okAsync(merge(MOCK_JWT_PAYLOAD_1, MOCK_COOKIE_TIMESTAMP)),
+        } as OidcServiceType<FormAuthType.CP>)
+        .mockReturnValueOnce({
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          extractJwt: (_arg1) => ok('jwt'),
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          extractJwtPayload: (_arg1) =>
+            okAsync(merge(MOCK_JWT_PAYLOAD_2, MOCK_COOKIE_TIMESTAMP)),
+        } as OidcServiceType<FormAuthType.CP>)
+
+      MockFormService.retrieveFullFormById.mockReturnValue(
+        okAsync(mockIsSingleSubmissionEnabledEmailModeForm),
+      )
+      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValue(
+        ok(mockIsSingleSubmissionEnabledEmailModeForm as IPopulatedEmailForm),
+      )
+      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValue(
+        okAsync(mockIsSingleSubmissionEnabledEmailModeForm),
+      )
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: 'some id' },
+        body: {
+          responses: [],
+        },
+      })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
+
+      // Act
+      await submitEmailModeForm(mockReq, mockRes, jest.fn())
+      await submitEmailModeForm(mockReq, mockRes, jest.fn())
+
+      // Assert
+      expect(
+        MockEmailSubmissionService.saveSubmissionMetadata,
+      ).toHaveBeenCalledTimes(2)
+      expect(
+        MockEmailSubmissionService.saveSubmissionMetadata.mock.calls[0][3],
+      ).toEqual(
+        MockEmailSubmissionService.saveSubmissionMetadata.mock.calls[1][3],
+      )
+    })
+
+    it('should have different submitterId if different uen but same nric for corppass', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockIsSingleSubmissionEnabledEmailModeForm = {
+        _id: mockFormId,
+        id: mockFormId.toHexString(),
+        title: 'some form',
+        authType: FormAuthType.CP,
+        form_fields: [] as FormFieldSchema[],
+      } as IPopulatedForm
+
+      const UEN_1 = 'uen1'
+      const UEN_2 = 'uen2'
+      const NRIC = 'S1234567A'
+      const MOCK_JWT_PAYLOAD_1 = {
+        userName: UEN_1,
+        userInfo: NRIC,
+        rememberMe: false,
+      }
+      const MOCK_JWT_PAYLOAD_2 = {
+        userName: UEN_2,
+        userInfo: NRIC,
+        rememberMe: false,
+      }
+
+      MockOidcService.getOidcService
+        .mockReturnValueOnce({
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          extractJwt: (_arg1) => ok('jwt'),
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          extractJwtPayload: (_arg1) =>
+            okAsync(merge(MOCK_JWT_PAYLOAD_1, MOCK_COOKIE_TIMESTAMP)),
+        } as OidcServiceType<FormAuthType.CP>)
+        .mockReturnValueOnce({
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          extractJwt: (_arg1) => ok('jwt'),
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          extractJwtPayload: (_arg1) =>
+            okAsync(merge(MOCK_JWT_PAYLOAD_2, MOCK_COOKIE_TIMESTAMP)),
+        } as OidcServiceType<FormAuthType.CP>)
+
+      MockFormService.retrieveFullFormById.mockReturnValue(
+        okAsync(mockIsSingleSubmissionEnabledEmailModeForm),
+      )
+      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValue(
+        ok(mockIsSingleSubmissionEnabledEmailModeForm as IPopulatedEmailForm),
+      )
+      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValue(
+        okAsync(mockIsSingleSubmissionEnabledEmailModeForm),
+      )
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: 'some id' },
+        body: {
+          responses: [],
+        },
+      })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
+
+      // Act
+      await submitEmailModeForm(mockReq, mockRes, jest.fn())
+      await submitEmailModeForm(mockReq, mockRes, jest.fn())
+
+      // Assert
+      expect(
+        MockEmailSubmissionService.saveSubmissionMetadata,
+      ).toHaveBeenCalledTimes(2)
+      expect(
+        MockEmailSubmissionService.saveSubmissionMetadata.mock.calls[0][3],
+      ).not.toEqual(
+        MockEmailSubmissionService.saveSubmissionMetadata.mock.calls[1][3],
+      )
+    })
+
     it('should hash submitterId if form is individual singpass type', async () => {
       // Arrange
       const mockFormId = new ObjectId()
       const mockIsSingleSubmissionEnabledEmailModeForm = {
         _id: mockFormId,
+        id: mockFormId.toHexString(),
         title: 'some form',
         authType: FormAuthType.SGID,
         form_fields: [] as FormFieldSchema[],
@@ -110,42 +273,45 @@ describe('email-submission.controller', () => {
       expect(
         MockEmailSubmissionService.saveSubmissionMetadata.mock.calls[0][3],
       ).toEqual(
-        '151c329a583a82e4a768f16ab8c9b7ae621fcfdea574e87925dd56d7f73e367d',
-      )
-    })
-  })
-
-  describe('single submission per submitterId', () => {
-    it('should return 200 ok and logout user when successfully submit form with single submission enabled', async () => {
-      // Arrange
-      const mockFormId = new ObjectId()
-      const mockSgidAuthTypeAndIsSingleSubmissionEnabledForm = {
-        _id: mockFormId,
-        title: 'some form',
-        authType: FormAuthType.SGID,
-        isSingleSubmission: true,
-        form_fields: [] as FormFieldSchema[],
-      } as IPopulatedForm
-      const MOCK_JWT_PAYLOAD_WITH_NRIC = {
-        userName: 'S1234567A',
-      }
-      const MOCK_VALID_SGID_PAYLOAD = {
-        userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
-        rememberMe: false,
-      }
-      MockFormService.retrieveFullFormById.mockReturnValueOnce(
-        okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
-      )
-      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
-        ok(
-          mockSgidAuthTypeAndIsSingleSubmissionEnabledForm as IPopulatedEmailForm,
+        generateHashedSubmitterId(
+          MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
+          mockIsSingleSubmissionEnabledEmailModeForm.id,
         ),
       )
-      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
-        okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+    })
+
+    it('should hash submitterId for CP form', async () => {
+      // Arrange
+      const MOCK_JWT_PAYLOAD = {
+        userName: 'uen',
+        userInfo: 'S1234567A',
+        rememberMe: false,
+      }
+      MockOidcService.getOidcService.mockReturnValueOnce({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        extractJwt: (_arg1) => ok('jwt'),
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        extractJwtPayload: (_arg1) =>
+          okAsync(merge(MOCK_JWT_PAYLOAD, MOCK_COOKIE_TIMESTAMP)),
+      } as OidcServiceType<FormAuthType.CP>)
+
+      const mockFormId = new ObjectId()
+      const mockIsSingleSubmissionEnabledEmailModeForm = {
+        _id: mockFormId,
+        id: mockFormId.toHexString(),
+        title: 'some form',
+        authType: FormAuthType.CP,
+        form_fields: [] as FormFieldSchema[],
+      } as IPopulatedForm
+
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(mockIsSingleSubmissionEnabledEmailModeForm),
       )
-      MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
-        ok(MOCK_VALID_SGID_PAYLOAD),
+      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
+        ok(mockIsSingleSubmissionEnabledEmailModeForm as IPopulatedEmailForm),
+      )
+      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+        okAsync(mockIsSingleSubmissionEnabledEmailModeForm),
       )
 
       const mockReq = expressHandler.mockRequest({
@@ -161,194 +327,256 @@ describe('email-submission.controller', () => {
       // Act
       await submitEmailModeForm(mockReq, mockRes, jest.fn())
 
-      // Assert email should be sent
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+      // Assert the saving of submission metadata is called with the hashed submitterId
       expect(
-        MockSubmissionService.sendEmailConfirmations,
+        MockEmailSubmissionService.saveSubmissionMetadata,
       ).toHaveBeenCalledTimes(1)
-      // Assert status not set, which means default ok response status
-      expect(mockRes.status).not.toHaveBeenCalled()
-      // Assert user is logged out if submission is successful
-      expect(mockRes.clearCookie).toHaveBeenCalledWith(
-        getCookieNameByAuthType(
-          mockSgidAuthTypeAndIsSingleSubmissionEnabledForm.authType as FormAuthType.SGID,
+      expect(
+        MockEmailSubmissionService.saveSubmissionMetadata.mock.calls[0][3],
+      ).toEqual(
+        generateHashedSubmitterId(
+          MOCK_JWT_PAYLOAD.userName,
+          mockIsSingleSubmissionEnabledEmailModeForm.id,
         ),
       )
     })
-    it('should return json response with single submission validation failure flag when submission is not unique', async () => {
-      // Arrange
-      // simulate a submission with duplicate submitterId for the same form
-      MockEmailSubmissionService.saveSubmissionMetadata.mockReset()
-      MockEmailSubmissionService.saveSubmissionMetadata.mockReturnValueOnce(
-        okAsync(null),
-      )
 
-      const mockFormId = new ObjectId()
-      const mockSgidAuthTypeAndIsSingleSubmissionEnabledForm = {
-        _id: mockFormId,
-        title: 'some form',
-        authType: FormAuthType.SGID,
-        isSingleSubmission: true,
-        form_fields: [] as FormFieldSchema[],
-      } as IPopulatedForm
-      const MOCK_JWT_PAYLOAD_WITH_NRIC = {
-        userName: 'S1234567A',
-      }
-      const MOCK_VALID_SGID_PAYLOAD = {
-        userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
-        rememberMe: false,
-      }
-      MockFormService.retrieveFullFormById.mockReturnValueOnce(
-        okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
-      )
-      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
-        ok(
-          mockSgidAuthTypeAndIsSingleSubmissionEnabledForm as IPopulatedEmailForm,
-        ),
-      )
-      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
-        okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
-      )
-      MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
-        ok(MOCK_VALID_SGID_PAYLOAD),
-      )
+    describe('single submission per submitterId', () => {
+      it('should return 200 ok and logout user when successfully submit form with single submission enabled', async () => {
+        // Arrange
+        const mockFormId = new ObjectId()
+        const mockSgidAuthTypeAndIsSingleSubmissionEnabledForm = {
+          _id: mockFormId,
+          title: 'some form',
+          authType: FormAuthType.SGID,
+          isSingleSubmission: true,
+          form_fields: [] as FormFieldSchema[],
+        } as IPopulatedForm
+        const MOCK_JWT_PAYLOAD_WITH_NRIC = {
+          userName: 'S1234567A',
+        }
+        const MOCK_VALID_SGID_PAYLOAD = {
+          userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
+          rememberMe: false,
+        }
+        MockFormService.retrieveFullFormById.mockReturnValueOnce(
+          okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+        )
+        MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
+          ok(
+            mockSgidAuthTypeAndIsSingleSubmissionEnabledForm as IPopulatedEmailForm,
+          ),
+        )
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+          okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+        )
+        MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
+          ok(MOCK_VALID_SGID_PAYLOAD),
+        )
 
-      const mockReq = expressHandler.mockRequest({
-        params: { formId: 'some id' },
-        body: {
-          responses: [],
-        },
+        const mockReq = expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        })
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
+
+        // Act
+        await submitEmailModeForm(mockReq, mockRes, jest.fn())
+
+        // Assert email should be sent
+        expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+        expect(
+          MockSubmissionService.sendEmailConfirmations,
+        ).toHaveBeenCalledTimes(1)
+        // Assert status not set, which means default ok response status
+        expect(mockRes.status).not.toHaveBeenCalled()
+        // Assert user is logged out if submission is successful
+        expect(mockRes.clearCookie).toHaveBeenCalledWith(
+          getCookieNameByAuthType(
+            mockSgidAuthTypeAndIsSingleSubmissionEnabledForm.authType as FormAuthType.SGID,
+          ),
+        )
       })
-      const mockRes = expressHandler.mockResponse({
-        clearCookie: jest.fn().mockReturnThis(),
-      })
+      it('should return json response with single submission validation failure flag when submission is not unique', async () => {
+        // Arrange
+        // simulate a submission with duplicate submitterId for the same form
+        MockEmailSubmissionService.saveSubmissionMetadata.mockReset()
+        MockEmailSubmissionService.saveSubmissionMetadata.mockReturnValueOnce(
+          okAsync(null),
+        )
 
-      // Act
-      await submitEmailModeForm(mockReq, mockRes, jest.fn())
+        const mockFormId = new ObjectId()
+        const mockSgidAuthTypeAndIsSingleSubmissionEnabledForm = {
+          _id: mockFormId,
+          title: 'some form',
+          authType: FormAuthType.SGID,
+          isSingleSubmission: true,
+          form_fields: [] as FormFieldSchema[],
+        } as IPopulatedForm
+        const MOCK_JWT_PAYLOAD_WITH_NRIC = {
+          userName: 'S1234567A',
+        }
+        const MOCK_VALID_SGID_PAYLOAD = {
+          userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
+          rememberMe: false,
+        }
+        MockFormService.retrieveFullFormById.mockReturnValueOnce(
+          okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+        )
+        MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
+          ok(
+            mockSgidAuthTypeAndIsSingleSubmissionEnabledForm as IPopulatedEmailForm,
+          ),
+        )
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+          okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+        )
+        MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
+          ok(MOCK_VALID_SGID_PAYLOAD),
+        )
 
-      // Assert email should not be sent
-      expect(MockMailService.sendSubmissionToAdmin).not.toHaveBeenCalled()
-      expect(
-        MockSubmissionService.sendEmailConfirmations,
-      ).not.toHaveBeenCalled()
+        const mockReq = expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        })
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
 
-      // Assert that response has the single submission validation failure flag
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message: 'Your NRIC/FIN has already been used to respond to this form.',
-        hasSingleSubmissionValidationFailure: true,
+        // Act
+        await submitEmailModeForm(mockReq, mockRes, jest.fn())
+
+        // Assert email should not be sent
+        expect(MockMailService.sendSubmissionToAdmin).not.toHaveBeenCalled()
+        expect(
+          MockSubmissionService.sendEmailConfirmations,
+        ).not.toHaveBeenCalled()
+
+        // Assert that response has the single submission validation failure flag
+        expect(mockRes.json).toHaveBeenCalledWith({
+          message:
+            'Your NRIC/FIN/UEN has already been used to respond to this form.',
+          hasSingleSubmissionValidationFailure: true,
+        })
       })
     })
-  })
 
-  describe('nricMask', () => {
-    it('should mask nric if form isNricMaskEnabled is true', async () => {
-      // Arrange
-      const mockFormId = new ObjectId()
-      const mockSgidAuthTypeAndNricMaskingEnabledForm = {
-        _id: mockFormId,
-        title: 'some form',
-        authType: FormAuthType.SGID,
-        isNricMaskEnabled: true,
-        form_fields: [] as FormFieldSchema[],
-      } as IPopulatedForm
-      const MOCK_JWT_PAYLOAD_WITH_NRIC = {
-        userName: 'S1234567A',
-      }
-      const MOCK_VALID_SGID_PAYLOAD = {
-        userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
-        rememberMe: false,
-      }
-      MockFormService.retrieveFullFormById.mockReturnValueOnce(
-        okAsync(mockSgidAuthTypeAndNricMaskingEnabledForm),
-      )
-      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
-        ok(mockSgidAuthTypeAndNricMaskingEnabledForm as IPopulatedEmailForm),
-      )
-      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
-        okAsync(mockSgidAuthTypeAndNricMaskingEnabledForm),
-      )
-      MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
-        ok(MOCK_VALID_SGID_PAYLOAD),
-      )
+    describe('nricMask', () => {
+      it('should mask nric if form isNricMaskEnabled is true', async () => {
+        // Arrange
+        const mockFormId = new ObjectId()
+        const mockSgidAuthTypeAndNricMaskingEnabledForm = {
+          _id: mockFormId,
+          title: 'some form',
+          authType: FormAuthType.SGID,
+          isNricMaskEnabled: true,
+          form_fields: [] as FormFieldSchema[],
+        } as IPopulatedForm
+        const MOCK_JWT_PAYLOAD_WITH_NRIC = {
+          userName: 'S1234567A',
+        }
+        const MOCK_VALID_SGID_PAYLOAD = {
+          userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
+          rememberMe: false,
+        }
+        MockFormService.retrieveFullFormById.mockReturnValueOnce(
+          okAsync(mockSgidAuthTypeAndNricMaskingEnabledForm),
+        )
+        MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
+          ok(mockSgidAuthTypeAndNricMaskingEnabledForm as IPopulatedEmailForm),
+        )
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+          okAsync(mockSgidAuthTypeAndNricMaskingEnabledForm),
+        )
+        MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
+          ok(MOCK_VALID_SGID_PAYLOAD),
+        )
 
-      const MOCK_REQ = expressHandler.mockRequest({
-        params: { formId: 'some id' },
-        body: {
-          responses: [],
-        },
-      })
-      const mockRes = expressHandler.mockResponse({
-        clearCookie: jest.fn().mockReturnThis(),
-      })
+        const MOCK_REQ = expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        })
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
 
-      // Act
-      await submitEmailModeForm(MOCK_REQ, mockRes, jest.fn())
+        // Act
+        await submitEmailModeForm(MOCK_REQ, mockRes, jest.fn())
 
-      // Assert email should be sent
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
-      expect(
-        MockSubmissionService.sendEmailConfirmations,
-      ).toHaveBeenCalledTimes(1)
-      // Assert nric is masked in email payload
-      expect(
-        MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
-          .answer,
-      ).toEqual('*****567A')
-    })
-
-    it('should not mask nric if form isNricMaskEnabled is false', async () => {
-      // Arrange
-      const mockFormId = new ObjectId()
-      const mockSgidAuthTypeAndNricMaskingDisabledForm = {
-        _id: mockFormId,
-        title: 'some form',
-        authType: FormAuthType.SGID,
-        isNricMaskEnabled: false,
-        form_fields: [] as FormFieldSchema[],
-      } as IPopulatedForm
-      const MOCK_JWT_PAYLOAD_WITH_NRIC = {
-        userName: 'S1234567A',
-      }
-      const MOCK_VALID_SGID_PAYLOAD = {
-        userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
-        rememberMe: false,
-      }
-      MockFormService.retrieveFullFormById.mockReturnValueOnce(
-        okAsync(mockSgidAuthTypeAndNricMaskingDisabledForm),
-      )
-      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
-        ok(mockSgidAuthTypeAndNricMaskingDisabledForm as IPopulatedEmailForm),
-      )
-      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
-        okAsync(mockSgidAuthTypeAndNricMaskingDisabledForm),
-      )
-      MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
-        ok(MOCK_VALID_SGID_PAYLOAD),
-      )
-
-      const MOCK_REQ = expressHandler.mockRequest({
-        params: { formId: 'some id' },
-        body: {
-          responses: [],
-        },
-      })
-      const mockRes = expressHandler.mockResponse({
-        clearCookie: jest.fn().mockReturnThis(),
+        // Assert email should be sent
+        expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+        expect(
+          MockSubmissionService.sendEmailConfirmations,
+        ).toHaveBeenCalledTimes(1)
+        // Assert nric is masked in email payload
+        expect(
+          MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
+            .answer,
+        ).toEqual('*****567A')
       })
 
-      // Act
-      await submitEmailModeForm(MOCK_REQ, mockRes, jest.fn())
+      it('should not mask nric if form isNricMaskEnabled is false', async () => {
+        // Arrange
+        const mockFormId = new ObjectId()
+        const mockSgidAuthTypeAndNricMaskingDisabledForm = {
+          _id: mockFormId,
+          title: 'some form',
+          authType: FormAuthType.SGID,
+          isNricMaskEnabled: false,
+          form_fields: [] as FormFieldSchema[],
+        } as IPopulatedForm
+        const MOCK_JWT_PAYLOAD_WITH_NRIC = {
+          userName: 'S1234567A',
+        }
+        const MOCK_VALID_SGID_PAYLOAD = {
+          userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
+          rememberMe: false,
+        }
+        MockFormService.retrieveFullFormById.mockReturnValueOnce(
+          okAsync(mockSgidAuthTypeAndNricMaskingDisabledForm),
+        )
+        MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
+          ok(mockSgidAuthTypeAndNricMaskingDisabledForm as IPopulatedEmailForm),
+        )
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+          okAsync(mockSgidAuthTypeAndNricMaskingDisabledForm),
+        )
+        MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
+          ok(MOCK_VALID_SGID_PAYLOAD),
+        )
 
-      // Assert email should be sent
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
-      expect(
-        MockSubmissionService.sendEmailConfirmations,
-      ).toHaveBeenCalledTimes(1)
-      // Assert nric is not masked
-      expect(
-        MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
-          .answer,
-      ).toEqual(MOCK_JWT_PAYLOAD_WITH_NRIC.userName)
+        const MOCK_REQ = expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        })
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
+
+        // Act
+        await submitEmailModeForm(MOCK_REQ, mockRes, jest.fn())
+
+        // Assert email should be sent
+        expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+        expect(
+          MockSubmissionService.sendEmailConfirmations,
+        ).toHaveBeenCalledTimes(1)
+        // Assert nric is not masked
+        expect(
+          MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
+            .answer,
+        ).toEqual(MOCK_JWT_PAYLOAD_WITH_NRIC.userName)
+      })
     })
   })
 })

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.controller.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.controller.spec.ts
@@ -15,6 +15,7 @@ import {
   IPopulatedForm,
 } from 'src/types'
 
+import { getCookieNameByAuthType } from '../../submission.utils'
 import { submitEmailModeForm } from '../email-submission.controller'
 
 jest.mock(
@@ -33,33 +34,213 @@ const MockSgidService = jest.mocked(SgidService)
 const MockMailService = jest.mocked(MailService)
 
 describe('email-submission.controller', () => {
-  describe('nricMask', () => {
-    beforeEach(() => {
-      const MOCK_SUBMISSION_HASH = {
-        hash: 'some hash',
-        salt: 'some salt',
+  beforeEach(() => {
+    const MOCK_SUBMISSION_HASH = {
+      hash: 'some hash',
+      salt: 'some salt',
+    }
+    MockEmailSubmissionService.hashSubmission.mockReturnValueOnce(
+      okAsync(MOCK_SUBMISSION_HASH),
+    )
+    MockEmailSubmissionService.saveSubmissionMetadata.mockReturnValueOnce(
+      okAsync({} as IEmailSubmissionSchema),
+    )
+    MockFormService.isFormPublic.mockReturnValueOnce(ok(true))
+
+    MockMailService.sendSubmissionToAdmin.mockReturnValueOnce(okAsync(true))
+
+    MockSubmissionService.validateAttachments.mockReturnValueOnce(okAsync(true))
+    MockSubmissionService.sendEmailConfirmations.mockReturnValueOnce(
+      okAsync(true),
+    )
+  })
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('submitterId', () => {
+    it('should hash submitterId if form is individual singpass type', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockIsSingleSubmissionEnabledEmailModeForm = {
+        _id: mockFormId,
+        title: 'some form',
+        authType: FormAuthType.SGID,
+        form_fields: [] as FormFieldSchema[],
+      } as IPopulatedForm
+
+      const MOCK_JWT_PAYLOAD_WITH_NRIC = {
+        userName: 'submitterId',
       }
-      MockEmailSubmissionService.hashSubmission.mockReturnValueOnce(
-        okAsync(MOCK_SUBMISSION_HASH),
+      const MOCK_VALID_SGID_PAYLOAD = {
+        userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
+        rememberMe: false,
+      }
+
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(mockIsSingleSubmissionEnabledEmailModeForm),
       )
+      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
+        ok(mockIsSingleSubmissionEnabledEmailModeForm as IPopulatedEmailForm),
+      )
+      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+        okAsync(mockIsSingleSubmissionEnabledEmailModeForm),
+      )
+      MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
+        ok(MOCK_VALID_SGID_PAYLOAD),
+      )
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: 'some id' },
+        body: {
+          responses: [],
+        },
+      })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
+
+      // Act
+      await submitEmailModeForm(mockReq, mockRes, jest.fn())
+
+      // Assert the saving of submission metadata is called with the hashed submitterId
+      expect(
+        MockEmailSubmissionService.saveSubmissionMetadata,
+      ).toHaveBeenCalledTimes(1)
+      expect(
+        MockEmailSubmissionService.saveSubmissionMetadata.mock.calls[0][3],
+      ).toEqual(
+        '151c329a583a82e4a768f16ab8c9b7ae621fcfdea574e87925dd56d7f73e367d',
+      )
+    })
+  })
+
+  describe('single submission per submitterId', () => {
+    it('should return 200 ok and logout user when successfully submit form with single submission enabled', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockSgidAuthTypeAndIsSingleSubmissionEnabledForm = {
+        _id: mockFormId,
+        title: 'some form',
+        authType: FormAuthType.SGID,
+        isSingleSubmission: true,
+        form_fields: [] as FormFieldSchema[],
+      } as IPopulatedForm
+      const MOCK_JWT_PAYLOAD_WITH_NRIC = {
+        userName: 'S1234567A',
+      }
+      const MOCK_VALID_SGID_PAYLOAD = {
+        userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
+        rememberMe: false,
+      }
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+      )
+      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
+        ok(
+          mockSgidAuthTypeAndIsSingleSubmissionEnabledForm as IPopulatedEmailForm,
+        ),
+      )
+      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+        okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+      )
+      MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
+        ok(MOCK_VALID_SGID_PAYLOAD),
+      )
+
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: 'some id' },
+        body: {
+          responses: [],
+        },
+      })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
+
+      // Act
+      await submitEmailModeForm(mockReq, mockRes, jest.fn())
+
+      // Assert email should be sent
+      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+      expect(
+        MockSubmissionService.sendEmailConfirmations,
+      ).toHaveBeenCalledTimes(1)
+      // Assert status not set, which means default ok response status
+      expect(mockRes.status).not.toHaveBeenCalled()
+      // Assert user is logged out if submission is successful
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        getCookieNameByAuthType(
+          mockSgidAuthTypeAndIsSingleSubmissionEnabledForm.authType as FormAuthType.SGID,
+        ),
+      )
+    })
+    it('should return json response with single submission validation failure flag when submission is not unique', async () => {
+      // Arrange
+      // simulate a submission with duplicate submitterId for the same form
+      MockEmailSubmissionService.saveSubmissionMetadata.mockReset()
       MockEmailSubmissionService.saveSubmissionMetadata.mockReturnValueOnce(
-        okAsync({} as IEmailSubmissionSchema),
+        okAsync(null),
       )
-      MockFormService.isFormPublic.mockReturnValueOnce(ok(true))
 
-      MockMailService.sendSubmissionToAdmin.mockReturnValueOnce(okAsync(true))
+      const mockFormId = new ObjectId()
+      const mockSgidAuthTypeAndIsSingleSubmissionEnabledForm = {
+        _id: mockFormId,
+        title: 'some form',
+        authType: FormAuthType.SGID,
+        isSingleSubmission: true,
+        form_fields: [] as FormFieldSchema[],
+      } as IPopulatedForm
+      const MOCK_JWT_PAYLOAD_WITH_NRIC = {
+        userName: 'S1234567A',
+      }
+      const MOCK_VALID_SGID_PAYLOAD = {
+        userName: MOCK_JWT_PAYLOAD_WITH_NRIC.userName,
+        rememberMe: false,
+      }
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+      )
+      MockEmailSubmissionService.checkFormIsEmailMode.mockReturnValueOnce(
+        ok(
+          mockSgidAuthTypeAndIsSingleSubmissionEnabledForm as IPopulatedEmailForm,
+        ),
+      )
+      MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+        okAsync(mockSgidAuthTypeAndIsSingleSubmissionEnabledForm),
+      )
+      MockSgidService.extractSgidSingpassJwtPayload.mockReturnValueOnce(
+        ok(MOCK_VALID_SGID_PAYLOAD),
+      )
 
-      MockSubmissionService.validateAttachments.mockReturnValueOnce(
-        okAsync(true),
-      )
-      MockSubmissionService.sendEmailConfirmations.mockReturnValueOnce(
-        okAsync(true),
-      )
+      const mockReq = expressHandler.mockRequest({
+        params: { formId: 'some id' },
+        body: {
+          responses: [],
+        },
+      })
+      const mockRes = expressHandler.mockResponse({
+        clearCookie: jest.fn().mockReturnThis(),
+      })
+
+      // Act
+      await submitEmailModeForm(mockReq, mockRes, jest.fn())
+
+      // Assert email should not be sent
+      expect(MockMailService.sendSubmissionToAdmin).not.toHaveBeenCalled()
+      expect(
+        MockSubmissionService.sendEmailConfirmations,
+      ).not.toHaveBeenCalled()
+
+      // Assert that response has the single submission validation failure flag
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Your NRIC/FIN has already been used to respond to this form.',
+        hasSingleSubmissionValidationFailure: true,
+      })
     })
-    afterEach(() => {
-      jest.clearAllMocks()
-    })
+  })
 
+  describe('nricMask', () => {
     it('should mask nric if form isNricMaskEnabled is true', async () => {
       // Arrange
       const mockFormId = new ObjectId()

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -314,7 +314,8 @@ export const submitEmailModeForm: ControllerHandler<
             (response) => response.fieldType === BasicField.Nric,
           ) as ProcessedSingleAnswerResponse
           submitterId =
-            ndiResponse?.answer ?? generateHashedSubmitterId(ndiResponse.answer)
+            ndiResponse?.answer ??
+            generateHashedSubmitterId(ndiResponse.answer, form.id)
         }
 
         if (form.isNricMaskEnabled) {

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -442,7 +442,7 @@ export const submitEmailModeForm: ControllerHandler<
           return res.status(StatusCodes.BAD_REQUEST).json({
             message:
               'Your NRIC/FIN has already been used to respond to this form.',
-            isSingleSubmissionValidationFailure: true,
+            hasSingleSubmissionValidationFailure: true,
           })
         }
         // Send email confirmations

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -433,16 +433,17 @@ export const submitEmailModeForm: ControllerHandler<
         },
       )
       .map(({ form, parsedResponses, submission, emailData, logMeta }) => {
-        // TODO: add json message for frontend to deal with no submission made error
         if (!submission) {
           logger.info({
             message:
               'Submission not created since NRIC/FIN already submitted and form has isSingleSubmission enabled',
             meta: logMeta,
           })
-          return res
-            .status(StatusCodes.BAD_REQUEST)
-            .json({ message: 'You have already submitted this form.' })
+          return res.status(StatusCodes.BAD_REQUEST).json({
+            message:
+              'Your NRIC/FIN has already been used to respond to this form.',
+            isSingleSubmissionValidationFailure: true,
+          })
         }
         // Send email confirmations
         void SubmissionService.sendEmailConfirmations({

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -41,7 +41,7 @@ import { ProcessedSingleAnswerResponse } from '../submission.types'
 import {
   checkIsIndividualSingpassAuthType,
   extractEmailConfirmationData,
-  generateHashedSubmitterSingpassId,
+  generateHashedSubmitterId,
   mapAttachmentsFromResponses,
 } from '../submission.utils'
 import { reportSubmissionResponseTime } from '../submissions.statsd-client'
@@ -308,14 +308,13 @@ export const submitEmailModeForm: ControllerHandler<
         }
       })
       .andThen(({ form, parsedResponses, hashedFields }) => {
-        let submitterSingpassId: string | undefined = undefined
+        let submitterId: string | undefined = undefined
         if (checkIsIndividualSingpassAuthType(form.authType)) {
           const ndiResponse = parsedResponses.ndiResponses.find(
             (response) => response.fieldType === BasicField.Nric,
           ) as ProcessedSingleAnswerResponse
-          submitterSingpassId =
-            ndiResponse?.answer ??
-            generateHashedSubmitterSingpassId(ndiResponse.answer)
+          submitterId =
+            ndiResponse?.answer ?? generateHashedSubmitterId(ndiResponse.answer)
         }
 
         if (form.isNricMaskEnabled) {
@@ -346,7 +345,7 @@ export const submitEmailModeForm: ControllerHandler<
           .andThen((submissionHash) =>
             EmailSubmissionService.saveSubmissionMetadata(
               form,
-              submitterSingpassId,
+              submitterId,
               submissionHash,
               responseMetadata,
             ),

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -347,9 +347,9 @@ export const submitEmailModeForm: ControllerHandler<
           .andThen((submissionHash) =>
             EmailSubmissionService.saveSubmissionMetadata(
               form,
-              submitterId,
               submissionHash,
               responseMetadata,
+              submitterId,
             ),
           )
           .map((submission) => ({

--- a/src/app/modules/submission/email-submission/email-submission.controller.ts
+++ b/src/app/modules/submission/email-submission/email-submission.controller.ts
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes'
 import { ok, okAsync, ResultAsync } from 'neverthrow'
 
 import {
@@ -36,8 +37,11 @@ import * as EmailSubmissionMiddleware from '../email-submission/email-submission
 import ParsedResponsesObject from '../ParsedResponsesObject.class'
 import * as ReceiverMiddleware from '../receiver/receiver.middleware'
 import * as SubmissionService from '../submission.service'
+import { ProcessedSingleAnswerResponse } from '../submission.types'
 import {
+  checkIsIndividualSingpassAuthType,
   extractEmailConfirmationData,
+  generateHashedSubmitterSingpassId,
   mapAttachmentsFromResponses,
 } from '../submission.utils'
 import { reportSubmissionResponseTime } from '../submissions.statsd-client'
@@ -304,6 +308,16 @@ export const submitEmailModeForm: ControllerHandler<
         }
       })
       .andThen(({ form, parsedResponses, hashedFields }) => {
+        let submitterSingpassId: string | undefined = undefined
+        if (checkIsIndividualSingpassAuthType(form.authType)) {
+          const ndiResponse = parsedResponses.ndiResponses.find(
+            (response) => response.fieldType === BasicField.Nric,
+          ) as ProcessedSingleAnswerResponse
+          submitterSingpassId =
+            ndiResponse?.answer ??
+            generateHashedSubmitterSingpassId(ndiResponse.answer)
+        }
+
         if (form.isNricMaskEnabled) {
           parsedResponses.ndiResponses = parsedResponses.ndiResponses.map(
             (response) => {
@@ -332,6 +346,7 @@ export const submitEmailModeForm: ControllerHandler<
           .andThen((submissionHash) =>
             EmailSubmissionService.saveSubmissionMetadata(
               form,
+              submitterSingpassId,
               submissionHash,
               responseMetadata,
             ),
@@ -360,6 +375,17 @@ export const submitEmailModeForm: ControllerHandler<
           emailData,
           responseMetadata,
         }) => {
+          if (!submission) {
+            return okAsync({
+              form,
+              parsedResponses,
+              submission,
+              emailData,
+              responseMetadata,
+              logMeta,
+            })
+          }
+
           const logMetaWithSubmission = {
             ...logMeta,
             submissionId: submission._id,
@@ -395,7 +421,7 @@ export const submitEmailModeForm: ControllerHandler<
               parsedResponses,
               submission,
               emailData,
-              logMetaWithSubmission,
+              logMeta: logMetaWithSubmission,
             }))
             .mapErr((error) => {
               logger.error({
@@ -407,50 +433,53 @@ export const submitEmailModeForm: ControllerHandler<
             })
         },
       )
-      .map(
-        ({
-          form,
-          parsedResponses,
-          submission,
-          emailData,
-          logMetaWithSubmission,
-        }) => {
-          // Send email confirmations
-          void SubmissionService.sendEmailConfirmations({
-            form,
-            submission,
-            attachments,
-            responsesData: emailData.autoReplyData,
-            recipientData: extractEmailConfirmationData(
-              parsedResponses.getAllResponses(),
-              form.form_fields,
-            ),
-          }).mapErr((error) => {
-            // NOTE: MyInfo access token is not cleared here.
-            // This is because if the reason for failure is not on the users' end,
-            // they should not be randomly signed out.
-            logger.error({
-              message: 'Error while sending email confirmations',
-              meta: logMetaWithSubmission,
-              error,
-            })
+      .map(({ form, parsedResponses, submission, emailData, logMeta }) => {
+        // TODO: add json message for frontend to deal with no submission made error
+        if (!submission) {
+          logger.info({
+            message:
+              'Submission not created since NRIC/FIN already submitted and form has isSingleSubmission enabled',
+            meta: logMeta,
           })
-          // MyInfo access token is single-use, so clear it
-          // Similarly for sgID-MyInfo
           return res
-            .clearCookie(MYINFO_LOGIN_COOKIE_NAME, MYINFO_LOGIN_COOKIE_OPTIONS)
-            .clearCookie(
-              SGID_MYINFO_LOGIN_COOKIE_NAME,
-              MYINFO_LOGIN_COOKIE_OPTIONS,
-            )
-            .json({
-              // Return the reply early to the submitter
-              message: 'Form submission successful.',
-              submissionId: submission.id,
-              timestamp: (submission.created || new Date()).getTime(),
-            })
-        },
-      )
+            .status(StatusCodes.BAD_REQUEST)
+            .json({ message: 'You have already submitted this form.' })
+        }
+        // Send email confirmations
+        void SubmissionService.sendEmailConfirmations({
+          form,
+          submission,
+          attachments,
+          responsesData: emailData.autoReplyData,
+          recipientData: extractEmailConfirmationData(
+            parsedResponses.getAllResponses(),
+            form.form_fields,
+          ),
+        }).mapErr((error) => {
+          // NOTE: MyInfo access token is not cleared here.
+          // This is because if the reason for failure is not on the users' end,
+          // they should not be randomly signed out.
+          logger.error({
+            message: 'Error while sending email confirmations',
+            meta: logMeta,
+            error,
+          })
+        })
+        // MyInfo access token is single-use, so clear it
+        // Similarly for sgID-MyInfo
+        return res
+          .clearCookie(MYINFO_LOGIN_COOKIE_NAME, MYINFO_LOGIN_COOKIE_OPTIONS)
+          .clearCookie(
+            SGID_MYINFO_LOGIN_COOKIE_NAME,
+            MYINFO_LOGIN_COOKIE_OPTIONS,
+          )
+          .json({
+            // Return the reply early to the submitter
+            message: 'Form submission successful.',
+            submissionId: submission.id,
+            timestamp: (submission.created || new Date()).getTime(),
+          })
+      })
       .mapErr((error) => {
         const { errorMessage, statusCode } = mapRouteError(error)
         return res

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -122,9 +122,8 @@ export const saveSubmissionMetadata = (
           submitterId,
           params,
         )
-      } else {
-        return EmailSubmissionModel.create(params)
       }
+      return EmailSubmissionModel.create(params)
     }
 
   return ResultAsync.fromPromise(

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -17,7 +17,7 @@ import {
 } from '../../../../types'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { getEmailSubmissionModel } from '../../../models/submission.server.model'
-import { DatabaseError } from '../../core/core.errors'
+import { ApplicationError, DatabaseError } from '../../core/core.errors'
 import { isEmailModeForm, transformEmails } from '../../form/form.utils'
 import { ResponseModeError } from '../submission.errors'
 import { ProcessedFieldResponse } from '../submission.types'
@@ -115,7 +115,7 @@ export const saveSubmissionMetadata = (
       ) {
         if (!submitterId) {
           return Promise.reject(
-            new DatabaseError(
+            new ApplicationError(
               'submitterId must be defined for isSingleSubmission enabled form',
             ),
           )

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -91,14 +91,14 @@ export const hashSubmission = (
  */
 export const saveSubmissionMetadata = (
   form: IPopulatedEmailForm,
-  submitterSingpassId: string | undefined,
+  submitterId: string | undefined,
   submissionHash: SubmissionHash,
   responseMetadata?: ResponseMetadata,
 ): ResultAsync<IEmailSubmissionSchema | null, DatabaseError> => {
   const params: EmailSubmissionContent = {
     form: form._id,
     authType: form.authType,
-    submitterSingpassId,
+    submitterId,
     myInfoFields: form.getUniqueMyInfoAttrs(),
     recipientEmails: transformEmails(form.emails),
     responseHash: submissionHash.hash,
@@ -113,16 +113,16 @@ export const saveSubmissionMetadata = (
         form.isSingleSubmission &&
         checkIsIndividualSingpassAuthType(form.authType)
       ) {
-        if (!submitterSingpassId) {
+        if (!submitterId) {
           return Promise.reject(
             new DatabaseError(
-              'submitterSingpassId must be defined for single submission form',
+              'submitterId must be defined for isSingleSubmission enabled form',
             ),
           )
         }
-        return EmailSubmissionModel.saveIfSubmitterSingpassIdIsUnique(
+        return EmailSubmissionModel.saveIfSubmitterIdIsUnique(
           form._id,
-          submitterSingpassId,
+          submitterId,
           params,
         )
       } else {

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -4,6 +4,7 @@ import { err, ok, Result, ResultAsync } from 'neverthrow'
 
 import {
   BasicField,
+  FormAuthType,
   FormResponseMode,
   ResponseMetadata,
   SubmissionType,
@@ -21,7 +22,6 @@ import { ApplicationError, DatabaseError } from '../../core/core.errors'
 import { isEmailModeForm, transformEmails } from '../../form/form.utils'
 import { ResponseModeError } from '../submission.errors'
 import { ProcessedFieldResponse } from '../submission.types'
-import { checkIsIndividualSingpassAuthType } from '../submission.utils'
 
 import {
   DIGEST_TYPE,
@@ -109,10 +109,7 @@ export const saveSubmissionMetadata = (
 
   const saveEmailSubmissionMetadataBasedOnFormSettings =
     async (): Promise<IEmailSubmissionSchema | null> => {
-      if (
-        form.isSingleSubmission &&
-        checkIsIndividualSingpassAuthType(form.authType)
-      ) {
+      if (form.isSingleSubmission && form.authType !== FormAuthType.NIL) {
         if (!submitterId) {
           return Promise.reject(
             new ApplicationError(

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -91,9 +91,9 @@ export const hashSubmission = (
  */
 export const saveSubmissionMetadata = (
   form: IPopulatedEmailForm,
-  submitterId: string | undefined,
   submissionHash: SubmissionHash,
   responseMetadata?: ResponseMetadata,
+  submitterId?: string,
 ): ResultAsync<IEmailSubmissionSchema | null, DatabaseError> => {
   const params: EmailSubmissionContent = {
     form: form._id,

--- a/src/app/modules/submission/email-submission/email-submission.types.ts
+++ b/src/app/modules/submission/email-submission/email-submission.types.ts
@@ -35,7 +35,7 @@ export interface IPopulatedStorageFormWithResponsesAndHash {
 export interface EmailSubmissionContent {
   form: IPopulatedEmailForm['_id']
   authType: IPopulatedEmailForm['authType']
-  submitterId: string | undefined
+  submitterId?: string
   myInfoFields: MyInfoKey[]
   recipientEmails: string[]
   responseHash: string

--- a/src/app/modules/submission/email-submission/email-submission.types.ts
+++ b/src/app/modules/submission/email-submission/email-submission.types.ts
@@ -1,4 +1,4 @@
-import { ResponseMetadata } from 'shared/types'
+import { ResponseMetadata, SubmissionType } from 'shared/types'
 
 import { FieldResponse, IPopulatedEmailForm } from '../../../../types'
 import { MyInfoKey } from '../../myinfo/myinfo.types'
@@ -30,4 +30,16 @@ export interface IPopulatedEmailFormWithResponsesAndHash {
 export interface IPopulatedStorageFormWithResponsesAndHash {
   parsedResponses: ParsedResponsesObject
   hashedFields?: Set<MyInfoKey>
+}
+
+export interface EmailSubmissionContent {
+  form: IPopulatedEmailForm['_id']
+  authType: IPopulatedEmailForm['authType']
+  submitterSingpassId: string | undefined
+  myInfoFields: MyInfoKey[]
+  recipientEmails: string[]
+  responseHash: string
+  responseSalt: string
+  submissionType: SubmissionType.Email
+  responseMetadata?: ResponseMetadata
 }

--- a/src/app/modules/submission/email-submission/email-submission.types.ts
+++ b/src/app/modules/submission/email-submission/email-submission.types.ts
@@ -35,7 +35,7 @@ export interface IPopulatedStorageFormWithResponsesAndHash {
 export interface EmailSubmissionContent {
   form: IPopulatedEmailForm['_id']
   authType: IPopulatedEmailForm['authType']
-  submitterSingpassId: string | undefined
+  submitterId: string | undefined
   myInfoFields: MyInfoKey[]
   recipientEmails: string[]
   responseHash: string

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -9,6 +9,7 @@ import { FormAuthType, MyInfoAttribute } from 'shared/types'
 import { getEncryptSubmissionModel } from 'src/app/models/submission.server.model'
 import * as OidcService from 'src/app/modules/spcp/spcp.oidc.service/index'
 import { OidcServiceType } from 'src/app/modules/spcp/spcp.oidc.service/spcp.oidc.service.types'
+import * as EncryptSubmissionService from 'src/app/modules/submission/encrypt-submission/encrypt-submission.service'
 import * as VerifiedContentService from 'src/app/modules/verified-content/verified-content.service'
 import {
   EncryptVerificationContentParams,
@@ -18,8 +19,12 @@ import MailService from 'src/app/services/mail/mail.service'
 import { FormFieldSchema, IPopulatedEncryptedForm } from 'src/types'
 import { EncryptSubmissionDto, FormCompleteDto } from 'src/types/api'
 
+import { getCookieNameByAuthType } from '../../submission.utils'
 import { submitEncryptModeFormForTest } from '../encrypt-submission.controller'
-import { SubmitEncryptModeFormHandlerRequest } from '../encrypt-submission.types'
+import {
+  EncryptSubmissionContent,
+  SubmitEncryptModeFormHandlerRequest,
+} from '../encrypt-submission.types'
 
 jest.mock('src/app/utils/pipeline-middleware', () => {
   const MockPipeline = jest.fn().mockImplementation(() => {
@@ -57,14 +62,22 @@ const MockVerifiedContentService = jest.mocked(VerifiedContentService)
 const EncryptSubmission = getEncryptSubmissionModel(mongoose)
 
 describe('encrypt-submission.controller', () => {
-  describe('nricMask', () => {
-    beforeAll(async () => await dbHandler.connect())
-    afterEach(async () => {
-      await dbHandler.clearDatabase()
-      jest.clearAllMocks()
-    })
-    afterAll(async () => await dbHandler.closeDatabase())
+  beforeAll(async () => await dbHandler.connect())
+  afterEach(async () => {
+    await dbHandler.clearDatabase()
+    jest.clearAllMocks()
+  })
+  afterAll(async () => await dbHandler.closeDatabase())
 
+  describe('submitterId', () => {
+    const MOCK_JWT_PAYLOAD = {
+      userName: 'submitterId',
+      rememberMe: false,
+    }
+    const MOCK_COOKIE_TIMESTAMP = {
+      iat: 1,
+      exp: 1,
+    }
     beforeEach(() => {
       MockOidcService.getOidcService.mockReturnValue({
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -77,6 +90,203 @@ describe('encrypt-submission.controller', () => {
       MockMailService.sendSubmissionToAdmin.mockResolvedValue(okAsync(true))
     })
 
+    it('should hash submitterId if form is individual singpass type', async () => {
+      const saveIfSubmitterIdIsUniqueSpy = jest
+        .spyOn(EncryptSubmission, 'saveIfSubmitterIdIsUnique')
+        .mockResolvedValueOnce(null)
+
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockSpAuthTypeAndIsSingleSubmissionEnabledForm = {
+        _id: mockFormId,
+        title: 'some form',
+        authType: FormAuthType.SP,
+        isSingleSubmission: true,
+        form_fields: [] as FormFieldSchema[],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
+
+      const mockReq = merge(
+        expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+            },
+            formDef: {
+              authType: FormAuthType.SP,
+            },
+            encryptedFormDef: mockSpAuthTypeAndIsSingleSubmissionEnabledForm,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitEncryptModeFormForTest(mockReq, mockRes)
+
+      // Assert that submitterId is hashed
+      expect(saveIfSubmitterIdIsUniqueSpy).toHaveBeenCalledTimes(1)
+      expect(saveIfSubmitterIdIsUniqueSpy.mock.calls[0][1]).toEqual(
+        '151c329a583a82e4a768f16ab8c9b7ae621fcfdea574e87925dd56d7f73e367d',
+      )
+      expect(saveIfSubmitterIdIsUniqueSpy.mock.calls[0][2].submitterId).toEqual(
+        '151c329a583a82e4a768f16ab8c9b7ae621fcfdea574e87925dd56d7f73e367d',
+      )
+    })
+  })
+
+  describe('single submission per submitterId', () => {
+    const MOCK_JWT_PAYLOAD = {
+      userName: 'submitterId',
+      rememberMe: false,
+    }
+    const MOCK_COOKIE_TIMESTAMP = {
+      iat: 1,
+      exp: 1,
+    }
+    beforeEach(() => {
+      MockOidcService.getOidcService.mockReturnValue({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        extractJwt: (_arg1) => ok('jwt'),
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        extractJwtPayload: (_arg1) =>
+          okAsync(merge(MOCK_JWT_PAYLOAD, MOCK_COOKIE_TIMESTAMP)),
+      } as OidcServiceType<FormAuthType.SP>)
+
+      MockMailService.sendSubmissionToAdmin.mockResolvedValue(okAsync(true))
+    })
+
+    it('should return 200 ok and logout user when successfully submit form with single submission enabled', async () => {
+      // Arrange
+      jest
+        .spyOn(EncryptSubmission, 'saveIfSubmitterIdIsUnique')
+        .mockResolvedValueOnce(
+          new EncryptSubmission({
+            id: 'dummySubmissionId',
+          } as unknown as EncryptSubmissionContent),
+        )
+
+      const performEncryptPostSubmissionActionsSpy = jest.spyOn(
+        EncryptSubmissionService,
+        'performEncryptPostSubmissionActions',
+      )
+
+      const mockFormId = new ObjectId()
+      const mockSpAuthTypeAndIsSingleSubmissionEnabledForm = {
+        _id: mockFormId,
+        title: 'some form',
+        authType: FormAuthType.SP,
+        isSingleSubmission: true,
+        form_fields: [] as FormFieldSchema[],
+        emails: ['test@example.com'],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
+
+      const mockReq = merge(
+        expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+            },
+            formDef: {
+              authType: FormAuthType.SP,
+            },
+            encryptedFormDef: mockSpAuthTypeAndIsSingleSubmissionEnabledForm,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitEncryptModeFormForTest(mockReq, mockRes)
+
+      // Assert email notification should be sent
+      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+
+      // Assert that status is not called, which defaults to intended 200 OK
+      expect(mockRes.status).not.toHaveBeenCalled()
+      // Assert that response does not have the single submission validation failure flag
+      expect(
+        (mockRes.json as jest.Mock).mock.calls[0][0]
+          .hasSingleSubmissionValidationFailure,
+      ).not.toBeDefined()
+
+      // Assert that user is logged out
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        getCookieNameByAuthType(
+          mockSpAuthTypeAndIsSingleSubmissionEnabledForm.authType as FormAuthType.SP,
+        ),
+      )
+
+      expect(performEncryptPostSubmissionActionsSpy).toHaveBeenCalledTimes(1)
+    })
+    it('should return json response with single submission validation failure flag when submission is not unique and does not save submission', async () => {
+      jest
+        .spyOn(EncryptSubmission, 'saveIfSubmitterIdIsUnique')
+        .mockResolvedValueOnce(null)
+
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockSpAuthTypeAndIsSingleSubmissionEnabledForm = {
+        _id: mockFormId,
+        title: 'some form',
+        authType: FormAuthType.SP,
+        isSingleSubmission: true,
+        form_fields: [] as FormFieldSchema[],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
+
+      const mockReq = merge(
+        expressHandler.mockRequest({
+          params: { formId: 'some id' },
+          body: {
+            responses: [],
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+            },
+            formDef: {
+              authType: FormAuthType.SP,
+            },
+            encryptedFormDef: mockSpAuthTypeAndIsSingleSubmissionEnabledForm,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitEncryptModeFormForTest(mockReq, mockRes)
+
+      // Assert that response has the single submission validation failure flag
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Your NRIC/FIN has already been used to respond to this form.',
+        hasSingleSubmissionValidationFailure: true,
+      })
+
+      // Assert that the submission is not saved
+      expect(await EncryptSubmission.countDocuments()).toEqual(0)
+    })
+  })
+
+  describe('nricMask', () => {
     const MOCK_NRIC = 'S1234567A'
     const MOCK_MASKED_NRIC = '*****567A'
 
@@ -88,6 +298,17 @@ describe('encrypt-submission.controller', () => {
       iat: 1,
       exp: 1,
     }
+    beforeEach(() => {
+      MockOidcService.getOidcService.mockReturnValue({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        extractJwt: (_arg1) => ok('jwt'),
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        extractJwtPayload: (_arg1) =>
+          okAsync(merge(MOCK_JWT_PAYLOAD, MOCK_COOKIE_TIMESTAMP)),
+      } as OidcServiceType<FormAuthType.SP>)
+
+      MockMailService.sendSubmissionToAdmin.mockResolvedValue(okAsync(true))
+    })
 
     it('should mask nric if form isNricMaskEnabled is true', async () => {
       // Arrange

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -765,7 +765,7 @@ const _createSubmission = async ({
 
   // Send success back to client
   // clear cookies to log out user if isSingleSubmission form
-  if (form.authType != FormAuthType.NIL && form.isSingleSubmission) {
+  if (form.authType !== FormAuthType.NIL && form.isSingleSubmission) {
     const authCookieName = getCookieNameByAuthType(form.authType)
     res.clearCookie(authCookieName)
   }

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -259,7 +259,7 @@ const submitEncryptModeForm = async (
   let submitterId
   // Generate submitterId for Singpass (excluding Corppass) auth types.
   if (uinFin && checkIsIndividualSingpassAuthType(form.authType)) {
-    submitterId = generateHashedSubmitterId(uinFin)
+    submitterId = generateHashedSubmitterId(uinFin, form.id)
   }
 
   // Mask if Nric masking is enabled
@@ -673,8 +673,7 @@ const _createSubmission = async ({
   try {
     if (
       form.isSingleSubmission &&
-      checkIsIndividualSingpassAuthType(form.authType) &&
-      form.authType !== FormAuthType.NIL
+      checkIsIndividualSingpassAuthType(form.authType)
     ) {
       if (!submissionContent.submitterId) {
         throw new ApplicationError(

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -676,7 +676,7 @@ const _createSubmission = async ({
     ) {
       if (!submissionContent.submitterId) {
         throw new ApplicationError(
-          'submitterId is required for isSingleSubmission enabled forms',
+          'Failed to find submitterId which is mandatory for isSingleSubmission enabled forms',
         )
       }
       submission = await EncryptSubmission.saveIfSubmitterIdIsUnique(
@@ -687,10 +687,11 @@ const _createSubmission = async ({
 
       // handles the case where submission has already been created for given submissionSingpassId
       if (!submission) {
-        // TODO: add json message for frontend to deal with no submission made error
-        return res
-          .status(StatusCodes.BAD_REQUEST)
-          .json({ message: 'You have already submitted this form.' })
+        return res.status(StatusCodes.BAD_REQUEST).json({
+          message:
+            'Your NRIC/FIN has already been used to respond to this form.',
+          isSingleSubmissionValidationFailure: true,
+        })
       }
     } else {
       submission = new EncryptSubmission(submissionContent)

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -39,6 +39,7 @@ import * as TurnstileMiddleware from '../../../services/turnstile/turnstile.midd
 import { Pipeline } from '../../../utils/pipeline-middleware'
 import { createReqMeta } from '../../../utils/request'
 import { getFormAfterPermissionChecks } from '../../auth/auth.service'
+import { ApplicationError } from '../../core/core.errors'
 import { ControllerHandler } from '../../core/core.types'
 import { setFormTags } from '../../datadog/datadog.utils'
 import { PermissionLevel } from '../../form/admin-form/admin-form.types'
@@ -674,8 +675,9 @@ const _createSubmission = async ({
       checkIsIndividualSingpassAuthType(form.authType)
     ) {
       if (!submissionContent.submitterSingpassId) {
-        // TODO: make this error type/message more specific
-        throw new Error('submitterSingpassId is required for single submission')
+        throw new ApplicationError(
+          'submitterSingpassId is required for single submission',
+        )
       }
       submission = await EncryptSubmission.saveIfSubmitterSingpassIdIsUnique(
         form.id,
@@ -685,6 +687,7 @@ const _createSubmission = async ({
 
       // handles the case where submission has already been created for given submissionSingpassId
       if (!submission) {
+        // TODO: add json message for frontend to deal with no submission made error
         return res
           .status(StatusCodes.BAD_REQUEST)
           .json({ message: 'You have already submitted this form.' })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -59,7 +59,7 @@ import { uploadAttachments } from '../submission.service'
 import { ProcessedFieldResponse } from '../submission.types'
 import {
   checkIsIndividualSingpassAuthType,
-  generateHashedSubmitterSingpassId,
+  generateHashedSubmitterId,
   mapRouteError,
 } from '../submission.utils'
 import { reportSubmissionResponseTime } from '../submissions.statsd-client'
@@ -255,10 +255,10 @@ const submitEncryptModeForm = async (
     }
   }
 
-  let submitterSingpassId
-  // Generate submitterSingpassId for Singpass (excluding Corppass) auth types.
+  let submitterId
+  // Generate submitterId for Singpass (excluding Corppass) auth types.
   if (uinFin && checkIsIndividualSingpassAuthType(form.authType)) {
-    submitterSingpassId = generateHashedSubmitterSingpassId(uinFin)
+    submitterId = generateHashedSubmitterId(uinFin)
   }
 
   // Mask if Nric masking is enabled
@@ -359,7 +359,7 @@ const submitEncryptModeForm = async (
   const submissionContent: EncryptSubmissionContent = {
     form: form._id,
     authType: form.authType,
-    submitterSingpassId,
+    submitterId,
     myInfoFields: form.getUniqueMyInfoAttrs(),
     encryptedContent: encryptedContent,
     verifiedContent: verified,
@@ -674,14 +674,14 @@ const _createSubmission = async ({
       form.isSingleSubmission &&
       checkIsIndividualSingpassAuthType(form.authType)
     ) {
-      if (!submissionContent.submitterSingpassId) {
+      if (!submissionContent.submitterId) {
         throw new ApplicationError(
-          'submitterSingpassId is required for single submission',
+          'submitterId is required for isSingleSubmission enabled forms',
         )
       }
-      submission = await EncryptSubmission.saveIfSubmitterSingpassIdIsUnique(
+      submission = await EncryptSubmission.saveIfSubmitterIdIsUnique(
         form.id,
-        submissionContent.submitterSingpassId,
+        submissionContent.submitterId,
         submissionContent,
       )
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -29,6 +29,7 @@ import {
   ResponseModeError,
   SendEmailConfirmationError,
   SubmissionNotFoundError,
+  UnsupportedSettingsError,
 } from '../submission.errors'
 import { sendEmailConfirmations } from '../submission.service'
 import { extractEmailConfirmationData } from '../submission.utils'
@@ -82,6 +83,18 @@ export const checkFormIsEncryptMode = (
   return isFormEncryptMode(form)
     ? ok(form)
     : err(new ResponseModeError(FormResponseMode.Encrypt, form.responseMode))
+}
+
+export const assertFormIsSingleSubmissionDisabled = (
+  form: IPopulatedForm,
+): Result<IPopulatedForm, UnsupportedSettingsError> => {
+  return !form.isSingleSubmission
+    ? ok(form)
+    : err(
+        new UnsupportedSettingsError(
+          'isSingleSubmission cannot be enabled for payment forms as it is not currently supported',
+        ),
+      )
 }
 
 /**

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.types.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.types.ts
@@ -80,6 +80,7 @@ export type SubmitEncryptModeFormHandlerRequest =
 export type EncryptSubmissionContent = {
   form: IPopulatedEncryptedForm['_id']
   authType: IPopulatedEncryptedForm['authType']
+  submitterSingpassId: string | undefined
   myInfoFields: MyInfoAttribute[]
   encryptedContent: string
   verifiedContent: string | undefined

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.types.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.types.ts
@@ -80,7 +80,7 @@ export type SubmitEncryptModeFormHandlerRequest =
 export type EncryptSubmissionContent = {
   form: IPopulatedEncryptedForm['_id']
   authType: IPopulatedEncryptedForm['authType']
-  submitterSingpassId: string | undefined
+  submitterId: string | undefined
   myInfoFields: MyInfoAttribute[]
   encryptedContent: string
   verifiedContent: string | undefined

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.types.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.types.ts
@@ -80,7 +80,7 @@ export type SubmitEncryptModeFormHandlerRequest =
 export type EncryptSubmissionContent = {
   form: IPopulatedEncryptedForm['_id']
   authType: IPopulatedEncryptedForm['authType']
-  submitterId: string | undefined
+  submitterId?: string
   myInfoFields: MyInfoAttribute[]
   encryptedContent: string
   verifiedContent: string | undefined

--- a/src/app/modules/submission/submission.errors.ts
+++ b/src/app/modules/submission/submission.errors.ts
@@ -79,6 +79,12 @@ export class ResponseModeError extends ApplicationError {
   }
 }
 
+export class UnsupportedSettingsError extends ApplicationError {
+  constructor(reason: string) {
+    super(`Unsupported form setting found: ${reason}`)
+  }
+}
+
 /**
  * Attachment greater than size limit
  */

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -768,20 +768,6 @@ export const getAnswersForChild = (
 }
 
 /**
- * Returns true if the authType is Singpass (with NRIC/FIN) and false if nil or Corppass.
- */
-export const checkIsIndividualSingpassAuthType = (
-  authType: FormAuthType,
-): boolean => {
-  return (
-    authType === FormAuthType.SP ||
-    authType === FormAuthType.MyInfo ||
-    authType === FormAuthType.SGID ||
-    authType === FormAuthType.SGID_MyInfo
-  )
-}
-
-/**
  * Generates a hash to mask the original submitterId.
  * @param id
  * @returns

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -776,10 +776,10 @@ export const checkIsIndividualSingpassAuthType = (
 
 // TODO: choose a hash later on (should be collision resistant & preferably reasonably one-way)
 /**
- * Generates a hash to mask the original Singpass ID.
+ * Generates a hash to mask the original submitterId.
  * @param id
  * @returns
  */
-export const generateHashedSubmitterSingpassId = (id: string) => {
+export const generateHashedSubmitterId = (id: string) => {
   return id
 }

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -19,6 +19,7 @@ import { MYINFO_ATTRIBUTE_MAP } from '../../../../shared/constants/field/myinfo'
 import {
   BasicField,
   FormAuthType,
+  FormAuthType,
   FormField,
   FormResponseMode,
   MyInfoAttribute,
@@ -81,6 +82,7 @@ import {
   PrivateFormError,
 } from '../form/form.errors'
 import { isFormEncryptModeOrMultirespondent } from '../form/form.utils'
+import { MYINFO_LOGIN_COOKIE_NAME } from '../myinfo/myinfo.constants'
 import {
   MyInfoCookieStateError,
   MyInfoHashDidNotMatchError,
@@ -96,6 +98,10 @@ import {
   PaymentNotFoundError,
 } from '../payments/payments.errors'
 import {
+  SGID_COOKIE_NAME,
+  SGID_MYINFO_LOGIN_COOKIE_NAME,
+} from '../sgid/sgid.constants'
+import {
   SgidInvalidJwtError,
   SgidMissingJwtError,
   SgidVerifyJwtError,
@@ -106,6 +112,7 @@ import {
   MissingJwtError,
   VerifyJwtError,
 } from '../spcp/spcp.errors'
+import { JwtName } from '../spcp/spcp.types'
 import { MissingUserError } from '../user/user.errors'
 
 import { MYINFO_PREFIX } from './email-submission/email-submission.constants'
@@ -782,4 +789,28 @@ export const checkIsIndividualSingpassAuthType = (
  */
 export const generateHashedSubmitterId = (id: string) => {
   return id
+}
+
+/**
+ * Returns the cookie name based on auth type
+ * Valid AuthTypes are SP / CP / MyInfo / SGID
+ */
+export const getCookieNameByAuthType = (
+  authType:
+    | FormAuthType.SP
+    | FormAuthType.CP
+    | FormAuthType.MyInfo
+    | FormAuthType.SGID
+    | FormAuthType.SGID_MyInfo,
+): string => {
+  switch (authType) {
+    case FormAuthType.SGID_MyInfo:
+      return SGID_MYINFO_LOGIN_COOKIE_NAME
+    case FormAuthType.MyInfo:
+      return MYINFO_LOGIN_COOKIE_NAME
+    case FormAuthType.SGID:
+      return SGID_COOKIE_NAME
+    default:
+      return JwtName[authType]
+  }
 }

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -18,6 +18,7 @@ import { FIELDS_TO_REJECT } from '../../../../shared/constants/field/basic'
 import { MYINFO_ATTRIBUTE_MAP } from '../../../../shared/constants/field/myinfo'
 import {
   BasicField,
+  FormAuthType,
   FormField,
   FormResponseMode,
   MyInfoAttribute,
@@ -757,4 +758,28 @@ export const getAnswersForChild = (
       }
     })
   })
+}
+
+/**
+ * Returns true if the authType is Singpass (with NRIC/FIN) and false if nil or Corppass.
+ */
+export const checkIsIndividualSingpassAuthType = (
+  authType: FormAuthType,
+): boolean => {
+  return (
+    authType === FormAuthType.SP ||
+    authType === FormAuthType.MyInfo ||
+    authType === FormAuthType.SGID ||
+    authType === FormAuthType.SGID_MyInfo
+  )
+}
+
+// TODO: choose a hash later on (should be collision resistant & preferably reasonably one-way)
+/**
+ * Generates a hash to mask the original Singpass ID.
+ * @param id
+ * @returns
+ */
+export const generateHashedSubmitterSingpassId = (id: string) => {
+  return id
 }

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -1,4 +1,5 @@
 import { encode as encodeBase64 } from '@stablelib/base64'
+import crypto from 'crypto'
 import StatusCodes from 'http-status-codes'
 import {
   chain,
@@ -18,7 +19,6 @@ import { FIELDS_TO_REJECT } from '../../../../shared/constants/field/basic'
 import { MYINFO_ATTRIBUTE_MAP } from '../../../../shared/constants/field/myinfo'
 import {
   BasicField,
-  FormAuthType,
   FormAuthType,
   FormField,
   FormResponseMode,
@@ -787,8 +787,15 @@ export const checkIsIndividualSingpassAuthType = (
  * @param id
  * @returns
  */
-export const generateHashedSubmitterId = (id: string) => {
-  return id
+
+export const generateHashedSubmitterId = (id: string, salt: string) => {
+  // if (!id || !salt) {
+  //   throw new ApplicationError('id and salt must be provided to hash id')
+  // }
+  return crypto
+    .createHash('sha256')
+    .update(id + salt)
+    .digest('hex')
 }
 
 /**

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -132,6 +132,7 @@ import {
   ResponseModeError,
   SubmissionFailedError,
   SubmissionNotFoundError,
+  UnsupportedSettingsError,
   ValidateFieldError,
   VirusScanFailedError,
 } from './submission.errors'
@@ -275,6 +276,11 @@ const errorMapper: MapRouteError = (
           'Missing Turnstile challenge. Please refresh and submit again.',
       }
     case MalformedParametersError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+      }
+    case UnsupportedSettingsError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -781,7 +781,6 @@ export const checkIsIndividualSingpassAuthType = (
   )
 }
 
-// TODO: choose a hash later on (should be collision resistant & preferably reasonably one-way)
 /**
  * Generates a hash to mask the original submitterId.
  * @param id
@@ -789,9 +788,6 @@ export const checkIsIndividualSingpassAuthType = (
  */
 
 export const generateHashedSubmitterId = (id: string, salt: string) => {
-  // if (!id || !salt) {
-  //   throw new ApplicationError('id and salt must be provided to hash id')
-  // }
   return crypto
     .createHash('sha256')
     .update(id + salt)

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -64,6 +64,7 @@ type FormDefaultableKey =
   | 'hasIssueNotification'
   | 'authType'
   | 'isNricMaskEnabled'
+  | 'isSingleSubmission'
   | 'status'
   | 'inactiveMessage'
   | 'submissionLimit'
@@ -262,6 +263,7 @@ interface IFormBaseDocument<T extends IFormSchema> {
   hasIssueNotification: NonNullable<T['hasIssueNotification']>
   authType: NonNullable<T['authType']>
   isNricMaskEnabled: NonNullable<T['isNricMaskEnabled']>
+  isSingleSubmission: NonNullable<T['isSingleSubmission']>
   status: NonNullable<T['status']>
   inactiveMessage: NonNullable<T['inactiveMessage']>
   // NOTE: Due to the way creating a form works, creating a form without specifying submissionLimit will throw an error.

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -104,6 +104,7 @@ export type PickDuplicateForm = Pick<
   | 'endPage'
   | 'authType'
   | 'isNricMaskEnabled'
+  | 'isSingleSubmission'
   | 'inactiveMessage'
   | 'submissionLimit'
   | 'responseMode'

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -64,10 +64,32 @@ export interface ISubmissionSchema extends SubmissionBase, Document {
 
 export type IPendingSubmissionSchema = ISubmissionSchema
 
+export type SaveIfSubmitterIdIsUniqueType = EmailSaveIfSubmitterIdIsUniqueType &
+  EncryptSaveIfSubmitterIdIsUniqueType
+
+type EmailSaveIfSubmitterIdIsUniqueType = (
+  formId: string,
+  submitterId: string,
+  submissionContent: EmailSubmissionContent,
+) => Promise<IEmailSubmissionSchema | null>
+
+type EncryptSaveIfSubmitterIdIsUniqueType = (
+  formId: string,
+  submitterId: string,
+  submissionContent: EncryptSubmissionContent,
+) => Promise<IEncryptedSubmissionSchema | null>
+
 export interface ISubmissionModel extends Model<ISubmissionSchema> {
   findFormsWithSubsAbove(
     minSubCount: number,
   ): Promise<FindFormsWithSubsAboveResult[]>
+  /**
+   * Creates a new submission only if provided submitterId is unique.
+   * This method ensures that isSingleSubmission is enforced.
+   * @param submitterId uniquely identifies the submitter
+   * @returns created submission if successful, null otherwise
+   */
+  saveIfSubmitterIdIsUnique: SaveIfSubmitterIdIsUniqueType
 }
 
 export interface IEmailSubmissionSchema
@@ -169,19 +191,7 @@ export type SubmissionData =
   | MultirespondentSubmissionData
 
 export type IEmailSubmissionModel = Model<IEmailSubmissionSchema> &
-  ISubmissionModel & {
-    /**
-     * Creates a new email submission only if provided submitterId is unique.
-     * This method ensures that isSingleSubmission is enforced.
-     * @param submitterId uniquely identifies the submitter
-     * @returns created submission if successful, null otherwise
-     */
-    saveIfSubmitterIdIsUnique(
-      formId: string,
-      submitterId: string,
-      submissionContent: EmailSubmissionContent,
-    ): Promise<IEmailSubmissionSchema | null>
-  }
+  ISubmissionModel
 export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
   ISubmissionModel & {
     /**
@@ -255,12 +265,6 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
     retrieveWebhookInfoById(
       submissionId: string,
     ): Promise<SubmissionWebhookInfo | null>
-
-    saveIfSubmitterIdIsUnique(
-      formId: string,
-      submitterId: string,
-      submissionContent: EncryptSubmissionContent,
-    ): Promise<IEncryptedSubmissionSchema | null>
   }
 
 export type IMultirespondentSubmissionModel =

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -171,14 +171,14 @@ export type SubmissionData =
 export type IEmailSubmissionModel = Model<IEmailSubmissionSchema> &
   ISubmissionModel & {
     /**
-     * Creates a new email submission only if provided submitterSingpassId is unique.
+     * Creates a new email submission only if provided submitterId is unique.
      * This method ensures that isSingleSubmission is enforced.
-     * @param submitterSingpassId uniquely identifies the submitter
+     * @param submitterId uniquely identifies the submitter
      * @returns created submission if successful, null otherwise
      */
-    saveIfSubmitterSingpassIdIsUnique(
+    saveIfSubmitterIdIsUnique(
       formId: string,
-      submitterSingpassId: string,
+      submitterId: string,
       submissionContent: EmailSubmissionContent,
     ): Promise<IEmailSubmissionSchema | null>
   }
@@ -256,9 +256,9 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
       submissionId: string,
     ): Promise<SubmissionWebhookInfo | null>
 
-    saveIfSubmitterSingpassIdIsUnique(
+    saveIfSubmitterIdIsUnique(
       formId: string,
-      submitterSingpassId: string,
+      submitterId: string,
       submissionContent: EncryptSubmissionContent,
     ): Promise<IEncryptedSubmissionSchema | null>
   }

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -1,5 +1,6 @@
 import { Cursor as QueryCursor, Document, Model, QueryOptions } from 'mongoose'
 
+import { EncryptSubmissionContent } from 'src/app/modules/submission/encrypt-submission/encrypt-submission.types'
 import { PaymentWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
 
 import {
@@ -66,6 +67,11 @@ export interface ISubmissionModel extends Model<ISubmissionSchema> {
   findFormsWithSubsAbove(
     minSubCount: number,
   ): Promise<FindFormsWithSubsAboveResult[]>
+  saveIfSubmitterSingpassIdIsUnique(
+    formId: string,
+    submitterSingpassId: string,
+    submissionContent: EncryptSubmissionContent,
+  ): Promise<IEncryptedSubmissionSchema | null>
 }
 
 export interface IEmailSubmissionSchema

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -1,5 +1,6 @@
 import { Cursor as QueryCursor, Document, Model, QueryOptions } from 'mongoose'
 
+import { EmailSubmissionContent } from 'src/app/modules/submission/email-submission/email-submission.types'
 import { EncryptSubmissionContent } from 'src/app/modules/submission/encrypt-submission/encrypt-submission.types'
 import { PaymentWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
 
@@ -67,11 +68,6 @@ export interface ISubmissionModel extends Model<ISubmissionSchema> {
   findFormsWithSubsAbove(
     minSubCount: number,
   ): Promise<FindFormsWithSubsAboveResult[]>
-  saveIfSubmitterSingpassIdIsUnique(
-    formId: string,
-    submitterSingpassId: string,
-    submissionContent: EncryptSubmissionContent,
-  ): Promise<IEncryptedSubmissionSchema | null>
 }
 
 export interface IEmailSubmissionSchema
@@ -173,7 +169,19 @@ export type SubmissionData =
   | MultirespondentSubmissionData
 
 export type IEmailSubmissionModel = Model<IEmailSubmissionSchema> &
-  ISubmissionModel
+  ISubmissionModel & {
+    /**
+     * Creates a new email submission only if provided submitterSingpassId is unique.
+     * This method ensures that isSingleSubmission is enforced.
+     * @param submitterSingpassId uniquely identifies the submitter
+     * @returns created submission if successful, null otherwise
+     */
+    saveIfSubmitterSingpassIdIsUnique(
+      formId: string,
+      submitterSingpassId: string,
+      submissionContent: EmailSubmissionContent,
+    ): Promise<IEmailSubmissionSchema | null>
+  }
 export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
   ISubmissionModel & {
     /**
@@ -247,6 +255,12 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
     retrieveWebhookInfoById(
       submissionId: string,
     ): Promise<SubmissionWebhookInfo | null>
+
+    saveIfSubmitterSingpassIdIsUnique(
+      formId: string,
+      submitterSingpassId: string,
+      submissionContent: EncryptSubmissionContent,
+    ): Promise<IEncryptedSubmissionSchema | null>
   }
 
 export type IMultirespondentSubmissionModel =


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
For some forms, we want to limit the form submissions to a single submission per NRIC. (Eg, each unique voter can only cast 1 vote) 

Closes FRM-1756

## Solution
Implement single limit per nric flow. 

## Storybook test: 
- toggle works 
- error messages for auth settings and payments settings reflects correctly 
- ...and more

## Unit tests: 
- test submitterId are hashed when saved 
- ensure backend validation works, also as a security practice 
- ...and more

**Breaking Changes** 
- No - this PR is backwards compatible  

## Before & After Screenshots
| Subject | Before | After | 
| ------- | ------- | ----- |
| single submission per submitterId toggle | <img width="1039" alt="image" src="https://github.com/opengovsg/FormSG/assets/55353265/336e8f47-4546-4574-9b76-8b071595e359"> | <img width="703" alt="image" src="https://github.com/opengovsg/FormSG/assets/55353265/0e3a5b56-d73a-47b6-b4f9-1f9ed64dc6d4"> | 
| block user from seeing form if already submitted | NA | <img width="758" alt="image" src="https://github.com/opengovsg/FormSG/assets/55353265/44411d0a-d8ed-4582-941d-797df2b0d66a"> | 
| modal popup if user has accessed form and submitting twice from 2 diff browser, firefox/chrome or incognito/private mode | NA | <img width="907" alt="image" src="https://github.com/opengovsg/FormSG/assets/55353265/09ba3504-3dbf-4899-9fdc-f2094a1bc34c"> | 
| toast error if user uses browser which share same cookie | NA | <img width="781" alt="image" src="https://github.com/opengovsg/FormSG/assets/55353265/fa60cd8e-b980-4895-8cc1-e7b0af85690d"> | 
 
## Tests
<!-- What tests should be run to confirm functionality? -->

### TC1: single submission per nric toggle is disabled/locked when payments is connected 
- [ ] create a new storage mode form 
- [ ] connect payments on settings page
- [ ] check that the singpass settings isSingleSubmission toggle is off and disabled and the reason is correctly displayed in the info box below. 

### TC2: payments cannot be connected when single submission per nric toggle is enabled, error message changes when both email notifications + single submission for storage mode 
- [ ] create a new storage mode form 
- [ ] toggle on isSingleSubmission toggle on singpass settings page
- [ ] go to payments settings, check that connect to stripe button is disabled and error message reflects correct reason. 
- [ ] go to email notif settings, add an email
- [ ] go to payments settings again, check still disabled and error message reflects correct reason  
- [ ] turn off isSingleSubmission toggle 
- [ ] go to payments settings again, check still disabled and error message reflects correct reason
- [ ] remove email notification emails 
- [ ] go to payments settings again, check now enabled and no more error message

### TC3: same nric can submit multiple times when isSingleSubmission is toggled off, does not affect other nric, same nric cannot submit once isSingleSubmission is toggled on (Remembers past submitterIds even before toggle is turned on). 
- [ ] create a new storage mode form, open the form to responses, enable singpass auth to any 
- [ ] respond to the form multiple times with the same singpass login credentials. the system should accept multiple form submissions from same singpass cred.
- [ ] go back to form and enable isSingleSubmission toggle. 
- [ ] try and respond using the same singpass account as previously. we should not be able to login to the form and will be stuck at the 'sign in with singpass' page, with an error box stating that duplicate nric submissions are not allowed. 
- [ ] use another singpass credential to login and submit the form, it should be allowed. 
- [ ] repeat the previous steps with email mode form. 

### TC4: if isSingleSubmission is toggled on from the start, same nric can only submit once. 
- [ ] create a storage mode form, choose any singpass auth setting and toggle on isSingleSubmission. 
- [ ] open the form to public and submit the form with singpass.
- [ ] complete the form and click submit another response button at the end. it should redirect back to log in with singpass with no error box anywhere. 
- [ ] log in with the same singpass credentials in previous steps. it should block from entering the form with an error box saying no duplicate submission for given singpass cred. 
- [ ] repeat with email mode form. 

### TC5: if isSingleSubmission is toggled on from the start, different nric can submit 
- [ ] create a storage mode form, choose any singpass auth setting and toggle on isSingleSubmission. 
- [ ] open the form to public and submit the form with singpass.
- [ ] complete the form and click submit another response button at the end. it should redirect back to log in with singpass with no error box anywhere. 
- [ ] log in with another singpass credentials from what is used in previous steps. it should allow submission of the form. 
- [ ] repeat with email mode form. 

### TC6: same nric cannot submit despite both logging in and having race condition, same browser 
 - [ ] create a storage mode form, choose any singpass auth setting and toggle on isSingleSubmission, open form to public. 
- [ ] open respondent form link on 2 separate tabs 
- [ ] log in with singpass on first tab
- [ ] log in with singpass on 2nd tab 
- [ ] both forms should now be logged in and enter the respondent form fields page to fill up form. 
- [ ] try to submit both forms. 
- [ ] 1st submission should be successful with no error 
- [ ] 2nd submission should have a toast message stating that something has failed (this is due to missing the cookie from forced log out) 
- [ ] repeat for email mode form 

### TC7: same nric cannot submit despite both logging in and having race condition, different browser 
 - [ ] create a storage mode form, choose any singpass auth setting and toggle on isSingleSubmission, open form to public. 
- [ ] open respondent form link on 2 separate browsers (eg, 1 chrome and 1 firefox)   
- [ ] log in with singpass on first browser
- [ ] log in with singpass on 2nd browser 
- [ ] both forms should now be logged in and enter the respondent form fields page to fill up form. 
- [ ] try to submit both forms. 
- [ ] 1st submission should be successful with no error 
- [ ] 2nd submission should have a pop up modal saying only one submission nric/fin per nric fin. 
- [ ] close the modal (click x or background) 
- [ ] try and submit the 2nd submission again. the same modal should pop up.  
- [ ] when the modal pops up, click on return to singpass login page action button on the modal. should be redirected to the login with singpass page with no error messages shown anywhere. 
- [ ] try and login with the same singpass account, it should block entrance and display an error box saying no duplicate submission per nric. 
- [ ] repeat for email mode form 

### TC8: when admin turns on isSingleSubmission while prev submitter is resubmitting form 
- [ ] create storage mode form, enable singpass auth 
- [ ] respond to form once with singpass cred
- [ ] submit another response but dont submit yet
- [ ] admin turns off form and then turns on isSingleSubmission toggle then turns form on again 
- [ ] submit the form from step 2, modal saying only one submission per nric should appear

## TC9: duplicate also retains the isSingleSubmission setting
- [ ] create email and storage form with isSingleSubmission on
- [ ] use template to duplicate the form, the duplicated form should also have the same isSingleSubmission setting on 
- [ ] duplicate action on dashboard to duplicate form, the duplicated form should also have the same isSingleSubmission setting on 