### PR TITLE
chore: remove jest-axios-mock, jest-localstorage-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -174,8 +174,6 @@
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
         "jest-extended": "^4.0.2",
-        "jest-localstorage-mock": "^2.4.26",
-        "jest-mock-axios": "^4.7.2",
         "lint-staged": "^15.2.7",
         "maildev": "^2.1.0",
         "mockdate": "^3.0.5",
@@ -18825,15 +18823,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-localstorage-mock": {
-      "version": "2.4.26",
-      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz",
-      "integrity": "sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.16.0"
-      }
-    },
     "node_modules/jest-matcher-utils": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
@@ -19033,17 +19022,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock-axios": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/jest-mock-axios/-/jest-mock-axios-4.7.2.tgz",
-      "integrity": "sha512-8xrkCuEsscOLSw4Noi40Pq5tQMlKg3tbDZ0XNkf3Mv0Yq+z6+qS2tToimNs/3RIsEzoPXHTf2+mcySaNaYXIyw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/globals": "^29.5.0",
-        "jest": "~29.5.0",
-        "synchronous-promise": "^2.0.17"
       }
     },
     "node_modules/jest-pnp-resolver": {
@@ -26307,12 +26285,6 @@
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "license": "MIT"
-    },
-    "node_modules/synchronous-promise": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
-      "integrity": "sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==",
-      "dev": true
     },
     "node_modules/synckit": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -220,8 +220,6 @@
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "jest-extended": "^4.0.2",
-    "jest-localstorage-mock": "^2.4.26",
-    "jest-mock-axios": "^4.7.2",
     "lint-staged": "^15.2.7",
     "maildev": "^2.1.0",
     "mockdate": "^3.0.5",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We're no longer using `jest-axios-mock` and `jest-localstorage-mock` libraries. But we're still getting dependabot PRs to them + security warnings.

## Solution
<!-- How did you solve the problem? -->

Remove unused deps.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
