### PR TITLE
fix(react): remove strict mode, temporarily

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -30,8 +30,15 @@ window.gtag = gtag
 // Init dayjs
 dayjs.init()
 
-createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+/**
+ * TODO(FRM-1855): Disable strict mode for validation to work properly
+ * This is not meant to be a permenant solution as the need to disable this
+ * reveals that there could be an existing issue with useEffect cleanup that is prevent
+ * pre-react 18.
+ */
+// createRoot(document.getElementById('root')!).render(
+//   <React.StrictMode>
+//     <App />,
+//   </React.StrictMode>,
+// )
+createRoot(document.getElementById('root')!).render(<App />)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Due to useEffect calling twice. This is as intended by the React Core team to help discover potential useEffect bugs on our system where we're not properly handling unsubscribes.

Potential workaround is to remove <React.StrictMode> from root. However, this is not recommended to be a permanent fixture.

References FRM-1871

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
`react-hook-form` submit should display errors on local development
- [ ] Create a storage mdoe form
- [ ] Add short field
- [ ] Open form
- [ ] Hit the submit button
- [ ] Observe that the error appears immediately
