### PR TITLE
feat: add copy for link to response page

### DIFF
--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -1,3 +1,4 @@
+import { ADMIN_FORM_PAGE_RESPONSES_INDIVIDUAL } from '__tests__/e2e/constants'
 import { render } from '@react-email/render'
 import tracer from 'dd-trace'
 import { get, inRange, isEmpty } from 'lodash'
@@ -495,9 +496,13 @@ export class MailService {
       answer: string | number
     }[]
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
+    console.log({ tejas: `${process.env.APP_URL}` })
     const refNo = String(submission.id)
     const formTitle = form.title
-    const formId: string = String(form._id)
+    const responseLink: string =
+      process.env.NODE_ENV === 'production'
+        ? `https://form.gov.sg/admin/form/${form._id}/results/${refNo}`
+        : `localhost:3000/admin/form/${form._id}/results/${refNo}`
     const responseMode: string = form.responseMode
     const submissionTime = moment(submission.created)
       .tz('Asia/Singapore')
@@ -508,7 +513,7 @@ export class MailService {
     const htmlData: SubmissionToAdminHtmlData = {
       appName: this.#appName,
       formTitle,
-      formId,
+      responseLink,
       responseMode,
       refNo,
       submissionTime,

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -486,7 +486,7 @@ export class MailService {
     formData,
   }: {
     replyToEmails?: string[]
-    form: Pick<IFormHasEmailSchema, '_id' | 'title' | 'emails'>
+    form: Pick<IFormHasEmailSchema, '_id' | 'title' | 'emails' | 'responseMode'>
     submission: Pick<ISubmissionSchema, 'id' | 'created'>
     attachments?: Mail.Attachment[]
     formData: EmailAdminDataField[]
@@ -497,6 +497,8 @@ export class MailService {
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
     const refNo = String(submission.id)
     const formTitle = form.title
+    const formId: string = String(form._id)
+    const responseMode: string = form.responseMode
     const submissionTime = moment(submission.created)
       .tz('Asia/Singapore')
       .format('ddd, DD MMM YYYY hh:mm:ss A')
@@ -506,6 +508,8 @@ export class MailService {
     const htmlData: SubmissionToAdminHtmlData = {
       appName: this.#appName,
       formTitle,
+      formId,
+      responseMode,
       refNo,
       submissionTime,
       formData,

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -65,7 +65,7 @@ export type MailOptions = Omit<Mail.Options, 'to'> & {
 export type SubmissionToAdminHtmlData = {
   refNo: string
   formTitle: string
-  formId: string
+  responseLink: string
   responseMode: string
   submissionTime: string
   formData: EmailAdminDataField[]

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -1,7 +1,7 @@
 import Mail from 'nodemailer/lib/mailer'
 import { OperationOptions } from 'retry'
 
-import { AutoReplyOptions } from '../../../../shared/types'
+import { AutoReplyOptions, FormResponseMode } from '../../../../shared/types'
 import { SMS_WARNING_TIERS } from '../../../../shared/utils/verification'
 import {
   EmailAdminDataField,
@@ -65,6 +65,8 @@ export type MailOptions = Omit<Mail.Options, 'to'> & {
 export type SubmissionToAdminHtmlData = {
   refNo: string
   formTitle: string
+  formId: string
+  responseMode: string
   submissionTime: string
   formData: EmailAdminDataField[]
   dataCollationData?: {

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -1,7 +1,7 @@
 import Mail from 'nodemailer/lib/mailer'
 import { OperationOptions } from 'retry'
 
-import { AutoReplyOptions, FormResponseMode } from '../../../../shared/types'
+import { AutoReplyOptions } from '../../../../shared/types'
 import { SMS_WARNING_TIERS } from '../../../../shared/utils/verification'
 import {
   EmailAdminDataField,

--- a/src/app/views/templates/submit-form-email.server.view.html
+++ b/src/app/views/templates/submit-form-email.server.view.html
@@ -4,9 +4,12 @@
   <body>
     <p>Hello there,</p>
     <p>A "<%= formTitle %>" form was submitted on <%= submissionTime %>.</p>
-    <br />
-    <p> View this submission and download attachments on FormSG </p>
-    <br />
+    <% if (responseMode === 'encrypt') { %>
+      <p>View this submission and download attachments on <a href="http://localhost:3000/admin/form/<%= formId %>/results/<%= refNo %>">FormSG</a></p>
+    <% } else { %>
+      <br />
+    <% } %>
+    <br/>
     <table
       id="formsg"
       width="100%"

--- a/src/app/views/templates/submit-form-email.server.view.html
+++ b/src/app/views/templates/submit-form-email.server.view.html
@@ -4,7 +4,9 @@
   <body>
     <p>Hello there,</p>
     <p>A "<%= formTitle %>" form was submitted on <%= submissionTime %>.</p>
-    <br /><br /><br />
+    <br />
+    <p> View this submission and download attachments on FormSG </p>
+    <br />
     <table
       id="formsg"
       width="100%"

--- a/src/app/views/templates/submit-form-email.server.view.html
+++ b/src/app/views/templates/submit-form-email.server.view.html
@@ -4,8 +4,9 @@
   <body>
     <p>Hello there,</p>
     <p>A "<%= formTitle %>" form was submitted on <%= submissionTime %>.</p>
+    <br/>
     <% if (responseMode === 'encrypt') { %>
-      <p>View this submission and download attachments on <a href="http://localhost:3000/admin/form/<%= formId %>/results/<%= refNo %>">FormSG</a></p>
+      <p><a href="<%= responseLink %>">View this submission and download attachments on FormSG</a></p>
     <% } else { %>
       <br />
     <% } %>


### PR DESCRIPTION
## Problem
Currrently, email mode notifications for encrypt forms do not have attachments as we plan on increasing the attachment size limit and other reasons. This PR makes it easy for admins to go from their email notifications to the settings page for downloading the attachments. 

<img width="864" alt="Screenshot 2024-07-07 at 5 23 02 PM" src="https://github.com/opengovsg/FormSG/assets/76802638/7a838355-031b-4353-bf78-fe6791738b69">


**Breaking Changes** 
- [x] No - this PR is backwards compatible  


## Tests
**Regression Test:** Email mode form notifications must work exactly the same
- [ ] 1. Create a new email mode form
- [ ] 2. Make form public and create a submission
- [ ] 3. Observe that the email notification arrives in inbox, and has the same format as before. 
- [ ] 4. Observe that the email notification has attachments attached. 

**New feature**
- [ ] 1. Create a new storage mode form
- [ ] 2. Add your email as the admin
- [ ] 3. Make form public and create a submission
- [ ] 4. Observe that email notification arrives in inbox
- [ ] 4. Observe that there's a link to the admin settings page, and the response Id and time should match exactly
- [ ] 5. Observe that there are no attachments.
