### PR TITLE
docs: remove angular from CREDITS.md

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -5385,37 +5385,6 @@ SOFTWARE.
 -------------------------------------------------------------------------------
 
 ## Project
-ui-select
-
-### Source
-https://github.com/angular-ui/ui-select
-
-### License
-The MIT License (MIT)
-
-Copyright (c) 2013-2014 AngularUI
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
--------------------------------------------------------------------------------
-
-## Project
 uid-generator
 
 ### Source


### PR DESCRIPTION
## Problem

Angular has been removed and no longer in used, but it's still found in the CREDITS.md

## Solution

- Removed it from CREDITS.md

**Breaking Changes** 

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  