### PR TITLE
feat: switch delete to edit button on logic page

### DIFF
--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
@@ -1,13 +1,6 @@
 import { useCallback, useMemo } from 'react'
-import { BiTrash } from 'react-icons/bi'
-import {
-  Box,
-  chakra,
-  Divider,
-  Stack,
-  StackDivider,
-  Text,
-} from '@chakra-ui/react'
+import { BiPencil } from 'react-icons/bi'
+import { Box, Divider, Stack, StackDivider, Text } from '@chakra-ui/react'
 
 import { LogicDto, LogicType } from '~shared/types/form'
 
@@ -26,12 +19,10 @@ import { LogicConditionValues } from './LogicConditionValues'
 
 interface InactiveLogicBlockProps {
   logic: LogicDto
-  handleOpenDeleteModal: () => void
 }
 
 export const InactiveLogicBlock = ({
   logic,
-  handleOpenDeleteModal,
 }: InactiveLogicBlockProps): JSX.Element | null => {
   const { idToFieldMap } = useAdminFormLogic()
   const setToEditing = useAdminLogicStore(setToEditingSelector)
@@ -98,29 +89,15 @@ export const InactiveLogicBlock = ({
 
   return (
     <Box pos="relative">
-      <chakra.button
-        type="button"
+      <Box
         w="100%"
         textAlign="start"
         borderRadius="4px"
         bg="white"
         border="1px solid"
         borderColor="neutral.300"
-        transitionProperty="common"
-        transitionDuration="normal"
         cursor={isPreventEdit ? 'not-allowed' : 'pointer'}
-        disabled={isPreventEdit}
         aria-disabled={isPreventEdit}
-        _hover={{
-          _disabled: {
-            bg: 'white',
-          },
-          bg: 'primary.100',
-        }}
-        _focus={{
-          boxShadow: `0 0 0 4px var(--chakra-colors-primary-300)`,
-        }}
-        onClick={handleClick}
       >
         <Stack
           spacing="1.5rem"
@@ -161,16 +138,17 @@ export const InactiveLogicBlock = ({
         >
           {renderThenContent}
         </Stack>
-      </chakra.button>
+      </Box>
       <IconButton
         top={{ base: '0.5rem', md: '2rem' }}
         right={{ base: '0.5rem', md: '2rem' }}
         pos="absolute"
         aria-label="Delete logic"
         variant="clear"
-        colorScheme="danger"
-        onClick={handleOpenDeleteModal}
-        icon={<BiTrash fontSize="1.5rem" />}
+        onClick={handleClick}
+        icon={<BiPencil fontSize="1.5rem" />}
+        cursor={isPreventEdit ? 'not-allowed' : 'pointer'}
+        aria-disabled={isPreventEdit}
       />
     </Box>
   )

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicBlockFactory/LogicBlockFactory.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicBlockFactory/LogicBlockFactory.tsx
@@ -40,10 +40,7 @@ export const LogicBlockFactory = ({
           handleOpenDeleteModal={onDeleteModalOpen}
         />
       ) : (
-        <InactiveLogicBlock
-          logic={logic}
-          handleOpenDeleteModal={onDeleteModalOpen}
-        />
+        <InactiveLogicBlock logic={logic} />
       )}
     </>
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Destructive actions should be hidden below the fold; this is a baseline practice in UX

Closes FRM-1906

## Solution
<!-- How did you solve the problem? -->

1. Replaced `<TrashIcon />` with `<PencilIcon />`
2. Fixed issue where deletion is still possible when editing another logic.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
| Header | Header | Header |
|--------|--------|--------|
| InactiveLogicBlock when nothing active| ![Screenshot 2024-11-14 at 1 19 05 PM](https://github.com/user-attachments/assets/dcf78176-56f9-4099-96eb-0e5bf48a420a) | ![Screenshot 2024-11-15 at 3 01 02 PM](https://github.com/user-attachments/assets/8f1cbe3c-2516-4f9d-8ab7-5b76f551b59c) | 
| InactiveLogicBlock when one is active | ![Screenshot 2024-11-14 at 1 19 02 PM](https://github.com/user-attachments/assets/2f322298-3e2b-4f89-900f-5888d251f42a) |   | 



## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
#### Edit logic can be triggered
- [ ] Add a "number field" and a "text field"
- [ ] Create a logic with "number field" as logic predicate, and show "text field" as outcome
- [ ] Press "Save changes"
- [ ] Ensure that the `<PencilIcon />` can be clicked
- [ ] Ensure that clicking on areas that are not part of `<PencilIcon />` does not enter edit mode

#### Editing another input should not be allowed if already in edit mode
- [ ] Create another logic with "number field" as logic predicate, and show "text field" as outcome
- [ ] Press "Save changes"
- [ ] Click on `<PencilIcon />` to enter edit mode
- [ ] Ensure that clicking on another logic step does not enter edit mode and onhover cursor is represented with "not-allowed"