### PR TITLE
feat: update form create modal response options

### DIFF
--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -66,9 +66,22 @@ export const FormResponseOptions = forwardRef<
           listItems={[
             { text: 'Supports webhooks for responses' },
             { text: 'Supports payments' },
-            { text: 'Enhanced Singpass features', badge: 'New' },
             { text: 'Up to Restricted and Sensitive (Normal) data' },
           ]}
+        />
+      </Tile>
+      <Tile
+        ref={ref}
+        variant="complex"
+        icon={BiMailSend}
+        isActive={value === FormResponseMode.Email}
+        onClick={() => onChange(FormResponseMode.Email)}
+        flex={1}
+      >
+        <Tile.Title>Email mode form</Tile.Title>
+        <Tile.Subtitle>Receive responses in your inbox only</Tile.Subtitle>
+        <OptionDescription
+          listItems={[{ text: 'Up to Restricted and Sensitive (High) data' }]}
         />
       </Tile>
       <Tile
@@ -90,20 +103,6 @@ export const FormResponseOptions = forwardRef<
             { text: 'Supports approvals', badge: 'New' },
             { text: 'Up to Restricted and Sensitive (Normal) data' },
           ]}
-        />
-      </Tile>
-      <Tile
-        ref={ref}
-        variant="complex"
-        icon={BiMailSend}
-        isActive={value === FormResponseMode.Email}
-        onClick={() => onChange(FormResponseMode.Email)}
-        flex={1}
-      >
-        <Tile.Title>Email mode form</Tile.Title>
-        <Tile.Subtitle>Receive responses in your inbox only</Tile.Subtitle>
-        <OptionDescription
-          listItems={[{ text: 'Up to Restricted and Sensitive (High) data' }]}
         />
       </Tile>
     </Stack>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -13,15 +13,32 @@ export interface FormResponseOptionsProps {
   isSingpass: boolean
 }
 
