### PR TITLE
chore(FE): use consistent vite port for dev with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npm run dev
 
 After the Docker image has finished building, the following local applications can be accessed:
 
-- React application can be accessed at [localhost:3000](localhost:3000)
+- React application can be accessed at [localhost:5173](localhost:5173)
 - The backend API server can be accessed at [localhost:5001](localhost:5001)
 - The development mail server can be accessed at [localhost:1080](localhost:1080)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
   "scripts": {
     "postinstall": "npm run gen:theme-typings && npm --prefix ../shared install",
     "gen:theme-typings": "chakra-cli tokens --template augmentation src/theme/index.ts || true",
-    "start": "vite --port 3000",
+    "start": "vite",
     "build": "npx tsc && vite build",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true vitest",
     "storybook": "storybook dev -p 6006",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
   "scripts": {
     "postinstall": "npm run gen:theme-typings && npm --prefix ../shared install",
     "gen:theme-typings": "chakra-cli tokens --template augmentation src/theme/index.ts || true",
-    "start": "vite",
+    "start": "vite --port 3000",
     "build": "npx tsc && vite build",
     "test": "cross-env SKIP_PREFLIGHT_CHECK=true vitest",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Problem
Frontend dev start script uses vite's default `5173` port, while README [states 3000 as FE port](https://github.com/opengovsg/FormSG/blob/develop/README.md#prerequisites).
Not touching `vite.config.ts`, afraid it might impact github job + deployment scripts.

## Solution
Update README to reflect the vite's port.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  