### PR TITLE
chore: add simple fix to date format for sample form submission api

### DIFF
--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -557,7 +557,7 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
     }
     case BasicField.Date: {
       const sampleValue = faker.date.anytime().toLocaleDateString('en-SG', {
-        day: 'numeric',
+        day: '2-digit',
         month: 'short',
         year: 'numeric',
       })


### PR DESCRIPTION
## Problem
Data from the sample form submission API are not in the correct format.

Date field should return the day in 2-digit format to standardise with formSG date format.

## Solution
Date field to return day as '2-digit'

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible 

