### PR TITLE
feat: remove openssl flag on deployment and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
       - run: npm run build
         env:
-          NODE_OPTIONS: '--max-old-space-size=4096 --openssl-legacy-provider'
+          NODE_OPTIONS: '--max-old-space-size=4096'
           AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE: 1
       - name: Upload build files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,7 @@ jobs:
           api-key: ${{ secrets.DD_API_KEY }}
       - name: Build
         env:
-          NODE_OPTIONS: --max-old-space-size=4096 --openssl-legacy-provider -r ${{ env.DD_TRACE_PACKAGE }}
+          NODE_OPTIONS: --max-old-space-size=4096 -r ${{ env.DD_TRACE_PACKAGE }}
           VITE_APP_FORMSG_SDK_MODE: 'test'
         run: npm run build
       - name: Run Playwright tests (login)

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -8,15 +8,8 @@ RUN chown 1001:1001 /mongodb_data
 
 ENV CHROMIUM_BIN=/usr/bin/chromium-browser
 ENV NODE_ENV=development
-# --openssl-legacy-provider flag
-# A breaking change in the SSL provider was introduced in node 17. This caused
-# webpack 4 to break. This is an interim solution; we should investigate removing
-# this flag once angular has been removed and we have upgraded to CRA5 (which uses
-# webpack 5).
-# See also:
-# * https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported
-# * https://github.com/webpack/webpack/issues/14532#issuecomment-1304378535
-ENV NODE_OPTIONS="--max-old-space-size=2048 --openssl-legacy-provider"
+
+ENV NODE_OPTIONS="--max-old-space-size=2048"
 RUN apk update && apk upgrade && \
     # Build dependencies for node_modules
     apk add --virtual native-deps \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -28,16 +28,8 @@ RUN npm ci --legacy-peer-deps
 
 COPY . ./
 
-# --openssl-legacy-provider flag
-# A breaking change in the SSL provider was introduced in node 17. This caused
-# webpack 4 to break. This is an interim solution; we should investigate removing
-# this flag once angular has been removed and we have upgraded to CRA5 (which uses
-# webpack 5).
-# See also:
-# * https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported
-# * https://github.com/webpack/webpack/issues/14532#issuecomment-1304378535
 # These options are only used in the build stage, not the start stage.
-ENV NODE_OPTIONS="--max-old-space-size=4096 --openssl-legacy-provider"
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 RUN npm run build
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,6 @@ To install the relevant npm packages (frontend, backend and virus-scanner), run 
 npm install && npm --prefix serverless/virus-scanner install
 ```
 
-To prevent breaking changes to webpack4 introduced in node 17 and above, enable the `--openssl-legacy-provider` flag:
-
-```bash
-export NODE_OPTIONS=--openssl-legacy-provider
-```
-
 If you are on Mac OS X, you may want to allow Docker to use more RAM (minimum of 4GB) by clicking on the Docker icon on the toolbar, clicking on the "Preferences" menu item, then clicking on the "Resources" link on the left.
 
 ### Running Locally


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

This was needed for `craco` previously as we were using `webpack@v4` in our tooling chain. However, since we've migrated over to `vite` for our FE bundling, this flag may not be required.

Closes FRM-1904

## Solution
<!-- How did you solve the problem? -->

Remove flags and mentions in READMEs.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
#### Deployment is successful
- [x] Ensure that FormSG Landing page loads