-const OptionDescription = ({ listItems = [] }: { listItems: string[] }) => {
+interface optionDescriptionIem {
+  text: string
+  badge?: string
+  badgeColorScheme?: string
+}
+
+const OptionDescription = ({
+  listItems = [],
+}: {
+  listItems: optionDescriptionIem[]
+}) => {
   return (
     <>
       <UnorderedList color="secondary.400" ml="1.5rem">
-        {listItems.map((text, index) => (
-          <Tile.ListItem key={index} textStyle="body-2" textAlign="left">
-            {text}
-          </Tile.ListItem>
-        ))}
+        {listItems.map(
+          ({ text, badge, badgeColorScheme = 'success' }, index) => (
+            <Tile.ListItem key={index} textStyle="body-2" textAlign="left">
+              {text}
+              {badge && (
+                <Badge size="xs" ml="0.2rem" colorScheme={badgeColorScheme}>
+                  {badge}
+                </Badge>
+              )}
+            </Tile.ListItem>
+          ),
+        )}
       </UnorderedList>
     </>
   )
@@ -47,10 +64,31 @@ export const FormResponseOptions = forwardRef<
         </Tile.Subtitle>
         <OptionDescription
           listItems={[
-            'Attachments: up to 20MB per form',
-            'Up to Restricted and Sensitive (Normal) data',
-            'Supports webhooks for responses',
-            'Supports payments',
+            { text: 'Supports webhooks for responses' },
+            { text: 'Supports payments' },
+            { text: 'Enhanced Singpass features', badge: 'New' },
+            { text: 'Up to Restricted and Sensitive (Normal) data' },
+          ]}
+        />
+      </Tile>
+      <Tile
+        ref={ref}
+        variant="complex"
+        icon={MultiParty}
+        isActive={value === FormResponseMode.Multirespondent}
+        onClick={() => onChange(FormResponseMode.Multirespondent)}
+        flex={1}
+        isDisabled={isSingpass}
+      >
+        <Tile.Title>Multi-respondent form</Tile.Title>
+        <Tile.Subtitle>
+          Collect responses from multiple people by adding a workflow to your
+          form and assigning fields to each person
+        </Tile.Subtitle>
+        <OptionDescription
+          listItems={[
+            { text: 'Supports approvals', badge: 'New' },
+            { text: 'Up to Restricted and Sensitive (Normal) data' },
           ]}
         />
       </Tile>
@@ -65,32 +103,7 @@ export const FormResponseOptions = forwardRef<
         <Tile.Title>Email mode form</Tile.Title>
         <Tile.Subtitle>Receive responses in your inbox only</Tile.Subtitle>
         <OptionDescription
-          listItems={[
-            'Attachments: up to 7MB per form',
-            'Up to Restricted and Sensitive (High) data',
-          ]}
-        />
-      </Tile>
-      <Tile
-        ref={ref}
-        variant="complex"
-        icon={MultiParty}
-        badge={<Badge colorScheme="success">New</Badge>}
-        isActive={value === FormResponseMode.Multirespondent}
-        onClick={() => onChange(FormResponseMode.Multirespondent)}
-        flex={1}
-        isDisabled={isSingpass}
-      >
-        <Tile.Title>Multi-respondent form</Tile.Title>
-        <Tile.Subtitle>
-          Collect responses from multiple people by adding a workflow to your
-          form and assigning fields to each person
-        </Tile.Subtitle>
-        <OptionDescription
-          listItems={[
-            'Attachments: Up to 20MB per form',
-            'Up to Restricted and Sensitive (Normal) data',
-          ]}
+          listItems={[{ text: 'Up to Restricted and Sensitive (High) data' }]}
         />
       </Tile>
     </Stack>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -73,20 +73,6 @@ export const FormResponseOptions = forwardRef<
       <Tile
         ref={ref}
         variant="complex"
-        icon={BiMailSend}
-        isActive={value === FormResponseMode.Email}
-        onClick={() => onChange(FormResponseMode.Email)}
-        flex={1}
-      >
-        <Tile.Title>Email mode form</Tile.Title>
-        <Tile.Subtitle>Receive responses in your inbox only</Tile.Subtitle>
-        <OptionDescription
-          listItems={[{ text: 'Up to Restricted and Sensitive (High) data' }]}
-        />
-      </Tile>
-      <Tile
-        ref={ref}
-        variant="complex"
         icon={MultiParty}
         isActive={value === FormResponseMode.Multirespondent}
         onClick={() => onChange(FormResponseMode.Multirespondent)}
@@ -103,6 +89,20 @@ export const FormResponseOptions = forwardRef<
             { text: 'Supports approvals', badge: 'New' },
             { text: 'Up to Restricted and Sensitive (Normal) data' },
           ]}
+        />
+      </Tile>
+      <Tile
+        ref={ref}
+        variant="complex"
+        icon={BiMailSend}
+        isActive={value === FormResponseMode.Email}
+        onClick={() => onChange(FormResponseMode.Email)}
+        flex={1}
+      >
+        <Tile.Title>Email mode form</Tile.Title>
+        <Tile.Subtitle>Receive responses in your inbox only</Tile.Subtitle>
+        <OptionDescription
+          listItems={[{ text: 'Up to Restricted and Sensitive (High) data' }]}
         />
       </Tile>
     </Stack>


### PR DESCRIPTION
## Problem
To drive propagation of new features

## Solution
<!-- How did you solve the problem? -->
Update the form create modal which has not been updated for a while. 

- move email mode to last
- remove new badge from MRF
- move supports text to top before mode limitations
- add new badge to new features (Enhanced Singpass features and Supports approvals)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Screenshots 
Before: 
<img width="1215" alt="image" src="https://github.com/user-attachments/assets/687c9ffd-d4cb-4986-aca4-c1d9107ac0d1">

After: 
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/d18300b5-7b66-443c-a4de-90017bfd2fd8">
