### PR TITLE
feat: replace hardcoded text in FeedbackBlock for i18n

### DIFF
--- a/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx
+++ b/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { Controller, useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { chakra, Flex, FormControl } from '@chakra-ui/react'
 
 import { FormColorTheme } from '~shared/types/form'
@@ -27,6 +28,8 @@ export const FeedbackBlock = ({
   onSubmit,
   colorTheme = FormColorTheme.Blue,
 }: FeedbackBlockProps): JSX.Element => {
+  const { t } = useTranslation()
+
   const {
     control,
     register,
@@ -39,8 +42,8 @@ export const FeedbackBlock = ({
   const { isPaymentEnabled } = usePublicFormContext()
 
   const feedbackTitle = isPaymentEnabled
-    ? 'How was your experience making payment on this form?'
-    : 'How was your form filling experience today?'
+    ? t('features.publicForm.components.FeedbackBlock.feedbackTitlePayment')
+    : t('features.publicForm.components.FeedbackBlock.feedbackTitleGeneral')
 
   const colorScheme = useMemo(() => {
     return `theme-${colorTheme}` as const
@@ -54,13 +57,19 @@ export const FeedbackBlock = ({
             {feedbackTitle}
           </FormLabel>
           <Controller
-            rules={{ required: 'Please select a rating' }}
+            rules={{
+              required: t(
+                'features.publicForm.components.FeedbackBlock.ratingError',
+              ),
+            }}
             control={control}
             name="rating"
             render={({ field }) => (
               <Rating
                 isRequired
-                fieldTitle="Form feedback rating"
+                fieldTitle={t(
+                  'features.publicForm.components.FeedbackBlock.ratingLabel',
+                )}
                 colorScheme={colorScheme}
                 numberOfRatings={5}
                 variant="star"
@@ -74,8 +83,12 @@ export const FeedbackBlock = ({
           isReadOnly={isSubmitting}
           mt="1rem"
           {...register('comment')}
-          aria-label="Tell us more about your experience"
-          placeholder="Tell us more about your experience"
+          aria-label={t(
+            'features.publicForm.components.FeedbackBlock.commentPlaceholder',
+          )}
+          placeholder={t(
+            'features.publicForm.components.FeedbackBlock.commentPlaceholder',
+          )}
         />
         <Button
           mt="1.5rem"
@@ -84,7 +97,7 @@ export const FeedbackBlock = ({
           colorScheme={colorScheme}
           isLoading={isSubmitting}
         >
-          Submit feedback
+          {t('features.publicForm.components.FeedbackBlock.submitButton')}
         </Button>
       </chakra.form>
     </Flex>

--- a/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -32,5 +32,15 @@ export const enSG: PublicForm = {
       proceedToPay: 'Proceed to pay',
       submitNow: 'Submit now',
     },
+
+    FeedbackBlock: {
+      feedbackTitlePayment:
+        'How was your experience making payment on this form?',
+      feedbackTitleGeneral: 'How was your form filling experience today?',
+      ratingLabel: 'Form feedback rating',
+      ratingError: 'Please select a rating',
+      commentPlaceholder: 'Tell us more about your experience',
+      submitButton: 'Submit feedback',
+    },
   },
 }

--- a/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/frontend/src/i18n/locales/features/public-form/index.ts
@@ -25,5 +25,13 @@ export interface PublicForm {
       proceedToPay: string
       submitNow: string
     }
+    FeedbackBlock: {
+      feedbackTitlePayment: string
+      feedbackTitleGeneral: string
+      ratingLabel: string
+      ratingError: string
+      commentPlaceholder: string
+      submitButton: string
+    }
   }
 }


### PR DESCRIPTION
## Problem

Follow up of #7427 to continue replacing hardcoded text in various components for i18n.

This PR focuses on `/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx`

## Solution

This PR replaces all hardcoded string in `FeedbackBlock`.

**Breaking Changes** 

- [x] No - this PR is backwards compatible  

**Improvements**:

- i18n locale in `/frontend/src/features/public-form/components/FormEndPage/components/FeedbackBlock.tsx` refactored

## Before & After Screenshots

**BEFORE**:

<img width="1050" alt="Screenshot 2024-07-11 at 7 38 42 PM" src="https://github.com/opengovsg/FormSG/assets/1209810/44a365ca-7e95-47c0-8ef5-ab1204f84006">


**AFTER**:

non-payment:

<img width="907" alt="Screenshot 2024-07-11 at 7 42 51 PM" src="https://github.com/opengovsg/FormSG/assets/1209810/9904d852-21db-4bd0-a19a-7d53c30a8d70">

payment:

<img width="935" alt="Screenshot 2024-07-11 at 7 44 23 PM" src="https://github.com/opengovsg/FormSG/assets/1209810/15b4ed7a-1957-433b-913b-42eaa454ae54">
