### PR TITLE
feat: add betaflag on submission key

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -19,6 +19,7 @@ import Spinner from '~components/Spinner'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 import { FormActivationSvg } from '~features/admin-form/settings/components/FormActivationSvg'
+import { useUser } from '~features/user/queries'
 
 import { SecretKeyVerification } from '../components/SecretKeyVerification'
 import { useStorageResponsesContext } from '../ResponsesPage/storage'
@@ -80,6 +81,8 @@ export const IndividualResponsePage = (): JSX.Element => {
   if (!formId) throw new Error('Missing formId')
 
   const { data: form } = useAdminForm()
+
+  const { user } = useUser()
   const { secretKey } = useStorageResponsesContext()
   const { data, isLoading, isError } = useIndividualSubmission()
 
@@ -187,14 +190,15 @@ export const IndividualResponsePage = (): JSX.Element => {
               </Skeleton>
             </Stack>
           )}
-          {form?.responseMode === FormResponseMode.Multirespondent && (
-            <StackRow
-              label="Response link"
-              value={responseLinkWithKey}
-              isLoading={isLoading}
-              isError={isError}
-            />
-          )}
+          {form?.responseMode === FormResponseMode.Multirespondent &&
+            user?.betaFlags?.mrfAdminSubmissionKey && (
+              <StackRow
+                label="Response link"
+                value={responseLinkWithKey}
+                isLoading={isLoading}
+                isError={isError}
+              />
+            )}
         </Stack>
         {isLoading || isError ? (
           <LoadingDecryption />

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -23,6 +23,7 @@ export const UserBase = z.object({
       postmanSms: z.boolean().optional(),
       // TODO: (MRF-email-notif) Remove betaFlag when MRF email notifications is out of beta
       mrfEmailNotifications: z.boolean().optional(),
+      mrfAdminSubmissionKey: z.boolean().optional(),
     })
     .optional(),
   flags: z.map(z.nativeEnum(SeenFlags), z.number()).optional(),

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -77,6 +77,7 @@ const compileUserModel = (db: Mongoose) => {
         postmanSms: Boolean,
         // TODO: (MRF-email-notif) Remove betaFlag when MRF email notifications is out of beta
         mrfEmailNotifications: Boolean,
+        mrfAdminSubmissionKey: Boolean
       },
       flags: {
         type: Schema.Types.Map, // of SeenFlags

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -77,7 +77,7 @@ const compileUserModel = (db: Mongoose) => {
         postmanSms: Boolean,
         // TODO: (MRF-email-notif) Remove betaFlag when MRF email notifications is out of beta
         mrfEmailNotifications: Boolean,
-        mrfAdminSubmissionKey: Boolean
+        mrfAdminSubmissionKey: Boolean,
       },
       flags: {
         type: Schema.Types.Map, // of SeenFlags


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Several admins have been surprised by the possibility of MRF being viewable, while others have been appreciative of the link. We want to remove this key to test whether this has a negative backlash on the user before making a product design on this.

## Solution
<!-- How did you solve the problem? -->
Adds new `mrfAdminSubmissionKey` that dynamically shows submission key for individual admins


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Screenshots

**Without betaflag** 
<img width="1102" alt="Screenshot 2024-09-16 at 1 21 47 AM" src="https://github.com/user-attachments/assets/12021da6-f607-4b89-9620-b1f4ab429bbe">


**With betaflag**
<img width="1056" alt="Screenshot 2024-09-16 at 1 17 07 AM" src="https://github.com/user-attachments/assets/37ca9c5d-3971-4655-a08b-41791148fe97">


## Tests
<!-- What tests should be run to confirm functionality? -->
Admin without `mrfAdminSubmissionKey` enabled would be able to view submission key
- [ ] Go to Admin Individual Response Page
- [ ] Ensure that betaflag `mrfAdminSubmissionKey` is not enabled for user
- [ ] Observe that Submission Link is not shown

Admin with `mrfAdminSubmissionKey` enabled would be able to view submission key
- [ ] Go to Admin Individual Response Page
- [ ] Ensure that betaflag `mrfAdminSubmissionKey` is enabled for user
- [ ] Observe that Submission Link is shown
