### PR TITLE
feat: unify email notification for response copy for storage and email modes  

### DIFF
--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -374,7 +374,7 @@ const addAdminEmails = async (
   ).toBeVisible()
 
   if (formSettings.emails) {
-    const emailInput = page.getByLabel('Send an email copy of new responses')
+    const emailInput = page.getByLabel('Notifications for new responses')
     await emailInput.focus()
 
     // Clear the current admin email

--- a/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
@@ -15,7 +15,7 @@ import { useAdminFormSettings } from './queries'
 const FormEmailSectionSkeleton = (): JSX.Element => {
   return (
     <Skeleton>
-      <FormLabel>Send an email copy of new responses</FormLabel>
+      <FormLabel>Notifications for new responses</FormLabel>
       <TagInput placeholder="me@example.com" isDisabled />
     </Skeleton>
   )

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -113,8 +113,7 @@ export const FormEmailSection = ({
 
   const isEmailMode = settings.responseMode === FormResponseMode.Email
 
-  const emailModeDescription = `Add at least **2 recipients** to prevent loss of response.`
-  const storageModeDescription = `FormSG securely stores responses in an encrypted format and does not retain any associated emails.`
+  const DESCRIPTION_TEXT = `All email addresses below will be notified. Learn more on [how to guard against email bounces](${GUIDE_PREVENT_EMAIL_BOUNCE}).`
 
   return (
     <>
@@ -123,12 +122,9 @@ export const FormEmailSection = ({
           <FormLabel
             isRequired={isEmailMode}
             useMarkdownForDescription
-            description={
-              (isEmailMode ? emailModeDescription : storageModeDescription) +
-              ` Learn more on [how to guard against email bounces](${GUIDE_PREVENT_EMAIL_BOUNCE}).`
-            }
+            description={DESCRIPTION_TEXT}
           >
-            Send an email copy of new responses
+            Notifications for new responses
           </FormLabel>
           <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} />
           <FormErrorMessage>{get(errors, 'emails.message')}</FormErrorMessage>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -116,9 +116,9 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             <FormControl isRequired isInvalid={!!errors.emails} mb="2.25rem">
               <FormLabel
                 useMarkdownForDescription
-                description={`Specify up to 30 emails. [How to guard against bounce emails](${GUIDE_PREVENT_EMAIL_BOUNCE}).`}
+                description={`All email addresses below will be notified. Learn more on [how to guard against email bounces](${GUIDE_PREVENT_EMAIL_BOUNCE}).`}
               >
-                Emails where responses will be sent
+                Notifications for new responses
               </FormLabel>
               <EmailFormRecipientsInput />
             </FormControl>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The copy for the same functionality (email notifications for responses) on email and storage mode differ. 

Closes FRM-1911 

## Solution
<!-- How did you solve the problem? -->
Make the copy the same for both modes. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  