### PR TITLE
fix: search fields drag and drop mismatch

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -28,13 +28,13 @@ export const BasicFieldPanel = ({ searchValue }: { searchValue: string }) => {
         <Box ref={provided.innerRef} {...provided.droppableProps}>
           <FieldSection>
             <FieldSection label="Basic">
-              {filteredCreateBasicFields.map((fieldType, index) => {
+              {filteredCreateBasicFields.map(({ fieldType, originalIndex }) => {
                 const shouldDisableField = isLoading
                 return (
                   <DraggableBasicFieldListOption
-                    index={index}
+                    index={originalIndex}
                     isDisabled={shouldDisableField}
-                    key={index}
+                    key={originalIndex}
                     fieldType={fieldType}
                   />
                 )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -165,14 +165,16 @@ export const MyInfoFieldPanel = ({ searchValue }: { searchValue: string }) => {
           <Box ref={provided.innerRef} {...provided.droppableProps}>
             {filteredCreateMyInfoPersonalFields.length > 0 && (
               <FieldSection label="Personal">
-                {filteredCreateMyInfoPersonalFields.map((fieldType, index) => (
-                  <DraggableMyInfoFieldListOption
-                    index={index}
-                    isDisabled={isDisabledCheck(fieldType)}
-                    key={index}
-                    fieldType={fieldType}
-                  />
-                ))}
+                {filteredCreateMyInfoPersonalFields.map(
+                  ({ fieldType, originalIndex }) => (
+                    <DraggableMyInfoFieldListOption
+                      index={originalIndex}
+                      isDisabled={isDisabledCheck(fieldType)}
+                      key={originalIndex}
+                      fieldType={fieldType}
+                    />
+                  ),
+                )}
               </FieldSection>
             )}
             <Box display="none">{provided.placeholder}</Box>
@@ -184,14 +186,16 @@ export const MyInfoFieldPanel = ({ searchValue }: { searchValue: string }) => {
           <Box ref={provided.innerRef} {...provided.droppableProps}>
             {filteredCreateMyInfoContactFields.length > 0 && (
               <FieldSection label="Contact">
-                {filteredCreateMyInfoContactFields.map((fieldType, index) => (
-                  <DraggableMyInfoFieldListOption
-                    index={index}
-                    isDisabled={isDisabledCheck(fieldType)}
-                    key={index}
-                    fieldType={fieldType}
-                  />
-                ))}
+                {filteredCreateMyInfoContactFields.map(
+                  ({ fieldType, originalIndex }) => (
+                    <DraggableMyInfoFieldListOption
+                      index={originalIndex}
+                      isDisabled={isDisabledCheck(fieldType)}
+                      key={originalIndex}
+                      fieldType={fieldType}
+                    />
+                  ),
+                )}
               </FieldSection>
             )}
             <Box display="none">{provided.placeholder}</Box>
@@ -204,11 +208,11 @@ export const MyInfoFieldPanel = ({ searchValue }: { searchValue: string }) => {
             {filteredCreateMyInfoParticularsFields.length > 0 && (
               <FieldSection label="Particulars">
                 {filteredCreateMyInfoParticularsFields.map(
-                  (fieldType, index) => (
+                  ({ fieldType, originalIndex }) => (
                     <DraggableMyInfoFieldListOption
-                      index={index}
+                      index={originalIndex}
                       isDisabled={isDisabledCheck(fieldType)}
-                      key={index}
+                      key={originalIndex}
                       fieldType={fieldType}
                     />
                   ),
@@ -224,14 +228,16 @@ export const MyInfoFieldPanel = ({ searchValue }: { searchValue: string }) => {
           <Box ref={provided.innerRef} {...provided.droppableProps}>
             {filteredCreateMyInfoMarriageFields.length > 0 && (
               <FieldSection label="Family (Marriage)">
-                {filteredCreateMyInfoMarriageFields.map((fieldType, index) => (
-                  <DraggableMyInfoFieldListOption
-                    index={index}
-                    isDisabled={isDisabledCheck(fieldType)}
-                    key={index}
-                    fieldType={fieldType}
-                  />
-                ))}
+                {filteredCreateMyInfoMarriageFields.map(
+                  ({ fieldType, originalIndex }) => (
+                    <DraggableMyInfoFieldListOption
+                      index={originalIndex}
+                      isDisabled={isDisabledCheck(fieldType)}
+                      key={originalIndex}
+                      fieldType={fieldType}
+                    />
+                  ),
+                )}
               </FieldSection>
             )}
             <Box display="none">{provided.placeholder}</Box>
@@ -246,11 +252,11 @@ export const MyInfoFieldPanel = ({ searchValue }: { searchValue: string }) => {
               {filteredCreateMyInfoChildrenFields.length > 0 && (
                 <FieldSection label="Family (Children)">
                   {filteredCreateMyInfoChildrenFields.map(
-                    (fieldType, index) => (
+                    ({ fieldType, originalIndex }) => (
                       <DraggableMyInfoFieldListOption
-                        index={index}
+                        index={originalIndex}
                         isDisabled={isDisabledCheck(fieldType)}
-                        key={index}
+                        key={originalIndex}
                         fieldType={fieldType}
                       />
                     ),

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/utils.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/utils.ts
@@ -5,9 +5,9 @@ import { BuilderSidebarFieldMeta } from '~features/admin-form/create/constants'
 const checkSearchValueMatchesFieldMeta = (
   searchValue: string,
   fieldMeta: BuilderSidebarFieldMeta,
-) => {
+): boolean => {
   const lowerCaseSearchValue = searchValue.toLowerCase()
-  return (
+  return !!(
     fieldMeta.label.toLowerCase().includes(lowerCaseSearchValue) ||
     fieldMeta.searchAliases?.some((searchAlias) =>
       searchAlias.toLowerCase().includes(lowerCaseSearchValue),
@@ -15,17 +15,31 @@ const checkSearchValueMatchesFieldMeta = (
   )
 }
 
+/**
+ * Filter field types by search value.
+ * @param searchValue - The search value to filter fields by
+ * @param orderedFields - The ordered fields to filter
+ * @param fieldsMeta - The fields meta to filter by
+ * @returns The filtered fields and their original indices based on the ordered fields.
+ * which follow the shape { fieldType: T; originalIndex: number representing the index of the field in the orderedFields array }[]
+ * NOTE: The originalIndex is necessary for the draggable component to maintain the order of the fields when dropped into the BuilderAndDesignTab.
+ */
 export const filterFieldsBySearchValue = <
   T extends BasicField | MyInfoAttribute,
 >(
   searchValue: string,
-  fields: T[],
+  orderedFields: T[],
   fieldsMeta: {
     [key in T]: BuilderSidebarFieldMeta
   },
-) => {
-  return fields.filter((fieldType) => {
-    const fieldMeta = fieldsMeta[fieldType]
-    return checkSearchValueMatchesFieldMeta(searchValue, fieldMeta)
-  })
+): { fieldType: T; originalIndex: number }[] => {
+  return orderedFields
+    .map((fieldType, originalIndex) => ({
+      fieldType,
+      originalIndex,
+    }))
+    .filter(({ fieldType }) => {
+      const fieldMeta = fieldsMeta[fieldType]
+      return checkSearchValueMatchesFieldMeta(searchValue, fieldMeta)
+    })
 }


### PR DESCRIPTION
## Problem
When dragging and dropping filtered fields, the field created is incorrect and based on the previous ordered fields list index.

## Solution
<!-- How did you solve the problem? -->
Retain the originalIndex and pass that in to match the drop index. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests 
TC1: drag and drop works 
- [ ] Filter for `radio` and drag and drop into the builder. 
- [ ] Ensure radio is created when saved. 

TC2: click save to create on left drawer works 
- [ ] Filter and create a attachment field 
- [ ] Click on the Save field button. 
- [ ] Ensure the attachment field is created.  