### PR TITLE
feat(admin-dashboard): add response mode text next to form title on dashboard

### DIFF
--- a/frontend/src/features/admin-form/common/constants.ts
+++ b/frontend/src/features/admin-form/common/constants.ts
@@ -1,0 +1,7 @@
+import { FormResponseMode } from '~shared/types'
+
+export const RESPONSE_MODE_TO_TEXT: { [key in FormResponseMode]: string } = {
+  [FormResponseMode.Multirespondent]: 'Multi-respondent form',
+  [FormResponseMode.Email]: 'Email mode',
+  [FormResponseMode.Encrypt]: 'Storage mode',
+}

--- a/frontend/src/features/admin-form/settings/components/GeneralTabHeader.tsx
+++ b/frontend/src/features/admin-form/settings/components/GeneralTabHeader.tsx
@@ -1,9 +1,8 @@
-import { useMemo } from 'react'
 import { Skeleton, Wrap } from '@chakra-ui/react'
 
-import { FormResponseMode } from '~shared/types/form'
-
 import Badge from '~components/Badge'
+
+import { RESPONSE_MODE_TO_TEXT } from '~features/admin-form/common/constants'
 
 import { useAdminFormSettings } from '../queries'
 
@@ -13,17 +12,10 @@ export const GeneralTabHeader = (): JSX.Element => {
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
-  const readableFormResponseMode = useMemo(() => {
-    switch (settings?.responseMode) {
-      case FormResponseMode.Email:
-        return 'Email mode'
-      case FormResponseMode.Encrypt:
-        return 'Storage mode'
-      case FormResponseMode.Multirespondent:
-        return 'Multi-respondent form'
-    }
-    return 'Loading...'
-  }, [settings?.responseMode])
+  const readableFormResponseMode = !settings
+    ? 'Loading...'
+    : RESPONSE_MODE_TO_TEXT[settings.responseMode]
+
   return (
     <Wrap
       shouldWrapChildren

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -3,9 +3,14 @@ import { Link as ReactLink } from 'react-router-dom'
 import { Box, ButtonProps, chakra, Flex, Text } from '@chakra-ui/react'
 import dayjs from 'dayjs'
 
-import { AdminDashboardFormMetaDto, FormStatus } from '~shared/types/form/form'
+import {
+  AdminDashboardFormMetaDto,
+  FormResponseMode,
+  FormStatus,
+} from '~shared/types/form/form'
 
 import { ADMINFORM_ROUTE } from '~constants/routes'
+import Badge from '~components/Badge'
 
 import { FormStatusLabel } from './FormStatusLabel'
 import { RowActions } from './RowActions'
@@ -21,6 +26,12 @@ const RELATIVE_DATE_FORMAT = {
   nextWeek: 'ddd, D MMM YYYY h:mma', // Tue, 17 Oct 2021 9:30pm
   lastWeek: 'ddd, D MMM YYYY h:mma', // Tue, 17 Oct 2021 9:30pm
   sameElse: 'D MMM YYYY h:mma', // 6 Oct 2021 9:30pm
+}
+
+const RESPONSE_MODE_TO_TEXT: { [key in FormResponseMode]: string } = {
+  [FormResponseMode.Multirespondent]: 'Multi-respondent form',
+  [FormResponseMode.Email]: 'Email form',
+  [FormResponseMode.Encrypt]: 'Storage form',
 }
 
 export const WorkspaceFormRow = ({
@@ -45,12 +56,12 @@ export const WorkspaceFormRow = ({
         justifyContent="space-between"
         gridTemplateColumns={{
           base: '1fr 2.75rem',
-          md: '1fr 4rem 8rem',
+          md: '1fr 10rem 4rem 8rem',
         }}
         gridTemplateRows={{ base: 'auto 2.75rem', md: 'auto' }}
         gridTemplateAreas={{
-          base: "'title title' 'status actions'",
-          md: "'title status actions'",
+          base: "'title title' 'formType' 'status actions'",
+          md: "'title formType status actions'",
         }}
         gridGap={{ base: '0.5rem', md: '1.5rem' }}
         _hover={{
@@ -83,6 +94,11 @@ export const WorkspaceFormRow = ({
             Edited {prettyLastModified}
           </Text>
         </Flex>
+        <Box gridArea="formType" alignSelf="center">
+          <Badge bgColor="primary.100" color="secondary.500">
+            {RESPONSE_MODE_TO_TEXT[formMeta.responseMode]}
+          </Badge>
+        </Box>
         <Box gridArea="status" alignSelf="center">
           <FormStatusLabel status={formMeta.status} />
         </Box>

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -60,7 +60,7 @@ export const WorkspaceFormRow = ({
         }}
         gridTemplateRows={{ base: 'auto 2.75rem', md: 'auto' }}
         gridTemplateAreas={{
-          base: "'title title' 'formType' 'status actions'",
+          base: "'title title' 'formType formType' 'status actions'",
           md: "'title formType status actions'",
         }}
         gridGap={{ base: '0.5rem', md: '1.5rem' }}

--- a/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceFormRow.tsx
@@ -3,14 +3,12 @@ import { Link as ReactLink } from 'react-router-dom'
 import { Box, ButtonProps, chakra, Flex, Text } from '@chakra-ui/react'
 import dayjs from 'dayjs'
 
-import {
-  AdminDashboardFormMetaDto,
-  FormResponseMode,
-  FormStatus,
-} from '~shared/types/form/form'
+import { AdminDashboardFormMetaDto, FormStatus } from '~shared/types/form/form'
 
 import { ADMINFORM_ROUTE } from '~constants/routes'
 import Badge from '~components/Badge'
+
+import { RESPONSE_MODE_TO_TEXT } from '~features/admin-form/common/constants'
 
 import { FormStatusLabel } from './FormStatusLabel'
 import { RowActions } from './RowActions'
@@ -26,12 +24,6 @@ const RELATIVE_DATE_FORMAT = {
   nextWeek: 'ddd, D MMM YYYY h:mma', // Tue, 17 Oct 2021 9:30pm
   lastWeek: 'ddd, D MMM YYYY h:mma', // Tue, 17 Oct 2021 9:30pm
   sameElse: 'D MMM YYYY h:mma', // 6 Oct 2021 9:30pm
-}
-
-const RESPONSE_MODE_TO_TEXT: { [key in FormResponseMode]: string } = {
-  [FormResponseMode.Multirespondent]: 'Multi-respondent form',
-  [FormResponseMode.Email]: 'Email form',
-  [FormResponseMode.Encrypt]: 'Storage form',
 }
 
 export const WorkspaceFormRow = ({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Users with lots of forms are unable to determine quickly what forms they have created.


## Solution
<!-- How did you solve the problem? -->

Add a label denoting form response type.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Component | Before | After |
|--------|--------|--------|
| Dashboard | <img width="1520" alt="Screenshot 2024-07-02 at 6 09 29 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/ef1fbabd-56a1-44c7-9792-f1fad6a87b26"> | <img width="1552" alt="Screenshot 2024-07-02 at 6 09 10 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/35cf6a9b-9f0f-4c99-9265-941e730cda9d"> |
| Dashboard (small screen) |<img width="553" alt="Screenshot 2024-07-03 at 9 10 58 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/d0aea877-fd38-4a86-a0e0-abcca11f0519"> | <img width="556" alt="Screenshot 2024-07-03 at 9 07 03 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/e4a2d068-b02f-43ce-91fe-50dcb0ed89bf">|

