### PR TITLE
fix: add debounce to break infinite call loop

### DIFF
--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -21,7 +21,7 @@ import {
   VisuallyHidden,
   VStack,
 } from '@chakra-ui/react'
-import { get } from 'lodash'
+import { debounce, get } from 'lodash'
 import simplur from 'simplur'
 
 import { DATE_DISPLAY_FORMAT } from '~shared/constants/dates'
@@ -439,13 +439,15 @@ const ChildrenBody = ({
                     items={
                       MYINFO_ATTRIBUTE_MAP[subField].fieldOptions as string[]
                     }
-                    onChange={(option) =>
-                      // This is bad practice but we have no choice because our
-                      // custom Select doesn't forward the event.
-                      // FIXME: Fix types
-                      // @ts-expect-error type inference issue
-                      setValue(fieldPath, option, { shouldValidate: true })
-                    }
+                    onChange={debounce(
+                      (option) =>
+                        // This is bad practice but we have no choice because our
+                        // custom Select doesn't forward the event.
+                        // FIXME: Fix types
+                        setValue(fieldPath, option, { shouldValidate: true }),
+                      200,
+                      { leading: true },
+                    )}
                   />
                   <FormErrorMessage>
                     {childrenSubFieldError?.message}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Child record fields that uses combobox (aka dropdown) freezes the page at times. This makes the form completely unusable and cannot be submitted.

Found that there's a infinite `setValue` on the combobox which starves the thread causing the page to be unresponsive.

## Solution
<!-- How did you solve the problem? -->

Adding a debounce seemed to break the loop. This is a temporary fix as we have not found the root cause of why there's an infinite loop.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression on myinfo child fields combo box data**
- [ ] Create a email form with myinfo child fields with child data of Race, Secondary Race, Vaccination Status 
- [ ] As an admin through the create builder
  - [ ] Select Race field and select "Afghan"
  - [ ] Ensure that the page is still interactive by scrolling up and down, clicking on other fields
  - [ ] Select Secondary Race and select "African 
  - [ ] Ensure that the page is still interactive by scrolling up and down, clicking on other fields
- [ ] As a respondent switch the browser to render under mobile view mode
  - [ ] Select Race field and select "Afghan"
  - [ ] Ensure that the page is still interactive by scrolling up and down, clicking on other fields
  - [ ] Select Secondary Race and select "African 
  - [ ] Ensure that the page is still interactive by scrolling up and down, clicking on other fields