### PR TITLE
fix: move dd span tags to separate field

### DIFF
--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -22,8 +22,8 @@ export const setFormTags = (form: IPopulatedForm) => {
 export const setErrorCode = (error: ApplicationError) => {
   const span = tracer.scope().active()
   if (span && error.code) {
-    span.setTag('error.type', error.code)
-    span.setTag('error.message', `[${error.code}] ${error.message}`)
-    if (error.stack) span.setTag('error.stack', `${error.stack}`)
+    span.setTag('span.error.type', error.code)
+    span.setTag('span.error.message', `[${error.code}] ${error.message}`)
+    if (error.stack) span.setTag('span.error.stack', `${error.stack}`)
   }
 }


### PR DESCRIPTION
## Problem
DD traces that are 200s are getting marked as errors because we use the error.type reserved tag. This incorrectly flags the traces as errors even though we have handled them internally. This dilutes the noise to signal ratio. Furthermore, the `@error.type` doesn't show up on traces when expanded even though the query succeeds. 

![image](https://github.com/user-attachments/assets/b02728a5-dbb9-4234-b1d7-d7b222f5a490)


Context: https://help.datadoghq.com/hc/en-us/requests/1769696


## Solution
Since tags on spans dont get billed, we can simply use a non-reserved tag without worrying about the billing. Only thing that gets billed is the cardinality of the tags in custom metrics (indexed spans). TLDR: Dont create custom metric unless absolutely necessary and if created, make sure that the cardinality is bounded, don't tag any user IDs or form IDs or anything user related.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  