### PR TITLE
fix: fix issue where attachments would fail locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - AWS_ACCESS_KEY_ID=fakeKey
       - AWS_SECRET_ACCESS_KEY=fakeSecret
       - SESSION_SECRET=thisisasecret
-      - AWS_ENDPOINT=http://localhost:4566
+      - AWS_ENDPOINT=http://127.0.0.1:4566
       - SECRET_ENV=development
       - SUBMISSIONS_RATE_LIMIT=200
       - SEND_AUTH_OTP_RATE_LIMIT=60


### PR DESCRIPTION
## Problem
When trying to submit attachments locally, an error is thrown saying error virus scanning fail

## Solution
On MacOS Sonoma, `localhost` resolves to the IPv6 loopback address `::1` which localstack doesn't support. This was verified by curling the attachments link from within the docker container which succeeded. The fix is to use `127.0.0.1` directly

[Known issue on localstack repo](https://github.com/localstack/localstack/issues/10874)

**Breaking Changes** 
- [x] No - this PR is backwards compatible  
On alpine images / other environments we use, localhost resolves to ipv4 loopback anyway. The only change here would be to developing locally on macos devices.

## Tests
**Regression Tests**
- [ ] 1. Create a storage mode form
- [ ] 2. Add attachments field
- [ ] 3. Make form public
- [ ] 4. Make a submission to the form
- [ ] 5. Go form responses page
- [ ] 6. Observe that responses contains attachments
- [ ] 7. Repeat for email mode forms

**New environment variables**:

- `AWS_ENDPOINT` : updated to 127.0.0.1 instead.