### PR TITLE
feat: no notify for steps after reject step

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -638,7 +638,7 @@ describe('multirespondent-submission.service', () => {
         },
       } as FieldResponsesV3
 
-      const fourStepApprovalWorkflow: FormWorkflowStepDto[] = [
+      const fiveStepApprovalWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
           workflow_type: WorkflowType.Dynamic,
@@ -673,14 +673,14 @@ describe('multirespondent-submission.service', () => {
         },
       ]
 
-      const currentStepNumber = 1 // 2nd step of 3 steps workflow
+      const currentStepNumber = 1 // 2nd step of 5 steps workflow
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
         form: {
           _id: mockFormId,
-          workflow: fourStepApprovalWorkflow,
+          workflow: fiveStepApprovalWorkflow,
           emails: [expectedEmails[1], expectedEmails[2]],
           stepsToNotify: [stepOneId, stepThreeId, stepFourId, stepFiveId],
         } as IPopulatedMultirespondentForm,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -187,9 +187,16 @@ const sendMrfOutcomeEmails = ({
   }
   const emailsToNotify = form.emails ?? []
 
+  const stepIdsBeforeAndIncludingCurrStep = form.workflow.slice(
+    0,
+    currentStepNumber + 1,
+  )
+
   const validWorkflowStepsToNotify = (form.stepsToNotify ?? [])
     .map((stepId) =>
-      form.workflow.find((step) => step._id.toString() === stepId),
+      stepIdsBeforeAndIncludingCurrStep.find(
+        (step) => step._id.toString() === stepId,
+      ),
     )
     .filter(
       (workflowStep) => workflowStep !== undefined,


### PR DESCRIPTION
## Problem
For rejected workflows, steps after the rejection should not be notified when a rejection happens earlier in the chain.  

Closes FRM-1876 

## Solution
Do not notify subsequent steps if earlier step rejects.

**Breaking Changes** 
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: Regression test for approve 
- [ ] Create MRF workflow with 3 steps  
- [ ] Set step 2 and step 3 as approval step 
- [ ] Set steps 2 and 3 as notification step 
- [ ] Approve form completely. 
- [ ] See that steps 2 and 3 email get approve email. 

TC2: No notify for steps after reject step
- [ ] From MRF from TC1 
- [ ] Reject at step 2
- [ ] Ensure only step 2 gets the reject email (Step 3 does not get an email) 

TC3: Regression test for reject 
- [ ] From MRF from TC1 
- [ ] Reject at step 3
- [ ] Ensure both step 2 and 3 gets the reject email 