### PR TITLE
chore: remove old banner

### DIFF
--- a/frontend/src/features/workspace/WorkspaceContent.tsx
+++ b/frontend/src/features/workspace/WorkspaceContent.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 import { Box, Container, Grid, useDisclosure } from '@chakra-ui/react'
 
-import { GUIDE_PAYMENTS_ENTRY } from '~constants/links'
 import { ROLLOUT_ANNOUNCEMENT_KEY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import InlineMessage from '~components/InlineMessage'
@@ -17,6 +16,14 @@ import {
 import { WorkspaceFormRows } from './components/WorkspaceFormRow'
 import { WorkspaceHeader } from './components/WorkspaceHeader'
 import { useWorkspaceContext } from './WorkspaceContext'
+
+/**
+ * Dashboard Message
+ * TODO: move to growthbook
+ *
+ * Example usage DASHBOARD_MESSAGE = `Introducing payments! Citizens can now pay for fees and services directly on your form. [Learn more](${GUIDE_PAYMENTS_ENTRY})`
+ */
+const DASHBOARD_MESSAGE = ``
 
 export const WorkspaceContent = (): JSX.Element => {
   const { isLoading, totalFormsCount, isDefaultWorkspace } =
@@ -35,8 +42,6 @@ export const WorkspaceContent = (): JSX.Element => {
     () => !isUserLoading && hasSeenAnnouncement === false,
     [isUserLoading, hasSeenAnnouncement],
   )
-
-  const dashboardMessage = `Introducing payments! Citizens can now pay for fees and services directly on your form. [Learn more](${GUIDE_PAYMENTS_ENTRY})`
 
   return (
     <>
@@ -65,14 +70,14 @@ export const WorkspaceContent = (): JSX.Element => {
             px={{ base: '2rem', md: '4rem' }}
             py="1rem"
           >
-            {isDefaultWorkspace && (
+            {isDefaultWorkspace && DASHBOARD_MESSAGE && (
               <InlineMessage
                 useMarkdown
                 mb="2rem"
                 mx="-2rem"
                 justifyContent="center"
               >
-                {dashboardMessage}
+                {DASHBOARD_MESSAGE}
               </InlineMessage>
             )}
             <WorkspaceHeader

--- a/frontend/src/pages/Landing/Home/LandingPage.tsx
+++ b/frontend/src/pages/Landing/Home/LandingPage.tsx
@@ -38,12 +38,10 @@ import {
   OGP_ALL_PRODUCTS,
   OGP_FORMSG_REPO,
 } from '~constants/links'
-import { LOGIN_ROUTE, TOU_ROUTE } from '~constants/routes'
+import { LOGIN_ROUTE } from '~constants/routes'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useMdComponents } from '~hooks/useMdComponents'
 import Button from '~components/Button'
-import { FeatureBanner } from '~components/FeatureBanner/FeatureBanner'
-import Link from '~components/Link'
 import { MarkdownText } from '~components/MarkdownText'
 import { Tab } from '~components/Tabs'
 import { LottieAnimation } from '~templates/LottieAnimation'
@@ -95,10 +93,6 @@ export const LandingPage = (): JSX.Element => {
         body="Respondents can now pay for fees and services directly on your form!"
         learnMoreLink={LANDING_PAYMENTS_ROUTE}
       /> */}
-      <FeatureBanner
-        body="We have updated FormSG's Terms of Use and Privacy Policy"
-        learnMoreLink={TOU_ROUTE}
-      />
       <AppPublicHeader />
       <LandingSection bg="primary.100" pt={{ base: '2rem', md: 0 }} px="0">
         <Stack


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
We have not revisited some of the banners that have up on the FormSG Platform for several months. They have served their purposes and have no further need to direct users attention to them, and to reduce visual noise / cluster.
Closes FRM-1780

## Solution
<!-- How did you solve the problem? -->
- remove PP + T&C Banner on Landing Page
- remove Payment Banner on Admin Dashbaord

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
| Page | Before | After |
|--------|--------|--------|
| Landing Page | <img width="900" alt="Screenshot 2024-07-16 at 4 15 11 PM" src="https://github.com/user-attachments/assets/3062a9c2-49ed-467f-9384-61c36dbb3783"> |  <img width="902" alt="Screenshot 2024-07-16 at 4 15 03 PM" src="https://github.com/user-attachments/assets/e578a2d7-5013-4751-9c95-404f0e3d09b2">|
| Admin Dashboard | <img width="901" alt="Screenshot 2024-07-16 at 4 15 14 PM" src="https://github.com/user-attachments/assets/f47a7e19-e0c7-454c-bae8-2a1834850914"> | <img width="899" alt="Screenshot 2024-07-16 at 4 14 50 PM" src="https://github.com/user-attachments/assets/c07bd535-4d38-491f-8aab-38d113361d25"> |
