### PR TITLE
fix: add workaround for docker-compose command issue on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Notable features include:
 
 Install [docker and docker-compose](https://docs.docker.com/get-docker/) and the [node version manager](https://github.com/nvm-sh/nvm).
 
+- Note: If you're using macOS, you may encounter an [issue](https://github.com/docker/for-mac/issues/7345) where the `docker-compose` command is not found. To fix this, run the following command manually (as documented in [this comment](https://github.com/docker/for-mac/issues/7345#issuecomment-2213570298)).
+  ```
+  sudo ln -sf /Applications/Docker.app/Contents/Resources/cli-plugins/docker-compose /usr/local/bin/docker-compose
+  ```
+
 ### First Setup
 
 First, make sure to install and use the node version used by the project:


### PR DESCRIPTION
## Problem

Hotfix for `docker-compose` command issue on MacOs that prevents running the application

Closes https://github.com/opengovsg/FormSG/issues/7571

## Solution

Adding an instruction in README for a workabout, since it's more pragmatic to wait for it to be fixed by the docker team and it only affects local development

**Breaking Changes** 

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  
