### PR TITLE
fix: trim text input before sending to backend

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -153,7 +153,7 @@ const transformFormInputCountryRegionToUpperCase = (
   )
 }
 
-// Text inputs are trimmed duirng validation and hence should also be trimmed before sending to the backend.
+// Trim text inputs before sending to backend to match frontend validation
 const transformFormInputTrimTextInputs = (
   formInputs: Record<string, unknown>,
   form_fields: Array<{ fieldType: BasicField; _id: string }>,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -14,6 +14,7 @@ import { useDisclosure } from '@chakra-ui/react'
 import { datadogLogs } from '@datadog/browser-logs'
 import { useGrowthBook } from '@growthbook/growthbook-react'
 import { differenceInMilliseconds, isPast } from 'date-fns'
+import { flow } from 'lodash'
 import get from 'lodash/get'
 
 import {
@@ -126,61 +127,59 @@ export function useCommonFormProvider(formId: string) {
 // Country/region data must be upper-case in backend for myinfo-countries compatibility,
 // while displaying in title-case to users in the frontend.
 // Hence, we need to map the frontend title-case to upper-case when submitting to backend.
-const transformFormInputCountryRegionToUpperCase = (
-  formInputs: Record<string, unknown>,
-  form_fields: Array<{ fieldType: BasicField; _id: string }>,
-) => {
-  const countryRegionFieldIds = new Set(
-    form_fields
-      .filter((field) => field.fieldType === BasicField.CountryRegion)
-      .map((field) => field._id),
-  )
+const transformFormInputCountryRegionToUpperCase =
+  (form_fields: Array<{ fieldType: BasicField; _id: string }>) =>
+  (formInputs: Record<string, unknown>) => {
+    const countryRegionFieldIds = new Set(
+      form_fields
+        .filter((field) => field.fieldType === BasicField.CountryRegion)
+        .map((field) => field._id),
+    )
 
-  return Object.keys(formInputs).reduce(
-    (newFormInputs: typeof formInputs, fieldId) => {
-      const currentInput = formInputs[fieldId]
-      if (
-        countryRegionFieldIds.has(fieldId) &&
-        typeof currentInput === 'string'
-      ) {
-        newFormInputs[fieldId] = currentInput.toUpperCase()
-      } else {
-        newFormInputs[fieldId] = currentInput
-      }
-      return newFormInputs
-    },
-    {},
-  )
-}
+    return Object.keys(formInputs).reduce(
+      (newFormInputs: typeof formInputs, fieldId) => {
+        const currentInput = formInputs[fieldId]
+        if (
+          countryRegionFieldIds.has(fieldId) &&
+          typeof currentInput === 'string'
+        ) {
+          newFormInputs[fieldId] = currentInput.toUpperCase()
+        } else {
+          newFormInputs[fieldId] = currentInput
+        }
+        return newFormInputs
+      },
+      {},
+    )
+  }
 
 // Trim text inputs before sending to backend to match frontend validation
-const transformFormInputTrimTextInputs = (
-  formInputs: Record<string, unknown>,
-  form_fields: Array<{ fieldType: BasicField; _id: string }>,
-) => {
-  const textFieldIds = new Set(
-    form_fields
-      .filter(
-        (field) =>
-          field.fieldType === BasicField.ShortText ||
-          field.fieldType === BasicField.LongText,
-      )
-      .map((field) => field._id),
-  )
+const transformFormInputTrimTextInputs =
+  (form_fields: Array<{ fieldType: BasicField; _id: string }>) =>
+  (formInputs: Record<string, unknown>) => {
+    const textFieldIds = new Set(
+      form_fields
+        .filter(
+          (field) =>
+            field.fieldType === BasicField.ShortText ||
+            field.fieldType === BasicField.LongText,
+        )
+        .map((field) => field._id),
+    )
 
-  return Object.keys(formInputs).reduce(
-    (newFormInputs: typeof formInputs, fieldId) => {
-      const currentInput = formInputs[fieldId]
-      if (textFieldIds.has(fieldId) && typeof currentInput === 'string') {
-        newFormInputs[fieldId] = currentInput.trim()
-      } else {
-        newFormInputs[fieldId] = currentInput
-      }
-      return newFormInputs
-    },
-    {},
-  )
-}
+    return Object.keys(formInputs).reduce(
+      (newFormInputs: typeof formInputs, fieldId) => {
+        const currentInput = formInputs[fieldId]
+        if (textFieldIds.has(fieldId) && typeof currentInput === 'string') {
+          newFormInputs[fieldId] = currentInput.trim()
+        } else {
+          newFormInputs[fieldId] = currentInput
+        }
+        return newFormInputs
+      },
+      {},
+    )
+  }
 
 export const PublicFormProvider = ({
   formId,
@@ -574,13 +573,10 @@ export const PublicFormProvider = ({
         }
       }
 
-      const transformedFormInputs = transformFormInputTrimTextInputs(
-        transformFormInputCountryRegionToUpperCase(
-          formInputs,
-          form.form_fields,
-        ),
-        form.form_fields,
-      ) as typeof formInputs
+      const transformedFormInputs = flow([
+        transformFormInputCountryRegionToUpperCase(form.form_fields),
+        transformFormInputTrimTextInputs(form.form_fields),
+      ])(formInputs) as typeof formInputs
 
       const formData = {
         formFields: form.form_fields,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -123,6 +123,65 @@ export function useCommonFormProvider(formId: string) {
   }
 }
 
+// Country/region data must be upper-case in backend for myinfo-countries compatibility,
+// while displaying in title-case to users in the frontend.
+// Hence, we need to map the frontend title-case to upper-case when submitting to backend.
+const transformFormInputCountryRegionToUpperCase = (
+  formInputs: Record<string, unknown>,
+  form_fields: Array<{ fieldType: BasicField; _id: string }>,
+) => {
+  const countryRegionFieldIds = new Set(
+    form_fields
+      .filter((field) => field.fieldType === BasicField.CountryRegion)
+      .map((field) => field._id),
+  )
+
+  return Object.keys(formInputs).reduce(
+    (newFormInputs: typeof formInputs, fieldId) => {
+      const currentInput = formInputs[fieldId]
+      if (
+        countryRegionFieldIds.has(fieldId) &&
+        typeof currentInput === 'string'
+      ) {
+        newFormInputs[fieldId] = currentInput.toUpperCase()
+      } else {
+        newFormInputs[fieldId] = currentInput
+      }
+      return newFormInputs
+    },
+    {},
+  )
+}
+
+// Text inputs are trimmed duirng validation and hence should also be trimmed before sending to the backend.
+const transformFormInputTrimTextInputs = (
+  formInputs: Record<string, unknown>,
+  form_fields: Array<{ fieldType: BasicField; _id: string }>,
+) => {
+  const textFieldIds = new Set(
+    form_fields
+      .filter(
+        (field) =>
+          field.fieldType === BasicField.ShortText ||
+          field.fieldType === BasicField.LongText,
+      )
+      .map((field) => field._id),
+  )
+
+  return Object.keys(formInputs).reduce(
+    (newFormInputs: typeof formInputs, fieldId) => {
+      const currentInput = formInputs[fieldId]
+      if (textFieldIds.has(fieldId) && typeof currentInput === 'string') {
+        newFormInputs[fieldId] = currentInput.trim()
+      } else {
+        newFormInputs[fieldId] = currentInput
+      }
+      return newFormInputs
+    },
+    {},
+  )
+}
+
 export const PublicFormProvider = ({
   formId,
   submissionId: previousSubmissionId,
@@ -515,32 +574,18 @@ export const PublicFormProvider = ({
         }
       }
 
-      const countryRegionFieldIds = new Set(
-        form.form_fields
-          .filter((field) => field.fieldType === BasicField.CountryRegion)
-          .map((field) => field._id),
-      )
-      // We want users to see the country/region options in title-case but we also need the data in the backend to remain in upper-case.
-      // Country/region data in the backend needs to remain in upper-case so that they remain consistent with myinfo-countries.
-      const formInputsWithCountryRegionInUpperCase = Object.keys(
-        formInputs,
-      ).reduce((newFormInputs: typeof formInputs, fieldId) => {
-        const currentInput = formInputs[fieldId]
-        if (
-          countryRegionFieldIds.has(fieldId) &&
-          typeof currentInput === 'string'
-        ) {
-          newFormInputs[fieldId] = currentInput.toUpperCase()
-        } else {
-          newFormInputs[fieldId] = currentInput
-        }
-        return newFormInputs
-      }, {})
+      const transformedFormInputs = transformFormInputTrimTextInputs(
+        transformFormInputCountryRegionToUpperCase(
+          formInputs,
+          form.form_fields,
+        ),
+        form.form_fields,
+      ) as typeof formInputs
 
       const formData = {
         formFields: form.form_fields,
         formLogics: form.form_logics,
-        formInputs: formInputsWithCountryRegionInUpperCase,
+        formInputs: transformedFormInputs,
         captchaResponse,
         captchaType,
         responseMetadata: {
@@ -602,7 +647,7 @@ export const PublicFormProvider = ({
               .mutateAsync(
                 {
                   ...formData,
-                  formInputs: formInputsWithCountryRegionInUpperCase,
+                  formInputs: transformedFormInputs,
                 },
                 { onSuccess },
               )
@@ -640,7 +685,7 @@ export const PublicFormProvider = ({
                 .mutateAsync(
                   {
                     ...formData,
-                    formInputs: formInputsWithCountryRegionInUpperCase,
+                    formInputs: transformedFormInputs,
                   },
                   { onSuccess },
                 )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
While the frontend validation performs trimming of the string input for text fields before validation, no trimming is done before the inputs are sent to the backend as response. 
This leads to validation failures reported by the backend despite passing the frontend validation.  

This is also a reason for false positives reported during MRF BE validation, where the untrimmed response input eg `   5chars   ` is evaluated as 5 characters during frontend validation and passes validation for exact 5 characters, but fails in the backend since there are 6 whitespace characters leading to 11 characters being found in the backend.

Closes FRM-1913

## Solution
<!-- How did you solve the problem? -->
Trim the text field inputs before sending the response to the backend. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  