### PR TITLE
fix(calendar): incorrect date conversion

### DIFF
--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -41,13 +41,18 @@ export const isDateAfterToday = (date: number | Date) => {
 }
 
 export const normalizeDateToUtc = (date: Date | null) => {
-  if (!date) return date
+  if (!date) return null
   return new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
 }
 
-export const loadDateFromNormalizedDate = (date: Date | null) => {
+export const loadDateFromNormalizedDate = (date: string | Date | null) => {
   if (!date) return date
-  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  const parsedDate = typeof date === 'string' ? parseISO(date) : date
+  return new Date(
+    parsedDate.getUTCFullYear(),
+    parsedDate.getUTCMonth(),
+    parsedDate.getUTCDate(),
+  )
 }
 
 /**

--- a/shared/types/field/dateField.ts
+++ b/shared/types/field/dateField.ts
@@ -18,8 +18,9 @@ export enum InvalidDaysOptions {
 }
 
 export type DateValidationOptions = {
-  customMaxDate: Date | null
-  customMinDate: Date | null
+  // NOTE: the customMaxDate and customMinDate becomes a string when fetched as a response from the server.
+  customMaxDate: Date | string | null
+  customMinDate: Date | string | null
   selectedDateValidation: DateSelectedValidation | null
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-1901

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression Test**
#### Selecting dates on edges should be allowed
- [ ] Create a date picker field
- [ ] Configure Date validation "custom date  range" and 10 Nov to 20 Nov
- [ ] Ensure that picker can be selected on 10 Nov
- [ ] Ensure that picker can be selected on 20 Nov