### PR TITLE
fix: change email summary response row to represent table row instead of cell

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -270,11 +270,20 @@ describe('multirespondent-submission.utils', () => {
       const formFields: FormFieldSchema[] = [
         {
           _id: '1',
-          title: 'Table',
+          title: 'Table of Name and Age',
           fieldType: BasicField.Table,
           columns: [
             { _id: 'col1', title: 'Name' },
             { _id: 'col2', title: 'Age' },
+          ],
+        } as ITableFieldSchema,
+        {
+          _id: '2',
+          title: 'Table of Hobbies',
+          fieldType: BasicField.Table,
+          columns: [
+            { _id: 'col3', title: 'Hobby' },
+            { _id: 'col4', title: 'Years' },
           ],
         } as ITableFieldSchema,
       ]
@@ -286,15 +295,34 @@ describe('multirespondent-submission.utils', () => {
             { col1: 'Bob', col2: '25' },
           ],
         } as TableResponseV3,
+        '2': {
+          fieldType: BasicField.Table,
+          answer: [
+            { col3: 'Swimming', col4: '5' },
+            { col3: 'Reading', col4: '10' },
+          ],
+        } as TableResponseV3,
       }
 
       const result = getQuestionTitleAnswerString({ formFields, responses })
 
       expect(result).toEqual([
-        { question: '[Table] Row 1: Name', answer: 'Alice' },
-        { question: '[Table] Row 1: Age', answer: '30' },
-        { question: '[Table] Row 2: Name', answer: 'Bob' },
-        { question: '[Table] Row 2: Age', answer: '25' },
+        {
+          question: '[Table] Table of Name and Age (Name; Age)',
+          answer: 'Alice; 30',
+        },
+        {
+          question: '[Table] Table of Name and Age (Name; Age)',
+          answer: 'Bob; 25',
+        },
+        {
+          question: '[Table] Table of Hobbies (Hobby; Years)',
+          answer: 'Swimming; 5',
+        },
+        {
+          question: '[Table] Table of Hobbies (Hobby; Years)',
+          answer: 'Reading; 10',
+        },
       ])
     })
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -190,16 +190,29 @@ export const getQuestionTitleAnswerString = ({
           {} as Record<string, string>,
         )
 
-        for (const [index, row] of response.answer.entries()) {
-          for (const [colId, colAns] of Object.entries(row)) {
-            if (!(colId in idToColTitleMap)) continue
-            const colTitle = idToColTitleMap[colId]
+        for (const row of response.answer) {
+          const validColumns = Object.entries(row).filter(
+            ([colId]) => colId in idToColTitleMap,
+          )
 
-            questionAnswerPair.push({
-              question: `[Table] Row ${index + 1}: ${colTitle}`,
-              answer: colAns ?? '',
+          const delimitedColumnTitles = validColumns
+            .map(([colId]) => {
+              const colTitle = idToColTitleMap[colId]
+              return `${colTitle}`
             })
-          }
+            .join('; ')
+
+          const delimitedColumnAnswers = validColumns
+            .map(([, colAns]) => colAns ?? '')
+            .join('; ')
+
+          const question = `[Table] ${formField.title} (${delimitedColumnTitles})`
+          const answer = delimitedColumnAnswers
+
+          questionAnswerPair.push({
+            question,
+            answer,
+          })
         }
         continue
       case BasicField.Radio:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Readability issue reported by admins splitting the table into per cell in the mrf email outcome notifications.  

Closes FRM-1898

## Solution
<!-- How did you solve the problem? -->
Each row represents a table row instead of an individual table cell.  (See option 3 in linear ticket) 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="566" alt="image" src="https://github.com/user-attachments/assets/f9b02719-8258-44aa-8eb5-4b580b0e8c26">

**AFTER**:
<!-- [insert screenshot here] -->
<img width="496" alt="image" src="https://github.com/user-attachments/assets/82751e0e-5ade-4db8-a514-7788d4e12f67">

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create an mrf with 1 step and a table field (with multiple rows and cols) to be filled in step 1. Set your email to be notified in email notif settings.
- [ ] Submit the form
- [ ] Verify that the format follows the after screenshot 