### PR TITLE
feat(nric): set default to false

### DIFF
--- a/__tests__/e2e/utils/settings.ts
+++ b/__tests__/e2e/utils/settings.ts
@@ -42,7 +42,7 @@ const _getSettings = (
     status: FormStatus.Public,
     collaborators: [],
     authType: FormAuthType.NIL,
-    isSubmitterIdCollectionEnabled: true, // TODO: (E-voting v1.0.1) Set back to false when form.server.model default is set to false
+    isSubmitterIdCollectionEnabled: false,
     // By default, if emails is undefined, only the admin (current user) will receive.
     ...custom,
   }

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -74,7 +74,7 @@ const MOCK_MULTIRESPONDENT_FORM_PARAMS = {
 
 const FORM_DEFAULTS = {
   authType: 'NIL',
-  isSubmitterIdCollectionEnabled: true, // TODO: (E-voting v1.0.1) Set to false after patching existing forms in production
+  isSubmitterIdCollectionEnabled: false,
   isSingleSubmission: false,
   inactiveMessage:
     'If you require further assistance, please contact the agency that gave you the form link.',

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -551,7 +551,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
       isSubmitterIdCollectionEnabled: {
         type: Boolean,
-        default: true, // TODO: (E-voting v1.0.1) Set back to false once all existing Singpass forms are opt-in
+        default: false,
       },
 
       isSingleSubmission: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We have completed the datafix, and there's no need to set as default. This PR should be released in concert with communications to our users

## Solution
<!-- How did you solve the problem? -->

Newly created forms will be defaulted to NRIC opt-in

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
