### PR TITLE
chore: add paperless form banner

### DIFF
--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryFn } from '@storybook/react'
 import { times } from 'lodash'
 import { rest } from 'msw'
 
+import { UserId } from '~shared/types'
 import {
   AdminDashboardFormMetaDto,
   FormResponseMode,
@@ -163,8 +164,38 @@ AllOpenDesktop.parameters = {
     ...BASE_MSW_HANDLERS,
   ],
 }
+
+export const AllOpenDesktopNoAnnouncementModal = Template.bind({})
+AllOpenDesktopNoAnnouncementModal.parameters = {
+  ...AllOpenDesktop.parameters,
+  msw: [
+    ...envHandlers,
+    rest.get<AdminDashboardFormMetaDto[]>(
+      '/api/v3/admin/forms',
+      (req, res, ctx) => {
+        return res(ctx.json(THIRTY_FORMS))
+      },
+    ),
+    getWorkspaces(),
+    getUser({
+      delay: 0,
+      mockUser: {
+        ...MOCK_USER,
+        _id: 'undefined' as UserId,
+        email: 'meh@example.com',
+      },
+    }),
+  ],
+}
+
 export const AllOpenMobile = Template.bind({})
 AllOpenMobile.parameters = {
   ...Mobile.parameters,
   ...AllOpenDesktop.parameters,
+}
+
+export const AllOpenMobileNoAnnouncementModal = Template.bind({})
+AllOpenMobileNoAnnouncementModal.parameters = {
+  ...Mobile.parameters,
+  ...AllOpenDesktopNoAnnouncementModal.parameters,
 }

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -158,7 +158,11 @@ export const WorkspacePage = (): JSX.Element => {
             <InlineMessage>
               <Text>
                 Do you still have paper forms in your agency?{' '}
-                <Link href={PAPERLESS_FORMSG_RESEARCH_LINK} target="_blank">
+                <Link
+                  display="inline"
+                  href={PAPERLESS_FORMSG_RESEARCH_LINK}
+                  target="_blank"
+                >
                   Tell us more so that we can help you digitalise them.
                 </Link>
               </Text>

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -10,9 +10,11 @@ import {
   Grid,
   GridItem,
   Stack,
+  Text,
   useDisclosure,
 } from '@chakra-ui/react'
 
+import { PAPERLESS_FORMSG_RESEARCH_LINK } from '~shared/constants'
 import { Workspace } from '~shared/types/workspace'
 
 import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
@@ -20,6 +22,8 @@ import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { getBannerProps } from '~utils/getBannerProps'
 import { Banner } from '~components/Banner'
+import InlineMessage from '~components/InlineMessage'
+import Link from '~components/Link'
 
 import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
@@ -151,6 +155,14 @@ export const WorkspacePage = (): JSX.Element => {
             defaultWorkspace={DEFAULT_WORKSPACE}
             setCurrentWorkspace={setCurrWorkspaceId}
           >
+            <InlineMessage>
+              <Text>
+                Do you still have paper forms in your agency?{' '}
+                <Link href={PAPERLESS_FORMSG_RESEARCH_LINK} target="_blank">
+                  Tell us more so that we can help you digitalise them.
+                </Link>
+              </Text>
+            </InlineMessage>
             <WorkspaceContent />
           </WorkspaceProvider>
         </GridItem>

--- a/shared/constants/links.ts
+++ b/shared/constants/links.ts
@@ -10,3 +10,5 @@ export const SGID_VALID_ORG_PAGE =
 // Growthbook proxy set up on cloudflare workers. For more info, see Worker script: https://github.com/opengovsg/formsg-private/pull/171.
 export const GROWTHBOOK_DEV_PROXY =
   'https://proxy-growthbook-stg.formsg.workers.dev'
+export const PAPERLESS_FORMSG_RESEARCH_LINK =
+  'https://go.gov.sg/paperformsresearch'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We want to drive more input from our admins to help us understand the existence of paper forms. 

## Solution
<!-- How did you solve the problem? -->

Add an admin only infobox on the workspace page. We've chosen not to use a banner as it should only be used for important information.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

See chromatic

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Ensure that the link shows up on admin dashboard
- [ ] Ensure that the link goes to our paperless survey form link