### PR TITLE
fix: settings page resets position glitch

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -121,7 +121,7 @@ export const SettingsPage = (): JSX.Element => {
   }
 
   return (
-    <Box overflow="auto" flex={1}>
+    <Box overflow="auto" position="sticky" flex={1}>
       <Tabs
         isLazy
         isManual

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -121,7 +121,7 @@ export const SettingsPage = (): JSX.Element => {
   }
 
   return (
-    <Box overflow="auto" position="sticky" flex={1}>
+    <Box overflow="auto" position="relative" flex={1}>
       <Tabs
         isLazy
         isManual

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -121,7 +121,19 @@ export const SettingsPage = (): JSX.Element => {
   }
 
   return (
-    <Box overflow="auto" position="relative" flex={1}>
+    <Box
+      overflow="auto"
+      /**
+       * HACK: Chromium browsers have a bug where sibling elements with `position: sticky` will not
+       * be correctly calculated during a reflow. This causes the sibling to not have the correct
+       * y-axis position.
+       *
+       * Setting the `position` to `sticky` or `relative` would workaround this issue. We're choosing
+       * not to use `sticky` since it has more side effects and gotchas.
+       */
+      position="relative"
+      flex={1}
+    >
       <Tabs
         isLazy
         isManual


### PR DESCRIPTION
## Problem

Closes FRM-1814 

Admin `<SettingsPage />` has a visual bug where click on some toggles would cause the element to not have the correct y-axis.

The admin experience is degraded as several UI elements could be outside of the view port and un-interactable. Admins would need to refresh in order to reset the page. 

This issue is exacerbated on GSIBs which are zoomed in and smaller screens (eg, mobile devices) where the shift is extremely obvious.

**For illustration**
![image](https://github.com/user-attachments/assets/b43f594d-16c3-4060-b3e6-024433bd4107)

Notice the white gap below `<SettingsPage />` (in pink) and how `<SettingsTab />` has an incorrect offset and obscured by `<AdminNavBar />`.

### To reproduce (only on chromium browsers): 

1. create encrypt mode form, go to settings 
2. enable response limit
3. scroll all the way down and click on Enable email notifications for reports made by respondents
4. notice that a giant white bar appears and the settings become squished 
5. notice even after scrolling up, the left side nav bar is truncated and cannot be scrolled unless the page is refreshed.

## Solution
Add `position: relative` to `<SettingsPage />` container. 

**Breaking Changes** 
- No - this PR is backwards compatible  