### PR TITLE
fix: fixed cursor appearance for inactive logic block

### DIFF
--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
@@ -98,6 +98,7 @@ export const InactiveLogicBlock = ({
         borderColor="neutral.300"
         cursor={isPreventEdit ? 'not-allowed' : 'pointer'}
         aria-disabled={isPreventEdit}
+        pointerEvents="none"
       >
         <Stack
           spacing="1.5rem"

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
@@ -96,9 +96,8 @@ export const InactiveLogicBlock = ({
         bg="white"
         border="1px solid"
         borderColor="neutral.300"
-        cursor={isPreventEdit ? 'not-allowed' : 'pointer'}
+        cursor={isPreventEdit ? 'not-allowed' : 'auto'}
         aria-disabled={isPreventEdit}
-        pointerEvents="none"
       >
         <Stack
           spacing="1.5rem"

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
@@ -132,10 +132,9 @@ export const InactiveStepBlock = ({
         borderColor="neutral.300"
         transitionProperty="common"
         transitionDuration="normal"
-        cursor={isPreventEdit ? 'not-allowed' : 'pointer'}
+        cursor={isPreventEdit ? 'not-allowed' : 'auto'}
         disabled={isPreventEdit}
         aria-disabled={isPreventEdit}
-        pointerEvents="none"
       >
         <Stack spacing="1.5rem" p={{ base: '1.5rem', md: '2rem' }}>
           <StepLabel stepNumber={stepNumber} />


### PR DESCRIPTION
## Problem
Similar to Inactive Workflow Block, cursor should not change to 'clickable' appearance upon hover; this behaviour should only occur when hovering over the <BiPencil> icon

## Solution
Adding pointerEvents="none"

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**AFTER**:

https://github.com/user-attachments/assets/6d4605a2-af62-4520-a39b-dee477734d00