### PR TITLE
fix: update the form field type for v3 test cases

### DIFF
--- a/__tests__/unit/backend/helpers/generate-form-data.ts
+++ b/__tests__/unit/backend/helpers/generate-form-data.ts
@@ -17,7 +17,6 @@ import {
   IDateFieldSchema,
   IDecimalFieldSchema,
   IDropdownFieldSchema,
-  IEmailFieldSchema,
   IHomenoFieldSchema,
   IImageFieldSchema,
   IMobileFieldSchema,
@@ -43,6 +42,7 @@ import {
   DropdownFieldBase,
   EmailResponseV3,
   FormField,
+  FormFieldDto,
   GenericStringAnswerFieldResponseV3,
   MobileResponseV3,
   RadioFieldResponsesV3,
@@ -56,6 +56,13 @@ import {
   YesNoFieldResponseV3,
   YesNoResponseV3,
 } from '../../../../shared/types'
+
+export const generateDefaultFieldV3 = (
+  fieldType: BasicField,
+  customParams?: Partial<FormField> & { _id?: string },
+): FormFieldDto => {
+  return generateDefaultField(fieldType, customParams) as FormFieldDto
+}
 
 export const generateDefaultField = (
   fieldType: BasicField,

--- a/src/app/utils/field-validation/validators/__tests__/attachment-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/attachment-validation.spec.ts
@@ -1,6 +1,7 @@
 import {
   generateAttachmentResponseV3,
   generateDefaultField,
+  generateDefaultFieldV3,
   generateNewAttachmentResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
 import { mongo as mongodb } from 'mongoose'
@@ -8,7 +9,11 @@ import { mongo as mongodb } from 'mongoose'
 import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
 import { validateField, validateFieldV3 } from 'src/app/utils/field-validation/'
 
-import { AttachmentSize, BasicField } from '../../../../../../shared/types'
+import {
+  AttachmentSize,
+  BasicField,
+  FormFieldDto,
+} from '../../../../../../shared/types'
 
 const { ObjectId } = mongodb
 
@@ -219,9 +224,9 @@ describe('Attachment validation V3', () => {
 
   describe('Required or optional', () => {
     it('should disallow submission with no attachment if it is required', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
-      })
+      }) as FormFieldDto
       const response = generateAttachmentResponseV3({
         content: undefined as unknown as Buffer,
         answer: 'Attachment answer',
@@ -241,7 +246,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should allow submission with attachment if it is required', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
       })
       const response = generateAttachmentResponseV3({
@@ -261,7 +266,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should allow submission with attachment if it is not required', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
         required: false,
       })
@@ -282,7 +287,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should allow submission with no attachment if it is not required', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
         required: false,
       })
@@ -303,7 +308,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should disallow submission with no answer if it is required', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
         required: true,
       })
@@ -326,7 +331,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should allow submission with no answer if it is not required', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
         required: false,
       })
@@ -347,7 +352,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should disallow when it is not required but with answer and no attachment', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
         required: false,
       })
