### PR TITLE
fix: drawer date picker invalid selection bug

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -136,8 +136,8 @@ const transformDateEditFormToField = (
     case DateSelectedValidation.Custom: {
       nextValidationOptions = {
         selectedDateValidation: inputs.dateValidation.selectedDateValidation,
-        customMinDate: inputs.dateValidation.customMinDate,
-        customMaxDate: inputs.dateValidation.customMaxDate,
+        customMinDate: normalizeDateToUtc(inputs.dateValidation.customMinDate),
+        customMaxDate: normalizeDateToUtc(inputs.dateValidation.customMaxDate),
       }
     }
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
![image](https://github.com/user-attachments/assets/cb833699-7888-4c19-8440-08df2ba40fde)
There is a mismatch in valid dates to select and the selection for custom date validation 

Closes FRM-1901

## Solution
**Explanation of bug:** 
The reason why there is a mismatch is because the date picker component fetches the valid start and end time from either the react client or server.

- for the client: we are using local time
- for the server: it is stored in UTC -> we need to convert to local time

the problem causing this bug is:
- when the drawer is extended, the start and end validation time is from the client which provides the date in local time, but is converted once again to local time
- when the server provides the dates: it is converted from utc -> sg time as expected.

**Fix:** 
The EditDate component input which is providing the date to the DateField should be normalized to UTC. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
date reflects correctly after custom date range selection: 
- [ ] Create a storage mode form with form field
- [ ] Select custom date validation and check the range on the form field builder is correct when the drawer is extended. 
- [ ] Save the form field setting. 
- [ ] Try to preview the form and check the date field. ensure the valid date range is correct.
- [ ] Try to submit the form and check the date field. ensure the valid date range is correct.