### PR TITLE
chore: update migrate to latest husky syntax

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 # Section for git-secrets
 if ! command -v git-secrets &> /dev/null
 then

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 # Section for git-secrets
 if ! command -v git-secrets &> /dev/null
 then

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,7 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-
 # Section for git-secrets
 if ! command -v git-secrets &> /dev/null
 then

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lint:frontend": "npm run --prefix frontend lint",
     "lint-ci": "eslint src/ shared/ --quiet",
     "version": "auto-changelog -p && git add CHANGELOG.md",
-    "prepare": "husky install",
+    "prepare": "husky",
     "pre-commit": "lint-staged",
     "storybook": "npm run --prefix frontend storybook",
     "postinstall:frontend": "npm --prefix frontend install",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Husky has a change in syntax, and no longer requires us to manually install / load husky.

```
husky - DEPRECATED

Please remove the following two lines from .husky/pre-commit:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0

Running git-secrets pre_commit_hook
husky - DEPRECATED

Please remove the following two lines from .husky/prepare-commit-msg:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0

Running git-secrets prepare_commit_msg_hook
husky - DEPRECATED

Please remove the following two lines from .husky/commit-msg:

#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

They WILL FAIL in v10.0.0
```

## Solution
<!-- How did you solve the problem? -->
Follow instructions in https://github.com/typicode/husky/releases/tag/v9.0.1

After migration here's how it looks
```
git commit -m "chore: update migrate to late
st husky syntax"
gRunning git-secrets pre_commit_hook
p
Running git-secrets prepare_commit_msg_hook
Running git-secrets commit_msg_hook
[fix/husky-upgrades cf504a5b5] chore: update migrate to latest husky syntax
 4 files changed, 1 insertion(+), 11 deletions(-)
```

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  