### PR TITLE
fix: ordering of arguments for bounce service functions

### DIFF
--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -413,24 +413,24 @@ describe('BounceService', () => {
       ).toHaveBeenCalledTimes(2)
       expect(
         MockedPostmanSmsService.sendBouncedSubmissionSms,
-      ).toHaveBeenCalledWith(
-        testUser.email,
-        String(testUser._id),
-        form._id,
-        form.title,
-        MOCK_CONTACT.contact,
-        MOCK_CONTACT.email,
-      )
+      ).toHaveBeenCalledWith({
+        adminEmail: testUser.email,
+        adminId: String(testUser._id),
+        formId: form._id,
+        formTitle: form.title,
+        recipientPhoneNumber: MOCK_CONTACT.contact,
+        recipientEmail: MOCK_CONTACT.email,
+      })
       expect(
         MockedPostmanSmsService.sendBouncedSubmissionSms,
-      ).toHaveBeenCalledWith(
-        testUser.email,
-        String(testUser._id),
-        form._id,
-        form.title,
-        MOCK_CONTACT_2.contact,
-        MOCK_CONTACT_2.email,
-      )
+      ).toHaveBeenCalledWith({
+        adminEmail: testUser.email,
+        adminId: String(testUser._id),
+        formId: form._id,
+        formTitle: form.title,
+        recipientPhoneNumber: MOCK_CONTACT_2.contact,
+        recipientEmail: MOCK_CONTACT_2.email,
+      })
       expect(notifiedRecipients._unsafeUnwrap()).toEqual([
         MOCK_CONTACT,
         MOCK_CONTACT_2,
@@ -461,24 +461,24 @@ describe('BounceService', () => {
       ).toHaveBeenCalledTimes(2)
       expect(
         MockedPostmanSmsService.sendBouncedSubmissionSms,
-      ).toHaveBeenCalledWith(
-        testUser.email,
-        String(testUser._id),
-        form._id,
-        form.title,
-        MOCK_CONTACT.contact,
-        MOCK_CONTACT.email,
-      )
+      ).toHaveBeenCalledWith({
+        adminEmail: testUser.email,
+        adminId: String(testUser._id),
+        formId: form._id,
+        formTitle: form.title,
+        recipientPhoneNumber: MOCK_CONTACT.contact,
+        recipientEmail: MOCK_CONTACT.email,
+      })
       expect(
         MockedPostmanSmsService.sendBouncedSubmissionSms,
-      ).toHaveBeenCalledWith(
-        testUser.email,
-        String(testUser._id),
-        form._id,
-        form.title,
-        MOCK_CONTACT_2.contact,
-        MOCK_CONTACT_2.email,
-      )
+      ).toHaveBeenCalledWith({
+        adminEmail: testUser.email,
+        adminId: String(testUser._id),
+        formId: form._id,
+        formTitle: form.title,
+        recipientPhoneNumber: MOCK_CONTACT_2.contact,
+        recipientEmail: MOCK_CONTACT_2.email,
+      })
       expect(notifiedRecipients._unsafeUnwrap()).toEqual([MOCK_CONTACT])
     })
   })
