### PR TITLE
feat: add migration script

### DIFF
--- a/scripts/20241029_copy-workflow-step1-email-field-to-settings/copy-workflow-step1-email-field-to-settings.js
+++ b/scripts/20241029_copy-workflow-step1-email-field-to-settings/copy-workflow-step1-email-field-to-settings.js
@@ -1,0 +1,43 @@
+/* eslint-disable */
+
+/**
+ * Copies email notification field from workflow[0].field over to its new location at `form.stepOneEmailNotificationFieldId`
+ */
+
+// BEFORE
+// COUNT existing number of forms with responseMode = multirespondent, workflow[0].workflow_type = dynamic, status = PUBLIC
+// Checks that we're only updating the correct forms
+db.getCollection('forms').find({
+  responseMode: 'multirespondent',
+  'workflow.0.workflow_type': 'dynamic',
+  status: 'PUBLIC',
+})
+
+// UPDATE
+db.getCollection('forms')
+  .find({
+    responseMode: 'multirespondent',
+    'workflow.0.workflow_type': 'dynamic',
+    status: 'PUBLIC',
+  })
+  .map((d) => {
+    db.getCollection('forms').updateOne(
+      {
+        _id: d._id,
+      },
+      {
+        $set: {
+          stepOneEmailNotificationFieldId: d.workflow[0].field.toString(),
+        },
+      },
+    )
+  })
+
+// After
+// Should be higher than count in BEFORE
+db.getCollection('forms').find({
+    responseMode: 'multirespondent',
+    stepOneEmailNotificationFieldId: { $exists: true },
+    status: 'PUBLIC',
+  })
+  


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1896


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

**New scripts**:

- `20241029_copy-workflow-step1-email-field-to-settings` : Copies email notification field from workflow[0].field over to its new location at `form.stepOneEmailNotificationFieldId`