### PR TITLE
fix: paragraph markdown styling error

### DIFF
--- a/frontend/src/templates/Field/Paragraph/ParagraphField.tsx
+++ b/frontend/src/templates/Field/Paragraph/ParagraphField.tsx
@@ -25,8 +25,10 @@ export const ParagraphField = ({
   })
 
   return (
-    <MarkdownText multilineBreaks components={mdComponents}>
-      {schema.description}
-    </MarkdownText>
+    <div>
+      <MarkdownText multilineBreaks components={mdComponents}>
+        {schema.description}
+      </MarkdownText>
+    </div>
   )
 }


### PR DESCRIPTION
## Problem

bullet and other styling of description in `<ParagraphField />` not rendering properly

Closes https://github.com/opengovsg/FormSG/issues/6309

## Solution

**Breaking Changes** 

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- it is inheriting the style of the parent component. Fixed by wrapping the output in `<div>`. IMO this isn't the best fix but it's the simplest and most straightforward one that does not require changing too much other things

## Before & After Screenshots

**BEFORE and AFTER (side-by-side comparison)**:

| Before | After |
| - | - |
| <img width="1178" alt="Screenshot 2024-08-07 at 12 25 06 AM" src="https://github.com/user-attachments/assets/0313d203-320a-4024-8f88-0a480ab5577d"> | <img width="1186" alt="Screenshot 2024-08-07 at 12 26 15 AM" src="https://github.com/user-attachments/assets/03e7a476-c309-4972-9d55-3d64ca3b93b8"> |
| <img width="976" alt="Screenshot 2024-08-07 at 12 25 13 AM" src="https://github.com/user-attachments/assets/99a6d592-f37a-4cf4-83b0-db921edf2937"> | <img width="959" alt="Screenshot 2024-08-07 at 12 33 48 AM" src="https://github.com/user-attachments/assets/74936ef3-84d8-4dc3-88fe-b2c2ee787391"> |