### PR TITLE
chore: update port number for vite fe in docker compose yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - DB_HOST=mongodb://database:27017/formsg?directConnection=true
       - APP_NAME=FormSG
       - APP_URL=http://localhost:5001
-      - FE_APP_URL=http://localhost:3000
+      - FE_APP_URL=http://localhost:5173
       - ATTACHMENT_S3_BUCKET=local-attachment-bucket
       - PAYMENT_PROOF_S3_BUCKET=local-payment-proof-bucket
       - IMAGE_S3_BUCKET=local-image-bucket
@@ -169,7 +169,7 @@ services:
     environment:
       - SERVICES=s3,sqs,secretsmanager
       - DNS_ADDRESS=0
-      - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:3000
+      - EXTRA_CORS_ALLOWED_ORIGINS=http://localhost:5173
     volumes:
       - ./.localstack/volume:/var/lib/localstack
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Problem
Port number in docker.compose is using the previous localhost:3000, causing maildev links to fail. 

Closes FRM-1877

## Solution
Update to port 5173.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  