### PR TITLE
chore(FE): cleanup date check on sex field

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/EditMyInfo.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/EditMyInfo.tsx
@@ -45,34 +45,9 @@ export const EditMyInfo = ({ field }: EditMyInfoProps): JSX.Element => {
       },
     })
 
-  function conditionallyDisplayInfoBox() {
-    const currentDate = new Date().toLocaleString('en-US', {
-      timeZone: 'Asia/Singapore',
-    })
-    const targetDate = new Date('2024-06-28T00:00:00').toLocaleString('en-US', {
-      timeZone: 'Asia/Singapore',
-    })
-
-    if (new Date(currentDate) <= new Date(targetDate)) {
-      return (
-        <>
-          <Box pb="1.5rem">
-            <InlineMessage variant="warning">
-              To align with MyInfo terminology, the “Gender” field will be
-              renamed to “Sex” from 28 Jun 2024.
-            </InlineMessage>
-          </Box>{' '}
-        </>
-      )
-    } else {
-      return null
-    }
-  }
-
   return (
     <CreatePageDrawerContentContainer>
       <VStack align="flex-start">
-        {conditionallyDisplayInfoBox()}
         <Text textStyle="subhead-1">Data source</Text>
         {extendedField.dataSource.map((dataSource, idx) => (
           <HStack key={idx} align="flex-start">

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
@@ -61,34 +61,9 @@ export const EditMyInfoChildren = ({
     },
   })
 
-  function conditionallyDisplayInfoBox() {
-    const currentDate = new Date().toLocaleString('en-US', {
-      timeZone: 'Asia/Singapore',
-    })
-    const targetDate = new Date('2024-06-28T00:00:00').toLocaleString('en-US', {
-      timeZone: 'Asia/Singapore',
-    })
-
-    if (new Date(currentDate) <= new Date(targetDate)) {
-      return (
-        <>
-          <Box pb="1.5rem">
-            <InlineMessage variant="warning">
-              To align with MyInfo terminology, the “Gender” field will be
-              renamed to “Sex” from 28 Jun 2024.
-            </InlineMessage>
-          </Box>{' '}
-        </>
-      )
-    } else {
-      return null
-    }
-  }
-
   return (
     <CreatePageDrawerContentContainer>
       <VStack align="flex-start">
-        {conditionallyDisplayInfoBox()}
         <Text textStyle="subhead-1">Data source</Text>
         {extendedField.dataSource.map((dataSource, idx) => (
           <HStack key={idx} align="flex-start">

--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -203,7 +203,7 @@ export const MYINFO_FIELD_TO_DRAWER_META: {
     isSubmitted: true,
   },
   [MyInfoAttribute.Sex]: {
-    label: 'Gender',
+    label: 'Sex',
     icon: BiInfinite,
     isSubmitted: true,
   },
@@ -346,7 +346,7 @@ export const MYINFO_FIELD_TO_DRAWER_META: {
     isSubmitted: true,
   },
   [MyInfoAttribute.ChildGender]: {
-    label: 'Gender',
+    label: 'Sex',
     icon: BiDummyIcon,
     isSubmitted: true,
   },
@@ -361,24 +361,3 @@ export const MYINFO_FIELD_TO_DRAWER_META: {
     isSubmitted: true,
   },
 }
-// TODO: remove after 28 Jun 2024 as this would have fully taken effect
-function updateLabelsBasedOnDate() {
-  const currentDate = new Date().toLocaleString('en-US', {
-    timeZone: 'Asia/Singapore',
-  })
-  const targetDate = new Date('2024-06-28T00:00:00').toLocaleString('en-US', {
-    timeZone: 'Asia/Singapore',
-  })
-  if (new Date(currentDate) >= new Date(targetDate)) {
-    const sexAttribute = MYINFO_FIELD_TO_DRAWER_META[MyInfoAttribute.Sex]
-    if (sexAttribute) {
-      sexAttribute.label = 'Sex'
-    }
-    const childGenderAttribute =
-      MYINFO_FIELD_TO_DRAWER_META[MyInfoAttribute.ChildGender]
-    if (childGenderAttribute) {
-      childGenderAttribute.label = 'Sex'
-    }
-  }
-}
-updateLabelsBasedOnDate()

--- a/shared/constants/field/myinfo/index.ts
+++ b/shared/constants/field/myinfo/index.ts
@@ -53,12 +53,12 @@ export const types: MyInfoFieldBlock[] = [
   },
   {
     name: MyInfoAttribute.Sex,
-    value: 'Gender',
+    value: 'Sex',
     category: 'personal',
     verified: ['SG', 'PR', 'F'],
     source: 'Immigration & Checkpoints Authority / Ministry of Manpower',
     description:
-      'The gender of the form-filler. This field is verified by ICA for Singaporeans/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.',
+      'The sex of the form-filler. This field is verified by ICA for Singaporeans/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.',
     fieldType: BasicField.Dropdown,
     fieldOptions: ['FEMALE', 'MALE', 'UNKNOWN'],
     previewValue: 'MALE',
@@ -349,11 +349,11 @@ export const types: MyInfoFieldBlock[] = [
   },
   {
     name: MyInfoAttribute.ChildGender,
-    value: "Child's gender",
+    value: "Child's sex",
     category: 'children',
     verified: [],
     source: 'Immigration & Checkpoints Authority',
-    description: 'Gender',
+    description: 'Sex',
     fieldType: BasicField.ShortText,
     fieldOptions: ['FEMALE', 'MALE', 'UNKNOWN'],
     previewValue: 'MALE',
@@ -394,30 +394,3 @@ export const types: MyInfoFieldBlock[] = [
 ]
 
 export const MYINFO_ATTRIBUTE_MAP = keyBy(types, 'name')
-
-// TODO: remove after 28 Jun 2024 as this would have fully taken effect
-function updateLabelBasedOnDate() {
-  const currentDate = new Date().toLocaleString('en-US', {
-    timeZone: 'Asia/Singapore',
-  })
-  const targetDate = new Date('2024-06-28T00:00:00').toLocaleString('en-US', {
-    timeZone: 'Asia/Singapore',
-  })
-  if (new Date(currentDate) >= new Date(targetDate)) {
-    const sexAttribute = MYINFO_ATTRIBUTE_MAP[MyInfoAttribute.Sex]
-    if (sexAttribute) {
-      sexAttribute.description = 'Sex'
-      sexAttribute.value = 'Sex'
-      sexAttribute.description =
-        'The sex of the form-filler. This field is verified by ICA for Singaporeans/PRs & foreigners on Long-Term Visit Pass, and by MOM for Employment Pass holders.'
-    }
-    const childGenderAttribute =
-      MYINFO_ATTRIBUTE_MAP[MyInfoAttribute.ChildGender]
-    if (childGenderAttribute) {
-      childGenderAttribute.value = "Child's Sex"
-      childGenderAttribute.description = 'Sex'
-    }
-  }
-}
-
-updateLabelBasedOnDate()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Date check was implemented on Sex field to support switch overs on a particular date. Since the date has already passed, there is no longer a need for us to check the date.

Closes FRM-1741

## Solution
<!-- How did you solve the problem? -->

Remove Infoboxes and permanently change update gender -> sex.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
