### PR TITLE
chore: remove unused sgid toggle

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -90,26 +90,20 @@ export const MyInfoFieldPanel = () => {
     }
   }, [growthbook, user])
 
-  const showSgidMyInfoV2 = useFeatureIsOn(featureFlags.myinfoSgid)
-
-  const sgidSupportedFinal = useMemo(() => {
-    return showSgidMyInfoV2 ? SGID_SUPPORTED_V2 : SGID_SUPPORTED_V1
-  }, [showSgidMyInfoV2])
-
   /**
    * If sgID is used, checks if the corresponding
    * MyInfo field is supported by sgID.
    */
   const sgIDUnSupported = useCallback(
     (form: AdminFormDto | undefined, fieldType: MyInfoAttribute): boolean => {
-      const sgidSupported: Set<MyInfoAttribute> = new Set(sgidSupportedFinal)
+      const sgidSupported: Set<MyInfoAttribute> = new Set(SGID_SUPPORTED_V2)
 
       return (
         form?.authType === FormAuthType.SGID_MyInfo &&
         !sgidSupported.has(fieldType)
       )
     },
-    [sgidSupportedFinal],
+    [],
   )
 
   // myInfo should be disabled if

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -3,6 +3,10 @@ export const featureFlags = {
   goLinks: 'goLinks' as const,
   turnstile: 'turnstile' as const,
   validateStripeEmailDomain: 'validateStripeEmailDomain' as const,
+  /**
+   * @deprecated since 2024-Aug-02
+   * On growthbook, kept permenently ON for all ENV
+   * */
   myinfoSgid: 'myinfo-sgid' as const,
   chartsMaxResponseCount: 'charts-max-response-count' as const,
   addingTwilioDisabled: 'adding-twilio-disabled' as const,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Toggle has been already on for 10 months, but have not had a cleanup.

## Solution
<!-- How did you solve the problem? -->

Simplified and removed toggle. Constants are still kept in to avoid clashing namespace between growthbook <> source.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
### Check that sgID MyInfo fields are available.
- [ ] Create a new form
- [ ] Enable "Singpass-App only Myinfo (Free)"
- [ ] Go to form builder
- [ ] Observe that all fields are enabled