### PR TITLE
feat(tracking): mrf workflow + creation

### DIFF
--- a/frontend/datadog-chunk.ts
+++ b/frontend/datadog-chunk.ts
@@ -7,7 +7,7 @@ import { datadogRum, RumInitConfiguration } from '@datadog/browser-rum'
 
 // Discard benign RUM errors.
 // Ensure that beforeSend returns true to keep the event and false to discard it.
-export const ddBeforeSend: RumInitConfiguration['beforeSend'] = (event) => {
+const ddBeforeSend: RumInitConfiguration['beforeSend'] = (event) => {
   if (event.type !== 'error') return true
 
   // Caused by @chakra-ui/react@latest-v1 -> @chakra-ui/modal@1.11.1 -> react-remove-scroll@2.4.1

--- a/frontend/datadog-chunk.ts
+++ b/frontend/datadog-chunk.ts
@@ -6,14 +6,9 @@
 import { datadogRum, RumInitConfiguration } from '@datadog/browser-rum'
 
 // Discard benign RUM errors.
+// Ensure that beforeSend returns true to keep the event and false to discard it.
 export const ddBeforeSend: RumInitConfiguration['beforeSend'] = (event) => {
-  // TODO(#4279): Might want to remove this once we are fully React, since then we will not need to check auth state.
-  // Discard unauth'd errors
-  if (event.type === 'resource' && event.resource.status_code === 404) {
-    return false
-  }
-
-  if (event.type !== 'error') return
+  if (event.type !== 'error') return true
 
   // Caused by @chakra-ui/react@latest-v1 -> @chakra-ui/modal@1.11.1 -> react-remove-scroll@2.4.1
   // Already fixed in @chakra-ui/react@latest, but we cannot upgrade until we upgrade to React 18.
@@ -27,6 +22,8 @@ export const ddBeforeSend: RumInitConfiguration['beforeSend'] = (event) => {
   if (event.error.message.includes('ResizeObserver loop limit exceeded')) {
     return false
   }
+
+  return true
 }
 
 // Init Datadog RUM
@@ -41,10 +38,9 @@ datadogRum.init({
 
   // Specify a version number to identify the deployed version of your application in Datadog
   version: '@REACT_APP_VERSION',
-  // TODO/RUM: Update these RUM percentages as we increase the rollout percentage!
-  sampleRate: Number('@REACT_APP_DD_SAMPLE_RATE') || 5,
-  replaySampleRate: 100,
-  trackInteractions: true,
+  sessionSampleRate: Number('@REACT_APP_DD_SAMPLE_RATE') || 5,
+  sessionReplaySampleRate: 100,
+  trackUserInteractions: true,
   defaultPrivacyLevel: 'mask-user-input',
   beforeSend: ddBeforeSend,
 })

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@chakra-ui/react": "^1.8.6",
         "@datadog/browser-logs": "^4.50.1",
-        "@datadog/browser-rum": "^4.34.1",
+        "@datadog/browser-rum": "^5.27.0",
         "@emotion/react": "^11.7.0",
         "@emotion/styled": "^11.6.0",
         "@floating-ui/react-dom-interactions": "^0.9.3",
@@ -3272,9 +3272,9 @@
       }
     },
     "node_modules/@datadog/browser-core": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.34.1.tgz",
-      "integrity": "sha512-xZUMxSEUlzXVGU8fvIG5J4xGGBShrxgTTmCd9p7Ju/rUPnWV0hTqhPIXwSgbMvHgmX1vNwoNvydmlzhNVpKr3g=="
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.27.0.tgz",
+      "integrity": "sha512-lgc2cTZFUNWaeTLIK6laXoTRIycSHcQWMDWhAkdROsqbXK5DEHMagKqn3WGBCFN7uEnnohLPBSzmbZP4wwQfJA=="
     },
     "node_modules/@datadog/browser-logs": {
       "version": "4.50.1",
@@ -3298,15 +3298,15 @@
       "integrity": "sha512-2ypS19XngsMu6W4qUBtDwvImFz886Im+PziOnEycO1w41TVS5LH8/vWBMvjSf8Suer+CeRjRN9IOu0ocRx9BVw=="
     },
     "node_modules/@datadog/browser-rum": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.34.1.tgz",
