### PR TITLE
fix: Table description to render markdown

### DIFF
--- a/frontend/src/templates/Field/Table/TableFieldContainer.tsx
+++ b/frontend/src/templates/Field/Table/TableFieldContainer.tsx
@@ -32,6 +32,7 @@ export const TableFieldContainer = ({
       isInvalid={!!errors[schema._id]}
     >
       <FormLabel
+        useMarkdownForDescription
         questionNumber={
           schema.questionNumber ? `${schema.questionNumber}.` : undefined
         }


### PR DESCRIPTION
## Problem

Closes https://github.com/opengovsg/FormSG/issues/6232

## Solution

- pass in `useMarkdownForDescription` props into `FormLabel`

**Breaking Changes** 

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:

<img width="863" alt="image" src="https://github.com/user-attachments/assets/bba8f000-c76f-4487-a269-e79a743c09ad">

**AFTER**:

<img width="884" alt="image" src="https://github.com/user-attachments/assets/00d1f842-3995-44f8-9f9c-bbedeff02434">