### PR TITLE
hotfix: fix issue where encrypt mode pdf attachments don't have responses

### DIFF
--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -542,7 +542,7 @@ const getAutoReplyFormattedResponse = (
   const { question, answer, isVisible } = response
   const answerSplitByNewLine = answer.split('\n')
   // Auto reply email will contain only visible fields
-  if (isVisible) {
+  if (isVisible !== false) {
     return {
       question, // No prefixes for autoreply
       answerTemplate: answerSplitByNewLine,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../../shared/types'
 import { maskNric } from '../../../../../shared/utils/nric-mask'
 import {
+  IAttachmentInfo,
   IEncryptedForm,
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
@@ -381,6 +382,7 @@ const submitEncryptModeForm = async (
     formId,
     form,
     responses: req.formsg.filteredResponses,
+    unencryptedAttachments: req.formsg.unencryptedAttachments,
     emailFields: parsedResponses.getAllResponses(),
     responseMetadata,
     submissionContent,
@@ -644,12 +646,14 @@ const _createSubmission = async ({
   form,
   responseMetadata,
   responses,
+  unencryptedAttachments,
   emailFields,
 }: {
   req: Parameters<SubmitEncryptModeFormHandlerType>[0]
   res: Parameters<SubmitEncryptModeFormHandlerType>[1]
   responseMetadata: EncryptSubmissionDto['responseMetadata']
   responses: ParsedClearFormFieldResponse[]
+  unencryptedAttachments?: IAttachmentInfo[]
   emailFields: ProcessedFieldResponse[]
   formId: string
   form: IPopulatedEncryptedForm
@@ -736,7 +740,12 @@ const _createSubmission = async ({
     timestamp: createdTime.getTime(),
   })
 
-  return await performEncryptPostSubmissionActions(submission, responses)
+  return await performEncryptPostSubmissionActions(
+    submission,
+    responses,
+    emailData,
+    unencryptedAttachments,
+  )
 }
 
 export const handleStorageSubmission = [

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -9,7 +9,7 @@ import {
   FormResponseMode,
   isPaymentsProducts,
 } from '../../../../../shared/types'
-import { IAttachmentInfo, IPopulatedForm } from '../../../../types'
+import { IPopulatedForm } from '../../../../types'
 import {
   EncryptAttachmentResponse,
   EncryptFormFieldResponse,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -9,7 +9,7 @@ import {
   FormResponseMode,
   isPaymentsProducts,
 } from '../../../../../shared/types'
-import { IPopulatedForm } from '../../../../types'
+import { IAttachmentInfo, IPopulatedForm } from '../../../../types'
 import {
   EncryptAttachmentResponse,
   EncryptFormFieldResponse,
@@ -462,6 +462,21 @@ export const encryptSubmission = async (
       publicKey,
       req.body.version,
     )
+
+  // Autoreplies are sent after the submission has been saved in the DB,
+  // but attachments are stripped here. To ensure that users receive their
+  // attachments in the autoreply we keep the attachments in req.formsg
+  if (req.formsg) {
+    req.formsg.unencryptedAttachments = req.body.responses
+      .filter(isAttachmentResponse)
+      .map((response) => {
+        return {
+          filename: response.filename,
+          content: response.content,
+          fieldId: response._id,
+        }
+      })
+  }
 
   const strippedBodyResponses = req.body.responses.map((response) => {
     if (isAttachmentResponse(response)) {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -133,7 +133,7 @@ export const createEncryptSubmissionWithoutSave = ({
 export const performEncryptPostSubmissionActions = (
   submission: IEncryptedSubmissionSchema,
   responses: FieldResponse[],
-  emailData: SubmissionEmailObj,
+  emailData?: SubmissionEmailObj,
   attachments?: IAttachmentInfo[],
 ): ResultAsync<
   true,
@@ -166,7 +166,7 @@ export const performEncryptPostSubmissionActions = (
         form,
         submission,
         attachments,
-        responsesData: emailData.autoReplyData,
+        responsesData: emailData?.autoReplyData,
         recipientData: extractEmailConfirmationData(
           responses,
           form.form_fields,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../../shared/types'
 import {
   FieldResponse,
+  IAttachmentInfo,
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
   IPopulatedForm,
@@ -25,13 +26,17 @@ import {
   WebhookValidationError,
 } from '../../webhook/webhook.errors'
 import { WebhookFactory } from '../../webhook/webhook.factory'
+import { SubmissionEmailObj } from '../email-submission/email-submission.util'
 import {
   ResponseModeError,
   SendEmailConfirmationError,
   SubmissionNotFoundError,
 } from '../submission.errors'
 import { sendEmailConfirmations } from '../submission.service'
-import { extractEmailConfirmationData } from '../submission.utils'
+import {
+  extractEmailConfirmationData,
+  mapAttachmentsFromResponses,
+} from '../submission.utils'
 
 import { CHARTS_MAX_SUBMISSION_RESULTS } from './encrypt-submission.constants'
 import { SaveEncryptSubmissionParams } from './encrypt-submission.types'
@@ -128,6 +133,8 @@ export const createEncryptSubmissionWithoutSave = ({
 export const performEncryptPostSubmissionActions = (
   submission: IEncryptedSubmissionSchema,
   responses: FieldResponse[],
+  emailData: SubmissionEmailObj,
+  attachments?: IAttachmentInfo[],
 ): ResultAsync<
   true,
   | FormNotFoundError
@@ -158,6 +165,8 @@ export const performEncryptPostSubmissionActions = (
       return sendEmailConfirmations({
         form,
         submission,
+        attachments,
+        responsesData: emailData.autoReplyData,
         recipientData: extractEmailConfirmationData(
           responses,
           form.form_fields,

--- a/src/types/vendor/express.d.ts
+++ b/src/types/vendor/express.d.ts
@@ -3,6 +3,7 @@ import { FormResponseMode } from 'shared/types'
 
 import { SgidUser } from '../../app/modules/auth/auth.types'
 import { EncryptSubmissionDto, MultirespondentSubmissionDto } from '../api'
+import { IAttachmentInfo } from '../email_mode_data'
 import { IPopulatedMultirespondentForm } from '../form'
 import { IPopulatedEncryptedForm, IPopulatedForm, IUserSchema } from '../types'
 
@@ -33,6 +34,7 @@ declare global {
             featureFlags?: string[]
             encryptedPayload?: EncryptSubmissionDto
             encryptedFormDef?: IPopulatedEncryptedForm
+            unencryptedAttachments?: IAttachmentInfo[]
           }
         | {
             responseMode: FormResponseMode.Multirespondent


### PR DESCRIPTION
## Problem

## Solution
We check for `isVisible !== false` because 
1. `isVisible === true` is in email mode forms when
2. `isVisible === undefined` is in encrypt mode forms, because the field gets stripped out in the [middleware](https://github.com/opengovsg/FormSG/blob/2d68a62533f1a502c72f3cb4a9e3af12f14d3e46/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts#L131) as mentioned in this [PR](https://github.com/opengovsg/FormSG/pull/6907). 
Hence we should allow the fields to show in the auto reply to account for these two cases

We add a new field `unencryptedAttachments` to `req.formsg` in the middleware. Here's why,
> Problem: Encrypt form attachments are stripped out in middleware, autoreply is sent at the end of the controller
**Option 1**: :no_entry: Move the autoreply sending to middleware. Issue w this is that if we move the autoreply sending to the last-est part where we do have access to attachments, the request can still fail somewhere down the pipeline and this email would have been prematurely sent to users. We need to send email out only when the submission is saved, which is after its saved to the db. Hence this option doesnt work
**Option 2**: Pass the unencrypted attachments down the middleware chain to the last controller. This allows us to keep autoreplies where they are, so they arent sent prematurely, and users also get. their attachments in the response.

Thus before we strip out the attachments in `encryptSubmission` middleware, we store it in the request, so that we can retrieve it at the end of the controller, to send with the user auto replies.


**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
**Regression Tests**
- [ ] 1.