### PR TITLE
chore: avoid duplicated package name

### DIFF
--- a/scripts/20230317_whitespace_issue/package.json
+++ b/scripts/20230317_whitespace_issue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "202202117_multi-language-forms-stats",
+  "name": "20230317_whitespace_issue",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Causes `jest-haste-map` to throw a warning relating to duplicated package names.

Generally this is harmless, but it is trivial to fix as well. Correcting this helps to avoid bad habits forming on the repository.

## Solution
<!-- How did you solve the problem? -->

Likely that this `package.json` file was copied from another file and the package name was forgotten to be renamed.

Since this `package.json` belongs in the `scripts/20230317_whitespace_issue` folder, it should use the folder name as it would be unique enough.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  