### PR TITLE
fix: check existence of response id in attachment map for body v3 

### DIFF
--- a/src/app/modules/submission/receiver/receiver.types.ts
+++ b/src/app/modules/submission/receiver/receiver.types.ts
@@ -17,6 +17,11 @@ export const isBodyVersion2AndBelow = (
   return (body.version ?? 0) < 3
 }
 
+/**
+ * Checks if body is for Multirespondent forms which use version >=3.
+ * @param body to check version for
+ * @returns true if body is for Multirespondent forms, false otherwise
+ */
 export const isBodyVersion3AndAbove = (
   body: ParsedMultipartForm<unknown>,
 ): body is ParsedMultipartForm<FieldResponsesV3> => {

--- a/src/app/modules/submission/receiver/receiver.utils.ts
+++ b/src/app/modules/submission/receiver/receiver.utils.ts
@@ -82,7 +82,7 @@ export const addAttachmentToResponses = (
   // default to 0 for email mode forms where version is undefined
   // TODO (FRM-1413): change to a version existence guardrail when
   // virus scanning has completed rollout, so that virus scanning
-  // cannot be bypassed on storage mode subscanAndRetrieveAttachmentsmissions.
+  // cannot be bypassed on storage mode submissions.
   const isVirusScannerEnabled =
     (body.version ?? 0) >= VIRUS_SCANNER_SUBMISSION_VERSION
 

--- a/src/app/modules/submission/receiver/receiver.utils.ts
+++ b/src/app/modules/submission/receiver/receiver.utils.ts
@@ -100,12 +100,12 @@ export const addAttachmentToResponses = (
       responses.forEach((response) => {
         if (checkIsAttachmentResponsesIdInMap(attachmentMap, response._id)) {
           const file = attachmentMap[response._id]
-          response = {
-            ...response,
-            filename: file.filename,
-            content: file.content,
-            answer: isVirusScannerEnabled ? file.filename : undefined,
-          } as ParsedClearAttachmentResponse
+          const attachmentResponse = response as ParsedClearAttachmentResponse
+          attachmentResponse.filename = file.filename
+          attachmentResponse.content = file.content
+          if (!isVirusScannerEnabled) {
+            attachmentResponse.answer = file.filename
+          }
         }
       })
     }

--- a/src/app/modules/submission/receiver/receiver.utils.ts
+++ b/src/app/modules/submission/receiver/receiver.utils.ts
@@ -54,19 +54,6 @@ export const mapRouteError: MapRouteError = (error) => {
 }
 
 /**
- * Checks whether attachmentMap contains the given response id.
- * @param attachmentMap Map of field ids to attachments
- * @param response The response field id to check
- * @returns true if response is in map, false otherwise
- */
-const checkIsAttachmentResponsesIdInMap = (
-  attachmentMap: Record<IAttachmentInfo['fieldId'], IAttachmentInfo>,
-  responseId: string,
-): boolean => {
-  return !!attachmentMap[responseId]
-}
-
-/**
  * Adds the attachment's content, filename to each response,
  * based on their fieldId.
  * The response's answer is also changed to the attachment's filename.
@@ -98,7 +85,10 @@ export const addAttachmentToResponses = (
     if (responses) {
       // matches responses to attachments using id, adding filename and content to response
       responses.forEach((response) => {
-        if (checkIsAttachmentResponsesIdInMap(attachmentMap, response._id)) {
+        if (
+          response.fieldType === BasicField.Attachment &&
+          response._id in attachmentMap
+        ) {
           const file = attachmentMap[response._id]
           const attachmentResponse = response as ParsedClearAttachmentResponse
           attachmentResponse.filename = file.filename
@@ -114,10 +104,7 @@ export const addAttachmentToResponses = (
   if (isBodyVersion3AndAbove(body)) {
     Object.keys(body.responses).forEach((id) => {
       const response = body.responses[id] as ParsedClearFormFieldResponseV3
-      if (
-        response.fieldType === BasicField.Attachment &&
-        checkIsAttachmentResponsesIdInMap(attachmentMap, id)
-      ) {
+      if (response.fieldType === BasicField.Attachment && id in attachmentMap) {
         const file = attachmentMap[id]
         response.answer.filename = file.filename
         response.answer.content = file.content


### PR DESCRIPTION
## Problem
Closes FRM-1844

## Solution
See ticket. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Manual tests: 
TC1: Check that attachment forms still work for mrf (v3 body): 
- [ ] create mrf form with attachment, with >=2 steps to test it out 
- [ ] let first step respondent (R1) upload the file 
- [ ] respondent 2 (R2) download file and check it is correct R1 uploaded file 
- [ ] R2 changes file 
- [ ] submit and complete the workflow 
- [ ] assert that the uploaded file can be viewed by admin and is correct 

TC2: Check that attachment forms still work for mrf (v2.1 body): 
- [ ] Create storage form with single attachment field 
- [ ] submit form with attachment 
- [ ] verify admin can see uploaded attachment 

TC3: Check that no longer reproduce FRM-1844: 
- [ ] From TC2, submit a form and go to network tab to find the XHR req. 
- [ ] Copy the cURL (or any preferred format) req and change version to any arbitrary number >= 3. 
- [ ] send the request, verify response is: 
```
{
    "message": "Invalid file key - file key is not found in the quarantine bucket. The file must be uploaded first."
}
```
instead of `http status code 502`
