### PR TITLE
fix: radio button saving others despite not selected

### DIFF
--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -368,7 +368,7 @@ const createResponsesV3 = (
           | FormFieldValue<typeof ff.fieldType>
           | undefined
         const isOthersSelected =
-          input?.value && input.value === CLIENT_RADIO_OTHERS_INPUT_VALUE
+          input?.value === CLIENT_RADIO_OTHERS_INPUT_VALUE
         if (!isOthersSelected && input?.value) {
           returnedInputs[ff._id] = {
             fieldType: ff.fieldType,

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -2,10 +2,7 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { encode as encodeBase64 } from '@stablelib/base64'
 import { chain, forOwn, isEmpty, keyBy, omit, pick } from 'lodash'
 
-import {
-  CLIENT_RADIO_OTHERS_INPUT_VALUE,
-  E2EE_SUBMISSION_VERSION,
-} from '~shared/constants'
+import { E2EE_SUBMISSION_VERSION } from '~shared/constants'
 import { FieldResponsesV3, FieldResponseV3, ProductItem } from '~shared/types'
 import { BasicField, FormFieldDto, PaymentFieldsDto } from '~shared/types/field'
 import {
@@ -28,6 +25,7 @@ import {
   FormFieldValue,
   FormFieldValues,
 } from '~templates/Field'
+import { RADIO_OTHERS_INPUT_VALUE } from '~templates/Field/Radio/constants'
 
 import { FieldIdToQuarantineKeyType } from '../PublicFormService'
 
@@ -367,8 +365,7 @@ const createResponsesV3 = (
         const input = formInputs[ff._id] as
           | FormFieldValue<typeof ff.fieldType>
           | undefined
-        const isOthersSelected =
-          input?.value === CLIENT_RADIO_OTHERS_INPUT_VALUE
+        const isOthersSelected = input?.value === RADIO_OTHERS_INPUT_VALUE
         if (!isOthersSelected && input?.value) {
           returnedInputs[ff._id] = {
             fieldType: ff.fieldType,

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -2,7 +2,10 @@ import { datadogLogs } from '@datadog/browser-logs'
 import { encode as encodeBase64 } from '@stablelib/base64'
 import { chain, forOwn, isEmpty, keyBy, omit, pick } from 'lodash'
 
-import { E2EE_SUBMISSION_VERSION } from '~shared/constants'
+import {
+  CLIENT_RADIO_OTHERS_INPUT_VALUE,
+  E2EE_SUBMISSION_VERSION,
+} from '~shared/constants'
 import { FieldResponsesV3, FieldResponseV3, ProductItem } from '~shared/types'
 import { BasicField, FormFieldDto, PaymentFieldsDto } from '~shared/types/field'
 import {
@@ -364,12 +367,14 @@ const createResponsesV3 = (
         const input = formInputs[ff._id] as
           | FormFieldValue<typeof ff.fieldType>
           | undefined
-        if (input?.value) {
+        const isOthersSelected =
+          input?.value && input.value === CLIENT_RADIO_OTHERS_INPUT_VALUE
+        if (!isOthersSelected && input?.value) {
           returnedInputs[ff._id] = {
             fieldType: ff.fieldType,
             answer: { value: input.value },
           }
-        } else if (input?.othersInput) {
+        } else if (isOthersSelected && input?.othersInput) {
           returnedInputs[ff._id] = {
             fieldType: ff.fieldType,
             answer: { othersInput: input.othersInput },

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -364,12 +364,16 @@ const createResponsesV3 = (
         const input = formInputs[ff._id] as
           | FormFieldValue<typeof ff.fieldType>
           | undefined
-        if (!input?.value && !input?.othersInput) break
-        returnedInputs[ff._id] = {
-          fieldType: ff.fieldType,
-          answer: input.othersInput
-            ? { othersInput: input.othersInput }
-            : { value: input.value },
+        if (input?.value) {
+          returnedInputs[ff._id] = {
+            fieldType: ff.fieldType,
+            answer: { value: input.value },
+          }
+        } else if (input?.othersInput) {
+          returnedInputs[ff._id] = {
+            fieldType: ff.fieldType,
+            answer: { othersInput: input.othersInput },
+          }
         }
         break
       }


### PR DESCRIPTION
Fixes bug where invalid submission responses collected for radio fields where others is submitted despite not selected. 

To reproduce:
1. create a radio field with others option enabled
2. fill in the others box but select other option
3. note that the submitted result is the others value despite the option Option 1 being selected

Closes FRM-1868