### PR TITLE
chore(nric): remove nric collection description

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormNricCollectionToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormNricCollectionToggle.tsx
@@ -33,7 +33,6 @@ export const FormSubmitterIdCollectionToggle = ({
       isLoading={!settings || mutateIsSubmitterIdCollectionEnabled.isLoading}
       isChecked={isSubmitterIdCollectionEnabled}
       label="Collect NRIC/FIN/UENs with form submissions"
-      description="NRIC/FIN/UENs are not collected or stored with form submissions by default"
       onChange={handleToggleCollection}
     />
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

After several showing to various people, it was found that the description can be very confusing. The description itself might be making things worser than better.

## Solution
<!-- How did you solve the problem? -->

Less is more. Remove the description for the toggle, the behaviour should be rather straightforward.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
