### PR TITLE
fix: set disable props on field

### DIFF
--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -153,6 +153,7 @@ export const Radio = forwardRef<RadioProps, 'input'>(
 
     const handleSelect = useCallback(
       (e: SyntheticEvent) => {
+        if (props.isDisabled) return
         if (isChecked && allowDeselect) {
           e.preventDefault()
           // Toggle off if onChange is given.
@@ -161,17 +162,18 @@ export const Radio = forwardRef<RadioProps, 'input'>(
           onChange?.({ target: { value: '' } })
         }
       },
-      [allowDeselect, isChecked, onChange],
+      [allowDeselect, isChecked, onChange, props.isDisabled],
     )
 
     const handleSpacebar = useCallback(
       (e: KeyboardEvent<HTMLInputElement>) => {
+        if (props.isDisabled) return
         if (e.key !== ' ') return
         if (isChecked && allowDeselect) {
           handleSelect(e)
         }
       },
-      [allowDeselect, handleSelect, isChecked],
+      [allowDeselect, handleSelect, isChecked, props.isDisabled],
     )
 
     // Update labelProps to include props to allow deselection of radio value if

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -100,6 +100,7 @@ export const RadioField = ({
                 {...(idx === 0 ? { ref } : {})}
                 // Required should apply to radio group rather than individual radio.
                 isRequired={false}
+                isDisabled={schema.disabled}
               >
                 {option}
               </Radio>

--- a/frontend/src/theme/components/Radio.ts
+++ b/frontend/src/theme/components/Radio.ts
@@ -85,6 +85,7 @@ export const Radio: ComponentMultiStyleConfig<typeof parts> = {
       _disabled: {
         borderColor: 'neutral.500',
         bg: 'white',
+        cursor: 'not-allowed',
         _checked: {
           borderColor: 'neutral.500',
           color: 'neutral.500',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`<Radio />` can be de-selected when the field is disabled. This is unexpected by users as the field should not be interactive. Likely, this bug was dormant until MRF which has a disabled state.

Closes FRM-1825

## Solution
<!-- How did you solve the problem? -->

1. Pass over is `disabled` state over to `RadioField`'s handler to know when to reject disable
2. Add cursor effect on mouseover to indicate that the action is forbidden

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
