### PR TITLE
chore: remove legacy routes

### DIFF
--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -9,10 +9,7 @@ import url from 'url'
 import config from '../../config/config'
 import { FrontendRouter } from '../../modules/frontend/frontend.routes'
 import * as IntranetMiddleware from '../../modules/intranet/intranet.middleware'
-import {
-  LEGACY_MYINFO_ROUTER_PREFIX,
-  MYINFO_ROUTER_PREFIX,
-} from '../../modules/myinfo/myinfo.constants'
+import { MYINFO_ROUTER_PREFIX } from '../../modules/myinfo/myinfo.constants'
 import { MyInfoRouter } from '../../modules/myinfo/myinfo.routes'
 import { SgidRouter } from '../../modules/sgid/sgid.routes'
 import { ApiRouter } from '../../routes/api'
@@ -118,8 +115,6 @@ const loadExpressApp = async (connection: Connection) => {
   app.use('/singpass/.well-known/jwks.json', SpOidcJwksRouter)
   // Registered routes with sgID
   app.use('/sgid', SgidRouter)
-  // Use constant for registered routes with MyInfo servers
-  app.use(LEGACY_MYINFO_ROUTER_PREFIX, MyInfoRouter)
   app.use(MYINFO_ROUTER_PREFIX, MyInfoRouter)
 
   // Legacy frontend routes which may still be in use

--- a/src/app/modules/myinfo/myinfo.constants.ts
+++ b/src/app/modules/myinfo/myinfo.constants.ts
@@ -7,8 +7,6 @@ import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
  * registered with MyInfo.
  */
 export const MYINFO_ROUTER_PREFIX = '/mi'
-// To support backwards compatibility with the old MyInfo router prefix
-export const LEGACY_MYINFO_ROUTER_PREFIX = '/myinfo'
 
 /**
  * Path to be added after MYINFO_ROUTER_PREFIX for the login


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

No longer require these routes as we've migrated them.
Closes FRM-1895

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
