### PR TITLE
feat: allows PR titles to start with "hotfix"

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -19,6 +19,7 @@ jobs:
           types: |
             feat
             fix
+            hotfix
             docs
             style
             refactor


### PR DESCRIPTION
## Problem
The `lint-pr.yml` workflow would fail if the PR title starts with "hotfix" since its not in the allowed list. Normally we prefix our branches with `hotfix` so it only makes sense to allow this in the PR title name as well for better filtering.


**Breaking Changes** 
- [x] No - this PR is backwards compatible  
