### PR TITLE
feat(mrf be validation): enable mrf response validation hard block

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -531,16 +531,13 @@ export const validateMultirespondentSubmission = async (
                 })
               })
               .andThen((previousResponses) => {
-                // TODO: (FRM-1688) Set to block after sure that validation logic works as expected.
-                validateMrfFieldResponses({
+                return validateMrfFieldResponses({
                   formId,
                   visibleFieldIds,
                   formFields: form_fields,
                   responses: req.body.responses,
                   previousResponses,
                 })
-
-                return ok(req.body.responses)
               }),
           )
         },

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -135,6 +135,7 @@ import {
   SubmissionSaveError,
   UnsupportedSettingsError,
   ValidateFieldError,
+  ValidateFieldErrorV3,
   VirusScanFailedError,
 } from './submission.errors'
 import {
@@ -309,6 +310,7 @@ const errorMapper: MapRouteError = (
           'Submission too large to be saved. Please reduce the size of your submission and try again.',
       }
     case ValidateFieldError:
+    case ValidateFieldErrorV3:
     case DatabaseValidationError:
     case InvalidFileExtensionError:
     case AttachmentTooLargeError:


### PR DESCRIPTION
## Problem
MRF BE Validation currently does not hard block invalid submissions.  

Closes FRM-1915

## Solution
<!-- How did you solve the problem? -->
Hard block when MRF BE response validation fails.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests 
TC1: Can submit MRF 
- [x] Create multiple step MRF with a few fields with validation enabled (Eg, text field validating for exactly 5 characters) 
- [x] Submit all steps of MRF
- [x] Assert it works and results are recorded 

TC2: Invalid response is blocked 
- [x] Copy the cURL request from TC1. 
- [x] Change the response to include invalid responses. 
- [x] Assert submission is blocked with the response message `There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page.`
