### PR TITLE
feat: implement field search functionality 

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -1,8 +1,14 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { BiSearch } from 'react-icons/bi'
 import {
   Box,
   Divider,
   Flex,
+  Icon,
+  Input,
+  InputGroup,
+  InputLeftElement,
   TabList,
   TabPanel,
   TabPanels,
@@ -24,10 +30,30 @@ import {
   PaymentsInputPanel,
 } from './field-panels'
 
+const FieldSearchBar = ({
+  searchValue,
+  onChange,
+}: {
+  searchValue: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}) => (
+  <InputGroup>
+    <InputLeftElement>
+      <Icon as={BiSearch} color="secondary.500" fontSize="1.25rem" />
+    </InputLeftElement>
+    <Input
+      value={searchValue}
+      onChange={onChange}
+      placeholder="Search fields"
+    />
+  </InputGroup>
+)
+
 export const FieldListDrawer = (): JSX.Element => {
   const { t } = useTranslation()
   const { fieldListTabIndex, setFieldListTabIndex } = useCreatePageSidebar()
   const { isLoading } = useCreateTabForm()
+  const [searchValue, setSearchValue] = useState('')
 
   const tabsDataList = [
     {
@@ -51,7 +77,12 @@ export const FieldListDrawer = (): JSX.Element => {
       isDisabled: isLoading,
       key: FieldListTabIndex.Payments,
     },
-  ].filter((tab) => !tab.isHidden)
+  ].filter((tab) => !tab.isHidden) as {
+    header: string
+    component: (props: { searchValue?: string }) => JSX.Element
+    isDisabled: boolean
+    key: FieldListTabIndex
+  }[]
 
   return (
     <Tabs
@@ -70,7 +101,11 @@ export const FieldListDrawer = (): JSX.Element => {
           </Text>
           <CreatePageDrawerCloseButton />
         </Flex>
-        <TabList mx="-0.25rem" w="100%">
+        <FieldSearchBar
+          searchValue={searchValue}
+          onChange={(val) => setSearchValue(val.target.value)}
+        />
+        <TabList mt="0.5rem" mx="-0.25rem" w="100%">
           {tabsDataList.map((tab) => (
             <Tab key={tab.key} isDisabled={tab.isDisabled}>
               {tab.header}
@@ -82,7 +117,7 @@ export const FieldListDrawer = (): JSX.Element => {
       <TabPanels pb="1rem" flex={1} overflowY="auto">
         {tabsDataList.map((tab) => (
           <TabPanel key={tab.key}>
-            <tab.component />
+            <tab.component searchValue={searchValue} />
           </TabPanel>
         ))}
       </TabPanels>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -1,14 +1,9 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { BiSearch } from 'react-icons/bi'
 import {
   Box,
   Divider,
   Flex,
-  Icon,
-  Input,
-  InputGroup,
-  InputLeftElement,
   TabList,
   TabPanel,
   TabPanels,
@@ -29,25 +24,7 @@ import {
   MyInfoFieldPanel,
   PaymentsInputPanel,
 } from './field-panels'
-
-const FieldSearchBar = ({
-  searchValue,
-  onChange,
-}: {
-  searchValue: string
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-}) => (
-  <InputGroup>
-    <InputLeftElement>
-      <Icon as={BiSearch} color="secondary.500" fontSize="1.25rem" />
-    </InputLeftElement>
-    <Input
-      value={searchValue}
-      onChange={onChange}
-      placeholder="Search fields"
-    />
-  </InputGroup>
-)
+import { FieldSearchBar } from './FieldSearchBar'
 
 export const FieldListDrawer = (): JSX.Element => {
   const { t } = useTranslation()

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -103,7 +103,7 @@ export const FieldListDrawer = (): JSX.Element => {
         </Flex>
         <FieldSearchBar
           searchValue={searchValue}
-          onChange={(val) => setSearchValue(val.target.value)}
+          onChange={(e) => setSearchValue(e.target.value)}
         />
         <TabList mt="0.5rem" mx="-0.25rem" w="100%">
           {tabsDataList.map((tab) => (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldSearchBar.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldSearchBar.tsx
@@ -1,0 +1,21 @@
+import { BiSearch } from 'react-icons/bi'
+import { Icon, Input, InputGroup, InputLeftElement } from '@chakra-ui/react'
+
+export const FieldSearchBar = ({
+  searchValue,
+  onChange,
+}: {
+  searchValue: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+}) => (
+  <InputGroup>
+    <InputLeftElement>
+      <Icon as={BiSearch} color="secondary.500" fontSize="1.25rem" />
+    </InputLeftElement>
+    <Input
+      value={searchValue}
+      onChange={onChange}
+      placeholder="Search fields"
+    />
+  </InputGroup>
+)

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { Box } from '@chakra-ui/react'
 import { Droppable } from '@hello-pangea/dnd'
 
@@ -12,16 +11,16 @@ import { useCreateTabForm } from '../../../../builder-and-design/useCreateTabFor
 import { DraggableBasicFieldListOption } from '../FieldListOption'
 
 import { FieldSection } from './FieldSection'
+import { filterFieldsBySearchValue } from './utils'
 
 export const BasicFieldPanel = ({ searchValue }: { searchValue: string }) => {
   const { isLoading } = useCreateTabForm()
 
-  const filteredCreateBasicFields = useMemo(() => {
-    return BASIC_FIELDS_ORDERED.filter((fieldType) => {
-      const meta = BASICFIELD_TO_DRAWER_META[fieldType]
-      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
-    })
-  }, [searchValue])
+  const filteredCreateBasicFields = filterFieldsBySearchValue(
+    searchValue,
+    BASIC_FIELDS_ORDERED,
+    BASICFIELD_TO_DRAWER_META,
+  )
 
   return (
     <Droppable isDropDisabled droppableId={CREATE_FIELD_DROP_ID}>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Box } from '@chakra-ui/react'
 import { Droppable } from '@hello-pangea/dnd'
 
@@ -5,32 +6,41 @@ import {
   BASIC_FIELDS_ORDERED,
   CREATE_FIELD_DROP_ID,
 } from '~features/admin-form/create/builder-and-design/constants'
+import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 
 import { useCreateTabForm } from '../../../../builder-and-design/useCreateTabForm'
 import { DraggableBasicFieldListOption } from '../FieldListOption'
 
 import { FieldSection } from './FieldSection'
 
-export const BasicFieldPanel = () => {
+export const BasicFieldPanel = ({ searchValue }: { searchValue: string }) => {
   const { isLoading } = useCreateTabForm()
+
+  const filteredCreateBasicFields = useMemo(() => {
+    return BASIC_FIELDS_ORDERED.filter((fieldType) => {
+      const meta = BASICFIELD_TO_DRAWER_META[fieldType]
+      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
+    })
+  }, [searchValue])
 
   return (
     <Droppable isDropDisabled droppableId={CREATE_FIELD_DROP_ID}>
       {(provided) => (
         <Box ref={provided.innerRef} {...provided.droppableProps}>
           <FieldSection>
-            {BASIC_FIELDS_ORDERED.map((fieldType, index) => {
-              const shouldDisableField = isLoading
-
-              return (
-                <DraggableBasicFieldListOption
-                  index={index}
-                  isDisabled={shouldDisableField}
-                  key={index}
-                  fieldType={fieldType}
-                />
-              )
-            })}
+            <FieldSection label="Basic">
+              {filteredCreateBasicFields.map((fieldType, index) => {
+                const shouldDisableField = isLoading
+                return (
+                  <DraggableBasicFieldListOption
+                    index={index}
+                    isDisabled={shouldDisableField}
+                    key={index}
+                    fieldType={fieldType}
+                  />
+                )
+              })}
+            </FieldSection>
             <Box display="none">{provided.placeholder}</Box>
           </FieldSection>
         </Box>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -36,6 +36,7 @@ import { useCreateTabForm } from '../../../../builder-and-design/useCreateTabFor
 import { DraggableMyInfoFieldListOption } from '../FieldListOption'
 
 import { FieldSection } from './FieldSection'
+import { filterFieldsBySearchValue } from './utils'
 
 const SGID_SUPPORTED_V1 = [
   MyInfoAttribute.Name,
@@ -126,40 +127,35 @@ export const MyInfoFieldPanel = ({ searchValue }: { searchValue: string }) => {
     [form, isDisabled, sgIDUnSupported],
   )
 
-  const filteredCreateMyInfoPersonalFields = useMemo(() => {
-    return CREATE_MYINFO_PERSONAL_FIELDS_ORDERED.filter((fieldType) => {
-      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
-      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
-    })
-  }, [searchValue])
+  const filteredCreateMyInfoPersonalFields = filterFieldsBySearchValue(
+    searchValue,
+    CREATE_MYINFO_PERSONAL_FIELDS_ORDERED,
+    MYINFO_FIELD_TO_DRAWER_META,
+  )
 
-  const filteredCreateMyInfoContactFields = useMemo(() => {
-    return CREATE_MYINFO_CONTACT_FIELDS_ORDERED.filter((fieldType) => {
-      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
-      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
-    })
-  }, [searchValue])
+  const filteredCreateMyInfoContactFields = filterFieldsBySearchValue(
+    searchValue,
+    CREATE_MYINFO_CONTACT_FIELDS_ORDERED,
+    MYINFO_FIELD_TO_DRAWER_META,
+  )
 
-  const filteredCreateMyInfoParticularsFields = useMemo(() => {
-    return CREATE_MYINFO_PARTICULARS_FIELDS_ORDERED.filter((fieldType) => {
-      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
-      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
-    })
-  }, [searchValue])
+  const filteredCreateMyInfoParticularsFields = filterFieldsBySearchValue(
+    searchValue,
+    CREATE_MYINFO_PARTICULARS_FIELDS_ORDERED,
+    MYINFO_FIELD_TO_DRAWER_META,
+  )
 
-  const filteredCreateMyInfoMarriageFields = useMemo(() => {
-    return CREATE_MYINFO_MARRIAGE_FIELDS_ORDERED.filter((fieldType) => {
-      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
-      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
-    })
-  }, [searchValue])
+  const filteredCreateMyInfoMarriageFields = filterFieldsBySearchValue(
+    searchValue,
+    CREATE_MYINFO_MARRIAGE_FIELDS_ORDERED,
+    MYINFO_FIELD_TO_DRAWER_META,
+  )
 
-  const filteredCreateMyInfoChildrenFields = useMemo(() => {
-    return CREATE_MYINFO_CHILDREN_FIELDS_ORDERED.filter((fieldType) => {
-      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
-      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
-    })
-  }, [searchValue])
+  const filteredCreateMyInfoChildrenFields = filterFieldsBySearchValue(
+    searchValue,
+    CREATE_MYINFO_CHILDREN_FIELDS_ORDERED,
+    MYINFO_FIELD_TO_DRAWER_META,
+  )
 
   return (
     <>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -28,6 +28,7 @@ import {
   CREATE_MYINFO_PERSONAL_DROP_ID,
   CREATE_MYINFO_PERSONAL_FIELDS_ORDERED,
 } from '~features/admin-form/create/builder-and-design/constants'
+import { MYINFO_FIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { isMyInfo } from '~features/myinfo/utils'
 import { useUser } from '~features/user/queries'
 
@@ -70,7 +71,7 @@ const SGID_SUPPORTED_V2 = [
   MyInfoAttribute.DivorceDate,
 ]
 
-export const MyInfoFieldPanel = () => {
+export const MyInfoFieldPanel = ({ searchValue }: { searchValue: string }) => {
   const { data: form, isLoading } = useCreateTabForm()
 
   const { user } = useUser()
@@ -125,22 +126,59 @@ export const MyInfoFieldPanel = () => {
     [form, isDisabled, sgIDUnSupported],
   )
 
+  const filteredCreateMyInfoPersonalFields = useMemo(() => {
+    return CREATE_MYINFO_PERSONAL_FIELDS_ORDERED.filter((fieldType) => {
+      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
+      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
+    })
+  }, [searchValue])
+
+  const filteredCreateMyInfoContactFields = useMemo(() => {
+    return CREATE_MYINFO_CONTACT_FIELDS_ORDERED.filter((fieldType) => {
+      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
+      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
+    })
+  }, [searchValue])
+
+  const filteredCreateMyInfoParticularsFields = useMemo(() => {
+    return CREATE_MYINFO_PARTICULARS_FIELDS_ORDERED.filter((fieldType) => {
+      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
+      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
+    })
+  }, [searchValue])
+
+  const filteredCreateMyInfoMarriageFields = useMemo(() => {
+    return CREATE_MYINFO_MARRIAGE_FIELDS_ORDERED.filter((fieldType) => {
+      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
+      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
+    })
+  }, [searchValue])
+
+  const filteredCreateMyInfoChildrenFields = useMemo(() => {
+    return CREATE_MYINFO_CHILDREN_FIELDS_ORDERED.filter((fieldType) => {
+      const meta = MYINFO_FIELD_TO_DRAWER_META[fieldType]
+      return meta.label.toLowerCase().includes(searchValue.toLowerCase())
+    })
+  }, [searchValue])
+
   return (
     <>
       <MyInfoMessage />
       <Droppable isDropDisabled droppableId={CREATE_MYINFO_PERSONAL_DROP_ID}>
         {(provided) => (
           <Box ref={provided.innerRef} {...provided.droppableProps}>
-            <FieldSection label="Personal">
-              {CREATE_MYINFO_PERSONAL_FIELDS_ORDERED.map((fieldType, index) => (
-                <DraggableMyInfoFieldListOption
-                  index={index}
-                  isDisabled={isDisabledCheck(fieldType)}
-                  key={index}
-                  fieldType={fieldType}
-                />
-              ))}
-            </FieldSection>
+            {filteredCreateMyInfoPersonalFields.length > 0 && (
+              <FieldSection label="Personal">
+                {filteredCreateMyInfoPersonalFields.map((fieldType, index) => (
+                  <DraggableMyInfoFieldListOption
+                    index={index}
+                    isDisabled={isDisabledCheck(fieldType)}
+                    key={index}
+                    fieldType={fieldType}
+                  />
+                ))}
+              </FieldSection>
+            )}
             <Box display="none">{provided.placeholder}</Box>
           </Box>
         )}
@@ -148,16 +186,18 @@ export const MyInfoFieldPanel = () => {
       <Droppable isDropDisabled droppableId={CREATE_MYINFO_CONTACT_DROP_ID}>
         {(provided) => (
           <Box ref={provided.innerRef} {...provided.droppableProps}>
-            <FieldSection label="Contact">
-              {CREATE_MYINFO_CONTACT_FIELDS_ORDERED.map((fieldType, index) => (
-                <DraggableMyInfoFieldListOption
-                  index={index}
-                  isDisabled={isDisabledCheck(fieldType)}
-                  key={index}
-                  fieldType={fieldType}
-                />
-              ))}
-            </FieldSection>
+            {filteredCreateMyInfoContactFields.length > 0 && (
+              <FieldSection label="Contact">
+                {filteredCreateMyInfoContactFields.map((fieldType, index) => (
+                  <DraggableMyInfoFieldListOption
+                    index={index}
+                    isDisabled={isDisabledCheck(fieldType)}
+                    key={index}
+                    fieldType={fieldType}
+                  />
+                ))}
+              </FieldSection>
+            )}
             <Box display="none">{provided.placeholder}</Box>
           </Box>
         )}
@@ -165,46 +205,9 @@ export const MyInfoFieldPanel = () => {
       <Droppable isDropDisabled droppableId={CREATE_MYINFO_PARTICULARS_DROP_ID}>
         {(provided) => (
           <Box ref={provided.innerRef} {...provided.droppableProps}>
-            <FieldSection label="Particulars">
-              {CREATE_MYINFO_PARTICULARS_FIELDS_ORDERED.map(
-                (fieldType, index) => (
-                  <DraggableMyInfoFieldListOption
-                    index={index}
-                    isDisabled={isDisabledCheck(fieldType)}
-                    key={index}
-                    fieldType={fieldType}
-                  />
-                ),
-              )}
-            </FieldSection>
-            <Box display="none">{provided.placeholder}</Box>
-          </Box>
-        )}
-      </Droppable>
-      <Droppable isDropDisabled droppableId={CREATE_MYINFO_MARRIAGE_DROP_ID}>
-        {(provided) => (
-          <Box ref={provided.innerRef} {...provided.droppableProps}>
-            <FieldSection label="Family (Marriage)">
-              {CREATE_MYINFO_MARRIAGE_FIELDS_ORDERED.map((fieldType, index) => (
-                <DraggableMyInfoFieldListOption
-                  index={index}
-                  isDisabled={isDisabledCheck(fieldType)}
-                  key={index}
-                  fieldType={fieldType}
-                />
-              ))}
-            </FieldSection>
-            <Box display="none">{provided.placeholder}</Box>
-          </Box>
-        )}
-      </Droppable>
-      {user?.betaFlags?.children &&
-      form?.responseMode === FormResponseMode.Email ? (
-        <Droppable isDropDisabled droppableId={CREATE_MYINFO_CHILDREN_DROP_ID}>
-          {(provided) => (
-            <Box ref={provided.innerRef} {...provided.droppableProps}>
-              <FieldSection label="Family (Children)">
-                {CREATE_MYINFO_CHILDREN_FIELDS_ORDERED.map(
+            {filteredCreateMyInfoParticularsFields.length > 0 && (
+              <FieldSection label="Particulars">
+                {filteredCreateMyInfoParticularsFields.map(
                   (fieldType, index) => (
                     <DraggableMyInfoFieldListOption
                       index={index}
@@ -215,6 +218,49 @@ export const MyInfoFieldPanel = () => {
                   ),
                 )}
               </FieldSection>
+            )}
+            <Box display="none">{provided.placeholder}</Box>
+          </Box>
+        )}
+      </Droppable>
+      <Droppable isDropDisabled droppableId={CREATE_MYINFO_MARRIAGE_DROP_ID}>
+        {(provided) => (
+          <Box ref={provided.innerRef} {...provided.droppableProps}>
+            {filteredCreateMyInfoMarriageFields.length > 0 && (
+              <FieldSection label="Family (Marriage)">
+                {filteredCreateMyInfoMarriageFields.map((fieldType, index) => (
+                  <DraggableMyInfoFieldListOption
+                    index={index}
+                    isDisabled={isDisabledCheck(fieldType)}
+                    key={index}
+                    fieldType={fieldType}
+                  />
+                ))}
+              </FieldSection>
+            )}
+            <Box display="none">{provided.placeholder}</Box>
+          </Box>
+        )}
+      </Droppable>
+      {user?.betaFlags?.children &&
+      form?.responseMode === FormResponseMode.Email ? (
+        <Droppable isDropDisabled droppableId={CREATE_MYINFO_CHILDREN_DROP_ID}>
+          {(provided) => (
+            <Box ref={provided.innerRef} {...provided.droppableProps}>
+              {filteredCreateMyInfoChildrenFields.length > 0 && (
+                <FieldSection label="Family (Children)">
+                  {filteredCreateMyInfoChildrenFields.map(
+                    (fieldType, index) => (
+                      <DraggableMyInfoFieldListOption
+                        index={index}
+                        isDisabled={isDisabledCheck(fieldType)}
+                        key={index}
+                        fieldType={fieldType}
+                      />
+                    ),
+                  )}
+                </FieldSection>
+              )}
               <Box display="none">{provided.placeholder}</Box>
             </Box>
           )}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/utils.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/utils.ts
@@ -9,8 +9,8 @@ const checkSearchValueMatchesFieldMeta = (
   const lowerCaseSearchValue = searchValue.toLowerCase()
   return (
     fieldMeta.label.toLowerCase().includes(lowerCaseSearchValue) ||
-    fieldMeta.alias?.some((alias) =>
-      alias.toLowerCase().includes(lowerCaseSearchValue),
+    fieldMeta.searchAliases?.some((searchAlias) =>
+      searchAlias.toLowerCase().includes(lowerCaseSearchValue),
     )
   )
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/utils.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/utils.ts
@@ -1,0 +1,31 @@
+import { BasicField, MyInfoAttribute } from '~shared/types'
+
+import { BuilderSidebarFieldMeta } from '~features/admin-form/create/constants'
+
+const checkSearchValueMatchesFieldMeta = (
+  searchValue: string,
+  fieldMeta: BuilderSidebarFieldMeta,
+) => {
+  const lowerCaseSearchValue = searchValue.toLowerCase()
+  return (
+    fieldMeta.label.toLowerCase().includes(lowerCaseSearchValue) ||
+    fieldMeta.alias?.some((alias) =>
+      alias.toLowerCase().includes(lowerCaseSearchValue),
+    )
+  )
+}
+
+export const filterFieldsBySearchValue = <
+  T extends BasicField | MyInfoAttribute,
+>(
+  searchValue: string,
+  fields: T[],
+  fieldsMeta: {
+    [key in T]: BuilderSidebarFieldMeta
+  },
+) => {
+  return fields.filter((fieldType) => {
+    const fieldMeta = fieldsMeta[fieldType]
+    return checkSearchValueMatchesFieldMeta(searchValue, fieldMeta)
+  })
+}

--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -52,7 +52,7 @@ export type BuilderSidebarFieldMeta = {
   icon: As
   // Is this fieldType included in submissions?
   isSubmitted: boolean
-  alias?: string[]
+  searchAliases?: string[]
 }
 
 // !!! Do not use this to reference field titles for MyInfo fields. !!!
@@ -64,42 +64,48 @@ export const BASICFIELD_TO_DRAWER_META: {
     label: 'Image',
     icon: BiImage,
     isSubmitted: false,
-    alias: ['photo', 'picture'],
+    searchAliases: ['photo', 'picture'],
   },
 
   [BasicField.Statement]: {
     label: 'Paragraph',
     icon: BiText,
     isSubmitted: false,
-    alias: ['description'],
+    searchAliases: ['description'],
   },
 
   [BasicField.Section]: {
     label: 'Heading',
     icon: BiHeading,
     isSubmitted: false,
-    alias: ['header', 'title', 'section'],
+    searchAliases: ['header', 'title', 'section'],
   },
 
   [BasicField.Attachment]: {
     label: 'Attachment',
     icon: BiCloudUpload,
     isSubmitted: true,
-    alias: ['document', 'file', 'upload'],
+    searchAliases: ['supporting', 'screenshot', 'document', 'file', 'upload'],
   },
 
   [BasicField.Checkbox]: {
     label: 'Checkbox',
     icon: BiSelectMultiple,
     isSubmitted: true,
-    alias: ['choice', 'options', 'multiple'],
+    searchAliases: [
+      'choice',
+      'options',
+      'multiple',
+      'declaration',
+      'acknowledgement',
+    ],
   },
 
   [BasicField.Date]: {
     label: 'Date',
     icon: BiCalendarEvent,
     isSubmitted: true,
-    alias: [
+    searchAliases: [
       'birthdate',
       'dob',
       'date of birth',
@@ -114,45 +120,46 @@ export const BASICFIELD_TO_DRAWER_META: {
     label: 'Decimal',
     icon: BiCalculator,
     isSubmitted: true,
-    alias: ['price', 'amount', 'cost'],
+    searchAliases: ['price', 'amount', 'cost'],
   },
 
   [BasicField.Dropdown]: {
     label: 'Dropdown',
     icon: BiCaretDownSquare,
     isSubmitted: true,
-    alias: ['choice', 'options', 'category', 'type', 'status'],
+    searchAliases: ['choice', 'options', 'category', 'type', 'status'],
   },
 
   [BasicField.CountryRegion]: {
     label: 'Country/Region',
     icon: BiFlag,
     isSubmitted: true,
-    alias: ['country', 'region', 'location', 'nationality'],
+    searchAliases: ['country', 'region', 'location', 'nationality'],
   },
 
   [BasicField.Email]: {
     label: 'Email',
     icon: BiMailSend,
     isSubmitted: true,
-    alias: ['contact'],
+    searchAliases: ['contact'],
   },
 
   [BasicField.HomeNo]: {
     label: 'Home number',
     icon: BiPhone,
     isSubmitted: true,
-    alias: ['phone', 'contact', 'telephone'],
+    searchAliases: ['phone', 'contact', 'telephone'],
   },
 
   [BasicField.LongText]: {
     label: 'Long answer',
     icon: BiAlignLeft,
     isSubmitted: true,
-    alias: [
+    searchAliases: [
       'text',
       'description',
       'comments',
+      'remarks',
       'feedback',
       'notes',
       'details',
@@ -165,49 +172,55 @@ export const BASICFIELD_TO_DRAWER_META: {
     label: 'Mobile number',
     icon: BiMobile,
     isSubmitted: true,
-    alias: ['phone', 'contact', 'telephone'],
+    searchAliases: ['phone', 'contact', 'telephone', 'sms'],
   },
 
   [BasicField.Nric]: {
     label: 'NRIC/FIN',
     icon: BiUser,
     isSubmitted: true,
-    alias: ['id', 'identification', 'national', 'singpass', 'ic number'],
+    searchAliases: [
+      'id',
+      'identification',
+      'national',
+      'singpass',
+      'ic number',
+    ],
   },
 
   [BasicField.Number]: {
     label: 'Number',
     icon: BiHash,
     isSubmitted: true,
-    alias: ['age', 'quantity', 'count'],
+    searchAliases: ['age', 'quantity', 'count'],
   },
 
   [BasicField.Radio]: {
     label: 'Radio',
     icon: BiRadioCircleMarked,
     isSubmitted: true,
-    alias: ['choice', 'options', 'mcq', 'multiple'],
+    searchAliases: ['choice', 'options', 'mcq', 'multiple'],
   },
 
   [BasicField.Rating]: {
     label: 'Rating',
     icon: BiStar,
     isSubmitted: true,
-    alias: ['satisfaction', 'quality', 'performance'],
+    searchAliases: ['satisfaction', 'quality', 'performance'],
   },
 
   [BasicField.ShortText]: {
     label: 'Short answer',
     icon: BiRename,
     isSubmitted: true,
-    alias: ['name', 'text'],
+    searchAliases: ['name', 'text'],
   },
 
   [BasicField.Table]: {
     label: 'Table',
     icon: BiTable,
     isSubmitted: true,
-    alias: [
+    searchAliases: [
       'grid',
       'spreadsheet',
       'list',
@@ -223,14 +236,29 @@ export const BASICFIELD_TO_DRAWER_META: {
     label: 'UEN',
     icon: BiBuilding,
     isSubmitted: true,
-    alias: ['business id', 'company registration', 'organization number'],
+    searchAliases: [
+      'id',
+      'business',
+      'company registration',
+      'organization',
+      'corporation',
+      'unique entity',
+      'number',
+    ],
   },
 
   [BasicField.YesNo]: {
     label: 'Yes/No',
     icon: BiToggleLeft,
     isSubmitted: true,
-    alias: ['consent', 'agreement', 'confirmation', 'approval', 'accept_terms'],
+    searchAliases: [
+      'consent',
+      'agreement',
+      'confirmation',
+      'approve',
+      'approval',
+      'accept',
+    ],
   },
 
   [BasicField.Children]: {
@@ -254,6 +282,7 @@ export const MYINFO_FIELD_TO_DRAWER_META: {
     label: 'Sex',
     icon: BiInfinite,
     isSubmitted: true,
+    searchAliases: ['gender'],
   },
   [MyInfoAttribute.DateOfBirth]: {
     label: 'Date of Birth',

--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -47,11 +47,12 @@ import { As } from '@chakra-ui/react'
 
 import { BasicField, MyInfoAttribute } from '~shared/types/field'
 
-type BuilderSidebarFieldMeta = {
+export type BuilderSidebarFieldMeta = {
   label: string
   icon: As
   // Is this fieldType included in submissions?
   isSubmitted: boolean
+  alias?: string[]
 }
 
 // !!! Do not use this to reference field titles for MyInfo fields. !!!
@@ -63,126 +64,173 @@ export const BASICFIELD_TO_DRAWER_META: {
     label: 'Image',
     icon: BiImage,
     isSubmitted: false,
+    alias: ['photo', 'picture'],
   },
 
   [BasicField.Statement]: {
     label: 'Paragraph',
     icon: BiText,
     isSubmitted: false,
+    alias: ['description'],
   },
 
   [BasicField.Section]: {
     label: 'Heading',
     icon: BiHeading,
     isSubmitted: false,
+    alias: ['header', 'title', 'section'],
   },
 
   [BasicField.Attachment]: {
     label: 'Attachment',
     icon: BiCloudUpload,
     isSubmitted: true,
+    alias: ['document', 'file', 'upload'],
   },
 
   [BasicField.Checkbox]: {
     label: 'Checkbox',
     icon: BiSelectMultiple,
     isSubmitted: true,
+    alias: ['choice', 'options', 'multiple'],
   },
 
   [BasicField.Date]: {
     label: 'Date',
     icon: BiCalendarEvent,
     isSubmitted: true,
+    alias: [
+      'birthdate',
+      'dob',
+      'date of birth',
+      'event date',
+      'start date',
+      'end date',
+      'time',
+    ],
   },
 
   [BasicField.Decimal]: {
     label: 'Decimal',
     icon: BiCalculator,
     isSubmitted: true,
+    alias: ['price', 'amount', 'cost'],
   },
 
   [BasicField.Dropdown]: {
     label: 'Dropdown',
     icon: BiCaretDownSquare,
     isSubmitted: true,
+    alias: ['choice', 'options', 'category', 'type', 'status'],
   },
 
   [BasicField.CountryRegion]: {
     label: 'Country/Region',
     icon: BiFlag,
     isSubmitted: true,
+    alias: ['country', 'region', 'location', 'nationality'],
   },
 
   [BasicField.Email]: {
     label: 'Email',
     icon: BiMailSend,
     isSubmitted: true,
+    alias: ['contact'],
   },
 
   [BasicField.HomeNo]: {
     label: 'Home number',
     icon: BiPhone,
     isSubmitted: true,
+    alias: ['phone', 'contact', 'telephone'],
   },
 
   [BasicField.LongText]: {
     label: 'Long answer',
     icon: BiAlignLeft,
     isSubmitted: true,
+    alias: [
+      'text',
+      'description',
+      'comments',
+      'feedback',
+      'notes',
+      'details',
+      'explanation',
+      'paragraph',
+    ],
   },
 
   [BasicField.Mobile]: {
     label: 'Mobile number',
     icon: BiMobile,
     isSubmitted: true,
+    alias: ['phone', 'contact', 'telephone'],
   },
 
   [BasicField.Nric]: {
     label: 'NRIC/FIN',
     icon: BiUser,
     isSubmitted: true,
+    alias: ['id', 'identification', 'national', 'singpass', 'ic number'],
   },
 
   [BasicField.Number]: {
     label: 'Number',
     icon: BiHash,
     isSubmitted: true,
+    alias: ['age', 'quantity', 'count'],
   },
 
   [BasicField.Radio]: {
     label: 'Radio',
     icon: BiRadioCircleMarked,
     isSubmitted: true,
+    alias: ['choice', 'options', 'mcq', 'multiple'],
   },
 
   [BasicField.Rating]: {
     label: 'Rating',
     icon: BiStar,
     isSubmitted: true,
+    alias: ['satisfaction', 'quality', 'performance'],
   },
 
   [BasicField.ShortText]: {
     label: 'Short answer',
     icon: BiRename,
     isSubmitted: true,
+    alias: ['name', 'text'],
   },
 
   [BasicField.Table]: {
     label: 'Table',
     icon: BiTable,
     isSubmitted: true,
+    alias: [
+      'grid',
+      'spreadsheet',
+      'list',
+      'collection',
+      'entries',
+      'records',
+      'items',
+      'multiple',
+    ],
   },
 
   [BasicField.Uen]: {
     label: 'UEN',
     icon: BiBuilding,
     isSubmitted: true,
+    alias: ['business id', 'company registration', 'organization number'],
   },
 
   [BasicField.YesNo]: {
     label: 'Yes/No',
     icon: BiToggleLeft,
     isSubmitted: true,
+    alias: ['consent', 'agreement', 'confirmation', 'approval', 'accept_terms'],
   },
 
   [BasicField.Children]: {


### PR DESCRIPTION
## Problem
- In some of the workshops we conducted for public officers, some didn't know which fields to use for what purposes.
- In addition, some admins are not aware that FormSG has certain kind of fields because they may have missed out or are overwhelmed with the options available.
- In some cases, admins use the wrong field for the questions (e.g. short answer for emails), which results in confusion when the feature does not work as intended (e.g. MRF)

Closes FRM-1914
See notion for full [PRD](https://www.notion.so/opengov/Field-Search-Functionality-15077dbba788804ab601dc5857099f68?pvs=4)

## Solution
<!-- How did you solve the problem? -->
Improve the field creation experience for admins. 
- Allow admins to more easily find fields they want to add to their forms
- Decrease barriers to understanding what form fields to create for each type of question

- Create a search bar which allows them to find relevant fields quickly.
    - Search for exact field name
    - Search based on hidden terms

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="590" alt="image" src="https://github.com/user-attachments/assets/447b2adf-b798-4299-8158-c5c70b0f8283">
no search bar 

**AFTER**:
<!-- [insert screenshot here] -->
<img width="544" alt="image" src="https://github.com/user-attachments/assets/e57d2d9e-81f4-4996-9c26-8a5f39675373">
search bar 

## Tests
<!-- What tests should be run to confirm functionality? -->
Search bar works and can drag and drop fields to create fields
- [ ] Create a new form 
- [ ] Enter search term into field (should find exact match + hidden field matches) 
- [ ] Drag and drop to create field
- [ ] Ensure field is created and form can be saved  
