### PR TITLE
fix: handle string response in DTO for date validation object

### DIFF
--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -46,16 +46,15 @@ export const normalizeDateToUtc = (date: Date | null) => {
 }
 
 export const loadDateFromNormalizedDate = (date: string | Date | null) => {
-  if (typeof date === 'string') {
-    const parsedDate = parseISO(date)
-    return new Date(
-      parsedDate.getUTCFullYear(),
-      parsedDate.getUTCMonth(),
-      parsedDate.getUTCDate(),
-    )
-  }
   if (!date) return date
-  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  const parsedDate = typeof date === 'string' ? parseISO(date) : date
+  return new Date(
+    Date.UTC(
+      parsedDate.getFullYear(),
+      parsedDate.getMonth(),
+      parsedDate.getDate(),
+    ),
+  )
 }
 
 /**

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -45,7 +45,15 @@ export const normalizeDateToUtc = (date: Date | null) => {
   return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
 }
 
-export const loadDateFromNormalizedDate = (date: Date | null) => {
+export const loadDateFromNormalizedDate = (date: string | Date | null) => {
+  if (typeof date === 'string') {
+    const parsedDate = parseISO(date)
+    return new Date(
+      parsedDate.getUTCFullYear(),
+      parsedDate.getUTCMonth(),
+      parsedDate.getUTCDate(),
+    )
+  }
   if (!date) return date
   return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
 }

--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -18,8 +18,9 @@ export enum InvalidDaysOptions {
 }
 
 export type DateValidationOptions = {
-  customMaxDate: Date | null
-  customMinDate: Date | null
+  // NOTE: the customMaxDate and customMinDate becomes a string when fetched as a response from the server.
+  customMaxDate: Date | string | null
+  customMinDate: Date | string | null
   selectedDateValidation: DateSelectedValidation | null
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Frontend crashes when the below steps are produced -> preventing MRF with date fields with validation from being edited and submitted  
![image](https://github.com/user-attachments/assets/12de0310-9798-4d8e-bc93-8d61e57a6397)

To reproduce:
1. create a date field with custom date range validation
2. set the date field as editable in step 2 of mrf
3. step 2 fails to submit due to the screenshotted error 

See linear ticket for more info. 

Closes FRM-1900

## Solution
<!-- How did you solve the problem? -->
Handle the case where the DTO is not a date object but rather a string. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create an mrf with date field with custom date range validation.
- [ ] Create 2 steps in workflow, allow date field to be modified for both steps. 
- [ ] Submit the 2 steps, should be able to submit without FE crashing.  