### PR TITLE
feat(i18n): extract general,notifs,webhooks settings

### DIFF
--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -181,9 +181,7 @@ const addSettings = async (
     await page.getByRole('tab', { name: 'General' }).dispatchEvent('click')
 
     // Ensure that we are on the general settings page
-    await expect(
-      page.getByRole('heading', { name: 'General settings' }),
-    ).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'General' })).toBeVisible()
 
     // Toggle form to be open
     await page
@@ -226,9 +224,7 @@ const addGeneralSettings = async (
   await page.getByRole('tab', { name: 'General' }).click()
 
   // Ensure that we are on the general settings page
-  await expect(
-    page.getByRole('heading', { name: 'General settings' }),
-  ).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'General' })).toBeVisible()
 
   await expectToast(page, /your form is closed to new responses/i)
 

--- a/frontend/src/components/Spinner/Spinner.tsx
+++ b/frontend/src/components/Spinner/Spinner.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiLoader } from 'react-icons/bi'
 import {
   Flex,
@@ -47,10 +48,11 @@ const spin = keyframes({
 export const Spinner = ({
   speed = '2.5s',
   color = 'inherit',
-  label = 'Loading...',
+  label: userSpecifiedLabel,
   fontSize = '1rem',
   ...flexProps
 }: SpinnerProps): JSX.Element => {
+  const { t } = useTranslation()
   const prefersReducedMotion = usePrefersReducedMotion()
 
   const animation = useMemo(
@@ -58,6 +60,8 @@ export const Spinner = ({
       prefersReducedMotion ? undefined : `${spin} ${speed} linear infinite`,
     [prefersReducedMotion, speed],
   )
+
+  const label = userSpecifiedLabel ?? t('features.common.loadingWithEllipsis')
 
   return (
     <Flex color={color} align="center" {...flexProps}>

--- a/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarBreadcrumbs.tsx
+++ b/frontend/src/features/admin-form/common/components/AdminFormNavbar/AdminFormNavbarBreadcrumbs.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { BiHomeAlt } from 'react-icons/bi'
 import { Link as ReactLink } from 'react-router-dom'
 import { Icon, Skeleton, Stack, Text } from '@chakra-ui/react'
@@ -13,6 +14,7 @@ type AdminFormNavbarDetailsProps = Pick<AdminFormNavbarProps, 'formInfo'>
 export const AdminFormNavbarBreadcrumbs = ({
   formInfo,
 }: AdminFormNavbarDetailsProps): JSX.Element => {
+  const { t } = useTranslation()
   const isMobile = useIsMobile()
 
   return (
@@ -44,7 +46,7 @@ export const AdminFormNavbarBreadcrumbs = ({
           overflow="hidden"
           color="secondary.500"
         >
-          {formInfo ? formInfo.title : 'Loading...'}
+          {formInfo ? formInfo.title : t('features.common.loadingWithEllipsis')}
         </Text>
       </Skeleton>
     </Stack>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiDownload } from 'react-icons/bi'
 import { useParams } from 'react-router-dom'
 import {
@@ -76,6 +77,7 @@ const StackRow = ({
 }
 
 export const IndividualResponsePage = (): JSX.Element => {
+  const { t } = useTranslation()
   const { submissionId, formId } = useParams()
   if (!submissionId) throw new Error('Missing submissionId')
   if (!formId) throw new Error('Missing formId')
@@ -156,7 +158,9 @@ export const IndividualResponsePage = (): JSX.Element => {
           />
           <StackRow
             label="Timestamp"
-            value={data?.submissionTime ?? 'Loading...'}
+            value={
+              data?.submissionTime ?? t('features.common.loadingWithEllipsis')
+            }
             isLoading={isLoading}
             isError={isError}
           />

--- a/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Skeleton } from '@chakra-ui/react'
 
 import { FormResponseMode, FormSettings, FormStatus } from '~shared/types/form'
@@ -37,6 +38,7 @@ const FormEmailSectionContainer = ({
 }
 
 export const SettingsEmailsPage = (): JSX.Element => {
+  const { t } = useTranslation()
   const { data: settings } = useAdminFormSettings()
 
   const isFormPublic = settings?.status === FormStatus.Public
@@ -54,7 +56,9 @@ export const SettingsEmailsPage = (): JSX.Element => {
 
   return (
     <>
-      <CategoryHeader>Email notifications</CategoryHeader>
+      <CategoryHeader>
+        {t('features.adminForm.settings.emailNotifications.title')}
+      </CategoryHeader>
       {settings ? (
         <>
           <EmailNotificationsHeader

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiCodeBlock, BiCog, BiDollar, BiKey, BiMailSend } from 'react-icons/bi'
 import { IconType } from 'react-icons/lib'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -34,6 +35,7 @@ interface TabEntry {
 
 export const SettingsPage = (): JSX.Element => {
   const { formId, settingsTab } = useParams()
+  const { t } = useTranslation()
 
   if (!formId) throw new Error('No formId provided')
 
@@ -49,32 +51,32 @@ export const SettingsPage = (): JSX.Element => {
 
   const tabConfig: TabEntry[] = [
     {
-      label: 'General',
+      label: t('features.adminForm.settings.general.title'),
       icon: BiCog,
       component: SettingsGeneralPage,
       path: 'general',
     },
     {
-      label: 'Singpass',
+      label: t('features.adminForm.settings.singpass.title'),
       icon: BiKey,
       component: SettingsAuthPage,
       path: 'singpass',
     },
     {
-      label: 'Email notifications',
+      label: t('features.adminForm.settings.emailNotifications.title'),
       icon: BiMailSend,
       component: SettingsEmailsPage,
       path: 'email-notifications',
       showRedDot: true,
     },
     {
-      label: 'Webhooks',
+      label: t('features.adminForm.settings.webhooks.title'),
       icon: BiCodeBlock,
       component: SettingsWebhooksPage,
       path: 'webhooks',
     },
     {
-      label: 'Payments',
+      label: t('features.adminForm.settings.payments.title'),
       icon: BiDollar,
       component: SettingsPaymentsPage,
       path: 'payments',

--- a/frontend/src/features/admin-form/settings/components/EmailNotificationsHeader.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailNotificationsHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { BiBulb } from 'react-icons/bi'
 import { Flex, Icon } from '@chakra-ui/react'
 
@@ -30,10 +31,13 @@ export const EmailNotificationsHeader = ({
   isPaymentsEnabled,
   isFormResponseModeEmail,
 }: EmailNotificationsHeaderProps) => {
+  const { t } = useTranslation()
   if (isFormPublic) {
     return (
       <InlineMessage marginBottom="40px">
-        To change email recipients, close your form to new responses.
+        {t(
+          'features.adminForm.settings.emailNotifications.header.closeFormFirst',
+        )}
       </InlineMessage>
     )
   }
@@ -41,7 +45,10 @@ export const EmailNotificationsHeader = ({
   if (isPaymentsEnabled) {
     return (
       <InlineMessage useMarkdown marginBottom="40px">
-        {`Email notifications for payment forms are not available in FormSG. You can configure them using [Plumber](${OGP_PLUMBER}).`}
+        {t(
+          'features.adminForm.settings.emailNotifications.header.noEmailsForPaymentForms',
+          { url: OGP_PLUMBER },
+        )}
       </InlineMessage>
     )
   }

--- a/frontend/src/features/admin-form/settings/components/FormCaptchaToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormCaptchaToggle.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Skeleton } from '@chakra-ui/react'
 
 import Toggle from '~components/Toggle'
@@ -7,6 +8,7 @@ import { useMutateFormSettings } from '../mutations'
 import { useAdminFormSettings } from '../queries'
 
 export const FormCaptchaToggle = (): JSX.Element => {
+  const { t } = useTranslation()
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -25,8 +27,9 @@ export const FormCaptchaToggle = (): JSX.Element => {
       <Toggle
         isLoading={mutateFormCaptcha.isLoading}
         isChecked={hasCaptcha}
-        label="Enable reCAPTCHA"
-        description="If you expect non-English-speaking respondents, they may have difficulty understanding the reCAPTCHA selection instructions."
+        {...t('features.adminForm.settings.general.captcha', {
+          returnObjects: true,
+        })}
         onChange={() => handleToggleCaptcha()}
       />
     </Skeleton>

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -5,6 +5,7 @@ import {
   useForm,
   useFormContext,
 } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { FormControl } from '@chakra-ui/react'
 import { get, isEmpty, isEqual } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
@@ -85,6 +86,7 @@ export const FormEmailSection = ({
   isDisabled,
   settings,
 }: EmailFormSectionProps): JSX.Element => {
+  const { t } = useTranslation()
   const initialEmailSet = useMemo(
     () => new Set(settings.emails),
     [settings.emails],
@@ -124,7 +126,9 @@ export const FormEmailSection = ({
             useMarkdownForDescription
             description={DESCRIPTION_TEXT}
           >
-            Notifications for new responses
+            {t(
+              'features.adminForm.settings.emailNotifications.section.regular.label',
+            )}
           </FormLabel>
           <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} />
           <FormErrorMessage>{get(errors, 'emails.message')}</FormErrorMessage>
@@ -134,7 +138,9 @@ export const FormEmailSection = ({
               mt="0.5rem"
               opacity={isDisabled ? '0.3' : '1'}
             >
-              Separate multiple email addresses with a comma
+              {t(
+                'features.adminForm.settings.emailNotifications.section.regular.description',
+              )}
             </FormLabel.Description>
           ) : null}
         </FormControl>

--- a/frontend/src/features/admin-form/settings/components/FormIssueNotificationToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormIssueNotificationToggle.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Skeleton } from '@chakra-ui/react'
 
 import Toggle from '~components/Toggle'
@@ -7,6 +8,7 @@ import { useMutateFormSettings } from '../mutations'
 import { useAdminFormSettings } from '../queries'
 
 export const FormIssueNotificationToggle = (): JSX.Element => {
+  const { t } = useTranslation()
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -26,8 +28,9 @@ export const FormIssueNotificationToggle = (): JSX.Element => {
       <Toggle
         isLoading={mutateFormIssueNotification.isLoading}
         isChecked={hasIssueNotification}
-        label="Receive email notifications for issues reported by respondents"
-        description="You will receive a maximum of one email per form, per day if there are any issues reported."
+        {...t('features.adminForm.settings.general.issueNotifications', {
+          returnObjects: true,
+        })}
         onChange={() => handleToggleIssueNotification()}
       />
     </Skeleton>

--- a/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FormControl, Skeleton } from '@chakra-ui/react'
 
 import { FormResponseMode } from '~shared/types'
@@ -30,6 +31,7 @@ const FormLimitBlock = ({
   initialLimit,
   currentResponseCount,
 }: FormLimitBlockProps): JSX.Element => {
+  const { t } = useTranslation()
   const [value, setValue] = useState(initialLimit)
   const [error, setError] = useState<string>()
 
@@ -43,13 +45,15 @@ const FormLimitBlock = ({
       setValue(nextVal)
       if (parseInt(nextVal, 10) <= currentResponseCount) {
         setError(
-          `Submission limit must be greater than current submission count (${currentResponseCount})`,
+          t('features.adminForm.settings.general.limit.limitLessThanCurrent', {
+            currentResponseCount,
+          }),
         )
       } else if (error) {
         setError(undefined)
       }
     },
-    [currentResponseCount, error],
+    [currentResponseCount, error, t],
   )
 
   const handleBlur = useCallback(() => {
@@ -83,10 +87,11 @@ const FormLimitBlock = ({
     <FormControl mt="2rem" isInvalid={!!error}>
       <FormLabel
         isRequired
-        description="Your form will automatically close once it reaches the set limit. Enable
-        reCAPTCHA to prevent spam submissions from triggering this limit."
+        description={t(
+          'features.adminForm.settings.general.limit.input.description',
+        )}
       >
-        Maximum number of responses allowed
+        {t('features.adminForm.settings.general.limit.input.label')}
       </FormLabel>
       <NumberInput
         maxW="16rem"
@@ -106,6 +111,7 @@ const FormLimitBlock = ({
 }
 
 export const FormLimitToggle = (): JSX.Element => {
+  const { t } = useTranslation()
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -157,12 +163,12 @@ export const FormLimitToggle = (): JSX.Element => {
         isDisabled={isMrf}
         isLoading={mutateFormLimit.isLoading}
         isChecked={isLimit}
-        label="Set a response limit"
+        label={t('features.adminForm.settings.general.limit.label')}
         onChange={() => handleToggleLimit()}
       />
       {isMrf ? (
         <InlineMessage variant="warning" mt="0.5rem">
-          Response limits cannot be applied for multi-respondent forms.
+          {t('features.adminForm.settings.general.limit.notForMRF')}
         </InlineMessage>
       ) : null}
       {settings && settings?.submissionLimit !== null && (

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Flex, Skeleton, Stack, Text, useDisclosure } from '@chakra-ui/react'
 
 import { BasicField } from '~shared/types'
@@ -19,6 +20,7 @@ import { useAdminFormSettings } from '../queries'
 import { SecretKeyActivationModal } from './SecretKeyActivationModal'
 
 export const FormStatusToggle = (): JSX.Element => {
+  const { t } = useTranslation()
   const { data: { form_fields } = {} } = useAdminForm()
   const { data: formSettings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
@@ -41,7 +43,9 @@ export const FormStatusToggle = (): JSX.Element => {
       ) &&
       !esrvcId
     ) {
-      return 'This form cannot be activated until a valid e-service ID is entered in the Singpass section.'
+      return t(
+        'features.adminForm.settings.general.status.supplySingpassEServiceId',
+      )
     }
 
     // For MRF, prevent form activation if form has an email confirmation field.
@@ -52,9 +56,9 @@ export const FormStatusToggle = (): JSX.Element => {
           ff.fieldType === BasicField.Email && ff.autoReplyOptions.hasAutoReply,
       )
     ) {
-      return 'Email confirmation is not supported in multi-respondent forms. Please remove email confirmations from email fields before activating your form.'
+      return t('features.adminForm.settings.general.status.noEmailsInMRF')
     }
-  }, [authType, esrvcId, formSettings?.responseMode, form_fields, status])
+  }, [authType, esrvcId, formSettings?.responseMode, form_fields, status, t])
 
   const { mutateFormStatus } = useMutateFormSettings()
 
@@ -81,6 +85,10 @@ export const FormStatusToggle = (): JSX.Element => {
     status,
   ])
 
+  const statusText = t(
+    `features.adminForm.settings.general.status.description.${isFormPublic ? 'open' : 'closed'}`,
+  )
+
   return (
     <Skeleton isLoaded={!isLoadingSettings && !!status}>
       <Stack>
@@ -98,12 +106,15 @@ export const FormStatusToggle = (): JSX.Element => {
           justify="space-between"
         >
           <Text textStyle="subhead-1" id="form-status">
-            Your form is <b>{isFormPublic ? 'OPEN' : 'CLOSED'}</b> to new
-            responses
+            {t('features.adminForm.settings.general.status.description.prefix')}
+            <b>{statusText}</b>
+            {t('features.adminForm.settings.general.status.description.suffix')}
           </Text>
           <Switch
             isDisabled={!!preventActivationMessage}
-            aria-label="Toggle form status"
+            aria-label={t(
+              'features.adminForm.settings.general.status.ariaLabel',
+            )}
             aria-describedby="form-status"
             isLoading={mutateFormStatus.isLoading}
             isChecked={isFormPublic}

--- a/frontend/src/features/admin-form/settings/components/GeneralTabHeader.tsx
+++ b/frontend/src/features/admin-form/settings/components/GeneralTabHeader.tsx
@@ -13,7 +13,7 @@ export const GeneralTabHeader = (): JSX.Element => {
     useAdminFormSettings()
 
   const readableFormResponseMode = !settings
-    ? 'Loading...'
+    ? t('features.common.loadingWithEllipsis')
     : t(`features.adminForm.meta.responseModeText.${settings.responseMode}`)
 
   return (
@@ -23,7 +23,9 @@ export const GeneralTabHeader = (): JSX.Element => {
       justify="space-between"
       mb="2.5rem"
     >
-      <CategoryHeader mb={0}>General settings</CategoryHeader>
+      <CategoryHeader mb={0}>
+        {t('features.adminForm.settings.general.title')}
+      </CategoryHeader>
       <Skeleton isLoaded={!isLoadingSettings}>
         <Badge variant="subtle" colorScheme="primary" color="secondary.500">
           {readableFormResponseMode}

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
 import { Controller, useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import {
   Box,
   FormControl,
@@ -42,6 +43,7 @@ const MrfEmailNotificationsForm = ({
   settings,
   isDisabled,
 }: MrfEmailNotificationsFormProps) => {
+  const { t } = useTranslation()
   const {
     isLoading,
     formWorkflow,
@@ -144,11 +146,15 @@ const MrfEmailNotificationsForm = ({
     <form onSubmit={handleSubmit(onSubmit)}>
       <Box>
         <Text textStyle="body-1" textColor="secondary.700" mb="1.5rem">
-          Select who to notify when the form and/or workflow is complete:
+          {t(
+            'features.adminForm.settings.emailNotifications.section.mrf.selectRecipient',
+          )}
         </Text>
         <Box>
           <FormLabel mb="0.75rem" textColor="secondary.700">
-            Respondent in Step 1
+            {t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.label',
+            )}
           </FormLabel>
           <Skeleton isLoaded={!isLoading}>
             <Controller
@@ -160,7 +166,9 @@ const MrfEmailNotificationsForm = ({
               }) => (
                 <SingleSelect
                   isDisabled={isLoading || isDisabled}
-                  placeholder="Select an email field from your form"
+                  placeholder={t(
+                    'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.placeholder',
+                  )}
                   items={emailFieldItems}
                   onBlur={handleSubmit(onSubmit)}
                   isClearable
@@ -173,7 +181,9 @@ const MrfEmailNotificationsForm = ({
         </Box>
         <Box my="1.5rem">
           <FormLabel mb="0.75rem" textColor="secondary.700">
-            Other respondents in your workflow
+            {t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
+            )}
           </FormLabel>
           <Skeleton isLoaded={!isLoading}>
             <Controller
@@ -186,14 +196,19 @@ const MrfEmailNotificationsForm = ({
                 <MultiSelect
                   items={formWorkflowStepsWithStepNumber
                     .filter((step) => step.stepNumber > 1)
-                    .map((step) => ({
-                      label: `Respondent(s) in Step ${step.stepNumber}`,
-                      value: step._id,
+                    .map(({ stepNumber, _id: value }) => ({
+                      label: t(
+                        'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.each',
+                        { stepNumber },
+                      ),
+                      value,
                     }))}
                   values={values}
                   onChange={onChange}
                   onBlur={handleSubmit(onSubmit)}
-                  placeholder="Select respondents from your form"
+                  placeholder={t(
+                    'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.placeholder',
+                  )}
                   isSelectedItemFullWidth
                   isDisabled={isLoading || isDisabled}
                   {...rest}
@@ -213,9 +228,13 @@ const MrfEmailNotificationsForm = ({
             mb="0.75rem"
             tooltipVariant="info"
             tooltipPlacement="top"
-            tooltipText="Include the admin's email to inform them whenever a workflow is completed"
+            tooltipText={t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
+            )}
           >
-            Others
+            {t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
+            )}
           </FormLabel>
           <Controller
             name={OTHER_PARTIES_EMAIL_INPUT_NAME}
@@ -233,7 +252,9 @@ const MrfEmailNotificationsForm = ({
           />
           {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
             <FormLabel.Description color="secondary.400" mt="0.5rem">
-              Separate multiple email addresses with a comma
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
+              )}
             </FormLabel.Description>
           ) : (
             <FormErrorMessage>

--- a/frontend/src/features/admin-form/settings/components/WebhooksSection/RetryToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/WebhooksSection/RetryToggle.tsx
@@ -1,4 +1,5 @@
 import { ChangeEventHandler, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { GUIDE_WEBHOOKS } from '~constants/links'
 import Toggle from '~components/Toggle'
@@ -7,6 +8,7 @@ import { useMutateFormSettings } from '../../mutations'
 import { useAdminFormSettings } from '../../queries'
 
 export const RetryToggle = (): JSX.Element | null => {
+  const { t } = useTranslation()
   const { data: settings } = useAdminFormSettings()
   const { mutateWebhookRetries } = useMutateFormSettings()
 
@@ -24,8 +26,10 @@ export const RetryToggle = (): JSX.Element | null => {
     <Toggle
       isLoading={mutateWebhookRetries.isLoading}
       isChecked={settings.webhook.isRetryEnabled}
-      label="Enable retries"
-      description={`Your system must meet certain requirements before retries can be safely enabled. [Learn more](${GUIDE_WEBHOOKS})`}
+      {...t('features.adminForm.settings.webhooks.retry', {
+        returnObjects: true,
+        url: GUIDE_WEBHOOKS,
+      })}
       onChange={handleToggleRetry}
     />
   )

--- a/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookUrlInput.tsx
+++ b/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookUrlInput.tsx
@@ -1,5 +1,6 @@
 import { KeyboardEventHandler, useCallback, useEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import {
   FormControl,
   InputGroup,
@@ -18,6 +19,7 @@ import { useMutateFormSettings } from '../../mutations'
 import { useAdminFormSettings } from '../../queries'
 
 export const WebhookUrlInput = (): JSX.Element => {
+  const { t } = useTranslation()
   const { data: settings, isLoading } = useAdminFormSettings()
   const { mutateFormWebhookUrl } = useMutateFormSettings()
   const {
@@ -86,8 +88,12 @@ export const WebhookUrlInput = (): JSX.Element => {
       isReadOnly={mutateFormWebhookUrl.isLoading}
       isInvalid={!!errors.url}
     >
-      <FormLabel description="For developers and IT officers usage. We will POST encrypted form responses in real-time to the HTTPS endpoint specified here.">
-        Endpoint URL
+      <FormLabel
+        description={t(
+          'features.adminForm.settings.webhooks.input.description',
+        )}
+      >
+        {t('features.adminForm.settings.webhooks.input.label')}
       </FormLabel>
       <Skeleton isLoaded={!isLoading}>
         <InputGroup>

--- a/frontend/src/i18n/locales/features/admin-form/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/en-sg.ts
@@ -1,6 +1,7 @@
 import { enSG as meta } from './meta'
 import { enSG as modals } from './modals'
 import { enSG as navbar } from './navbar'
+import { enSG as settings } from './settings'
 import { enSG as sidebar } from './sidebar'
 import { enSG as toasts } from './toasts'
 
@@ -10,4 +11,5 @@ export const enSG = {
   meta,
   modals,
   toasts,
+  settings,
 }

--- a/frontend/src/i18n/locales/features/admin-form/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/index.ts
@@ -2,8 +2,11 @@ export * from './en-sg'
 export { type Meta } from './meta'
 export { type Modals } from './modals'
 export { type Navbar } from './navbar'
-export { type Fields } from './sidebar'
-export { type HeaderAndInstructions } from './sidebar'
-export { type Logic } from './sidebar'
-export { type ThankYou } from './sidebar'
+export { type Settings } from './settings'
+export {
+  type Fields,
+  type HeaderAndInstructions,
+  type Logic,
+  type ThankYou,
+} from './sidebar'
 export { type Toasts } from './toasts'

--- a/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
@@ -1,0 +1,37 @@
+export const enSG = {
+  title: 'Email notifications',
+  header: {
+    closeFormFirst:
+      'To change email recipients, close your form to new responses.',
+    noEmailsForPaymentForms: `Email notifications for payment forms are not available in FormSG. You can configure them using [Plumber]({url}).`,
+  },
+  section: {
+    mrf: {
+      selectRecipient:
+        'Select who to notify when the form and/or workflow is complete:',
+      respondents: {
+        step1: {
+          label: 'Respondent in Step 1',
+          placeholder: 'Select an email field from your form',
+        },
+        stepN: {
+          label: {
+            overall: 'Other respondents in your workflow',
+            each: 'Respondent(s) in Step {stepNumber}',
+          },
+          placeholder: 'Select respondents from your form',
+        },
+        others: {
+          label: 'Others',
+          tooltipText:
+            "Include the admin's email to inform them whenever a workflow is completed",
+          description: 'Separate multiple email addresses with a comma',
+        },
+      },
+    },
+    regular: {
+      label: 'Notifications for new responses',
+      description: 'Separate multiple email addresses with a comma',
+    },
+  },
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
@@ -1,0 +1,37 @@
+import { type HasTitle } from '..'
+
+export * from './en-sg'
+
+export interface EmailNotifications extends HasTitle {
+  header: {
+    closeFormFirst: string
+    noEmailsForPaymentForms: string
+  }
+  section: {
+    mrf: {
+      selectRecipient: string
+      respondents: {
+        step1: {
+          label: string
+          placeholder: string
+        }
+        stepN: {
+          label: {
+            overall: string
+            each: string
+          }
+          placeholder: string
+        }
+        others: {
+          label: string
+          description: string
+          tooltipText: string
+        }
+      }
+    }
+    regular: {
+      label: string
+      description: string
+    }
+  }
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
@@ -1,0 +1,15 @@
+import { enSG as emailNotifications } from './email-notifications'
+import { enSG as general } from './general'
+import { enSG as webhooks } from './webhooks'
+
+export const enSG = {
+  general,
+  singpass: {
+    title: 'Singpass',
+  },
+  emailNotifications,
+  webhooks,
+  payments: {
+    title: 'Payments',
+  },
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -1,0 +1,40 @@
+export const enSG = {
+  title: 'General',
+  status: {
+    supplySingpassEServiceId:
+      'This form cannot be activated until a valid e-service ID is entered in the Singpass section.',
+    noEmailsInMRF:
+      'Email confirmation is not supported in multi-respondent forms. Please remove email confirmations from email fields before activating your form.',
+    description: {
+      prefix: 'Your form is ',
+      suffix: ' to new responses',
+      open: 'OPEN',
+      closed: 'CLOSED',
+    },
+    ariaLabel: 'Toggle form status',
+  },
+  limit: {
+    label: 'Set a response limit',
+    notForMRF: 'Response limits cannot be applied for multi-respondent forms.',
+    input: {
+      label: 'Maximum number of responses allowed',
+      description:
+        'Your form will automatically close once it reaches the set limit. Enable reCAPTCHA to prevent spam submissions from triggering this limit.',
+    },
+    limitLessThanCurrent:
+      'Submission limit must be greater than current submission count ({currentResponseCount})',
+  },
+  customisation: {
+    label: 'Set message for closed form',
+  },
+  captcha: {
+    label: 'Enable reCAPTCHA',
+    description:
+      'If you expect non-English-speaking respondents, they may have difficulty understanding the reCAPTCHA selection instructions.',
+  },
+  issueNotifications: {
+    label: 'Receive email notifications for issues reported by respondents',
+    description:
+      'You will receive a maximum of one email per form, per day if there are any issues reported.',
+  },
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
@@ -1,0 +1,37 @@
+import { type HasTitle } from '..'
+
+export * from './en-sg'
+
+export interface General extends HasTitle {
+  status: {
+    supplySingpassEServiceId: string
+    noEmailsInMRF: string
+    description: {
+      prefix: string
+      suffix: string
+      open: string
+      closed: string
+    }
+    ariaLabel: string
+  }
+  limit: {
+    label: string
+    notForMRF: string
+    input: {
+      label: string
+      description: string
+    }
+    limitLessThanCurrent: string
+  }
+  customisation: {
+    label: string
+  }
+  captcha: {
+    label: string
+    description: string
+  }
+  issueNotifications: {
+    label: string
+    description: string
+  }
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/index.ts
@@ -1,0 +1,17 @@
+import { EmailNotifications } from './email-notifications'
+import { General } from './general'
+import { Webhooks } from './webhooks'
+
+export * from './en-sg'
+
+export type HasTitle = {
+  title: string
+}
+
+export interface Settings {
+  general: General
+  singpass: HasTitle
+  emailNotifications: EmailNotifications
+  webhooks: Webhooks
+  payments: HasTitle
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
@@ -1,0 +1,12 @@
+export const enSG = {
+  title: 'Webhooks',
+  input: {
+    label: 'Endpoint URL',
+    description:
+      'For developers and IT officers usage. We will POST encrypted form responses in real-time to the HTTPS endpoint specified here.',
+  },
+  retry: {
+    label: 'Enable retries',
+    description: `Your system must meet certain requirements before retries can be safely enabled. [Learn more]({url})`,
+  },
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/webhooks/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/webhooks/index.ts
@@ -1,0 +1,14 @@
+import { type HasTitle } from '..'
+
+export * from './en-sg'
+
+export interface Webhooks extends HasTitle {
+  input: {
+    label: string
+    description: string
+  }
+  retry: {
+    label: string
+    description: string
+  }
+}

--- a/frontend/src/i18n/locales/features/common/en-sg.ts
+++ b/frontend/src/i18n/locales/features/common/en-sg.ts
@@ -30,6 +30,7 @@ export const enSG: Common = {
   back: 'Back',
   edit: 'Edit',
   loading: 'Loading',
+  loadingWithEllipsis: 'Loading...',
   saving: 'Saving',
   responses: 'Responses',
   feedback: 'Feedback',

--- a/frontend/src/i18n/locales/features/common/index.ts
+++ b/frontend/src/i18n/locales/features/common/index.ts
@@ -30,6 +30,7 @@ export interface Common {
   back: string
   edit: string
   loading: string
+  loadingWithEllipsis: string
   saving: string
   responses: string
   feedback: string

--- a/frontend/src/i18n/locales/features/index.ts
+++ b/frontend/src/i18n/locales/features/index.ts
@@ -5,6 +5,7 @@ export {
   type Meta,
   type Modals,
   type Navbar,
+  type Settings,
   type ThankYou,
   type Toasts,
 } from './admin-form'

--- a/frontend/src/i18n/locales/types.ts
+++ b/frontend/src/i18n/locales/types.ts
@@ -10,6 +10,7 @@ import {
   Modals,
   Navbar,
   PublicForm,
+  Settings,
   ThankYou,
   Toasts,
 } from './features'
@@ -28,6 +29,7 @@ interface Translation {
         meta?: Meta
         modals?: Modals
         toasts?: Toasts
+        settings?: Settings
       }
       common?: Common
       publicForm?: PublicForm


### PR DESCRIPTION
## Problem and Solution
- Extract text in general, email notifications, and webhooks pages
- Take the trouble to also extract the common 'Loading...' text at various points in the codebase
- Deliberately change the title of the general settings page to line with the tab label

With this, most of the usable text from FormID has been successfully brought over, with stubbing of the workspace i18n work outstanding
