### PR TITLE
chore: fix typo on runner tag

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -38,7 +38,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.frontend == 'true' }}
     # Operating System
-    runs-on: ubuntu-latest\
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Our chromatic-frontend action is not running due to it waiting forever for the gh runner `ubuntu-latest\`. There is a typo on the stray `\` at the end of runner tag. GH does not detect if the runner name exist or not and thus the action keeps waiting for the non-existent runner to be available (which will never be since it doesn't even exist).

## Solution
<!-- How did you solve the problem? -->

Remove the typo.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
