### PR TITLE
fix(attachment): convoy separation

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -195,13 +195,13 @@ const useDecryptionWorkers = ({
                       // Ensure attachments downloads are spaced out to avoid browser blocking downloads
                       if (progress % ATTACHMENT_DOWNLOAD_CONVOY_SIZE === 0) {
                         const now = new Date().getTime()
-                        const elaspedSinceXDownloads =
+                        const elapsedSinceXDownloads =
                           now - timeSinceLastXAttachmentDownload
 
                         const waitTime = Math.max(
                           0,
                           ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME -
-                            elaspedSinceXDownloads,
+                            elapsedSinceXDownloads,
                         )
                         if (waitTime > 0) {
                           await waitForMs(waitTime)

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMutation, UseMutationOptions } from 'react-query'
 import { datadogLogs } from '@datadog/browser-logs'
 
+import { waitForMs } from '~utils/waitForMs'
+
 import { useAdminForm } from '~features/admin-form/common/queries'
 import {
   trackDownloadNetworkFailure,
@@ -26,6 +28,12 @@ import {
 } from './types'
 
 const NUM_OF_METADATA_ROWS = 5
+
+// We will download attachments in convoys of 7
+// This is to prevent the script from downloading too many attachments at once
+// which could cause it to block downloads.
+const ATTACHMENT_DOWNLOAD_CONVOY_SIZE = 7
+const ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME = 1000
 
 const killWorkers = (workers: CleanableDecryptionWorkerApi[]): void => {
   return workers.forEach((worker) => worker.cleanup())
@@ -141,6 +149,7 @@ const useDecryptionWorkers = ({
       const downloadStartTime = performance.now()
 
       let progress = 0
+      let timeSinceLastXAttachmentDownload = 0
 
       return new Promise<DownloadResult>((resolve, reject) => {
         reader
@@ -181,7 +190,24 @@ const useDecryptionWorkers = ({
                       errorCount++
                       console.error('Error in getResponseInstance', e)
                     }
+
                     if (downloadAttachments && decryptResult.downloadBlob) {
+                      // Ensure attachments downloads are spaced out to avoid browser blocking downloads
+                      if (progress % ATTACHMENT_DOWNLOAD_CONVOY_SIZE === 0) {
+                        const now = new Date().getTime()
+                        const elaspedSinceXDownloads =
+                          now - timeSinceLastXAttachmentDownload
+
+                        const waitTime = Math.max(
+                          0,
+                          ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME -
+                            elaspedSinceXDownloads,
+                        )
+                        if (waitTime >= 0) {
+                          await waitForMs(waitTime)
+                        }
+                        timeSinceLastXAttachmentDownload = now
+                      }
                       await downloadResponseAttachment(
                         decryptResult.downloadBlob,
                         decryptResult.id,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -29,10 +29,10 @@ import {
 
 const NUM_OF_METADATA_ROWS = 5
 
-// We will download attachments in convoys of 7
+// We will download attachments in convoys of 5
 // This is to prevent the script from downloading too many attachments at once
 // which could cause it to block downloads.
-const ATTACHMENT_DOWNLOAD_CONVOY_SIZE = 7
+const ATTACHMENT_DOWNLOAD_CONVOY_SIZE = 5
 const ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME = 1000
 
 const killWorkers = (workers: CleanableDecryptionWorkerApi[]): void => {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -203,7 +203,7 @@ const useDecryptionWorkers = ({
                           ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME -
                             elaspedSinceXDownloads,
                         )
-                        if (waitTime >= 0) {
+                        if (waitTime > 0) {
                           await waitForMs(waitTime)
                         }
                         timeSinceLastXAttachmentDownload = now

--- a/frontend/src/utils/waitForMs.ts
+++ b/frontend/src/utils/waitForMs.ts
@@ -1,0 +1,5 @@
+export const waitForMs = (ms: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1757

Admins are not able to receive all the download responses when clicking download with CSV.

Most modern browser blocks sequential downloads that run in quick successions.

**Symptoms**
- results are mainly without attachments
- responses > 10

## Solution

Implementation of convoy separation. 

Downloads are grouped into convoys where the front of the convoy must be `x` ms away from the next convoy.
```
[ o . o . . o o o ] . . [ o o o . . o . o] [ o o o o ]
  ^                       ^                  ^
  1st convoy              2nd convoy         3rd convoy                  

CONVOY_SIZE = 5
The time between each convoy should X amount of distance away to avoid a flood
3rd Convoy is too close and thus will be forced to wait

[ o . o . . o o o ] . . [ o o o . . o . o] . . . . [ o o o o ]
  ^                       ^                          ^
  1st convoy              2nd convoy                 3rd convoy
```

**Additional Context**

Total responses = 44
Experiments:

Control Group
- no delay -> get 20 zips

**Batch delay**
- 1000ms of delay every 7 files -> get all 44 zips (increased completion time of 6 seconds)
- 200ms of delay every 7 files -> get 22 zips

**Convoy delay (CONVOY_SIZE = 7)**
- 1000ms between first of next convoy, -> get 39 zips

**Convoy delay (CONVOY_SIZE = 5)**
- 1000ms between first of next convoy, -> get all 44 zips
- 
**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Regression on large submissions >10 crossing two convoys
- [ ] Create 40 submissions with 20 attachments
- [ ] Ensure that Download CSV (without attachment) returns 1 `.csv` file
- [ ] Ensure that Download CSV with attachment returns 40 `.zip` and 1 `.csv` file

Regression on small submissions < 10
- [ ] Create 7 submissions with 3 attachments only 1 convoy
- [ ] Ensure that Download CSV (without attachment) returns 1 `.csv` file
- [ ] Ensure that Download CSV with attachment returns 7 `.zip` and 1 `.csv` file
