### PR TITLE
fix: trim previous text responses

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -489,9 +489,10 @@ export const validateMultirespondentSubmission = async (
                       prevResField.fieldType === BasicField.ShortText ||
                       prevResField.fieldType === BasicField.LongText
                     ) {
-                      // NOTE: this is done as prior to https://github.com/opengovsg/FormSG/pull/7937,
-                      // text fields were saved without trimming.
-                      // This caused isFieldResponseV3Equal to be false since the incomingResField is trimmed but the prevResField was not.
+                      // NOTE: LEGACY ISSUE
+                      // Since text fields were saved without trimming prior to https://github.com/opengovsg/FormSG/pull/7937.
+                      // Without this, isFieldResponseV3Equal fails since the prevResField was not trimmed,
+                      // causing a mismatch between the newly trimmed incomingResField.
                       prevResField.answer = prevResField.answer.trim()
                     }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -485,6 +485,16 @@ export const validateMultirespondentSubmission = async (
                     const incomingResField = req.body.responses[fieldId]
                     const prevResField = previousResponses[fieldId]
 
+                    if (
+                      prevResField.fieldType === BasicField.ShortText ||
+                      prevResField.fieldType === BasicField.LongText
+                    ) {
+                      // NOTE: this is done as prior to https://github.com/opengovsg/FormSG/pull/7937,
+                      // text fields were saved without trimming.
+                      // This caused isFieldResponseV3Equal to be false since the incomingResField is trimmed but the prevResField was not.
+                      prevResField.answer = prevResField.answer.trim()
+                    }
+
                     const resp = isFieldResponseV3Equal(
                       incomingResField,
                       prevResField,


### PR DESCRIPTION
## Problem
Missed the edge case comparison, where previous submission which was saved untrimmed.

## Solution
Implement trimming on the previous submission before comparing.