### PR TITLE
feat: add pdf attachments for encrypt forms

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -130,14 +130,9 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
 
   const { data: form } = useCreateTabForm()
   const isPdfResponseEnabled = useMemo(
-    () => form?.responseMode !== FormResponseMode.Encrypt,
+    () => form?.responseMode !== FormResponseMode.Multirespondent,
     [form],
   )
-  const pdfResponseToggleDescription = useMemo(() => {
-    if (!isPdfResponseEnabled) {
-      return 'For security reasons, PDF responses are not included in email confirmations for Storage mode forms'
-    }
-  }, [isPdfResponseEnabled])
 
   // email confirmation is not supported on MRF
   const isToggleEmailConfirmationDisabled = useMemo(
@@ -239,7 +234,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
               <Toggle
                 {...register('autoReplyOptions.includeFormSummary')}
                 label="Include PDF response"
-                description={pdfResponseToggleDescription}
                 isDisabled={!isPdfResponseEnabled}
               />
             </FormControl>

--- a/src/app/models/field/__tests__/emailField.spec.ts
+++ b/src/app/models/field/__tests__/emailField.spec.ts
@@ -44,7 +44,7 @@ describe('models.fields.emailField', () => {
   beforeEach(async () => await dbHandler.clearDatabase())
   afterAll(async () => await dbHandler.closeDatabase())
 
-  it('should set includeFormSummary to false on ResponseMode.Encrypt forms', async () => {
+  it('should set includeFormSummary to given value on ResponseMode.Encrypt forms', async () => {
     // Arrange
     const mockEmailField = {
       autoReplyOptions: {
@@ -66,8 +66,7 @@ describe('models.fields.emailField', () => {
     const expected = merge(EMAIL_FIELD_DEFAULTS, mockEmailField, {
       _id: expect.anything(),
       autoReplyOptions: {
-        // Regardless, should be false since ResponseMode is Encrypt.
-        includeFormSummary: false,
+        includeFormSummary: true,
       },
     })
     expect(actual.field.toObject()).toEqual(expected)

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -31,8 +31,8 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
         type: Boolean,
         default: false,
         set: function (this: IEmailFieldSchema, v: boolean) {
-          // Set to false if encrypt mode regardless of initial value.
-          return this.parent().responseMode === FormResponseMode.Encrypt
+          // Set to false if mrf mode regardless of initial value.
+          return this.parent().responseMode === FormResponseMode.Multirespondent
             ? false
             : v
         },


### PR DESCRIPTION
## Problem
In order to deprecate email mode eventually, we have to bring encrypt-mode up to parity with email mode, and one of the things encrypt mode is lacking is pdf attachments for responses. After encryption boundary shift, this should be possible. 


Closes FRM-1360


**Breaking Changes** 
- [x] No - this PR is backwards compatible  


## Tests
**Regression Tests**
- [ ] 1. Create a new storage mode form and add an email field
- [ ] 2. Enable email notifications WITHOUT pdf summary
- [ ] 3.  Make the form public
- [ ] 4. Create a submission with your email
- [ ] 5. Observe that the email confirmation does not contain the pdf attachment

**New feature**
- [ ] 1. Create a new storage mode form and add an email field
- [ ] 2. Enable email confirmations and enable pdf attachments. 
- [ ] 3. Make the form public 
- [ ] 4. Create a submission with your email
- [ ] 5. Notice that the email confirmation contains the pdf attachment. 
