### PR TITLE
fix: add missed v3 to log

### DIFF
--- a/src/app/utils/field-validation/validators/checkboxValidator.ts
+++ b/src/app/utils/field-validation/validators/checkboxValidator.ts
@@ -291,7 +291,7 @@ const makeValidOptionsValidatorV3: ResponseValidatorConstructor<
     (!answer.value.includes(CLIENT_CHECKBOX_OTHERS_INPUT_VALUE) ||
       othersRadioButton)
     ? right(response)
-    : left(`CheckboxValidator:\t answer is not valid`)
+    : left(`CheckboxValidatorV3:\t answer is not valid`)
 }
 
 /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
One of the logs missed the V3 identifier which is used to identify if validation failures are from the old validators or the new V3 validators. 

Closes FRM-1688

## Solution
Add the missing log 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
-  No - this PR is backwards compatible  