### PR TITLE
fix: coverall allow empty lcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,9 +176,10 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096 -r ${{ env.DD_TRACE_PACKAGE }}
           AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE: 1
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-empty: false
 
   backend_lint:
     needs: [changes, install]


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We've turned on selectively skipping tests which may inadvertently causes no files to be marked as testable. This results in no coverage file being generated which `coveralls` uses to upload coverage statistics.

## Solution
<!-- How did you solve the problem? -->

Upgrade `coveralls` to enable options for us to `allow-empty` lcov.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  