### PR TITLE
feat: add logs for uploads to s3

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -253,11 +253,14 @@ export const scanAndRetrieveAttachments = async (
       ? Result.combine(
           await devModeSyncVirusScanning(
             req.body.responses,
-            req.formsg.formDef._id,
+            req.formsg.formDef._id.toString(),
           ),
         )
       : await ResultAsync.combine(
-          asyncVirusScanning(req.body.responses, req.formsg.formDef._id),
+          asyncVirusScanning(
+            req.body.responses,
+            req.formsg.formDef._id.toString(),
+          ),
         )
 
   if (scanAndRetrieveFilesResult.isErr()) {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -166,6 +166,7 @@ export const validateStorageSubmissionParams = celebrate({
  */
 const asyncVirusScanning = (
   responses: ParsedClearFormFieldResponse[],
+  formId: string,
 ): ResultAsync<
   ParsedClearFormFieldResponse,
   | VirusScanFailedError
@@ -176,6 +177,7 @@ const asyncVirusScanning = (
     if (isQuarantinedAttachmentResponse(response)) {
       return SubmissionService.triggerVirusScanThenDownloadCleanFileChain(
         response,
+        formId,
       )
     }
 
@@ -191,6 +193,7 @@ const asyncVirusScanning = (
  */
 const devModeSyncVirusScanning = async (
   responses: ParsedClearFormFieldResponse[],
+  formId: string,
 ): Promise<
   Result<
     ParsedClearFormFieldResponse,
@@ -209,6 +212,7 @@ const devModeSyncVirusScanning = async (
       const attachmentResponse =
         await SubmissionService.triggerVirusScanThenDownloadCleanFileChain(
           response,
+          formId,
         )
       results.push(attachmentResponse)
       if (attachmentResponse.isErr()) break
@@ -246,8 +250,15 @@ export const scanAndRetrieveAttachments = async (
     // run the virus scanning asynchronously for better performance (lower latency).
     // Note on .combine: if any scans or downloads error out, it will short circuit and return the first error.
     isDev
-      ? Result.combine(await devModeSyncVirusScanning(req.body.responses))
-      : await ResultAsync.combine(asyncVirusScanning(req.body.responses))
+      ? Result.combine(
+          await devModeSyncVirusScanning(
+            req.body.responses,
+            req.formsg.formDef._id,
+          ),
+        )
+      : await ResultAsync.combine(
+          asyncVirusScanning(req.body.responses, req.formsg.formDef._id),
+        )
 
   if (scanAndRetrieveFilesResult.isErr()) {
     logger.error({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -204,6 +204,7 @@ const asyncVirusScanning = (
  */
 const devModeSyncVirusScanning = async (
   responses: IdTaggedParsedClearAttachmentResponseV3[],
+  formId: string,
 ): Promise<
   Result<
     IdTaggedParsedClearAttachmentResponseV3,
@@ -217,6 +218,7 @@ const devModeSyncVirusScanning = async (
     // await to pause for...of loop until the virus scanning and downloading of clean file is completed.
     const attachmentResponse = await triggerVirusScanThenDownloadCleanFileChain(
       response.answer,
+      formId,
     )
     if (attachmentResponse.isErr()) {
       results.push(err(attachmentResponse.error))
@@ -268,12 +270,15 @@ export const scanAndRetrieveAttachments = async (
     // Note on .combine: if any scans or downloads error out, it will short circuit and return the first error.
     isDev
       ? Result.combine(
-          await devModeSyncVirusScanning(attachmentResponsesToRetrieve),
+          await devModeSyncVirusScanning(
+            attachmentResponsesToRetrieve,
+            req.formsg.formDef._id.toString(),
+          ),
         )
       : await ResultAsync.combine(
           asyncVirusScanning(
             attachmentResponsesToRetrieve,
-            req.formsg.formDef._id,
+            req.formsg.formDef._id.toString(),
           ),
         )
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -184,6 +184,7 @@ type IdTaggedParsedClearAttachmentResponseV3 =
  */
 const asyncVirusScanning = (
   responses: IdTaggedParsedClearAttachmentResponseV3[],
+  formId: string,
 ): ResultAsync<
   IdTaggedParsedClearAttachmentResponseV3,
   | VirusScanFailedError
@@ -191,7 +192,7 @@ const asyncVirusScanning = (
   | MaliciousFileDetectedError
 >[] =>
   responses.map((response) =>
-    triggerVirusScanThenDownloadCleanFileChain(response.answer).map(
+    triggerVirusScanThenDownloadCleanFileChain(response.answer, formId).map(
       (attachmentResponse) => ({ ...response, answer: attachmentResponse }),
     ),
   )
@@ -270,7 +271,10 @@ export const scanAndRetrieveAttachments = async (
           await devModeSyncVirusScanning(attachmentResponsesToRetrieve),
         )
       : await ResultAsync.combine(
-          asyncVirusScanning(attachmentResponsesToRetrieve),
+          asyncVirusScanning(
+            attachmentResponsesToRetrieve,
+            req.formsg.formDef._id,
+          ),
         )
 
   if (scanAndRetrieveFilesResult.isErr()) {

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -552,7 +552,6 @@ export const uploadAttachments = (
       meta: {
         action: 'uploadAttachments',
         formId,
-        attachmentMetadata: Array.from(attachmentMetadata.entries()),
       },
     })
     return attachmentMetadata

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -432,33 +432,55 @@ export const triggerVirusScanThenDownloadCleanFileChain = <
     | ParsedClearAttachmentFieldResponseV3,
 >(
   response: T,
+  formId: string,
 ): ResultAsync<
   T,
   | VirusScanFailedError
   | DownloadCleanFileFailedError
   | MaliciousFileDetectedError
-> =>
+> => {
+  const logMeta = {
+    action: 'triggerVirusScanThenDownloadCleanFileChain',
+    formId,
+    quarantineFileKey: response.answer,
+  }
   // Step 3: Trigger lambda to scan attachments.
-  triggerVirusScanning(response.answer)
-    .mapErr((error) => {
-      if (error instanceof MaliciousFileDetectedError)
-        return new MaliciousFileDetectedError(response.filename)
-      return error
-    })
-    .map((lambdaOutput) => lambdaOutput.body)
-    // Step 4: Retrieve attachments from the clean bucket.
-    .andThen((cleanAttachment) =>
-      // Retrieve attachment from clean bucket.
-      downloadCleanFile(
-        cleanAttachment.cleanFileKey,
-        cleanAttachment.destinationVersionId,
-      ).map((attachmentBuffer) => ({
-        ...response,
-        // Replace content with attachmentBuffer and answer with filename.
-        content: attachmentBuffer,
-        answer: response.filename,
-      })),
-    )
+  return (
+    triggerVirusScanning(response.answer)
+      .mapErr((error) => {
+        if (error instanceof MaliciousFileDetectedError) {
+          logger.error({
+            message: 'Malicious file detected in virus scanning lambda',
+            meta: logMeta,
+            error,
+          })
+          return new MaliciousFileDetectedError(response.filename)
+        }
+        return error
+      })
+      .map((lambdaOutput) => {
+        logger.info({
+          message:
+            'Successfully retrieved clean file from virus scanning lambda',
+          meta: { ...logMeta, cleanFileKey: lambdaOutput.body.cleanFileKey },
+        })
+        return lambdaOutput.body
+      })
+      // Step 4: Retrieve attachments from the clean bucket.
+      .andThen((cleanAttachment) =>
+        // Retrieve attachment from clean bucket.
+        downloadCleanFile(
+          cleanAttachment.cleanFileKey,
+          cleanAttachment.destinationVersionId,
+        ).map((attachmentBuffer) => ({
+          ...response,
+          // Replace content with attachmentBuffer and answer with filename.
+          content: attachmentBuffer,
+          answer: response.filename,
+        })),
+      )
+  )
+}
 
 type AttachmentReducerData = {
   attachmentMetadata: AttachmentMetadata // type alias for Map<string, string>

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -450,7 +450,7 @@ export const triggerVirusScanThenDownloadCleanFileChain = <
       .mapErr((error) => {
         if (error instanceof MaliciousFileDetectedError) {
           logger.error({
-            message: 'Malicious file detected in virus scanning lambda',
+            message: 'Malicious file detected during lambda virus scan',
             meta: logMeta,
             error,
           })

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -552,6 +552,7 @@ export const uploadAttachments = (
       meta: {
         action: 'uploadAttachments',
         formId,
+        attachmentMetadata: Array.from(attachmentMetadata.entries()),
       },
     })
     return attachmentMetadata

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -546,17 +546,7 @@ export const uploadAttachments = (
       })
       return new AttachmentUploadError()
     },
-  ).map(() => {
-    logger.info({
-      message: 'Successfully uploaded attachments to S3',
-      meta: {
-        action: 'uploadAttachments',
-        formId,
-        attachmentMetadata: Array.from(attachmentMetadata.entries()),
-      },
-    })
-    return attachmentMetadata
-  })
+  ).map(() => attachmentMetadata)
 }
 
 /**

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -524,7 +524,17 @@ export const uploadAttachments = (
       })
       return new AttachmentUploadError()
     },
-  ).map(() => attachmentMetadata)
+  ).map(() => {
+    logger.info({
+      message: 'Successfully uploaded attachments to S3',
+      meta: {
+        action: 'uploadAttachments',
+        formId,
+        attachmentMetadata: Array.from(attachmentMetadata.entries()),
+      },
+    })
+    return attachmentMetadata
+  })
 }
 
 /**


### PR DESCRIPTION
## Problem 
Currently, it is difficult to link object keys from the various S3 buckets to a formId and submissionId for investigation during incidents. 

## Solution 
Add logs to link the various bucket object ids to the formId.  
With the formId + estimate of the submission time (and ip), we will be able to better narrow down the submissionId. 
