### PR TITLE
fix(deps): jest extended upgrade to 4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -180,7 +180,7 @@
         "husky": "^9.1.6",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
-        "jest-extended": "^3.2.4",
+        "jest-extended": "^4.0.2",
         "jest-localstorage-mock": "^2.4.26",
         "jest-mock-axios": "^4.7.2",
         "lint-staged": "^15.2.7",
@@ -19299,9 +19299,9 @@
       }
     },
     "node_modules/jest-extended": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.4.tgz",
-      "integrity": "sha512-lSEYhSmvXZG/7YXI7KO3LpiUiQ90gi5giwCJNDMMsX5a+/NZhdbQF2G4ALOBN+KcXVT3H6FPVPohAuMXooaLTQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-4.0.2.tgz",
+      "integrity": "sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "husky": "^9.1.6",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
-    "jest-extended": "^3.2.4",
+    "jest-extended": "^4.0.2",
     "jest-localstorage-mock": "^2.4.26",
     "jest-mock-axios": "^4.7.2",
     "lint-staged": "^15.2.7",

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -798,7 +798,7 @@ describe('public-form.controller', () => {
         expect((mockRes.json as jest.Mock).mock.calls[0][0]).not.toContainKey(
           'spcpSession',
         )
-        expect(mockRes.clearCookie).toHaveBeenCalledOnceWith(
+        expect(mockRes.clearCookie).toHaveBeenCalledExactlyOnceWith(
           getCookieNameByAuthType(FormAuthType.SP),
         )
       })

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -146,15 +146,15 @@ describe('stripe.controller', () => {
       expect(mockRes.redirect).toHaveBeenCalledWith(
         `${config.app.appUrl}/admin/form/${MOCK_FORM_ID}/settings/payments`,
       )
-      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledOnceWith(
-        MOCK_FORM_ID,
-      )
+      expect(
+        MockFormService.retrieveFullFormById,
+      ).toHaveBeenCalledExactlyOnceWith(MOCK_FORM_ID)
       expect(
         MockStripeService.exchangeCodeForAccessToken,
-      ).toHaveBeenCalledOnceWith('someCode')
+      ).toHaveBeenCalledExactlyOnceWith('someCode')
       expect(
         MockStripeService.linkStripeAccountToForm,
-      ).toHaveBeenCalledOnceWith(mockForm, {
+      ).toHaveBeenCalledExactlyOnceWith(mockForm, {
         accountId: mockStripeToken.stripe_user_id,
         publishableKey: mockStripeToken.stripe_publishable_key,
       })
@@ -183,9 +183,9 @@ describe('stripe.controller', () => {
       expect(mockRes.redirect).toHaveBeenCalledWith(
         `${config.app.appUrl}/admin/form/formId/settings/payments`,
       )
-      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledOnceWith(
-        'formId',
-      )
+      expect(
+        MockFormService.retrieveFullFormById,
+      ).toHaveBeenCalledExactlyOnceWith('formId')
       expect(
         MockStripeService.exchangeCodeForAccessToken,
       ).not.toHaveBeenCalledWith()

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -645,7 +645,7 @@ describe('encrypt-submission.controller', () => {
       // Assert email notification not sent since submission not allowed
       expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(0)
 
-      expect(mockRes.status).toHaveBeenCalledOnceWith(403)
+      expect(mockRes.status).toHaveBeenCalledExactlyOnceWith(403)
 
       expect((mockRes.json as jest.Mock).mock.calls[0][0].message).toEqual(
         FORM_RESPONDENT_NOT_WHITELISTED_ERROR_MESSAGE,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`jest-extended` introduced some [breaking changes](https://github.com/jest-community/jest-extended/blob/main/CHANGELOG.md#400) with renaming `toHaveBeenCalledOnceWith` to `toHaveBeenCalledExactlyOnceWith`

## Solution
<!-- How did you solve the problem? -->

Replace function names.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
