### PR TITLE
fix: statsD default route not found

### DIFF
--- a/src/app/config/datadog-statsd-client.ts
+++ b/src/app/config/datadog-statsd-client.ts
@@ -3,6 +3,6 @@ import { StatsD } from 'hot-shots'
 import config from './config'
 
 export const statsdClient = new StatsD({
-  useDefaultRoute: true,
+  useDefaultRoute: !config.isDev,
   mock: config.isDev,
 })

--- a/src/app/config/datadog-statsd-client.ts
+++ b/src/app/config/datadog-statsd-client.ts
@@ -4,5 +4,4 @@ import config from './config'
 
 export const statsdClient = new StatsD({
   useDefaultRoute: !config.isDev,
-  mock: config.isDev,
 })


### PR DESCRIPTION
Problem
Edit: Just realised that the previous solution was not sufficient to remove the error messages. Hence a second PR is made. 

When running tests locally (esp during verbose mode), the jest logs are often spammed with error messages due to the above. Adding to the noise and making it hard to debug test cases.

This is a acknowledged issue and occurs all the time when backend unit tests are run.

Verification: 
<img width="1145" alt="image" src="https://github.com/user-attachments/assets/45d09538-8b1b-4267-bda8-f078f0fda271">
Only the AWS deprecation warning is shown. the `default route not found error` is gone. 

Solution

- The hotshot client should not useDefaultRoute during dev/test and only in prod when it is running in a linux container. 
- mock is removed since we do not need to read from the mockBuffer during dev or test. 