### PR TITLE
fix: add validation rules to controller

### DIFF
--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -432,6 +432,7 @@ const ChildrenBody = ({
                   <Controller
                     control={control}
                     name={fieldPath}
+                    rules={validationRules}
                     render={({
                       field: { value, onChange, onBlur, ...rest },
                     }) => (
@@ -466,6 +467,7 @@ const ChildrenBody = ({
                   <Controller
                     control={control}
                     name={fieldPath}
+                    rules={validationRules}
                     render={({ field: { value, onChange, ...rest } }) => (
                       <DatePicker
                         {...rest}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
After making the changes for myinfo child fields introducing controller in #7871, the new controllers do not include the required property `rules` which performs FE field validation. 

## Solution
<!-- How did you solve the problem? -->
Add the required `rules={validationRules}` property to the added controllers. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests 
Assert that the FE validation for my info child sub fields work 
- [ ] Create an email mode form with my info child field 
- [ ] Include all myinfo child subfields 
- [ ] Submit the form, try to submit with missing / invalid values and ensure FE validation works for all subfields.