### PR TITLE
feat(mrf-admin-view): hawkeye v1.0

### DIFF
--- a/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
@@ -9,6 +9,7 @@ import {
   createFormBuilderMocks,
   getAdminFormCollaborators,
   getAdminFormSubmissions,
+  getMultiRespondentSubmissionMetadataResponse,
   getStorageSubmissionMetadataResponse,
 } from '~/mocks/msw/handlers/admin-form'
 import { getUser } from '~/mocks/msw/handlers/user'
@@ -184,6 +185,24 @@ StorageFormLoading.parameters = {
     getAdminFormCollaborators(),
   ],
 }
+
+export const MultiRespondentFormUnlocked = Template.bind({})
+MultiRespondentFormUnlocked.parameters = {
+  msw: [
+    ...createFormBuilderMocks(
+      {
+        responseMode: FormResponseMode.Multirespondent,
+        publicKey: MOCK_KEYPAIR.publicKey,
+      },
+      0,
+    ),
+    getAdminFormSubmissions({ override: 5 }),
+    getMultiRespondentSubmissionMetadataResponse(),
+    getUser(),
+    getAdminFormCollaborators(),
+  ],
+}
+MultiRespondentFormUnlocked.play = StorageFormUnlocked.play
 
 export const Loading = Template.bind({})
 Loading.parameters = {

--- a/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -138,6 +138,10 @@ export const getDecryptedSubmissionById = async ({
       encryptedSubmission.submissionType === SubmissionType.Encrypt
         ? encryptedSubmission.payment
         : undefined,
+    mrf:
+      encryptedSubmission.submissionType === SubmissionType.Multirespondent
+        ? encryptedSubmission.mrfMeta
+        : undefined,
     responses,
     mrfVersion,
   }

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -192,21 +192,6 @@ export const IndividualResponsePage = (): JSX.Element => {
             </>
           ) : null}
           <StackRow
-            label="Status"
-            value={responseMrfStatus}
-            isLoading={isLoading}
-            isError={isError}
-          />
-          <StackRow
-            label="Current step"
-            value={getCurrentStepString(
-              data?.mrf?.workflowCurrentStepNumber,
-              data?.mrf?.workflowNumTotalSteps,
-            )}
-            isLoading={isLoading}
-            isError={isError}
-          />
-          <StackRow
             label={isMrf ? MRF_FIRST_STEP_TIMESTAMP_LABEL : 'Timestamp'}
             value={
               data?.submissionTime ?? t('features.common.loadingWithEllipsis')

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -10,6 +10,7 @@ import {
   StackDivider,
   Text,
 } from '@chakra-ui/react'
+import moment from 'moment'
 import simplur from 'simplur'
 
 import { FormResponseMode } from '~shared/types'
@@ -23,14 +24,14 @@ import { FormActivationSvg } from '~features/admin-form/settings/components/Form
 import { useUser } from '~features/user/queries'
 
 import {
-  getCurrentStepString,
+  getPendingResponseAtString,
   getStatusFromWorkflowStatus,
 } from '../common/utils/mrfSubmissionView'
 import { SecretKeyVerification } from '../components/SecretKeyVerification'
 import {
-  MRF_CURRENT_STEP_LABEL,
-  MRF_FIRST_STEP_TIMESTAMP_LABEL,
-  MRF_STATUS_LABEL,
+  MRF_PENDING_RESPONSE_AT_LABEL,
+  MRF_RESPONSE_TIMESTAMP_LABEL,
+  MRF_WORKFLOW_STATUS_LABEL,
 } from '../constants'
 import { useStorageResponsesContext } from '../ResponsesPage/storage'
 
@@ -157,6 +158,12 @@ export const IndividualResponsePage = (): JSX.Element => {
     ? getStatusFromWorkflowStatus(workflowStatus)
     : ''
 
+  const lastSubmittedAt = data?.mrf?.lastSubmittedAt
+    ? moment(data.mrf.lastSubmittedAt)
+        .tz('Asia/Singapore')
+        .format('ddd, D MMM YYYY, hh:mm:ss A')
+    : ''
+
   return (
     <Flex flexDir="column" marginTop={{ base: '-1.5rem', md: '-3rem' }}>
       <IndividualResponseNavbar />
@@ -175,26 +182,28 @@ export const IndividualResponsePage = (): JSX.Element => {
           {isMrf ? (
             <>
               <StackRow
-                label={MRF_STATUS_LABEL}
+                label={MRF_WORKFLOW_STATUS_LABEL}
                 value={responseMrfStatus}
                 isLoading={isLoading}
                 isError={isError}
               />
               <StackRow
-                label={MRF_CURRENT_STEP_LABEL}
-                value={getCurrentStepString(
-                  data?.mrf?.workflowCurrentStepNumber,
-                  data?.mrf?.workflowNumTotalSteps,
-                )}
+                label={MRF_PENDING_RESPONSE_AT_LABEL}
+                value={getPendingResponseAtString({
+                  workflowCurrentStepNumber:
+                    data?.mrf?.workflowCurrentStepNumber,
+                  workflowNumTotalSteps: data?.mrf?.workflowNumTotalSteps,
+                })}
                 isLoading={isLoading}
                 isError={isError}
               />
             </>
           ) : null}
           <StackRow
-            label={isMrf ? MRF_FIRST_STEP_TIMESTAMP_LABEL : 'Timestamp'}
+            label={isMrf ? MRF_RESPONSE_TIMESTAMP_LABEL : 'Timestamp'}
             value={
-              data?.submissionTime ?? t('features.common.loadingWithEllipsis')
+              (isMrf ? lastSubmittedAt : data?.submissionTime) ??
+              t('features.common.loadingWithEllipsis')
             }
             isLoading={isLoading}
             isError={isError}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -10,7 +10,7 @@ import {
   StackDivider,
   Text,
 } from '@chakra-ui/react'
-import moment from 'moment'
+import { formatInTimeZone } from 'date-fns-tz'
 import simplur from 'simplur'
 
 import { FormResponseMode } from '~shared/types'
@@ -159,9 +159,11 @@ export const IndividualResponsePage = (): JSX.Element => {
     : ''
 
   const lastSubmittedAt = data?.mrf?.lastSubmittedAt
-    ? moment(data.mrf.lastSubmittedAt)
-        .tz('Asia/Singapore')
-        .format('ddd, D MMM YYYY, hh:mm:ss A')
+    ? formatInTimeZone(
+        data.mrf.lastSubmittedAt,
+        'Asia/Singapore',
+        'eee, d MMM yyyy, hh:mm:ss a',
+      )
     : ''
 
   return (

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -27,6 +27,11 @@ import {
   getStatusFromWorkflowStatus,
 } from '../common/utils/mrfSubmissionView'
 import { SecretKeyVerification } from '../components/SecretKeyVerification'
+import {
+  MRF_CURRENT_STEP_LABEL,
+  MRF_FIRST_STEP_TIMESTAMP_LABEL,
+  MRF_STATUS_LABEL,
+} from '../constants'
 import { useStorageResponsesContext } from '../ResponsesPage/storage'
 
 import { DecryptedRow } from './DecryptedRow'
@@ -87,6 +92,8 @@ export const IndividualResponsePage = (): JSX.Element => {
   if (!formId) throw new Error('Missing formId')
 
   const { data: form } = useAdminForm()
+
+  const isMrf = form?.responseMode === FormResponseMode.Multirespondent
 
   const { user } = useUser()
   const { secretKey } = useStorageResponsesContext()
@@ -160,6 +167,25 @@ export const IndividualResponsePage = (): JSX.Element => {
             isLoading={isLoading}
             isError={isError}
           />
+          {isMrf ? (
+            <>
+              <StackRow
+                label={MRF_STATUS_LABEL}
+                value={getStatusFromWorkflowStatus(data?.mrf?.workflowStatus)}
+                isLoading={isLoading}
+                isError={isError}
+              />
+              <StackRow
+                label={MRF_CURRENT_STEP_LABEL}
+                value={getCurrentStepString(
+                  data?.mrf?.workflowCurrentStepNumber,
+                  data?.mrf?.workflowNumTotalSteps,
+                )}
+                isLoading={isLoading}
+                isError={isError}
+              />
+            </>
+          ) : null}
           <StackRow
             label="Status"
             value={getStatusFromWorkflowStatus(data?.mrf?.workflowStatus)}
@@ -176,7 +202,7 @@ export const IndividualResponsePage = (): JSX.Element => {
             isError={isError}
           />
           <StackRow
-            label="Timestamp"
+            label={isMrf ? MRF_FIRST_STEP_TIMESTAMP_LABEL : 'Timestamp'}
             value={
               data?.submissionTime ?? t('features.common.loadingWithEllipsis')
             }

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -22,6 +22,7 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 import { FormActivationSvg } from '~features/admin-form/settings/components/FormActivationSvg'
 import { useUser } from '~features/user/queries'
 
+import { getCurrentStepString } from '../common/utils/mrfSubmissionView'
 import { SecretKeyVerification } from '../components/SecretKeyVerification'
 import { useStorageResponsesContext } from '../ResponsesPage/storage'
 
@@ -153,6 +154,21 @@ export const IndividualResponsePage = (): JSX.Element => {
           <StackRow
             label="Response ID"
             value={submissionId}
+            isLoading={isLoading}
+            isError={isError}
+          />
+          <StackRow
+            label="Status"
+            value={data?.mrf?.workflowStatus ?? ''}
+            isLoading={isLoading}
+            isError={isError}
+          />
+          <StackRow
+            label="Current step"
+            value={getCurrentStepString(
+              data?.mrf?.workflowCurrentStepNumber,
+              data?.mrf?.workflowNumTotalSteps,
+            )}
             isLoading={isLoading}
             isError={isError}
           />

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -152,6 +152,11 @@ export const IndividualResponsePage = (): JSX.Element => {
     key: data?.submissionSecretKey || '',
   })}`
 
+  const workflowStatus = data?.mrf?.workflowStatus
+  const responseMrfStatus = workflowStatus
+    ? getStatusFromWorkflowStatus(workflowStatus)
+    : ''
+
   return (
     <Flex flexDir="column" marginTop={{ base: '-1.5rem', md: '-3rem' }}>
       <IndividualResponseNavbar />
@@ -171,7 +176,7 @@ export const IndividualResponsePage = (): JSX.Element => {
             <>
               <StackRow
                 label={MRF_STATUS_LABEL}
-                value={getStatusFromWorkflowStatus(data?.mrf?.workflowStatus)}
+                value={responseMrfStatus}
                 isLoading={isLoading}
                 isError={isError}
               />
@@ -188,7 +193,7 @@ export const IndividualResponsePage = (): JSX.Element => {
           ) : null}
           <StackRow
             label="Status"
-            value={getStatusFromWorkflowStatus(data?.mrf?.workflowStatus)}
+            value={responseMrfStatus}
             isLoading={isLoading}
             isError={isError}
           />

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -22,7 +22,10 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 import { FormActivationSvg } from '~features/admin-form/settings/components/FormActivationSvg'
 import { useUser } from '~features/user/queries'
 
-import { getCurrentStepString } from '../common/utils/mrfSubmissionView'
+import {
+  getCurrentStepString,
+  getStatusFromWorkflowStatus,
+} from '../common/utils/mrfSubmissionView'
 import { SecretKeyVerification } from '../components/SecretKeyVerification'
 import { useStorageResponsesContext } from '../ResponsesPage/storage'
 
@@ -159,7 +162,7 @@ export const IndividualResponsePage = (): JSX.Element => {
           />
           <StackRow
             label="Status"
-            value={data?.mrf?.workflowStatus ?? ''}
+            value={getStatusFromWorkflowStatus(data?.mrf?.workflowStatus)}
             isLoading={isLoading}
             isError={isError}
           />

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesProvider.tsx
@@ -45,8 +45,9 @@ export const StorageResponsesProvider = ({
       responsesCount: dateRangeResponsesCount,
       startDate: dateRange[0],
       endDate: dateRange[1],
+      isMrf: form?.responseMode === FormResponseMode.Multirespondent,
     }
-  }, [dateRange, dateRangeResponsesCount, secretKey])
+  }, [dateRange, dateRangeResponsesCount, secretKey, form?.responseMode])
 
   return (
     <StorageResponsesContext.Provider

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -123,14 +123,24 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   },
   {
     Header: 'Status',
-    accessor: 'workflowStatus',
+    accessor: ({ mrf }) => {
+      if (!mrf?.workflowStatus) {
+        return ''
+      }
+      return mrf.workflowStatus
+    },
     width: 176,
     minWidth: 176,
     maxWidth: 176,
   },
   {
     Header: 'Current Step',
-    accessor: 'workflowStep',
+    accessor: ({ mrf }) => {
+      if (!(mrf?.workflowCurrentStepNumber && mrf?.workflowNumTotalSteps)) {
+        return ''
+      }
+      return `Step ${mrf.workflowCurrentStepNumber} of ${mrf.workflowNumTotalSteps}`
+    },
     width: 176,
     minWidth: 176,
     maxWidth: 176,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -67,7 +67,7 @@ const CompletedBadge = () => (
   </Badge>
 )
 
-const NON_MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
+const BASE_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   {
     Header: '#',
     accessor: 'number',
@@ -204,7 +204,7 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
 ]
 
 const PAYMENT_RESPONSE_TABLE_COLUMNS =
-  NON_MRF_RESPONSE_TABLE_COLUMNS.concat(PAYMENT_COLUMNS)
+  BASE_RESPONSE_TABLE_COLUMNS.concat(PAYMENT_COLUMNS)
 
 export const ResponsesTable = () => {
   const { data: form } = useAdminForm()
@@ -245,7 +245,7 @@ export const ResponsesTable = () => {
     if (isPaymentsForm) {
       return PAYMENT_RESPONSE_TABLE_COLUMNS
     }
-    return NON_MRF_RESPONSE_TABLE_COLUMNS
+    return BASE_RESPONSE_TABLE_COLUMNS
   }, [isMultiRespondentForm, isPaymentsForm])
 
   const {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -17,7 +17,7 @@ import {
   Thead,
   Tr,
 } from '@chakra-ui/react'
-import moment from 'moment-timezone'
+import { formatInTimeZone } from 'date-fns-tz'
 
 import {
   FormResponseMode,
@@ -233,9 +233,11 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     Header: MRF_RESPONSE_TIMESTAMP_LABEL,
     accessor: ({ mrf }) =>
       mrf?.lastSubmittedAt
-        ? moment(mrf.lastSubmittedAt)
-            .tz('Asia/Singapore')
-            .format('Do MMM YYYY, h:mm:ss a')
+        ? formatInTimeZone(
+            mrf.lastSubmittedAt,
+            'Asia/Singapore',
+            'do MMM yyyy, hh:mm:ss a',
+          )
         : '',
     width: 250,
     minWidth: 250,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -82,6 +82,7 @@ const NON_MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     Header: 'Timestamp',
     accessor: 'submissionTime',
     width: 250,
+    minWidth: 250,
     disableResizing: true,
   },
 ]
@@ -193,7 +194,8 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     Header: MRF_FIRST_STEP_TIMESTAMP_LABEL,
     accessor: 'submissionTime',
     width: 250,
-    disableResizing: true
+    minWidth: 250,
+    disableResizing: true,
   },
 ]
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -35,6 +35,7 @@ import { getCurrentStepString } from '../../../../common/utils/mrfSubmissionView
 import { useUnlockedResponses } from '../UnlockedResponsesProvider'
 
 import { getNetAmount } from './utils'
+import { MRF_CURRENT_STEP_LABEL, MRF_STATUS_LABEL, MRF_FIRST_STEP_TIMESTAMP_LABEL } from '~features/admin-form/responses/constants'
 
 type ResponseColumnData = SubmissionMetadata
 
@@ -163,7 +164,7 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     maxWidth: 300,
   },
   {
-    Header: 'Status',
+    Header: MRF_STATUS_LABEL,
     accessor: ({ mrf }) => {
       if (!mrf?.workflowStatus) {
         return ''
@@ -178,7 +179,7 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     maxWidth: 220,
   },
   {
-    Header: 'Current Step',
+    Header: MRF_CURRENT_STEP_LABEL,
     accessor: ({ mrf }) =>
       getCurrentStepString(
         mrf?.workflowCurrentStepNumber,
@@ -189,7 +190,7 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     maxWidth: 220,
   },
   {
-    Header: 'Timestamp of first response',
+    Header: MRF_FIRST_STEP_TIMESTAMP_LABEL,
     accessor: 'submissionTime',
     width: 250,
     disableResizing: true

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -30,6 +30,7 @@ import { centsToDollars } from '~shared/utils/payments'
 import Badge from '~components/Badge'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { getCurrentStepString } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
 
 import { useUnlockedResponses } from '../UnlockedResponsesProvider'
 
@@ -179,12 +180,11 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   },
   {
     Header: 'Current Step',
-    accessor: ({ mrf }) => {
-      if (!(mrf?.workflowCurrentStepNumber && mrf?.workflowNumTotalSteps)) {
-        return ''
-      }
-      return `Step ${mrf.workflowCurrentStepNumber} of ${mrf.workflowNumTotalSteps}`
-    },
+    accessor: ({ mrf }) =>
+      getCurrentStepString(
+        mrf?.workflowCurrentStepNumber,
+        mrf?.workflowNumTotalSteps,
+      ),
     width: 176,
     minWidth: 176,
     maxWidth: 176,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -30,8 +30,8 @@ import { centsToDollars } from '~shared/utils/payments'
 import Badge from '~components/Badge'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
-import { getCurrentStepString } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
 
+import { getCurrentStepString } from '../../../../common/utils/mrfSubmissionView'
 import { useUnlockedResponses } from '../UnlockedResponsesProvider'
 
 import { getNetAmount } from './utils'

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -30,12 +30,16 @@ import { centsToDollars } from '~shared/utils/payments'
 import Badge from '~components/Badge'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
+import {
+  MRF_CURRENT_STEP_LABEL,
+  MRF_FIRST_STEP_TIMESTAMP_LABEL,
+  MRF_STATUS_LABEL,
+} from '~features/admin-form/responses/constants'
 
 import { getCurrentStepString } from '../../../../common/utils/mrfSubmissionView'
 import { useUnlockedResponses } from '../UnlockedResponsesProvider'
 
 import { getNetAmount } from './utils'
-import { MRF_CURRENT_STEP_LABEL, MRF_STATUS_LABEL, MRF_FIRST_STEP_TIMESTAMP_LABEL } from '~features/admin-form/responses/constants'
 
 type ResponseColumnData = SubmissionMetadata
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -24,54 +24,16 @@ const NON_MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   {
     Header: '#',
     accessor: 'number',
-    minWidth: 80, // minWidth is only used as a limit for resizing
     width: 80, // width is used for both the flex-basis and flex-grow
+    minWidth: 80, // minWidth is only used as a limit for resizing
     maxWidth: 100, // maxWidth is only used as a limit for resizing
   },
   {
     Header: 'Response ID',
     accessor: 'refNo',
-    minWidth: 300,
     width: 300,
-    maxWidth: 240, // maxWidth is only used as a limit for resizing
-  },
-  {
-    Header: 'Timestamp',
-    accessor: 'submissionTime',
-    minWidth: 250,
-    width: 250,
-    disableResizing: true,
-  },
-]
-
-const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
-  {
-    Header: '#',
-    accessor: 'number',
-    minWidth: 30,
-    width: 40,
-    maxWidth: 50,
-  },
-  {
-    Header: 'Response ID',
-    accessor: 'refNo',
-    minWidth: 100,
-    maxWidth: 150,
-    width: 120,
-  },
-  {
-    Header: 'Status',
-    accessor: 'workflowStatus',
-    minWidth: 50,
-    maxWidth: 100,
-    width: 50,
-  },
-  {
-    Header: 'Current Step',
-    accessor: 'workflowStep',
-    minWidth: 50,
-    maxWidth: 100,
-    width: 50,
+    minWidth: 300,
+    maxWidth: 300,
   },
   {
     Header: 'Timestamp',
@@ -144,6 +106,44 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
   },
 ]
 
+const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
+  {
+    Header: '#',
+    accessor: 'number',
+    width: 80,
+    minWidth: 80,
+    maxWidth: 100,
+  },
+  {
+    Header: 'Response ID',
+    accessor: 'refNo',
+    width: 300,
+    minWidth: 300,
+    maxWidth: 300,
+  },
+  {
+    Header: 'Status',
+    accessor: 'workflowStatus',
+    width: 176,
+    minWidth: 176,
+    maxWidth: 176,
+  },
+  {
+    Header: 'Current Step',
+    accessor: 'workflowStep',
+    width: 176,
+    minWidth: 176,
+    maxWidth: 176,
+  },
+  {
+    Header: 'Timestamp of first response',
+    accessor: 'submissionTime',
+    width: 320,
+    minWidth: 320,
+    maxWidth: 320,
+  },
+]
+
 const PAYMENT_RESPONSE_TABLE_COLUMNS =
   NON_MRF_RESPONSE_TABLE_COLUMNS.concat(PAYMENT_COLUMNS)
 
@@ -179,6 +179,16 @@ export const ResponsesTable = () => {
     }
   }, [filteredMetadata, metadata, submissionId])
 
+  const columns = useMemo(() => {
+    if (isMultiRespondentForm) {
+      return MRF_RESPONSE_TABLE_COLUMNS
+    }
+    if (isPaymentsForm) {
+      return PAYMENT_RESPONSE_TABLE_COLUMNS
+    }
+    return NON_MRF_RESPONSE_TABLE_COLUMNS
+  }, [isMultiRespondentForm, isPaymentsForm])
+
   const {
     prepareRow,
     getTableProps,
@@ -188,11 +198,7 @@ export const ResponsesTable = () => {
     gotoPage,
   } = useTable<ResponseColumnData>(
     {
-      columns: isMultiRespondentForm
-        ? MRF_RESPONSE_TABLE_COLUMNS
-        : isPaymentsForm
-          ? PAYMENT_RESPONSE_TABLE_COLUMNS
-          : NON_MRF_RESPONSE_TABLE_COLUMNS,
+      columns,
       data: metadataToUse,
       // Server side pagination.
       manualPagination: true,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo } from 'react'
-import { BiCheckDouble, BiSolidHourglass } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
 import {
   Column,
@@ -9,16 +8,16 @@ import {
   useTable,
 } from 'react-table'
 import {
+  BadgeProps,
   Flex,
-  Icon,
   Table,
   Tbody,
   Td,
-  Text,
   Th,
   Thead,
   Tr,
 } from '@chakra-ui/react'
+import moment from 'moment-timezone'
 
 import {
   FormResponseMode,
@@ -30,41 +29,69 @@ import { centsToDollars } from '~shared/utils/payments'
 import Badge from '~components/Badge'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { getPendingResponseAtString } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
 import {
-  MRF_CURRENT_STEP_LABEL,
-  MRF_FIRST_STEP_TIMESTAMP_LABEL,
-  MRF_STATUS_LABEL,
+  MRF_PENDING_RESPONSE_AT_LABEL,
+  MRF_RESPONSE_TIMESTAMP_LABEL,
+  MRF_WORKFLOW_STATUS_LABEL,
 } from '~features/admin-form/responses/constants'
 
-import { getCurrentStepString } from '../../../../common/utils/mrfSubmissionView'
 import { useUnlockedResponses } from '../UnlockedResponsesProvider'
 
 import { getNetAmount } from './utils'
 
 type ResponseColumnData = SubmissionMetadata
 
-const PendingBadge = () => (
+const StatusBadge = ({
+  textColor,
+  backgroundColor,
+  statusText,
+}: {
+  textColor: BadgeProps['textColor']
+  backgroundColor: BadgeProps['backgroundColor']
+  statusText: string
+}) => (
   <Badge
     width="fit-content"
     display="flex"
-    textColor="warning.700"
-    backgroundColor="warning.100"
+    textColor={textColor}
+    textStyle="caption-1"
+    backgroundColor={backgroundColor}
   >
-    <Icon as={BiSolidHourglass} mr="0.25rem" fontSize="1rem" />
-    <Text textStyle="caption-1">Pending</Text>
+    {statusText}
   </Badge>
 )
 
+const PendingBadge = () => (
+  <StatusBadge
+    textColor="warning.700"
+    backgroundColor="warning.100"
+    statusText="Pending"
+  />
+)
+
 const CompletedBadge = () => (
-  <Badge
-    width="fit-content"
-    display="flex"
+  <StatusBadge
     textColor="success.700"
     backgroundColor="success.100"
-  >
-    <Icon as={BiCheckDouble} mr="0.25rem" fontSize="1rem" />
-    <Text textStyle="caption-1">Completed</Text>
-  </Badge>
+    statusText="Completed"
+  />
+)
+
+const ApprovedBadge = () => (
+  <StatusBadge
+    textColor="success.700"
+    backgroundColor="success.100"
+    statusText="Approved"
+  />
+)
+
+const NotApprovedBadge = () => (
+  <StatusBadge
+    textColor="danger.700"
+    backgroundColor="danger.100"
+    statusText="Not approved"
+  />
 )
 
 const BASE_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
@@ -169,7 +196,7 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     maxWidth: 300,
   },
   {
-    Header: MRF_STATUS_LABEL,
+    Header: MRF_WORKFLOW_STATUS_LABEL,
     accessor: ({ mrf }) => {
       if (!mrf?.workflowStatus) {
         return ''
@@ -177,26 +204,39 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
       if (mrf.workflowStatus === WorkflowStatus.PENDING) {
         return <PendingBadge />
       }
-      return <CompletedBadge />
+      if (mrf.workflowStatus === WorkflowStatus.APPROVED) {
+        return <ApprovedBadge />
+      }
+      if (mrf.workflowStatus === WorkflowStatus.REJECTED) {
+        return <NotApprovedBadge />
+      }
+      if (mrf.workflowStatus === WorkflowStatus.COMPLETED) {
+        return <CompletedBadge />
+      }
     },
     width: 200,
     minWidth: 180,
     maxWidth: 220,
   },
   {
-    Header: MRF_CURRENT_STEP_LABEL,
+    Header: MRF_PENDING_RESPONSE_AT_LABEL,
     accessor: ({ mrf }) =>
-      getCurrentStepString(
-        mrf?.workflowCurrentStepNumber,
-        mrf?.workflowNumTotalSteps,
-      ),
+      getPendingResponseAtString({
+        workflowCurrentStepNumber: mrf?.workflowCurrentStepNumber,
+        workflowNumTotalSteps: mrf?.workflowNumTotalSteps,
+      }),
     width: 200,
     minWidth: 180,
     maxWidth: 220,
   },
   {
-    Header: MRF_FIRST_STEP_TIMESTAMP_LABEL,
-    accessor: 'submissionTime',
+    Header: MRF_RESPONSE_TIMESTAMP_LABEL,
+    accessor: ({ mrf }) =>
+      mrf?.lastSubmittedAt
+        ? moment(mrf.lastSubmittedAt)
+            .tz('Asia/Singapore')
+            .format('Do MMM YYYY, h:mm:ss a')
+        : '',
     width: 250,
     minWidth: 250,
     disableResizing: true,
@@ -300,11 +340,17 @@ export const ResponsesTable = () => {
           <Tr
             as="div"
             {...headerGroup.getHeaderGroupProps()}
+            key={headerGroup.getHeaderGroupProps().key}
             // To toggle _groupHover styles to show divider when header is hovered.
             data-group
           >
             {headerGroup.headers.map((column) => (
-              <Th as="div" pos="relative" {...column.getHeaderProps()}>
+              <Th
+                as="div"
+                pos="relative"
+                {...column.getHeaderProps()}
+                key={column.getHeaderProps().key}
+              >
                 <Flex align="center">{column.render('Header')}</Flex>
 
                 {column.disableResizing ? null : (
@@ -347,6 +393,7 @@ export const ResponsesTable = () => {
             <Tr
               as="div"
               {...row.getRowProps()}
+              key={row.getRowProps().key}
               px={0}
               onClick={() =>
                 handleRowClick(row.values.refNo, row.values.number)
@@ -361,7 +408,11 @@ export const ResponsesTable = () => {
             >
               {row.cells.map((cell) => {
                 return (
-                  <Td as="div" {...cell.getCellProps()}>
+                  <Td
+                    as="div"
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                  >
                     {cell.render('Cell')}
                   </Td>
                 )

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -80,7 +80,6 @@ const NON_MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   {
     Header: 'Timestamp',
     accessor: 'submissionTime',
-    minWidth: 250,
     width: 250,
     disableResizing: true,
   },
@@ -174,9 +173,9 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
       }
       return <CompletedBadge />
     },
-    width: 176,
-    minWidth: 176,
-    maxWidth: 176,
+    width: 200,
+    minWidth: 180,
+    maxWidth: 220,
   },
   {
     Header: 'Current Step',
@@ -185,16 +184,15 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
         mrf?.workflowCurrentStepNumber,
         mrf?.workflowNumTotalSteps,
       ),
-    width: 176,
-    minWidth: 176,
-    maxWidth: 176,
+    width: 200,
+    minWidth: 180,
+    maxWidth: 220,
   },
   {
     Header: 'Timestamp of first response',
     accessor: 'submissionTime',
-    width: 320,
-    minWidth: 320,
-    maxWidth: 320,
+    width: 250,
+    disableResizing: true
   },
 ]
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -20,7 +20,7 @@ import { getNetAmount } from './utils'
 
 type ResponseColumnData = SubmissionMetadata
 
-const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
+const NON_MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   {
     Header: '#',
     accessor: 'number',
@@ -43,6 +43,45 @@ const RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     disableResizing: true,
   },
 ]
+
+const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
+  {
+    Header: '#',
+    accessor: 'number',
+    minWidth: 30,
+    width: 40,
+    maxWidth: 50,
+  },
+  {
+    Header: 'Response ID',
+    accessor: 'refNo',
+    minWidth: 100,
+    maxWidth: 150,
+    width: 120,
+  },
+  {
+    Header: 'Status',
+    accessor: 'workflowStatus',
+    minWidth: 50,
+    maxWidth: 100,
+    width: 50,
+  },
+  {
+    Header: 'Current Step',
+    accessor: 'workflowStep',
+    minWidth: 50,
+    maxWidth: 100,
+    width: 50,
+  },
+  {
+    Header: 'Timestamp',
+    accessor: 'submissionTime',
+    minWidth: 250,
+    width: 250,
+    disableResizing: true,
+  },
+]
+
 const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
   {
     Header: 'Email',
@@ -106,7 +145,7 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
 ]
 
 const PAYMENT_RESPONSE_TABLE_COLUMNS =
-  RESPONSE_TABLE_COLUMNS.concat(PAYMENT_COLUMNS)
+  NON_MRF_RESPONSE_TABLE_COLUMNS.concat(PAYMENT_COLUMNS)
 
 export const ResponsesTable = () => {
   const { data: form } = useAdminForm()
@@ -114,6 +153,8 @@ export const ResponsesTable = () => {
     form?.responseMode === FormResponseMode.Encrypt
       ? form.payments_field.enabled
       : false
+  const isMultiRespondentForm =
+    form?.responseMode === FormResponseMode.Multirespondent
 
   const {
     currentPage: currentPage1Indexed,
@@ -147,9 +188,11 @@ export const ResponsesTable = () => {
     gotoPage,
   } = useTable<ResponseColumnData>(
     {
-      columns: isPaymentsForm
-        ? PAYMENT_RESPONSE_TABLE_COLUMNS
-        : RESPONSE_TABLE_COLUMNS,
+      columns: isMultiRespondentForm
+        ? MRF_RESPONSE_TABLE_COLUMNS
+        : isPaymentsForm
+          ? PAYMENT_RESPONSE_TABLE_COLUMNS
+          : NON_MRF_RESPONSE_TABLE_COLUMNS,
       data: metadataToUse,
       // Server side pagination.
       manualPagination: true,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react'
+import { BiCheckDouble, BiSolidHourglass } from 'react-icons/bi'
 import { useNavigate } from 'react-router-dom'
 import {
   Column,
@@ -7,10 +8,26 @@ import {
   useResizeColumns,
   useTable,
 } from 'react-table'
-import { Flex, Table, Tbody, Td, Th, Thead, Tr } from '@chakra-ui/react'
+import {
+  Flex,
+  Icon,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react'
 
-import { FormResponseMode, SubmissionMetadata } from '~shared/types'
+import {
+  FormResponseMode,
+  SubmissionMetadata,
+  WorkflowStatus,
+} from '~shared/types'
 import { centsToDollars } from '~shared/utils/payments'
+
+import Badge from '~components/Badge'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 
@@ -19,6 +36,30 @@ import { useUnlockedResponses } from '../UnlockedResponsesProvider'
 import { getNetAmount } from './utils'
 
 type ResponseColumnData = SubmissionMetadata
+
+const PendingBadge = () => (
+  <Badge
+    width="fit-content"
+    display="flex"
+    textColor="warning.700"
+    backgroundColor="warning.100"
+  >
+    <Icon as={BiSolidHourglass} mr="0.25rem" fontSize="1rem" />
+    <Text textStyle="caption-1">Pending</Text>
+  </Badge>
+)
+
+const CompletedBadge = () => (
+  <Badge
+    width="fit-content"
+    display="flex"
+    textColor="success.700"
+    backgroundColor="success.100"
+  >
+    <Icon as={BiCheckDouble} mr="0.25rem" fontSize="1rem" />
+    <Text textStyle="caption-1">Completed</Text>
+  </Badge>
+)
 
 const NON_MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   {
@@ -127,7 +168,10 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
       if (!mrf?.workflowStatus) {
         return ''
       }
-      return mrf.workflowStatus
+      if (mrf.workflowStatus === WorkflowStatus.PENDING) {
+        return <PendingBadge />
+      }
+      return <CompletedBadge />
     },
     width: 176,
     minWidth: 176,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
@@ -2,6 +2,8 @@ import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 import { Remote } from 'comlink'
 import { SetRequired } from 'type-fest'
 
+import { SubmissionMrfMetadata } from '~shared/types'
+
 import { CsvRecord } from './utils/CsvRecord.class'
 import { DecryptionWorkerApi } from './worker/decryption.worker'
 
@@ -23,6 +25,7 @@ export type CsvRecordData = FormField
 export type DecryptedSubmissionData = {
   created: string
   submissionId: string
+  mrfMeta?: SubmissionMrfMetadata
   record: CsvRecordData[]
 }
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -48,6 +48,8 @@ export type DownloadEncryptedParams = EncryptedResponsesStreamParams & {
   secretKey: string
   // Number of responses to expect to download.
   responsesCount: number
+  // Used to determine if we should add MRF related columns to the CSV.
+  isMrf: boolean
 }
 interface UseDecryptionWorkersProps {
   onProgress: (progress: number) => void
@@ -104,6 +106,7 @@ const useDecryptionWorkers = ({
       secretKey,
       endDate,
       startDate,
+      isMrf,
     }: DownloadEncryptedParams) => {
       if (!adminForm || !responsesCount) {
         return Promise.resolve({
@@ -158,6 +161,7 @@ const useDecryptionWorkers = ({
       const csvGenerator = new EncryptedResponseCsvGenerator(
         responsesCount,
         NUM_OF_METADATA_ROWS,
+        isMrf,
       )
 
       const stream = await getEncryptedResponsesStream(

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -386,6 +386,7 @@ const useDecryptionWorkers = ({
       secretKey,
       endDate,
       startDate,
+      isMrf,
     }: DownloadEncryptedParams) => {
       if (!adminForm || !responsesCount) {
         return Promise.resolve({
@@ -439,6 +440,7 @@ const useDecryptionWorkers = ({
       const csvGenerator = new EncryptedResponseCsvGenerator(
         responsesCount,
         NUM_OF_METADATA_ROWS,
+        isMrf,
       )
 
       const stream = await getEncryptedResponsesStream(

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash'
 
-import { SubmissionPaymentDto } from '~shared/types'
+import { SubmissionMrfMetadata, SubmissionPaymentDto } from '~shared/types'
 
 import { getPaymentDataView } from '~features/admin-form/responses/common/utils/getPaymentDataView'
 
@@ -34,6 +34,7 @@ export class CsvRecord {
     public form: string,
     public hostOrigin: string,
     public paymentData?: SubmissionPaymentDto,
+    public mrfData?: SubmissionMrfMetadata,
   ) {
     this.#statusMessage = status
     this.#record = []

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
@@ -136,6 +136,7 @@ export class CsvRecord {
     this.submissionData = {
       created: this.created,
       submissionId: this.id,
+      mrfMeta: this.mrfData,
       record: output,
     }
   }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -6,13 +6,13 @@ import { SetOptional } from 'type-fest'
 import { WorkflowStatus } from '~shared/types/submission'
 
 import {
-  getCurrentStepString,
+  getPendingResponseAtString,
   MRF_STATUS,
 } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
 import {
-  MRF_CURRENT_STEP_LABEL,
-  MRF_FIRST_STEP_TIMESTAMP_LABEL,
-  MRF_STATUS_LABEL,
+  MRF_PENDING_RESPONSE_AT_LABEL,
+  MRF_RESPONSE_TIMESTAMP_LABEL,
+  MRF_WORKFLOW_STATUS_LABEL,
 } from '~features/admin-form/responses/constants'
 
 import { CsvRecordData, DecryptedSubmissionData } from '../../types'
@@ -386,6 +386,7 @@ describe('EncryptedResponseCsvGenerator', () => {
             workflowStatus: WorkflowStatus.REJECTED,
             workflowCurrentStepNumber: 2,
             workflowNumTotalSteps: 3,
+            lastSubmittedAt: '2024-01-01T00:00:00.000Z',
           },
         }
         mrfGenerator.addRecord(mockRecord)
@@ -398,18 +399,19 @@ describe('EncryptedResponseCsvGenerator', () => {
         expect(mrfGenerator.records.length).toEqual(2 + BOM_LENGTH)
         const expectedHeaderRow = stringify([
           'Response ID',
-          MRF_STATUS_LABEL,
-          MRF_CURRENT_STEP_LABEL,
-          MRF_FIRST_STEP_TIMESTAMP_LABEL,
+          MRF_WORKFLOW_STATUS_LABEL,
+          MRF_PENDING_RESPONSE_AT_LABEL,
+          MRF_RESPONSE_TIMESTAMP_LABEL,
           mockDecryptedRecord[0].question,
         ])
         const expectedSubmissionRow = stringify([
           mockRecord.submissionId,
           MRF_STATUS.COMPLETED,
-          getCurrentStepString(
-            mockRecord.mrfMeta.workflowCurrentStepNumber,
-            mockRecord.mrfMeta.workflowNumTotalSteps,
-          ),
+          getPendingResponseAtString({
+            workflowCurrentStepNumber:
+              mockRecord.mrfMeta.workflowCurrentStepNumber,
+            workflowNumTotalSteps: mockRecord.mrfMeta.workflowNumTotalSteps,
+          }),
           getFormattedDate(mockRecord.created),
           mockDecryptedRecord[0].answer,
         ])

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -101,6 +101,7 @@ describe('EncryptedResponseCsvGenerator', () => {
     generator = new EncryptedResponseCsvGenerator(
       mockExpectedNumberOfRecords,
       mockNumOfMetaDataRows,
+      false,
     )
   })
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -3,6 +3,18 @@ import { stringify } from 'csv-string'
 import { formatInTimeZone } from 'date-fns-tz'
 import { SetOptional } from 'type-fest'
 
+import { WorkflowStatus } from '~shared/types/submission'
+
+import {
+  getCurrentStepString,
+  MRF_STATUS,
+} from '~features/admin-form/responses/common/utils/mrfSubmissionView'
+import {
+  MRF_CURRENT_STEP_LABEL,
+  MRF_FIRST_STEP_TIMESTAMP_LABEL,
+  MRF_STATUS_LABEL,
+} from '~features/admin-form/responses/constants'
+
 import { CsvRecordData, DecryptedSubmissionData } from '../../types'
 import {
   DisplayedResponseWithoutAnswer,
@@ -359,6 +371,54 @@ describe('EncryptedResponseCsvGenerator', () => {
       // Act + Assert
       generator.process()
       expect(generator.hasBeenProcessed).toBe(true)
+    })
+
+    describe('mrf form submissions', () => {
+      it('should include header and data columns for mrf metadata', () => {
+        // Arrange
+        const mrfGenerator = new EncryptedResponseCsvGenerator(1, 0, true)
+        const mockDecryptedRecord = [generateRecord(1)]
+        const mockRecord = {
+          record: mockDecryptedRecord,
+          created: mockCreatedEarly,
+          submissionId: 'mockSubmissionId',
+          mrfMeta: {
+            workflowStatus: WorkflowStatus.REJECTED,
+            workflowCurrentStepNumber: 2,
+            workflowNumTotalSteps: 3,
+          },
+        }
+        mrfGenerator.addRecord(mockRecord)
+
+        // Act
+        mrfGenerator.process()
+
+        // Assert
+        // Should have 1 header row and 1 submission row
+        expect(mrfGenerator.records.length).toEqual(2 + BOM_LENGTH)
+        const expectedHeaderRow = stringify([
+          'Response ID',
+          MRF_STATUS_LABEL,
+          MRF_CURRENT_STEP_LABEL,
+          MRF_FIRST_STEP_TIMESTAMP_LABEL,
+          mockDecryptedRecord[0].question,
+        ])
+        const expectedSubmissionRow = stringify([
+          mockRecord.submissionId,
+          MRF_STATUS.COMPLETED,
+          getCurrentStepString(
+            mockRecord.mrfMeta.workflowCurrentStepNumber,
+            mockRecord.mrfMeta.workflowNumTotalSteps,
+          ),
+          getFormattedDate(mockRecord.created),
+          mockDecryptedRecord[0].answer,
+        ])
+        expect(mrfGenerator.records).toEqual([
+          UTF8_BYTE_ORDER_MARK,
+          expectedHeaderRow,
+          expectedSubmissionRow,
+        ])
+      })
     })
 
     describe('submissions with only answer key', () => {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -412,7 +412,7 @@ describe('EncryptedResponseCsvGenerator', () => {
               mockRecord.mrfMeta.workflowCurrentStepNumber,
             workflowNumTotalSteps: mockRecord.mrfMeta.workflowNumTotalSteps,
           }),
-          getFormattedDate(mockRecord.created),
+          getFormattedDate(mockRecord.mrfMeta.lastSubmittedAt),
           mockDecryptedRecord[0].answer,
         ])
         expect(mrfGenerator.records).toEqual([

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -4,12 +4,11 @@ import type { Dictionary } from 'lodash'
 import { keyBy } from 'lodash'
 import type { Merge } from 'type-fest'
 
+import { CsvGenerator } from '../../../../common/utils'
 import {
   getCurrentStepString,
   getStatusFromWorkflowStatus,
-} from '~features/admin-form/responses/common/utils/mrfSubmissionView'
-
-import { CsvGenerator } from '../../../../common/utils'
+} from '../../../../common/utils/mrfSubmissionView'
 import type { DecryptedSubmissionData } from '../../types'
 import type { Response } from '../csv-response-classes'
 import { getDecryptedResponseInstance } from '../getDecryptedResponseInstance'

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -118,9 +118,12 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     if (this.hasBeenProcessed) return
 
     // Create a header row in CSV using the fieldIdToQuestion map.
+    // NOTE: de-structuring is necessary to avoid mutating the array referenced by the `headers` array below.
+    // See: https://github.com/opengovsg/FormSG/pull/7965#discussion_r1883954194.
     const headers = this.isMrf ? [...MRF_CSV_HEADERS] : [...NON_MRF_CSV_HEADERS]
     this.fieldIdToQuestion.forEach((value, fieldId) => {
       for (let i = 0; i < this.fieldIdToNumCols[fieldId]; i++) {
+        // TODO: (Code quality) Refactor to avoid mutating the `headers` array.
         headers.push(value.question)
       }
     })

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -4,7 +4,10 @@ import type { Dictionary } from 'lodash'
 import { keyBy } from 'lodash'
 import type { Merge } from 'type-fest'
 
-import { getCurrentStepString } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
+import {
+  getCurrentStepString,
+  getStatusFromWorkflowStatus,
+} from '~features/admin-form/responses/common/utils/mrfSubmissionView'
 
 import { CsvGenerator } from '../../../../common/utils'
 import type { DecryptedSubmissionData } from '../../types'
@@ -124,7 +127,10 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
       const row = [up.submissionId]
 
       if (this.isMrf) {
-        row.push(up.mrfMeta?.workflowStatus ?? '')
+        const mrfSubmissionStatus = getStatusFromWorkflowStatus(
+          up.mrfMeta?.workflowStatus,
+        )
+        row.push(mrfSubmissionStatus)
         const currentStepString = getCurrentStepString(
           up.mrfMeta?.workflowCurrentStepNumber,
           up.mrfMeta?.workflowNumTotalSteps,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -5,14 +5,14 @@ import { keyBy } from 'lodash'
 import type { Merge } from 'type-fest'
 
 import {
-  MRF_CURRENT_STEP_LABEL,
-  MRF_FIRST_STEP_TIMESTAMP_LABEL,
-  MRF_STATUS_LABEL,
+  MRF_PENDING_RESPONSE_AT_LABEL,
+  MRF_RESPONSE_TIMESTAMP_LABEL,
+  MRF_WORKFLOW_STATUS_LABEL,
 } from '~features/admin-form/responses/constants'
 
 import { CsvGenerator } from '../../../../common/utils'
 import {
-  getCurrentStepString,
+  getPendingResponseAtString,
   getStatusFromWorkflowStatus,
 } from '../../../../common/utils/mrfSubmissionView'
 import type { DecryptedSubmissionData } from '../../types'
@@ -27,9 +27,9 @@ type UnprocessedRecord = Merge<
 
 const MRF_CSV_HEADERS = [
   'Response ID',
-  MRF_STATUS_LABEL,
-  MRF_CURRENT_STEP_LABEL,
-  MRF_FIRST_STEP_TIMESTAMP_LABEL,
+  MRF_WORKFLOW_STATUS_LABEL,
+  MRF_PENDING_RESPONSE_AT_LABEL,
+  MRF_RESPONSE_TIMESTAMP_LABEL,
 ]
 
 const BASE_CSV_HEADERS = ['Response ID', 'Timestamp']
@@ -134,26 +134,38 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     this.unprocessed.forEach((up) => {
       const row = [up.submissionId]
 
-      if (this.isMrf) {
-        const workflowStatus = up.mrfMeta?.workflowStatus
-        const mrfSubmissionStatus = workflowStatus
-          ? getStatusFromWorkflowStatus(workflowStatus)
-          : ''
-        row.push(mrfSubmissionStatus)
-        const currentStepString = getCurrentStepString(
-          up.mrfMeta?.workflowCurrentStepNumber,
-          up.mrfMeta?.workflowNumTotalSteps,
-        )
-        row.push(currentStepString)
-      }
-
-      const formattedDate = isValid(parseISO(up.created))
+      let formattedDate = isValid(parseISO(up.created))
         ? formatInTimeZone(
             up.created,
             'Asia/Singapore',
             'dd MMM yyyy hh:mm:ss a',
           )
         : up.created
+
+      if (this.isMrf) {
+        const workflowStatus = up.mrfMeta?.workflowStatus
+        const mrfSubmissionStatus = workflowStatus
+          ? getStatusFromWorkflowStatus(workflowStatus)
+          : ''
+        row.push(mrfSubmissionStatus)
+        const pendingAtString = getPendingResponseAtString({
+          workflowCurrentStepNumber: up.mrfMeta?.workflowCurrentStepNumber,
+          workflowNumTotalSteps: up.mrfMeta?.workflowNumTotalSteps,
+        })
+        row.push(pendingAtString)
+
+        const lastSubmittedAt = up.mrfMeta?.lastSubmittedAt
+        if (lastSubmittedAt) {
+          formattedDate = isValid(parseISO(lastSubmittedAt))
+            ? formatInTimeZone(
+                lastSubmittedAt,
+                'Asia/Singapore',
+                'dd MMM yyyy hh:mm:ss a',
+              )
+            : lastSubmittedAt
+        }
+      }
+
       row.push(formattedDate)
 
       this.fieldIdToQuestion.forEach((_question, fieldId) => {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -112,7 +112,7 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     if (this.hasBeenProcessed) return
 
     // Create a header row in CSV using the fieldIdToQuestion map.
-    const headers = this.isMrf ? MRF_CSV_HEADERS : NON_MRF_CSV_HEADERS
+    const headers = this.isMrf ? [...MRF_CSV_HEADERS] : [...NON_MRF_CSV_HEADERS]
     this.fieldIdToQuestion.forEach((value, fieldId) => {
       for (let i = 0; i < this.fieldIdToNumCols[fieldId]; i++) {
         headers.push(value.question)

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -4,6 +4,12 @@ import type { Dictionary } from 'lodash'
 import { keyBy } from 'lodash'
 import type { Merge } from 'type-fest'
 
+import {
+  MRF_CURRENT_STEP_LABEL,
+  MRF_FIRST_STEP_TIMESTAMP_LABEL,
+  MRF_STATUS_LABEL,
+} from '~features/admin-form/responses/constants'
+
 import { CsvGenerator } from '../../../../common/utils'
 import {
   getCurrentStepString,
@@ -21,9 +27,9 @@ type UnprocessedRecord = Merge<
 
 const MRF_CSV_HEADERS = [
   'Response ID',
-  'Status',
-  'Current step',
-  'Timestamp of first response',
+  MRF_STATUS_LABEL,
+  MRF_CURRENT_STEP_LABEL,
+  MRF_FIRST_STEP_TIMESTAMP_LABEL,
 ]
 
 const NON_MRF_CSV_HEADERS = ['Response ID', 'Timestamp']

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -4,6 +4,8 @@ import type { Dictionary } from 'lodash'
 import { keyBy } from 'lodash'
 import type { Merge } from 'type-fest'
 
+import { getCurrentStepString } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
+
 import { CsvGenerator } from '../../../../common/utils'
 import type { DecryptedSubmissionData } from '../../types'
 import type { Response } from '../csv-response-classes'
@@ -123,11 +125,10 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
 
       if (this.isMrf) {
         row.push(up.mrfMeta?.workflowStatus ?? '')
-        const currentStepString =
-          up.mrfMeta?.workflowCurrentStepNumber &&
-          up.mrfMeta.workflowNumTotalSteps
-            ? `Step ${up.mrfMeta?.workflowCurrentStepNumber} of ${up.mrfMeta?.workflowNumTotalSteps}`
-            : ''
+        const currentStepString = getCurrentStepString(
+          up.mrfMeta?.workflowCurrentStepNumber,
+          up.mrfMeta?.workflowNumTotalSteps,
+        )
         row.push(currentStepString)
       }
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -32,7 +32,7 @@ const MRF_CSV_HEADERS = [
   MRF_FIRST_STEP_TIMESTAMP_LABEL,
 ]
 
-const NON_MRF_CSV_HEADERS = ['Response ID', 'Timestamp']
+const BASE_CSV_HEADERS = ['Response ID', 'Timestamp']
 
 export class EncryptedResponseCsvGenerator extends CsvGenerator {
   hasBeenProcessed: boolean
@@ -120,7 +120,7 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     // Create a header row in CSV using the fieldIdToQuestion map.
     // NOTE: de-structuring is necessary to avoid mutating the array referenced by the `headers` array below.
     // See: https://github.com/opengovsg/FormSG/pull/7965#discussion_r1883954194.
-    const headers = this.isMrf ? [...MRF_CSV_HEADERS] : [...NON_MRF_CSV_HEADERS]
+    const headers = this.isMrf ? [...MRF_CSV_HEADERS] : [...BASE_CSV_HEADERS]
     this.fieldIdToQuestion.forEach((value, fieldId) => {
       for (let i = 0; i < this.fieldIdToNumCols[fieldId]; i++) {
         // TODO: (Code quality) Refactor to avoid mutating the `headers` array.

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -15,14 +15,28 @@ type UnprocessedRecord = Merge<
   { record: Dictionary<Response> }
 >
 
+const MRF_CSV_HEADERS = [
+  'Response ID',
+  'Status',
+  'Current step',
+  'Timestamp of first response',
+]
+
+const NON_MRF_CSV_HEADERS = ['Response ID', 'Timestamp']
+
 export class EncryptedResponseCsvGenerator extends CsvGenerator {
   hasBeenProcessed: boolean
   hasBeenSorted: boolean
   fieldIdToQuestion: Map<string, { created: string; question: string }>
   fieldIdToNumCols: Record<string, number>
   unprocessed: UnprocessedRecord[]
+  isMrf: boolean
 
-  constructor(expectedNumberOfRecords: number, numOfMetaDataRows: number) {
+  constructor(
+    expectedNumberOfRecords: number,
+    numOfMetaDataRows: number,
+    isMrf: boolean,
+  ) {
     super(expectedNumberOfRecords, numOfMetaDataRows)
 
     this.hasBeenProcessed = false
@@ -30,6 +44,7 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     this.fieldIdToQuestion = new Map()
     this.fieldIdToNumCols = {}
     this.unprocessed = []
+    this.isMrf = isMrf
   }
 
   /**
@@ -43,7 +58,11 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
    * Extracts information from input record, rearranges record and then adds an UnprocessedRecord to `this.unprocessed`
    * @throws Error when trying to convert record into a response instance. Should be caught in submissions client factory.
    */
-  addRecord({ record, created, submissionId }: DecryptedSubmissionData): void {
+  addRecord({
+    record,
+    created,
+    ...otherSubmissionProperties
+  }: DecryptedSubmissionData): void {
     // First pass, create object with { [fieldId]: question } from
     // decryptedContent to get all the questions.
     const fieldRecords = record.map((content) => {
@@ -75,8 +94,8 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     // Rearrange record to be an object identified by field ID.
     this.unprocessed.push({
       created,
-      submissionId,
       record: keyBy(fieldRecords, (fieldRecord) => fieldRecord.id),
+      ...otherSubmissionProperties,
     })
   }
 
@@ -89,7 +108,7 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     if (this.hasBeenProcessed) return
 
     // Create a header row in CSV using the fieldIdToQuestion map.
-    const headers = ['Response ID', 'Timestamp']
+    const headers = this.isMrf ? MRF_CSV_HEADERS : NON_MRF_CSV_HEADERS
     this.fieldIdToQuestion.forEach((value, fieldId) => {
       for (let i = 0; i < this.fieldIdToNumCols[fieldId]; i++) {
         headers.push(value.question)
@@ -100,6 +119,18 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
     // Craft a new csv row for each unprocessed record
     // O(qn), where q = number of unique questions, n = number of submissions.
     this.unprocessed.forEach((up) => {
+      const row = [up.submissionId]
+
+      if (this.isMrf) {
+        row.push(up.mrfMeta?.workflowStatus ?? '')
+        const currentStepString =
+          up.mrfMeta?.workflowCurrentStepNumber &&
+          up.mrfMeta.workflowNumTotalSteps
+            ? `Step ${up.mrfMeta?.workflowCurrentStepNumber} of ${up.mrfMeta?.workflowNumTotalSteps}`
+            : ''
+        row.push(currentStepString)
+      }
+
       const formattedDate = isValid(parseISO(up.created))
         ? formatInTimeZone(
             up.created,
@@ -107,7 +138,7 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
             'dd MMM yyyy hh:mm:ss a',
           )
         : up.created
-      const row = [up.submissionId, formattedDate]
+      row.push(formattedDate)
 
       this.fieldIdToQuestion.forEach((_question, fieldId) => {
         const numCols = this.fieldIdToNumCols[fieldId]

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -135,9 +135,10 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
       const row = [up.submissionId]
 
       if (this.isMrf) {
-        const mrfSubmissionStatus = getStatusFromWorkflowStatus(
-          up.mrfMeta?.workflowStatus,
-        )
+        const workflowStatus = up.mrfMeta?.workflowStatus
+        const mrfSubmissionStatus = workflowStatus
+          ? getStatusFromWorkflowStatus(workflowStatus)
+          : ''
         row.push(mrfSubmissionStatus)
         const currentStepString = getCurrentStepString(
           up.mrfMeta?.workflowCurrentStepNumber,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -13,15 +13,6 @@ import {
 } from '../types'
 import { CsvRecord } from '../utils/CsvRecord.class'
 
-// Fixes issue raised at https://stackoverflow.com/questions/66472945/referenceerror-refreshreg-is-not-defined
-// Something to do with babel-loader.
-if (import.meta.env.MODE !== 'production') {
-  // eslint-disable-next-line
-  ;(global as any).$RefreshReg$ = () => {}
-  // eslint-disable-next-line
-  ;(global as any).$RefreshSig$ = () => () => {}
-}
-
 const queue = new PQueue({ concurrency: 1 })
 
 /**
@@ -212,7 +203,7 @@ async function decryptIntoCsv(
     } catch (error) {
       csvRecord.setStatus(CsvRecordStatus.Error, 'Decryption Error')
     }
-  } catch (err) {
+  } catch (error) {
     csvRecord = new CsvRecord(
       CsvRecordStatus.Error,
       formatInTimeZone(new Date(), 'Asia/Singapore', 'dd MMM yyyy hh:mm:ss z'),

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -2,6 +2,8 @@ import { expose } from 'comlink'
 import { formatInTimeZone } from 'date-fns-tz'
 import PQueue from 'p-queue'
 
+import { MultirespondentSubmissionStreamDto } from '~shared/types/submission'
+
 import formsgSdk from '~utils/formSdk'
 
 import {
@@ -98,6 +100,14 @@ async function decryptIntoCsv(
       hostOrigin,
       submission.submissionType === SubmissionType.Encrypt
         ? submission.payment
+        : undefined,
+      submission.submissionType === SubmissionType.Multirespondent
+        ? {
+            workflowStatus: (submission as MultirespondentSubmissionStreamDto)
+              .workflowStatus,
+            workflowCurrentStepNumber: submission.workflowStep + 1,
+            workflowNumTotalSteps: submission.numTotalSteps,
+          }
         : undefined,
     )
     try {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -2,8 +2,6 @@ import { expose } from 'comlink'
 import { formatInTimeZone } from 'date-fns-tz'
 import PQueue from 'p-queue'
 
-import { MultirespondentSubmissionStreamDto } from '~shared/types/submission'
-
 import formsgSdk from '~utils/formSdk'
 
 import {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -96,6 +96,7 @@ async function decryptIntoCsv(
             workflowCurrentStepNumber:
               submission.mrfMeta.workflowCurrentStepNumber,
             workflowNumTotalSteps: submission.mrfMeta.workflowNumTotalSteps,
+            lastSubmittedAt: submission.mrfMeta.lastSubmittedAt,
           }
         : undefined,
     )

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -103,10 +103,10 @@ async function decryptIntoCsv(
         : undefined,
       submission.submissionType === SubmissionType.Multirespondent
         ? {
-            workflowStatus: (submission as MultirespondentSubmissionStreamDto)
-              .workflowStatus,
-            workflowCurrentStepNumber: submission.workflowStep + 1,
-            workflowNumTotalSteps: submission.numTotalSteps,
+            workflowStatus: submission.mrfMeta.workflowStatus,
+            workflowCurrentStepNumber:
+              submission.mrfMeta.workflowCurrentStepNumber,
+            workflowNumTotalSteps: submission.mrfMeta.workflowNumTotalSteps,
           }
         : undefined,
     )

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -1,0 +1,8 @@
+/** Gets the business friendly string for current step of workflow. */
+export const getCurrentStepString = (
+  workflowCurrentStepNumber: number | undefined,
+  workflowNumTotalSteps: number | undefined,
+) =>
+  workflowCurrentStepNumber && workflowNumTotalSteps
+    ? `Step ${workflowCurrentStepNumber} of ${workflowNumTotalSteps}`
+    : ''

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -17,7 +17,7 @@ export const getCurrentStepString = (
 /** Gets the business friendly string for MRF submission status. */
 export const getStatusFromWorkflowStatus = (
   workflowStatus: WorkflowStatus | undefined,
-) => {
+): MRF_STATUS | '' => {
   switch (workflowStatus) {
     case WorkflowStatus.COMPLETED:
     case WorkflowStatus.APPROVED:
@@ -25,7 +25,7 @@ export const getStatusFromWorkflowStatus = (
       return MRF_STATUS.COMPLETED
     case WorkflowStatus.PENDING:
       return MRF_STATUS.PENDING
-    default:
+    case undefined:
       return ''
   }
 }

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -16,8 +16,8 @@ export const getCurrentStepString = (
 
 /** Gets the business friendly string for MRF submission status. */
 export const getStatusFromWorkflowStatus = (
-  workflowStatus: WorkflowStatus | undefined,
-): MRF_STATUS | '' => {
+  workflowStatus: WorkflowStatus,
+): MRF_STATUS => {
   switch (workflowStatus) {
     case WorkflowStatus.COMPLETED:
     case WorkflowStatus.APPROVED:
@@ -25,7 +25,10 @@ export const getStatusFromWorkflowStatus = (
       return MRF_STATUS.COMPLETED
     case WorkflowStatus.PENDING:
       return MRF_STATUS.PENDING
-    case undefined:
-      return ''
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _: never = workflowStatus
+      throw new Error('Invalid WorkflowStatus encountered.')
+    }
   }
 }

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -5,14 +5,38 @@ export enum MRF_STATUS {
   PENDING = 'Pending',
 }
 
+interface CurrentStepInfo {
+  workflowCurrentStepNumber: number | undefined
+  workflowNumTotalSteps: number | undefined
+}
+
+/** Gets the business friendly message for the current pending step of the workflow.  */
+export const getPendingResponseAtString = ({
+  workflowCurrentStepNumber,
+  workflowNumTotalSteps,
+}: CurrentStepInfo) => {
+  if (!workflowCurrentStepNumber || !workflowNumTotalSteps) {
+    return ''
+  }
+  const isPending = workflowCurrentStepNumber < workflowCurrentStepNumber
+  if (!isPending) {
+    return ''
+  }
+  return getCurrentStepString({
+    workflowCurrentStepNumber,
+    workflowNumTotalSteps,
+  })
+}
+
 /** Gets the business friendly string for current step of workflow. */
-export const getCurrentStepString = (
-  workflowCurrentStepNumber: number | undefined,
-  workflowNumTotalSteps: number | undefined,
-) =>
-  workflowCurrentStepNumber && workflowNumTotalSteps
+const getCurrentStepString = ({
+  workflowCurrentStepNumber,
+  workflowNumTotalSteps,
+}: CurrentStepInfo) => {
+  return workflowCurrentStepNumber && workflowNumTotalSteps
     ? `Step ${workflowCurrentStepNumber} of ${workflowNumTotalSteps}`
     : ''
+}
 
 /** Gets the business friendly string for MRF submission status. */
 export const getStatusFromWorkflowStatus = (

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -1,5 +1,10 @@
 import { WorkflowStatus } from '~shared/types'
 
+export enum MRF_STATUS {
+  COMPLETED = 'Completed',
+  PENDING = 'Pending',
+}
+
 /** Gets the business friendly string for current step of workflow. */
 export const getCurrentStepString = (
   workflowCurrentStepNumber: number | undefined,
@@ -17,9 +22,9 @@ export const getStatusFromWorkflowStatus = (
     case WorkflowStatus.COMPLETED:
     case WorkflowStatus.APPROVED:
     case WorkflowStatus.REJECTED:
-      return 'Completed'
+      return MRF_STATUS.COMPLETED
     case WorkflowStatus.PENDING:
-      return 'Pending'
+      return MRF_STATUS.PENDING
     default:
       return ''
   }

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -1,3 +1,5 @@
+import { WorkflowStatus } from '~shared/types'
+
 /** Gets the business friendly string for current step of workflow. */
 export const getCurrentStepString = (
   workflowCurrentStepNumber: number | undefined,
@@ -6,3 +8,19 @@ export const getCurrentStepString = (
   workflowCurrentStepNumber && workflowNumTotalSteps
     ? `Step ${workflowCurrentStepNumber} of ${workflowNumTotalSteps}`
     : ''
+
+/** Gets the business friendly string for MRF submission status. */
+export const getStatusFromWorkflowStatus = (
+  workflowStatus: WorkflowStatus | undefined,
+) => {
+  switch (workflowStatus) {
+    case WorkflowStatus.COMPLETED:
+    case WorkflowStatus.APPROVED:
+    case WorkflowStatus.REJECTED:
+      return 'Completed'
+    case WorkflowStatus.PENDING:
+      return 'Pending'
+    default:
+      return ''
+  }
+}

--- a/frontend/src/features/admin-form/responses/constants.ts
+++ b/frontend/src/features/admin-form/responses/constants.ts
@@ -1,3 +1,3 @@
-export const MRF_FIRST_STEP_TIMESTAMP_LABEL = 'Response timestamp'
-export const MRF_CURRENT_STEP_LABEL = 'Pending response at'
-export const MRF_STATUS_LABEL = 'Workflow status'
+export const MRF_RESPONSE_TIMESTAMP_LABEL = 'Response timestamp'
+export const MRF_PENDING_RESPONSE_AT_LABEL = 'Pending response at'
+export const MRF_WORKFLOW_STATUS_LABEL = 'Workflow status'

--- a/frontend/src/features/admin-form/responses/constants.ts
+++ b/frontend/src/features/admin-form/responses/constants.ts
@@ -1,3 +1,3 @@
-export const MRF_FIRST_STEP_TIMESTAMP_LABEL = 'Submission time of first step'
-export const MRF_CURRENT_STEP_LABEL = 'Current step'
-export const MRF_STATUS_LABEL = 'Status'
+export const MRF_FIRST_STEP_TIMESTAMP_LABEL = 'Response timestamp'
+export const MRF_CURRENT_STEP_LABEL = 'Pending response at'
+export const MRF_STATUS_LABEL = 'Workflow status'

--- a/frontend/src/features/admin-form/responses/constants.ts
+++ b/frontend/src/features/admin-form/responses/constants.ts
@@ -1,0 +1,3 @@
+export const MRF_FIRST_STEP_TIMESTAMP_LABEL = 'Submission time of first step'
+export const MRF_CURRENT_STEP_LABEL = 'Current step'
+export const MRF_STATUS_LABEL = 'Status'

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -31,7 +31,10 @@ import {
 } from '~shared/types/form/form'
 import { FormLogoState } from '~shared/types/form/form_logo'
 import { DateString } from '~shared/types/generic'
-import { SubmissionMetadataList } from '~shared/types/submission'
+import {
+  SubmissionMetadataList,
+  WorkflowStatus,
+} from '~shared/types/submission'
 import { UserDto } from '~shared/types/user'
 import { insertAt, reorder } from '~shared/utils/immutable-array-fns'
 
@@ -588,6 +591,63 @@ export const MOCK_FORM_FIELDS_WITH_TRANSLATIONS: FormFieldDto[] = [
   },
 ]
 
+const DEFAULT_MULTIRESPONDENT_METADATA = [
+  [
+    {
+      number: 1,
+      refNo: '62a8a7476f4f3e005bcd5ab7',
+      submissionTime: '14th Jun 2022, 11:20:39 pm',
+      mrf: {
+        workflowCurrentStepNumber: 1,
+        workflowNumTotalSteps: 5,
+        workflowStatus: WorkflowStatus.PENDING,
+      },
+    },
+    {
+      number: 2,
+      refNo: '62a8a7476f4f3e005bcd5ab8',
+      submissionTime: '14th Jun 2022, 11:21:39 pm',
+      mrf: {
+        workflowCurrentStepNumber: 3,
+        workflowNumTotalSteps: 3,
+        workflowStatus: WorkflowStatus.APPROVED,
+      },
+    },
+    {
+      number: 3,
+      refNo: '62a8a7476f4f3e005bcd5ab9',
+      submissionTime: '14th Jun 2022, 11:22:39 pm',
+      mrf: {
+        workflowCurrentStepNumber: 2,
+        workflowNumTotalSteps: 3,
+        workflowStatus: WorkflowStatus.REJECTED,
+      },
+    },
+    {
+      number: 4,
+      refNo: '62a8a7476f4f3e005bcd5ac0',
+      submissionTime: '14th Jun 2022, 11:23:39 pm',
+      mrf: {
+        workflowCurrentStepNumber: 4,
+        workflowNumTotalSteps: 4,
+        workflowStatus: WorkflowStatus.COMPLETED,
+      },
+    },
+    // simulates a submission prior to https://github.com/opengovsg/FormSG/pull/7965
+    // which the workflowStatus cannot be determined as submittedSteps is undefined.
+    {
+      number: 5,
+      refNo: '62a8a7476f4f3e005bcd5ac1',
+      submissionTime: '14th Jun 2022, 11:24:39 pm',
+      mrf: {
+        workflowCurrentStepNumber: 1,
+        workflowNumTotalSteps: 4,
+        workflowStatus: undefined,
+      },
+    },
+  ],
+]
+
 const DEFAULT_STORAGE_METADATA = [
   [
     {
@@ -1041,8 +1101,33 @@ export const getStorageSubmissionMetadataResponse = (
         ctx.json<SubmissionMetadataList>(
           merge(
             {
-              count: 39,
+              count: DEFAULT_STORAGE_METADATA.flat().length,
               metadata: DEFAULT_STORAGE_METADATA[pageNum - 1],
+            },
+            props,
+          ),
+        ),
+      )
+    },
+  )
+}
+
+export const getMultiRespondentSubmissionMetadataResponse = (
+  props: Partial<SubmissionMetadataList> = {},
+  delay: number | 'infinite' | 'real' = 0,
+) => {
+  return rest.get<SubmissionMetadataList>(
+    '/api/v3/admin/forms/:formId/submissions/metadata',
+    (req, res, ctx) => {
+      const pageNum = parseInt(req.url.searchParams.get('page') ?? '1')
+      return res(
+        ctx.delay(delay),
+        ctx.status(200),
+        ctx.json<SubmissionMetadataList>(
+          merge(
+            {
+              count: DEFAULT_MULTIRESPONDENT_METADATA.flat().length,
+              metadata: DEFAULT_MULTIRESPONDENT_METADATA[pageNum - 1],
             },
             props,
           ),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -61,5 +61,10 @@ export default defineConfig(() => {
       plugins: () => [tsconfigPaths()],
       format: 'es' as const,
     },
+    define: {
+      // On local dev, global is undefined, causing decryption workers to fail.
+      // This is a workaround based on https://github.com/vitejs/vite/discussions/5912.
+      global: 'globalThis',
+    },
   }
 })

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -61,10 +61,5 @@ export default defineConfig(() => {
       plugins: () => [tsconfigPaths()],
       format: 'es' as const,
     },
-    define: {
-      // On local dev, global is undefined, causing decryption workers to fail.
-      // This is a workaround based on https://github.com/vitejs/vite/discussions/5912.
-      global: 'globalThis',
-    },
   }
 })

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -254,11 +254,13 @@ export type SubmissionPaymentMetadata = {
   email: string
 } | null
 
-export type SubmissionMrfMetadata = {
-  workflowCurrentStepNumber: number
-  workflowNumTotalSteps: number
-  workflowStatus: WorkflowStatus | undefined // `undefined` is due to submissions before this PR not storing this value
-} | null
+export type SubmissionMrfMetadata =
+  | {
+      workflowCurrentStepNumber: number
+      workflowNumTotalSteps: number
+      workflowStatus: WorkflowStatus | undefined // `undefined` is due to submissions before this PR not storing this value
+    }
+  | undefined
 
 export type SubmissionMetadata = {
   number: number

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -223,10 +223,13 @@ export const MultirespondentSubmissionStreamDto =
     encryptedContent: true,
     version: true,
     mrfVersion: true,
+    workflowStep: true,
   }).extend({
     attachmentMetadata: z.record(z.string()),
     _id: SubmissionId,
     created: DateString,
+    workflowStatus: z.nativeEnum(WorkflowStatus),
+    numTotalSteps: z.number(),
   })
 
 export type MultirespondentSubmissionStreamDto = z.infer<

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -192,6 +192,8 @@ export type MultirespondentSubmissionDto = SubmissionDtoBase & {
 
   version: number
   mrfVersion: number
+
+  mrfMeta: SubmissionMrfMetadata
 }
 
 export type SubmissionDto =

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -233,6 +233,7 @@ export const MultirespondentSubmissionStreamDto =
       workflowCurrentStepNumber: z.number(),
       workflowNumTotalSteps: z.number(),
       workflowStatus: z.nativeEnum(WorkflowStatus).optional(),
+      lastSubmittedAt: z.string(),
     }),
   })
 
@@ -259,6 +260,7 @@ export type SubmissionMrfMetadata =
       workflowCurrentStepNumber: number
       workflowNumTotalSteps: number
       workflowStatus: WorkflowStatus | undefined // `undefined` is due to submissions before this PR not storing this value
+      lastSubmittedAt: string | undefined
     }
   | undefined
 
@@ -268,7 +270,7 @@ export type SubmissionMetadata = {
   /** Not a DateString, format is `Do MMM YYYY, h:mm:ss a` */
   submissionTime: string
   payments: SubmissionPaymentMetadata
-  mrf: SubmissionMrfMetadata
+  mrf?: SubmissionMrfMetadata
 }
 
 export type SubmissionMetadataList = {

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -213,11 +213,18 @@ export type SubmissionPaymentMetadata = {
   email: string
 } | null
 
-type SubmissionMrfMetadata = {
-  workflow: FormWorkflowDto
-  workflowStep: number
-  workflowStatus: string | undefined // `undefined` is due to submissions before this PR not storing this value
+export enum WorkflowStatus {
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  PENDING = 'PENDING',
+  COMPLETED = 'COMPLETED',
 }
+
+export type SubmissionMrfMetadata = {
+  workflowCurrentStepNumber: number
+  workflowNumTotalSteps: number
+  workflowStatus: WorkflowStatus | undefined // `undefined` is due to submissions before this PR not storing this value
+} | null
 
 export type SubmissionMetadata = {
   number: number
@@ -225,7 +232,8 @@ export type SubmissionMetadata = {
   /** Not a DateString, format is `Do MMM YYYY, h:mm:ss a` */
   submissionTime: string
   payments: SubmissionPaymentMetadata
-} & SubmissionMrfMetadata
+  mrf: SubmissionMrfMetadata
+}
 
 export type SubmissionMetadataList = {
   metadata: SubmissionMetadata[]

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -223,13 +223,15 @@ export const MultirespondentSubmissionStreamDto =
     encryptedContent: true,
     version: true,
     mrfVersion: true,
-    workflowStep: true,
   }).extend({
     attachmentMetadata: z.record(z.string()),
     _id: SubmissionId,
     created: DateString,
-    workflowStatus: z.nativeEnum(WorkflowStatus),
-    numTotalSteps: z.number(),
+    mrfMeta: z.object({
+      workflowCurrentStepNumber: z.number(),
+      workflowNumTotalSteps: z.number(),
+      workflowStatus: z.nativeEnum(WorkflowStatus).optional(),
+    }),
   })
 
 export type MultirespondentSubmissionStreamDto = z.infer<

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -213,13 +213,19 @@ export type SubmissionPaymentMetadata = {
   email: string
 } | null
 
+type SubmissionMrfMetadata = {
+  workflow: FormWorkflowDto
+  workflowStep: number
+  workflowStatus: string | undefined // `undefined` is due to submissions before this PR not storing this value
+}
+
 export type SubmissionMetadata = {
   number: number
   refNo: SubmissionId
   /** Not a DateString, format is `Do MMM YYYY, h:mm:ss a` */
   submissionTime: string
   payments: SubmissionPaymentMetadata
-}
+} & SubmissionMrfMetadata
 
 export type SubmissionMetadataList = {
   metadata: SubmissionMetadata[]

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -80,6 +80,39 @@ export type StorageModeSubmissionBase = z.infer<
  * Multirespondent submission typings as stored in the database.
  */
 
+export enum WorkflowStatus {
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  PENDING = 'PENDING',
+  COMPLETED = 'COMPLETED',
+}
+
+export const ApprovalStatus = z.enum([
+  WorkflowStatus.APPROVED,
+  WorkflowStatus.REJECTED,
+])
+
+const SubmittedNonApprovalStep = z.object({
+  isApproval: z.literal(false),
+  submittedAt: z.string(),
+})
+
+export type SubmittedNonApprovalStep = z.infer<typeof SubmittedNonApprovalStep>
+
+const SubmittedApprovalStep = SubmittedNonApprovalStep.extend({
+  isApproval: z.literal(true),
+  status: ApprovalStatus,
+})
+
+export type SubmittedApprovalStep = z.infer<typeof SubmittedApprovalStep>
+
+export const SubmittedStep = z.discriminatedUnion('isApproval', [
+  SubmittedApprovalStep,
+  SubmittedNonApprovalStep,
+])
+
+export type SubmittedStep = z.infer<typeof SubmittedStep>
+
 export const MultirespondentSubmissionBase = SubmissionBase.extend({
   // Store the form fields and logic here, to use as reference for future
   // submitters. Don't bother to validate since this is injected by the backend.
@@ -95,6 +128,7 @@ export const MultirespondentSubmissionBase = SubmissionBase.extend({
   version: z.number(),
   workflowStep: z.number(),
   mrfVersion: z.number().optional(),
+  submittedSteps: z.array(SubmittedStep).optional(),
 })
 
 export type MultirespondentSubmissionBase = z.infer<
@@ -212,13 +246,6 @@ export type SubmissionPaymentMetadata = {
   transactionFee: number | null
   email: string
 } | null
-
-export enum WorkflowStatus {
-  APPROVED = 'APPROVED',
-  REJECTED = 'REJECTED',
-  PENDING = 'PENDING',
-  COMPLETED = 'COMPLETED',
-}
 
 export type SubmissionMrfMetadata = {
   workflowCurrentStepNumber: number

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -94,7 +94,7 @@ export const ApprovalStatus = z.enum([
 
 const SubmittedNonApprovalStep = z.object({
   isApproval: z.literal(false),
-  submittedAt: z.string(),
+  submittedAt: z.string().datetime({ precision: 3 }),
 })
 
 export type SubmittedNonApprovalStep = z.infer<typeof SubmittedNonApprovalStep>

--- a/src/app/models/__tests__/multirespondent-submission.server.model.spec.ts
+++ b/src/app/models/__tests__/multirespondent-submission.server.model.spec.ts
@@ -3,7 +3,13 @@ import { ObjectId } from 'bson'
 import { pick, times } from 'lodash'
 import moment from 'moment-timezone'
 import mongoose from 'mongoose'
-import { SubmissionMetadata, SubmissionType } from 'shared/types'
+import {
+  BasicField,
+  SubmissionMetadata,
+  SubmissionType,
+  WorkflowStatus,
+  WorkflowType,
+} from 'shared/types'
 
 import getSubmissionModel, {
   getEmailSubmissionModel,
@@ -24,6 +30,34 @@ describe('Multirespondent Submission Model', () => {
   const MOCK_ENCRYPTED_SUBMISSION_SECRET_KEY = 'This is an encrypted secret key'
   const MOCK_ENCRYPTED_CONTENT = 'abcdefg encryptedContent'
 
+  const YES_NO_FIELD = {
+    _id: 'yes_no_field_id',
+    title: 'Yes or No',
+    description: '',
+    required: true,
+    disabled: false,
+    fieldType: BasicField.YesNo,
+  }
+  const WORKFLOW_STEP_1 = {
+    _id: 'step_1_id',
+    workflow_type: WorkflowType.Static,
+    emails: ['example@example.com'],
+    edit: [],
+  }
+  const WORKFLOW_STEP_2 = {
+    _id: 'step_2_id',
+    workflow_type: WorkflowType.Static,
+    emails: ['example@example.com'],
+    edit: [YES_NO_FIELD._id],
+  }
+  const WORKFLOW_APPROVAL_STEP = {
+    _id: 'approval_step_id',
+    workflow_type: WorkflowType.Static,
+    emails: ['example@example.com'],
+    edit: [YES_NO_FIELD._id],
+    approval_field: YES_NO_FIELD._id,
+  }
+
   describe('Statics', () => {
     describe('findSingleMetadata', () => {
       it('should return submission metadata', async () => {
@@ -34,15 +68,26 @@ describe('Multirespondent Submission Model', () => {
         const validSubmission = await MultirespondentSubmission.create({
           form: validFormId,
           submissionType: SubmissionType.Multirespondent,
-          form_fields: [],
+          form_fields: [YES_NO_FIELD, WORKFLOW_APPROVAL_STEP],
           form_logics: [],
-          workflow: [],
+          workflow: [WORKFLOW_STEP_1, WORKFLOW_APPROVAL_STEP],
           submissionPublicKey: MOCK_SUBMISSION_PUBLIC_KEY,
           encryptedSubmissionSecretKey: MOCK_ENCRYPTED_SUBMISSION_SECRET_KEY,
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 3,
           created: createdDate,
-          workflowStep: 0,
+          workflowStep: 1,
+          submittedSteps: [
+            {
+              isApproval: false,
+              submittedAt: '2024-01-01T00:00:00.000Z',
+            },
+            {
+              isApproval: true,
+              status: WorkflowStatus.REJECTED,
+              submittedAt: '2024-01-01T00:00:00.000Z',
+            },
+          ],
         })
 
         // Act
@@ -59,6 +104,11 @@ describe('Multirespondent Submission Model', () => {
           submissionTime: moment(createdDate)
             .tz('Asia/Singapore')
             .format('Do MMM YYYY, h:mm:ss a'),
+          mrf: {
+            workflowCurrentStepNumber: 2,
+            workflowNumTotalSteps: 2,
+            workflowStatus: WorkflowStatus.REJECTED,
+          },
         }
         expect(result).toEqual(expected)
       })
@@ -118,13 +168,19 @@ describe('Multirespondent Submission Model', () => {
             submissionType: SubmissionType.Multirespondent,
             form_fields: [],
             form_logics: [],
-            workflow: [],
+            workflow: [WORKFLOW_STEP_1],
             submissionPublicKey: MOCK_SUBMISSION_PUBLIC_KEY,
             encryptedSubmissionSecretKey: MOCK_ENCRYPTED_SUBMISSION_SECRET_KEY,
             encryptedContent: MOCK_ENCRYPTED_CONTENT,
             version: 3,
             created: MOCK_CREATED_DATES_ASC[idx],
             workflowStep: 0,
+            submittedSteps: [
+              {
+                isApproval: false,
+                submittedAt: '2024-01-01T00:00:00.000Z',
+              },
+            ],
           }),
         )
         const validSubmissions: IMultirespondentSubmissionSchema[] =
@@ -146,6 +202,11 @@ describe('Multirespondent Submission Model', () => {
               submissionTime: moment(data.created)
                 .tz('Asia/Singapore')
                 .format('Do MMM YYYY, h:mm:ss a'),
+              mrf: {
+                workflowCurrentStepNumber: 1,
+                workflowNumTotalSteps: 1,
+                workflowStatus: WorkflowStatus.COMPLETED,
+              },
             }))
             .reverse(),
         }
@@ -161,13 +222,24 @@ describe('Multirespondent Submission Model', () => {
             submissionType: SubmissionType.Multirespondent,
             form_fields: [],
             form_logics: [],
-            workflow: [],
+            workflow: [WORKFLOW_STEP_1, WORKFLOW_APPROVAL_STEP],
             submissionPublicKey: MOCK_SUBMISSION_PUBLIC_KEY,
             encryptedSubmissionSecretKey: MOCK_ENCRYPTED_SUBMISSION_SECRET_KEY,
             encryptedContent: MOCK_ENCRYPTED_CONTENT,
             version: 3,
             created: MOCK_CREATED_DATES_ASC[idx],
-            workflowStep: 0,
+            workflowStep: 1,
+            submittedSteps: [
+              {
+                isApproval: false,
+                submittedAt: '2024-01-01T00:00:00.000Z',
+              },
+              {
+                isApproval: true,
+                status: WorkflowStatus.APPROVED,
+                submittedAt: '2024-01-01T00:00:00.000Z',
+              },
+            ],
           }),
         )
         const validSubmissions: IMultirespondentSubmissionSchema[] =
@@ -194,6 +266,11 @@ describe('Multirespondent Submission Model', () => {
               submissionTime: moment(secondSubmission.created)
                 .tz('Asia/Singapore')
                 .format('Do MMM YYYY, h:mm:ss a'),
+              mrf: {
+                workflowCurrentStepNumber: 2,
+                workflowNumTotalSteps: 2,
+                workflowStatus: WorkflowStatus.APPROVED,
+              },
             },
           ],
         }
@@ -209,13 +286,23 @@ describe('Multirespondent Submission Model', () => {
             submissionType: SubmissionType.Multirespondent,
             form_fields: [],
             form_logics: [],
-            workflow: [],
+            workflow: [WORKFLOW_STEP_1, WORKFLOW_STEP_2],
             submissionPublicKey: MOCK_SUBMISSION_PUBLIC_KEY,
             encryptedSubmissionSecretKey: MOCK_ENCRYPTED_SUBMISSION_SECRET_KEY,
             encryptedContent: MOCK_ENCRYPTED_CONTENT,
             version: 3,
             created: MOCK_CREATED_DATES_ASC[idx],
-            workflowStep: 0,
+            workflowStep: 1,
+            submittedSteps: [
+              {
+                isApproval: false,
+                submittedAt: '2024-01-01T00:00:00.000Z',
+              },
+              {
+                isApproval: false,
+                submittedAt: '2024-01-02T00:00:00.000Z',
+              },
+            ],
           }),
         )
         const validSubmissions: IMultirespondentSubmissionSchema[] =
@@ -242,6 +329,11 @@ describe('Multirespondent Submission Model', () => {
               submissionTime: moment(latestSubmission.created)
                 .tz('Asia/Singapore')
                 .format('Do MMM YYYY, h:mm:ss a'),
+              mrf: {
+                workflowCurrentStepNumber: 2,
+                workflowNumTotalSteps: 2,
+                workflowStatus: WorkflowStatus.COMPLETED,
+              },
             },
           ],
         }
@@ -332,6 +424,8 @@ describe('Multirespondent Submission Model', () => {
           'encryptedContent',
           'submissionType',
           'version',
+          'submittedSteps',
+          'workflowStep',
         )
         // Native-ify arrays as mongoose documents contain a mongoose-specific array type.
         expectedSubmission.form_fields = JSON.parse(
@@ -417,6 +511,7 @@ describe('Multirespondent Submission Model', () => {
           'submissionType',
           'version',
           'workflowStep',
+          'submittedSteps',
         )
         expect(actual).not.toBeNull()
         expect(actual?.toJSON()).toEqual(expected)

--- a/src/app/models/__tests__/multirespondent-submission.server.model.spec.ts
+++ b/src/app/models/__tests__/multirespondent-submission.server.model.spec.ts
@@ -108,6 +108,7 @@ describe('Multirespondent Submission Model', () => {
             workflowCurrentStepNumber: 2,
             workflowNumTotalSteps: 2,
             workflowStatus: WorkflowStatus.REJECTED,
+            lastSubmittedAt: '2024-01-01T00:00:00.000Z',
           },
         }
         expect(result).toEqual(expected)
@@ -206,6 +207,7 @@ describe('Multirespondent Submission Model', () => {
                 workflowCurrentStepNumber: 1,
                 workflowNumTotalSteps: 1,
                 workflowStatus: WorkflowStatus.COMPLETED,
+                lastSubmittedAt: '2024-01-01T00:00:00.000Z',
               },
             }))
             .reverse(),
@@ -270,6 +272,7 @@ describe('Multirespondent Submission Model', () => {
                 workflowCurrentStepNumber: 2,
                 workflowNumTotalSteps: 2,
                 workflowStatus: WorkflowStatus.APPROVED,
+                lastSubmittedAt: '2024-01-01T00:00:00.000Z',
               },
             },
           ],
@@ -333,6 +336,7 @@ describe('Multirespondent Submission Model', () => {
                 workflowCurrentStepNumber: 2,
                 workflowNumTotalSteps: 2,
                 workflowStatus: WorkflowStatus.COMPLETED,
+                lastSubmittedAt: '2024-01-02T00:00:00.000Z',
               },
             },
           ],

--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -579,8 +579,13 @@ describe('Submission Model', () => {
         // Arrange
         const formId = new ObjectId()
         const submission = await EncryptedSubmission.create({
-          form: formId,
           submissionType: SubmissionType.Encrypt,
+          form: formId,
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
+          version: 1,
+          authType: FormAuthType.NIL,
+          myInfoFields: [],
+          webhookResponses: [],
         })
 
         // Act
@@ -639,8 +644,13 @@ describe('Submission Model', () => {
         // Arrange
         const formId = new ObjectId()
         await EncryptedSubmission.create({
-          form: formId,
           submissionType: SubmissionType.Encrypt,
+          form: formId,
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
+          version: 1,
+          authType: FormAuthType.NIL,
+          myInfoFields: [],
+          webhookResponses: [],
         })
 
         // Act

--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -9,6 +9,7 @@ import getSubmissionModel, {
   getEncryptSubmissionModel,
   getMultirespondentSubmissionModel,
 } from 'src/app/models/submission.server.model'
+import { buildMrfMetadata } from 'src/app/modules/submission/submission.utils'
 
 import {
   BasicField,
@@ -629,11 +630,13 @@ describe('Submission Model', () => {
 
         // Assert
         expect(result).toBeDefined()
-        expect(result?.mrf).toEqual({
-          workflowStep: submission.workflowStep,
-          workflow: submission.workflow,
-          submittedSteps: submission.submittedSteps,
-        })
+        expect(result?.mrf).toEqual(
+          buildMrfMetadata({
+            workflow: submission.workflow,
+            workflowStep: submission.workflowStep,
+            submittedSteps: submission.submittedSteps,
+          }),
+        )
         expect(result?.refNo).toBeDefined()
         expect(result?.number).toEqual(1)
       })
@@ -695,11 +698,13 @@ describe('Submission Model', () => {
 
         // Assert
         expect(result.count).toEqual(1)
-        expect(omit(result.metadata[0], ['_id', 'created'])).toEqual({
-          workflowStep: submission.workflowStep,
-          workflow: submission.workflow,
-          submittedSteps: submission.submittedSteps,
-        })
+        expect(result.metadata[0].mrf).toEqual(
+          buildMrfMetadata({
+            workflowStep: submission.workflowStep,
+            workflow: submission.workflow,
+            submittedSteps: submission.submittedSteps,
+          }),
+        )
         expect(result.metadata[0].refNo).toBeDefined()
         expect(result.metadata[0].number).toEqual(1)
       })

--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -91,6 +91,7 @@ describe('Submission Model', () => {
           field: new ObjectId(),
         },
       ],
+      submittedSteps: [],
       submissionPublicKey: 'This is a public key',
       encryptedSubmissionSecretKey: 'This is an encrypted secret key',
       encryptedContent: MOCK_ENCRYPTED_CONTENT,

--- a/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/src/app/models/__tests__/submission.server.model.spec.ts
@@ -7,6 +7,7 @@ import mongoose from 'mongoose'
 import getSubmissionModel, {
   getEmailSubmissionModel,
   getEncryptSubmissionModel,
+  getMultirespondentSubmissionModel,
 } from 'src/app/models/submission.server.model'
 
 import {
@@ -29,6 +30,7 @@ const MockDns = jest.mocked(dns)
 
 const Submission = getSubmissionModel(mongoose)
 const EncryptedSubmission = getEncryptSubmissionModel(mongoose)
+const MultirespondentSubmission = getMultirespondentSubmissionModel(mongoose)
 const EmailSubmission = getEmailSubmissionModel(mongoose)
 const PaymentSubmission = getPaymentModel(mongoose)
 
@@ -569,6 +571,127 @@ describe('Submission Model', () => {
 
         // Assert
         expect(actualResult).toEqual([])
+      })
+    })
+
+    describe('findSingleMetadata', () => {
+      it('should not return mrf metadata for storage mode form', async () => {
+        // Arrange
+        const formId = new ObjectId()
+        const submission = await EncryptedSubmission.create({
+          form: formId,
+          submissionType: SubmissionType.Encrypt,
+        })
+
+        // Act
+        const result = await EncryptedSubmission.findSingleMetadata(
+          String(formId),
+          String(submission._id),
+        )
+
+        // Assert
+        expect(result?.mrf).toBeUndefined()
+      })
+
+      it('should return mrf metadata for an mrf form', async () => {
+        // Arrange
+        const formId = new ObjectId()
+        const workflowId = new ObjectId()
+        const fieldId = new ObjectId()
+        const submission = await MultirespondentSubmission.create({
+          form: formId,
+          submissionType: SubmissionType.Multirespondent,
+          form_fields: [{ _id: fieldId, fieldType: BasicField.ShortText }],
+          form_logics: [],
+          workflow: [
+            { _id: workflowId, workflow_type: WorkflowType.Static, emails: [] },
+          ],
+          submissionPublicKey: 'test public key',
+          encryptedSubmissionSecretKey: 'test secret key',
+          encryptedContent: 'test encrypted content',
+          version: 1,
+          workflowStep: 0,
+          submittedSteps: [],
+        })
+
+        await submission.save()
+
+        // Act
+        const result = await MultirespondentSubmission.findSingleMetadata(
+          String(formId),
+          String(submission._id),
+        )
+
+        // Assert
+        expect(result).toBeDefined()
+        expect(result?.mrf).toEqual({
+          workflowStep: submission.workflowStep,
+          workflow: submission.workflow,
+          submittedSteps: submission.submittedSteps,
+        })
+        expect(result?.refNo).toBeDefined()
+        expect(result?.number).toEqual(1)
+      })
+    })
+
+    describe('findAllMetadataByFormId', () => {
+      it('should not return mrf metadata for storage mode form', async () => {
+        // Arrange
+        const formId = new ObjectId()
+        await EncryptedSubmission.create({
+          form: formId,
+          submissionType: SubmissionType.Encrypt,
+        })
+
+        // Act
+        const result = await EncryptedSubmission.findAllMetadataByFormId(
+          String(formId),
+        )
+
+        // Assert
+        expect(result.metadata[0].mrf).toBeUndefined()
+        expect(result.metadata[0].refNo).toBeDefined()
+        expect(result.metadata[0].number).toEqual(1)
+        expect(result.count).toEqual(1)
+      })
+
+      it('should return mrf metadata for an mrf form', async () => {
+        // Arrange
+        const formId = new ObjectId()
+        const workflowId = new ObjectId()
+        const fieldId = new ObjectId()
+        const submission = await MultirespondentSubmission.create({
+          form: formId,
+          submissionType: SubmissionType.Multirespondent,
+          form_fields: [{ _id: fieldId, fieldType: BasicField.ShortText }],
+          form_logics: [],
+          workflow: [
+            { _id: workflowId, workflow_type: WorkflowType.Static, emails: [] },
+          ],
+          submissionPublicKey: 'test public key',
+          encryptedSubmissionSecretKey: 'test secret key',
+          encryptedContent: 'test encrypted content',
+          version: 1,
+          workflowStep: 0,
+          submittedSteps: [],
+        })
+
+        await submission.save()
+
+        // Act
+        const result = await MultirespondentSubmission.findAllMetadataByFormId(
+          String(formId),
+        )
+
+        // Assert
+        expect(result.count).toEqual(1)
+        expect(omit(result.metadata[0], ['_id', 'created'])).toEqual({
+          workflowStep: submission.workflowStep,
+          workflow: submission.workflow,
+          submittedSteps: submission.submittedSteps,
+        })
+        expect(result.metadata[0].refNo).toBeDefined()
+        expect(result.metadata[0].number).toEqual(1)
       })
     })
   })

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -37,7 +37,7 @@ import {
   WebhookView,
 } from '../../types'
 import { getPaymentWebhookEventObject } from '../modules/payments/payment.service.utils'
-import { getMrfSubmissionWorkflowStatus } from '../modules/submission/submission.utils'
+import { buildMrfMetadata } from '../modules/submission/submission.utils'
 import { createQueryWithDateParam } from '../utils/date'
 
 import { FORM_SCHEMA_ID } from './form.server.model'
@@ -814,14 +814,11 @@ const buildSubmissionMetadata = (
         }
       : null,
     mrf: mrfMeta
-      ? {
-          workflowCurrentStepNumber: mrfMeta.workflowStep + 1 ?? 0, // need to add 1 as workflowStep is 0-indexed
-          workflowNumTotalSteps: mrfMeta.workflow?.length ?? 0,
-          workflowStatus: getMrfSubmissionWorkflowStatus(
-            mrfMeta.submittedSteps ?? [],
-            mrfMeta.workflow?.length ?? 0,
-          ),
-        }
+      ? buildMrfMetadata({
+          workflow: mrfMeta.workflow,
+          workflowStep: mrfMeta.workflowStep,
+          submittedSteps: mrfMeta.submittedSteps,
+        })
       : null,
   }
 }

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -367,7 +367,11 @@ EncryptSubmissionSchema.statics.findSingleMetadata = function (
     const paymentMeta = result.payments?.[0]
 
     // Build submissionMetadata object.
-    const metadata = buildSubmissionMetadata(result, 1, paymentMeta)
+    const metadata = buildSubmissionMetadata({
+      result,
+      currentNumber: 1,
+      paymentMeta,
+    })
 
     return metadata
   })
@@ -436,11 +440,11 @@ EncryptSubmissionSchema.statics.findAllMetadataByFormId = function (
 
     const metadata = results.map((result) => {
       const paymentMeta = result.payments?.[0]
-      const metadataEntry = buildSubmissionMetadata(
+      const metadataEntry = buildSubmissionMetadata({
         result,
         currentNumber,
         paymentMeta,
-      )
+      })
 
       currentNumber--
       return metadataEntry
@@ -592,7 +596,11 @@ MultirespondentSubmissionSchema.statics.findSingleMetadata = function (
       submittedSteps: result.submittedSteps,
     }
     // Build submissionMetadata object.
-    const metadata = buildSubmissionMetadata(result, 1, undefined, mrfMeta)
+    const metadata = buildSubmissionMetadata({
+      result,
+      currentNumber: 1,
+      mrfMeta,
+    })
 
     return metadata
   })
@@ -647,12 +655,12 @@ MultirespondentSubmissionSchema.statics.findAllMetadataByFormId = function (
         workflow: result.workflow,
         submittedSteps: result.submittedSteps,
       }
-      const metadataEntry = buildSubmissionMetadata(
+      const metadataEntry = buildSubmissionMetadata({
         result,
         currentNumber,
         paymentMeta,
         mrfMeta,
-      )
+      })
 
       currentNumber--
       return metadataEntry
@@ -787,12 +795,17 @@ export const getMultirespondentSubmissionModel = (
   >(SubmissionType.Multirespondent)
 }
 
-const buildSubmissionMetadata = (
-  result: MetadataAggregateResult,
-  currentNumber: number,
-  paymentMeta?: PaymentAggregates,
-  mrfMeta?: MultiRespondentAggregates,
-): SubmissionMetadata => {
+const buildSubmissionMetadata = ({
+  result,
+  currentNumber,
+  paymentMeta,
+  mrfMeta,
+}: {
+  result: MetadataAggregateResult
+  currentNumber: number
+  paymentMeta?: PaymentAggregates
+  mrfMeta?: MultiRespondentAggregates
+}): SubmissionMetadata => {
   return {
     number: currentNumber,
     refNo: result._id,

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -818,7 +818,7 @@ const buildSubmissionMetadata = (
           workflowStep: mrfMeta.workflowStep,
           submittedSteps: mrfMeta.submittedSteps,
         })
-      : null,
+      : undefined,
   }
 }
 

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -731,6 +731,7 @@ MultirespondentSubmissionSchema.statics.findEncryptedSubmissionById = function (
       version: 1,
       workflowStep: 1,
       mrfVersion: 1,
+      submittedSteps: 1,
     })
     .exec()
 }

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -12,6 +12,7 @@ import {
   SubmissionMetadata,
   SubmissionType,
   WebhookResponse,
+  WorkflowStatus,
 } from '../../../shared/types'
 import {
   FindFormsWithSubsAboveResult,
@@ -551,20 +552,29 @@ export const MultirespondentSubmissionSchema = new Schema<
   },
 })
 
+type MultiRespondentAggregates = Pick<
+  IMultirespondentSubmissionSchema,
+  'workflowStep' | 'workflow'
+>
+type MultiRespondentAggregateResult = MetadataAggregateResult &
+  MultiRespondentAggregates
+
 MultirespondentSubmissionSchema.statics.findSingleMetadata = function (
   formId: string,
   submissionId: string,
 ): Promise<SubmissionMetadata | null> {
-  const pageResults: Promise<MetadataAggregateResult[]> = this.aggregate([
-    {
-      $match: {
-        submissionType: SubmissionType.Multirespondent,
-        form: new mongoose.Types.ObjectId(formId),
-        _id: new mongoose.Types.ObjectId(submissionId),
+  const pageResults: Promise<MultiRespondentAggregateResult[]> = this.aggregate(
+    [
+      {
+        $match: {
+          submissionType: SubmissionType.Multirespondent,
+          form: new mongoose.Types.ObjectId(formId),
+          _id: new mongoose.Types.ObjectId(submissionId),
+        },
       },
-    },
-    { $limit: 1 },
-  ]).exec()
+      { $limit: 1 },
+    ],
+  ).exec()
 
   return Promise.resolve(pageResults).then((results) => {
     if (!results || results.length <= 0) {
@@ -572,9 +582,12 @@ MultirespondentSubmissionSchema.statics.findSingleMetadata = function (
     }
 
     const result = results[0]
-
+    const mrfMeta = {
+      workflowStep: result.workflowStep,
+      workflow: result.workflow,
+    }
     // Build submissionMetadata object.
-    const metadata = buildSubmissionMetadata(result, 1)
+    const metadata = buildSubmissionMetadata(result, 1, undefined, mrfMeta)
 
     return metadata
   })
@@ -595,18 +608,22 @@ MultirespondentSubmissionSchema.statics.findAllMetadataByFormId = function (
 }> {
   const numToSkip = (page - 1) * pageSize
   // return documents within the page
-  const pageResults: Promise<MetadataAggregateResult[]> = this.aggregate([
-    { $match: { form: new mongoose.Types.ObjectId(formId) } },
-    { $sort: { created: -1 } },
-    { $skip: numToSkip },
-    { $limit: pageSize },
-    {
-      $project: {
-        _id: 1,
-        created: 1,
+  const pageResults: Promise<MultiRespondentAggregateResult[]> = this.aggregate(
+    [
+      { $match: { form: new mongoose.Types.ObjectId(formId) } },
+      { $sort: { created: -1 } },
+      { $skip: numToSkip },
+      { $limit: pageSize },
+      {
+        $project: {
+          _id: 1,
+          created: 1,
+          workflowStep: 1,
+          workflow: 1,
+        },
       },
-    },
-  ]).exec()
+    ],
+  ).exec()
 
   const count =
     this.countDocuments({
@@ -619,10 +636,15 @@ MultirespondentSubmissionSchema.statics.findAllMetadataByFormId = function (
 
     const metadata = results.map((result) => {
       const paymentMeta = result.payments?.[0]
+      const mrfMeta = {
+        workflowStep: result.workflowStep,
+        workflow: result.workflow,
+      }
       const metadataEntry = buildSubmissionMetadata(
         result,
         currentNumber,
         paymentMeta,
+        mrfMeta,
       )
 
       currentNumber--
@@ -759,6 +781,7 @@ const buildSubmissionMetadata = (
   result: MetadataAggregateResult,
   currentNumber: number,
   paymentMeta?: PaymentAggregates,
+  mrfMeta?: MultiRespondentAggregates,
 ): SubmissionMetadata => {
   return {
     number: currentNumber,
@@ -777,6 +800,13 @@ const buildSubmissionMetadata = (
           paymentAmt: paymentMeta.amount,
           transactionFee: paymentMeta.completedPayment?.transactionFee ?? null,
           email: paymentMeta.email,
+        }
+      : null,
+    mrf: mrfMeta
+      ? {
+          workflowCurrentStepNumber: mrfMeta.workflowStep + 1 ?? 0,
+          workflowNumTotalSteps: mrfMeta.workflow?.length ?? 0,
+          workflowStatus: WorkflowStatus.PENDING,
         }
       : null,
   }

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -37,6 +37,7 @@ import {
   WebhookView,
 } from '../../types'
 import { getPaymentWebhookEventObject } from '../modules/payments/payment.service.utils'
+import { getMrfSubmissionWorkflowStatus } from '../modules/submission/submission.utils'
 import { createQueryWithDateParam } from '../utils/date'
 
 import { FORM_SCHEMA_ID } from './form.server.model'
@@ -687,6 +688,8 @@ MultirespondentSubmissionSchema.statics.getSubmissionCursorByFormId = function (
         form_fields: 1,
         form_logics: 1,
         workflow: 1,
+        workflowStep: 1,
+        submittedSteps: 1,
         encryptedSubmissionSecretKey: 1,
         encryptedContent: 1,
         attachmentMetadata: 1,
@@ -785,33 +788,6 @@ export const getMultirespondentSubmissionModel = (
   >(SubmissionType.Multirespondent)
 }
 
-const getWorkflowStatus = (
-  submittedSteps: SubmittedStep[],
-  numTotalSteps: number,
-): WorkflowStatus | undefined => {
-  if (submittedSteps.length <= 0 || numTotalSteps <= 0) {
-    // NOTE: this occurs when no steps are recorded for submissions prior to this change or when no workflow is defined.
-    return undefined
-  }
-  const latestSubmittedStep = submittedSteps[submittedSteps.length - 1]
-  if (
-    latestSubmittedStep.isApproval &&
-    latestSubmittedStep.status === WorkflowStatus.REJECTED
-  ) {
-    return WorkflowStatus.REJECTED
-  }
-  if (submittedSteps.length === numTotalSteps) {
-    if (
-      latestSubmittedStep.isApproval &&
-      latestSubmittedStep.status === WorkflowStatus.APPROVED
-    ) {
-      return WorkflowStatus.APPROVED
-    }
-    return WorkflowStatus.COMPLETED
-  }
-  return WorkflowStatus.PENDING
-}
-
 const buildSubmissionMetadata = (
   result: MetadataAggregateResult,
   currentNumber: number,
@@ -841,7 +817,7 @@ const buildSubmissionMetadata = (
       ? {
           workflowCurrentStepNumber: mrfMeta.workflowStep + 1 ?? 0, // need to add 1 as workflowStep is 0-indexed
           workflowNumTotalSteps: mrfMeta.workflow?.length ?? 0,
-          workflowStatus: getWorkflowStatus(
+          workflowStatus: getMrfSubmissionWorkflowStatus(
             mrfMeta.submittedSteps ?? [],
             mrfMeta.workflow?.length ?? 0,
           ),

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -11,9 +11,7 @@ import {
   MyInfoAttribute,
   SubmissionMetadata,
   SubmissionType,
-  SubmittedStep,
   WebhookResponse,
-  WorkflowStatus,
 } from '../../../shared/types'
 import {
   FindFormsWithSubsAboveResult,

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -11,6 +11,7 @@ import {
   MyInfoAttribute,
   SubmissionMetadata,
   SubmissionType,
+  SubmittedStep,
   WebhookResponse,
   WorkflowStatus,
 } from '../../../shared/types'
@@ -550,11 +551,15 @@ export const MultirespondentSubmissionSchema = new Schema<
   mrfVersion: {
     type: Number,
   },
+  submittedSteps: {
+    type: Array,
+    default: [],
+  },
 })
 
 type MultiRespondentAggregates = Pick<
   IMultirespondentSubmissionSchema,
-  'workflowStep' | 'workflow'
+  'workflowStep' | 'workflow' | 'submittedSteps'
 >
 type MultiRespondentAggregateResult = MetadataAggregateResult &
   MultiRespondentAggregates
@@ -585,6 +590,7 @@ MultirespondentSubmissionSchema.statics.findSingleMetadata = function (
     const mrfMeta = {
       workflowStep: result.workflowStep,
       workflow: result.workflow,
+      submittedSteps: result.submittedSteps,
     }
     // Build submissionMetadata object.
     const metadata = buildSubmissionMetadata(result, 1, undefined, mrfMeta)
@@ -620,6 +626,7 @@ MultirespondentSubmissionSchema.statics.findAllMetadataByFormId = function (
           created: 1,
           workflowStep: 1,
           workflow: 1,
+          submittedSteps: 1,
         },
       },
     ],
@@ -639,6 +646,7 @@ MultirespondentSubmissionSchema.statics.findAllMetadataByFormId = function (
       const mrfMeta = {
         workflowStep: result.workflowStep,
         workflow: result.workflow,
+        submittedSteps: result.submittedSteps,
       }
       const metadataEntry = buildSubmissionMetadata(
         result,
@@ -777,6 +785,33 @@ export const getMultirespondentSubmissionModel = (
   >(SubmissionType.Multirespondent)
 }
 
+const getWorkflowStatus = (
+  submittedSteps: SubmittedStep[],
+  numTotalSteps: number,
+): WorkflowStatus | undefined => {
+  if (submittedSteps.length <= 0 || numTotalSteps <= 0) {
+    // NOTE: this occurs when no steps are recorded for submissions prior to this change or when no workflow is defined.
+    return undefined
+  }
+  const latestSubmittedStep = submittedSteps[submittedSteps.length - 1]
+  if (
+    latestSubmittedStep.isApproval &&
+    latestSubmittedStep.status === WorkflowStatus.REJECTED
+  ) {
+    return WorkflowStatus.REJECTED
+  }
+  if (submittedSteps.length === numTotalSteps) {
+    if (
+      latestSubmittedStep.isApproval &&
+      latestSubmittedStep.status === WorkflowStatus.APPROVED
+    ) {
+      return WorkflowStatus.APPROVED
+    }
+    return WorkflowStatus.COMPLETED
+  }
+  return WorkflowStatus.PENDING
+}
+
 const buildSubmissionMetadata = (
   result: MetadataAggregateResult,
   currentNumber: number,
@@ -804,9 +839,12 @@ const buildSubmissionMetadata = (
       : null,
     mrf: mrfMeta
       ? {
-          workflowCurrentStepNumber: mrfMeta.workflowStep + 1 ?? 0,
+          workflowCurrentStepNumber: mrfMeta.workflowStep + 1 ?? 0, // need to add 1 as workflowStep is 0-indexed
           workflowNumTotalSteps: mrfMeta.workflow?.length ?? 0,
-          workflowStatus: WorkflowStatus.PENDING,
+          workflowStatus: getWorkflowStatus(
+            mrfMeta.submittedSteps ?? [],
+            mrfMeta.workflow?.length ?? 0,
+          ),
         }
       : null,
   }

--- a/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -41,9 +41,12 @@ import {
   AutoReplyOptions,
   BasicField,
   FormResponseMode,
+  FormWorkflowStepDto,
   SubmissionId,
   SubmissionMetadata,
   SubmissionType,
+  SubmittedNonApprovalStep,
+  WorkflowType,
 } from '../../../../../shared/types'
 import { PaymentNotFoundError } from '../../payments/payments.errors'
 import * as PaymentsService from '../../payments/payments.service'
@@ -66,7 +69,10 @@ import {
   transformAttachmentMetasToSignedUrls,
   triggerVirusScanning,
 } from '../submission.service'
-import { extractEmailConfirmationData } from '../submission.utils'
+import {
+  buildMrfMetadata,
+  extractEmailConfirmationData,
+} from '../submission.utils'
 
 jest.mock('src/app/services/mail/mail.service')
 const MockMailService = jest.mocked(MailService)
@@ -1634,6 +1640,88 @@ describe('submission.service', () => {
         1,
         MOCK_SUB_CURSOR_DATA_1.paymentId,
       )
+    })
+  })
+
+  describe('addMrfMetadata', () => {
+    it('should return original object without mrf metadata when submission is not multirespondent submission type', () => {
+      // Arrange
+      const mockInput = new PassThrough()
+      const actualTransformedData: any[] = []
+
+      // Act
+      // Build pipeline for testing
+      mockInput.pipe(SubmissionService.addMrfMetadata()).on('data', (data) => {
+        actualTransformedData.push(data)
+      })
+
+      // Emit events
+      const mockData = {
+        submissionType: SubmissionType.Encrypt,
+        formId: 'mockFormId',
+        submissionId: 'mockSubmissionId',
+      }
+      mockInput.emit('data', mockData)
+      mockInput.end()
+
+      // Assert
+      expect(actualTransformedData).toEqual([mockData])
+    })
+
+    it('should add mrf metadata when submission is multirespondent type', () => {
+      // Arrange
+      const WORKFLOW_STEP_1: FormWorkflowStepDto = {
+        _id: 'step_1_id',
+        workflow_type: WorkflowType.Static,
+        emails: ['example@example.com'],
+        edit: [],
+      }
+      const WORKFLOW_STEP_2: FormWorkflowStepDto = {
+        _id: 'step_2_id',
+        workflow_type: WorkflowType.Static,
+        emails: ['example@example.com'],
+        edit: [],
+      }
+
+      const mockInput = new PassThrough()
+      const actualTransformedData: any[] = []
+
+      // Act
+      // Build pipeline for testing
+      mockInput.pipe(SubmissionService.addMrfMetadata()).on('data', (data) => {
+        actualTransformedData.push(data)
+      })
+
+      // Emit events
+      const mockData = {
+        submissionType: SubmissionType.Multirespondent,
+        formId: 'mockFormId',
+        submissionId: 'mockSubmissionId',
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_STEP_2],
+        workflowStep: 0,
+        submittedSteps: [
+          {
+            isApproval: false,
+            submittedAt: '2024-01-01T00:00:00.000Z',
+          } as SubmittedNonApprovalStep,
+        ],
+      }
+      mockInput.emit('data', mockData)
+      mockInput.end()
+
+      // Assert
+      expect(actualTransformedData).toEqual([
+        {
+          submissionType: SubmissionType.Multirespondent,
+          formId: 'mockFormId',
+          submissionId: 'mockSubmissionId',
+          mrfMeta: buildMrfMetadata({
+            workflow: mockData.workflow,
+            workflowStep: mockData.workflowStep,
+            submittedSteps: mockData.submittedSteps,
+          }),
+        },
+      ])
     })
   })
 

--- a/src/app/modules/submission/__tests__/submission.utils.spec.ts
+++ b/src/app/modules/submission/__tests__/submission.utils.spec.ts
@@ -9,7 +9,10 @@ import {
   WorkflowStatus,
   WorkflowType,
 } from '../../../../../shared/types'
-import { SingleAnswerFieldResponse } from '../../../../types'
+import {
+  IMultirespondentSubmissionSchema,
+  SingleAnswerFieldResponse,
+} from '../../../../types'
 import {
   areAttachmentsMoreThanLimit,
   buildMrfMetadata,
@@ -103,14 +106,50 @@ describe('submission.utils', () => {
       approval_field: YES_NO_FIELD._id,
     }
 
+    it('should return undefined for lastSubmittedAt when submittedSteps is empty', () => {
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_STEP_2],
+        workflowStep: 0,
+        submittedSteps: [],
+      })
+      expect(metadata!.lastSubmittedAt).toBeUndefined()
+    })
+
+    it('should extract correct lastSubmittedAt timing based on submittedSteps', () => {
+      const submittedSteps: IMultirespondentSubmissionSchema['submittedSteps'] =
+        [
+          {
+            isApproval: false,
+            submittedAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            isApproval: true,
+            status: WorkflowStatus.APPROVED,
+            submittedAt: '2024-01-02T00:00:00.000Z',
+          },
+          {
+            isApproval: false,
+            submittedAt: '2024-01-03R00:00:00.000Z',
+          },
+        ]
+
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_APPROVAL_STEP, WORKFLOW_STEP_2],
+        workflowStep: 2,
+        submittedSteps,
+      })
+      expect(metadata!.lastSubmittedAt).toBe(submittedSteps[2].submittedAt)
+    })
+
     it('should build mrf metadata successfully for pending submission without approval step', () => {
+      const submittedAt = '2024-01-01T00:00:00.000Z'
       const metadata = buildMrfMetadata({
         workflow: [WORKFLOW_STEP_1, WORKFLOW_STEP_2],
         workflowStep: 0,
         submittedSteps: [
           {
             isApproval: false,
-            submittedAt: '2024-01-01T00:00:00.000Z',
+            submittedAt,
           },
         ],
       })
@@ -119,14 +158,13 @@ describe('submission.utils', () => {
         workflowCurrentStepNumber: 1,
         workflowNumTotalSteps: 2,
         workflowStatus: WorkflowStatus.PENDING,
+        lastSubmittedAt: submittedAt,
       })
     })
 
     it('should build mrf metadata successfully for completed submission without approval step', () => {
-      const metadata = buildMrfMetadata({
-        workflow: [WORKFLOW_STEP_1, WORKFLOW_STEP_2],
-        workflowStep: 1,
-        submittedSteps: [
+      const submittedSteps: IMultirespondentSubmissionSchema['submittedSteps'] =
+        [
           {
             isApproval: false,
             submittedAt: '2024-01-01T00:00:00.000Z',
@@ -135,13 +173,19 @@ describe('submission.utils', () => {
             isApproval: false,
             submittedAt: '2024-01-02T00:00:00.000Z',
           },
-        ],
+        ]
+
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_STEP_2],
+        workflowStep: 1,
+        submittedSteps,
       })
 
       expect(metadata).toEqual({
         workflowCurrentStepNumber: 2,
         workflowNumTotalSteps: 2,
         workflowStatus: WorkflowStatus.COMPLETED,
+        lastSubmittedAt: submittedSteps[submittedSteps.length - 1].submittedAt,
       })
     })
 
@@ -166,14 +210,13 @@ describe('submission.utils', () => {
         workflowCurrentStepNumber: 2,
         workflowNumTotalSteps: 3,
         workflowStatus: WorkflowStatus.PENDING,
+        lastSubmittedAt: '2024-01-02T00:00:00.000Z',
       })
     })
 
     it('should build mrf metadata successfully for approval submission with approval step', () => {
-      const metadata = buildMrfMetadata({
-        workflow: [WORKFLOW_STEP_1, WORKFLOW_APPROVAL_STEP, WORKFLOW_STEP_2],
-        workflowStep: 2,
-        submittedSteps: [
+      const submittedSteps: IMultirespondentSubmissionSchema['submittedSteps'] =
+        [
           {
             isApproval: false,
             submittedAt: '2024-01-01T00:00:00.000Z',
@@ -187,13 +230,19 @@ describe('submission.utils', () => {
             isApproval: false,
             submittedAt: '2024-01-03T00:00:00.000Z',
           },
-        ],
+        ]
+
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_APPROVAL_STEP, WORKFLOW_STEP_2],
+        workflowStep: 2,
+        submittedSteps,
       })
 
       expect(metadata).toEqual({
         workflowCurrentStepNumber: 3,
         workflowNumTotalSteps: 3,
         workflowStatus: WorkflowStatus.APPROVED,
+        lastSubmittedAt: submittedSteps[submittedSteps.length - 1].submittedAt,
       })
     })
 
@@ -218,6 +267,7 @@ describe('submission.utils', () => {
         workflowCurrentStepNumber: 2,
         workflowNumTotalSteps: 3,
         workflowStatus: WorkflowStatus.REJECTED,
+        lastSubmittedAt: '2024-01-02T00:00:00.000Z',
       })
     })
   })

--- a/src/app/modules/submission/__tests__/submission.utils.spec.ts
+++ b/src/app/modules/submission/__tests__/submission.utils.spec.ts
@@ -2,10 +2,17 @@ import { ObjectId } from 'bson'
 import { readFileSync } from 'fs'
 import { cloneDeep, merge } from 'lodash'
 
-import { BasicField, FormResponseMode } from '../../../../../shared/types'
+import {
+  BasicField,
+  FormResponseMode,
+  FormWorkflowStepDto,
+  WorkflowStatus,
+  WorkflowType,
+} from '../../../../../shared/types'
 import { SingleAnswerFieldResponse } from '../../../../types'
 import {
   areAttachmentsMoreThanLimit,
+  buildMrfMetadata,
   getInvalidFileExtensions,
   getResponseModeFilter,
   mapAttachmentsFromResponses,
@@ -66,6 +73,155 @@ const getResponse = (_id: string, answer: string): SingleAnswerFieldResponse =>
   }) as unknown as SingleAnswerFieldResponse
 
 describe('submission.utils', () => {
+  describe('buildMrfMetadata', () => {
+    const YES_NO_FIELD = {
+      _id: 'yes_no_field_id',
+      title: 'Yes or No',
+      description: '',
+      required: true,
+      disabled: false,
+      fieldType: BasicField.YesNo,
+    }
+    const WORKFLOW_STEP_1: FormWorkflowStepDto = {
+      _id: 'step_1_id',
+      workflow_type: WorkflowType.Static,
+      emails: ['example@example.com'],
+      edit: [],
+    }
+
+    const WORKFLOW_STEP_2: FormWorkflowStepDto = {
+      _id: 'step_2_id',
+      workflow_type: WorkflowType.Static,
+      emails: ['example@example.com'],
+      edit: [YES_NO_FIELD._id],
+    }
+    const WORKFLOW_APPROVAL_STEP: FormWorkflowStepDto = {
+      _id: 'approval_step_id',
+      workflow_type: WorkflowType.Static,
+      emails: ['example@example.com'],
+      edit: [YES_NO_FIELD._id],
+      approval_field: YES_NO_FIELD._id,
+    }
+
+    it('should build mrf metadata successfully for pending submission without approval step', () => {
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_STEP_2],
+        workflowStep: 0,
+        submittedSteps: [
+          {
+            isApproval: false,
+            submittedAt: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      })
+
+      expect(metadata).toEqual({
+        workflowCurrentStepNumber: 1,
+        workflowNumTotalSteps: 2,
+        workflowStatus: WorkflowStatus.PENDING,
+      })
+    })
+
+    it('should build mrf metadata successfully for completed submission without approval step', () => {
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_STEP_2],
+        workflowStep: 1,
+        submittedSteps: [
+          {
+            isApproval: false,
+            submittedAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            isApproval: false,
+            submittedAt: '2024-01-02T00:00:00.000Z',
+          },
+        ],
+      })
+
+      expect(metadata).toEqual({
+        workflowCurrentStepNumber: 2,
+        workflowNumTotalSteps: 2,
+        workflowStatus: WorkflowStatus.COMPLETED,
+      })
+    })
+
+    it('should build mrf metadata successfully for pending submission with approval step', () => {
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_APPROVAL_STEP, WORKFLOW_STEP_2],
+        workflowStep: 1,
+        submittedSteps: [
+          {
+            isApproval: false,
+            submittedAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            isApproval: true,
+            status: WorkflowStatus.APPROVED,
+            submittedAt: '2024-01-02T00:00:00.000Z',
+          },
+        ],
+      })
+
+      expect(metadata).toEqual({
+        workflowCurrentStepNumber: 2,
+        workflowNumTotalSteps: 3,
+        workflowStatus: WorkflowStatus.PENDING,
+      })
+    })
+
+    it('should build mrf metadata successfully for approval submission with approval step', () => {
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_APPROVAL_STEP, WORKFLOW_STEP_2],
+        workflowStep: 2,
+        submittedSteps: [
+          {
+            isApproval: false,
+            submittedAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            isApproval: true,
+            status: WorkflowStatus.APPROVED,
+            submittedAt: '2024-01-02T00:00:00.000Z',
+          },
+          {
+            isApproval: false,
+            submittedAt: '2024-01-03T00:00:00.000Z',
+          },
+        ],
+      })
+
+      expect(metadata).toEqual({
+        workflowCurrentStepNumber: 3,
+        workflowNumTotalSteps: 3,
+        workflowStatus: WorkflowStatus.APPROVED,
+      })
+    })
+
+    it('should build mrf metadata successfully for rejected submission with approval step', () => {
+      const metadata = buildMrfMetadata({
+        workflow: [WORKFLOW_STEP_1, WORKFLOW_APPROVAL_STEP, WORKFLOW_STEP_2],
+        workflowStep: 1,
+        submittedSteps: [
+          {
+            isApproval: false,
+            submittedAt: '2024-01-01T00:00:00.000Z',
+          },
+          {
+            isApproval: true,
+            status: WorkflowStatus.REJECTED,
+            submittedAt: '2024-01-02T00:00:00.000Z',
+          },
+        ],
+      })
+
+      expect(metadata).toEqual({
+        workflowCurrentStepNumber: 2,
+        workflowNumTotalSteps: 3,
+        workflowStatus: WorkflowStatus.REJECTED,
+      })
+    })
+  })
+
   describe('getResponseModeFilter', () => {
     const ALL_FIELD_TYPES = Object.values(BasicField).map((fieldType) => ({
       fieldType,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -331,6 +331,7 @@ describe('multiresponodent-submision.controller', () => {
       expect(
         MockMultiRespondentSubmissionService.updateMultiRespondentFormSubmission,
       ).toHaveBeenCalledOnce()
+
       expect(
         omit(
           MockMultiRespondentSubmissionService
@@ -338,7 +339,6 @@ describe('multiresponodent-submision.controller', () => {
           'logMeta',
         ),
       ).toEqual({
-        formId: mockFormId,
         submissionId: mockSubmissionId,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
         form: mockSubmitMrfReq.formsg.formDef,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -10,6 +10,7 @@ import {
   ChildBirthRecordsResponseV3,
   EmailResponseV3,
   FieldResponsesV3,
+  FormFieldDto,
   FormWorkflowStepDto,
   LongTextResponseV3,
   NumberResponseV3,
@@ -42,7 +43,7 @@ import {
 } from '../multirespondent-submission.utils'
 
 describe('multirespondent-submission.utils', () => {
-  const WORKFLOW_STEP_1 = {
+  const WORKFLOW_STEP_1: FormWorkflowStepDto = {
     _id: 'step_1_id',
     workflow_type: WorkflowType.Static,
     emails: ['example@example.com'],
@@ -140,7 +141,7 @@ describe('multirespondent-submission.utils', () => {
       const result = validateMrfFieldResponses({
         formId: mockFormId,
         visibleFieldIds: mockVisibleFieldIds,
-        formFields: mockFormFields,
+        formFields: mockFormFields as FormFieldDto[],
         responses: mockResponses,
       })
 
@@ -174,7 +175,7 @@ describe('multirespondent-submission.utils', () => {
       validateMrfFieldResponses({
         formId: mockFormId,
         visibleFieldIds: mockVisibleFieldIds,
-        formFields: mockFormFields,
+        formFields: mockFormFields as FormFieldDto[],
         responses: mockResponses,
       })
 
@@ -217,7 +218,7 @@ describe('multirespondent-submission.utils', () => {
       validateMrfFieldResponses({
         formId: mockFormId,
         visibleFieldIds: mockVisibleFieldIds,
-        formFields: mockFormFields,
+        formFields: mockFormFields as FormFieldDto[],
         responses: mockResponses,
       })
 

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -53,6 +53,12 @@ describe('multirespondent-submission.utils', () => {
   describe('createMultirespondentSubmissionDto', () => {
     it('should create an encrypted submission DTO sucessfully', () => {
       // Arrange
+      const submittedSteps = [
+        {
+          isApproval: false,
+          submittedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ]
       const createdDate = new Date()
       const submissionData = {
         submissionType: SubmissionType.Multirespondent,
@@ -68,12 +74,7 @@ describe('multirespondent-submission.utils', () => {
         attachmentMetadata: {},
         version: 3,
         mrfVersion: 3,
-        submittedSteps: [
-          {
-            isApproval: false,
-            submittedAt: '2024-01-01T00:00:00.000Z',
-          },
-        ],
+        submittedSteps,
       } as unknown as MultirespondentSubmissionData
       const attachmentPresignedUrls = {
         someSubmissionId: 'some presigned url',
@@ -107,6 +108,8 @@ describe('multirespondent-submission.utils', () => {
           workflowCurrentStepNumber: 1,
           workflowNumTotalSteps: 1,
           workflowStatus: WorkflowStatus.COMPLETED,
+          lastSubmittedAt:
+            submittedSteps[submittedSteps.length - 1].submittedAt,
         },
       })
     })

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -16,6 +16,7 @@ import {
   ShortTextResponseV3,
   SubmissionType,
   TableResponseV3,
+  WorkflowStatus,
   WorkflowType,
 } from 'shared/types'
 
@@ -41,18 +42,38 @@ import {
 } from '../multirespondent-submission.utils'
 
 describe('multirespondent-submission.utils', () => {
+  const WORKFLOW_STEP_1 = {
+    _id: 'step_1_id',
+    workflow_type: WorkflowType.Static,
+    emails: ['example@example.com'],
+    edit: [],
+  }
+
   describe('createMultirespondentSubmissionDto', () => {
     it('should create an encrypted submission DTO sucessfully', () => {
       // Arrange
       const createdDate = new Date()
       const submissionData = {
+        submissionType: SubmissionType.Multirespondent,
         _id: new ObjectId(),
         created: createdDate,
         submissionPublicKey: 'some public key',
         encryptedSubmissionSecretKey: 'some encrypted secret key',
         encryptedContent: 'some encrypted content',
-        submissionType: SubmissionType.Multirespondent,
-      } as MultirespondentSubmissionData
+        workflow: [WORKFLOW_STEP_1],
+        workflowStep: 0,
+        form_fields: [],
+        form_logics: [],
+        attachmentMetadata: {},
+        version: 3,
+        mrfVersion: 3,
+        submittedSteps: [
+          {
+            isApproval: false,
+            submittedAt: '2024-01-01T00:00:00.000Z',
+          },
+        ],
+      } as unknown as MultirespondentSubmissionData
       const attachmentPresignedUrls = {
         someSubmissionId: 'some presigned url',
       }
@@ -75,6 +96,17 @@ describe('multirespondent-submission.utils', () => {
           submissionData.encryptedSubmissionSecretKey,
         attachmentMetadata: attachmentPresignedUrls,
         submissionType: SubmissionType.Multirespondent,
+        workflow: submissionData.workflow,
+        form_fields: submissionData.form_fields,
+        form_logics: submissionData.form_logics,
+        version: submissionData.version,
+        workflowStep: submissionData.workflowStep,
+        mrfVersion: submissionData.mrfVersion,
+        mrfMeta: {
+          workflowCurrentStepNumber: 1,
+          workflowNumTotalSteps: 1,
+          workflowStatus: WorkflowStatus.COMPLETED,
+        },
       })
     })
   })

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -183,7 +183,6 @@ const updateMultirespondentSubmission = async (
 
   const updateMultiRespondentFormSubmissionResult =
     await updateMultiRespondentFormSubmission({
-      formId,
       submissionId,
       form,
       encryptedPayload,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -7,6 +7,9 @@ import {
   FieldResponsesV3,
   FormResponseMode,
   FormWorkflowStepDto,
+  SubmittedApprovalStep,
+  SubmittedNonApprovalStep,
+  WorkflowStatus,
 } from '../../../../../shared/types'
 import { getMultirespondentSubmissionEditPath } from '../../../../../shared/utils/urls'
 import {
@@ -350,6 +353,12 @@ export const createMultiRespondentFormSubmission = ({
         mrfVersion,
       } = encryptedPayload
 
+      // For non-approval steps, we only need isApproval: false and submittedAt
+      const submittedStepMeta: SubmittedNonApprovalStep = {
+        isApproval: false, // first step cannot be approval step
+        submittedAt: new Date().toISOString(),
+      }
+
       const submissionContent: MultirespondentSubmissionContent = {
         form: form._id,
         authType: form.authType,
@@ -364,6 +373,7 @@ export const createMultiRespondentFormSubmission = ({
         version,
         workflowStep: 0,
         mrfVersion,
+        submittedSteps: [submittedStepMeta],
       }
 
       const submission = new MultirespondentSubmission(submissionContent)
@@ -469,7 +479,6 @@ export const updateMultiRespondentFormSubmission = ({
   encryptedPayload,
   logMeta,
 }: {
-  formId: string
   submissionId: string
   form: IPopulatedMultirespondentForm
   encryptedPayload: MultirespondentSubmissionDto
@@ -512,6 +521,31 @@ export const updateMultiRespondentFormSubmission = ({
         mrfVersion,
       } = encryptedPayload
 
+      const isApprovalForm = checkIsFormApproval(form)
+      const isStepRejected = checkIsStepRejected({
+        zeroIndexedStepNumber: workflowStep,
+        form,
+        responses: encryptedPayload.responses,
+      })
+      const submittedStepMeta = isApprovalForm
+        ? ({
+            status: isStepRejected
+              ? WorkflowStatus.REJECTED
+              : WorkflowStatus.APPROVED,
+            stepNumber: workflowStep,
+            isApproval: true,
+            submittedAt: new Date().toISOString(),
+          } as SubmittedApprovalStep)
+        : ({
+            isApproval: false,
+            stepNumber: workflowStep,
+            submittedAt: new Date().toISOString(),
+          } as SubmittedNonApprovalStep)
+
+      submission.submittedSteps = [
+        ...(submission.submittedSteps ?? []),
+        submittedStepMeta,
+      ]
       submission.responseMetadata = responseMetadata
       submission.submissionPublicKey = submissionPublicKey
       submission.encryptedSubmissionSecretKey = encryptedSubmissionSecretKey

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -522,11 +522,21 @@ export const updateMultiRespondentFormSubmission = ({
       } = encryptedPayload
 
       const isApprovalForm = checkIsFormApproval(form)
-      const isStepRejected = checkIsStepRejected({
+      const isStepRejectedResult = checkIsStepRejected({
         zeroIndexedStepNumber: workflowStep,
         form,
         responses: encryptedPayload.responses,
       })
+      if (isStepRejectedResult.isErr()) {
+        logger.error({
+          message: 'Error occurred when checking if step is rejected',
+          meta: logMeta,
+          error: isStepRejectedResult.error,
+        })
+        return errAsync(isStepRejectedResult.error)
+      }
+
+      const isStepRejected = isStepRejectedResult.value
       const submittedStepMeta = isApprovalForm
         ? ({
             status: isStepRejected

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -353,7 +353,6 @@ export const createMultiRespondentFormSubmission = ({
         mrfVersion,
       } = encryptedPayload
 
-      // For non-approval steps, we only need isApproval: false and submittedAt
       const submittedStepMeta: SubmittedNonApprovalStep = {
         isApproval: false, // first step cannot be approval step
         submittedAt: new Date().toISOString(),

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.types.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.types.ts
@@ -5,6 +5,7 @@ import {
   MyInfoAttribute,
   SubmissionErrorDto,
   SubmissionResponseDto,
+  SubmittedStep,
 } from '../../../../../shared/types'
 import {
   MultirespondentFormCompleteDto,
@@ -88,6 +89,7 @@ export type MultirespondentSubmissionContent = {
   version: number
   workflowStep: number
   mrfVersion: number
+  submittedSteps: SubmittedStep[]
 }
 
 export type StrippedAttachmentResponseV3 = AttachmentResponseV3 & {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -25,6 +25,7 @@ import {
   ProcessingError,
   ValidateFieldErrorV3,
 } from '../submission.errors'
+import { buildMrfMetadata } from '../submission.utils'
 
 /**
  * Creates and returns a MultirespondentSubmissionDto object from submissionData and
@@ -52,6 +53,11 @@ export const createMultirespondentSubmissionDto = (
     version: submissionData.version,
     workflowStep: submissionData.workflowStep,
     mrfVersion: submissionData.mrfVersion,
+    mrfMeta: buildMrfMetadata({
+      workflow: submissionData.workflow,
+      workflowStep: submissionData.workflowStep,
+      submittedSteps: submissionData.submittedSteps,
+    }),
   }
 }
 

--- a/src/app/modules/submission/submission.controller.ts
+++ b/src/app/modules/submission/submission.controller.ts
@@ -29,8 +29,8 @@ import { createStorageModeSubmissionDto } from './encrypt-submission/encrypt-sub
 import { createMultirespondentSubmissionDto } from './multirespondent-submission/multirespondent-submission.utils'
 import { InvalidSubmissionTypeError } from './submission.errors'
 import {
+  addMrfMetadata,
   addPaymentDataStream,
-  buildMrfMetadata,
   getEncryptedSubmissionData,
   getQuarantinePresignedPostData,
   getSubmissionCursor,
@@ -371,7 +371,7 @@ export const streamEncryptedResponses: ControllerHandler<
         urlValidDuration: (req.session?.cookie.maxAge ?? 0) / 1000,
       }),
     )
-    .pipe(buildMrfMetadata())
+    .pipe(addMrfMetadata())
     // TODO: Can we include this within the cursor query as aggregation pipeline
     // instead, so that we make one query to mongo rather than two.
     .pipe(addPaymentDataStream())

--- a/src/app/modules/submission/submission.controller.ts
+++ b/src/app/modules/submission/submission.controller.ts
@@ -94,7 +94,7 @@ export const getMetadata: ControllerHandler<
           level: PermissionLevel.Read,
         }),
       )
-      // Step 3: Check whether form is encrypt mode.
+      // Step 3: Check whether form is encrypt or multirespondent mode.
       .andThen(checkFormIsEncryptModeOrMultirespondent)
       // Step 4: Retrieve submission metadata.
       .andThen((form) => {

--- a/src/app/modules/submission/submission.controller.ts
+++ b/src/app/modules/submission/submission.controller.ts
@@ -30,6 +30,7 @@ import { createMultirespondentSubmissionDto } from './multirespondent-submission
 import { InvalidSubmissionTypeError } from './submission.errors'
 import {
   addPaymentDataStream,
+  buildMrfMetadata,
   getEncryptedSubmissionData,
   getQuarantinePresignedPostData,
   getSubmissionCursor,
@@ -328,7 +329,7 @@ export const streamEncryptedResponses: ControllerHandler<
         level: PermissionLevel.Read,
       }),
     )
-    // Step 3: Check whether form is encrypt mode.
+    // Step 3: Check whether form is encrypt or multirespondent mode.
     .andThen(checkFormIsEncryptModeOrMultirespondent)
     // Step 4: Retrieve submissions cursor.
     .andThen((form) =>
@@ -370,6 +371,7 @@ export const streamEncryptedResponses: ControllerHandler<
         urlValidDuration: (req.session?.cookie.maxAge ?? 0) / 1000,
       }),
     )
+    .pipe(buildMrfMetadata())
     // TODO: Can we include this within the cursor query as aggregation pipeline
     // instead, so that we make one query to mongo rather than two.
     .pipe(addPaymentDataStream())

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -17,7 +17,6 @@ import {
   FormResponseMode,
   SubmissionMetadata,
   SubmissionMetadataList,
-  SubmissionMrfMetadata,
   SubmissionPaymentDto,
   SubmissionType,
 } from '../../../../shared/types'
@@ -89,10 +88,10 @@ import {
 } from './submission.types'
 import {
   areAttachmentsMoreThanLimit,
+  buildMrfMetadata,
   fileSizeLimitBytes,
   getEncryptedSubmissionModelByResponseMode,
   getInvalidFileExtensions,
-  getMrfSubmissionWorkflowStatus,
   mapAttachmentsFromResponses,
 } from './submission.utils'
 
@@ -807,7 +806,7 @@ export const getSubmissionCursor = (
 /**
  * Adds mrf metadata to each submission.
  */
-export const buildMrfMetadata = (): Transform => {
+export const addMrfMetadata = (): Transform => {
   return new Transform({
     objectMode: true,
     transform: async (
@@ -821,14 +820,11 @@ export const buildMrfMetadata = (): Transform => {
         const { workflow, workflowStep, submittedSteps, ...rest } = data
         const dataWithMrfMeta = {
           ...rest,
-          mrfMeta: {
-            workflowCurrentStepNumber: workflowStep,
-            workflowNumTotalSteps: workflow.length,
-            workflowStatus: getMrfSubmissionWorkflowStatus(
-              submittedSteps ?? [],
-              workflow.length,
-            ),
-          } as SubmissionMrfMetadata,
+          mrfMeta: buildMrfMetadata({
+            workflow,
+            workflowStep,
+            submittedSteps,
+          }),
         }
         return callback(null, dataWithMrfMeta)
       }

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -17,7 +17,9 @@ import {
   FormResponseMode,
   SubmissionMetadata,
   SubmissionMetadataList,
+  SubmissionMrfMetadata,
   SubmissionPaymentDto,
+  SubmissionType,
 } from '../../../../shared/types'
 import {
   EmailRespondentConfirmationField,
@@ -26,6 +28,7 @@ import {
   IMultirespondentSubmissionModel,
   IPopulatedForm,
   ISubmissionSchema,
+  MultirespondentSubmissionCursorData,
   StorageModeSubmissionCursorData,
   SubmissionData,
 } from '../../../types'
@@ -89,6 +92,7 @@ import {
   fileSizeLimitBytes,
   getEncryptedSubmissionModelByResponseMode,
   getInvalidFileExtensions,
+  getMrfSubmissionWorkflowStatus,
   mapAttachmentsFromResponses,
 } from './submission.utils'
 
@@ -798,6 +802,35 @@ export const getSubmissionCursor = (
     (modelToUse) =>
       ok(modelToUse.getSubmissionCursorByFormId(formId, dateRange)),
   )
+}
+
+export const buildMrfMetadata = (): Transform => {
+  return new Transform({
+    objectMode: true,
+    transform: async (
+      data:
+        | StorageModeSubmissionCursorData
+        | MultirespondentSubmissionCursorData,
+      _encoding,
+      callback,
+    ) => {
+      if (data.submissionType === SubmissionType.Multirespondent) {
+        const { workflow, workflowStep, submittedSteps, ...rest } = data
+        return callback(null, {
+          ...rest,
+          mrfMeta: {
+            workflowCurrentStepNumber: workflowStep,
+            workflowNumTotalSteps: workflow.length,
+            workflowStatus: getMrfSubmissionWorkflowStatus(
+              submittedSteps ?? [],
+              workflow.length,
+            ),
+          } as SubmissionMrfMetadata,
+        })
+      }
+      return callback(null, data)
+    },
+  })
 }
 
 /**

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -804,6 +804,9 @@ export const getSubmissionCursor = (
   )
 }
 
+/**
+ * Adds mrf metadata to each submission.
+ */
 export const buildMrfMetadata = (): Transform => {
   return new Transform({
     objectMode: true,
@@ -816,7 +819,7 @@ export const buildMrfMetadata = (): Transform => {
     ) => {
       if (data.submissionType === SubmissionType.Multirespondent) {
         const { workflow, workflowStep, submittedSteps, ...rest } = data
-        return callback(null, {
+        const dataWithMrfMeta = {
           ...rest,
           mrfMeta: {
             workflowCurrentStepNumber: workflowStep,
@@ -826,7 +829,8 @@ export const buildMrfMetadata = (): Transform => {
               workflow.length,
             ),
           } as SubmissionMrfMetadata,
-        })
+        }
+        return callback(null, dataWithMrfMeta)
       }
       return callback(null, data)
     },

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -11,6 +11,7 @@ import {
   sumBy,
   uniqBy,
 } from 'lodash'
+import moment from 'moment'
 import mongoose from 'mongoose'
 import { err, ok, Result } from 'neverthrow'
 
@@ -872,9 +873,15 @@ export const buildMrfMetadata = ({
     submittedSteps ?? [],
     workflow.length,
   )
+
+  const lastSubmittedAt =
+    submittedSteps && submittedSteps.length > 0
+      ? submittedSteps[submittedSteps.length - 1].submittedAt.toString()
+      : undefined
   return {
     workflowCurrentStepNumber,
     workflowNumTotalSteps,
     workflowStatus,
+    lastSubmittedAt,
   }
 }

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -11,7 +11,6 @@ import {
   sumBy,
   uniqBy,
 } from 'lodash'
-import moment from 'moment'
 import mongoose from 'mongoose'
 import { err, ok, Result } from 'neverthrow'
 

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -25,6 +25,8 @@ import {
   MyInfoAttribute,
   SubmissionAttachment,
   SubmissionAttachmentsMap,
+  SubmittedStep,
+  WorkflowStatus,
 } from '../../../../shared/types'
 import * as FileValidation from '../../../../shared/utils/file-validation'
 import {
@@ -145,10 +147,6 @@ import {
 } from './submission.types'
 
 const logger = createLoggerWithLabel(module)
-
-const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
-const MultirespondentSubmissionModel =
-  getMultirespondentSubmissionModel(mongoose)
 
 type ResponseModeFilterParam = {
   fieldType: BasicField
@@ -401,6 +399,10 @@ export const getEncryptedSubmissionModelByResponseMode = (
   IEncryptSubmissionModel | IMultirespondentSubmissionModel,
   ResponseModeError
 > => {
+  const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
+  const MultirespondentSubmissionModel =
+    getMultirespondentSubmissionModel(mongoose)
+
   switch (responseMode) {
     case FormResponseMode.Encrypt:
       return ok(EncryptSubmissionModel)
@@ -810,4 +812,38 @@ export const getCookieNameByAuthType = (
     default:
       return JwtName[authType]
   }
+}
+
+/**
+ * Determines the workflow status of a submission based on the submitted steps and the total number of steps.
+ * @param submittedSteps - The submitted steps of the submission.
+ * @param numTotalSteps - The total number of steps in the workflow.
+ * @returns The workflow status of the submission based on the enum `WorkflowStatus`.
+ * Otherwise, returns `undefined` if no submitted steps or total steps are found or when no workflow has been defined by the form admin.
+ */
+export const getMrfSubmissionWorkflowStatus = (
+  submittedSteps: SubmittedStep[],
+  numTotalSteps: number,
+): WorkflowStatus | undefined => {
+  if (submittedSteps.length <= 0 || numTotalSteps <= 0) {
+    // NOTE: this occurs when no steps are recorded for submissions prior to this change or when no workflow is defined.
+    return undefined
+  }
+  const latestSubmittedStep = submittedSteps[submittedSteps.length - 1]
+  if (
+    latestSubmittedStep.isApproval &&
+    latestSubmittedStep.status === WorkflowStatus.REJECTED
+  ) {
+    return WorkflowStatus.REJECTED
+  }
+  if (submittedSteps.length === numTotalSteps) {
+    if (
+      latestSubmittedStep.isApproval &&
+      latestSubmittedStep.status === WorkflowStatus.APPROVED
+    ) {
+      return WorkflowStatus.APPROVED
+    }
+    return WorkflowStatus.COMPLETED
+  }
+  return WorkflowStatus.PENDING
 }

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -25,6 +25,7 @@ import {
   MyInfoAttribute,
   SubmissionAttachment,
   SubmissionAttachmentsMap,
+  SubmissionMrfMetadata,
   SubmittedStep,
   WorkflowStatus,
 } from '../../../../shared/types'
@@ -36,6 +37,7 @@ import {
   IEncryptSubmissionModel,
   IFormDocument,
   IMultirespondentSubmissionModel,
+  IMultirespondentSubmissionSchema,
   IPopulatedEncryptedForm,
   IPopulatedForm,
   IPopulatedMultirespondentForm,
@@ -821,7 +823,7 @@ export const getCookieNameByAuthType = (
  * @returns The workflow status of the submission based on the enum `WorkflowStatus`.
  * Otherwise, returns `undefined` if no submitted steps or total steps are found or when no workflow has been defined by the form admin.
  */
-export const getMrfSubmissionWorkflowStatus = (
+const getMrfSubmissionWorkflowStatus = (
   submittedSteps: SubmittedStep[],
   numTotalSteps: number,
 ): WorkflowStatus | undefined => {
@@ -846,4 +848,28 @@ export const getMrfSubmissionWorkflowStatus = (
     return WorkflowStatus.COMPLETED
   }
   return WorkflowStatus.PENDING
+}
+
+/**
+ * Builds the metadata for a multirespondent form submission.
+ */
+export const buildMrfMetadata = ({
+  workflow,
+  workflowStep,
+  submittedSteps,
+}: Pick<
+  IMultirespondentSubmissionSchema,
+  'workflow' | 'workflowStep' | 'submittedSteps'
+>): SubmissionMrfMetadata => {
+  const workflowCurrentStepNumber = workflowStep + 1 // since workflowStep is zero indexed.
+  const workflowNumTotalSteps = workflow.length
+  const workflowStatus = getMrfSubmissionWorkflowStatus(
+    submittedSteps ?? [],
+    workflow.length,
+  )
+  return {
+    workflowCurrentStepNumber,
+    workflowNumTotalSteps,
+    workflowStatus,
+  }
 }

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -26,6 +26,7 @@ import {
   SubmissionAttachment,
   SubmissionAttachmentsMap,
   SubmissionMrfMetadata,
+  SubmittedApprovalStep,
   SubmittedStep,
   WorkflowStatus,
 } from '../../../../shared/types'
@@ -839,9 +840,13 @@ const getMrfSubmissionWorkflowStatus = (
     return WorkflowStatus.REJECTED
   }
   if (submittedSteps.length === numTotalSteps) {
+    const latestApprovalStep = submittedSteps
+      .slice()
+      .reverse()
+      .find((step) => step.isApproval) as SubmittedApprovalStep | undefined
     if (
-      latestSubmittedStep.isApproval &&
-      latestSubmittedStep.status === WorkflowStatus.APPROVED
+      latestApprovalStep &&
+      latestApprovalStep.status === WorkflowStatus.APPROVED
     ) {
       return WorkflowStatus.APPROVED
     }

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -186,6 +186,7 @@ export type MultirespondentSubmissionData = {
   | 'version'
   | 'workflowStep'
   | 'mrfVersion'
+  | 'submittedSteps'
 > &
   Document
 

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -149,6 +149,9 @@ export type MultirespondentSubmissionCursorData = Pick<
   | 'id'
   | 'version'
   | 'mrfVersion'
+  | 'workflowStep'
+  | 'submittedSteps'
+  | 'workflow'
 > & { attachmentMetadata?: Record<string, string> } & Document
 
 export type SubmissionCursorData =


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, admins want a way to track the status of their multi-respondent submissions/workflows to see: 
- is the workflow completed / pending? 
- what is the current step of the workflow? 

Closes FRM-1919

## Solution
<!-- How did you solve the problem? -->
Add the above-mentioned information to the responses dashboard, csv download and individual responses page so admins can track the status. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/bd117ea3-4770-430f-9b34-df8724074fd4" />

**AFTER**:
<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/3b31945c-2f7e-41e0-9117-67f9981cc014)
New columns added and new name for timestamp column.

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Hawk eye view dashboard shows the new `status`, `current step` and `submission time of first step`
- [ ] Create 2 step MRF form without approval step
- [ ] Submit step 1 
- [ ] Check responses dashboard, individual submission and download CSV. It should show pending status and correct step which is 1 of 2. 
- [ ] Submit step 2. 
- [ ] Check responses dashboard, individual submission and download CSV. It should show completed status and correct step which is 2 of 2.

TC2: Reject and approve show correctly. 
- [ ] Create a 3 step form with step 2 being approval step. Also, add a compulsory attachment field at step 1. When submitting the form in subsequent steps of the test case, always upload an attachment.
- [ ] Submit step 1 and 2 of form, rejecting at step 2. (ie click `No`) 
- [ ] Check responses dashboard, individual submission and download CSV. It should show completed status and correct step which is 2 of 3. 
- [ ] Try download CSV with attachment. Ensure the csv file is correctly downloaded and the data in the csv is as expected and attachment files are downloaded. 
- [ ] Submit step 1, 2 and 3 of form, ensuring that step 2 is approve (ie click `Yes`) 
- [ ] Check responses dashboard, individual submission and download CSV. It should show completed status and correct step which is 3 of 3.
- [ ] Try download CSV with attachment. Ensure the csv file is correctly downloaded and the data in the csv is as expected and attachment files are downloaded.

TC3: Storage mode and storage mode with with payments unaffected. 
- [ ] Create a storage mode form. 
- [ ] Submit and check the dashboard. Ensure `status`, `current step` and `submission time of first step` do not exist in the dashboard and the other expected columns exist (ie, same as before the changes introduced in this PR / refer to prod env)
- [ ] Download the CSV, ensure that `status`, `current step` and `submission time of first step` do not exist in the csv. 
- [ ] Add payments to the storage mode form. 
- [ ] Submit and check the dashboard. Ensure `status`, `current step` and `submission time of first step` do not exist and the dashboard is same as previous (ie, same as before the changes introduced in this PR / refer to prod env). 