### PR TITLE
chore(approvals-ga): remove beta flag for MRF email notifications and approvals

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
@@ -16,7 +16,6 @@ import {
   BASICFIELD_TO_DRAWER_META,
   MYINFO_FIELD_TO_DRAWER_META,
 } from '~features/admin-form/create/constants'
-import { useUser } from '~features/user/queries'
 
 import { useCreateTabForm } from '../../useCreateTabForm'
 import {
@@ -150,9 +149,6 @@ export const DraggableMyInfoFieldListOption = ({
 
 export const BasicFieldOption = forwardRef<BasicFieldOptionProps, 'button'>(
   ({ fieldType, isDisabled, ...props }, ref) => {
-    // TODO: (MRF-email-notif) Remove isTest and useUser when approvals is out of beta
-    const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-    const { user } = useUser()
     const meta = useMemo(
       () => BASICFIELD_TO_DRAWER_META[fieldType],
       [fieldType],
@@ -183,13 +179,10 @@ export const BasicFieldOption = forwardRef<BasicFieldOptionProps, 'button'>(
       >
         <Icon fontSize="1.5rem" as={meta.icon} />
         <Text textStyle="body-1">{meta.label}</Text>
-        {/* TODO: (MRF-email-notif) Remove isTest and betaFlag check when approvals is out of beta */}
-        {isTest || user?.betaFlags?.mrfEmailNotifications ? (
-          isMrf && fieldType === BasicField.YesNo ? (
-            <Badge maxW="100%" variant="subtle" colorScheme="secondary">
-              <Text noOfLines={1}>Use for approvals</Text>
-            </Badge>
-          ) : null
+        {isMrf && fieldType === BasicField.YesNo ? (
+          <Badge maxW="100%" variant="subtle" colorScheme="secondary">
+            <Text noOfLines={1}>Use for approvals</Text>
+          </Badge>
         ) : null}
       </FieldListOption>
     )

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -113,9 +113,6 @@ export const EditStepBlock = ({
 
   const isFirstStep = isFirstStepByStepNumber(stepNumber)
 
-  // TODO: (MRF-email-notif) Remove isTest check when approvals is out of beta
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-
   return (
     <Stack
       ref={wrapperRef}
@@ -141,14 +138,11 @@ export const EditStepBlock = ({
       />
       <Divider />
       <QuestionsBlock formMethods={formMethods} isLoading={_isLoading} />
-      {/*TODO: (MRF-email-notif) Remove isTest and betaFlag check when approvals is out of beta */}
-      {isTest || user?.betaFlags?.mrfEmailNotifications ? (
-        !isFirstStep ? (
-          <>
-            <Divider />
-            <ApprovalsBlock formMethods={formMethods} stepNumber={stepNumber} />
-          </>
-        ) : null
+      {!isFirstStep ? (
+        <>
+          <Divider />
+          <ApprovalsBlock formMethods={formMethods} stepNumber={stepNumber} />
+        </>
       ) : null}
       <Divider />
       <SaveActionGroup

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
@@ -11,7 +11,6 @@ import IconButton from '~components/IconButton'
 import { FieldLogicBadge } from '~features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge'
 import { LogicBadge } from '~features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/LogicBadge'
 import { FormFieldWithQuestionNo } from '~features/form/types'
-import { useUser } from '~features/user/queries'
 
 import {
   createOrEditDataSelector,
@@ -64,10 +63,6 @@ export const InactiveStepBlock = ({
   const { idToFieldMap } = useAdminFormWorkflow()
   const setToEditing = useAdminWorkflowStore(setToEditingSelector)
   const stateData = useAdminWorkflowStore(createOrEditDataSelector)
-
-  const { user } = useUser()
-  // TODO: (MRF-email-notif) Remove isTest check when MRF email notifications and approvals are both out of beta
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
 
   // Prevent editing step if some other step is being edited.
   const isPreventEdit = useMemo(() => !!stateData, [stateData])
@@ -141,8 +136,6 @@ export const InactiveStepBlock = ({
 
           <Stack>
             <Text textStyle="subhead-3">Respondent in this step</Text>
-            {/* TODO: (MRF-email-notif) Remove isTest and betaFlag check when MRF email
-            notifications is out of beta */}
             {isFirstStep ? (
               <Text>Anyone who has access to your form</Text>
             ) : (
@@ -166,11 +159,8 @@ export const InactiveStepBlock = ({
               {questionBadges}
             </Stack>
           </Stack>
-          {/* TODO: (MRF-email-notif) Remove isTest and betaFlag check when approvals is out of beta */}
-          {isTest || user?.betaFlags?.mrfEmailNotifications ? (
-            !isFirstStep ? (
-              <InactiveApprovalsBlock step={step} idToFieldMap={idToFieldMap} />
-            ) : null
+          {!isFirstStep ? (
+            <InactiveApprovalsBlock step={step} idToFieldMap={idToFieldMap} />
           ) : null}
         </Stack>
       </chakra.button>

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -2,8 +2,6 @@ import { Box, Divider, Stack } from '@chakra-ui/react'
 
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
 
-import { useUser } from '~features/user/queries'
-
 import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
 
 import { NewStepBlock } from './NewStepBlock'
@@ -12,9 +10,6 @@ import { WorkflowCompletionMessageBlock } from './WorkflowCompletionMessageBlock
 
 export const WorkflowContent = (): JSX.Element | null => {
   const { formWorkflow, isLoading } = useAdminFormWorkflow()
-  // TODO: (MRF-email-notif) Remove isTest and useUser when email notifications is out of beta
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-  const { user } = useUser()
 
   if (isLoading) return null
 
@@ -26,10 +21,7 @@ export const WorkflowContent = (): JSX.Element | null => {
         ))}
         <NewStepBlock />
       </Stack>
-      {/*TODO: (MRF-email-notif) Remove flag check when email notifications is out of beta */}
-      {isTest || user?.betaFlags?.mrfEmailNotifications ? (
-        <WorkflowCompletionMessageBlock />
-      ) : null}
+      <WorkflowCompletionMessageBlock />
     </Stack>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -1,12 +1,5 @@
 import { useEffect } from 'react'
-import {
-  BiCodeBlock,
-  BiCog,
-  BiDollar,
-  BiKey,
-  BiMailSend,
-  BiMessage,
-} from 'react-icons/bi'
+import { BiCodeBlock, BiCog, BiDollar, BiKey, BiMailSend } from 'react-icons/bi'
 import { IconType } from 'react-icons/lib'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
@@ -19,17 +12,12 @@ import {
   Tabs,
 } from '@chakra-ui/react'
 
-import { FormResponseMode } from '~shared/types'
-
 import { ADMINFORM_RESULTS_SUBROUTE, ADMINFORM_ROUTE } from '~constants/routes'
 import { useDraggable } from '~hooks/useDraggable'
-
-import { useUser } from '~features/user/queries'
 
 import { useAdminFormCollaborators } from '../common/queries'
 
 import { SettingsTab } from './components/SettingsTab'
-import { useAdminFormSettings } from './queries'
 import { SettingsAuthPage } from './SettingsAuthPage'
 import { SettingsEmailsPage } from './SettingsEmailsPage'
 import { SettingsGeneralPage } from './SettingsGeneralPage'
@@ -46,9 +34,6 @@ interface TabEntry {
 
 export const SettingsPage = (): JSX.Element => {
   const { formId, settingsTab } = useParams()
-  const { data: formSettings, isLoading: isFormSettingLoading } =
-    useAdminFormSettings()
-  const { user, isLoading: isUserLoading } = useUser()
 
   if (!formId) throw new Error('No formId provided')
 
@@ -61,25 +46,6 @@ export const SettingsPage = (): JSX.Element => {
     if (!isCollabLoading && !hasEditAccess)
       navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_RESULTS_SUBROUTE}`)
   }, [formId, hasEditAccess, isCollabLoading, navigate])
-
-  // TODO: (MRF-email-notif) Remove isTest when email notifications is out of beta
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-  // For beta flagging email notifications tab.
-  const emailNotificationsTab =
-    isUserLoading ||
-    isFormSettingLoading ||
-    // TODO: (MRF-email-notif) Remove isTest and betaFlag check when MRF email notifications is out of beta
-    (!isTest &&
-      formSettings?.responseMode === FormResponseMode.Multirespondent &&
-      !user?.betaFlags?.mrfEmailNotifications)
-      ? null
-      : {
-          label: 'Email notifications',
-          icon: BiMailSend,
-          component: SettingsEmailsPage,
-          path: 'email-notifications',
-          showRedDot: true,
-        }
 
   const tabConfig: TabEntry[] = [
     {
@@ -94,7 +60,13 @@ export const SettingsPage = (): JSX.Element => {
       component: SettingsAuthPage,
       path: 'singpass',
     },
-    emailNotificationsTab,
+    {
+      label: 'Email notifications',
+      icon: BiMailSend,
+      component: SettingsEmailsPage,
+      path: 'email-notifications',
+      showRedDot: true,
+    },
     {
       label: 'Webhooks',
       icon: BiCodeBlock,

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -21,6 +21,7 @@ export const UserBase = z.object({
       payment: z.boolean().optional(),
       children: z.boolean().optional(),
       postmanSms: z.boolean().optional(),
+      mrfEmailNotifications: z.boolean().optional(), // Previously used for MRF email notifications, not currently used
       mrfAdminSubmissionKey: z.boolean().optional(),
       mfb: z.boolean().optional(),
     })

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -21,8 +21,6 @@ export const UserBase = z.object({
       payment: z.boolean().optional(),
       children: z.boolean().optional(),
       postmanSms: z.boolean().optional(),
-      // TODO: (MRF-email-notif) Remove betaFlag when MRF email notifications is out of beta
-      mrfEmailNotifications: z.boolean().optional(),
       mrfAdminSubmissionKey: z.boolean().optional(),
       mfb: z.boolean().optional(),
     })

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -75,6 +75,7 @@ const compileUserModel = (db: Mongoose) => {
         payment: Boolean,
         children: Boolean,
         postmanSms: Boolean,
+        mrfEmailNotifications: Boolean, // Previously used for MRF email notifications, not currently used
         mrfAdminSubmissionKey: Boolean,
         mfb: Boolean,
       },

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -75,8 +75,6 @@ const compileUserModel = (db: Mongoose) => {
         payment: Boolean,
         children: Boolean,
         postmanSms: Boolean,
-        // TODO: (MRF-email-notif) Remove betaFlag when MRF email notifications is out of beta
-        mrfEmailNotifications: Boolean,
         mrfAdminSubmissionKey: Boolean,
         mfb: Boolean,
       },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Need to release mrf email notifications and approvals from beta to General Availability. 

## Solution
<!-- How did you solve the problem? -->
Remove the beta flags for mrf email notifications and approvals.

Note that the `mrfEmailNotification` beta flag has been retained to prevent accidental reuse of prior flags. I.e., we might have another feature that uses the same flag name of mrfEmailNotification which is not known to the developer cause it no longer exist in the records, but exist in User collection.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests

Test set up: 
- [ ] Create an MRF form called 'finance claims approval' 
- [ ] Add 2 approval yes/no fields named 'RO approve', 'Finance dept approve'. Assert that `Use for approvals` badge appears beside yes/no fields in drawer. 
- [ ] Add 2 email fields
- [ ] Assign 1 email field to step 1 to edit, Assign approval field to step 2 to edit and Assign approval field to step 3 to edit. (do not assign approval field or step 1 email notification field yet)
- [ ] Let step 2 be static email, let step 3 be dynamic email field 
  
TC1: Regression test - MRF still works
- [ ] Open the form to public 
- [ ] Respond to form, ensure that all steps of mrf can be completed and result is in admin responses tab. 
- [ ] Assert no email outcomes are sent, since not yet configured in email notification settings.  

TC2: Regression test - email notif works: 
- [ ] From TC1, config email notif setting to step 2 and static email of choice.
- [ ] Complete submission, assert that workflow completed (note that it is not an outcome status email) is sent to expected emails.  
- [ ] Remove the email notifs to prepare for TC3. 

TC3: Approve without email notif. Expect no email sent  
- [ ] Assign approval field to step 2 only. 
- [ ] Complete all 3 steps of mrf workflow and approve at step 2.  
- [ ] No email is sent. 

TC4: Reject without email notif. Expect no email sent  
- [ ] Use same form from TC3
- [ ] Reject at step 2 of mrf workflow.  
- [ ] No email is sent to step 3 respondent since workflow ends, no outcome email is sent. 

TC5: Approve and reject with email notification works: 
- [ ] Add step 1 and step 3 to email notification and a static email to email notification. 
- [ ] Repeat TC3. Assert that only email from step 3 and static email receives approve email, since step 1 does not have email field setup. 
- [ ] Add email field to step 1 in workflow. 
- [ ] Repeat TC4. Assert step 1 and step 3 and static email receive not approved email. 

TC6: Multiple approval steps - approve all
- [ ] From TC5, add approval step for step 3 of workflow. 
- [ ] Approve all approval steps, approve email should be received. 

TC7: Multiple approval steps  - Reject at step 2 (middle step) 
- [ ] From TC6, make submission
- [ ] Reject at step 2, assert R3 does not receive email and not approved email is sent to expected emails. 

TC8: Multiple approval steps - Reject at last step 
- [ ] From TC7, make submission
- [ ] Approve at step 2 but Reject at step 3, assert not approved email is sent to all expected emails. 

Edge cases: 
TC10: approval field set to optional, respondent did not fill  
- [ ] From TC9, set the approval field used for step 2 as optional. 
- [ ] Try and submit the steps of form, but at step 2, do not fill in the optional approval field. 
- [ ] assert that R3 no longer gets the next step email, no completion/approval outcome emails are sent. 
- [ ] Visit the responses page, the R2 submission is recorded. 
- [ ] Share the next step response link, it goes to R3 and can be resumed.
- [ ] Try and submit R3 and approve/reject, it should send out approved/reject email to expected emails.  

TC10: approval field deleted, admin did not reassign 
- [ ] From TC9, delete the approval field used for step 2. 
- [ ] Try and submit the steps of the form.
- [ ] assert that R3 no longer gets the next step email, no completion/approval outcome emails are sent. 
- [ ] Visit the responses page, the R2 submission is recorded. 
- [ ] Share the next step response link, it goes to R3 and can be resumed. 
- [ ] Try and submit R3 and approve/reject, it should send out approved/reject email to expected emails.  