### PR TITLE
fix(DateRangePicker): react migration date range gap

### DIFF
--- a/frontend/src/components/DateRangePicker/components/DateRangePickerInput.tsx
+++ b/frontend/src/components/DateRangePicker/components/DateRangePickerInput.tsx
@@ -66,8 +66,7 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
           aria-label="Start date of range"
           inputMode="numeric" // Nudge Android mobile keyboard to be numeric
           pattern="\d*" // Nudge numeric keyboard on iOS Safari.
-          sx={styles.field}
-          width="6rem"
+          sx={{ ...styles.field, width: '6rem' }}
           as={ReactInputMask}
           mask="99/99/9999"
           value={startInputDisplay}
@@ -87,8 +86,7 @@ export const DateRangePickerInput = forwardRef<{}, 'input'>((_props, ref) => {
           aria-label="Start date of range"
           inputMode="numeric" // Nudge Android mobile keyboard to be numeric
           pattern="\d*" // Nudge numeric keyboard on iOS Safari.
-          sx={styles.field}
-          width="6rem"
+          sx={{ ...styles.field, width: '6rem' }}
           as={ReactInputMask}
           mask="99/99/9999"
           value={endInputDisplay}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Huge gaps between `Input` fields is present on `DateRangePicker` component.

Closes FRM-1870

## Solution
<!-- How did you solve the problem? -->

Chakra `Input` no longer references width on the input-props level. We'll need to supply styling tweaks on `sx` prop instead.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
| Component | Before | After |
|--------|--------|--------|
| DateRangePicker | <img width="655" alt="Screenshot 2024-10-09 at 4 26 55 PM" src="https://github.com/user-attachments/assets/db4009c3-2026-4958-a2a4-c510b49b6c25"> | <img width="483" alt="Screenshot 2024-10-09 at 4 26 41 PM" src="https://github.com/user-attachments/assets/d6f44c93-33b7-4de2-8442-a6a6cd4acb96"> | 

## Tests
<!-- What tests should be run to confirm functionality? -->
Regression
- [ ] Go to Results Page
- [ ] Observe that DateRangePicker component does not have huge gaps