### PR TITLE
fix: use settimeout instead of debounce

### DIFF
--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -21,7 +21,7 @@ import {
   VisuallyHidden,
   VStack,
 } from '@chakra-ui/react'
-import { debounce, get } from 'lodash'
+import { get } from 'lodash'
 import simplur from 'simplur'
 
 import { DATE_DISPLAY_FORMAT } from '~shared/constants/dates'
@@ -439,15 +439,20 @@ const ChildrenBody = ({
                     items={
                       MYINFO_ATTRIBUTE_MAP[subField].fieldOptions as string[]
                     }
-                    onChange={debounce(
-                      (option) =>
+                    onChange={(option) => {
+                      // prevent updates if there's no change to the values
+                      // there's an infinite loop on the update
+                      // upgrading to v8.xx, or v9.xx doesn't seem to have resolved the issue
+                      // https://github.com/downshift-js/downshift/issues/1511#issuecomment-1598307130
+
+                      setTimeout(() =>
                         // This is bad practice but we have no choice because our
                         // custom Select doesn't forward the event.
                         // FIXME: Fix types
+                        // @ts-expect-error type inference issue
                         setValue(fieldPath, option, { shouldValidate: true }),
-                      200,
-                      { leading: true },
-                    )}
+                      )
+                    }}
                   />
                   <FormErrorMessage>
                     {childrenSubFieldError?.message}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

1. Another stab at resolving #7848.
  - Was found that this is not an isolated issue in FormSG, but also happens elsewhere. 

## Solution
<!-- How did you solve the problem? -->


Following https://github.com/downshift-js/downshift/issues/1511#issuecomment-1598307130 which elegantly uses `setTimeout` instead of `debounce`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->

**Regression on myinfo child fields combo box data**
- [ ] Create a email form with myinfo child fields with child data of Race, Secondary Race, Vaccination Status 
- [ ] As an admin through the create builder
  - [ ] Select Race field and select "Afghan"
  - [ ] Ensure that the page is still interactive by scrolling up and down, clicking on other fields
  - [ ] Select Secondary Race and select "African 
  - [ ] Ensure that the page is still interactive by scrolling up and down, clicking on other fields
- [ ] As a respondent switch the browser to render under mobile view mode
  - [ ] Select Race field and select "Afghan"
  - [ ] Ensure that the page is still interactive by scrolling up and down, clicking on other fields
  - [ ] Select Secondary Race and select "African 
  - [ ] Ensure that the page is still interactive by scrolling up and down, clicking on other fields