### PR TITLE
fix: mock statsD client during dev/test env

### DIFF
--- a/src/app/config/datadog-statsd-client.ts
+++ b/src/app/config/datadog-statsd-client.ts
@@ -1,3 +1,8 @@
 import { StatsD } from 'hot-shots'
 
-export const statsdClient = new StatsD({ useDefaultRoute: true })
+import config from './config'
+
+export const statsdClient = new StatsD({
+  useDefaultRoute: true,
+  mock: config.isDev,
+})


### PR DESCRIPTION
## Problem

Closes FRM-1800

When running tests locally (esp during verbose mode), the jest logs are often spammed with error messages due to the above. Adding to the noise and making it hard to debug test cases.  

This is a acknowledged issue and occurs all the time when backend unit tests are run. 

See example of noise added to test debug logs: 
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/e752539d-82ce-4b01-bec6-7bccd73243cb">

## Solution

The hotshot client should be run as a mock during dev/test mode as logging to DD is not desired during test/dev.
( see hot-shot mock: https://github.com/brightcove/hot-shots )

Doing so removes the error messages above 