### PR TITLE
chore: allow empty coveralls to pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          allow-empty: false
+          allow-empty: true
 
   backend_lint:
     needs: [changes, install]


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Typo-ed. We should enable `allow-empty` instead of dis-allowing in #7722

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  