### PR TITLE
fix: add default close drawer when modal opens

### DIFF
--- a/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceFormRow/RowActions/RowActionsDrawer.tsx
@@ -58,6 +58,14 @@ export const RowActionsDrawer = ({
     handleShareForm,
   } = useRowAction(formMeta)
 
+  const onClickDefault = useCallback(
+    (onClick: () => void) => () => {
+      onClose()
+      onClick()
+    },
+    [onClose],
+  )
+
   const buttonProps: Partial<ButtonProps> = useMemo(
     () => ({
       isFullWidth: true,
@@ -124,21 +132,21 @@ export const RowActionsDrawer = ({
                   </Button>
                   <Button
                     {...buttonProps}
-                    onClick={handleDuplicateForm}
+                    onClick={onClickDefault(handleDuplicateForm)}
                     leftIcon={<BiDuplicate fontSize="1.25rem" />}
                   >
                     Duplicate
                   </Button>
                   <Button
                     {...buttonProps}
-                    onClick={handleShareForm}
+                    onClick={onClickDefault(handleShareForm)}
                     leftIcon={<BiShareAlt fontSize="1.25rem" />}
                   >
                     Share form
                   </Button>
                   <Button
                     {...buttonProps}
-                    onClick={handleCollaborators}
+                    onClick={onClickDefault(handleCollaborators)}
                     leftIcon={<BiUserPlus fontSize="1.25rem" />}
                   >
                     Manage form admins
@@ -162,7 +170,7 @@ export const RowActionsDrawer = ({
                       <Divider />
                       <Button
                         {...buttonProps}
-                        onClick={handleDeleteForm}
+                        onClick={onClickDefault(handleDeleteForm)}
                         color="danger.500"
                         leftIcon={<BiTrash fontSize="1.25rem" />}
                       >


### PR DESCRIPTION
## Problem

Scroll does not work on the admin modals on smaller screens.
 
Closes FRM-1818

## Solution
Currently, mobile behavior defers from the desktop behavior. Similar to desktop/laptop view, the drawer should close when an option is clicked and modal pops up.  
This makes sense since the user has already interacted with the drawer and hence it should be closed (verified with Alicia).  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  