### PR TITLE
fix: regression on dropdown input, workflow save action step component

### DIFF
--- a/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -94,6 +94,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             isInvalid={isInvalid}
             isDisabled={isDisabled}
             placeholder={selectedItem ? undefined : placeholder}
+            hasInputRightElement
             sx={styles.field}
             {...getInputProps({
               onClick: handleToggleMenu,

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/SaveActionGroup.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/SaveActionGroup.tsx
@@ -28,7 +28,6 @@ export const SaveActionGroup = ({
     <Flex
       justify="space-between"
       align="center"
-      mt="1.5rem"
       px={{ base: '1.5rem', md: '2rem' }}
     >
       {handleDelete ? (

--- a/frontend/src/features/user/billing/BillingPage.stories.tsx
+++ b/frontend/src/features/user/billing/BillingPage.stories.tsx
@@ -6,7 +6,7 @@ import {
 } from '~/mocks/msw/handlers/billing'
 
 import { BILLING_ROUTE } from '~constants/routes'
-import { StoryRouter, viewports } from '~utils/storybook'
+import { mockDateDecorator, StoryRouter, viewports } from '~utils/storybook'
 
 import { BillCharges, BillChargesProps } from './BillCharges'
 import { BillingPage } from './BillingPage'
@@ -21,10 +21,12 @@ export default {
       initialEntries: [BILLING_ROUTE],
       path: BILLING_ROUTE,
     }),
+    mockDateDecorator,
   ],
   parameters: {
     layout: 'fullscreen',
     chromatic: { delay: 200 },
+    mockdate: new Date('2024-10-07T19:52:00.000Z'),
   },
 } as Meta
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Regression introduced from react migration that was detected from Chromatic.

1. DateRangePicker (super huge gap, deferring now cause we are not using a wide DatePicker)
2. Workflow Approvals gap too big (need fix)
3. RightElement overlap (need fix)

## Solution
<!-- How did you solve the problem? -->

1. N/A
2. Remove `mt` that is no longer required as dividers now properly provide margins.
3. Utilise `hasInputRightElement` props to accommodate right element spacing.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  