-      "integrity": "sha512-fKw1EUwlPNliUJnOftsIgNGbW70+pZGwt2BbiUsWxp+CBHsw+MRFENUJybAK2l4PqNm+AZKVkvultiCDGvo3gg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-5.27.0.tgz",
+      "integrity": "sha512-8tCHJ6yU6O91fcJmQL29nRj9yEqxIMcJdP6eMziXRJhCrpQqz9c34FwVyrY9KfJG4KBnvakNV53aVE6AOOfhSA==",
       "dependencies": {
-        "@datadog/browser-core": "4.34.1",
-        "@datadog/browser-rum-core": "4.34.1"
+        "@datadog/browser-core": "5.27.0",
+        "@datadog/browser-rum-core": "5.27.0"
       },
       "peerDependencies": {
-        "@datadog/browser-logs": "4.34.1"
+        "@datadog/browser-logs": "5.27.0"
       },
       "peerDependenciesMeta": {
         "@datadog/browser-logs": {
@@ -3315,11 +3315,11 @@
       }
     },
     "node_modules/@datadog/browser-rum-core": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.34.1.tgz",
-      "integrity": "sha512-s1nHAXREKRlTl2EOn+J/786D7pvQ2lg9MunhmC5Juh9DeNrYrmAooxbrXCaCy0gKRBHbm68HM4h59FXuA5iNGg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.27.0.tgz",
+      "integrity": "sha512-YFKnoglFnujAGgefXl+7NUmnpmlox9bJ3wYK7AFje2mh6O6MtquyLHHkNJI9lGLEmvdjubipgF0Fh45S8bIUHw==",
       "dependencies": {
-        "@datadog/browser-core": "4.34.1"
+        "@datadog/browser-core": "5.27.0"
       }
     },
     "node_modules/@design-systems/utils": {
@@ -52165,9 +52165,9 @@
       "integrity": "sha512-ej5oVy6lykXsvieQtqZxCOaLT+xD4+QNarq78cIYISHmZXshCvROLudpQN3lfL8G0NL7plMSSK+zlyvCaIJ4Iw=="
     },
     "@datadog/browser-core": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.34.1.tgz",
-      "integrity": "sha512-xZUMxSEUlzXVGU8fvIG5J4xGGBShrxgTTmCd9p7Ju/rUPnWV0hTqhPIXwSgbMvHgmX1vNwoNvydmlzhNVpKr3g=="
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-5.27.0.tgz",
+      "integrity": "sha512-lgc2cTZFUNWaeTLIK6laXoTRIycSHcQWMDWhAkdROsqbXK5DEHMagKqn3WGBCFN7uEnnohLPBSzmbZP4wwQfJA=="
     },
     "@datadog/browser-logs": {
       "version": "4.50.1",
@@ -52185,20 +52185,20 @@
       }
     },
     "@datadog/browser-rum": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-4.34.1.tgz",
-      "integrity": "sha512-fKw1EUwlPNliUJnOftsIgNGbW70+pZGwt2BbiUsWxp+CBHsw+MRFENUJybAK2l4PqNm+AZKVkvultiCDGvo3gg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-5.27.0.tgz",
+      "integrity": "sha512-8tCHJ6yU6O91fcJmQL29nRj9yEqxIMcJdP6eMziXRJhCrpQqz9c34FwVyrY9KfJG4KBnvakNV53aVE6AOOfhSA==",
       "requires": {
-        "@datadog/browser-core": "4.34.1",
-        "@datadog/browser-rum-core": "4.34.1"
+        "@datadog/browser-core": "5.27.0",
+        "@datadog/browser-rum-core": "5.27.0"
       }
     },
     "@datadog/browser-rum-core": {
-      "version": "4.34.1",
-      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-4.34.1.tgz",
-      "integrity": "sha512-s1nHAXREKRlTl2EOn+J/786D7pvQ2lg9MunhmC5Juh9DeNrYrmAooxbrXCaCy0gKRBHbm68HM4h59FXuA5iNGg==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-5.27.0.tgz",
+      "integrity": "sha512-YFKnoglFnujAGgefXl+7NUmnpmlox9bJ3wYK7AFje2mh6O6MtquyLHHkNJI9lGLEmvdjubipgF0Fh45S8bIUHw==",
       "requires": {
-        "@datadog/browser-core": "4.34.1"
+        "@datadog/browser-core": "5.27.0"
       }
     },
     "@design-systems/utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@chakra-ui/react": "^1.8.6",
     "@datadog/browser-logs": "^4.50.1",
-    "@datadog/browser-rum": "^4.34.1",
+    "@datadog/browser-rum": "^5.27.0",
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",
     "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
