### PR TITLE
feat: add model fields to represent translations for form fields

### DIFF
--- a/__tests__/unit/backend/helpers/generate-form-data.ts
+++ b/__tests__/unit/backend/helpers/generate-form-data.ts
@@ -51,6 +51,8 @@ export const generateDefaultField = (
     fieldType,
     required: true,
     disabled: false,
+    titleTranslations: [],
+    descriptionTranslations: [],
   }
   switch (fieldType) {
     case BasicField.Table:
@@ -77,6 +79,7 @@ export const generateDefaultField = (
       return {
         ...defaultParams,
         fieldOptions: ['Option 1', 'Option 2'],
+        fieldOptionsTranslations: [],
         getQuestion: () => defaultParams.title,
         ValidationOptions: {
           customMin: null,
@@ -116,6 +119,7 @@ export const generateDefaultField = (
       return {
         ...defaultParams,
         fieldOptions: ['Option 1', 'Option 2'],
+        fieldOptionsTranslations: [],
         getQuestion: () => defaultParams.title,
         ...customParams,
       } as IDropdownFieldSchema
@@ -376,6 +380,7 @@ export const generateTableDropdownColumn = (
     required: true,
     _id: new ObjectId().toHexString(),
     fieldOptions: ['a', 'b', 'c'],
+    fieldOptionsTranslations: [],
     ...customParams,
     toObject() {
       // mock toObject method of mongoose document
@@ -385,6 +390,7 @@ export const generateTableDropdownColumn = (
         required: true,
         _id: new ObjectId().toHexString(),
         fieldOptions: ['a', 'b', 'c'],
+        fieldOptionsTranslations: [],
         ...customParams,
       }
     },

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -8,8 +8,10 @@ const PUBLIC_FORM_FIELDS = <const>[
   'form_logics',
   'hasCaptcha',
   'hasIssueNotification',
+  'hasMultiLang',
   'startPage',
   'status',
+  'supportedLanguages',
   'title',
   '_id',
   'responseMode',
@@ -39,6 +41,8 @@ const FORM_SETTINGS_FIELDS = <const>[
   'submissionLimit',
   'title',
   'webhook',
+  'hasMultiLang',
+  'supportedLanguages',
 ]
 
 export const EMAIL_FORM_SETTINGS_FIELDS = <const>[

--- a/shared/types/field/base.ts
+++ b/shared/types/field/base.ts
@@ -1,3 +1,5 @@
+import { Language } from '../form'
+
 export enum BasicField {
   Section = 'section',
   Statement = 'statement',
@@ -85,6 +87,11 @@ export type VerifiableFieldBase = {
   isVerifiable: boolean
 }
 
+export type TranslationMapping = {
+  language: Language
+  translation: string
+}
+
 export type FieldBase = {
   globalId?: string
   title: string
@@ -92,6 +99,8 @@ export type FieldBase = {
   required: boolean
   disabled: boolean
   fieldType: BasicField
+  titleTranslations?: TranslationMapping[]
+  descriptionTranslations?: TranslationMapping[]
 }
 
 export type MyInfoableFieldBase = FieldBase & AllowMyInfoBase

--- a/shared/types/field/checkboxField.ts
+++ b/shared/types/field/checkboxField.ts
@@ -1,3 +1,4 @@
+import { TranslationOptionMapping } from '../form'
 import { BasicField, FieldBase } from './base'
 
 export type CheckboxValidationOptions = {
@@ -8,6 +9,7 @@ export type CheckboxValidationOptions = {
 export interface CheckboxFieldBase extends FieldBase {
   fieldType: BasicField.Checkbox
   fieldOptions: string[]
+  fieldOptionsTranslations?: TranslationOptionMapping[]
   othersRadioButton: boolean
   ValidationOptions: CheckboxValidationOptions
   validateByValue: boolean

--- a/shared/types/field/dropdownField.ts
+++ b/shared/types/field/dropdownField.ts
@@ -1,6 +1,8 @@
+import { TranslationOptionMapping } from '../form'
 import { BasicField, MyInfoableFieldBase } from './base'
 
 export interface DropdownFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Dropdown
   fieldOptions: string[]
+  fieldOptionsTranslations?: TranslationOptionMapping[]
 }

--- a/shared/types/field/radioField.ts
+++ b/shared/types/field/radioField.ts
@@ -1,7 +1,9 @@
+import { TranslationOptionMapping } from '../form'
 import { BasicField, FieldBase } from './base'
 
 export interface RadioFieldBase extends FieldBase {
   fieldType: BasicField.Radio
   fieldOptions: string[]
+  fieldOptionsTranslations?: TranslationOptionMapping[]
   othersRadioButton: boolean
 }

--- a/shared/types/field/tableField.ts
+++ b/shared/types/field/tableField.ts
@@ -1,5 +1,5 @@
 import type { Merge } from 'type-fest'
-import { FieldBase, BasicField } from './base'
+import { FieldBase, BasicField, TranslationMapping } from './base'
 import { DropdownFieldBase } from './dropdownField'
 import { ShortTextFieldBase } from './shortTextField'
 
@@ -7,6 +7,7 @@ import { ShortTextFieldBase } from './shortTextField'
 type ColumnBase<T extends FieldBase> = Omit<T, keyof FieldBase> & {
   title: string
   required: boolean
+  titleTranslations?: TranslationMapping[]
 }
 export interface ShortTextColumnBase extends ColumnBase<ShortTextFieldBase> {
   columnType: BasicField.ShortText

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -74,10 +74,10 @@ export enum FormAuthType {
 }
 
 export enum Language {
-  ENGLISH = 'English',
-  CHINESE = 'Chinese',
-  MALAY = 'Malay',
-  TAMIL = 'Tamil',
+  ENGLISH = 'en-SG',
+  CHINESE = 'zh-SG',
+  MALAY = 'ms-SG',
+  TAMIL = 'ta-SG',
 }
 
 export enum FormStatus {

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -1,5 +1,10 @@
 import { PublicUserDto, UserDto } from '../user'
-import { FormField, FormFieldDto, MyInfoChildData } from '../field'
+import {
+  FormField,
+  FormFieldDto,
+  MyInfoChildData,
+  TranslationMapping,
+} from '../field'
 
 import { FormLogo } from './form_logo'
 import type { Merge, Tagged, PartialDeep } from 'type-fest'
@@ -35,11 +40,17 @@ export type FormPermission = {
   write: boolean
 }
 
+export type TranslationOptionMapping = {
+  language: Language
+  translation: string[]
+}
+
 export type FormStartPage = {
   logo: FormLogo
   colorTheme: FormColorTheme
   estTimeTaken?: number
   paragraph?: string
+  paragraphTranslations?: TranslationMapping[]
 }
 
 export type FormEndPage = {
@@ -49,6 +60,8 @@ export type FormEndPage = {
   buttonText: string
   paymentTitle: string
   paymentParagraph: string
+  titleTranslations?: TranslationMapping[]
+  paragraphTranslations?: TranslationMapping[]
 }
 
 export enum FormAuthType {
@@ -60,10 +73,22 @@ export enum FormAuthType {
   SGID_MyInfo = 'SGID_MyInfo',
 }
 
+export enum Language {
+  ENGLISH = 'English',
+  CHINESE = 'Chinese',
+  MALAY = 'Malay',
+  TAMIL = 'Tamil',
+}
+
 export enum FormStatus {
   Private = 'PRIVATE',
   Public = 'PUBLIC',
   Archived = 'ARCHIVED',
+}
+
+export type FormSupportedLanguages = {
+  nextSupportedLanguages?: Language[]
+  selectedLanguage?: Language | null
 }
 
 export type FormWebhook = {
@@ -162,6 +187,9 @@ export interface FormBase {
   responseMode: FormResponseMode
 
   goLinkSuffix?: string
+
+  hasMultiLang?: boolean
+  supportedLanguages?: Language[]
 }
 
 export interface EmailFormBase extends FormBase {

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -53,6 +53,7 @@ const MOCK_ADMIN_EMAIL = `test@${MOCK_ADMIN_DOMAIN}`
 const MOCK_FORM_PARAMS = {
   title: 'Test Form',
   admin: MOCK_ADMIN_OBJ_ID,
+  supportedLanguages: [],
 }
 const MOCK_ENCRYPTED_FORM_PARAMS = {
   ...MOCK_FORM_PARAMS,
@@ -81,12 +82,15 @@ const FORM_DEFAULTS = {
     logo: {
       state: FormLogoState.Default,
     },
+    paragraphTranslations: [],
   },
   endPage: {
     title: 'Thank you for filling out the form.',
     buttonText: 'Submit another response',
     paymentTitle: 'Thank you, your payment has been made successfully.',
     paymentParagraph: 'Your form has been submitted and payment has been made.',
+    titleTranslations: [],
+    paragraphTranslations: [],
   },
   hasCaptcha: true,
   hasIssueNotification: true,
@@ -1836,7 +1840,11 @@ describe('Form Model', () => {
         expect(actual?.toObject()).toEqual({
           ...form,
           lastModified: expect.any(Date),
-          endPage: { ...updatedEndPage },
+          endPage: {
+            ...updatedEndPage,
+            paragraphTranslations: [],
+            titleTranslations: [],
+          },
         })
       })
 
@@ -1867,6 +1875,8 @@ describe('Form Model', () => {
             paymentParagraph:
               'Your form has been submitted and payment has been made.',
             paymentTitle: 'Thank you, your payment has been made successfully.',
+            paragraphTranslations: [],
+            titleTranslations: [],
           },
         })
       })
@@ -2130,6 +2140,7 @@ describe('Form Model', () => {
             logo: {
               state: FormLogoState.Default,
             },
+            paragraphTranslations: [],
           },
         })
       })

--- a/src/app/models/field/baseField.ts
+++ b/src/app/models/field/baseField.ts
@@ -1,7 +1,7 @@
 import { Schema } from 'mongoose'
 import UIDGenerator from 'uid-generator'
 
-import { BasicField, MyInfoAttribute } from '../../../../shared/types'
+import { BasicField, Language, MyInfoAttribute } from '../../../../shared/types'
 import { IFieldSchema, IMyInfoSchema, ITableFieldSchema } from '../../../types'
 
 const uidgen3 = new UIDGenerator(256, UIDGenerator.BASE62)
@@ -44,6 +44,36 @@ export const BaseFieldSchema = new Schema<IFieldSchema>(
       type: String,
       enum: Object.values(BasicField),
       required: true,
+    },
+    titleTranslations: {
+      type: [
+        {
+          language: {
+            type: String,
+            enum: Object.values(Language),
+          },
+          translation: {
+            type: String,
+          },
+        },
+      ],
+      default: [],
+      _id: false,
+    },
+    descriptionTranslations: {
+      type: [
+        {
+          language: {
+            type: String,
+            enum: Object.values(Language),
+          },
+          translation: {
+            type: String,
+          },
+        },
+      ],
+      default: [],
+      _id: false,
     },
   },
   {

--- a/src/app/models/field/checkboxField.ts
+++ b/src/app/models/field/checkboxField.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'mongoose'
+import { Language } from 'shared/types'
 
 import { ICheckboxFieldSchema } from '../../../types'
 
@@ -12,6 +13,18 @@ const createCheckboxFieldSchema = () => {
         },
         message: 'Please ensure that there are no duplicate checkbox options.',
       },
+    },
+    fieldOptionsTranslations: {
+      type: [
+        {
+          language: {
+            type: String,
+            enum: Object.values(Language),
+          },
+          translation: [String],
+        },
+      ],
+      default: [],
     },
     othersRadioButton: {
       type: Boolean,

--- a/src/app/models/field/dropdownField.ts
+++ b/src/app/models/field/dropdownField.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'mongoose'
+import { Language } from 'shared/types'
 
 import { IDropdownFieldSchema } from '../../../types'
 
@@ -7,6 +8,18 @@ import { MyInfoSchema } from './baseField'
 const createDropdownFieldSchema = () => {
   return new Schema<IDropdownFieldSchema>({
     fieldOptions: [String],
+    fieldOptionsTranslations: {
+      type: [
+        {
+          language: {
+            type: String,
+            enum: Object.values(Language),
+          },
+          translation: [String],
+        },
+      ],
+      default: [],
+    },
     myInfo: MyInfoSchema,
   })
 }

--- a/src/app/models/field/radioField.ts
+++ b/src/app/models/field/radioField.ts
@@ -1,10 +1,23 @@
 import { Schema } from 'mongoose'
+import { Language } from 'shared/types'
 
 import { IRadioFieldSchema } from '../../../types'
 
 const createRadioFieldSchema = () => {
   return new Schema<IRadioFieldSchema>({
     fieldOptions: [String],
+    fieldOptionsTranslations: {
+      type: [
+        {
+          language: {
+            type: String,
+            enum: Object.values(Language),
+          },
+          translation: [String],
+        },
+      ],
+      default: [],
+    },
     othersRadioButton: {
       type: Boolean,
       default: false,

--- a/src/app/models/field/tableField.ts
+++ b/src/app/models/field/tableField.ts
@@ -1,7 +1,7 @@
 import { isEmpty } from 'lodash'
 import { Schema } from 'mongoose'
 
-import { BasicField } from '../../../../shared/types'
+import { BasicField, Language } from '../../../../shared/types'
 import { IColumnSchema, ITableFieldSchema } from '../../../types'
 
 const createColumnSchema = () => {
@@ -15,6 +15,18 @@ const createColumnSchema = () => {
       required: {
         type: Boolean,
         required: true,
+      },
+      titleTranslations: {
+        type: [
+          {
+            language: {
+              type: String,
+              enum: Object.values(Language),
+            },
+            translation: [String],
+          },
+        ],
+        default: [],
       },
     },
     {

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -41,6 +41,7 @@ import {
   FormStatus,
   FormWebhookResponseModeSettings,
   FormWebhookSettings,
+  Language,
   LogicConditionState,
   LogicDto,
   LogicType,
@@ -469,6 +470,21 @@ const compileFormModel = (db: Mongoose): IFormModel => {
           type: FormLogoSchema,
           default: () => ({}),
         },
+        paragraphTranslations: {
+          type: [
+            {
+              language: {
+                type: String,
+                enum: Object.values(Language),
+              },
+              translation: {
+                type: String,
+              },
+            },
+          ],
+          default: [],
+          _id: false,
+        },
       },
 
       endPage: {
@@ -489,6 +505,36 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         paymentParagraph: {
           type: String,
           default: 'Your form has been submitted and payment has been made.',
+        },
+        titleTranslations: {
+          type: [
+            {
+              language: {
+                type: String,
+                enum: Object.values(Language),
+              },
+              translation: {
+                type: String,
+              },
+            },
+          ],
+          default: [],
+          _id: false,
+        },
+        paragraphTranslations: {
+          type: [
+            {
+              language: {
+                type: String,
+                enum: Object.values(Language),
+              },
+              translation: {
+                type: String,
+              },
+            },
+          ],
+          default: [],
+          _id: false,
         },
       },
 
@@ -596,6 +642,20 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         type: String,
         required: false,
         default: '',
+      },
+
+      // boolean value to indicate if form supports multi
+      // language
+      hasMultiLang: {
+        type: Boolean,
+        required: false,
+      },
+
+      // languages that is supported by form for translations
+      supportedLanguages: {
+        type: [String],
+        enum: Object.values(Language),
+        require: false,
       },
     },
     formSchemaOptions,

--- a/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -2531,6 +2531,7 @@ describe('admin-form.form.routes', () => {
         state: FormLogoState.None,
       },
       estTimeTaken: 10,
+      paragraphTranslations: [],
     }
 
     it('should return 200 when the request is successful', async () => {


### PR DESCRIPTION
## Context
- Add fields in the model layer to represent the translations for the form fields and which languages are supported for the form.
- This PR will be the first PR to introduce the additional model fields to support for the multi translation feature.

## Changes
- Added new type called `TranslationMapping` which represents the translations for the specific language
- Added `titleTranslations` and `descriptionTranslations` for`baseField` type
- Added `paragraphTranslations` for `startPage` type
- Added `fieldOptionsTranslations` for `CheckboxFieldSchema`, `RadioFieldSchema` and `DropdownFieldSchema`