### PR TITLE
fix: add the code to error tag in datadog traces

### DIFF
--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -22,7 +22,7 @@ export const setFormTags = (form: IPopulatedForm) => {
 export const setErrorCode = (error: ApplicationError) => {
   const span = tracer.scope().active()
   if (span && error.code) {
-    span.setTag('error.type', String(error.code))
+    span.setTag('error.type', error.code)
     span.setTag('error.message', `[${error.code}] ${error.message}`)
     if (error.stack) span.setTag('error.stack', `${error.stack}`)
   }

--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -22,7 +22,7 @@ export const setFormTags = (form: IPopulatedForm) => {
 export const setErrorCode = (error: ApplicationError) => {
   const span = tracer.scope().active()
   if (span && error.code) {
-    span.setTag('error.type', error.code)
+    span.setTag('error.type', String(error.code))
     span.setTag('error.message', `[${error.code}] ${error.message}`)
     if (error.stack) span.setTag('error.stack', `${error.stack}`)
   }

--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -23,7 +23,7 @@ export const setErrorCode = (error: ApplicationError) => {
   const span = tracer.scope().active()
   if (span && error.code) {
     span.setTag('error.type', error.code)
-    span.setTag('error.message', error.message)
+    span.setTag('error.message', `[${error.code}] ${error.message}`)
     if (error.stack) span.setTag('error.stack', `${error.stack}`)
   }
 }


### PR DESCRIPTION
## Problem
The error message for traces in datadog only has the error msg and can be difficult to deduce the error code without going to `core.errors.ts` manually to check. The `@error.type` flag also doesn't appear on the trace explorer for some reason, only the message.

## Solution
This prefixes the error message with the error code to make filtering traces easier.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  


## Tests
