### PR TITLE
fix(mrf): prevent infinite loop on r2

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -162,6 +162,11 @@ export const PublicFormProvider = ({
     setHasSingleSubmissionValidationError(false)
   }, [])
 
+  const [
+    hasPreviousSubmissionDecryptionError,
+    setHasPreviousSubmissionDecryptionError,
+  ] = useState(false)
+
   useEffect(() => {
     if (
       data?.errorCodes?.find(
@@ -240,10 +245,7 @@ export const PublicFormProvider = ({
           )
         } catch (e) {
           console.error(e, 'failed to decrypt attachment', id)
-          toast({
-            status: 'danger',
-            description: 'Failed to decrypt attachment',
-          })
+          setHasPreviousSubmissionDecryptionError(true)
         }
         if (!decryptedContent) return
 
@@ -274,12 +276,7 @@ export const PublicFormProvider = ({
         setPreviousAttachments(previousAttachments)
       }
     }
-  }, [
-    encryptedPreviousSubmission,
-    previousSubmission,
-    submissionSecretKey,
-    toast,
-  ])
+  }, [encryptedPreviousSubmission, previousSubmission, submissionSecretKey])
 
   if (
     previousSubmissionId &&
@@ -394,7 +391,13 @@ export const PublicFormProvider = ({
         description: t('features.publicForm.errors.myinfo'),
       })
     }
-  }, [hasMyInfoError, toast, t])
+    if (hasPreviousSubmissionDecryptionError) {
+      toast({
+        status: 'danger',
+        description: 'Failed to decrypt attachment',
+      })
+    }
+  }, [hasMyInfoError, hasPreviousSubmissionDecryptionError, toast, t])
 
   const showErrorToast = useCallback(
     (error: unknown, form: PublicFormDto) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Infinite loop occurs when:
1. `useToast` returns a function that is always changed when re-rendered
2. `useEffect` has `toast` as a dependency
3. `useEffect` subsequently calls a `setState` which re-render causing 1 to update

```
const FooProvider = () => {
  const toast = useToast({ isClosable: true }) // [1]
  const [space, setSpace] = useState({})

  useEffect(() => {
    const result = doSomething(barDeps)
    if(result.pass) {
      setSpace() // [3]
    } else {
      toast({ description: "show toast" })
    }
  }, [toast, barDeps, setSpace]) // [2]
  
}
```
Closes FRM-1872

## Solution
<!-- How did you solve the problem? -->

Hoisting out the usage of `toast` within the context of this `useEffect`, essentially what this effect should solely perform asynchronous calculation on `barDeps`, and defer the handling of results to another effect that handles it.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
Screen freezes after awhile (main thread entered infinite loop)

https://github.com/user-attachments/assets/f75ba381-5982-4ef4-a4d7-e922deb50231


**AFTER**:
Doesn't enter infinite loops

https://github.com/user-attachments/assets/4ab21944-1dea-4f89-9195-cafc838cb5a9




## Tests
<!-- What tests should be run to confirm functionality? -->
Regression TC 1: User should be able to edit and submit
- [ ] Create an MRF
- [ ] Add a short text field
- [ ] Add Workflow Step 1 with short text under "Select field(s) for this respondent to fill"
- [ ] Add Workflow Step 2 with short text under "Select field(s) for this respondent to fill" and your email under "Respondent > Fixed emails(s)" section
- [ ] Open the MRF
- [ ] As respondent 1
  - [ ] Ensure that "123" can be entered on the short text field
  - [ ] Ensure that form can be submitted
- [ ] As respondent 2
  - [ ] Ensure that "456" can be entered on the short text field
  - [ ] Ensure that form can be submitted
- [ ] Ensure that during the submission flow, there are no signs of freezing

Regression TC 2: User should be able to select a radio field
- [ ] Create an MRF
- [ ] Add a short text field
- [ ] Add a radio field
- [ ] Add Workflow Step 1 with short text under "Select field(s) for this respondent to fill"
- [ ] Add Workflow Step 2 with radio under "Select field(s) for this respondent to fill" and your email under "Respondent > Fixed emails(s)" section
- [ ] Open the MRF
- [ ] As respondent 1
  - [ ] Ensure that "123" can be entered on the short text field
  - [ ] Ensure that form can be submitted
- [ ] As respondent 2
  - [ ] Ensure that the radio button can be clicked and selected
  - [ ] Ensure that form can be submitted
- [ ] Ensure that during the submission flow, there are no signs of freezing
