### PR TITLE
fix(config): default S3 endpoint with region

### DIFF
--- a/src/app/config/schema.ts
+++ b/src/app/config/schema.ts
@@ -502,7 +502,7 @@ export const loadS3BucketUrlSchema = ({
       doc: 'Endpoint for S3 buckets',
       format: (val) =>
         validateS3BucketUrl(val, { isDev, hasTrailingSlash: false, region }),
-      default: 'https://s3.ap-southeast-1.amazonaws.com', // NOTE NO TRAILING / AT THE END OF THIS URL!
+      default: `https://s3.${region}.amazonaws.com`, // NOTE NO TRAILING / AT THE END OF THIS URL!
       env: 'AWS_ENDPOINT',
     },
     attachmentBucketUrl: {


### PR DESCRIPTION
## Problem
`AWS_ENDPOINT` defaults to an S3 endpoint hard-coded to ap-southeast-1. This affects deployment scenarios to other AWS regions, unless `AWS_ENDPOINT` is specified to line up with `AWS_REGION`.


## Solution

It can be argued that the default for `AWS_ENDPOINT` should be driven by the specific region that FormSG is deployed to, so accordingly, at runtime, change `loadBucketS3UrlSchema()` so that the default endpoint for S3 buckets reflects the region where FormSG is currently deployed.