### PR TITLE
fix: chromatic build failure

### DIFF
--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -37,6 +37,32 @@ module.exports = {
             test: /\.mjs$/,
             include: /node_modules/,
           },
+          {
+            // Added to fix ticket:
+            // https://linear.app/ogp/issue/FRM-1857/fix-chromatic-build-failure-due-es2018-features-not-supported
+            test: /\.(?:jsx?|tsx?|vue)$/,
+            use: [
+              {
+                loader: 'babel-loader',
+                options: {
+                  presets: [
+                    '@babel/preset-env',
+                    [
+                      '@babel/preset-react',
+                      {
+                        runtime: 'automatic',
+                      },
+                    ],
+                    '@babel/preset-typescript',
+                  ],
+                  plugins: [
+                    '@babel/plugin-transform-async-to-generator',
+                    '@babel/plugin-proposal-async-generator-functions',
+                  ],
+                },
+              },
+            ],
+          },
         ],
       },
     }


### PR DESCRIPTION
## Problem
We are experiencing sudden chromatic build failures due to the errors listed below in the screenshot. 
![image](https://github.com/user-attachments/assets/a9f7d0db-9074-4536-9d31-e0edd96224ca)

This blocks design from being able to review changes and visual/interaction tests from working to assert expected behavior and prevent visual regressions.

Closes FRM-1857

## Solution
Add babel compilation presets to chromatic config to support ES2018 features required above. 

**Breaking Changes** 
- No - this PR is backwards compatible  