### PR TITLE
chore: remove nric mask toggle if nricmask is false

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSingpassSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSingpassSection.tsx
@@ -22,8 +22,15 @@ export const AuthSettingsSingpassSection = ({
         settings={settings}
         isDisabled={isFormPublic || containsMyInfoFields}
       />
-      <Divider my="2.5rem" />
-      <FormNricMaskToggle settings={settings} isDisabled={isFormPublic} />
+
+      {/* Hide the NRIC mask toggle if they have not yet enabled it as part of
+      PMO circular */}
+      {settings.isNricMaskEnabled ? (
+        <>
+          <Divider my="2.5rem" />
+          <FormNricMaskToggle settings={settings} isDisabled={isFormPublic} />
+        </>
+      ) : null}
     </>
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

## Solution
Hide Nric toggle if admin has not enabled the toggle for their form. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  