@@ -110,6 +110,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
       <Stack spacing="0.5rem">
         <DrawerTabIcon
           label="Add fields"
+          trackingLabel="create_builder.drawer_tab.add_fields"
           icon={<BxsWidget fontSize="1.5rem" />}
           onClick={handleDrawerBuilderClick}
           isActive={activeTab === DrawerTabs.Builder}
@@ -117,6 +118,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
         />
         <DrawerTabIcon
           label="Edit header and instructions"
+          trackingLabel="create_builder.drawer_tab.edit_header"
           icon={<BxsDockTop fontSize="1.5rem" />}
           onClick={handleDrawerDesignClick}
           isActive={activeTab === DrawerTabs.Design}
@@ -124,6 +126,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
         />
         <DrawerTabIcon
           label="Add logic"
+          trackingLabel="create_builder.drawer_tab.add_logic"
           icon={<BiGitMerge fontSize="1.5rem" />}
           onClick={handleDrawerLogicClick}
           isActive={activeTab === DrawerTabs.Logic}
@@ -131,6 +134,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
         />
         <DrawerTabIcon
           label="Edit Thank you page"
+          trackingLabel="create_builder.drawer_tab.edit_thank_you_page"
           icon={<PhHandsClapping fontSize="1.5rem" />}
           onClick={handleDrawerEndpageClick}
           isActive={activeTab === DrawerTabs.EndPage}
@@ -141,6 +145,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
             <Divider />
             <DrawerTabIcon
               label="Add workflow"
+              trackingLabel="create_builder.drawer_tab.add_workflow"
               icon={<MultiParty fontSize="1.5rem" />}
               onClick={handleDrawerWorkflowClick}
               isActive={activeTab === DrawerTabs.Workflow}
@@ -157,6 +162,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
           icon={<BiQuestionMark />}
           borderRadius="full"
           aria-label="Help"
