### PR TITLE
feat: add reddot on email noti

### DIFF
--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbar.tsx
@@ -5,6 +5,7 @@ import {
   BiShow,
   BiUserPlus,
 } from 'react-icons/bi'
+import { GoPrimitiveDot } from 'react-icons/go'
 import { Link as ReactLink, useLocation } from 'react-router-dom'
 import {
   Box,
@@ -18,6 +19,7 @@ import {
   Flex,
   Grid,
   GridItem,
+  Icon,
   Skeleton,
   Text,
   useBreakpointValue,
@@ -25,6 +27,7 @@ import {
 } from '@chakra-ui/react'
 import format from 'date-fns/format'
 
+import { SeenFlags } from '~shared/types'
 import { AdminFormDto } from '~shared/types/form/form'
 
 import {
@@ -39,6 +42,11 @@ import Button, { ButtonProps } from '~components/Button'
 import IconButton from '~components/IconButton'
 import Tooltip from '~components/Tooltip'
 import { NavigationTab, NavigationTabList } from '~templates/NavigationTabs'
+
+import { SeenFlagsMapVersion } from '~features/user/constants'
+import { useUserMutations } from '~features/user/mutations'
+import { useUser } from '~features/user/queries'
+import { getShowFeatureFlagLastSeen } from '~features/user/utils'
 
 import { AdminFormNavbarBreadcrumbs } from './AdminFormNavbarBreadcrumbs'
 
@@ -67,6 +75,13 @@ export const AdminFormNavbar = ({
   const { ref, onMouseDown } = useDraggable<HTMLDivElement>()
   const { isOpen, onClose, onOpen } = useDisclosure()
   const { pathname } = useLocation()
+
+  const { user, isLoading: isUserLoading } = useUser()
+  const { updateLastSeenFlagMutation } = useUserMutations()
+  const shouldShowSettingsReddot = useMemo(() => {
+    if (isUserLoading || !user) return false
+    return getShowFeatureFlagLastSeen(user, SeenFlags.SettingsNotification)
+  }, [isUserLoading, user])
 
   const tabResponsiveVariant = useBreakpointValue({
     base: 'line-dark',
@@ -171,8 +186,25 @@ export const AdminFormNavbar = ({
           hidden={viewOnly}
           to={ADMINFORM_SETTINGS_SUBROUTE}
           isActive={checkTabActive(ADMINFORM_SETTINGS_SUBROUTE)}
+          onClick={() => {
+            if (shouldShowSettingsReddot) {
+              updateLastSeenFlagMutation.mutate({
+                flag: SeenFlags.SettingsNotification,
+                version: SeenFlagsMapVersion[SeenFlags.SettingsNotification],
+              })
+            }
+          }}
         >
           Settings
+          {shouldShowSettingsReddot ? (
+            <Icon
+              as={GoPrimitiveDot}
+              color="danger.500"
+              position="absolute"
+              right="-8px"
+              top="2px"
+            />
+          ) : null}
         </NavigationTab>
         <NavigationTab
           to={ADMINFORM_RESULTS_SUBROUTE}

--- a/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
@@ -22,7 +22,7 @@ const AdminEmailSection = () => {
 
   // should render null
   if (!isEmailOrStorageMode) {
-    return false
+    return null
   }
 
   return <EmailFormSection settings={settings} />

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -19,16 +19,11 @@ import {
   Tabs,
 } from '@chakra-ui/react'
 
-import { FormResponseMode, SeenFlags } from '~shared/types'
+import { FormResponseMode } from '~shared/types'
 import { isNonEmpty } from '~shared/utils/isNonEmpty'
 
 import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 import { useDraggable } from '~hooks/useDraggable'
-
-import { SeenFlagsMapVersion } from '~features/user/constants'
-import { useUserMutations } from '~features/user/mutations'
-import { useUser } from '~features/user/queries'
-import { getShowFeatureFlagLastSeen } from '~features/user/utils'
 
 import { useAdminFormCollaborators } from '../common/queries'
 
@@ -47,18 +42,11 @@ interface TabEntry {
   component: () => JSX.Element
   path: string
   showRedDot?: boolean
-  onClick?: () => void
 }
 
 export const SettingsPage = (): JSX.Element => {
   const { formId, settingsTab } = useParams()
   const { data: settings } = useAdminFormSettings()
-  const { user, isLoading: isUserLoading } = useUser()
-  const { updateLastSeenFlagMutation } = useUserMutations()
-  const shouldShowSettingsEmailNotiReddot = useMemo(() => {
-    if (isUserLoading || !user) return false
-    return getShowFeatureFlagLastSeen(user, SeenFlags.SettingsEmailNotification)
-  }, [isUserLoading, user])
 
   if (!formId) throw new Error('No formId provided')
 
@@ -81,16 +69,7 @@ export const SettingsPage = (): JSX.Element => {
             icon: BiMailSend,
             component: SettingsEmailsPage,
             path: 'email-notifications',
-            showRedDot: shouldShowSettingsEmailNotiReddot,
-            onClick: () => {
-              if (shouldShowSettingsEmailNotiReddot) {
-                updateLastSeenFlagMutation.mutate({
-                  flag: SeenFlags.SettingsEmailNotification,
-                  version:
-                    SeenFlagsMapVersion[SeenFlags.SettingsEmailNotification],
-                })
-              }
-            },
+            showRedDot: true,
           }
         : null
 
@@ -129,11 +108,7 @@ export const SettingsPage = (): JSX.Element => {
     ]
 
     return baseConfig.filter(isNonEmpty)
-  }, [
-    settings?.responseMode,
-    shouldShowSettingsEmailNotiReddot,
-    updateLastSeenFlagMutation,
-  ])
+  }, [settings?.responseMode])
 
   const { ref, onMouseDown } = useDraggable<HTMLDivElement>()
 
@@ -157,7 +132,7 @@ export const SettingsPage = (): JSX.Element => {
         index={tabIndex === -1 ? 0 : tabIndex}
         onChange={(index) => {
           handleTabChange(index)
-          tabConfig[index].onClick?.()
+          tabConfig[index]
         }}
       >
         <Flex
@@ -192,7 +167,7 @@ export const SettingsPage = (): JSX.Element => {
                 key={tab.label}
                 label={tab.label}
                 icon={tab.icon}
-                showRedDot={tab.showRedDot}
+                showNewBadge={tab.showRedDot}
               />
             ))}
           </TabList>

--- a/frontend/src/features/admin-form/settings/components/SettingsTab.tsx
+++ b/frontend/src/features/admin-form/settings/components/SettingsTab.tsx
@@ -1,32 +1,33 @@
-import { GoPrimitiveDot } from 'react-icons/go'
 import { As, Box, Icon, Tab } from '@chakra-ui/react'
+
+import Badge from '~components/Badge'
 
 export interface SettingsTabProps {
   label: string
   icon: As
-  showRedDot?: boolean
+  showNewBadge?: boolean
 }
 
 export const SettingsTab = ({
   label,
   icon,
-  showRedDot,
+  showNewBadge = false,
 }: SettingsTabProps): JSX.Element => {
   return (
     <Tab justifyContent="flex-start" p="1rem">
       <Icon as={icon} color="currentcolor" fontSize="1.5rem" />
-      {showRedDot ? (
-        <Icon
-          as={GoPrimitiveDot}
-          color="danger.500"
-          position="absolute"
-          ml="20px"
-          mt="-20px"
-        />
-      ) : null}
       <Box ml="1.5rem" display={{ base: 'none', lg: 'initial' }}>
         {label}
       </Box>
+      {showNewBadge ? (
+        <Badge
+          ml="0.5rem"
+          colorScheme="success"
+          display={{ base: 'none', lg: 'initial' }}
+        >
+          New
+        </Badge>
+      ) : null}
     </Tab>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/SettingsTab.tsx
+++ b/frontend/src/features/admin-form/settings/components/SettingsTab.tsx
@@ -1,14 +1,29 @@
+import { GoPrimitiveDot } from 'react-icons/go'
 import { As, Box, Icon, Tab } from '@chakra-ui/react'
 
 export interface SettingsTabProps {
   label: string
   icon: As
+  showRedDot?: boolean
 }
 
-export const SettingsTab = ({ label, icon }: SettingsTabProps): JSX.Element => {
+export const SettingsTab = ({
+  label,
+  icon,
+  showRedDot,
+}: SettingsTabProps): JSX.Element => {
   return (
     <Tab justifyContent="flex-start" p="1rem">
       <Icon as={icon} color="currentcolor" fontSize="1.5rem" />
+      {showRedDot ? (
+        <Icon
+          as={GoPrimitiveDot}
+          color="danger.500"
+          position="absolute"
+          ml="20px"
+          mt="-20px"
+        />
+      ) : null}
       <Box ml="1.5rem" display={{ base: 'none', lg: 'initial' }}>
         {label}
       </Box>

--- a/frontend/src/features/user/constants.ts
+++ b/frontend/src/features/user/constants.ts
@@ -8,6 +8,6 @@ const LegacySeenFlags = {
 
 export const SeenFlagsMapVersion: { [key in SeenFlags]: number } = {
   ...LegacySeenFlags,
-  [SeenFlags.SettingsEmailNotification]: 0, // stub
-  [SeenFlags.CreateBuilderMrfWorkflow]: 0, // stub
+  [SeenFlags.SettingsNotification]: 0,
+  [SeenFlags.CreateBuilderMrfWorkflow]: 0,
 }

--- a/frontend/src/templates/NavigationTabs/NavigationTab.tsx
+++ b/frontend/src/templates/NavigationTabs/NavigationTab.tsx
@@ -7,6 +7,7 @@ const Link = chakra(ReactLink)
 interface NavigationTabProps extends ComponentProps<typeof Link> {
   isActive?: boolean
   isDisabled?: boolean
+  showReddot?: boolean
 }
 
 /** Must be nested inside NavigationTabList component, uses styles provided by that component. */

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -7,7 +7,7 @@ export type UserId = Tagged<string, 'UserId'>
 
 export enum SeenFlags {
   LastSeenFeatureUpdateVersion = 'lastSeenFeatureUpdateVersion',
-  SettingsEmailNotification = 'settingsEmailNotification',
+  SettingsNotification = 'settingsNotification',
   CreateBuilderMrfWorkflow = 'createBuilderMrfWorkflow',
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1747

## Solution
<!-- How did you solve the problem? -->

Adds reddot on Admin Form Settings > Email Notifications

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
| Component  |Before   |After   | 
|---|---|---|
|  Settings Navbar (Small Screen) | <img width="267" alt="Screenshot 2024-07-04 at 8 06 01 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/4aa324ba-f994-4a69-a07e-2ab288ec09c3">  |   <img width="297" alt="Screenshot 2024-07-04 at 8 05 55 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/f095b61b-c629-43d6-9720-17d28d5c4971"> |
| Settings Navbar (Normal Screen) | <img width="260" alt="Screenshot 2024-07-04 at 8 06 05 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/f1961300-8bb4-42df-99c6-463e41e4bd96">| <img width="287" alt="Screenshot 2024-07-04 at 8 05 50 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/dc53078c-05ad-4e2d-80ac-349715174f49"> | 
| Email Notification Tab (Small Screen) | ![Screenshot 2024-07-02 at 11.11.33 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/1pRrlAd2KXkLRBeP0wKD/96b3461d-00c6-4300-a84a-a594e724500b.png) | No change |
| Email Notification Tab | ![Screenshot 2024-07-02 at 11.11.37 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/1pRrlAd2KXkLRBeP0wKD/80f5adcc-667c-4dbd-9228-a79c6c856208.png)  | <img width="720" alt="Screenshot 2024-07-04 at 8 16 57 PM" src="https://github.com/opengovsg/FormSG/assets/12391617/72a39541-8710-43f2-88bc-86d76d30a332"> |






## Tests
<!-- What tests should be run to confirm functionality? -->
Email Settings reddot should show if not seen, and removed on click
- [ ] Create a new Form
- [ ] Go to Form Settings Page
- [ ] Ensure that red dot is shown on Settings NavBar
- [ ] Click on Settings Page NavBar
- [ ] Ensure that red dot is not shown
- [ ] Reload the page
- [ ] Ensure that red dot is still not shown
