### PR TITLE
fix: update husky commit hook status msg

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -11,6 +11,6 @@ fi
 # Initialise git-secrets configuration
 git-secrets --register-aws > /dev/null
 
-echo "Running git-secrets..."
+echo "Running git-secrets commit_msg_hook"
 # Scans the commit message.
 git-secrets --commit_msg_hook -- "$@"

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -12,7 +12,7 @@ fi
 # Initialise git-secrets configuration
 git-secrets --register-aws > /dev/null
 
-echo "Running git-secrets..."
+echo "Running git-secrets prepare_commit_msg_hook"
 # Determines if merging in a commit will introduce tainted history.
 git-secrets --prepare_commit_msg_hook -- "$@"
 


### PR DESCRIPTION
## Problem
The commit messages for the husky git commit hooks were previously all the same (suggesting the same hook runs 3 times) but this updates the msg.

Although we have git guardian now which only runs as workflows, its still good to have commit hooks on the local machine itself as a first line of defense.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  