@@ -372,7 +377,7 @@ describe('Attachment validation V3', () => {
 
   describe('Validation of attachment size', () => {
     it('should allow attachment with valid size', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
       })
       const response = generateAttachmentResponseV3({
@@ -392,7 +397,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should disallow attachment that exceeds size', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
       })
       const response = generateAttachmentResponseV3({
@@ -414,7 +419,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should respect the attachmentSize from formField', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.ThreeMb,
       })
       const response = generateAttachmentResponseV3({
@@ -436,7 +441,7 @@ describe('Attachment validation V3', () => {
 
   describe('check for responses on hidden fields', () => {
     it('should disallow responses submitted for hidden fields when response contains file content', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.ThreeMb,
       })
       const response = generateAttachmentResponseV3({
@@ -460,7 +465,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should disallow responses submitted for hidden fields when response contains answer', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.ThreeMb,
       })
       const response = generateAttachmentResponseV3({
@@ -484,7 +489,7 @@ describe('Attachment validation V3', () => {
     })
 
     it('should disallow responses submitted for hidden fields when response contains filename', () => {
-      const formField = generateDefaultField(BasicField.Attachment, {
+      const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.ThreeMb,
       })
       const response = generateAttachmentResponseV3({

--- a/src/app/utils/field-validation/validators/__tests__/attachment-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/attachment-validation.spec.ts
@@ -9,11 +9,7 @@ import { mongo as mongodb } from 'mongoose'
 import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
 import { validateField, validateFieldV3 } from 'src/app/utils/field-validation/'
 
-import {
-  AttachmentSize,
-  BasicField,
-  FormFieldDto,
-} from '../../../../../../shared/types'
+import { AttachmentSize, BasicField } from '../../../../../../shared/types'
 
 const { ObjectId } = mongodb
 

--- a/src/app/utils/field-validation/validators/__tests__/attachment-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/attachment-validation.spec.ts
@@ -226,7 +226,7 @@ describe('Attachment validation V3', () => {
     it('should disallow submission with no attachment if it is required', () => {
       const formField = generateDefaultFieldV3(BasicField.Attachment, {
         attachmentSize: AttachmentSize.OneMb,
-      }) as FormFieldDto
+      })
       const response = generateAttachmentResponseV3({
         content: undefined as unknown as Buffer,
         answer: 'Attachment answer',

--- a/src/app/utils/field-validation/validators/__tests__/checkbox-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/checkbox-validation.spec.ts
@@ -1,6 +1,7 @@
 import {
   generateCheckboxResponseV3,
   generateDefaultField,
+  generateDefaultFieldV3,
   generateNewCheckboxResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
 import { mongo as mongodb } from 'mongoose'
@@ -318,7 +319,7 @@ describe('Checkbox validation V3', () => {
   describe('Required or optional', () => {
     it('should disallow empty submission if checkbox is required', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
       })
       const response = generateCheckboxResponseV3({ value: [] })
@@ -336,7 +337,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow empty submission if checkbox is optional', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         required: false,
       })
@@ -355,7 +356,7 @@ describe('Checkbox validation V3', () => {
   describe('Validation of field options', () => {
     it('should disallow responses submitted for hidden fields', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         required: true,
       })
@@ -378,7 +379,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow a valid option to be selected', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
       })
       const response = generateCheckboxResponseV3({ value: ['a'] })
@@ -394,7 +395,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow multiple valid options to be selected', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
       })
       const response = generateCheckboxResponseV3({ value: ['a', 'b'] })
@@ -410,7 +411,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow answers not in fieldOptions', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
       })
       const response = generateCheckboxResponseV3({
@@ -430,7 +431,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow duplicate answers', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
       })
       const response = generateCheckboxResponseV3({
@@ -450,7 +451,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow self-configured others options in field options', () => {
       const fieldOptions = ['a', 'b', 'c', 'Others: <please specify>']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
       })
       const response = generateCheckboxResponseV3({
@@ -468,7 +469,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow Others option to be submitted if field is configured for Others', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: true,
       })
@@ -488,7 +489,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow Others option to be submitted if field is configured for Others but othersInput is undefined', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: true,
       })
@@ -509,7 +510,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow Others option to be submitted if field is not configured for Others', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: false,
       })
@@ -531,7 +532,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow Others option to be submitted with admin defined Others: if field is configured for Others', () => {
       const fieldOptions = ['a', 'b', 'c', 'Others: xyz']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: true,
       })
@@ -551,7 +552,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow Others option to be submitted with empty string answer if field is configured for Others', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: true,
       })
@@ -573,7 +574,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow Others option to be submitted with whitespace answer if field is configured for Others', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: true,
       })
@@ -595,7 +596,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow multiple CLIENT_CHECKBOX_OTHERS_INPUT_VALUE to be submitted if field is configured for Others', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: true,
       })
@@ -621,7 +622,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow admin defined Others: and othersInput option which causes string collision to be submitted if field is configured for Others', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: true,
       })
@@ -643,7 +644,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow submission without Others option even if field is configured for Others', () => {
       const fieldOptions = ['a', 'b', 'c']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         othersRadioButton: true,
       })
@@ -664,7 +665,7 @@ describe('Checkbox validation V3', () => {
   describe('Selection limits', () => {
     it('should disallow more answers than customMax if selection limits are configured', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: true,
         ValidationOptions: { customMax: 2, customMin: null },
@@ -686,7 +687,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow more answers than customMax if selection limits are configured including others', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: true,
         othersRadioButton: true,
@@ -710,7 +711,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow less than or equal answers than customMax if selection limits are configured including others', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: true,
         othersRadioButton: true,
@@ -732,7 +733,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow fewer answers than customMin if selection limits are configured', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: true,
         ValidationOptions: { customMax: null, customMin: 2 },
@@ -754,7 +755,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow more or equal answers than customMin if selection limits are configured', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: true,
         ValidationOptions: { customMax: null, customMin: 2 },
@@ -774,7 +775,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow more or equal answers than customMin if selection limits are configured including others', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: true,
         othersRadioButton: true,
@@ -796,7 +797,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow more answers than customMax if selection limits are not configured', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: false,
         ValidationOptions: { customMax: 2, customMin: null },
@@ -816,7 +817,7 @@ describe('Checkbox validation V3', () => {
 
     it('should allow fewer answers than customMin if selection limits are not configured', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: false,
         ValidationOptions: { customMax: null, customMin: 2 },
@@ -836,7 +837,7 @@ describe('Checkbox validation V3', () => {
 
     it('should disallow more answers than customMax, and fewer answers than customMin, if selection limits are configured', () => {
       const fieldOptions = ['a', 'b', 'c', 'd', 'e']
-      const formField = generateDefaultField(BasicField.Checkbox, {
+      const formField = generateDefaultFieldV3(BasicField.Checkbox, {
         fieldOptions,
         validateByValue: true,
         ValidationOptions: { customMax: 4, customMin: 2 },

--- a/src/app/utils/field-validation/validators/__tests__/country-region-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/country-region-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -117,7 +118,7 @@ describe('Country/region validation', () => {
 
 describe('Country/region validation V3', () => {
   it('should allow valid option', () => {
-    const formField = generateDefaultField(BasicField.CountryRegion, {})
+    const formField = generateDefaultFieldV3(BasicField.CountryRegion, {})
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.CountryRegion,
       answer: simulateTransformationsHandleSubmitForm(CountryRegion.Singapore),
@@ -133,7 +134,7 @@ describe('Country/region validation V3', () => {
   })
 
   it('should disallow invalid option', () => {
-    const formField = generateDefaultField(BasicField.CountryRegion, {})
+    const formField = generateDefaultFieldV3(BasicField.CountryRegion, {})
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.CountryRegion,
       answer: 'NOT A COUNTRY/REGION',
@@ -151,7 +152,7 @@ describe('Country/region validation V3', () => {
   })
 
   it('should disallow empty answer when required', () => {
-    const formField = generateDefaultField(BasicField.CountryRegion, {
+    const formField = generateDefaultFieldV3(BasicField.CountryRegion, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -171,7 +172,7 @@ describe('Country/region validation V3', () => {
   })
 
   it('should allow empty answer when not required', () => {
-    const formField = generateDefaultField(BasicField.CountryRegion, {
+    const formField = generateDefaultFieldV3(BasicField.CountryRegion, {
       required: false,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -189,7 +190,7 @@ describe('Country/region validation V3', () => {
   })
 
   it('should allow empty answer when it is required but not visible', () => {
-    const formField = generateDefaultField(BasicField.CountryRegion, {
+    const formField = generateDefaultFieldV3(BasicField.CountryRegion, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -207,7 +208,7 @@ describe('Country/region validation V3', () => {
   })
 
   it('should disallow empty answer when it is required and visible', () => {
-    const formField = generateDefaultField(BasicField.CountryRegion, {
+    const formField = generateDefaultFieldV3(BasicField.CountryRegion, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -227,7 +228,7 @@ describe('Country/region validation V3', () => {
   })
 
   it('should disallow multiple answers', () => {
-    const formField = generateDefaultField(BasicField.CountryRegion, {})
+    const formField = generateDefaultFieldV3(BasicField.CountryRegion, {})
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.CountryRegion,
       answer: [
@@ -248,7 +249,7 @@ describe('Country/region validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.CountryRegion, {
+    const formField = generateDefaultFieldV3(BasicField.CountryRegion, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({

--- a/src/app/utils/field-validation/validators/__tests__/date-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/date-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -416,7 +417,7 @@ describe('Date field validation V3', () => {
     jest.clearAllMocks()
   })
   it('should allow valid date <DD/MM/YYYY>', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '09/01/2019',
@@ -433,7 +434,9 @@ describe('Date field validation V3', () => {
   })
 
   it('should allow empty string when not required', () => {
-    const formField = generateDefaultField(BasicField.Date, { required: false })
+    const formField = generateDefaultFieldV3(BasicField.Date, {
+      required: false,
+    })
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '',
@@ -450,7 +453,9 @@ describe('Date field validation V3', () => {
   })
 
   it('should allow valid leap year date', () => {
-    const formField = generateDefaultField(BasicField.Date, { required: false })
+    const formField = generateDefaultFieldV3(BasicField.Date, {
+      required: false,
+    })
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '29/02/2016',
@@ -467,7 +472,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow 00 date', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '00/01/2019',
@@ -486,7 +491,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow date less than 2 char', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '9/01/2019',
@@ -505,7 +510,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow date more than 2 char', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '009/01/2019',
@@ -524,7 +529,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow date not in month', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '39/01/2019',
@@ -543,7 +548,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow invalid month', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '09/13/2019',
@@ -562,7 +567,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow month less then 2 chars', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '09/1/2019',
@@ -581,7 +586,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow month more then 2 chars', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '09/001/2019',
@@ -600,7 +605,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow text year', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '09/01/beans',
@@ -619,7 +624,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow year less than 4 chars', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '09/01/19',
@@ -638,7 +643,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow year more than 4 chars', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '09/01/02019',
@@ -657,7 +662,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow empty string when required', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -678,7 +683,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow invalid leap year date', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '29/02/2019',
@@ -697,7 +702,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should allow past dates for normal date fields', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '01/01/2017',
@@ -714,7 +719,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should allow past dates if disallow past dates is not set', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '01/01/2017',
@@ -731,7 +736,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow past dates if disallow past dates is set', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: DateSelectedValidation.NoPast,
         customMaxDate: null,
@@ -756,7 +761,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should allow future dates if disallow future dates is not set', () => {
-    const formField = generateDefaultField(BasicField.Date)
+    const formField = generateDefaultFieldV3(BasicField.Date)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Date,
       answer: '01/01/2022',
@@ -773,7 +778,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow future dates if disallow future dates is set', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: DateSelectedValidation.NoFuture,
         customMaxDate: null,
@@ -798,7 +803,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should allow dates inside of Custom Date Range if set', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: DateSelectedValidation.Custom,
         customMinDate: new Date('2020-06-25'),
@@ -821,7 +826,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow dates earlier than Custom Date Range if set', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: DateSelectedValidation.Custom,
         customMinDate: new Date('2020-06-25'),
@@ -846,7 +851,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow dates later than of Custom Date Range if set', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: DateSelectedValidation.Custom,
         customMinDate: new Date('2020-06-25'),
@@ -871,7 +876,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: DateSelectedValidation.Custom,
         customMinDate: new Date('2020-06-25'),
@@ -896,7 +901,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should allow dates if invalid day array is empty', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: null,
         customMinDate: null,
@@ -920,7 +925,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should allow dates that is not an invalid day', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: null,
         customMinDate: null,
@@ -951,7 +956,7 @@ describe('Date field validation V3', () => {
   })
 
   it('should disallow dates that is an invalid day', () => {
-    const formField = generateDefaultField(BasicField.Date, {
+    const formField = generateDefaultFieldV3(BasicField.Date, {
       dateValidation: {
         selectedDateValidation: null,
         customMinDate: null,

--- a/src/app/utils/field-validation/validators/__tests__/decimal-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/decimal-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -280,7 +281,7 @@ describe('Decimal Validation', () => {
 
 describe('Decimal Validation V3', () => {
   it('should allow decimal with valid maximum', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: null,
         customMax: 5,
@@ -302,7 +303,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should allow decimal with valid maximum (inclusive)', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: null,
         customMax: 5,
@@ -324,7 +325,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow decimal with invalid maximum', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: null,
         customMax: 5,
@@ -347,7 +348,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should allow decimal with valid minimum', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: 2,
         customMax: null,
@@ -368,7 +369,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should allow decimal with valid minimum (inclusive)', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: 2,
         customMax: null,
@@ -389,7 +390,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow decimal with invalid minimum', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: 2,
         customMax: null,
@@ -412,7 +413,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should allow decimal with no custom validation', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: null,
         customMax: null,
@@ -433,7 +434,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should allow empty answer with optional field', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       required: false,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -451,7 +452,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should allow answer to be zero', () => {
-    const formField = generateDefaultField(BasicField.Decimal)
+    const formField = generateDefaultFieldV3(BasicField.Decimal)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Decimal,
       answer: '0',
@@ -467,7 +468,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should allow negative answers', () => {
-    const formField = generateDefaultField(BasicField.Decimal)
+    const formField = generateDefaultFieldV3(BasicField.Decimal)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Decimal,
       answer: '-5.0',
@@ -483,7 +484,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow leading zeroes', () => {
-    const formField = generateDefaultField(BasicField.Decimal)
+    const formField = generateDefaultFieldV3(BasicField.Decimal)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Decimal,
       answer: '001.3',
@@ -502,7 +503,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow decimal points with no leading numbers', () => {
-    const formField = generateDefaultField(BasicField.Decimal)
+    const formField = generateDefaultFieldV3(BasicField.Decimal)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Decimal,
       answer: '.3',
@@ -521,7 +522,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow negative answers with no leading number', () => {
-    const formField = generateDefaultField(BasicField.Decimal)
+    const formField = generateDefaultFieldV3(BasicField.Decimal)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Decimal,
       answer: '-.3',
@@ -540,7 +541,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow floats (<16 decimal places) that are out of range (min)', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: 2,
         customMax: null,
@@ -564,7 +565,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow floats (<16 decimal places) that are out of range (max)', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: null,
         customMax: 2,
@@ -588,7 +589,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow floats less than 0 when customMin is 0', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: 0,
         customMax: null,
@@ -611,7 +612,7 @@ describe('Decimal Validation V3', () => {
     )
   })
   it('should disallow floats more than 0 when customMax is 0', () => {
-    const formField = generateDefaultField(BasicField.Decimal, {
+    const formField = generateDefaultFieldV3(BasicField.Decimal, {
       ValidationOptions: {
         customMin: null,
         customMax: 0,
@@ -635,7 +636,7 @@ describe('Decimal Validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Decimal)
+    const formField = generateDefaultFieldV3(BasicField.Decimal)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Decimal,
       answer: '3',

--- a/src/app/utils/field-validation/validators/__tests__/dropdown-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/dropdown-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -122,7 +123,7 @@ describe('Dropdown validation', () => {
 
 describe('Dropdown validation V3', () => {
   it('should allow valid option', () => {
-    const formField = generateDefaultField(BasicField.Dropdown, {
+    const formField = generateDefaultFieldV3(BasicField.Dropdown, {
       fieldOptions: ['KISS', 'DRY', 'YAGNI'],
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -141,7 +142,7 @@ describe('Dropdown validation V3', () => {
   })
 
   it('should disallow invalid option', () => {
-    const formField = generateDefaultField(BasicField.Dropdown, {
+    const formField = generateDefaultFieldV3(BasicField.Dropdown, {
       fieldOptions: ['KISS', 'DRY', 'YAGNI'],
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -162,7 +163,7 @@ describe('Dropdown validation V3', () => {
   })
 
   it('should disallow empty answer when required', () => {
-    const formField = generateDefaultField(BasicField.Dropdown, {
+    const formField = generateDefaultFieldV3(BasicField.Dropdown, {
       fieldOptions: ['KISS', 'DRY', 'YAGNI'],
       required: true,
     })
@@ -184,7 +185,7 @@ describe('Dropdown validation V3', () => {
   })
 
   it('should allow empty answer when not required', () => {
-    const formField = generateDefaultField(BasicField.Dropdown, {
+    const formField = generateDefaultFieldV3(BasicField.Dropdown, {
       fieldOptions: ['KISS', 'DRY', 'YAGNI'],
       required: false,
     })
@@ -204,7 +205,7 @@ describe('Dropdown validation V3', () => {
   })
 
   it('should allow empty answer when it is required but not visible', () => {
-    const formField = generateDefaultField(BasicField.Dropdown, {
+    const formField = generateDefaultFieldV3(BasicField.Dropdown, {
       fieldOptions: ['KISS', 'DRY', 'YAGNI'],
       required: true,
     })
@@ -224,7 +225,7 @@ describe('Dropdown validation V3', () => {
   })
 
   it('should disallow empty answer when it is required and visible', () => {
-    const formField = generateDefaultField(BasicField.Dropdown, {
+    const formField = generateDefaultFieldV3(BasicField.Dropdown, {
       fieldOptions: ['KISS', 'DRY', 'YAGNI'],
       required: true,
     })
@@ -246,7 +247,7 @@ describe('Dropdown validation V3', () => {
   })
 
   it('should disallow multiple answers', () => {
-    const formField = generateDefaultField(BasicField.Dropdown, {
+    const formField = generateDefaultFieldV3(BasicField.Dropdown, {
       fieldOptions: ['KISS', 'DRY', 'YAGNI'],
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -267,7 +268,7 @@ describe('Dropdown validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Dropdown, {
+    const formField = generateDefaultFieldV3(BasicField.Dropdown, {
       fieldOptions: ['KISS', 'DRY', 'YAGNI'],
       required: true,
     })

--- a/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
@@ -1,5 +1,5 @@
 import {
-  generateDefaultField,
+  generateDefaultFieldV3,
   generateVerifiableAnswerResponseV3,
 } from '__tests__/unit/backend/helpers/generate-form-data'
 
@@ -257,6 +257,7 @@ describe('Email field validation', () => {
         hasAutoReply: true,
         includeFormSummary: true,
       },
+      disabled: false,
     } as OmitUnusedValidatorProps<IEmailFieldSchema>
 
     const response = {
@@ -405,6 +406,7 @@ describe('Email field validation', () => {
         hasAutoReply: true,
         includeFormSummary: true,
       },
+      disabled: false,
     } as OmitUnusedValidatorProps<IEmailFieldSchema>
     const response = {
       _id: 'abc123',
@@ -578,7 +580,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow valid emails', () => {
-    const formField = generateDefaultField(BasicField.Email)
+    const formField = generateDefaultFieldV3(BasicField.Email)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Email,
       answer: {
@@ -596,7 +598,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow emails with 163.com domain', () => {
-    const formField = generateDefaultField(BasicField.Email)
+    const formField = generateDefaultFieldV3(BasicField.Email)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Email,
       answer: {
@@ -614,7 +616,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow emails with 126.com domain', () => {
-    const formField = generateDefaultField(BasicField.Email)
+    const formField = generateDefaultFieldV3(BasicField.Email)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Email,
       answer: {
@@ -632,7 +634,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should disallow invalid emails', () => {
-    const formField = generateDefaultField(BasicField.Email)
+    const formField = generateDefaultFieldV3(BasicField.Email)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Email,
       answer: {
@@ -652,7 +654,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow empty answer for required logic field that is not required', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       required: false,
     })
     const response = generateVerifiableAnswerResponseV3({
@@ -672,7 +674,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow non empty valid answer for required logic field that is not required', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       required: false,
     })
     const response = generateVerifiableAnswerResponseV3({
@@ -692,7 +694,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow empty answer for required logic field that is not visible', () => {
-    const formField = generateDefaultField(BasicField.Email)
+    const formField = generateDefaultFieldV3(BasicField.Email)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Email,
       answer: {
@@ -710,7 +712,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow email addresses whose email domain belongs to allowedEmailDomains when isVerifiable is true, hasAllowedEmailDomains is true and allowedEmailDomains is not empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: true,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@test.gov.sg'],
@@ -733,7 +735,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow email addresses supplied with a mixed-case domain', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: true,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@test.gov.sg'], // note: domains are always read lowercased from store
@@ -756,7 +758,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should not allow email addresses whose email domain does not belong to allowedEmailDomains when isVerifiable is true, hasAllowedEmailDomains is true and allowedEmailDomains is not empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: true,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@example.com'],
@@ -781,7 +783,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow any valid email address when isVerifiable is true, hasAllowedEmailDomains is true but allowedEmailDomains is empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: true,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: [],
@@ -811,7 +813,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow any valid email address not in allowedEmailDomains when isVerifiable is true and hasAllowedEmailDomains is false, regardless of the cardinality of allowedEmailDomains', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: true,
       hasAllowedEmailDomains: false,
       allowedEmailDomains: ['@example.com'],
@@ -834,7 +836,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow any email address with a domain in allowedEmailDomains when isVerifiable is true and hasAllowedEmailDomains is false, and allowedEmailDomains is not empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: true,
       hasAllowedEmailDomains: false,
       allowedEmailDomains: ['@example.com', '@test.gov.sg'],
@@ -857,7 +859,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should not allow email address which are not in allowedEmailDomains when isVerifiable is false and hasAllowedEmailDomains is true, if allowedEmailDomains is not empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: false,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@example.com'],
@@ -881,7 +883,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow email address which are in allowedEmailDomains when isVerifiable is false and hasAllowedEmailDomains is true, if allowedEmailDomains is not empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: false,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@example.com', '@test.gov.sg'],
@@ -903,7 +905,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow any valid email address when isVerifiable is false and hasAllowedEmailDomains is true if allowedEmailDomains is empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: false,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: [],
@@ -932,7 +934,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow any valid email address not in allowedEmailDomains when isVerifiable is false and hasAllowedEmailDomains is false and allowedEmailDomains is not empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: false,
       hasAllowedEmailDomains: false,
       allowedEmailDomains: ['@example.com'],
@@ -954,7 +956,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should allow any valid email address in allowedEmailDomains when isVerifiable is false and hasAllowedEmailDomains is false and allowedEmailDomains is not empty', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: false,
       hasAllowedEmailDomains: false,
       allowedEmailDomains: ['@example.com', '@test.gov.sg'],
@@ -976,7 +978,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: false,
       hasAllowedEmailDomains: true,
       allowedEmailDomains: ['@example.com'],
@@ -1000,7 +1002,7 @@ describe('Email field validation V3', () => {
   })
 
   it('should reject email addresses if isVerifiable is true but there is no signature present', () => {
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: true,
     })
     const response = generateVerifiableAnswerResponseV3({
@@ -1029,7 +1031,7 @@ describe('Email field validation V3', () => {
       )
       .mockImplementation(() => false)
 
-    const formField = generateDefaultField(BasicField.Email, {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
       isVerifiable: true,
     })
     const response = generateVerifiableAnswerResponseV3({

--- a/src/app/utils/field-validation/validators/__tests__/home-num-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/home-num-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -143,7 +144,7 @@ describe('Home phone number validation tests', () => {
 
 describe('Home phone number validation tests V3', () => {
   it('should allow empty answer for required field that is not visible', () => {
-    const formField = generateDefaultField(BasicField.HomeNo)
+    const formField = generateDefaultFieldV3(BasicField.HomeNo)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.HomeNo,
       answer: '',
@@ -160,7 +161,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should allow empty answer for not required field', () => {
-    const formField = generateDefaultField(BasicField.HomeNo, {
+    const formField = generateDefaultFieldV3(BasicField.HomeNo, {
       required: false,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -179,7 +180,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should not allow empty answer for required field', () => {
-    const formField = generateDefaultField(BasicField.HomeNo, {
+    const formField = generateDefaultFieldV3(BasicField.HomeNo, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -199,7 +200,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should allow valid home numbers for homeno fieldType', () => {
-    const formField = generateDefaultField(BasicField.HomeNo)
+    const formField = generateDefaultFieldV3(BasicField.HomeNo)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.HomeNo,
       answer: '+6563334444',
@@ -215,7 +216,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should allow valid sg home numbers starting with 666 for homeno fieldType', () => {
-    const formField = generateDefaultField(BasicField.HomeNo)
+    const formField = generateDefaultFieldV3(BasicField.HomeNo)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.HomeNo,
       answer: '+6566634424',
@@ -231,7 +232,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should allow valid sg home numbers starting with 3 for homeno fieldType', () => {
-    const formField = generateDefaultField(BasicField.HomeNo)
+    const formField = generateDefaultFieldV3(BasicField.HomeNo)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.HomeNo,
       answer: '+6536634424',
@@ -247,7 +248,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should disallow home numbers without "+" prefix', () => {
-    const formField = generateDefaultField(BasicField.HomeNo)
+    const formField = generateDefaultFieldV3(BasicField.HomeNo)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.HomeNo,
       answer: '6563334444',
@@ -265,7 +266,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should disallow mobile numbers on homeno fieldType', () => {
-    const formField = generateDefaultField(BasicField.HomeNo)
+    const formField = generateDefaultFieldV3(BasicField.HomeNo)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.HomeNo,
       answer: '+6598765432',
@@ -283,7 +284,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should disallow international numbers when field does not allow for it', () => {
-    const formField = generateDefaultField(BasicField.HomeNo, {
+    const formField = generateDefaultFieldV3(BasicField.HomeNo, {
       allowIntlNumbers: false,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -304,7 +305,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should allow international numbers when field allows for it', () => {
-    const formField = generateDefaultField(BasicField.HomeNo, {
+    const formField = generateDefaultFieldV3(BasicField.HomeNo, {
       allowIntlNumbers: true,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -323,7 +324,7 @@ describe('Home phone number validation tests V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.HomeNo, {
+    const formField = generateDefaultFieldV3(BasicField.HomeNo, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({

--- a/src/app/utils/field-validation/validators/__tests__/mobile-num-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/mobile-num-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateNewSingleAnswerResponse,
   generateVerifiableAnswerResponseV3,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -206,7 +207,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should allow empty answer for required logic field that is not visible', () => {
-    const formField = generateDefaultField(BasicField.Mobile)
+    const formField = generateDefaultFieldV3(BasicField.Mobile)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Mobile,
       answer: {
@@ -225,7 +226,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should allow empty answer for not required field', () => {
-    const formField = generateDefaultField(BasicField.Mobile, {
+    const formField = generateDefaultFieldV3(BasicField.Mobile, {
       required: false,
     })
     const response = generateVerifiableAnswerResponseV3({
@@ -246,7 +247,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should not allow empty answer for required field', () => {
-    const formField = generateDefaultField(BasicField.Mobile)
+    const formField = generateDefaultFieldV3(BasicField.Mobile)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Mobile,
       answer: {
@@ -267,7 +268,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should allow valid mobile numbers for mobile fieldType', () => {
-    const formField = generateDefaultField(BasicField.Mobile)
+    const formField = generateDefaultFieldV3(BasicField.Mobile)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Mobile,
       answer: {
@@ -286,7 +287,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should disallow mobile numbers without "+" prefix', () => {
-    const formField = generateDefaultField(BasicField.Mobile)
+    const formField = generateDefaultFieldV3(BasicField.Mobile)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Mobile,
       answer: {
@@ -307,7 +308,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should disallow home numbers on mobile fieldType', () => {
-    const formField = generateDefaultField(BasicField.Mobile)
+    const formField = generateDefaultFieldV3(BasicField.Mobile)
     const response = generateVerifiableAnswerResponseV3({
       fieldType: BasicField.Mobile,
       answer: {
@@ -328,7 +329,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should disallow international numbers when field does not allow for it', () => {
-    const formField = generateDefaultField(BasicField.Mobile, {
+    const formField = generateDefaultFieldV3(BasicField.Mobile, {
       allowIntlNumbers: false,
     })
     const response = generateVerifiableAnswerResponseV3({
@@ -351,7 +352,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should allow international numbers when field allows for it', () => {
-    const formField = generateDefaultField(BasicField.Mobile, {
+    const formField = generateDefaultFieldV3(BasicField.Mobile, {
       allowIntlNumbers: true,
     })
     const response = generateVerifiableAnswerResponseV3({
@@ -372,7 +373,7 @@ describe('Mobile number validation tests V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Mobile, {
+    const formField = generateDefaultFieldV3(BasicField.Mobile, {
       allowIntlNumbers: true,
     })
     const response = generateVerifiableAnswerResponseV3({
@@ -396,7 +397,7 @@ describe('Mobile number validation tests V3', () => {
 
   describe('signature validation', () => {
     it('should allow mobile numbers if isVerifiable is true and signature is present and valid', () => {
-      const formField = generateDefaultField(BasicField.Mobile, {
+      const formField = generateDefaultFieldV3(BasicField.Mobile, {
         isVerifiable: true,
       })
       const response = generateVerifiableAnswerResponseV3({
@@ -418,7 +419,7 @@ describe('Mobile number validation tests V3', () => {
     })
 
     it('should reject mobile numbers if isVerifiable is true but there is no signature present', () => {
-      const formField = generateDefaultField(BasicField.Mobile, {
+      const formField = generateDefaultFieldV3(BasicField.Mobile, {
         isVerifiable: true,
       })
       const response = generateVerifiableAnswerResponseV3({
@@ -449,7 +450,7 @@ describe('Mobile number validation tests V3', () => {
         )
         .mockImplementation(() => false)
 
-      const formField = generateDefaultField(BasicField.Mobile, {
+      const formField = generateDefaultFieldV3(BasicField.Mobile, {
         isVerifiable: true,
       })
       const response = generateVerifiableAnswerResponseV3({

--- a/src/app/utils/field-validation/validators/__tests__/nric-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/nric-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -144,7 +145,7 @@ describe('NRIC field validation', () => {
 
 describe('NRIC field validation V3', () => {
   it('should allow valid NRIC with S prefix', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'S9912345A',
@@ -161,7 +162,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should allow valid NRIC with T prefix', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'T1394524H',
@@ -178,7 +179,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should allow valid NRIC with F prefix', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'F0477844T',
@@ -195,7 +196,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should allow valid NRIC with G prefix', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'G9592927W',
@@ -212,7 +213,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should disallow invalid NRIC with S prefix', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'S9912345B',
@@ -232,7 +233,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should disallow invalid NRIC with T prefix', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'T1394524I',
@@ -252,7 +253,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should disallow invalid NRIC with F prefix', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'F0477844U',
@@ -271,7 +272,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should disallow invalid NRIC with G prefix', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'G9592927X',
@@ -290,7 +291,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should allow empty string for not required NRIC', () => {
-    const formField = generateDefaultField(BasicField.Nric, {
+    const formField = generateDefaultFieldV3(BasicField.Nric, {
       required: false,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -308,7 +309,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should disallow empty string for required NRIC', () => {
-    const formField = generateDefaultField(BasicField.Nric, {
+    const formField = generateDefaultFieldV3(BasicField.Nric, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -328,7 +329,7 @@ describe('NRIC field validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Nric)
+    const formField = generateDefaultFieldV3(BasicField.Nric)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Nric,
       answer: 'S9912345A',

--- a/src/app/utils/field-validation/validators/__tests__/number-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/number-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -314,7 +315,7 @@ describe('Range field validation', () => {
 
 describe('Base number field validation V3', () => {
   it('should allow number with no custom validation', () => {
-    const formField = generateDefaultField(BasicField.Number)
+    const formField = generateDefaultFieldV3(BasicField.Number)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Number,
       answer: '55',
@@ -330,7 +331,7 @@ describe('Base number field validation V3', () => {
   })
 
   it('should allow number with optional answer', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       required: false,
     })
 
@@ -350,7 +351,7 @@ describe('Base number field validation V3', () => {
   })
 
   it('should allow empty answer when not required', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       required: false,
     })
 
@@ -370,7 +371,7 @@ describe('Base number field validation V3', () => {
   })
 
   it('should allow answer to be zero', () => {
-    const formField = generateDefaultField(BasicField.Number)
+    const formField = generateDefaultFieldV3(BasicField.Number)
 
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Number,
@@ -388,7 +389,7 @@ describe('Base number field validation V3', () => {
   })
 
   it('should disallow negative answers', () => {
-    const formField = generateDefaultField(BasicField.Number)
+    const formField = generateDefaultFieldV3(BasicField.Number)
 
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Number,
@@ -408,7 +409,7 @@ describe('Base number field validation V3', () => {
   })
 
   it('should allow leading zeroes in answer', () => {
-    const formField = generateDefaultField(BasicField.Number)
+    const formField = generateDefaultFieldV3(BasicField.Number)
 
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Number,
@@ -426,7 +427,7 @@ describe('Base number field validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Number)
+    const formField = generateDefaultFieldV3(BasicField.Number)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Number,
       answer: '2',
@@ -447,7 +448,7 @@ describe('Base number field validation V3', () => {
 
 describe('Number field validation V3', () => {
   it('should allow number with valid maximum length', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Length,
         LengthValidationOptions: {
@@ -472,7 +473,7 @@ describe('Number field validation V3', () => {
   })
 
   it('should allow number with valid maximum length (inclusive)', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Length,
         LengthValidationOptions: {
@@ -496,7 +497,7 @@ describe('Number field validation V3', () => {
   })
 
   it('should disallow number with invalid maximum length', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Length,
         LengthValidationOptions: {
@@ -522,7 +523,7 @@ describe('Number field validation V3', () => {
   })
 
   it('should allow number with valid minimum length', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Length,
         LengthValidationOptions: {
@@ -546,7 +547,7 @@ describe('Number field validation V3', () => {
   })
 
   it('should allow number with valid minimum length (inclusive)', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Length,
         LengthValidationOptions: {
@@ -570,7 +571,7 @@ describe('Number field validation V3', () => {
   })
 
   it('should allow number with valid exact length', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Length,
         LengthValidationOptions: {
@@ -594,7 +595,7 @@ describe('Number field validation V3', () => {
   })
 
   it('should disallow number with invalid exact length', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Length,
         LengthValidationOptions: {
@@ -622,7 +623,7 @@ describe('Number field validation V3', () => {
 
 describe('Range field validation V3', () => {
   it('should allow number with that is within range (both min and max)', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Range,
         RangeValidationOptions: {
@@ -646,7 +647,7 @@ describe('Range field validation V3', () => {
   })
 
   it('should allow number with that is within maximum (inclusive)', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Range,
         RangeValidationOptions: {
@@ -670,7 +671,7 @@ describe('Range field validation V3', () => {
   })
 
   it('should allow number with that is within minimum (inclusive)', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Range,
         RangeValidationOptions: {
@@ -694,7 +695,7 @@ describe('Range field validation V3', () => {
   })
 
   it('should disallow number that is below minimum', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Range,
         RangeValidationOptions: {
@@ -720,7 +721,7 @@ describe('Range field validation V3', () => {
   })
 
   it('should disallow number that is above maximum', () => {
-    const formField = generateDefaultField(BasicField.Number, {
+    const formField = generateDefaultFieldV3(BasicField.Number, {
       ValidationOptions: {
         selectedValidation: NumberSelectedValidation.Range,
         RangeValidationOptions: {

--- a/src/app/utils/field-validation/validators/__tests__/radio-button-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/radio-button-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateNewSingleAnswerResponse,
   generateRadioResponseV3,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -163,7 +164,7 @@ describe('Radio button validation', () => {
 
 describe('Radio button validation V3', () => {
   it('should allow valid field option', () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
     })
     const response = generateRadioResponseV3({
@@ -181,7 +182,7 @@ describe('Radio button validation V3', () => {
   })
 
   it('should disallow invalid field option', () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
     })
     const response = generateRadioResponseV3({
@@ -201,7 +202,7 @@ describe('Radio button validation V3', () => {
   })
 
   it('should disallow empty answer when required and is visible', () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
     })
     const response = generateRadioResponseV3({
@@ -221,7 +222,7 @@ describe('Radio button validation V3', () => {
   })
 
   it('should allow empty answer when not required', () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
       required: false,
     })
@@ -240,7 +241,7 @@ describe('Radio button validation V3', () => {
   })
 
   it('should allow empty answer when required and not visible', () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
     })
     const response = generateRadioResponseV3({
@@ -258,7 +259,7 @@ describe('Radio button validation V3', () => {
   })
 
   it('should disallow empty answer when required and visible', () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
     })
     const response = generateRadioResponseV3({
@@ -278,7 +279,7 @@ describe('Radio button validation V3', () => {
   })
 
   it('should disallow empty othersInput answer when others is selected if required', () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
       required: true,
       othersRadioButton: true,
@@ -300,7 +301,7 @@ describe('Radio button validation V3', () => {
   })
 
   it(`should allow othersInput when others option is selected`, () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
       othersRadioButton: true,
     })
@@ -319,7 +320,7 @@ describe('Radio button validation V3', () => {
   })
 
   it(`should disallow othersInput when others option is not selected`, () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
       othersRadioButton: false,
     })
@@ -340,7 +341,7 @@ describe('Radio button validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Radio, {
+    const formField = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
     })
     const response = generateRadioResponseV3({
@@ -358,7 +359,7 @@ describe('Radio button validation V3', () => {
       new ValidateFieldError('Attempted to submit response on a hidden field'),
     )
 
-    const formFieldOthers = generateDefaultField(BasicField.Radio, {
+    const formFieldOthers = generateDefaultFieldV3(BasicField.Radio, {
       fieldOptions: ['a', 'b', 'c'],
       othersRadioButton: true,
     })

--- a/src/app/utils/field-validation/validators/__tests__/rating-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/rating-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -176,7 +177,7 @@ describe('Rating field validation', () => {
 
 describe('Rating field validation V3', () => {
   it('should allow answer within range', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       ratingOptions: {
         steps: 5,
         shape: RatingShape.Heart,
@@ -198,7 +199,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should allow number with valid maximum (inclusive)', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       ratingOptions: {
         steps: 5,
         shape: RatingShape.Heart,
@@ -219,7 +220,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should disallow number with invalid maximum', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       ratingOptions: {
         steps: 5,
         shape: RatingShape.Heart,
@@ -242,7 +243,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should allow number with valid minimum (inclusive)', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       ratingOptions: {
         steps: 5,
         shape: RatingShape.Heart,
@@ -263,7 +264,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should allow number with optional answer', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       required: false,
       ratingOptions: {
         steps: 5,
@@ -285,7 +286,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should disallow negative answers', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       ratingOptions: {
         steps: 5,
         shape: RatingShape.Heart,
@@ -308,7 +309,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should disallow leading zeroes in answer', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       ratingOptions: {
         steps: 5,
         shape: RatingShape.Heart,
@@ -331,7 +332,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should allow empty answer if optional', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       required: false,
       ratingOptions: {
         steps: 5,
@@ -353,7 +354,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should disallow empty answer if required', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       required: true,
       ratingOptions: {
         steps: 5,
@@ -377,7 +378,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should disallow strings not representing numbers as answer', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       ratingOptions: {
         steps: 10,
         shape: RatingShape.Heart,
@@ -400,7 +401,7 @@ describe('Rating field validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Rating, {
+    const formField = generateDefaultFieldV3(BasicField.Rating, {
       ratingOptions: {
         steps: 5,
         shape: RatingShape.Heart,

--- a/src/app/utils/field-validation/validators/__tests__/table-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/table-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateNewTableResponse,
   generateTableDropdownColumn,
   generateTableResponseV3,
@@ -313,7 +314,7 @@ describe('Table validation V3', () => {
 
   describe('Dropdown column', () => {
     it('should disallow empty submissions if columns are required', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [generateTableDropdownColumn({ _id: COL1_ID })],
       })
       const response = generateTableResponseV3([
@@ -334,7 +335,7 @@ describe('Table validation V3', () => {
     })
 
     it('should allow empty submissions for not required columns', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID, required: false }),
         ],
@@ -355,7 +356,7 @@ describe('Table validation V3', () => {
     })
 
     it('should allow valid submission for dropdown column', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({
             _id: COL1_ID,
@@ -380,7 +381,7 @@ describe('Table validation V3', () => {
     })
 
     it('should disallow values not found in field options for dropdown column', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({
             _id: COL1_ID,
@@ -408,7 +409,7 @@ describe('Table validation V3', () => {
 
   describe('Textfield column', () => {
     it('should disallow empty submissions if columns are required', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [generateTableShortTextColumn({ _id: COL1_ID })],
       })
       const response = generateTableResponseV3([
@@ -430,7 +431,7 @@ describe('Table validation V3', () => {
     })
 
     it('should allow empty submissions for not required columns', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableShortTextColumn({ _id: COL1_ID, required: false }),
         ],
@@ -452,7 +453,7 @@ describe('Table validation V3', () => {
     })
 
     it('should allow valid submission for textfield column', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [generateTableShortTextColumn({ _id: COL1_ID })],
       })
       const response = generateTableResponseV3([
@@ -474,7 +475,7 @@ describe('Table validation V3', () => {
 
   describe('Multiple columns and rows', () => {
     it('should allow valid submissions for multiple columns', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({
             _id: COL1_ID,
@@ -502,7 +503,7 @@ describe('Table validation V3', () => {
 
     it('should disallow input with number of columns that do not match', () => {
       const extraColumnId = '000000000000000000000003'
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID }),
           generateTableShortTextColumn({ _id: COL2_ID }),
@@ -529,7 +530,7 @@ describe('Table validation V3', () => {
     })
 
     it('should allow valid submissions for multiple rows', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID }),
           generateTableShortTextColumn({ _id: COL2_ID }),
@@ -558,7 +559,7 @@ describe('Table validation V3', () => {
     })
 
     it('should disallow invalid submissions for multiple rows', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID }),
           generateTableShortTextColumn({ _id: COL2_ID }),
@@ -591,7 +592,7 @@ describe('Table validation V3', () => {
 
   describe('Number of rows', () => {
     it('should allow submissions with zero rows if minimum rows not set', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID }),
           generateTableShortTextColumn({ _id: COL2_ID }),
@@ -611,7 +612,7 @@ describe('Table validation V3', () => {
     })
 
     it('should disallow submissions with zero rows if minimum rows set to 1', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID }),
           generateTableShortTextColumn({ _id: COL2_ID }),
@@ -633,7 +634,7 @@ describe('Table validation V3', () => {
     })
 
     it('should disallow submissions with fewer than min rows', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID }),
           generateTableShortTextColumn({ _id: COL2_ID }),
@@ -660,7 +661,7 @@ describe('Table validation V3', () => {
     })
 
     it('should disallow submissions with more rows than min rows if addMoreRows is not set', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID }),
           generateTableShortTextColumn({ _id: COL2_ID }),
@@ -695,7 +696,7 @@ describe('Table validation V3', () => {
     })
 
     it('should disallow submissions with more than max rows if max rows is set and addMoreRows is configured for that field', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [
           generateTableDropdownColumn({ _id: COL1_ID }),
           generateTableShortTextColumn({ _id: COL2_ID }),
@@ -736,7 +737,7 @@ describe('Table validation V3', () => {
     })
 
     it('should allow submissions with unlimited rows if max rows is not set and addMoreRows is configured for that field', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [generateTableShortTextColumn({ _id: COL1_ID })],
         maximumRows: undefined,
         addMoreRows: true,
@@ -760,7 +761,7 @@ describe('Table validation V3', () => {
 
   describe('Invalid input', () => {
     it('should disallow null input for text col', () => {
-      const formField = generateDefaultField(BasicField.Table, {
+      const formField = generateDefaultFieldV3(BasicField.Table, {
         columns: [generateTableShortTextColumn({ _id: COL1_ID })],
       })
 
@@ -783,7 +784,7 @@ describe('Table validation V3', () => {
   })
 
   it('should disallow null input for dropdown col', () => {
-    const formField = generateDefaultField(BasicField.Table, {
+    const formField = generateDefaultFieldV3(BasicField.Table, {
       columns: [generateTableDropdownColumn({ _id: COL1_ID })],
     })
 
@@ -805,7 +806,7 @@ describe('Table validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Table, {
+    const formField = generateDefaultFieldV3(BasicField.Table, {
       columns: [generateTableShortTextColumn({ _id: COL1_ID })],
     })
     const response = generateTableResponseV3([

--- a/src/app/utils/field-validation/validators/__tests__/text-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/text-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
   generateNewSingleAnswerResponse,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -309,7 +310,7 @@ describe('Text validation', () => {
 describe('Text validation V3', () => {
   describe('Short text', () => {
     it('should allow valid short text answer when not required', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         required: false,
       })
       const response = generateGenericStringAnswerResponseV3({
@@ -327,7 +328,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow empty submissions if field is required', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         required: true,
       })
       const response = generateGenericStringAnswerResponseV3({
@@ -348,7 +349,7 @@ describe('Text validation V3', () => {
     })
 
     it('should allow empty submissions if field is not required', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         required: false,
       })
       const response = generateGenericStringAnswerResponseV3({
@@ -366,7 +367,7 @@ describe('Text validation V3', () => {
     })
 
     it('should allow any number of characters in submission if selectedValidation is not set', () => {
-      const formField = generateDefaultField(BasicField.ShortText)
+      const formField = generateDefaultFieldV3(BasicField.ShortText)
       const response = generateGenericStringAnswerResponseV3({
         fieldType: BasicField.ShortText,
         answer: 'dim sum',
@@ -382,7 +383,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow whitespace answer if field is required', () => {
-      const formField = generateDefaultField(BasicField.ShortText)
+      const formField = generateDefaultFieldV3(BasicField.ShortText)
       const response = generateGenericStringAnswerResponseV3({
         fieldType: BasicField.ShortText,
         answer: ' ',
@@ -400,7 +401,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow fewer characters than customVal if selectedValidation is Exact', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Exact,
           customVal: 10,
@@ -423,7 +424,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow more characters than customVal if selectedValidation is Exact', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Exact,
           customVal: 10,
@@ -447,7 +448,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow fewer characters than customVal if selectedValidation is Minimum', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Minimum,
           customVal: 10,
@@ -470,7 +471,7 @@ describe('Text validation V3', () => {
     })
 
     it('should allow more characters than customVal if selectedValidation is Minimum', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Minimum,
           customVal: 10,
@@ -491,7 +492,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow more characters than customVal if selectedValidation is Maximum', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Maximum,
           customVal: 10,
@@ -514,7 +515,7 @@ describe('Text validation V3', () => {
     })
 
     it('should allow less characters than customVal if selectedValidation is Maximum', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Maximum,
           customVal: 10,
@@ -535,7 +536,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow responses submitted for hidden fields', () => {
-      const formField = generateDefaultField(BasicField.ShortText, {
+      const formField = generateDefaultFieldV3(BasicField.ShortText, {
         ValidationOptions: {
           selectedValidation: null,
           customVal: null,
@@ -562,7 +563,7 @@ describe('Text validation V3', () => {
 
   describe('Long text', () => {
     it('should allow valid long text answer when not required', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         required: false,
         ValidationOptions: {
           selectedValidation: null,
@@ -584,7 +585,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow empty submissions if field is required', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         required: true,
         ValidationOptions: {
           selectedValidation: null,
@@ -609,7 +610,7 @@ describe('Text validation V3', () => {
     })
 
     it('should allow empty submissions if field is not required', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         required: false,
         ValidationOptions: {
           selectedValidation: null,
@@ -631,7 +632,7 @@ describe('Text validation V3', () => {
     })
 
     it('should allow any number of characters in submission if selectedValidation is not set', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: null,
           customVal: null,
@@ -652,7 +653,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow whitespace answer if field is required', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: null,
           customVal: null,
@@ -675,7 +676,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow fewer characters than customVal if selectedValidation is Exact', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Exact,
           customVal: 10,
@@ -698,7 +699,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow more characters than customVal if selectedValidation is Exact', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Exact,
           customVal: 10,
@@ -722,7 +723,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow fewer characters than customVal if selectedValidation is Minimum', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Minimum,
           customVal: 10,
@@ -745,7 +746,7 @@ describe('Text validation V3', () => {
     })
 
     it('should allow more characters than customVal if selectedValidation is Minimum', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Minimum,
           customVal: 10,
@@ -766,7 +767,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow more characters than customVal if selectedValidation is Maximum', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Maximum,
           customVal: 10,
@@ -789,7 +790,7 @@ describe('Text validation V3', () => {
     })
 
     it('should allow less characters than customVal if selectedValidation is Maximum', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: TextSelectedValidation.Maximum,
           customVal: 10,
@@ -810,7 +811,7 @@ describe('Text validation V3', () => {
     })
 
     it('should disallow responses submitted for hidden fields', () => {
-      const formField = generateDefaultField(BasicField.LongText, {
+      const formField = generateDefaultFieldV3(BasicField.LongText, {
         ValidationOptions: {
           selectedValidation: null,
           customVal: null,

--- a/src/app/utils/field-validation/validators/__tests__/uen-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/uen-validation.spec.ts
@@ -1,5 +1,5 @@
 import {
-  generateDefaultField,
+  generateDefaultFieldV3,
   generateGenericStringAnswerResponseV3,
 } from '__tests__/unit/backend/helpers/generate-form-data'
 import { BasicField } from 'shared/types'
@@ -10,7 +10,7 @@ import { validateFieldV3 } from '../..'
 
 describe('UEN field validation V3', () => {
   it('should allow valid UEN', () => {
-    const formField = generateDefaultField(BasicField.Uen)
+    const formField = generateDefaultFieldV3(BasicField.Uen)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Uen,
       answer: '53308948D',
@@ -27,7 +27,7 @@ describe('UEN field validation V3', () => {
   })
 
   it('should disallow invalid UEN', () => {
-    const formField = generateDefaultField(BasicField.Uen)
+    const formField = generateDefaultFieldV3(BasicField.Uen)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Uen,
       answer: 'notavaliduen',
@@ -47,7 +47,7 @@ describe('UEN field validation V3', () => {
   })
 
   it('should allow empty string for not required UEN', () => {
-    const formField = generateDefaultField(BasicField.Uen, {
+    const formField = generateDefaultFieldV3(BasicField.Uen, {
       required: false,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -65,7 +65,7 @@ describe('UEN field validation V3', () => {
   })
 
   it('should disallow empty string for required UEN', () => {
-    const formField = generateDefaultField(BasicField.Uen, {
+    const formField = generateDefaultFieldV3(BasicField.Uen, {
       required: true,
     })
     const response = generateGenericStringAnswerResponseV3({
@@ -85,7 +85,7 @@ describe('UEN field validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.Uen)
+    const formField = generateDefaultFieldV3(BasicField.Uen)
     const response = generateGenericStringAnswerResponseV3({
       fieldType: BasicField.Uen,
       answer: '53308948D',

--- a/src/app/utils/field-validation/validators/__tests__/yesno-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/yesno-validation.spec.ts
@@ -1,5 +1,6 @@
 import {
   generateDefaultField,
+  generateDefaultFieldV3,
   generateNewSingleAnswerResponse,
   generateYesNoAnswerResponseV3,
 } from '__tests__/unit/backend/helpers/generate-form-data'
@@ -92,7 +93,7 @@ describe('Yes/No field validation', () => {
 
 describe('Yes/No field validation V3', () => {
   it('should allow Yes', () => {
-    const formField = generateDefaultField(BasicField.YesNo)
+    const formField = generateDefaultFieldV3(BasicField.YesNo)
     const response = generateYesNoAnswerResponseV3('Yes')
 
     const validateResult = validateFieldV3({
@@ -106,7 +107,7 @@ describe('Yes/No field validation V3', () => {
   })
 
   it('should allow No', () => {
-    const formField = generateDefaultField(BasicField.YesNo)
+    const formField = generateDefaultFieldV3(BasicField.YesNo)
     const response = generateYesNoAnswerResponseV3('No')
 
     const validateResult = validateFieldV3({
@@ -120,7 +121,7 @@ describe('Yes/No field validation V3', () => {
   })
 
   it('should allow empty string when not required', () => {
-    const formField = generateDefaultField(BasicField.YesNo, {
+    const formField = generateDefaultFieldV3(BasicField.YesNo, {
       required: false,
     })
     const response = generateYesNoAnswerResponseV3(
@@ -138,7 +139,7 @@ describe('Yes/No field validation V3', () => {
   })
 
   it('should disallow empty string when required', () => {
-    const formField = generateDefaultField(BasicField.YesNo, {
+    const formField = generateDefaultFieldV3(BasicField.YesNo, {
       required: true,
     })
     const response = generateYesNoAnswerResponseV3(
@@ -158,7 +159,7 @@ describe('Yes/No field validation V3', () => {
   })
 
   it('should disallow invalid input', () => {
-    const formField = generateDefaultField(BasicField.YesNo, {
+    const formField = generateDefaultFieldV3(BasicField.YesNo, {
       required: true,
     })
     const response = generateYesNoAnswerResponseV3(
@@ -177,7 +178,7 @@ describe('Yes/No field validation V3', () => {
   })
 
   it('should perform validation and disallow invalid field even when not required', () => {
-    const formField = generateDefaultField(BasicField.YesNo, {
+    const formField = generateDefaultFieldV3(BasicField.YesNo, {
       required: false,
     })
     const response = generateYesNoAnswerResponseV3(
@@ -196,7 +197,7 @@ describe('Yes/No field validation V3', () => {
   })
 
   it('should disallow responses submitted for hidden fields', () => {
-    const formField = generateDefaultField(BasicField.YesNo)
+    const formField = generateDefaultFieldV3(BasicField.YesNo)
     const response = generateYesNoAnswerResponseV3('No')
 
     const validateResult = validateFieldV3({


### PR DESCRIPTION
## Problem
Due to the update in the type that the `fieldValidatorV3` argument accepts, the test case types are mismatched. 

Closes FRM-1881

## Solution
Update the formfield to use defaultFieldGenerator which casts the type to `FormFieldDto`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  