### PR TITLE
feat: add view for translation input

### DIFF
--- a/frontend/src/constants/routes.ts
+++ b/frontend/src/constants/routes.ts
@@ -54,3 +54,7 @@ export const ACTIVE_ADMINFORM_RESULTS_ROUTE_REGEX = new RegExp(
 
 export const PAYMENT_PAGE_SUBROUTE = 'payment/:paymentId'
 export const EDIT_SUBMISSION_PAGE_SUBROUTE = 'edit/:submissionId'
+
+// Search param keys for multi-language
+export const UNICODE_LOCALE = 'unicodeLocale'
+export const TRANSLATION_INPUT = 'translationInput'

--- a/frontend/src/features/admin-form/settings/SettingsMultiLangPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsMultiLangPage.tsx
@@ -1,15 +1,40 @@
 import { useSearchParams } from 'react-router-dom'
+import _ from 'lodash'
+
+import { TRANSLATION_INPUT, UNICODE_LOCALE } from '~constants/routes'
 
 import { MultiLanguageSection } from './components/MultiLanguageSection/MultiLanguageSection'
 import { TranslationListSection } from './components/MultiLanguageSection/TranslationListSection'
+import { TranslationSection } from './components/MultiLanguageSection/TranslationSection'
 
 export const SettingsMultiLangPage = (): JSX.Element => {
   const [searchParams] = useSearchParams()
-  const unicodeLocale = searchParams.get('unicodeLocale')
+  const unicodeLocale = searchParams.get(UNICODE_LOCALE)
+  const translationInput = searchParams.get(TRANSLATION_INPUT)
+  const isTranslationInput = !_.isNull(translationInput)
+  const isEndPageTranslationInput = translationInput === 'endPage'
+  const isStartPageTransltionInput = translationInput === 'startPage'
 
   return (
     <>
-      {unicodeLocale ? <TranslationListSection language={unicodeLocale} /> : <MultiLanguageSection />}
+      {unicodeLocale ? (
+        isTranslationInput ? (
+          <TranslationSection
+            language={unicodeLocale}
+            formFieldNumToBeTranslated={
+              isEndPageTranslationInput || isStartPageTransltionInput
+                ? -1
+                : _.toNumber(translationInput)
+            }
+            isEndPageTranslations={isEndPageTranslationInput}
+            isStartPageTranslations={isStartPageTransltionInput}
+          />
+        ) : (
+          <TranslationListSection language={unicodeLocale} />
+        )
+      ) : (
+        <MultiLanguageSection />
+      )}
     </>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsMultiLangPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsMultiLangPage.tsx
@@ -15,26 +15,24 @@ export const SettingsMultiLangPage = (): JSX.Element => {
   const isEndPageTranslationInput = translationInput === 'endPage'
   const isStartPageTransltionInput = translationInput === 'startPage'
 
+  // Request user to select a language
+  if (!unicodeLocale) {
+    return <MultiLanguageSection />
+  }
+  // Request user to select fields to translate
+  if (!isTranslationInput) {
+    return <TranslationListSection language={unicodeLocale} />
+  }
   return (
-    <>
-      {unicodeLocale ? (
-        isTranslationInput ? (
-          <TranslationSection
-            language={unicodeLocale}
-            formFieldNumToBeTranslated={
-              isEndPageTranslationInput || isStartPageTransltionInput
-                ? -1
-                : _.toNumber(translationInput)
-            }
-            isEndPageTranslations={isEndPageTranslationInput}
-            isStartPageTranslations={isStartPageTransltionInput}
-          />
-        ) : (
-          <TranslationListSection language={unicodeLocale} />
-        )
-      ) : (
-        <MultiLanguageSection />
-      )}
-    </>
+    <TranslationSection
+      language={unicodeLocale}
+      formFieldNumToBeTranslated={
+        isEndPageTranslationInput || isStartPageTransltionInput
+          ? -1
+          : _.toNumber(translationInput)
+      }
+      isEndPageTranslations={isEndPageTranslationInput}
+      isStartPageTranslations={isStartPageTransltionInput}
+    />
   )
 }

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/EndPageTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/EndPageTranslationContainer.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { Divider, Flex, Text } from '@chakra-ui/react'
+
+import { FormEndPage, Language } from '~shared/types'
+
+import { TranslationContainer } from './TranslationContainer'
+
+interface EndPageTranslationsContainerProps {
+  endPage?: FormEndPage
+  capitalisedLanguage: string
+  unicodeLocale: Language
+}
+
+export const EndPageTranslationsContainer: React.FC<EndPageTranslationsContainerProps> =
+  React.memo(({ endPage, capitalisedLanguage, unicodeLocale }) => {
+    if (!endPage) return null
+
+    const hasParagraph = endPage.paragraph && endPage.paragraph.trim() !== ''
+
+    const currentTitleTranslations = endPage.titleTranslations ?? []
+    const currentParagraphTranslations = endPage.paragraphTranslations ?? []
+
+    const previousTitleTranslation =
+      currentTitleTranslations.find(
+        (translation) => translation.language === unicodeLocale,
+      )?.translation ?? ''
+
+    const previousParagraphTranslation =
+      currentParagraphTranslations.find(
+        (translation) => translation.language === unicodeLocale,
+      )?.translation ?? ''
+
+    return (
+      <>
+        <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+          <Text
+            color="secondary.500"
+            fontSize="1.25rem"
+            fontWeight="600"
+            mb="1rem"
+          >
+            Question
+          </Text>
+          <TranslationContainer
+            language={capitalisedLanguage}
+            defaultString={endPage.title}
+            editingTranslation="titleTranslation"
+            previousTranslation={previousTitleTranslation}
+          />
+        </Flex>
+        <Divider mb="2.5rem" />
+        {hasParagraph && (
+          <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+            <Text
+              color="secondary.500"
+              fontSize="1.25rem"
+              fontWeight="600"
+              mb="1rem"
+            >
+              Follow-up instructions
+            </Text>
+            <TranslationContainer
+              language={capitalisedLanguage}
+              defaultString={endPage.paragraph}
+              editingTranslation="paragraphTranslations"
+              previousTranslation={previousParagraphTranslation}
+            />
+          </Flex>
+        )}
+      </>
+    )
+  })

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/EndPageTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/EndPageTranslationContainer.tsx
@@ -11,27 +11,48 @@ interface EndPageTranslationsContainerProps {
   unicodeLocale: Language
 }
 
-export const EndPageTranslationsContainer: React.FC<EndPageTranslationsContainerProps> =
-  React.memo(({ endPage, capitalisedLanguage, unicodeLocale }) => {
-    if (!endPage) return null
+export const EndPageTranslationsContainer = ({
+  endPage,
+  capitalisedLanguage,
+  unicodeLocale,
+}: EndPageTranslationsContainerProps) => {
+  if (!endPage) return null
 
-    const hasParagraph = endPage.paragraph && endPage.paragraph.trim() !== ''
+  const hasParagraph = endPage.paragraph && endPage.paragraph.trim() !== ''
 
-    const currentTitleTranslations = endPage.titleTranslations ?? []
-    const currentParagraphTranslations = endPage.paragraphTranslations ?? []
+  const currentTitleTranslations = endPage.titleTranslations ?? []
+  const currentParagraphTranslations = endPage.paragraphTranslations ?? []
 
-    const previousTitleTranslation =
-      currentTitleTranslations.find(
-        (translation) => translation.language === unicodeLocale,
-      )?.translation ?? ''
+  const previousTitleTranslation =
+    currentTitleTranslations.find(
+      (translation) => translation.language === unicodeLocale,
+    )?.translation ?? ''
 
-    const previousParagraphTranslation =
-      currentParagraphTranslations.find(
-        (translation) => translation.language === unicodeLocale,
-      )?.translation ?? ''
+  const previousParagraphTranslation =
+    currentParagraphTranslations.find(
+      (translation) => translation.language === unicodeLocale,
+    )?.translation ?? ''
 
-    return (
-      <>
+  return (
+    <>
+      <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+        <Text
+          color="secondary.500"
+          fontSize="1.25rem"
+          fontWeight="600"
+          mb="1rem"
+        >
+          Question
+        </Text>
+        <TranslationContainer
+          language={capitalisedLanguage}
+          defaultString={endPage.title}
+          editingTranslation="titleTranslation"
+          previousTranslation={previousTitleTranslation}
+        />
+      </Flex>
+      <Divider mb="2.5rem" />
+      {hasParagraph && (
         <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
           <Text
             color="secondary.500"
@@ -39,34 +60,16 @@ export const EndPageTranslationsContainer: React.FC<EndPageTranslationsContainer
             fontWeight="600"
             mb="1rem"
           >
-            Question
+            Follow-up instructions
           </Text>
           <TranslationContainer
             language={capitalisedLanguage}
-            defaultString={endPage.title}
-            editingTranslation="titleTranslation"
-            previousTranslation={previousTitleTranslation}
+            defaultString={endPage.paragraph}
+            editingTranslation="paragraphTranslations"
+            previousTranslation={previousParagraphTranslation}
           />
         </Flex>
-        <Divider mb="2.5rem" />
-        {hasParagraph && (
-          <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
-            <Text
-              color="secondary.500"
-              fontSize="1.25rem"
-              fontWeight="600"
-              mb="1rem"
-            >
-              Follow-up instructions
-            </Text>
-            <TranslationContainer
-              language={capitalisedLanguage}
-              defaultString={endPage.paragraph}
-              editingTranslation="paragraphTranslations"
-              previousTranslation={previousParagraphTranslation}
-            />
-          </Flex>
-        )}
-      </>
-    )
-  })
+      )}
+    </>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/EndPageTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/EndPageTranslationContainer.tsx
@@ -18,7 +18,7 @@ export const EndPageTranslationsContainer = ({
 }: EndPageTranslationsContainerProps) => {
   if (!endPage) return null
 
-  const hasParagraph = endPage.paragraph && endPage.paragraph.trim() !== ''
+  const hasParagraph = endPage.paragraph?.trim() !== ''
 
   const currentTitleTranslations = endPage.titleTranslations ?? []
   const currentParagraphTranslations = endPage.paragraphTranslations ?? []

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormFieldTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormFieldTranslationContainer.tsx
@@ -14,88 +14,91 @@ interface FormFieldTranslationContainerProps {
   unicodeLocale: Language
 }
 
-export const FormFieldTranslationContainer: React.FC<FormFieldTranslationContainerProps> =
-  React.memo(({ formFieldData, capitalisedLanguage, unicodeLocale }) => {
-    if (!formFieldData) return null
+export const FormFieldTranslationContainer = ({
+  formFieldData,
+  capitalisedLanguage,
+  unicodeLocale,
+}: FormFieldTranslationContainerProps) => {
+  if (!formFieldData) return null
 
-    const hasDescription =
-      formFieldData.description && formFieldData.description !== ''
-    const titleTranslations = formFieldData.titleTranslations ?? []
-    const descriptionTranslations = formFieldData.descriptionTranslations ?? []
+  const hasDescription =
+    formFieldData.description && formFieldData.description !== ''
+  const titleTranslations = formFieldData.titleTranslations ?? []
+  const descriptionTranslations = formFieldData.descriptionTranslations ?? []
 
-    const prevTitleTranslation =
-      titleTranslations.find(
-        (translation) => translation.language === unicodeLocale,
-      )?.translation ?? ''
+  const prevTitleTranslation =
+    titleTranslations.find(
+      (translation) => translation.language === unicodeLocale,
+    )?.translation ?? ''
 
-    const prevDescriptionTranslation =
-      descriptionTranslations.find(
-        (translation) => translation.language === unicodeLocale,
-      )?.translation ?? ''
+  const prevDescriptionTranslation =
+    descriptionTranslations.find(
+      (translation) => translation.language === unicodeLocale,
+    )?.translation ?? ''
 
-    const isTableField = formFieldData.fieldType === BasicField.Table
+  const isTableField = formFieldData.fieldType === BasicField.Table
 
-    return (
-      <>
-        <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
-          <Text
-            color="secondary.500"
-            fontSize="1.25rem"
-            fontWeight="600"
-            mb="1rem"
-          >
-            Question
-          </Text>
-          <TranslationContainer
+  return (
+    <>
+      <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+        <Text
+          color="secondary.500"
+          fontSize="1.25rem"
+          fontWeight="600"
+          mb="1rem"
+        >
+          Question
+        </Text>
+        <TranslationContainer
+          language={capitalisedLanguage}
+          defaultString={formFieldData.title}
+          editingTranslation="titleTranslation"
+          previousTranslation={prevTitleTranslation}
+        />
+      </Flex>
+      {hasDescription && (
+        <>
+          <Divider mb="2.5rem" />
+          <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+            <Text
+              color="secondary.500"
+              fontSize="1.25rem"
+              fontWeight="600"
+              mb="1rem"
+            >
+              Description
+            </Text>
+            <TranslationContainer
+              language={capitalisedLanguage}
+              defaultString={formFieldData.description}
+              editingTranslation="descriptionTranslation"
+              previousTranslation={prevDescriptionTranslation}
+            />
+          </Flex>
+        </>
+      )}
+      {(formFieldData.fieldType === BasicField.Radio ||
+        formFieldData.fieldType === BasicField.Checkbox ||
+        formFieldData.fieldType === BasicField.Dropdown) && (
+        <>
+          <Divider mb="2.5rem" />
+          <OptionsTranslationContainer
+            unicodeLocale={unicodeLocale}
             language={capitalisedLanguage}
-            defaultString={formFieldData.title}
-            editingTranslation="titleTranslation"
-            previousTranslation={prevTitleTranslation}
+            formFieldData={formFieldData}
           />
-        </Flex>
-        {hasDescription && (
-          <>
-            <Divider mb="2.5rem" />
-            <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
-              <Text
-                color="secondary.500"
-                fontSize="1.25rem"
-                fontWeight="600"
-                mb="1rem"
-              >
-                Description
-              </Text>
-              <TranslationContainer
-                language={capitalisedLanguage}
-                defaultString={formFieldData.description}
-                editingTranslation="descriptionTranslation"
-                previousTranslation={prevDescriptionTranslation}
-              />
-            </Flex>
-          </>
-        )}
-        {(formFieldData.fieldType === BasicField.Radio ||
-          formFieldData.fieldType === BasicField.Checkbox ||
-          formFieldData.fieldType === BasicField.Dropdown) && (
-          <>
-            <Divider mb="2.5rem" />
-            <OptionsTranslationContainer
-              unicodeLocale={unicodeLocale}
-              language={capitalisedLanguage}
-              formFieldData={formFieldData}
-            />
-          </>
-        )}
-        {isTableField && (
-          <>
-            <Divider mb="2.5rem" />
-            <TableTranslationContainer
-              unicodeLocale={unicodeLocale}
-              language={capitalisedLanguage}
-              columns={formFieldData.columns}
-            />
-          </>
-        )}
-      </>
-    )
-  })
+        </>
+      )}
+      {isTableField && (
+        <>
+          <Divider mb="2.5rem" />
+          <TableTranslationContainer
+            unicodeLocale={unicodeLocale}
+            language={capitalisedLanguage}
+            columns={formFieldData.columns}
+          />
+        </>
+      )}
+    </>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormFieldTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormFieldTranslationContainer.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { Divider, Flex, Text } from '@chakra-ui/react'
+
+import { FormField, Language } from '~shared/types'
+import { BasicField } from '~shared/types/field'
+
+import { OptionsTranslationContainer } from './OptionsTranslationContainer'
+import { TableTranslationContainer } from './TableTranslationContainer'
+import { TranslationContainer } from './TranslationContainer'
+
+interface FormFieldTranslationContainerProps {
+  formFieldData: FormField | undefined
+  capitalisedLanguage: string
+  unicodeLocale: Language
+}
+
+export const FormFieldTranslationContainer: React.FC<FormFieldTranslationContainerProps> =
+  React.memo(({ formFieldData, capitalisedLanguage, unicodeLocale }) => {
+    if (!formFieldData) return null
+
+    const hasDescription =
+      formFieldData.description && formFieldData.description !== ''
+    const titleTranslations = formFieldData.titleTranslations ?? []
+    const descriptionTranslations = formFieldData.descriptionTranslations ?? []
+
+    const prevTitleTranslation =
+      titleTranslations.find(
+        (translation) => translation.language === unicodeLocale,
+      )?.translation ?? ''
+
+    const prevDescriptionTranslation =
+      descriptionTranslations.find(
+        (translation) => translation.language === unicodeLocale,
+      )?.translation ?? ''
+
+    const isTableField = formFieldData.fieldType === BasicField.Table
+
+    return (
+      <>
+        <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+          <Text
+            color="secondary.500"
+            fontSize="1.25rem"
+            fontWeight="600"
+            mb="1rem"
+          >
+            Question
+          </Text>
+          <TranslationContainer
+            language={capitalisedLanguage}
+            defaultString={formFieldData.title}
+            editingTranslation="titleTranslation"
+            previousTranslation={prevTitleTranslation}
+          />
+        </Flex>
+        {hasDescription && (
+          <>
+            <Divider mb="2.5rem" />
+            <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+              <Text
+                color="secondary.500"
+                fontSize="1.25rem"
+                fontWeight="600"
+                mb="1rem"
+              >
+                Description
+              </Text>
+              <TranslationContainer
+                language={capitalisedLanguage}
+                defaultString={formFieldData.description}
+                editingTranslation="descriptionTranslation"
+                previousTranslation={prevDescriptionTranslation}
+              />
+            </Flex>
+          </>
+        )}
+        {(formFieldData.fieldType === BasicField.Radio ||
+          formFieldData.fieldType === BasicField.Checkbox ||
+          formFieldData.fieldType === BasicField.Dropdown) && (
+          <>
+            <Divider mb="2.5rem" />
+            <OptionsTranslationContainer
+              unicodeLocale={unicodeLocale}
+              language={capitalisedLanguage}
+              formFieldData={formFieldData}
+            />
+          </>
+        )}
+        {isTableField && (
+          <>
+            <Divider mb="2.5rem" />
+            <TableTranslationContainer
+              unicodeLocale={unicodeLocale}
+              language={capitalisedLanguage}
+              columns={formFieldData.columns}
+            />
+          </>
+        )}
+      </>
+    )
+  })

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormMultiLanguageToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormMultiLanguageToggle.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 import { BiEditAlt } from 'react-icons/bi'
 import { GoEye, GoEyeClosed } from 'react-icons/go'
-import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 import {
   Box,
   Divider,
@@ -43,8 +43,7 @@ const LanguageTranslationRow = ({
 }: LanguageTranslationRowProps): JSX.Element => {
   const { formId } = useParams()
   const { data: settings } = useAdminFormSettings()
-  const navigate = useNavigate()
-  const [_, setSearchParams] = useSearchParams()
+  const [, setSearchParams] = useSearchParams()
 
   if (!formId) throw new Error('No formId provided')
 
@@ -84,7 +83,7 @@ const LanguageTranslationRow = ({
     (language: Language) => {
       setSearchParams({ unicodeLocale: language.toString() })
     },
-    [formId, navigate],
+    [setSearchParams],
   )
 
   return (

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/OptionsTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/OptionsTranslationContainer.tsx
@@ -36,7 +36,7 @@ export const OptionsTranslationContainer = ({
 
   return (
     <Flex direction="column" width="100%" mb="2.5rem">
-      <Flex alignItems="center" mb="2rem">
+      <Flex alignItems="flex-start" mb="2rem">
         <Text
           color="secondary.700"
           fontWeight="400"
@@ -55,7 +55,7 @@ export const OptionsTranslationContainer = ({
           overflow="hidden"
         />
       </Flex>
-      <Flex alignItems="center">
+      <Flex alignItems="flex-start">
         <Text color="secondary.700" mr="7.5rem" width="6.25rem">
           {language}
         </Text>

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/OptionsTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/OptionsTranslationContainer.tsx
@@ -1,6 +1,5 @@
-import React from 'react'
 import { useFormContext } from 'react-hook-form'
-import { Flex, FormControl, Text, Textarea } from '@chakra-ui/react'
+import { Flex, FormControl, Text } from '@chakra-ui/react'
 
 import {
   CheckboxFieldBase,
@@ -8,6 +7,8 @@ import {
   Language,
   RadioFieldBase,
 } from '~shared/types'
+
+import Textarea from '~components/Textarea'
 
 import { TranslationInput } from './TranslationSection'
 
@@ -34,7 +35,7 @@ export const OptionsTranslationContainer = ({
       ?.translation.join('\n') || []
 
   return (
-    <Flex direction="column" width="100%">
+    <Flex direction="column" width="100%" mb="2.5rem">
       <Flex alignItems="center" mb="2rem">
         <Text
           color="secondary.700"
@@ -51,6 +52,7 @@ export const OptionsTranslationContainer = ({
           padding="0.75rem"
           resize="none"
           height="max-content"
+          overflow="hidden"
         />
       </Flex>
       <Flex alignItems="center">

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/OptionsTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/OptionsTranslationContainer.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { Flex, FormControl, Text, Textarea } from '@chakra-ui/react'
+
+import {
+  CheckboxFieldBase,
+  DropdownFieldBase,
+  Language,
+  RadioFieldBase,
+} from '~shared/types'
+
+import { TranslationInput } from './TranslationSection'
+
+interface OptionsTranslationContainerProps {
+  language: string
+  unicodeLocale: Language
+  formFieldData: CheckboxFieldBase | DropdownFieldBase | RadioFieldBase
+}
+
+export const OptionsTranslationContainer = ({
+  language,
+  unicodeLocale,
+  formFieldData,
+}: OptionsTranslationContainerProps) => {
+  const { register } = useFormContext<TranslationInput>()
+
+  const fieldOptions = formFieldData.fieldOptions || []
+  const defaultFieldOptions = fieldOptions.join('\n')
+  const fieldOptionsTranslations = formFieldData.fieldOptionsTranslations || []
+
+  const previousTranslations =
+    fieldOptionsTranslations
+      .find((translation) => translation.language === unicodeLocale)
+      ?.translation.join('\n') || []
+
+  return (
+    <Flex direction="column" width="100%">
+      <Flex alignItems="center" mb="2rem">
+        <Text
+          color="secondary.700"
+          fontWeight="400"
+          mr="7.5rem"
+          width="6.25rem"
+        >
+          Default
+        </Text>
+        <Textarea
+          placeholder={defaultFieldOptions}
+          width="100%"
+          isDisabled={true}
+          padding="0.75rem"
+          resize="none"
+          height="max-content"
+        />
+      </Flex>
+      <Flex alignItems="center">
+        <Text color="secondary.700" mr="7.5rem" width="6.25rem">
+          {language}
+        </Text>
+        <FormControl>
+          <Textarea
+            width="100%"
+            {...register('fieldOptionsTranslations')}
+            defaultValue={previousTranslations}
+          />
+        </FormControl>
+      </Flex>
+    </Flex>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/StartPageTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/StartPageTranslationContainer.tsx
@@ -11,32 +11,30 @@ interface StartPageTranslationContainerProps {
   unicodeLocale: Language
 }
 
-export const StartPageTranslationContainer: React.FC<StartPageTranslationContainerProps> =
-  React.memo(({ startPage, capitalisedLanguage, unicodeLocale }) => {
-    if (!startPage) return null
+export const StartPageTranslationContainer = ({
+  startPage,
+  capitalisedLanguage,
+  unicodeLocale,
+}: StartPageTranslationContainerProps) => {
+  if (!startPage) return null
 
-    const currentTranslations = startPage.paragraphTranslations ?? []
-    const previousTranslation =
-      currentTranslations.find(
-        (translation) => translation.language === unicodeLocale,
-      )?.translation ?? ''
+  const currentTranslations = startPage.paragraphTranslations ?? []
+  const previousTranslation =
+    currentTranslations.find(
+      (translation) => translation.language === unicodeLocale,
+    )?.translation ?? ''
 
-    return (
-      <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
-        <Text
-          color="secondary.500"
-          fontSize="1.25rem"
-          fontWeight="600"
-          mb="1rem"
-        >
-          Question
-        </Text>
-        <TranslationContainer
-          language={capitalisedLanguage}
-          defaultString={startPage.paragraph}
-          editingTranslation="paragraphTranslations"
-          previousTranslation={previousTranslation}
-        />
-      </Flex>
-    )
-  })
+  return (
+    <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+      <Text color="secondary.500" fontSize="1.25rem" fontWeight="600" mb="1rem">
+        Question
+      </Text>
+      <TranslationContainer
+        language={capitalisedLanguage}
+        defaultString={startPage.paragraph}
+        editingTranslation="paragraphTranslations"
+        previousTranslation={previousTranslation}
+      />
+    </Flex>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/StartPageTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/StartPageTranslationContainer.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Flex, Text } from '@chakra-ui/react'
+
+import { FormStartPage, Language } from '~shared/types'
+
+import { TranslationContainer } from './TranslationContainer'
+
+interface StartPageTranslationContainerProps {
+  startPage?: FormStartPage
+  capitalisedLanguage: string
+  unicodeLocale: Language
+}
+
+export const StartPageTranslationContainer: React.FC<StartPageTranslationContainerProps> =
+  React.memo(({ startPage, capitalisedLanguage, unicodeLocale }) => {
+    if (!startPage) return null
+
+    const currentTranslations = startPage.paragraphTranslations ?? []
+    const previousTranslation =
+      currentTranslations.find(
+        (translation) => translation.language === unicodeLocale,
+      )?.translation ?? ''
+
+    return (
+      <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+        <Text
+          color="secondary.500"
+          fontSize="1.25rem"
+          fontWeight="600"
+          mb="1rem"
+        >
+          Question
+        </Text>
+        <TranslationContainer
+          language={capitalisedLanguage}
+          defaultString={startPage.paragraph}
+          editingTranslation="paragraphTranslations"
+          previousTranslation={previousTranslation}
+        />
+      </Flex>
+    )
+  })

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
@@ -61,7 +61,7 @@ export const TableTranslationContainer = ({
               Column
             </Text>
             <Flex direction="column" width="100%">
-              <Flex alignItems="center" mb="2rem">
+              <Flex alignItems="flex-start" mb="2rem">
                 <Text
                   color="secondary.700"
                   fontWeight="400"
@@ -78,7 +78,7 @@ export const TableTranslationContainer = ({
                   resize="none"
                 />
               </Flex>
-              <Flex alignItems="center">
+              <Flex alignItems="flex-start">
                 <Text color="secondary.700" mr="7.5rem" width="6.25rem">
                   {language}
                 </Text>
@@ -101,7 +101,7 @@ export const TableTranslationContainer = ({
                 >
                   Options
                 </Text>
-                <Flex alignItems="center" mb="2rem">
+                <Flex alignItems="flex-start" mb="2rem">
                   <Text
                     color="secondary.700"
                     fontWeight="400"
@@ -116,7 +116,7 @@ export const TableTranslationContainer = ({
                     overflow="hidden"
                   />
                 </Flex>
-                <Flex alignItems="center">
+                <Flex alignItems="flex-start">
                   <Text color="secondary.700" mr="7.5rem" width="6.25rem">
                     {language}
                   </Text>

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
@@ -1,16 +1,11 @@
 import React from 'react'
 import { useFormContext } from 'react-hook-form'
-import {
-  Divider,
-  Flex,
-  FormControl,
-  Input,
-  Text,
-  Textarea,
-} from '@chakra-ui/react'
+import { Divider, Flex, FormControl, Text } from '@chakra-ui/react'
 
 import { Language } from '~shared/types'
 import { BasicField } from '~shared/types/field'
+
+import Textarea from '~components/Textarea'
 
 import { TranslationInput } from './TranslationSection'
 
@@ -28,41 +23,84 @@ interface TableTranslationContainerProps {
   unicodeLocale: Language
 }
 
-export const TableTranslationContainer: React.FC<TableTranslationContainerProps> =
-  React.memo(({ language, columns, unicodeLocale }) => {
-    const { register } = useFormContext<TranslationInput>()
+export const TableTranslationContainer = ({
+  language,
+  columns,
+  unicodeLocale,
+}: TableTranslationContainerProps) => {
+  const { register } = useFormContext<TranslationInput>()
 
-    return (
-      <>
-        {columns.map((column, index) => {
-          const previousColumnTitleTranslation =
-            column?.titleTranslations?.find(
+  return (
+    <>
+      {columns.map((column, index) => {
+        const previousColumnTitleTranslation =
+          column?.titleTranslations?.find(
+            (translation) => translation.language === unicodeLocale,
+          )?.translation ?? ''
+
+        let previousFieldOptionsTranslations: string[] = []
+
+        if (column.columnType === BasicField.Dropdown) {
+          previousFieldOptionsTranslations =
+            column?.fieldOptionsTranslations?.find(
               (translation) => translation.language === unicodeLocale,
-            )?.translation ?? ''
+            )?.translation ?? []
+        }
 
-          let previousFieldOptionsTranslations: string[] = []
+        const previousFieldOptionsTranslationsString =
+          previousFieldOptionsTranslations.join('\n')
 
-          if (column.columnType === BasicField.Dropdown) {
-            previousFieldOptionsTranslations =
-              column?.fieldOptionsTranslations?.find(
-                (translation) => translation.language === unicodeLocale,
-              )?.translation ?? []
-          }
-
-          const previousFieldOptionsTranslationsString =
-            previousFieldOptionsTranslations.join('\n')
-
-          return (
-            <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
-              <Text
-                color="secondary.500"
-                fontSize="1.25rem"
-                fontWeight="600"
-                mb="1rem"
-              >
-                Column
-              </Text>
+        return (
+          <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+            <Text
+              color="secondary.500"
+              fontSize="1.25rem"
+              fontWeight="600"
+              mb="1rem"
+            >
+              Column
+            </Text>
+            <Flex direction="column" width="100%">
+              <Flex alignItems="center" mb="2rem">
+                <Text
+                  color="secondary.700"
+                  fontWeight="400"
+                  mr="7.5rem"
+                  width="6.25rem"
+                >
+                  Default
+                </Text>
+                <Textarea
+                  placeholder={column.title}
+                  width="100%"
+                  isDisabled={true}
+                  padding="0.75rem"
+                  resize="none"
+                />
+              </Flex>
+              <Flex alignItems="center">
+                <Text color="secondary.700" mr="7.5rem" width="6.25rem">
+                  {language}
+                </Text>
+                <FormControl>
+                  <Textarea
+                    defaultValue={previousColumnTitleTranslation}
+                    {...register(`tableColumnTitleTranslations.${index}`)}
+                  />
+                </FormControl>
+              </Flex>
+            </Flex>
+            {column.columnType === BasicField.Dropdown && (
               <Flex direction="column" width="100%">
+                <Text
+                  color="secondary.500"
+                  fontSize="1.25rem"
+                  fontWeight="600"
+                  mb="1rem"
+                  mt="2rem"
+                >
+                  Options
+                </Text>
                 <Flex alignItems="center" mb="2rem">
                   <Text
                     color="secondary.700"
@@ -73,11 +111,9 @@ export const TableTranslationContainer: React.FC<TableTranslationContainerProps>
                     Default
                   </Text>
                   <Textarea
-                    placeholder={column.title}
-                    width="100%"
+                    placeholder={column.fieldOptions?.join('\n') ?? ''}
                     isDisabled={true}
-                    padding="0.75rem"
-                    resize="none"
+                    overflow="hidden"
                   />
                 </Flex>
                 <Flex alignItems="center">
@@ -85,64 +121,19 @@ export const TableTranslationContainer: React.FC<TableTranslationContainerProps>
                     {language}
                   </Text>
                   <FormControl>
-                    <Input
-                      type="text"
+                    <Textarea
                       width="100%"
-                      {...register(`tableColumnTitleTranslations.${index}`)}
-                      defaultValue={previousColumnTitleTranslation}
+                      {...register(`tableColumnDropdownTranslations.${index}`)}
+                      defaultValue={previousFieldOptionsTranslationsString}
                     />
                   </FormControl>
                 </Flex>
               </Flex>
-              {column.columnType === BasicField.Dropdown && (
-                <Flex direction="column" width="100%">
-                  <Text
-                    color="secondary.500"
-                    fontSize="1.25rem"
-                    fontWeight="600"
-                    mb="1rem"
-                    mt="2rem"
-                  >
-                    Options
-                  </Text>
-                  <Flex alignItems="center" mb="2rem">
-                    <Text
-                      color="secondary.700"
-                      fontWeight="400"
-                      mr="7.5rem"
-                      width="6.25rem"
-                    >
-                      Default
-                    </Text>
-                    <Textarea
-                      placeholder={column.fieldOptions?.join('\n') ?? ''}
-                      width="100%"
-                      isDisabled={true}
-                      padding="0.75rem"
-                      resize="none"
-                      height="max-content"
-                    />
-                  </Flex>
-                  <Flex alignItems="center">
-                    <Text color="secondary.700" mr="7.5rem" width="6.25rem">
-                      {language}
-                    </Text>
-                    <FormControl>
-                      <Textarea
-                        width="100%"
-                        {...register(
-                          `tableColumnDropdownTranslations.${index}`,
-                        )}
-                        defaultValue={previousFieldOptionsTranslationsString}
-                      />
-                    </FormControl>
-                  </Flex>
-                </Flex>
-              )}
-              {index !== columns.length - 1 && <Divider mt="2.5rem" />}
-            </Flex>
-          )
-        })}
-      </>
-    )
-  })
+            )}
+            {index !== columns.length - 1 && <Divider mt="2.5rem" />}
+          </Flex>
+        )
+      })}
+    </>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
@@ -1,0 +1,148 @@
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import {
+  Divider,
+  Flex,
+  FormControl,
+  Input,
+  Text,
+  Textarea,
+} from '@chakra-ui/react'
+
+import { Language } from '~shared/types'
+import { BasicField } from '~shared/types/field'
+
+import { TranslationInput } from './TranslationSection'
+
+interface TableColumn {
+  title: string
+  columnType: BasicField
+  fieldOptions?: string[]
+  titleTranslations?: { language: string; translation: string }[]
+  fieldOptionsTranslations?: { language: string; translation: string[] }[]
+}
+
+interface TableTranslationContainerProps {
+  language: string
+  columns: TableColumn[]
+  unicodeLocale: Language
+}
+
+export const TableTranslationContainer: React.FC<TableTranslationContainerProps> =
+  React.memo(({ language, columns, unicodeLocale }) => {
+    const { register } = useFormContext<TranslationInput>()
+
+    return (
+      <>
+        {columns.map((column, index) => {
+          const previousColumnTitleTranslation =
+            column?.titleTranslations?.find(
+              (translation) => translation.language === unicodeLocale,
+            )?.translation ?? ''
+
+          let previousFieldOptionsTranslations: string[] = []
+
+          if (column.columnType === BasicField.Dropdown) {
+            previousFieldOptionsTranslations =
+              column?.fieldOptionsTranslations?.find(
+                (translation) => translation.language === unicodeLocale,
+              )?.translation ?? []
+          }
+
+          const previousFieldOptionsTranslationsString =
+            previousFieldOptionsTranslations.join('\n')
+
+          return (
+            <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
+              <Text
+                color="secondary.500"
+                fontSize="1.25rem"
+                fontWeight="600"
+                mb="1rem"
+              >
+                Column
+              </Text>
+              <Flex direction="column" width="100%">
+                <Flex alignItems="center" mb="2rem">
+                  <Text
+                    color="secondary.700"
+                    fontWeight="400"
+                    mr="7.5rem"
+                    width="6.25rem"
+                  >
+                    Default
+                  </Text>
+                  <Textarea
+                    placeholder={column.title}
+                    width="100%"
+                    isDisabled={true}
+                    padding="0.75rem"
+                    resize="none"
+                  />
+                </Flex>
+                <Flex alignItems="center">
+                  <Text color="secondary.700" mr="7.5rem" width="6.25rem">
+                    {language}
+                  </Text>
+                  <FormControl>
+                    <Input
+                      type="text"
+                      width="100%"
+                      {...register(`tableColumnTitleTranslations.${index}`)}
+                      defaultValue={previousColumnTitleTranslation}
+                    />
+                  </FormControl>
+                </Flex>
+              </Flex>
+              {column.columnType === BasicField.Dropdown && (
+                <Flex direction="column" width="100%">
+                  <Text
+                    color="secondary.500"
+                    fontSize="1.25rem"
+                    fontWeight="600"
+                    mb="1rem"
+                    mt="2rem"
+                  >
+                    Options
+                  </Text>
+                  <Flex alignItems="center" mb="2rem">
+                    <Text
+                      color="secondary.700"
+                      fontWeight="400"
+                      mr="7.5rem"
+                      width="6.25rem"
+                    >
+                      Default
+                    </Text>
+                    <Textarea
+                      placeholder={column.fieldOptions?.join('\n') ?? ''}
+                      width="100%"
+                      isDisabled={true}
+                      padding="0.75rem"
+                      resize="none"
+                      height="max-content"
+                    />
+                  </Flex>
+                  <Flex alignItems="center">
+                    <Text color="secondary.700" mr="7.5rem" width="6.25rem">
+                      {language}
+                    </Text>
+                    <FormControl>
+                      <Textarea
+                        width="100%"
+                        {...register(
+                          `tableColumnDropdownTranslations.${index}`,
+                        )}
+                        defaultValue={previousFieldOptionsTranslationsString}
+                      />
+                    </FormControl>
+                  </Flex>
+                </Flex>
+              )}
+              {index !== columns.length - 1 && <Divider mt="2.5rem" />}
+            </Flex>
+          )
+        })}
+      </>
+    )
+  })

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationContainer.tsx
@@ -23,7 +23,7 @@ export const TranslationContainer = ({
 
   return (
     <Flex direction="column" width="100%">
-      <Flex alignItems="center" mb="2rem">
+      <Flex alignItems="flex-start" mb="2rem">
         <Text
           color="secondary.700"
           fontWeight="400"
@@ -39,7 +39,7 @@ export const TranslationContainer = ({
           resize="none"
         />
       </Flex>
-      <Flex alignItems="center">
+      <Flex alignItems="flex-start">
         <Text color="secondary.700" mr="7.5rem" width="6.25rem">
           {language}
         </Text>

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationContainer.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { useFormContext } from 'react-hook-form'
-import { Flex, FormControl, Input, Text, Textarea } from '@chakra-ui/react'
+import { Flex, FormControl, Text } from '@chakra-ui/react'
+
+import Textarea from '~components/Textarea'
 
 import { TranslationInput } from './TranslationSection'
 
@@ -11,44 +13,43 @@ interface TranslationContainerProps {
   previousTranslation?: string
 }
 
-export const TranslationContainer: React.FC<TranslationContainerProps> =
-  React.memo(
-    ({ language, defaultString, editingTranslation, previousTranslation }) => {
-      const { register } = useFormContext<TranslationInput>()
+export const TranslationContainer = ({
+  language,
+  defaultString,
+  editingTranslation,
+  previousTranslation,
+}: TranslationContainerProps) => {
+  const { register } = useFormContext<TranslationInput>()
 
-      return (
-        <Flex direction="column" width="100%">
-          <Flex alignItems="center" mb="2rem">
-            <Text
-              color="secondary.700"
-              fontWeight="400"
-              mr="7.5rem"
-              width="6.25rem"
-            >
-              Default
-            </Text>
-            <Textarea
-              placeholder={defaultString}
-              width="100%"
-              isDisabled={true}
-              padding="0.75rem"
-              resize="none"
-            />
-          </Flex>
-          <Flex alignItems="center">
-            <Text color="secondary.700" mr="7.5rem" width="6.25rem">
-              {language}
-            </Text>
-            <FormControl>
-              <Input
-                type="text"
-                width="100%"
-                {...register(editingTranslation)}
-                defaultValue={previousTranslation}
-              />
-            </FormControl>
-          </Flex>
-        </Flex>
-      )
-    },
+  return (
+    <Flex direction="column" width="100%">
+      <Flex alignItems="center" mb="2rem">
+        <Text
+          color="secondary.700"
+          fontWeight="400"
+          mr="7.5rem"
+          width="6.25rem"
+        >
+          Default
+        </Text>
+        <Textarea
+          placeholder={defaultString}
+          width="100%"
+          isDisabled={true}
+          resize="none"
+        />
+      </Flex>
+      <Flex alignItems="center">
+        <Text color="secondary.700" mr="7.5rem" width="6.25rem">
+          {language}
+        </Text>
+        <FormControl>
+          <Textarea
+            defaultValue={previousTranslation}
+            {...register(editingTranslation)}
+          />
+        </FormControl>
+      </Flex>
+    </Flex>
   )
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationContainer.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { useFormContext } from 'react-hook-form'
+import { Flex, FormControl, Input, Text, Textarea } from '@chakra-ui/react'
+
+import { TranslationInput } from './TranslationSection'
+
+interface TranslationContainerProps {
+  language: string
+  defaultString: string | undefined
+  editingTranslation: keyof TranslationInput
+  previousTranslation?: string
+}
+
+export const TranslationContainer: React.FC<TranslationContainerProps> =
+  React.memo(
+    ({ language, defaultString, editingTranslation, previousTranslation }) => {
+      const { register } = useFormContext<TranslationInput>()
+
+      return (
+        <Flex direction="column" width="100%">
+          <Flex alignItems="center" mb="2rem">
+            <Text
+              color="secondary.700"
+              fontWeight="400"
+              mr="7.5rem"
+              width="6.25rem"
+            >
+              Default
+            </Text>
+            <Textarea
+              placeholder={defaultString}
+              width="100%"
+              isDisabled={true}
+              padding="0.75rem"
+              resize="none"
+            />
+          </Flex>
+          <Flex alignItems="center">
+            <Text color="secondary.700" mr="7.5rem" width="6.25rem">
+              {language}
+            </Text>
+            <FormControl>
+              <Input
+                type="text"
+                width="100%"
+                {...register(editingTranslation)}
+                defaultValue={previousTranslation}
+              />
+            </FormControl>
+          </Flex>
+        </Flex>
+      )
+    },
+  )

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationListSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationListSection.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 import { BiArrowBack, BiCheck, BiError } from 'react-icons/bi'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import {
   As,
   Divider,
@@ -43,6 +43,10 @@ interface QuestionRowProps {
   icon: As
   isMyInfoField: boolean
   hasTranslations: boolean
+  unicodeLocale: string
+  formFieldNum?: number
+  isStartPage?: boolean
+  isEndPage?: boolean
 }
 
 export const QuestionRow = ({
@@ -50,13 +54,24 @@ export const QuestionRow = ({
   icon,
   isMyInfoField,
   hasTranslations,
+  unicodeLocale,
+  formFieldNum = -1,
+  isStartPage = false,
+  isEndPage = false,
 }: QuestionRowProps): JSX.Element => {
+  const [, setSearchParams] = useSearchParams()
+
   const isTranslationRowDisabled = isMyInfoField
 
-  // TODO: Introduce view for user to add in translation input in next PR
+  const translationInput = isEndPage
+    ? 'endPage'
+    : isStartPage
+      ? 'startPage'
+      : formFieldNum.toString()
+
   const handleOnListClick = useCallback(() => {
-    console.log('handleOnListClick')
-  }, [])
+    setSearchParams({ unicodeLocale, translationInput })
+  }, [setSearchParams, translationInput, unicodeLocale])
 
   return (
     <Flex direction="row">
@@ -301,6 +316,8 @@ export const TranslationListSection = ({
                 icon={BxsDockTop}
                 isMyInfoField={false}
                 hasTranslations={hasStartPageTranslations}
+                isStartPage={true}
+                unicodeLocale={language}
               />
               <Divider />
             </>
@@ -320,6 +337,8 @@ export const TranslationListSection = ({
                   icon={questionIcon}
                   isMyInfoField={isMyInfoField}
                   hasTranslations={getHasTranslations(form_field)}
+                  formFieldNum={id}
+                  unicodeLocale={language}
                 />
                 <Divider />
               </>
@@ -333,6 +352,8 @@ export const TranslationListSection = ({
               icon={PhHandsClapping}
               isMyInfoField={false}
               hasTranslations={hasEndPageTranslations}
+              isEndPage={true}
+              unicodeLocale={language}
             />
           )}
         </Flex>

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationListSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationListSection.tsx
@@ -129,7 +129,7 @@ const getHasFormFieldBaseTranslations = ({
   const hasTitleTranslation = titleTranslations.some(
     (titleTranslation) =>
       titleTranslation.language === unicodeLocale &&
-      titleTranslation.translation,
+      !_.isEmpty(titleTranslation.translation),
   )
 
   // Value to represent whether or not the required field have translations for description.
@@ -332,7 +332,7 @@ export const TranslationListSection = ({
             return (
               <>
                 <QuestionRow
-                  key={id}
+                  key={form_field._id}
                   questionTitle={form_field.title}
                   icon={questionIcon}
                   isMyInfoField={isMyInfoField}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationSection.tsx
@@ -31,12 +31,12 @@ interface TranslationSectionProps {
   isEndPageTranslations?: boolean
 }
 
-export const TranslationSection: React.FC<TranslationSectionProps> = ({
+export const TranslationSection = ({
   language,
   formFieldNumToBeTranslated,
   isStartPageTranslations = false,
   isEndPageTranslations = false,
-}) => {
+}: TranslationSectionProps) => {
   const { data: form, isLoading } = useAdminForm()
   const methods = useForm<TranslationInput>()
   const { getValues } = methods

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationSection.tsx
@@ -1,0 +1,116 @@
+import React from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { BiChevronLeft } from 'react-icons/bi'
+import { Button, Flex, Skeleton } from '@chakra-ui/react'
+
+import { Language } from '~shared/types'
+
+import { useToast } from '~hooks/useToast'
+import { convertUnicodeLocaleToLanguage } from '~utils/multiLanguage'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+
+import { useTranslationLogic } from './mutations/useTranslationLogic'
+import { EndPageTranslationsContainer } from './EndPageTranslationContainer'
+import { FormFieldTranslationContainer } from './FormFieldTranslationContainer'
+import { StartPageTranslationContainer } from './StartPageTranslationContainer'
+
+export type TranslationInput = {
+  titleTranslation: string
+  descriptionTranslation: string
+  paragraphTranslations: string
+  fieldOptionsTranslations: string
+  tableColumnTitleTranslations: string[]
+  tableColumnDropdownTranslations: string[]
+}
+
+interface TranslationSectionProps {
+  language: string
+  formFieldNumToBeTranslated: number
+  isStartPageTranslations?: boolean
+  isEndPageTranslations?: boolean
+}
+
+export const TranslationSection: React.FC<TranslationSectionProps> = ({
+  language,
+  formFieldNumToBeTranslated,
+  isStartPageTranslations = false,
+  isEndPageTranslations = false,
+}) => {
+  const { data: form, isLoading } = useAdminForm()
+  const methods = useForm<TranslationInput>()
+  const { getValues } = methods
+  const toast = useToast({ status: 'danger' })
+  const isFormField = formFieldNumToBeTranslated !== -1
+  const unicodeLocale = language as Language
+  const capitalisedLanguage = convertUnicodeLocaleToLanguage(unicodeLocale)
+
+  if (!isLoading && !form) {
+    toast({
+      description:
+        'There was an error retrieving your form. Please try again later.',
+    })
+  }
+
+  const {
+    handleOnBackClick,
+    handleOnSaveClick,
+    formFieldData,
+    formStartPage,
+    formEndPage,
+  } = useTranslationLogic({
+    form,
+    getValues,
+    language,
+    formFieldNumToBeTranslated,
+    isStartPageTranslations,
+    isEndPageTranslations,
+    isFormField,
+  })
+
+  return (
+    <Skeleton isLoaded={!isLoading && !!form}>
+      <Flex mb="3.75rem">
+        <Button
+          variant="clear"
+          colorScheme="primary"
+          aria-label="Back Button"
+          size="sm"
+          leftIcon={<BiChevronLeft fontSize="1.5rem" />}
+          onClick={handleOnBackClick}
+          marginRight="2.25rem"
+        >
+          Back to all questions
+        </Button>
+      </Flex>
+      <FormProvider {...methods}>
+        <Flex ml="6.25rem" direction="column">
+          {isStartPageTranslations && (
+            <StartPageTranslationContainer
+              startPage={formStartPage}
+              capitalisedLanguage={capitalisedLanguage}
+              unicodeLocale={unicodeLocale}
+            />
+          )}
+          {isFormField && formFieldData && (
+            <FormFieldTranslationContainer
+              formFieldData={formFieldData}
+              capitalisedLanguage={capitalisedLanguage}
+              unicodeLocale={unicodeLocale}
+            />
+          )}
+          {isEndPageTranslations && formEndPage && (
+            <EndPageTranslationsContainer
+              endPage={formEndPage}
+              capitalisedLanguage={capitalisedLanguage}
+              unicodeLocale={unicodeLocale}
+            />
+          )}
+          <Button variant="solid" width="30%" onClick={handleOnSaveClick}>
+            Save Translation
+          </Button>
+        </Flex>
+      </FormProvider>
+    </Skeleton>
+  )
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/mutations/useTranslationLogic.ts
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/mutations/useTranslationLogic.ts
@@ -88,6 +88,7 @@ export const useTranslationLogic = ({
           updatedTitleTranslation,
           updatedDescriptionTranslation,
         })
+
         editFieldMutation.mutate(
           { ...updatedTableData, _id: fieldId } as FormFieldDto,
           { onSuccess: handleOnBackClick },

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/mutations/useTranslationLogic.ts
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/mutations/useTranslationLogic.ts
@@ -123,7 +123,6 @@ export const useTranslationLogic = ({
         language,
         updatedParagraphTranslation,
       })
-      console.log(updatedFormStartPage)
       startPageMutation.mutate(updatedFormStartPage as FormStartPage, {
         onSuccess: handleOnBackClick,
       })
@@ -136,8 +135,6 @@ export const useTranslationLogic = ({
         updatedTitleTranslation,
         updatedParagraphTranslation,
       })
-
-      console.log(updatedFormEndPage)
 
       endPageMutation.mutate(updatedFormEndPage as FormEndPage, {
         onSuccess: handleOnBackClick,

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/mutations/useTranslationLogic.ts
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/mutations/useTranslationLogic.ts
@@ -1,0 +1,168 @@
+import { useCallback, useEffect } from 'react'
+import { UseFormGetValues } from 'react-hook-form'
+import { useSearchParams } from 'react-router-dom'
+import _ from 'lodash'
+
+import {
+  AdminFormDto,
+  BasicField,
+  FormEndPage,
+  FormFieldDto,
+  FormStartPage,
+} from '~shared/types'
+
+import { useMutateFormPage } from '~features/admin-form/common/mutations'
+import { useEditFormField } from '~features/admin-form/create/builder-and-design/mutations/useEditFormField'
+import {
+  updateEditStateSelector,
+  useFieldBuilderStore,
+} from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
+
+import { TranslationInput } from '../TranslationSection'
+import {
+  updateFormEndPageTranslations,
+  updateFormFieldTranslations,
+  updateFormStartPageTranslations,
+  updateTableTranslations,
+} from '../utils/translationUtils'
+
+interface UseTranslationLogicProps {
+  form: AdminFormDto | undefined
+  language: string
+  formFieldNumToBeTranslated: number
+  isStartPageTranslations: boolean
+  isEndPageTranslations: boolean
+  isFormField: boolean
+  getValues: UseFormGetValues<TranslationInput>
+}
+
+export const useTranslationLogic = ({
+  form,
+  language,
+  formFieldNumToBeTranslated,
+  isStartPageTranslations,
+  isEndPageTranslations,
+  isFormField,
+  getValues,
+}: UseTranslationLogicProps) => {
+  const [, setSearchParams] = useSearchParams()
+  const { editFieldMutation } = useEditFormField()
+  const { endPageMutation, startPageMutation } = useMutateFormPage()
+  const updateEditState = useFieldBuilderStore(updateEditStateSelector)
+
+  const formFieldData =
+    formFieldNumToBeTranslated !== -1
+      ? form?.form_fields[formFieldNumToBeTranslated]
+      : undefined
+  const formStartPage = form?.startPage
+  const formEndPage = form?.endPage
+  const fieldId = formFieldData?._id
+
+  useEffect(() => {
+    if (formFieldData) updateEditState(formFieldData)
+  }, [formFieldData, updateEditState])
+
+  const handleOnBackClick = useCallback(() => {
+    setSearchParams({ unicodeLocale: language })
+  }, [language, setSearchParams])
+
+  const handleOnSaveClick = useCallback(() => {
+    const updatedTitleTranslation = getValues('titleTranslation')
+    const updatedDescriptionTranslation = getValues('descriptionTranslation')
+    const updatedParagraphTranslation = getValues('paragraphTranslations')
+    const updatedFieldOptionsTranslation = getValues('fieldOptionsTranslations')
+    const updatedTableColumnTitleTranslation = getValues(
+      'tableColumnTitleTranslations',
+    )
+    const updatedTableColumnDropdownTranslation = getValues(
+      'tableColumnDropdownTranslations',
+    )
+
+    if (isFormField && formFieldData) {
+      if (formFieldData.fieldType === BasicField.Table) {
+        const updatedTableData = updateTableTranslations({
+          data: formFieldData,
+          language,
+          updatedTableColumnTitleTranslation,
+          updatedTableColumnDropdownTranslation,
+          updatedTitleTranslation,
+          updatedDescriptionTranslation,
+        })
+        editFieldMutation.mutate(
+          { ...updatedTableData, _id: fieldId } as FormFieldDto,
+          { onSuccess: handleOnBackClick },
+        )
+      } else {
+        let updatedFieldOptionsTranslationArr =
+          updatedFieldOptionsTranslation.split('\n')
+
+        updatedFieldOptionsTranslationArr =
+          updatedFieldOptionsTranslationArr.filter(
+            (optionsTranslation) => !_.isEmpty(optionsTranslation),
+          )
+
+        const updatedFormData = updateFormFieldTranslations({
+          data: formFieldData,
+          language,
+          updatedTitleTranslation,
+          updatedDescriptionTranslation,
+          updatedFieldOptionsTranslation: updatedFieldOptionsTranslationArr,
+        })
+
+        editFieldMutation.mutate(
+          { ...updatedFormData, _id: fieldId } as FormFieldDto,
+          { onSuccess: handleOnBackClick },
+        )
+      }
+    }
+
+    if (isStartPageTranslations && formStartPage) {
+      const updatedFormStartPage = updateFormStartPageTranslations({
+        data: formStartPage,
+        language,
+        updatedParagraphTranslation,
+      })
+      console.log(updatedFormStartPage)
+      startPageMutation.mutate(updatedFormStartPage as FormStartPage, {
+        onSuccess: handleOnBackClick,
+      })
+    }
+
+    if (isEndPageTranslations && formEndPage) {
+      const updatedFormEndPage = updateFormEndPageTranslations({
+        data: formEndPage,
+        language,
+        updatedTitleTranslation,
+        updatedParagraphTranslation,
+      })
+
+      console.log(updatedFormEndPage)
+
+      endPageMutation.mutate(updatedFormEndPage as FormEndPage, {
+        onSuccess: handleOnBackClick,
+      })
+    }
+  }, [
+    getValues,
+    isFormField,
+    formFieldData,
+    isStartPageTranslations,
+    formStartPage,
+    isEndPageTranslations,
+    formEndPage,
+    language,
+    editFieldMutation,
+    fieldId,
+    handleOnBackClick,
+    startPageMutation,
+    endPageMutation,
+  ])
+
+  return {
+    handleOnSaveClick,
+    formFieldData,
+    formStartPage,
+    formEndPage,
+    handleOnBackClick,
+  }
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/utils/translationUtils.ts
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/utils/translationUtils.ts
@@ -1,0 +1,226 @@
+import _ from 'lodash'
+
+import {
+  FormEndPage,
+  FormField,
+  FormStartPage,
+  Language,
+  TranslationMapping,
+  TranslationOptionMapping,
+} from '~shared/types'
+import { BasicField, TableFieldBase } from '~shared/types/field'
+
+export const updateFormFieldTranslations = ({
+  data,
+  language,
+  updatedTitleTranslation,
+  updatedDescriptionTranslation,
+  updatedFieldOptionsTranslation,
+}: {
+  data: FormField
+  language: string
+  updatedTitleTranslation: string
+  updatedDescriptionTranslation: string
+  updatedFieldOptionsTranslation: string[]
+}): FormField => {
+  let updatedFormFieldData = { ...data }
+
+  const doesFormFieldHaveOptions =
+    data.fieldType === BasicField.Dropdown ||
+    data.fieldType === BasicField.Checkbox ||
+    data.fieldType === BasicField.Radio
+
+  // Update title translations
+  const updatedTitleTranslations = updateTranslations({
+    translations: data?.titleTranslations,
+    language,
+    newTranslation: updatedTitleTranslation,
+  })
+
+  // Update description translations
+  const updatedDescriptionTranslations = updateTranslations({
+    translations: data?.descriptionTranslations,
+    language,
+    newTranslation: updatedDescriptionTranslation,
+  })
+
+  updatedFormFieldData = {
+    ...updatedFormFieldData,
+    descriptionTranslations: updatedDescriptionTranslations,
+    titleTranslations: updatedTitleTranslations,
+  }
+
+  // If form field is dropdown, radio or checkbox => update field options translations
+  if (doesFormFieldHaveOptions) {
+    const updatedFieldOptionsTranslations = updateOptionsTranslations({
+      translations: data?.fieldOptionsTranslations,
+      language,
+      newTranslations: updatedFieldOptionsTranslation,
+    })
+
+    updatedFormFieldData = {
+      ...updatedFormFieldData,
+      ...(doesFormFieldHaveOptions && {
+        fieldOptionsTranslations: updatedFieldOptionsTranslations,
+      }),
+    }
+  }
+
+  return updatedFormFieldData
+}
+
+export const updateFormStartPageTranslations = ({
+  data,
+  language,
+  updatedParagraphTranslation,
+}: {
+  data: FormStartPage
+  language: string
+  updatedParagraphTranslation: string
+}): FormStartPage => {
+  const updatedParagraphTranslations = updateTranslations({
+    translations: data?.paragraphTranslations,
+    language,
+    newTranslation: updatedParagraphTranslation,
+  })
+
+  return { ...data, paragraphTranslations: updatedParagraphTranslations }
+}
+
+export const updateFormEndPageTranslations = ({
+  data,
+  language,
+  updatedTitleTranslation,
+  updatedParagraphTranslation,
+}: {
+  data: FormEndPage
+  language: string
+  updatedTitleTranslation: string
+  updatedParagraphTranslation: string
+}): FormEndPage => {
+  const updatedTitleTranslations = updateTranslations({
+    translations: data?.titleTranslations,
+    language,
+    newTranslation: updatedTitleTranslation,
+  })
+  const updatedParagraphTranslations = updateTranslations({
+    translations: data?.paragraphTranslations,
+    language,
+    newTranslation: updatedParagraphTranslation,
+  })
+
+  return {
+    ...data,
+    paragraphTranslations: updatedParagraphTranslations,
+    titleTranslations: updatedTitleTranslations,
+  }
+}
+
+export const updateTableTranslations = ({
+  data,
+  language,
+  updatedTableColumnTitleTranslation,
+  updatedTableColumnDropdownTranslation,
+  updatedTitleTranslation,
+  updatedDescriptionTranslation,
+}: {
+  data: TableFieldBase
+  language: string
+  updatedTableColumnTitleTranslation: string[]
+  updatedTableColumnDropdownTranslation: string[]
+  updatedTitleTranslation: string
+  updatedDescriptionTranslation: string
+}): TableFieldBase => {
+  const columns = data.columns
+
+  const updatedTitleTranslations = updateTranslations({
+    translations: data?.titleTranslations,
+    language,
+    newTranslation: updatedTitleTranslation,
+  })
+  const updatedDescriptionTranslations = updateTranslations({
+    translations: data?.descriptionTranslations,
+    language,
+    newTranslation: updatedDescriptionTranslation,
+  })
+
+  const updatedColumns = columns.map((column, columnIdx) => {
+    console.log(column)
+    return {
+      ...column,
+      titleTranslations: updateTranslations({
+        translations: column?.titleTranslations,
+        language,
+        newTranslation: updatedTableColumnTitleTranslation[columnIdx],
+      }),
+      ...(column.columnType === BasicField.Dropdown && {
+        fieldOptionsTranslations: updateOptionsTranslations({
+          translations: column?.fieldOptionsTranslations,
+          language,
+          newTranslations: updatedTableColumnDropdownTranslation[columnIdx]
+            .split('\n')
+            .filter((optionsTranslation) => !_.isEmpty(optionsTranslation)),
+        }),
+      }),
+    }
+  })
+
+  return {
+    ...data,
+    titleTranslations: updatedTitleTranslations,
+    descriptionTranslations: updatedDescriptionTranslations,
+    columns: updatedColumns,
+  }
+}
+
+const updateTranslations = ({
+  translations,
+  language,
+  newTranslation,
+}: {
+  translations: TranslationMapping[] | undefined
+  language: string
+  newTranslation: string
+}): TranslationMapping[] => {
+  const updatedTranslations = translations || []
+  const translationIndex = updatedTranslations.findIndex(
+    (t) => t.language === language,
+  )
+
+  if (translationIndex !== -1) {
+    updatedTranslations[translationIndex].translation = newTranslation
+  } else {
+    updatedTranslations.push({
+      language: language as Language,
+      translation: newTranslation,
+    })
+  }
+
+  return updatedTranslations
+}
+
+const updateOptionsTranslations = ({
+  translations,
+  language,
+  newTranslations,
+}: {
+  translations: TranslationOptionMapping[] | undefined
+  language: string
+  newTranslations: string[]
+}): TranslationOptionMapping[] => {
+  const updatedTranslations = translations || []
+  const translationIndex = updatedTranslations.findIndex(
+    (t) => t.language === language,
+  )
+
+  if (translationIndex !== -1) {
+    updatedTranslations[translationIndex].translation = newTranslations
+  } else {
+    updatedTranslations.push({
+      language: language as Language,
+      translation: newTranslations,
+    })
+  }
+
+  return updatedTranslations
+}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/utils/translationUtils.ts
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/utils/translationUtils.ts
@@ -145,7 +145,6 @@ export const updateTableTranslations = ({
   })
 
   const updatedColumns = columns.map((column, columnIdx) => {
-    console.log(column)
     return {
       ...column,
       titleTranslations: updateTranslations({

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -107,9 +107,9 @@ const loadExpressApp = async (connection: Connection) => {
   app.use(IntranetMiddleware.logIntranetUsage)
 
   // Growthbook should not be enabled in test environment to avoid flakiness
-  // if (!config.isTest) {
-  //   app.use(growthbookMiddleware)
-  // }
+  if (!config.isTest) {
+    app.use(growthbookMiddleware)
+  }
 
   // jwks endpoint for SP OIDC
   app.use('/singpass/.well-known/jwks.json', SpOidcJwksRouter)

--- a/src/app/loaders/express/index.ts
+++ b/src/app/loaders/express/index.ts
@@ -107,9 +107,9 @@ const loadExpressApp = async (connection: Connection) => {
   app.use(IntranetMiddleware.logIntranetUsage)
 
   // Growthbook should not be enabled in test environment to avoid flakiness
-  if (!config.isTest) {
-    app.use(growthbookMiddleware)
-  }
+  // if (!config.isTest) {
+  //   app.use(growthbookMiddleware)
+  // }
 
   // jwks endpoint for SP OIDC
   app.use('/singpass/.well-known/jwks.json', SpOidcJwksRouter)

--- a/src/app/models/field/tableField.ts
+++ b/src/app/models/field/tableField.ts
@@ -23,7 +23,9 @@ const createColumnSchema = () => {
               type: String,
               enum: Object.values(Language),
             },
-            translation: [String],
+            translation: {
+              type: String,
+            },
           },
         ],
         default: [],


### PR DESCRIPTION
## Changes
- Add views to allow users to add translation input
- Link to [view](https://www.figma.com/design/wNcuzzF3ciL8f6xYNvGZgK/Form-Exploration?node-id=11536-21618&node-type=frame&t=0av2bQA7SjvvIw2k-0)

## Before & After Screenshots
| Description | Before | After | 
| ----------- | ------- | ----- |
|Translation container for users to input translations for base form fields| |<img width="547" alt="Screenshot 2024-11-18 at 10 21 18 AM" src="https://github.com/user-attachments/assets/0a795589-f492-41d5-bf07-4eecbe26ad4a">|
|Translation container for users to input their translations for form fields with options| |<img width="744" alt="Screenshot 2024-11-18 at 10 06 32 AM" src="https://github.com/user-attachments/assets/e4f1399f-0aed-45cb-93ea-37ecad798220">|
|Translation container for users to input translations for table container| |<img width="540" alt="Screenshot 2024-11-18 at 10 19 48 AM" src="https://github.com/user-attachments/assets/e4c36d2b-702c-4922-befa-1cbf62d4f649">|





