### PR TITLE
chore: move infobox message to within tab

### DIFF
--- a/frontend/src/features/admin-form/share/ShareFormModal.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.tsx
@@ -104,13 +104,42 @@ export interface ShareFormModalProps {
   isFormPrivate: boolean | undefined
 }
 
+const FormActivationMessage = ({
+  isFormPrivate,
+  formId,
+  onClose,
+}: {
+  isFormPrivate: boolean | undefined
+  onClose: () => void
+  formId: string | undefined
+}) => {
+  const navigate = useNavigate()
+  const handleRedirectToSettings = useCallback(() => {
+    onClose()
+    navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_SETTINGS_SUBROUTE}`)
+  }, [formId, navigate, onClose])
+
+  if (!isFormPrivate) return null
+
+  return (
+    <InlineMessage variant="warning" mb="1rem">
+      <Box>
+        This form is currently closed to new responses. Activate your form in{' '}
+        <Button p={0} variant="link" onClick={handleRedirectToSettings}>
+          Settings
+        </Button>{' '}
+        to allow new responses or to share it as a template.
+      </Box>
+    </InlineMessage>
+  )
+}
+
 export const ShareFormModal = ({
   isOpen,
   onClose,
   formId,
   isFormPrivate,
 }: ShareFormModalProps): JSX.Element => {
-  const navigate = useNavigate()
   const modalSize = useBreakpointValue({
     base: 'mobile',
     xs: 'mobile',
@@ -177,11 +206,6 @@ export const ShareFormModal = ({
       </div>
     `)
   }, [shareLink])
-
-  const handleRedirectToSettings = useCallback(() => {
-    onClose()
-    navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_SETTINGS_SUBROUTE}`)
-  }, [formId, navigate, onClose])
 
   const { data: goLinkSuffixData } = useGoLink(formId ?? '')
   const [goLinkSuffixInput, setGoLinkSuffixInput] = useState('')
@@ -339,18 +363,6 @@ export const ShareFormModal = ({
         <ModalCloseButton />
         <ModalHeader color="secondary.700">Share form</ModalHeader>
         <ModalBody whiteSpace="pre-wrap">
-          {isFormPrivate ? (
-            <InlineMessage variant="warning" mb="1rem">
-              <Box>
-                This form is currently closed to new responses. Activate your
-                form in{' '}
-                <Button p={0} variant="link" onClick={handleRedirectToSettings}>
-                  Settings
-                </Button>{' '}
-                to allow new responses or to share it as a template.
-              </Box>
-            </InlineMessage>
-          ) : null}
           <Tabs pos="relative" h="100%" display="flex" flexDir="column" isLazy>
             <Box bg="white">
               <TabList mx="-0.25rem" w="100%">
@@ -362,6 +374,11 @@ export const ShareFormModal = ({
             </Box>
             <TabPanels mt="1.5rem" pb="2rem" flex={1} overflowY="auto">
               <TabPanel>
+                <FormActivationMessage
+                  isFormPrivate={isFormPrivate}
+                  formId={formId}
+                  onClose={onClose}
+                />
                 <FormLinkSection />
                 {/* GoLinkSection */}
                 {(displayGoLink && whitelisted) ||
@@ -420,9 +437,19 @@ export const ShareFormModal = ({
                 ) : null}
               </TabPanel>
               <TabPanel>
+                <FormActivationMessage
+                  isFormPrivate={isFormPrivate}
+                  formId={formId}
+                  onClose={onClose}
+                />
                 <TemplateSection />
               </TabPanel>
               <TabPanel>
+                <FormActivationMessage
+                  isFormPrivate={isFormPrivate}
+                  formId={formId}
+                  onClose={onClose}
+                />
                 <EmbedSection />
               </TabPanel>
             </TabPanels>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Infobox message regarding form closure should be associated to specific Tabs of Share modal rather than having it emplaced in its own space. This doesn't break visual continuity.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  


## Before & After Screenshots
| Component | Before | After |
|--------|--------|--------|
| Share Modal | <img width="676" alt="Screenshot 2024-08-08 at 6 31 20 PM" src="https://github.com/user-attachments/assets/a0f032c3-7f18-4f0a-bd60-b7122ca50b9d"> | <img width="676" alt="Screenshot 2024-08-08 at 6 31 12 PM" src="https://github.com/user-attachments/assets/11aff63e-b3b2-4ace-af81-05f900709d57"> | 