+          data-dd-action-name="create_builder.drawer_tab.help"
           onClick={(e) => {
             e.preventDefault()
             window.open(FORM_GUIDE)

--- a/frontend/src/features/admin-form/create/common/CreatePageSidebar/DrawerTabIcon.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageSidebar/DrawerTabIcon.tsx
@@ -11,6 +11,7 @@ interface DrawerTabIconProps {
   isActive: boolean
   id?: string
   showRedDot?: boolean
+  trackingLabel?: string
 }
 
 export const DrawerTabIcon = ({
@@ -20,6 +21,7 @@ export const DrawerTabIcon = ({
   isActive,
   id,
   showRedDot,
+  trackingLabel,
 }: DrawerTabIconProps): JSX.Element => {
   return (
     <Tooltip label={label} placement="right">
@@ -27,6 +29,7 @@ export const DrawerTabIcon = ({
         <IconButton
           variant="reverse"
           aria-label={label}
+          data-dd-action-name={trackingLabel}
           isActive={isActive}
           icon={icon}
           onClick={onClick}

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
@@ -9,7 +9,6 @@ import {
 } from '../../../adminWorkflowStore'
 import { useWorkflowMutations } from '../../../mutations'
 import { EditStepBlock } from '../EditStepBlock'
-import { isFirstStepByStepNumber } from '../utils/isFirstStepByStepNumber'
 
 export interface ActiveStepBlockProps {
   stepNumber: number

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
@@ -1,5 +1,4 @@
 import { useCallback } from 'react'
-import { datadogRum } from '@datadog/browser-rum'
 
 import { FormWorkflowStep, FormWorkflowStepDto } from '~shared/types'
 
@@ -16,6 +15,9 @@ export interface ActiveStepBlockProps {
   handleOpenDeleteModal: () => void
 }
 
+// Hack
+// @ts-expect-error hack
+const datadogRum = window.DD_RUM
 const handleTracking = (step: FormWorkflowStep, stepNumber: number) => {
   // stepNumber is 0-indexed
   if (stepNumber === 0) {

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
@@ -2,6 +2,8 @@ import { useCallback } from 'react'
 
 import { FormWorkflowStep, FormWorkflowStepDto } from '~shared/types'
 
+import { datadogRum } from '~utils/datadog'
+
 import {
   setToInactiveSelector,
   useAdminWorkflowStore,
@@ -15,9 +17,6 @@ export interface ActiveStepBlockProps {
   handleOpenDeleteModal: () => void
 }
 
-// Hack
-// @ts-expect-error hack
-const datadogRum = window.DD_RUM
 const handleTracking = (step: FormWorkflowStep, stepNumber: number) => {
   // stepNumber is 0-indexed
   if (stepNumber === 0) {

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { datadogRum } from '@datadog/browser-rum'
 
 import { FormWorkflowStep, FormWorkflowStepDto } from '~shared/types'
 
@@ -8,11 +9,33 @@ import {
 } from '../../../adminWorkflowStore'
 import { useWorkflowMutations } from '../../../mutations'
 import { EditStepBlock } from '../EditStepBlock'
+import { isFirstStepByStepNumber } from '../utils/isFirstStepByStepNumber'
 
 export interface ActiveStepBlockProps {
   stepNumber: number
   step: FormWorkflowStepDto
   handleOpenDeleteModal: () => void
+}
+
+const handleTracking = (step: FormWorkflowStep, stepNumber: number) => {
+  // stepNumber is 0-indexed
+  if (stepNumber === 0) {
+    const hasFieldsSelected = step.edit.length > 0
+    if (hasFieldsSelected) {
+      datadogRum.addAction(
+        'workflow_builder.active_step_block.step_one_save_action',
+      )
+    }
+  }
+
+  if (stepNumber === 1) {
+    const hasFieldsSelected = step.edit.length > 0
+    if (hasFieldsSelected) {
+      datadogRum.addAction(
+        'workflow_builder.active_step_block.step_two_save_action',
+      )
+    }
+  }
 }
 
 export const ActiveStepBlock = ({
@@ -24,7 +47,8 @@ export const ActiveStepBlock = ({
   const setToInactive = useAdminWorkflowStore(setToInactiveSelector)
 
   const handleSubmit = useCallback(
-    (step: FormWorkflowStep) =>
+    (step: FormWorkflowStep) => {
+      handleTracking(step, stepNumber)
       updateStepMutation.mutate(
         {
           stepNumber,
@@ -33,7 +57,8 @@ export const ActiveStepBlock = ({
         {
           onSuccess: () => setToInactive(),
         },
-      ),
+      )
+    },
     [updateStepMutation, stepNumber, setToInactive],
   )
 

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -29,6 +29,24 @@ import { FormResponseOptions } from './FormResponseOptions'
 /** The length of form title to start showing warning text */
 const FORM_TITLE_LENGTH_WARNING = 65
 
+const getTrackingSubmissionActionName = (
+  responseModeValue: FormResponseMode,
+) => {
+  switch (responseModeValue) {
+    case FormResponseMode.Email:
+      return 'dashboard.create.create_email'
+    case FormResponseMode.Encrypt:
+      return 'dashboard.create.create_encrypt'
+    case FormResponseMode.Multirespondent:
+      return 'dashboard.create.create_multirespondent'
+
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _exhaustiveCheck: never = responseModeValue
+    }
+  }
+}
+
 export const CreateFormDetailsScreen = (): JSX.Element => {
   const {
     formMethods,
@@ -48,9 +66,6 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
   const titleInputValue = watch('title')
   const responseModeValue = watch('responseMode')
 
-  const trackingSubmitActionName = (
-    'dashboard.create.create_' + responseModeValue
-  ).toLowerCase()
   return (
     <>
       <ModalHeader color="secondary.700">
@@ -115,7 +130,9 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             isDisabled={isFetching}
             onClick={handleDetailsSubmit}
             isFullWidth
-            data-dd-action-name={trackingSubmitActionName}
+            data-dd-action-name={getTrackingSubmissionActionName(
+              responseModeValue,
+            )}
           >
             <Text lineHeight="1.5rem">Next step</Text>
           </Button>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -48,6 +48,9 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
   const titleInputValue = watch('title')
   const responseModeValue = watch('responseMode')
 
+  const trackingSubmitActionName = (
+    'dashboard.create.create_' + responseModeValue
+  ).toLowerCase()
   return (
     <>
       <ModalHeader color="secondary.700">
@@ -112,6 +115,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             isDisabled={isFetching}
             onClick={handleDetailsSubmit}
             isFullWidth
+            data-dd-action-name={trackingSubmitActionName}
           >
             <Text lineHeight="1.5rem">Next step</Text>
           </Button>

--- a/frontend/src/typings/window.d.ts
+++ b/frontend/src/typings/window.d.ts
@@ -1,0 +1,7 @@
+import type { RumGlobal } from '@datadog/browser-rum'
+
+declare global {
+  interface Window {
+    DD_RUM: RumGlobal | undefined
+  }
+}

--- a/frontend/src/utils/__tests__/datadog.tests.ts
+++ b/frontend/src/utils/__tests__/datadog.tests.ts
@@ -1,0 +1,49 @@
+describe('datadogRum', () => {
+  describe('DD_RUM is undefined', () => {
+    beforeEach(() => {
+      window.DD_RUM = undefined
+    })
+
+    afterEach(() => {
+      jest.resetModules()
+    })
+
+    it('should return a noop function for addAction', () => {
+      // Arrange
+
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const datadogRum = require('../datadog').datadogRum
+      // Assert
+      expect(window.DD_RUM).not.toBeDefined()
+      expect(datadogRum.addAction).not.toThrow()
+    })
+  })
+
+  describe('DD_RUM is defined', () => {
+    let addActionSpy: jest.Mock
+    beforeEach(() => {
+      addActionSpy = jest.fn()
+      // @ts-expect-error mocking undefined DD_RUM
+      window.DD_RUM = {
+        addAction: addActionSpy,
+      }
+    })
+
+    afterEach(() => {
+      jest.resetModules()
+    })
+
+    it('should call addAction without throwing', () => {
+      // Arrange
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const datadogRum = require('../datadog').datadogRum
+
+      // Assert
+      expect(window.DD_RUM).toBeDefined()
+      expect(datadogRum.addAction).not.toThrow()
+      expect(addActionSpy).toBeCalledTimes(1)
+    })
+  })
+})
+
+export {}

--- a/frontend/src/utils/datadog.ts
+++ b/frontend/src/utils/datadog.ts
@@ -6,6 +6,16 @@ import type { RumGlobal } from '@datadog/browser-rum'
  * `datadogRum` imported from `'@datadog/browser-rum'` refers to a different datadog instance as the chunk is loaded separately from the js bundle.
  * Instead, we have to extract the global variable from the window object.
  * */
+const _datadogRum = window.DD_RUM as RumGlobal | undefined
 
-// @ts-expect-error extracting DD_RUM that's initialised from window
-export const datadogRum = window.DD_RUM as RumGlobal
+const noop = () => {}
+const handler = {
+  get: (target: RumGlobal, prop: keyof RumGlobal) => {
+    if (Object.keys(target).length === 0) {
+      return noop
+    }
+    return target[prop]
+  },
+}
+
+export const datadogRum = new Proxy(_datadogRum || {}, handler)

--- a/frontend/src/utils/datadog.ts
+++ b/frontend/src/utils/datadog.ts
@@ -8,6 +8,7 @@ import type { RumGlobal } from '@datadog/browser-rum'
  * */
 const _datadogRum = window.DD_RUM as RumGlobal | undefined
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {}
 const handler = {
   get: (target: RumGlobal, prop: keyof RumGlobal) => {

--- a/frontend/src/utils/datadog.ts
+++ b/frontend/src/utils/datadog.ts
@@ -1,0 +1,11 @@
+import type { RumGlobal } from '@datadog/browser-rum'
+
+/**
+ * Retrieves the datadogRum instance from the window object.
+ *
+ * `datadogRum` imported from `'@datadog/browser-rum'` refers to a different datadog instance as the chunk is loaded separately from the js bundle.
+ * Instead, we have to extract the global variable from the window object.
+ * */
+
+// @ts-expect-error extracting DD_RUM that's initialised from window
+export const datadogRum = window.DD_RUM as RumGlobal

--- a/src/app/loaders/express/constants.ts
+++ b/src/app/loaders/express/constants.ts
@@ -41,6 +41,7 @@ export const CSP_CORE_DIRECTIVES = {
     'https://www.google-analytics.com/',
     'https://ssl.google-analytics.com/',
     'https://*.browser-intake-datadoghq.com',
+    'https://browser-intake-datadoghq.com',
     config.aws.attachmentBucketUrl,
     config.aws.imageBucketUrl,
     config.aws.logoBucketUrl,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
To track the ideal flow for a user session.

Closes FRM-1864

## Solution
<!-- How did you solve the problem? -->
Track that user have created an MRF with some fields.
Track that user have added least 2 workflow steps with fields assigned.

**Notes**
Introduced at new `utils/datadog.ts` that helps to capture `datadogRum` for FE usage safely.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

*Regression*
Workflow can be added 
- [ ] Create an MRF
- [ ] Add an email field
- [ ] Click on Add Workflow
- [ ] Assign email field to Step 1
- [ ] Ensure that Step 1 "Save field" saves
- [ ] Assign email field to Step 2
- [ ] Ensure that Step 2 "Save field" saves