### PR TITLE
feat: add myinfo child field for encrypt form

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -205,8 +205,7 @@ export const MyInfoFieldPanel = () => {
           </Box>
         )}
       </Droppable>
-      {user?.betaFlags?.children &&
-      form?.responseMode === FormResponseMode.Email ? (
+      {user?.betaFlags?.children ? (
         <Droppable isDropDisabled droppableId={CREATE_MYINFO_CHILDREN_DROP_ID}>
           {(provided) => (
             <Box ref={provided.innerRef} {...provided.droppableProps}>


### PR DESCRIPTION
This mockpass persona has a child: S9912374E

## Problem
Two issues
1. SGID with MyInfo doesn't have children field
2. Webhooks doesn't work with compound field (child field)

This PR enables it for encrypt forms. 

Look at https://github.com/opengovsg/FormSG/pull/6447

Closes FRM-1520


One child field:
<img width="1267" alt="Screenshot 2024-07-04 at 2 32 18 PM" src="https://github.com/opengovsg/FormSG/assets/76802638/49446343-b037-4377-847a-50b8ca935db3">


Multiple children added:
<img width="902" alt="Screenshot 2024-07-04 at 2 35 39 PM" src="https://github.com/opengovsg/FormSG/assets/76802638/89911ecf-e257-484a-a9a5-71f1a6c140e5">


**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
- [ ] 1. Create a storage mode form
- [ ] 2. Enable Singpass with MyInfo (not SGID)
- [ ] 3. Add [webhook](https://webhook.site/) to the form
- [ ] 4. Make form public and make a submission
- [ ] 5. Check that webhook has been triggered with the children information