### PR TITLE
fix: tighten gstatic.cn csp config

### DIFF
--- a/src/app/loaders/express/constants.ts
+++ b/src/app/loaders/express/constants.ts
@@ -32,7 +32,7 @@ export const CSP_CORE_DIRECTIVES = {
     'https://*.googletagmanager.com/gtag/',
     'https://*.cloudflareinsights.com/', // Cloudflare web analytics https://developers.cloudflare.com/analytics/types-of-analytics/#web-analytics
     'https://www.gstatic.com/charts/', // React Google Charts for FormSG charts
-    'https://www.gstatic.cn',
+    'https://www.gstatic.cn/recaptcha/releases/',
     (_req: Parameters<RequestHandler>[0], res: Parameters<RequestHandler>[1]) =>
       `'nonce-${res.locals.nonce}'`,
   ],


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`gstatic.cn` was added back in as it broke recaptcha for users in CN. However, this re-introduced an issue where the csp domain is too wide.

Closes FRM-1853

## Solution
<!-- How did you solve the problem? -->
Tighten CSP `gstatic.cn` domain

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
