### PR TITLE
fix: failing gh actions due to runner out of disk space 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,17 +144,6 @@ jobs:
     # if: ${{ needs.changes.outputs.backend == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      # prevent CI from failing when worker runs out of memory
-      # https://github.com/actions/runner-images/discussions/7188#discussioncomment-6750749
-      - name: Increase swapfile
-        run: |
-          df -h
-          sudo swapoff -a
-          sudo fallocate -l 15G /swapfile
-          sudo chmod 600 /swapfile
-          sudo mkswap /swapfile
-          sudo swapon /swapfile
-          sudo swapon --show
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Issue:

backend_test cache node modules step failing due to out of memory: cache lookup restores the tar file in memory, but when unzipped to storage, out of disk space memory occurs. This causes all our github actions to fail.
The error message is the github runnner running out of disk storage space when extracting the restored cached tar file. 

```
/usr/bin/tar -z -xf /home/runner/work/_temp/20c9e7c9-42f5-4d22-8c2c-7e6e58b541ec/cache.tgz -P -C /home/runner/work/FormSG/FormSG
[14](https://github.com/opengovsg/FormSG/actions/runs/10218808254/job/28333961131#step:6:15)
/usr/bin/tar: node_modules/@datadog/native-appsec/prebuilds/linux-x64/libddwaf.so: Wrote only 8704 of 10240 bytes
[15](https://github.com/opengovsg/FormSG/actions/runs/10218808254/job/28333961131#step:6:16)
/usr/bin/tar: node_modules/@datadog/native-appsec/prebuilds/linux-arm64: Cannot mkdir: No space left on device
[16](https://github.com/opengovsg/FormSG/actions/runs/10218808254/job/28333961131#step:6:17)
/usr/bin/tar: node_modules/@datadog/native-appsec/prebuilds/linux-arm64: Cannot mkdir: No space left on device
[17](https://github.com/opengovsg/FormSG/actions/runs/10218808254/job/28333961131#step:6:18)
/usr/bin/tar: node_modules/@datadog/native-appsec/prebuilds/linux-arm64/node-napi.node: Cannot open: No such file or directory
[18](https://github.com/opengovsg/FormSG/actions/runs/10218808254/job/28333961131#step:6:19)
/usr/bin/tar: node_modules/@datadog/native-appsec/prebuilds/linux-arm64: Cannot mkdir: No space left on device
```

## Fix:
Remove the code to generate swapfile since it is no longer needed. 

## Explanation: 
running `df -h` shows we have 19GB of disk space (despite 14GB indicated by github). We previously allocate 15GB to swapfile, leaving 4GB for storage. 
Recently, the disk space usage has likely exceeded the 4GB and hence caused this OO disk space error. 

Since GH runners now provide 16GB of memory instead of the previous 7GB, we do not need to manually add this swapfile any more.  

## Additional context: 
From @g-tejas using wayback machine: 
![image](https://github.com/user-attachments/assets/1473a6e8-c100-4027-a581-7daeb9372317)
back when swap file of 15G was selected, there was only 7GB of RAM allocated to standard github runners. Today, there is 16GB allocated to standard github runners. Hence, we do not need the extra RAM for github runner. 