@@ -866,24 +866,24 @@ describe('BounceService', () => {
       ).toHaveBeenCalledTimes(2)
       expect(
         MockedPostmanSmsService.sendFormDeactivatedSms,
-      ).toHaveBeenCalledWith(
-        form.admin.email,
-        String(form.admin._id),
-        form._id,
-        form.title,
-        MOCK_CONTACT.contact,
-        MOCK_CONTACT.email,
-      )
+      ).toHaveBeenCalledWith({
+        adminEmail: form.admin.email,
+        adminId: String(form.admin._id),
+        formId: form._id,
+        formTitle: form.title,
+        recipientPhoneNumber: MOCK_CONTACT.contact,
+        recipientEmail: MOCK_CONTACT.email,
+      })
       expect(
         MockedPostmanSmsService.sendFormDeactivatedSms,
-      ).toHaveBeenCalledWith(
-        form.admin.email,
-        String(form.admin._id),
-        form._id,
-        form.title,
-        MOCK_CONTACT_2.contact,
-        MOCK_CONTACT_2.email,
-      )
+      ).toHaveBeenCalledWith({
+        adminEmail: form.admin.email,
+        adminId: String(form.admin._id),
+        formId: form._id,
+        formTitle: form.title,
+        recipientPhoneNumber: MOCK_CONTACT_2.contact,
+        recipientEmail: MOCK_CONTACT_2.email,
+      })
     })
 
     it('should return true even when some SMSes fail', async () => {
@@ -906,24 +906,24 @@ describe('BounceService', () => {
       ).toHaveBeenCalledTimes(2)
       expect(
         MockedPostmanSmsService.sendFormDeactivatedSms,
-      ).toHaveBeenCalledWith(
-        form.admin.email,
-        String(form.admin._id),
-        form._id,
-        form.title,
-        MOCK_CONTACT.contact,
-        MOCK_CONTACT.email,
-      )
+      ).toHaveBeenCalledWith({
+        adminEmail: form.admin.email,
+        adminId: String(form.admin._id),
+        formId: form._id,
+        formTitle: form.title,
+        recipientPhoneNumber: MOCK_CONTACT.contact,
+        recipientEmail: MOCK_CONTACT.email,
+      })
       expect(
         MockedPostmanSmsService.sendFormDeactivatedSms,
-      ).toHaveBeenCalledWith(
-        form.admin.email,
-        String(form.admin._id),
-        form._id,
-        form.title,
-        MOCK_CONTACT_2.contact,
-        MOCK_CONTACT_2.email,
-      )
+      ).toHaveBeenCalledWith({
+        adminEmail: form.admin.email,
+        adminId: String(form.admin._id),
+        formId: form._id,
+        formTitle: form.title,
+        recipientPhoneNumber: MOCK_CONTACT_2.contact,
+        recipientEmail: MOCK_CONTACT_2.email,
+      })
     })
   })
 })

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -219,14 +219,14 @@ export const sendSmsBounceNotification = (
   // empty array as list of recipients.
 ): ResultAsync<UserWithContactNumber[], never> => {
   const smsResults = possibleSmsRecipients.map((recipient) =>
-    PostmanSmsService.sendBouncedSubmissionSms(
-      form.admin.email,
-      String(form.admin._id),
-      form._id,
-      form.title,
-      recipient.contact,
-      recipient.email,
-    )
+    PostmanSmsService.sendBouncedSubmissionSms({
+      adminEmail: form.admin.email,
+      adminId: String(form.admin._id),
+      formId: form._id,
+      formTitle: form.title,
+      recipientPhoneNumber: recipient.contact,
+      recipientEmail: recipient.email,
+    })
       .map(() => recipient)
       .mapErr(
         (error) => new SendBounceSmsNotificationError(error, recipient.contact),
@@ -368,14 +368,14 @@ export const notifyAdminsOfDeactivation = (
   // Best-effort attempt to send SMSes, don't propagate error upwards
 ): ResultAsync<true, never> => {
   const smsResults = possibleSmsRecipients.map((recipient) =>
-    PostmanSmsService.sendFormDeactivatedSms(
-      form.admin.email,
-      String(form.admin._id),
-      form._id,
-      form.title,
-      recipient.contact,
-      recipient.email,
-    ),
+    PostmanSmsService.sendFormDeactivatedSms({
+      adminEmail: form.admin.email,
+      adminId: String(form.admin._id),
+      formId: form._id,
+      formTitle: form.title,
+      recipientPhoneNumber: recipient.contact,
+      recipientEmail: recipient.email,
+    }),
   )
   return ResultAsync.combineWithAllErrors(smsResults)
     .map(() => true as const)

--- a/src/app/modules/user/__tests__/user.controller.spec.ts
+++ b/src/app/modules/user/__tests__/user.controller.spec.ts
@@ -62,12 +62,12 @@ describe('user.controller', () => {
         MOCK_REQ.body.userId,
         MOCK_REQ.body.contact,
       )
-      expect(MockPostmanSmsService.sendAdminContactOtp).toHaveBeenCalledWith(
-        MOCK_REQ.body.contact,
-        expectedOtp,
-        MOCK_REQ.body.userId,
-        'MOCK_IP',
-      )
+      expect(MockPostmanSmsService.sendAdminContactOtp).toHaveBeenCalledWith({
+        recipientPhoneNumber: MOCK_REQ.body.contact,
+        otp: expectedOtp,
+        userId: MOCK_REQ.body.userId,
+        senderIp: 'MOCK_IP',
+      })
       expect(mockRes.sendStatus).toHaveBeenCalledWith(200)
     })
 

--- a/src/app/modules/user/user.controller.ts
+++ b/src/app/modules/user/user.controller.ts
@@ -70,12 +70,12 @@ export const _handleContactSendOtp: ControllerHandler<
 
   // Step 2: No error, send verification OTP to contact.
   const otp = createResult.value
-  const sendOtpResult = await PostmanSmsService.sendAdminContactOtp(
-    contact,
+  const sendOtpResult = await PostmanSmsService.sendAdminContactOtp({
+    recipientPhoneNumber: contact,
     otp,
     userId,
     senderIp,
-  )
+  })
 
   // Error sending OTP.
   if (sendOtpResult.isErr()) {

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -486,13 +486,13 @@ const sendOtpForField = (
                   senderIp,
                 )
               }
-              return PostmanSmsService.sendVerificationOtp(
-                recipient,
+              return PostmanSmsService.sendVerificationOtp({
+                recipientPhoneNumber: recipient,
                 otp,
                 otpPrefix,
                 formId,
                 senderIp,
-              )
+              })
             })
         : errAsync(new MalformedParametersError('Field id not present'))
     case BasicField.Email:

--- a/src/app/services/postman-sms/__tests__/postman-sms.service.spec.ts
+++ b/src/app/services/postman-sms/__tests__/postman-sms.service.spec.ts
@@ -46,14 +46,14 @@ describe('postman-sms.service', () => {
         .mockResolvedValueOnce(okAsync(true))
 
       // Act
-      await PostmanSmsService.sendFormDeactivatedSms(
-        TEST_NUMBER,
-        MOCK_ADMIN_EMAIL,
-        MOCK_ADMIN_ID,
-        MOCK_FORM_ID,
-        MOCK_FORM_TITLE,
-        MOCK_RECIPIENT_EMAIL,
-      )
+      await PostmanSmsService.sendFormDeactivatedSms({
+        recipientPhoneNumber: TEST_NUMBER,
+        recipientEmail: MOCK_RECIPIENT_EMAIL,
+        adminEmail: MOCK_ADMIN_EMAIL,
+        adminId: MOCK_ADMIN_ID,
+        formId: MOCK_FORM_ID,
+        formTitle: MOCK_FORM_TITLE,
+      })
 
       // Assert
       expect(postmanInternalSendSpy).toHaveBeenCalledOnce()
@@ -73,14 +73,14 @@ describe('postman-sms.service', () => {
       const invalidNumber = '1+11'
 
       // Act
-      const actualResult = await PostmanSmsService.sendFormDeactivatedSms(
-        invalidNumber,
-        MOCK_ADMIN_EMAIL,
-        MOCK_ADMIN_ID,
-        MOCK_FORM_ID,
-        MOCK_FORM_TITLE,
-        MOCK_RECIPIENT_EMAIL,
-      )
+      const actualResult = await PostmanSmsService.sendFormDeactivatedSms({
+        recipientPhoneNumber: invalidNumber,
+        recipientEmail: MOCK_RECIPIENT_EMAIL,
+        adminEmail: MOCK_ADMIN_EMAIL,
+        adminId: MOCK_ADMIN_ID,
+        formId: MOCK_FORM_ID,
+        formTitle: MOCK_FORM_TITLE,
+      })
 
       // Assert
       expect(actualResult._unsafeUnwrapErr()).toEqual(new InvalidNumberError())
@@ -101,14 +101,14 @@ describe('postman-sms.service', () => {
         .mockResolvedValueOnce(okAsync(true))
 
       // Act
-      await PostmanSmsService.sendBouncedSubmissionSms(
-        TEST_NUMBER,
-        MOCK_ADMIN_EMAIL,
-        MOCK_ADMIN_ID,
-        MOCK_FORM_ID,
-        MOCK_FORM_TITLE,
-        MOCK_RECIPIENT_EMAIL,
-      )
+      await PostmanSmsService.sendBouncedSubmissionSms({
+        recipientPhoneNumber: TEST_NUMBER,
+        recipientEmail: MOCK_RECIPIENT_EMAIL,
+        adminEmail: MOCK_ADMIN_EMAIL,
+        adminId: MOCK_ADMIN_ID,
+        formId: MOCK_FORM_ID,
+        formTitle: MOCK_FORM_TITLE,
+      })
 
       expect(postmanInternalSendSpy).toHaveBeenCalledOnce()
       expect(postmanMopSendSpy).not.toHaveBeenCalled()
@@ -127,14 +127,14 @@ describe('postman-sms.service', () => {
       const invalidNumber = '1+11'
 
       // Act
-      const actualResult = await PostmanSmsService.sendBouncedSubmissionSms(
-        invalidNumber,
-        MOCK_ADMIN_EMAIL,
-        MOCK_ADMIN_ID,
-        MOCK_FORM_ID,
-        MOCK_FORM_TITLE,
-        MOCK_RECIPIENT_EMAIL,
-      )
+      const actualResult = await PostmanSmsService.sendBouncedSubmissionSms({
+        recipientPhoneNumber: invalidNumber,
+        recipientEmail: MOCK_RECIPIENT_EMAIL,
+        adminEmail: MOCK_ADMIN_EMAIL,
+        adminId: MOCK_ADMIN_ID,
+        formId: MOCK_FORM_ID,
+        formTitle: MOCK_FORM_TITLE,
+      })
 
       // Assert
       expect(actualResult._unsafeUnwrapErr()).toEqual(new InvalidNumberError())
@@ -174,13 +174,13 @@ describe('postman-sms.service', () => {
         .mockResolvedValueOnce(okAsync(true))
 
       // Act
-      const actualResult = await PostmanSmsService.sendVerificationOtp(
-        TEST_NUMBER,
-        '111111',
-        'ABC',
-        testForm._id,
-        MOCK_SENDER_IP,
-      )
+      const actualResult = await PostmanSmsService.sendVerificationOtp({
+        recipientPhoneNumber: TEST_NUMBER,
+        otp: '111111',
+        otpPrefix: 'ABC',
+        formId: testForm._id,
+        senderIp: MOCK_SENDER_IP,
+      })
 
       // Assert
       expect(actualResult._unsafeUnwrapErr()).toEqual(
@@ -200,13 +200,13 @@ describe('postman-sms.service', () => {
         .mockResolvedValueOnce(okAsync(true))
 
       // Act
-      const actualResult = await PostmanSmsService.sendVerificationOtp(
-        TEST_NUMBER,
-        '111111',
-        'ABC',
-        testForm._id,
-        MOCK_SENDER_IP,
-      )
+      const actualResult = await PostmanSmsService.sendVerificationOtp({
+        recipientPhoneNumber: TEST_NUMBER,
+        otp: '111111',
+        otpPrefix: 'ABC',
+        formId: testForm._id,
+        senderIp: MOCK_SENDER_IP,
+      })
 
       // Assert
       expect(actualResult._unsafeUnwrap()).toEqual(true)
@@ -222,13 +222,13 @@ describe('postman-sms.service', () => {
 
       const invalidNumber = '1+11123'
       // Act
-      const actualResult = await PostmanSmsService.sendVerificationOtp(
-        invalidNumber,
-        '111111',
-        'ABC',
-        testForm._id,
-        MOCK_SENDER_IP,
-      )
+      const actualResult = await PostmanSmsService.sendVerificationOtp({
+        recipientPhoneNumber: invalidNumber,
+        otp: '111111',
+        otpPrefix: 'ABC',
+        formId: testForm._id,
+        senderIp: MOCK_SENDER_IP,
+      })
 
       // Assert
       expect(actualResult._unsafeUnwrapErr()).toEqual(new InvalidNumberError())
@@ -248,12 +248,12 @@ describe('postman-sms.service', () => {
         .mockResolvedValueOnce(okAsync(true))
 
       // Act
-      const actualResult = await PostmanSmsService.sendAdminContactOtp(
-        TEST_NUMBER,
-        '111111',
-        testUser._id,
-        MOCK_SENDER_IP,
-      )
+      const actualResult = await PostmanSmsService.sendAdminContactOtp({
+        recipientPhoneNumber: TEST_NUMBER,
+        otp: '111111',
+        userId: testUser._id,
+        senderIp: MOCK_SENDER_IP,
+      })
 
       // Assert
       expect(actualResult._unsafeUnwrap()).toEqual(true)
@@ -274,12 +274,12 @@ describe('postman-sms.service', () => {
       const invalidNumber = '1+11123'
 
       // Act
-      const actualResult = await PostmanSmsService.sendAdminContactOtp(
-        invalidNumber,
-        '111111',
-        testUser._id,
-        MOCK_SENDER_IP,
-      )
+      const actualResult = await PostmanSmsService.sendAdminContactOtp({
+        recipientPhoneNumber: invalidNumber,
+        otp: '111111',
+        userId: testUser._id,
+        senderIp: MOCK_SENDER_IP,
+      })
 
       // Assert
       expect(actualResult._unsafeUnwrapErr()).toEqual(new InvalidNumberError())


### PR DESCRIPTION
## Problem
When emails bounce, admins should get an sms to their provided contact number informing them that emails have bounced. However, they are not receiving it and the following errors occur.

Closes FRM-1867

## Solution
After investigation, the cause was that the order of arguments passed to the invoked function were mis-matched.  
Use object argument with named keys to prevent mismatch of arguments in future.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests

`sendBouncedSubmissionSms` and `sendFormDeactivatedSms`: Admins with email submissions bounced should receive SMS notification thru Postman
- [ ] Login as admin
- [ ] Update your emergency contact number through Profile > Emergency Contact > Verify
- [ ] Create an email form, set the email notification email targets to be invalid emails eg, `abc@xyz098.com` and `abcxyz!@open.gov.sg`  
- [ ] As a respondent, make a submission to form (since all emails are invalid and bounce, a 'critical' bounce where all emails to notify have bounced occurs which triggers the next 2 emails) 
- [ ] Ensure that `bounce` SMS is received on number and `form deactivated` SMS is received. (note that 2 sms should be received)