### PR TITLE
fix: forbid stripe acc connection with pdf summary enabled

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -141,7 +141,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
 
   const pdfResponseToggleDescription = isPdfResponseEnabled
     ? undefined
-    : 'PDF responses are not supported for encrypt forms with active payment fields'
+    : 'PDF responses are not available for payment forms.'
 
   // email confirmation is not supported on MRF
   const isToggleEmailConfirmationDisabled =

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -157,7 +157,6 @@ const BeforeConnectionInstructions = ({
     const hasEmailFieldWithFormSummary = emailFields.some(
       (field) => field.autoReplyOptions.includeFormSummary,
     )
-    console.log({ hasEmailFieldWithFormSummary })
     return hasEmailFieldWithFormSummary
   }, [formDef])
 

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -57,6 +57,8 @@ const PaymentsDisabledRationaleText = ({
     isPDFResponseEnabled,
   ].filter(Boolean).length
 
+  const { data: formDef } = useAdminForm()
+
   if (disabledCount > 1) {
     return (
       <Text>
@@ -71,7 +73,7 @@ const PaymentsDisabledRationaleText = ({
           ) : undefined}
           {isPDFResponseEnabled ? (
             <ListItem>
-              <Link as={ReactLink} to={'settings'}>
+              <Link as={ReactLink} to={`/admin/form/${formDef!._id}`}>
                 Turn off "Include PDF responses" in all email fields
               </Link>
             </ListItem>
@@ -114,7 +116,7 @@ const PaymentsDisabledRationaleText = ({
     return (
       <Text>
         To enable payment fields,{' '}
-        <Link as={ReactLink} to={''}>
+        <Link as={ReactLink} to={`/admin/form/${formDef!._id}`}>
           turn off "Include PDF Responses" in all email fields.
         </Link>
       </Text>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -150,15 +150,12 @@ const BeforeConnectionInstructions = ({
   }, [settings])
 
   const isPDFResponseEnabled = useMemo(() => {
-    if (formDef?.responseMode !== FormResponseMode.Encrypt) return false
-    const emailFields: EmailFieldBase[] = formDef.form_fields.filter(
-      (field) => field.fieldType === 'email',
-    ) as EmailFieldBase[]
-    const hasEmailFieldWithFormSummary = emailFields.some(
-      (field) => field.autoReplyOptions.includeFormSummary,
-    )
-    return hasEmailFieldWithFormSummary
-  }, [formDef])
+    return formDef?.form_fields
+      .filter((field) => field.fieldType === 'email')
+      .map((field) => field as EmailFieldBase)
+      .map((field) => field.autoReplyOptions.includeFormSummary)
+      .some((x) => x)
+  }, [formDef?.form_fields])
 
   const isSingleSubmission = !!settings?.isSingleSubmission
 

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -58,6 +58,7 @@ const PaymentsDisabledRationaleText = ({
   ].filter(Boolean).length
 
   const { data: formDef } = useAdminForm()
+  if (!formDef) return <></>
 
   if (disabledCount > 1) {
     return (

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Link as ReactLink, useSearchParams } from 'react-router-dom'
+import { Link as ReactLink, useParams, useSearchParams } from 'react-router-dom'
 import {
   As,
   Box,
@@ -57,8 +57,8 @@ const PaymentsDisabledRationaleText = ({
     isPDFResponseEnabled,
   ].filter(Boolean).length
 
-  const { data: formDef } = useAdminForm()
-  if (!formDef) return <></>
+  const { formId } = useParams()
+  if (!formId) return <></>
 
   if (disabledCount > 1) {
     return (
@@ -74,7 +74,7 @@ const PaymentsDisabledRationaleText = ({
           ) : undefined}
           {isPDFResponseEnabled ? (
             <ListItem>
-              <Link as={ReactLink} to={`/admin/form/${formDef!._id}`}>
+              <Link as={ReactLink} to={`/admin/form/${formId}`}>
                 Turn off "Include PDF responses" in all email fields
               </Link>
             </ListItem>
@@ -117,7 +117,7 @@ const PaymentsDisabledRationaleText = ({
     return (
       <Text>
         To enable payment fields,{' '}
-        <Link as={ReactLink} to={`/admin/form/${formDef!._id}`}>
+        <Link as={ReactLink} to={`/admin/form/${formId}`}>
           turn off "Include PDF Responses" in all email fields.
         </Link>
       </Text>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -151,11 +151,13 @@ const BeforeConnectionInstructions = ({
   }, [settings])
 
   const isPDFResponseEnabled = useMemo(() => {
-    return formDef?.form_fields
-      .filter((field) => field.fieldType === 'email')
-      .map((field) => field as EmailFieldBase)
-      .map((field) => field.autoReplyOptions.includeFormSummary)
-      .some((x) => x)
+    return (
+      formDef?.form_fields
+        .filter((field) => field.fieldType === 'email')
+        .map((field) => field as EmailFieldBase)
+        .map((field) => field.autoReplyOptions.includeFormSummary)
+        .some((x) => x) ?? false
+    )
   }, [formDef?.form_fields])
 
   const isSingleSubmission = !!settings?.isSingleSubmission

--- a/src/app/modules/payments/__tests__/stripe.service.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.service.spec.ts
@@ -4,7 +4,12 @@ import { ObjectId } from 'bson'
 import { keyBy } from 'lodash'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, ResultAsync } from 'neverthrow'
-import { PaymentChannel, PaymentStatus, SubmissionType } from 'shared/types'
+import {
+  BasicField,
+  PaymentChannel,
+  PaymentStatus,
+  SubmissionType,
+} from 'shared/types'
 import Stripe from 'stripe'
 
 import { stripe } from 'src/app/loaders/stripe'
@@ -24,7 +29,10 @@ import * as AuthService from '../../auth/auth.service'
 import * as FeatureFlagService from '../../feature-flags/feature-flags.service'
 import { PaymentNotFoundError } from '../payments.errors'
 import * as PaymentsService from '../payments.service'
-import { StripeMetadataInvalidError } from '../stripe.errors'
+import {
+  StripeAccountError,
+  StripeMetadataInvalidError,
+} from '../stripe.errors'
 import * as StripeService from '../stripe.service'
 import * as StripeUtils from '../stripe.utils'
 
@@ -846,6 +854,58 @@ describe('stripe.service', () => {
       expect(authServiceSpy).toHaveBeenCalledTimes(0)
       expect(addPaymentAccountIdSpy).toHaveBeenCalledTimes(1)
       expect(result.isOk()).toBeTrue()
+    })
+
+    it('should not connect stripe account when form has email fields with pdf summary enabled', async () => {
+      // Arrange
+      const mockForm = (await new EncryptedForm({
+        admin: MOCK_USER,
+        title: 'Test Form',
+        publicKey: 'mockPublicKey',
+        form_fields: [
+          {
+            _id: new mongoose.Types.ObjectId(),
+            fieldType: BasicField.Email,
+            title: 'Email Field',
+            autoReplyOptions: {
+              hasAutoReply: true,
+              includeFormSummary: true,
+            },
+          },
+        ],
+      }).populate('admin')) as IPopulatedEncryptedForm
+
+      const getFeatureFlagSpy = jest
+        .spyOn(FeatureFlagService, 'getFeatureFlag')
+        .mockReturnValueOnce(okAsync(true))
+      const addPaymentAccountIdSpy = jest.spyOn(mockForm, 'addPaymentAccountId')
+      const stripeAccountsRetrieveApiSpy = jest
+        .spyOn(stripe.accounts, 'retrieve')
+        .mockReturnValueOnce(
+          Promise.resolve({
+            email: 'mockEmail',
+          } as unknown as Stripe.Response<Stripe.Account>),
+        )
+      const authServiceSpy = jest
+        .spyOn(AuthService, 'validateEmailDomain')
+        .mockReturnValue(okAsync(true) as any)
+
+      // Act
+      const result = await StripeService.linkStripeAccountToForm(mockForm, {
+        accountId: 'accountId',
+        publishableKey: 'publishableKey',
+      })
+
+      // Assert
+      expect(getFeatureFlagSpy).toHaveBeenCalledTimes(0)
+      expect(stripeAccountsRetrieveApiSpy).toHaveBeenCalledTimes(0)
+      expect(authServiceSpy).toHaveBeenCalledTimes(0)
+      expect(addPaymentAccountIdSpy).not.toHaveBeenCalled()
+      expect(result.isErr()).toBeTrue()
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(StripeAccountError)
+      expect(result._unsafeUnwrapErr().message).toBe(
+        'Email fields with pdf summary is not allowed',
+      )
     })
   })
 

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -28,11 +28,7 @@ import {
 } from '../../utils/handle-mongo-error'
 import { InvalidDomainError } from '../auth/auth.errors'
 import * as AuthService from '../auth/auth.service'
-import {
-  ApplicationError,
-  DatabaseError,
-  DatabaseWriteConflictError,
-} from '../core/core.errors'
+import { DatabaseError, DatabaseWriteConflictError } from '../core/core.errors'
 import { getFeatureFlag } from '../feature-flags/feature-flags.service'
 import { FormNotFoundError } from '../form/form.errors'
 import {

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -9,6 +9,7 @@ import isURL from 'validator/lib/isURL'
 
 import { featureFlags } from '../../../../shared/constants'
 import {
+  EmailFieldBase,
   PaymentStatus,
   ReconciliationReportLine,
 } from '../../../../shared/types'
@@ -27,7 +28,11 @@ import {
 } from '../../utils/handle-mongo-error'
 import { InvalidDomainError } from '../auth/auth.errors'
 import * as AuthService from '../auth/auth.service'
-import { DatabaseError, DatabaseWriteConflictError } from '../core/core.errors'
+import {
+  ApplicationError,
+  DatabaseError,
+  DatabaseWriteConflictError,
+} from '../core/core.errors'
 import { getFeatureFlag } from '../feature-flags/feature-flags.service'
 import { FormNotFoundError } from '../form/form.errors'
 import {
@@ -681,6 +686,18 @@ export const linkStripeAccountToForm = (
     stripeAccountId: accountId,
     stripePublishableKey: publishableKey,
     formId: form._id,
+  }
+
+  const hasEmailFieldWithFormSummary = form.form_fields
+    .filter((field) => field.fieldType === 'email')
+    .map((field) => field as EmailFieldBase)
+    .map((field) => field.autoReplyOptions.includeFormSummary)
+    .some((x) => x)
+
+  if (hasEmailFieldWithFormSummary) {
+    return errAsync(
+      new StripeAccountError('Email fields with pdf summary is not allowed'),
+    )
   }
 
   return getFeatureFlag(featureFlags.validateStripeEmailDomain, {


### PR DESCRIPTION
## Problem
Currently, toggle stays on but locked when someone tries to connect a stripe account pdf summary enabled. This PR makes it so that he or she would have to disable pdf responses before trying to connect a stripe account.

We also change how the warnings are being shown, in bullet point instead of sentences as the combination of messages would increase factorially if we had to to create a new message for each

**Breaking Changes** 
- No - this PR is backwards compatible  

## Before & After Screenshots
<img width="1439" alt="Screenshot 2024-08-06 at 1 24 48 PM" src="https://github.com/user-attachments/assets/129c5b6b-9f2a-4f88-9878-41f3484cef32">

## Tests
**Ensure that payment forms cannot toggle on pdf response**
- [ ] 1. Create an encrypt mode form
- [ ] 2. Connect stripe account
- [ ] 3. Add email field
- [ ] 4. Toggle on email confirmation
- [ ] 5. Try to toggle on pdf response, should not allow, it should be locked
- [ ] 6. Observe that there's description text saying "PDF resposnse not available for payment forms"

**Ensure that forms with pdf response toggled cannot connect stripe**
- [ ] 1. Create an encrypt mode form
- [ ] 2. Add an email field
- [ ] 3. Toggle on email confirmation and also toggle pdf response.
- [ ] 4. Try to connect stripe account, it should not allow you to. 
- [ ] 5. Observe that there's a info box to remind users to disable pdf response

**Ensure that forms with pdf response disabled can connect stripe**
- [ ] 1. Create an encrypt mode form
- [ ] 2. Add an email field
- [ ] 3. Toggle on email confirmation and also DO NOT toggle pdf response.
- [ ] 4. Try to connect stripe account, it should allow you to.

**Ensure that error message is unordered list for all 6 permutations of payment exclusions**
- [ ] 1. Create an encrypt mode form
- [ ] 2. Add an admin email in the settings page
- [ ] 3. Add an email field, and enable Email confirmations + Enable pdf response
- [ ] 4. Enable singpass toggle and enable single submission toggle as well.
- [ ] 5. Navigate to payments page
- [ ] 6. Observe that the info box is in unordered list format
- [ ] 7. Repeat for 5 of the remaining permutations, ensure that if > 1 error is present, it should be an unordered list. Otherwise its just a sentence
