### PR TITLE
fix(workflow): step 2 email subtitle

### DIFF
--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
@@ -129,6 +129,61 @@ export const Step2Empty = {
   },
 }
 
+export const Step2FixedEmailDefault = {
+  // due to the double registration of 'workflow_type' there would be a weird interaction
+  // where the default value will be reset
+  // thus we have to manually select the field again
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(
+      async () =>
+        expect(await canvas.getByText('Save step')).not.toBeDisabled(),
+      {
+        timeout: 5000,
+      },
+    )
+    await waitFor(
+      async () => {
+        await userEvent.click(await canvas.getByText('Fixed email(s)'))
+      },
+      {
+        timeout: 5000,
+      },
+    )
+  },
+  args: {
+    stepNumber: 1,
+    defaultValues: {
+      workflow_type: WorkflowType.Static,
+      emails: ['me@open.gov.sg', 'invalidemail'],
+    },
+  },
+}
+export const Step2FixedEmailEmpty = {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(
+      async () =>
+        expect(await canvas.getByText('Save step')).not.toBeDisabled(),
+      {
+        timeout: 5000,
+      },
+    )
+    await waitFor(
+      async () => {
+        await userEvent.click(await canvas.getByText('Fixed email(s)'))
+      },
+      {
+        timeout: 5000,
+      },
+    )
+  },
+
+  args: {
+    stepNumber: 1,
+  },
+}
+
 export const DeletedApprovalFieldSelected = {
   args: {
     stepNumber: 1,

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock.tsx
@@ -99,7 +99,7 @@ const StaticRespondentOption = ({
             />
             <FormErrorMessage>{staticTagInputErrorMessage}</FormErrorMessage>
             {!staticTagInputErrorMessage ? (
-              <Text textStyle="body-2" mt="0.5rem">
+              <Text textStyle="body-2" color="secondary.400" mt="0.5rem">
                 Separate multiple emails with a comma
               </Text>
             ) : null}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1874

## Solution
<!-- How did you solve the problem? -->

Set color to `secondary.400`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/40be5d57-6689-439f-9796-32f14ca9bbc9)

**AFTER**:
<!-- [insert screenshot here] -->
<img width="363" alt="Screenshot 2024-10-10 at 9 01 32 PM" src="https://github.com/user-attachments/assets/adaaa641-74ab-4b84-8a1b-5c935f2f566a">