### PR TITLE
fix: mrf be validation isSignatureTimeValid false positive

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -515,15 +515,18 @@ export const validateMultirespondentSubmission = async (
 
                     return ok(undefined)
                   }),
-                ).map(() => undefined)
+                ).map(() => {
+                  return previousResponses
+                })
               })
-              .andThen(() => {
+              .andThen((previousResponses) => {
                 // TODO: (FRM-1688) Set to block after sure that validation logic works as expected.
                 validateMrfFieldResponses({
                   formId,
                   visibleFieldIds,
                   formFields: form_fields,
                   responses: req.body.responses,
+                  previousResponses,
                 })
 
                 return ok(req.body.responses)

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -95,11 +95,13 @@ export const validateMrfFieldResponses = ({
   visibleFieldIds,
   formFields,
   responses,
+  previousResponses,
 }: {
   formId: string
   visibleFieldIds: FieldIdSet
   formFields: FormFieldDto[]
   responses: ParsedClearFormFieldResponsesV3
+  previousResponses?: ParsedClearFormFieldResponsesV3
 }): Result<
   ParsedClearFormFieldResponsesV3,
   ValidateFieldErrorV3 | ProcessingError
@@ -132,6 +134,7 @@ export const validateMrfFieldResponses = ({
       formId,
       formField,
       response,
+      prevResponse: previousResponses?.[responseId],
       isVisible: visibleFieldIds.has(responseId),
     })
     if (validateFieldV3Result.isErr()) {

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -351,11 +351,13 @@ const isResponsePresentOnHiddenFieldV3 = ({
 const isValidationRequiredV3 = ({
   formField,
   response,
+  prevResponse,
   isVisible,
   formId,
 }: {
   formField: FormFieldDto
   response: ParsedClearFormFieldResponseV3
+  prevResponse?: ParsedClearFormFieldResponseV3
   isVisible: boolean
   formId: string
 }): Result<boolean, ValidateFieldErrorV3> => {
@@ -373,6 +375,16 @@ const isValidationRequiredV3 = ({
       )
     case BasicField.Email:
     case BasicField.Mobile:
+      // For verifiable field, if the value and signature are the same as the previous response,
+      // then the field does not need to be validated again.
+      if (
+        prevResponse &&
+        response.fieldType === prevResponse.fieldType &&
+        prevResponse.answer.value === response.answer.value &&
+        prevResponse.answer.signature === response.answer.signature
+      ) {
+        return ok(false)
+      }
       return ok(
         (formField.required && isVisible) ||
           response.answer.value.trim() !== '' ||
@@ -441,11 +453,13 @@ export const validateFieldV3 = ({
   formId,
   formField,
   response,
+  prevResponse,
   isVisible,
 }: {
   formId: string
   formField: FormFieldDto
   response: ParsedClearFormFieldResponseV3
+  prevResponse?: ParsedClearFormFieldResponseV3
   isVisible: boolean
 }): Result<true, ValidateFieldErrorV3> => {
   if (!isValidResponseFieldType(response.fieldType)) {
@@ -498,5 +512,11 @@ export const validateFieldV3 = ({
     formField,
     isVisible,
   })
-  return validateResponseWithValidatorV3(validator, formId, formField, response)
+  return validateResponseWithValidatorV3(
+    validator,
+    formId,
+    formField,
+    response,
+    prevResponse,
+  )
 }

--- a/src/app/utils/field-validation/index.ts
+++ b/src/app/utils/field-validation/index.ts
@@ -495,6 +495,7 @@ export const validateFieldV3 = ({
   const isValidationRequiredV3Result = isValidationRequiredV3({
     formField,
     response,
+    prevResponse,
     isVisible,
     formId,
   })
@@ -512,11 +513,5 @@ export const validateFieldV3 = ({
     formField,
     isVisible,
   })
-  return validateResponseWithValidatorV3(
-    validator,
-    formId,
-    formField,
-    response,
-    prevResponse,
-  )
+  return validateResponseWithValidatorV3(validator, formId, formField, response)
 }

--- a/src/app/utils/field-validation/validators/__tests__/mobile-num-validation.spec.ts
+++ b/src/app/utils/field-validation/validators/__tests__/mobile-num-validation.spec.ts
@@ -473,4 +473,131 @@ describe('Mobile number validation tests V3', () => {
       )
     })
   })
+
+  describe('validation occurs based on if the value and signature of the current response are the same as the previous response', () => {
+    let authenticateSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      authenticateSpy = jest
+        .spyOn(
+          formsgSdk.verification as unknown as VerificationMock,
+          'authenticate',
+        )
+        .mockImplementation(() => true)
+    })
+
+    afterEach(() => {
+      authenticateSpy.mockClear()
+    })
+
+    it('should validate if no previous response is present', () => {
+      const formField = generateDefaultFieldV3(BasicField.Mobile, {
+        isVerifiable: true,
+      })
+      const response = generateVerifiableAnswerResponseV3({
+        fieldType: BasicField.Mobile,
+        answer: {
+          value: '+6598765432',
+          signature: 'some signature',
+        },
+      })
+      const validateResult = validateFieldV3({
+        formId: 'formId',
+        formField,
+        response,
+        prevResponse: undefined,
+        isVisible: true,
+      })
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+      expect(authenticateSpy).toHaveBeenCalled()
+    })
+
+    it('should not validate if the value and signature are the same as the previous response', () => {
+      const formField = generateDefaultFieldV3(BasicField.Mobile, {
+        isVerifiable: true,
+      })
+      const response = generateVerifiableAnswerResponseV3({
+        fieldType: BasicField.Mobile,
+        answer: {
+          value: '+6598765432',
+          signature: 'some signature',
+        },
+      })
+      const validateResult = validateFieldV3({
+        formId: 'formId',
+        formField,
+        response,
+        prevResponse: { ...response },
+        isVisible: true,
+      })
+      expect(authenticateSpy).not.toHaveBeenCalled()
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should validate if the value is different from the previous response', () => {
+      authenticateSpy.mockImplementation(() => false)
+
+      const formField = generateDefaultFieldV3(BasicField.Mobile, {
+        isVerifiable: true,
+      })
+      const response = generateVerifiableAnswerResponseV3({
+        fieldType: BasicField.Mobile,
+        answer: {
+          value: '+6598765432',
+          signature: 'some signature',
+        },
+      })
+      const prevResponse = generateVerifiableAnswerResponseV3({
+        fieldType: BasicField.Mobile,
+        answer: {
+          value: '+6587654321',
+          signature: 'some signature',
+        },
+      })
+      const validateResult = validateFieldV3({
+        formId: 'formId',
+        formField,
+        response,
+        prevResponse,
+        isVisible: true,
+      })
+      expect(authenticateSpy).toHaveBeenCalled()
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldError('Invalid answer submitted'),
+      )
+    })
+
+    it('should validate if the signature is different from the previous response', () => {
+      const formField = generateDefaultFieldV3(BasicField.Mobile, {
+        isVerifiable: true,
+      })
+      const response = generateVerifiableAnswerResponseV3({
+        fieldType: BasicField.Mobile,
+        answer: {
+          value: '+6598765432',
+          signature: 'new signature',
+        },
+      })
+      const prevResponse = generateVerifiableAnswerResponseV3({
+        fieldType: BasicField.Mobile,
+        answer: {
+          value: '+6598765432',
+          signature: 'old signature',
+        },
+      })
+      const validateResult = validateFieldV3({
+        formId: 'formId',
+        formField,
+        response,
+        prevResponse,
+        isVisible: true,
+      })
+      expect(authenticateSpy).toHaveBeenCalled()
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+  })
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
False positives during MRF BE validation for verifiable fields where the signature is marked as invalid when >=step 2 submissions are made past the `isSignatureTimeRangeValid` valid transaction range.

Closes FRM-1902

### Technical details

`isSignatureTimeRangeValid` is verified based on two criteria:
1. "signature time" is before "submission time"
2. "signature time" is within a reasonable bound before "submission time"

**Examples**
- if the submission is made in year 2024, it does not make sense for the signature to be generated in year 2025.
- if the submission is made on 12 nov 2024 at 10am, it does not make sense for the signature to be generated (aka when the otp is verified) on 1st jan 2023.

This works for storage mode which only has 1 submission.

For MRF, we can have >=1 submissions (and hence >= 1 submission times) per 'submission': 
- When the signature is generated in step 1, we use the step 1 submission time to validate the signature which works
- When a respondent submits at step 2 however e.g., 2 days later, the submission time of step 2 violates criteria (2) defined earlier

Hence, the verification failed and the false positive occurs.

## Solution
<!-- How did you solve the problem? -->

**Proposal 1**
Store in a field the submission time of step 1 as part of the verify field or spoof a submission timing to be submission time + 1000ms. This allows the `isSignatureTimeValid` to pass.

**Proposal 2**
Skip verification if it is an existing field and the answer & signature is unchanged.
Since must have been validated in the earlier step.

**Proposal Chosen**
Proposal 2.
1. Does not introduce a "hack" which goes against the intention of `isSignatureTimeValid` check.
2. More intuitive. If a response has been validated in earlier step and has not changed, it does not have to be validated again.
3. Does not introduce additional "time" that we need to maintain. This requires more headspace for the reader understand.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Unit tests (Automated)  
Written to enforce that: 
- if no prev response eg, not an edit field for prev step or step 1 of form submission, then the validation runs. 
- if the value or signature changes, then a validation executes. 
- if prev response value and signature are both equal, no validation runs. 
Hence, these can be excluded from manual tests. 

## Tests