### PR TITLE
fix: ses default configset

### DIFF
--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -183,6 +183,7 @@ const mailConfig: MailConfig = (function () {
     official,
     mailer,
     transporter,
+    sesConfigSet: prodOnlyVars.sesConfigSet,
   }
 })()
 

--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -452,6 +452,13 @@ export const prodOnlyVarsSchema: Schema<IProdOnlyVarsSchema> = {
     env: 'SES_PASS',
     sensitive: true,
   },
+  sesConfigSet: {
+    doc: 'Config set for SES when sending email',
+    format: String,
+    default: null,
+    env: 'SES_CONFIG_SET',
+    sensitive: true,
+  },
   dbHost: {
     doc: 'Database URI',
     format: (val) => {

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -247,10 +247,21 @@ export class MailService {
     }
 
     return ResultAsync.fromPromise(
-      this.#sendMailWithRetries(mail, {
-        mailId: sendOptions?.mailId,
-        formId: sendOptions?.formId,
-      }),
+      this.#sendMailWithRetries(
+        {
+          ...mail,
+          headers: config.mail.sesConfigSet
+            ? {
+                'X-SES-CONFIGURATION-SET': config.mail.sesConfigSet,
+                ...mail.headers,
+              }
+            : mail.headers,
+        },
+        {
+          mailId: sendOptions?.mailId,
+          formId: sendOptions?.formId,
+        },
+      ),
       (error) => {
         logger.error({
           message: 'Error returned from sendMail retries',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -54,6 +54,7 @@ export type MailConfig = {
   }
   official: string
   transporter: Mail
+  sesConfigSet: string
 }
 
 export type RateLimitConfig = {
@@ -121,6 +122,7 @@ export interface IProdOnlyVarsSchema {
   user: string
   pass: string
   dbHost: string
+  sesConfigSet: string
 }
 
 export interface ICompulsoryVarsSchema {


### PR DESCRIPTION
As part of mitigating AWS SES incident where default config is not applied.  
- add explicit configset to nodemailer email header 