### PR TITLE
feat: move step1 email field to settings

### DIFF
--- a/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/frontend/src/components/Dropdown/SelectContext.tsx
@@ -54,6 +54,7 @@ interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>
   virtualListRef: RefObject<VirtuosoHandle>
   /** Height to assign to virtual list */
   virtualListHeight: number
+  onBlur?: () => void
 }
 
 export const SelectContext = createContext<SelectContextReturn | undefined>(

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ChangeHandler } from 'react-hook-form'
 import { VirtuosoHandle } from 'react-virtuoso'
 import {
   FormControlOptions,
@@ -24,9 +25,9 @@ export interface SingleSelectProviderProps<
   value: string
   /** Controlled selected item onChange handler */
   onChange: (value: string) => void
-  onBlur?: () => void
+  onBlur?: (() => void) | ChangeHandler
   /** Function based on which items in dropdown are filtered. Default filter filters by fuzzy match. */
-  filter?(items: Item[], value: string): Item[]
+  filter?: (items: Item[], value: string) => Item[]
   /** Initial dropdown opened state. */
   initialIsOpen?: boolean
   /** Props to override default useComboboxProps, if any. */

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -24,6 +24,7 @@ export interface SingleSelectProviderProps<
   value: string
   /** Controlled selected item onChange handler */
   onChange: (value: string) => void
+  onBlur?: () => void
   /** Function based on which items in dropdown are filtered. Default filter filters by fuzzy match. */
   filter?(items: Item[], value: string): Item[]
   /** Initial dropdown opened state. */
@@ -45,6 +46,7 @@ export interface SingleSelectProviderProps<
 export const SingleSelectProvider = ({
   items: rawItems,
   value,
+  onBlur,
   onChange,
   name,
   filter = defaultFilter,
@@ -272,6 +274,7 @@ export const SingleSelectProvider = ({
         virtualListRef,
         virtualListHeight,
         fullWidth,
+        onBlur,
       }}
     >
       {children}

--- a/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ChangeHandler } from 'react-hook-form'
 import { VirtuosoHandle } from 'react-virtuoso'
 import {
   FormControlOptions,
@@ -25,7 +24,7 @@ export interface SingleSelectProviderProps<
   value: string
   /** Controlled selected item onChange handler */
   onChange: (value: string) => void
-  onBlur?: (() => void) | ChangeHandler
+  onBlur?: () => void
   /** Function based on which items in dropdown are filtered. Default filter filters by fuzzy match. */
   filter?: (items: Item[], value: string) => Item[]
   /** Initial dropdown opened state. */

--- a/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -33,6 +33,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       isOpen,
       resetInputValue,
       inputRef,
+      onBlur,
     } = useSelectContext()
 
     const mergedInputRef = useMergeRefs(inputRef, ref)
@@ -51,7 +52,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
     }, [isDisabled, isReadOnly, toggleMenu])
 
     return (
-      <Flex>
+      <Flex onBlur={onBlur}>
         <InputGroup
           pos="relative"
           display="grid"

--- a/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
+++ b/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
@@ -152,30 +152,6 @@ const workflow_step_2_with_all_fields_deleted: FormWorkflowStepDto = {
   edit: ['deleted_object_id_1', 'deleted_object_id_2'],
 }
 
-const workflow_step_1_with_respondent: FormWorkflowStepDto = {
-  _id: '61e6857c9c794b0012f1c6g1',
-  workflow_type: WorkflowType.Dynamic,
-  field: form_field_5._id,
-  edit: [
-    form_field_1._id,
-    form_field_2._id,
-    form_field_5._id,
-    form_field_6._id,
-  ],
-}
-
-const workflow_step_1_with_deleted_respondent: FormWorkflowStepDto = {
-  _id: '61e6857c9c794b0012f1c6g9',
-  workflow_type: WorkflowType.Dynamic,
-  field: 'invalid_object_id',
-  edit: [
-    form_field_1._id,
-    form_field_2._id,
-    form_field_5._id,
-    form_field_6._id,
-  ],
-}
-
 const workflow_step_3_with_approval: FormWorkflowStepDto = {
   _id: '61e6857c9c794b0012f1c6g2',
   workflow_type: WorkflowType.Dynamic,
@@ -231,12 +207,16 @@ MobileWithWorkflow.parameters = {
   chromatic: { viewports: [viewports.xs] },
 }
 
-export const Step1Respondent = Template.bind({})
-Step1Respondent.parameters = {
+export const Step1 = Template.bind({})
+Step1.parameters = {
   msw: buildMswRoutes({
     ...FORM_WITH_WORKFLOW,
-    workflow: [workflow_step_1_with_respondent],
+    workflow: [workflow_step_1],
   }),
+  documentation: {
+    storyDescription:
+      'Step 1 of a workflow should not show any respondent selected',
+  },
 }
 
 export const Step3Approval = Template.bind({})
@@ -244,14 +224,6 @@ Step3Approval.parameters = {
   msw: buildMswRoutes({
     ...FORM_WITH_WORKFLOW,
     workflow: [workflow_step_1, workflow_step_2, workflow_step_3_with_approval],
-  }),
-}
-
-export const Step1RespondentDeleted = Template.bind({})
-Step1RespondentDeleted.parameters = {
-  msw: buildMswRoutes({
-    ...FORM_WITH_WORKFLOW,
-    workflow: [workflow_step_1_with_deleted_respondent],
   }),
 }
 

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
@@ -203,36 +203,6 @@ export const DeletedApprovalFieldSelected = {
   },
 }
 
-export const DeletedStep1RespondentSelected = {
-  args: {
-    stepNumber: 0,
-    defaultValues: {
-      workflow_type: WorkflowType.Dynamic,
-      field: 'deleted_objectId',
-      edit: [form_field_3._id],
-    },
-  },
-  parameters: {
-    docs: {
-      description: {
-        component:
-          'When submit is clicked, no validation error should occur since email field is set to empty string',
-      },
-    },
-  },
-}
-
-export const Step1RespondentSelected = {
-  args: {
-    stepNumber: 0,
-    defaultValues: {
-      workflow_type: WorkflowType.Dynamic,
-      field: form_field_3._id,
-      edit: [form_field_3._id],
-    },
-  },
-}
-
 export const Step3AllSelectedValid = {
   args: {
     stepNumber: 2,

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { Controller, UseFormReturn } from 'react-hook-form'
 import { As, FormControl, Stack, Text } from '@chakra-ui/react'
 import { get } from 'lodash'
@@ -202,17 +201,11 @@ export const RespondentBlock = ({
   stepNumber,
   isLoading,
   formMethods,
-  user,
 }: RespondentBlockProps): JSX.Element => {
   const {
     formState: { errors },
     watch,
-    setValue,
-    control,
   } = formMethods
-
-  // TODO: (MRF-email-notif) Remove isTest check when MRF email notifications is out of beta
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
 
   const { emailFormFields = [] } = useAdminFormWorkflow()
 
@@ -223,22 +216,6 @@ export const RespondentBlock = ({
       icon: BASICFIELD_TO_DRAWER_META[fieldType].icon,
     }),
   )
-  const emailFieldIds = emailFormFields.map(({ _id }) => _id)
-
-  const getValueIfNotDeleted = useCallback(
-    // Why: When the Yes/No field has been deleted, the approval_field is still set to the
-    // invalid form field id but cannot be seen or cleared in the SingleSelect component
-    // since no matching Yes/No item can be found.
-    // Hence, we clear the approval_field to allow the user to re-select a new valid value.
-    (value: string) => {
-      if (!isLoading && value && !emailFieldIds.includes(value)) {
-        setValue('field', '')
-        return ''
-      }
-      return value
-    },
-    [isLoading, setValue, emailFieldIds],
-  )
 
   const selectedWorkflowType = watch('workflow_type')
 
@@ -247,47 +224,10 @@ export const RespondentBlock = ({
   return (
     <EditStepBlockContainer>
       {isFirstStep ? (
-        <>
-          {/* TODO: (MRF-email-notif) Remove isTest and betaFlag check when MRF email
-          notifications is out of beta */}
-          {isTest || user?.betaFlags?.mrfEmailNotifications ? (
-            <FormControl isInvalid={!!errors.field}>
-              <FormLabel style={textStyles.h4}>
-                Select email field for notifications to be sent to this
-                respondent
-              </FormLabel>
-              <Controller
-                name="field"
-                rules={{
-                  validate: (selectedValue) => {
-                    return (
-                      !selectedValue ||
-                      !emailFieldItems ||
-                      emailFieldItems.some(
-                        ({ value: fieldValue }) => fieldValue === selectedValue,
-                      ) ||
-                      'Field is not an email field'
-                    )
-                  },
-                }}
-                control={control}
-                render={({ field: { value = '', ...rest } }) => (
-                  <SingleSelect
-                    isDisabled={isLoading}
-                    placeholder="Select an email field from your form"
-                    items={emailFieldItems}
-                    value={getValueIfNotDeleted(value)}
-                    isClearable
-                    {...rest}
-                  />
-                )}
-              />
-              <FormErrorMessage>{errors.field?.message}</FormErrorMessage>
-            </FormControl>
-          ) : (
-            <Text>Anyone you share the form link with</Text>
-          )}
-        </>
+        <Stack spacing="0.5rem">
+          <Text style={textStyles.h4}>Respondent in this step</Text>
+          <Text>Anyone who has access to your form</Text>
+        </Stack>
       ) : (
         <FormControl
           isReadOnly={isLoading}

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
@@ -34,25 +34,6 @@ interface RespondentBadgeProps {
   step: FormWorkflowStepDto
   idToFieldMap: Dictionary<FormFieldWithQuestionNo<FormField>>
 }
-const FirstStepRespondentBadge = ({
-  step,
-  idToFieldMap,
-}: RespondentBadgeProps): JSX.Element | null => {
-  if (
-    step.workflow_type === WorkflowType.Static ||
-    (step.workflow_type === WorkflowType.Dynamic && !step.field)
-  ) {
-    return (
-      <FieldLogicBadge
-        defaults={{
-          variant: 'info',
-          message: 'No email field included in this step',
-        }}
-      />
-    )
-  }
-  return <FieldLogicBadge field={idToFieldMap[step.field]} />
-}
 
 const SubsequentStepRespondentBadges = ({
   step,
@@ -179,14 +160,7 @@ export const InactiveStepBlock = ({
             {/* TODO: (MRF-email-notif) Remove isTest and betaFlag check when MRF email
             notifications is out of beta */}
             {isFirstStep ? (
-              isTest || user?.betaFlags?.mrfEmailNotifications ? (
-                <FirstStepRespondentBadge
-                  step={step}
-                  idToFieldMap={idToFieldMap}
-                />
-              ) : (
-                <Text>Anyone you share the form link with</Text>
-              )
+              <Text>Anyone who has access to your form</Text>
             ) : (
               <Flex
                 flexDir={{ base: 'column', md: 'row' }}

--- a/frontend/src/features/admin-form/settings/SettingsEmailsPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsEmailsPage.stories.tsx
@@ -1,6 +1,11 @@
 import { Meta, StoryFn } from '@storybook/react'
 
-import { PaymentChannel, PaymentType } from '~shared/types'
+import {
+  BasicField,
+  FormFieldDto,
+  PaymentChannel,
+  PaymentType,
+} from '~shared/types'
 import {
   AdminFormDto,
   FormDto,
@@ -125,9 +130,17 @@ PrivateMultiRespondentForm.parameters = {
   msw: buildMswRoutes({
     mode: FormResponseMode.Multirespondent,
     overrides: {
+      form_fields: [
+        {
+          _id: 'email_field_id',
+          fieldType: BasicField.Email,
+          title: 'Respondent 1 Email',
+        } as FormFieldDto,
+      ],
       status: FormStatus.Private,
-      emails: [],
-      stepsToNotify: [],
+      stepOneEmailNotificationFieldId: 'email_field_id',
+      emails: ['selected_email@example.com', 'selected_email_2@example.com'],
+      stepsToNotify: ['field_id_2'],
       workflow: [
         {
           _id: 'field_id_1',
@@ -142,6 +155,48 @@ PrivateMultiRespondentForm.parameters = {
           edit: [],
         },
       ],
+    },
+  }),
+}
+
+export const PrivateMultiRespondentFormWithInvalidStepOneEmailNotificationFieldId =
+  Template.bind({})
+PrivateMultiRespondentFormWithInvalidStepOneEmailNotificationFieldId.parameters =
+  {
+    msw: buildMswRoutes({
+      mode: FormResponseMode.Multirespondent,
+      overrides: {
+        status: FormStatus.Private,
+        stepOneEmailNotificationFieldId: 'invalid_field_id',
+        emails: ['selected_email@example.com', 'selected_email_2@example.com'],
+        stepsToNotify: ['field_id_2'],
+        workflow: [
+          {
+            _id: 'field_id_1',
+            workflow_type: WorkflowType.Dynamic,
+            field: 'email_field_id',
+            edit: [],
+          },
+          {
+            _id: 'field_id_2',
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [],
+          },
+        ],
+      },
+    }),
+  }
+
+export const PrivateMultiRespondentFormNothingSelected = Template.bind({})
+PrivateMultiRespondentFormNothingSelected.parameters = {
+  msw: buildMswRoutes({
+    mode: FormResponseMode.Multirespondent,
+    overrides: {
+      status: FormStatus.Private,
+      emails: [],
+      stepsToNotify: [],
+      stepOneEmailNotificationFieldId: undefined,
     },
   }),
 }
@@ -163,24 +218,31 @@ PublicMultiRespondentForm.parameters = {
   msw: buildMswRoutes({
     mode: FormResponseMode.Multirespondent,
     overrides: {
+      form_fields: [
+        {
+          _id: 'email_field_id',
+          fieldType: BasicField.Email,
+          title: 'Respondent 1 Email',
+        } as FormFieldDto,
+      ],
       status: FormStatus.Public,
-      emails: ['expected1@example.com', 'expected2@example.com'],
-      stepsToNotify: ['field_1_id'],
+      stepOneEmailNotificationFieldId: 'email_field_id',
+      emails: ['selected_email@example.com', 'selected_email_2@example.com'],
+      stepsToNotify: ['field_id_2'],
       workflow: [
         {
-          _id: 'field_1_id',
+          _id: 'field_id_1',
           workflow_type: WorkflowType.Dynamic,
           field: 'email_field_id',
           edit: [],
         },
         {
-          _id: 'field_2_id',
+          _id: 'field_id_2',
           workflow_type: WorkflowType.Static,
           emails: [],
           edit: [],
         },
       ],
-      ...PAYMENTS_DISABLED,
     },
   }),
 }

--- a/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -27,6 +27,7 @@ type UpdateStorageFormFn<T extends keyof StorageFormSettings> = (
 export interface MrfEmailNotificationSettings {
   emails: string[]
   stepsToNotify: string[]
+  stepOneEmailNotificationFieldId: string
 }
 
 type UpdateMultiRespondentFormFn<

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import {
   Box,
@@ -140,6 +140,32 @@ const MrfEmailNotificationsForm = ({
       ? undefined
       : 'me@example.com'
 
+  const isStepOneEmailFieldDeleted = useMemo(() => {
+    return Boolean(
+      !isLoading &&
+        stepOneEmailNotificationFieldId &&
+        !emailFieldItems
+          .map(({ value: fieldValue }) => fieldValue)
+          .includes(stepOneEmailNotificationFieldId),
+    )
+  }, [isLoading, stepOneEmailNotificationFieldId, emailFieldItems])
+
+  const getValueIfNotDeleted = useCallback(
+    (value: string) => {
+      // Why: When previously selected email field has been deleted, the value is still set to the previous,
+      // we need to clear the value to allow the user to re-select a new valid value.
+      if (
+        value === stepOneEmailNotificationFieldId &&
+        isStepOneEmailFieldDeleted
+      ) {
+        setValue(STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME, '')
+        return ''
+      }
+      return value
+    },
+    [setValue, isStepOneEmailFieldDeleted, stepOneEmailNotificationFieldId],
+  )
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Box>
@@ -151,40 +177,48 @@ const MrfEmailNotificationsForm = ({
           workflow is complete.
         </Text>
         <Box>
-          <FormLabel mb="0.75rem" textColor="secondary.700">
-            Notify Respondent in Step 1
-          </FormLabel>
-          <Skeleton isLoaded={!isLoading}>
-            <Controller
-              rules={{
-                validate: (selectedValue) => {
-                  return (
-                    !selectedValue ||
-                    !emailFieldItems ||
-                    emailFieldItems.some(
-                      ({ value: fieldValue }) => fieldValue === selectedValue,
-                    ) ||
-                    'Field is not an email field'
-                  )
-                },
-              }}
-              control={control}
-              name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
-              render={({
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                field: { onBlur, ...rest },
-              }) => (
-                <SingleSelect
-                  isDisabled={isLoading || isDisabled}
-                  placeholder="Select an email field from your form"
-                  items={emailFieldItems}
-                  onBlur={handleSubmit(onSubmit)}
-                  isClearable
-                  {...rest}
-                />
-              )}
-            />
-          </Skeleton>
+          <FormControl isInvalid={isStepOneEmailFieldDeleted}>
+            <FormLabel mb="0.75rem" textColor="secondary.700">
+              Notify Respondent in Step 1
+            </FormLabel>
+            <Skeleton isLoaded={!isLoading}>
+              <Controller
+                // rules={{
+                //   validate: (selectedValue) => {
+                //     return (
+                //       !selectedValue ||
+                //       !emailFieldItems ||
+                //       emailFieldItems.some(
+                //         ({ value: fieldValue }) => fieldValue === selectedValue,
+                //       ) ||
+                //       'Field is not an email field'
+                //     )
+                //   },
+                // }}
+                control={control}
+                name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
+                render={({
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  field: { value, onBlur, ...rest },
+                }) => (
+                  <SingleSelect
+                    isDisabled={isLoading || isDisabled}
+                    placeholder="Select an email field from your form"
+                    items={emailFieldItems}
+                    onBlur={handleSubmit(onSubmit)}
+                    isClearable
+                    value={value}
+                    {...rest}
+                  />
+                )}
+              />
+            </Skeleton>
+            <FormErrorMessage>
+              {errors[STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]
+                ?.message ||
+                'The previously selected email field has been deleted'}
+            </FormErrorMessage>
+          </FormControl>
         </Box>
         <Box my="1.5rem">
           <FormLabel mb="0.75rem" textColor="secondary.700">

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -156,6 +156,18 @@ const MrfEmailNotificationsForm = ({
           </FormLabel>
           <Skeleton isLoaded={!isLoading}>
             <Controller
+              rules={{
+                validate: (selectedValue) => {
+                  return (
+                    !selectedValue ||
+                    !emailFieldItems ||
+                    emailFieldItems.some(
+                      ({ value: fieldValue }) => fieldValue === selectedValue,
+                    ) ||
+                    'Field is not an email field'
+                  )
+                },
+              }}
               control={control}
               name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
               render={({

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 import {
   Box,
@@ -140,32 +140,6 @@ const MrfEmailNotificationsForm = ({
       ? undefined
       : 'me@example.com'
 
-  const isStepOneEmailFieldDeleted = useMemo(() => {
-    return Boolean(
-      !isLoading &&
-        stepOneEmailNotificationFieldId &&
-        !emailFieldItems
-          .map(({ value: fieldValue }) => fieldValue)
-          .includes(stepOneEmailNotificationFieldId),
-    )
-  }, [isLoading, stepOneEmailNotificationFieldId, emailFieldItems])
-
-  const getValueIfNotDeleted = useCallback(
-    (value: string) => {
-      // Why: When previously selected email field has been deleted, the value is still set to the previous,
-      // we need to clear the value to allow the user to re-select a new valid value.
-      if (
-        value === stepOneEmailNotificationFieldId &&
-        isStepOneEmailFieldDeleted
-      ) {
-        setValue(STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME, '')
-        return ''
-      }
-      return value
-    },
-    [setValue, isStepOneEmailFieldDeleted, stepOneEmailNotificationFieldId],
-  )
-
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Box>
@@ -177,48 +151,29 @@ const MrfEmailNotificationsForm = ({
           workflow is complete.
         </Text>
         <Box>
-          <FormControl isInvalid={isStepOneEmailFieldDeleted}>
-            <FormLabel mb="0.75rem" textColor="secondary.700">
-              Notify Respondent in Step 1
-            </FormLabel>
-            <Skeleton isLoaded={!isLoading}>
-              <Controller
-                // rules={{
-                //   validate: (selectedValue) => {
-                //     return (
-                //       !selectedValue ||
-                //       !emailFieldItems ||
-                //       emailFieldItems.some(
-                //         ({ value: fieldValue }) => fieldValue === selectedValue,
-                //       ) ||
-                //       'Field is not an email field'
-                //     )
-                //   },
-                // }}
-                control={control}
-                name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
-                render={({
-                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                  field: { value, onBlur, ...rest },
-                }) => (
-                  <SingleSelect
-                    isDisabled={isLoading || isDisabled}
-                    placeholder="Select an email field from your form"
-                    items={emailFieldItems}
-                    onBlur={handleSubmit(onSubmit)}
-                    isClearable
-                    value={value}
-                    {...rest}
-                  />
-                )}
-              />
-            </Skeleton>
-            <FormErrorMessage>
-              {errors[STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]
-                ?.message ||
-                'The previously selected email field has been deleted'}
-            </FormErrorMessage>
-          </FormControl>
+          <FormLabel mb="0.75rem" textColor="secondary.700">
+            Notify Respondent in Step 1
+          </FormLabel>
+          <Skeleton isLoaded={!isLoading}>
+            <Controller
+              control={control}
+              name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
+              render={({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                field: { value, onBlur, ...rest },
+              }) => (
+                <SingleSelect
+                  isDisabled={isLoading || isDisabled}
+                  placeholder="Select an email field from your form"
+                  items={emailFieldItems}
+                  onBlur={handleSubmit(onSubmit)}
+                  isClearable
+                  value={value}
+                  {...rest}
+                />
+              )}
+            />
+          </Skeleton>
         </Box>
         <Box my="1.5rem">
           <FormLabel mb="0.75rem" textColor="secondary.700">

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -13,10 +13,11 @@ import isEmail from 'validator/lib/isEmail'
 import { MultirespondentFormSettings } from '~shared/types/form'
 
 import { OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES } from '~utils/formValidation'
-import { MultiSelect } from '~components/Dropdown'
+import { MultiSelect, SingleSelect } from '~components/Dropdown'
 import FormLabel from '~components/FormControl/FormLabel'
 import { TagInput } from '~components/TagInput'
 
+import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { useAdminFormWorkflow } from '~features/admin-form/create/workflow/hooks/useAdminFormWorkflow'
 
 import { useMutateFormSettings } from '../mutations'
@@ -27,18 +28,25 @@ interface MrfEmailNotificationsFormProps {
 }
 
 const WORKFLOW_EMAIL_MULTISELECT_NAME = 'email-multi-select'
+const STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME =
+  'step-1-notify-single-select'
 const OTHER_PARTIES_EMAIL_INPUT_NAME = 'other-parties-email-input'
 
 interface FormData {
   [WORKFLOW_EMAIL_MULTISELECT_NAME]: string[]
   [OTHER_PARTIES_EMAIL_INPUT_NAME]: string[]
+  [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]: string
 }
 
 const MrfEmailNotificationsForm = ({
   settings,
   isDisabled,
 }: MrfEmailNotificationsFormProps) => {
-  const { isLoading, formWorkflow } = useAdminFormWorkflow()
+  const {
+    isLoading,
+    formWorkflow,
+    emailFormFields = [],
+  } = useAdminFormWorkflow()
 
   const formWorkflowStepsWithStepNumber =
     formWorkflow?.map((step, index) => ({
@@ -46,12 +54,20 @@ const MrfEmailNotificationsForm = ({
       stepNumber: index + 1,
     })) ?? []
 
+  const emailFieldItems = emailFormFields.map(
+    ({ _id, questionNumber, title, fieldType }) => ({
+      label: `${questionNumber}. ${title}`,
+      value: _id,
+      icon: BASICFIELD_TO_DRAWER_META[fieldType].icon,
+    }),
+  )
+
   const filterInvalidEmails = useCallback((emails: string[]) => {
     if (!emails) return []
     return emails.filter((email) => isEmail(email))
   }, [])
 
-  const { stepsToNotify, emails } = settings
+  const { stepsToNotify, emails, stepOneEmailNotificationFieldId } = settings
 
   const {
     handleSubmit,
@@ -60,12 +76,15 @@ const MrfEmailNotificationsForm = ({
     getValues,
     formState: { errors },
   } = useForm<{
+    [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]: string
     [WORKFLOW_EMAIL_MULTISELECT_NAME]: string[]
     [OTHER_PARTIES_EMAIL_INPUT_NAME]: string[]
   }>({
     defaultValues: {
       [WORKFLOW_EMAIL_MULTISELECT_NAME]: stepsToNotify,
       [OTHER_PARTIES_EMAIL_INPUT_NAME]: emails,
+      [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]:
+        stepOneEmailNotificationFieldId,
     },
   })
 
@@ -74,29 +93,37 @@ const MrfEmailNotificationsForm = ({
   const handleSubmitEmailNotificationSettings = ({
     nextStaticEmails,
     nextStepsToNotify,
+    nextStepOneEmailNotificationFieldId,
   }: {
     nextStaticEmails: string[]
     nextStepsToNotify: string[]
+    nextStepOneEmailNotificationFieldId: string
   }) => {
     if (
       isEqual(nextStaticEmails, emails) &&
-      isEqual(nextStepsToNotify, stepsToNotify)
+      isEqual(nextStepsToNotify, stepsToNotify) &&
+      nextStepOneEmailNotificationFieldId === stepOneEmailNotificationFieldId
     ) {
       return
     }
     return mutateMrfEmailNotifications.mutate({
       emails: nextStaticEmails,
       stepsToNotify: nextStepsToNotify,
+      stepOneEmailNotificationFieldId: nextStepOneEmailNotificationFieldId,
     })
   }
 
   const onSubmit = (formData: FormData) => {
     const selectedSteps = formData[WORKFLOW_EMAIL_MULTISELECT_NAME]
     const selectedEmails = formData[OTHER_PARTIES_EMAIL_INPUT_NAME]
+    const selectedStepOneEmailNotificationFieldId =
+      formData[STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]
 
     return handleSubmitEmailNotificationSettings({
       nextStepsToNotify: selectedSteps,
       nextStaticEmails: selectedEmails,
+      nextStepOneEmailNotificationFieldId:
+        selectedStepOneEmailNotificationFieldId,
     })
   }
 
@@ -119,15 +146,39 @@ const MrfEmailNotificationsForm = ({
         <Text textStyle="h3" textColor="secondary.500" mb="0.25rem">
           Workflow outcome notifications
         </Text>
-        <Text textStyle="body-1" textColor="secondary.700" mb="2.5rem">
+        <Text textStyle="body-1" textColor="secondary.700" mb="1.5rem">
           Send an email to inform selected respondents when the form and/or
           workflow is complete.
         </Text>
-        <FormLabel textColor="secondary.700">
-          Notify respondents in your workflow
-        </FormLabel>
-        <Skeleton isLoaded={!isLoading}>
-          <Box my="0.75rem">
+        <Box>
+          <FormLabel mb="0.75rem" textColor="secondary.700">
+            Notify Respondent in Step 1
+          </FormLabel>
+          <Skeleton isLoaded={!isLoading}>
+            <Controller
+              control={control}
+              name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
+              render={({
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                field: { onBlur, ...rest },
+              }) => (
+                <SingleSelect
+                  isDisabled={isLoading || isDisabled}
+                  placeholder="Select an email field from your form"
+                  items={emailFieldItems}
+                  onBlur={handleSubmit(onSubmit)}
+                  isClearable
+                  {...rest}
+                />
+              )}
+            />
+          </Skeleton>
+        </Box>
+        <Box my="1.5rem">
+          <FormLabel mb="0.75rem" textColor="secondary.700">
+            Notify other respondents in your workflow
+          </FormLabel>
+          <Skeleton isLoaded={!isLoading}>
             <Controller
               control={control}
               name={WORKFLOW_EMAIL_MULTISELECT_NAME}
@@ -136,10 +187,12 @@ const MrfEmailNotificationsForm = ({
                 field: { value: values = [], onChange, onBlur, ...rest },
               }) => (
                 <MultiSelect
-                  items={formWorkflowStepsWithStepNumber.map((step) => ({
-                    label: `Respondent(s) in Step ${step.stepNumber}`,
-                    value: step._id,
-                  }))}
+                  items={formWorkflowStepsWithStepNumber
+                    .filter((step) => step.stepNumber > 1)
+                    .map((step) => ({
+                      label: `Respondent(s) in Step ${step.stepNumber}`,
+                      value: step._id,
+                    }))}
                   values={values}
                   onChange={onChange}
                   onBlur={handleSubmit(onSubmit)}
@@ -150,16 +203,17 @@ const MrfEmailNotificationsForm = ({
                 />
               )}
             />
-          </Box>
-        </Skeleton>
+          </Skeleton>
+        </Box>
       </Box>
-      <Box my="2rem">
+      <Box my="1.5rem">
         <FormControl
           isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
           isDisabled={isDisabled}
         >
           <FormLabel
             textColor="secondary.700"
+            mb="0.75rem"
             tooltipVariant="info"
             tooltipPlacement="top"
             tooltipText="Include the admin's email to inform them whenever a workflow is completed"

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -229,6 +229,7 @@ const ChildrenBody = ({
   const {
     ref: childNameRegisterRef,
     onChange: selectOnChange,
+    onBlur: selectOnBlur,
     ...selectRest
   } = register(childNamePath, validationRules)
 
@@ -421,6 +422,7 @@ const ChildrenBody = ({
             case MyInfoChildAttributes.ChildGender:
             case MyInfoChildAttributes.ChildRace:
             case MyInfoChildAttributes.ChildSecondaryRace: {
+              const { onBlur, ...rest } = register(fieldPath, validationRules)
               return (
                 <FormControl
                   key={key}
@@ -432,7 +434,7 @@ const ChildrenBody = ({
                     {MYINFO_ATTRIBUTE_MAP[subField].description}
                   </FormLabel>
                   <SingleSelect
-                    {...register(fieldPath, validationRules)}
+                    {...rest}
                     value={value}
                     items={
                       MYINFO_ATTRIBUTE_MAP[subField].fieldOptions as string[]

--- a/shared/constants/form.ts
+++ b/shared/constants/form.ts
@@ -64,6 +64,7 @@ export const MULTIRESPONDENT_FORM_SETTINGS_FIELDS = [
   'publicKey',
   'emails',
   'stepsToNotify',
+  'stepOneEmailNotificationFieldId',
 ] as const
 
 // Fields that are necessary for decrypting the cipherTexts given peer's private key

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -196,6 +196,7 @@ export interface MultirespondentFormBase extends FormBase {
   workflow: FormWorkflow
   emails: string[]
   stepsToNotify: FormWorkflowStepDto['_id'][]
+  stepOneEmailNotificationFieldId?: string
 }
 
 /**

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -916,7 +916,12 @@ describe('Form Model', () => {
 
     describe('Multirespondent form schema', () => {
       const MULTIRESPONDENT_FORM_DEFAULTS = merge(
-        { responseMode: 'multirespondent', stepsToNotify: [], emails: [] },
+        {
+          responseMode: 'multirespondent',
+          stepsToNotify: [],
+          emails: [],
+          stepOneEmailNotificationFieldId: '',
+        },
         FORM_DEFAULTS,
       )
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -380,6 +380,10 @@ const MultirespondentFormSchema = new Schema<IMultirespondentFormSchema>({
     ],
     required: true,
   },
+  stepOneEmailNotificationFieldId: {
+    type: String,
+    default: '',
+  },
 })
 
 const MultirespondentFormWorkflowPath = MultirespondentFormSchema.path(

--- a/src/app/modules/form/admin-form/admin-form.middlewares.ts
+++ b/src/app/modules/form/admin-form/admin-form.middlewares.ts
@@ -28,6 +28,7 @@ export const updateSettingsValidator = celebrate({
       Joi.string().email({ multiple: true }),
     ),
     stepsToNotify: Joi.array().items(Joi.string()),
+    stepOneEmailNotificationFieldId: Joi.string().allow(''),
     esrvcId: Joi.string().allow(''),
     hasCaptcha: Joi.boolean(),
     hasIssueNotification: Joi.boolean(),

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1,6 +1,5 @@
 import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
-import { email } from 'convict-format-with-validator'
 import {
   BasicField,
   FieldResponsesV3,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1,5 +1,6 @@
 import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
+import { email } from 'convict-format-with-validator'
 import {
   BasicField,
   FieldResponsesV3,
@@ -89,8 +90,8 @@ describe('multirespondent-submission.service', () => {
       const threeStepApprovalWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -118,7 +119,7 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
-          stepsToNotify: [stepOneId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
@@ -137,9 +138,9 @@ describe('multirespondent-submission.service', () => {
       expect(sendMrfWorkflowCompletionEmailSpy).not.toHaveBeenCalled()
       expect(sendMRFWorkflowStepEmailSpy).toHaveBeenCalledTimes(1)
       // destination emails are correct
-      expect(sendMRFWorkflowStepEmailSpy.mock.calls[0][0].emails).toEqual(
-        expectedEmails,
-      )
+      expect(
+        sendMRFWorkflowStepEmailSpy.mock.calls[0][0].emails,
+      ).toContainValues(expectedEmails)
       expect(sendMRFWorkflowStepEmailSpy.mock.calls[0][0].emails.length).toBe(
         expectedEmails.length,
       )
@@ -198,8 +199,8 @@ describe('multirespondent-submission.service', () => {
       const threeStepApprovalWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -227,7 +228,7 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
-          stepsToNotify: [stepOneId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
@@ -247,7 +248,7 @@ describe('multirespondent-submission.service', () => {
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
       // is approve email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeFalse()
-      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toEqual(
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
         expectedEmails,
       )
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails.length).toBe(
@@ -313,8 +314,8 @@ describe('multirespondent-submission.service', () => {
       const threeStepApprovalWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -342,7 +343,8 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[3]],
-          stepsToNotify: [stepOneId, stepTwoId, stepThreeId],
+          stepsToNotify: [stepTwoId, stepThreeId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
@@ -362,7 +364,7 @@ describe('multirespondent-submission.service', () => {
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
       // is approve email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeFalse()
-      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toEqual(
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
         expectedEmails,
       )
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails.length).toBe(
@@ -423,8 +425,8 @@ describe('multirespondent-submission.service', () => {
       const threeStepApprovalWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -452,7 +454,7 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
-          stepsToNotify: [stepOneId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
@@ -472,7 +474,7 @@ describe('multirespondent-submission.service', () => {
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
       // is approve email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeFalse()
-      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toEqual(
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
         expectedEmails,
       )
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails.length).toBe(
@@ -529,8 +531,8 @@ describe('multirespondent-submission.service', () => {
       const threeStepApprovalWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -558,7 +560,7 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
-          stepsToNotify: [stepOneId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
@@ -578,7 +580,7 @@ describe('multirespondent-submission.service', () => {
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
       // is rejected email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeTrue()
-      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toEqual(
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
         expectedEmails,
       )
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails.length).toBe(
@@ -641,8 +643,8 @@ describe('multirespondent-submission.service', () => {
       const fiveStepApprovalWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -682,7 +684,8 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: fiveStepApprovalWorkflow,
           emails: [expectedEmails[1], expectedEmails[2]],
-          stepsToNotify: [stepOneId, stepThreeId, stepFourId, stepFiveId],
+          stepsToNotify: [stepThreeId, stepFourId, stepFiveId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
@@ -702,7 +705,7 @@ describe('multirespondent-submission.service', () => {
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
       // is rejected email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeTrue()
-      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toEqual(
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
         expectedEmails,
       )
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails.length).toBe(
@@ -763,8 +766,8 @@ describe('multirespondent-submission.service', () => {
       const threeStepApprovalWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -792,7 +795,7 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
-          stepsToNotify: [stepOneId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber,
         encryptedPayload: {
@@ -812,7 +815,7 @@ describe('multirespondent-submission.service', () => {
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
       // is rejected email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeTrue()
-      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toEqual(
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
         expectedEmails,
       )
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails.length).toBe(
@@ -857,9 +860,9 @@ describe('multirespondent-submission.service', () => {
 
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
-      expect(sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails).toEqual(
-        ['email1@example.com'],
-      )
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
+      ).toContainValues(['email1@example.com'])
       expect(
         sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.length,
       ).toBe(1)
@@ -905,8 +908,8 @@ describe('multirespondent-submission.service', () => {
       const fourStepWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -938,7 +941,8 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: fourStepWorkflow,
           emails: [expectedEmails[3]],
-          stepsToNotify: [stepOneId, stepFourId],
+          stepsToNotify: [stepFourId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber,
         encryptedPayload: {
@@ -955,9 +959,9 @@ describe('multirespondent-submission.service', () => {
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
       // The emails sent to should only be the expected emails exactly
-      expect(sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails).toEqual(
-        expectedEmails,
-      )
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
+      ).toContainValues(expectedEmails)
       expect(
         sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.length,
       ).toBe(expectedEmails.length)
@@ -1003,8 +1007,8 @@ describe('multirespondent-submission.service', () => {
       const fourStepWorkflow: FormWorkflowStepDto[] = [
         {
           _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: emailFieldId1,
+          workflow_type: WorkflowType.Static,
+          emails: [],
           edit: [],
         },
         {
@@ -1036,7 +1040,8 @@ describe('multirespondent-submission.service', () => {
           _id: mockFormId,
           workflow: fourStepWorkflow,
           emails: [selectedEmails[3]],
-          stepsToNotify: [stepOneId, stepFourId],
+          stepsToNotify: [stepFourId],
+          stepOneEmailNotificationFieldId: emailFieldId1,
         } as IPopulatedMultirespondentForm,
         currentStepNumber,
         encryptedPayload: {
@@ -1052,6 +1057,322 @@ describe('multirespondent-submission.service', () => {
 
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('step one email notification field id', () => {
+    const mockFormId = new ObjectId().toHexString()
+    const mockSubmissionId = new ObjectId().toHexString()
+
+    it('sends completion email to step one email notification field id, stepsToNotify and static emails when step one email notification field id is set', async () => {
+      // Arrange
+      const sendMrfWorkflowCompletionEmailSpy = jest.spyOn(
+        MailService,
+        'sendMrfWorkflowCompletionEmail',
+      )
+      const stepOneEmailNotificationFieldId = new ObjectId().toHexString()
+      const stepOneEditEmailFieldId = new ObjectId().toHexString()
+
+      const expectedStepOneEmail = 'expected_step_one_email@example.com'
+      const notExpectedStepOneEmail = 'not_expected_step_one_email@example.com'
+      const expectedStaticEmail = 'expected_static_email@example.com'
+      const expectedStepTwoEmail = 'expected_step_two_static_email@example.com'
+
+      const expectedEmails = [
+        expectedStepOneEmail,
+        expectedStaticEmail,
+        expectedStepTwoEmail,
+      ]
+
+      const stepOneId = new ObjectId().toHexString()
+      const stepTwoId = new ObjectId().toHexString()
+
+      const workflow: FormWorkflowStepDto[] = [
+        {
+          _id: stepOneId,
+          workflow_type: WorkflowType.Dynamic,
+          field: stepOneEditEmailFieldId,
+          edit: [stepOneEditEmailFieldId],
+        },
+        {
+          _id: stepTwoId,
+          workflow_type: WorkflowType.Static,
+          emails: [expectedStepTwoEmail],
+          edit: [],
+        },
+      ]
+
+      const form: IPopulatedMultirespondentForm = {
+        _id: mockFormId,
+        workflow,
+        emails: [expectedStaticEmail],
+        stepsToNotify: [stepOneId, stepTwoId], // Including step one in stepsToNotify
+        stepOneEmailNotificationFieldId,
+      } as IPopulatedMultirespondentForm
+
+      const submissionResponses: FieldResponsesV3 = {
+        [stepOneEmailNotificationFieldId]: {
+          fieldType: BasicField.Email,
+          answer: {
+            value: expectedStepOneEmail,
+          },
+        },
+        [stepOneEditEmailFieldId]: {
+          fieldType: BasicField.Email,
+          answer: {
+            value: notExpectedStepOneEmail,
+          },
+        },
+      }
+
+      // Act
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submissionId: mockSubmissionId,
+        form,
+        currentStepNumber: workflow.length - 1,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+          responses: submissionResponses,
+          workflowStep: workflow.length - 1,
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+      })
+
+      // Assert
+      expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
+      ).toContainValues(expectedEmails)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.length,
+      ).toBe(expectedEmails.length)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.includes(
+          notExpectedStepOneEmail,
+        ),
+      ).toBe(false)
+    })
+
+    it('does not send completion to step one email notification field id but still sends to stepsToNotify and static emails when step one email notification field id is not set', async () => {
+      // Arrange
+      const sendMrfWorkflowCompletionEmailSpy = jest.spyOn(
+        MailService,
+        'sendMrfWorkflowCompletionEmail',
+      )
+      const staticEmail = 'expected_static_email@example.com'
+      const stepTwoEmail = 'expected_step_two_static_email@example.com'
+      const expectedEmails = [staticEmail, stepTwoEmail]
+
+      const stepOneId = new ObjectId().toHexString()
+      const stepTwoId = new ObjectId().toHexString()
+
+      const workflow: FormWorkflowStepDto[] = [
+        {
+          _id: stepOneId,
+          workflow_type: WorkflowType.Static,
+          emails: [],
+          edit: [],
+        },
+        {
+          _id: stepTwoId,
+          workflow_type: WorkflowType.Static,
+          emails: [stepTwoEmail],
+          edit: [],
+        },
+      ]
+
+      const form: IPopulatedMultirespondentForm = {
+        _id: mockFormId,
+        workflow,
+        emails: [staticEmail],
+        stepsToNotify: [stepTwoId],
+      } as IPopulatedMultirespondentForm
+
+      // Act
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submissionId: mockSubmissionId,
+        form,
+        currentStepNumber: workflow.length - 1,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+          workflowStep: workflow.length - 1,
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+      })
+
+      // Assert
+      expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
+      ).toContainValues(expectedEmails)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.length,
+      ).toBe(expectedEmails.length)
+    })
+
+    it('does not send completion email to step one email notification field id but still sends to stepsToNotify and static emails when it is deleted', async () => {
+      // Arrange
+      const sendMrfWorkflowCompletionEmailSpy = jest.spyOn(
+        MailService,
+        'sendMrfWorkflowCompletionEmail',
+      )
+      const stepOneEmailNotificationFieldId = new ObjectId().toHexString()
+      const staticEmail = 'expected_static_email@example.com'
+      const stepTwoEmail = 'expected_step_two_static_email@example.com'
+
+      const stepOneId = new ObjectId().toHexString()
+      const stepTwoId = new ObjectId().toHexString()
+      const expectedEmails = [staticEmail, stepTwoEmail]
+
+      const workflow: FormWorkflowStepDto[] = [
+        {
+          _id: stepOneId,
+          workflow_type: WorkflowType.Static,
+          emails: [],
+          edit: [],
+        },
+        {
+          _id: stepTwoId,
+          workflow_type: WorkflowType.Static,
+          emails: [stepTwoEmail],
+          edit: [],
+        },
+      ]
+
+      const form: IPopulatedMultirespondentForm = {
+        _id: mockFormId,
+        workflow,
+        emails: [staticEmail],
+        stepsToNotify: [stepTwoId],
+        stepOneEmailNotificationFieldId,
+      } as IPopulatedMultirespondentForm
+
+      const submissionResponses: FieldResponsesV3 = {
+        // stepOneEmailNotificationFieldId is not present in responses
+      }
+
+      // Act
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submissionId: mockSubmissionId,
+        form,
+        currentStepNumber: workflow.length - 1,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+          responses: submissionResponses,
+          workflowStep: workflow.length - 1,
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+      })
+
+      // Assert
+      expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
+      ).toContainValues(expectedEmails)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.length,
+      ).toBe(expectedEmails.length)
+    })
+
+    it('does not send duplicate completion email to step one in stepsToNotify', async () => {
+      // Arrange
+      const sendMrfWorkflowCompletionEmailSpy = jest.spyOn(
+        MailService,
+        'sendMrfWorkflowCompletionEmail',
+      )
+      const stepOneEmailNotificationFieldId = new ObjectId().toHexString()
+      const emailFieldId2 = new ObjectId().toHexString()
+
+      const expectedStepOneEmail = 'expected_step_one_email@example.com'
+      const notExpectedStepOneEmail = 'not_expected_step_one_email@example.com'
+      const expectedStaticEmail = 'expected_static_email@example.com'
+      const expectedStepTwoEmail = 'expected_step_two_static_email@example.com'
+
+      const expectedEmails = [
+        expectedStepOneEmail,
+        expectedStaticEmail,
+        expectedStepTwoEmail,
+      ]
+
+      const stepOneId = new ObjectId().toHexString()
+      const stepTwoId = new ObjectId().toHexString()
+
+      const workflow: FormWorkflowStepDto[] = [
+        {
+          _id: stepOneId,
+          workflow_type: WorkflowType.Dynamic,
+          field: emailFieldId2,
+          edit: [emailFieldId2],
+        },
+        {
+          _id: stepTwoId,
+          workflow_type: WorkflowType.Static,
+          emails: [expectedStepTwoEmail],
+          edit: [],
+        },
+      ]
+
+      const form: IPopulatedMultirespondentForm = {
+        _id: mockFormId,
+        workflow,
+        emails: [expectedStaticEmail],
+        stepsToNotify: [stepOneId, stepTwoId], // Including step one in stepsToNotify
+        stepOneEmailNotificationFieldId,
+      } as IPopulatedMultirespondentForm
+
+      const submissionResponses: FieldResponsesV3 = {
+        [stepOneEmailNotificationFieldId]: {
+          fieldType: BasicField.Email,
+          answer: {
+            value: expectedStepOneEmail,
+          },
+        },
+        [emailFieldId2]: {
+          fieldType: BasicField.Email,
+          answer: {
+            value: notExpectedStepOneEmail,
+          },
+        },
+      }
+
+      // Act
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submissionId: mockSubmissionId,
+        form,
+        currentStepNumber: workflow.length - 1,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+          responses: submissionResponses,
+          workflowStep: workflow.length - 1,
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+      })
+
+      // Assert
+      expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
+      ).toContainValues(expectedEmails)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.length,
+      ).toBe(expectedEmails.length)
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.includes(
+          notExpectedStepOneEmail,
+        ),
+      ).toBe(false)
     })
   })
 })

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -54,6 +54,15 @@ export const createMultirespondentSubmissionDto = (
   }
 }
 
+export const getEmailFromResponses = (
+  fieldId: string,
+  responses: FieldResponsesV3,
+): string | null => {
+  const field = responses[fieldId]
+  if (!field || field.fieldType !== BasicField.Email) return null // Not an error, misconfigured or respondent has not filled.
+  return field.answer.value
+}
+
 export const retrieveWorkflowStepEmailAddresses = (
   step: FormWorkflowStepDto,
   responses: FieldResponsesV3,
@@ -64,9 +73,9 @@ export const retrieveWorkflowStepEmailAddresses = (
       return ok(step.emails)
     }
     case WorkflowType.Dynamic: {
-      const field = responses[step.field]
-      if (!field || field.fieldType !== BasicField.Email) return ok([]) // Not an error, misconfigured or respondent has not filled.
-      return ok([field.answer.value])
+      const email = getEmailFromResponses(step.field, responses)
+      if (!email) return ok([])
+      return ok([email])
     }
     default: {
       return err(new InvalidWorkflowTypeError())

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -332,6 +332,7 @@ export interface IMultirespondentForm extends IForm {
   publicKey: string
   workflow: FormWorkflowDto
   stepsToNotify: string[]
+  stepOneEmailNotificationFieldId: string
 }
 
 export type IMultirespondentFormSchema = IMultirespondentForm & IFormSchema


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The current placement of the email field for step 1 respondent is placed at the workflow builder step 1. At the point of time where admins are filling up the workflow, they are not thinking about email notifications, causing confusion to admins who have to context switch.

Closes FRM-1885

## Solution
<!-- How did you solve the problem? -->
- A more natural position is the settings page under 'email notifications'.

## Technical notes 
Shifting email step id from `form.workflow[0].field` to `form.stepOneEmailFieldId`:
1. On the `<SettingsPage />` `stepsToNotify` and `emails` are updated on blur. Thus, `stepOneEmailFieldId` should also retain a similar behaviour of updating on blur.
2. It is hoisted to the `form`-level so as to retain principle of locality.
3. The mutation is also updated as it should not be referenced by the `workflow.mutation` but rather the `settings.mutation`.

Datafix: 
- since the values are being migrated from 1 place to another. A data fix is required to move the prev selected email field id stored in the workflow element 0 to the new  `stepOneEmailFieldId` field in the root form document. 
Note that since the `field` property in element 0 and `workflowType` of the workflow array is not being used anymore and can be left as is.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="611" alt="image" src="https://github.com/user-attachments/assets/12b106ff-2713-4871-9a77-17638f876825">

**AFTER**:
<img width="775" alt="image" src="https://github.com/user-attachments/assets/86285573-2536-4671-8b6a-94409acc7a6c">

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: Selecting step 1 email field sends completion email to step 1 email response value: 
- [ ] Create MRF with email field 
- [ ] Create 2 steps 
- [ ] Add email field to step 1 of workflow 
- [ ] Go to email notifications settings page 
- [ ] Add step 2 to notify other respondents 
- [ ] Add the email field to step 1 email field 
- [ ] Add other parties static emails 
- [ ] Complete the mrf flow 
- [ ] Assert that email is sent to all parties (this includes step 1 email selected, step 2 email and static emails) 

TC2:  Selecting step 1 email field sends approve/reject email to step 1 email response value: 
- [ ] From TC1 
- [ ] Make step 2 an approval step with yes, no field 
- [ ] Approve / reject the workflow and verify the email is sent to all parties (this includes step 1 email selected, step 2 email and static emails) 

TC3: Deleting the email field causes email to not send to that step 1 party anymore 
- [ ] From TC2
- [ ] Delete the email field selected previously 
- [ ] Complete the MRF workflow
- [ ] Verify that step 2 email and static emails receive the outcome but there is no email for the previous step 1 email (since the email field has been deleted) 