### PR TITLE
fix: set table field required false to cols instead of whole field

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.assistance.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.assistance.service.ts
@@ -51,13 +51,13 @@ const mapSuggestedFormFieldToFieldCreateDto = (
       return {
         fieldType: BasicField.Table,
         title: tableFormField.title,
-        required: tableFormField.required,
+        required: true,
         description: tableFormField.description ?? '',
         columns: tableFormField.columns.map((colTitle) => {
           // Only support short text columns for now
           return {
             title: colTitle,
-            required: true,
+            required: tableFormField.required,
             columnType: BasicField.ShortText,
             ValidationOptions: {
               customVal: null,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The table field itself is always `required: true` and its col fields can be `required: false`. 
However, the table field was allowed to be set to `required: false` by the AI response.  

Closes FRM-1899

## Solution
<!-- How did you solve the problem? -->
Apply the `required: false` to the column fields instead of the table field itself.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**AFTER**:
 <img width="925" alt="image" src="https://github.com/user-attachments/assets/c69f9181-20f2-4e8d-8a0c-c2bf7ba251cd">

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: not required table field applies to column fields only: 
- [ ] Use MFB to create a form - include `add a table field type that is not required` in the prompt. 
- [ ] Ensure that such a table field is created and the optional is applied to the column fields instead of the table field itself. 

TC2: required table fields work as usual 
- [ ] Use MFB to create a form - include `add a table field type that is required` in the prompt. 
- [ ] Ensure that such a table field is created and that the table field and its column fields are set to required. 