### PR TITLE
feat: add frame messaging

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -67,6 +67,7 @@ import {
 
 import { FormNotFound } from './components/FormNotFound'
 import { decryptAttachment, decryptSubmission } from './utils/decryptSubmission'
+import { postIFrameMessage } from './utils/iframeMessaging'
 import { usePublicAuthMutations, usePublicFormMutations } from './mutations'
 import { PublicFormContext, SubmissionData } from './PublicFormContext'
 import { useEncryptedSubmission, usePublicFormView } from './queries'
@@ -584,6 +585,8 @@ export const PublicFormProvider = ({
         }
       }
 
+      postIFrameMessage({ state: 'submitting' })
+
       switch (form.responseMode) {
         case FormResponseMode.Email: {
           // Using mutateAsync so react-hook-form goes into loading state.
@@ -717,6 +720,7 @@ export const PublicFormProvider = ({
                     paymentData,
                   }) => {
                     trackSubmitForm(form)
+                    postIFrameMessage({ state: 'submitted', submissionId })
 
                     if (paymentData) {
                       navigate(getPaymentPageUrl(formId, paymentData.paymentId))
@@ -739,6 +743,7 @@ export const PublicFormProvider = ({
                 },
               )
               .catch(async (error) => {
+                postIFrameMessage({ state: 'submitError' })
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
                   meta: {
                     ...logMeta,
@@ -781,6 +786,7 @@ export const PublicFormProvider = ({
                   paymentData,
                 }) => {
                   trackSubmitForm(form)
+                  postIFrameMessage({ state: 'submitted', submissionId })
                   if (paymentData) {
                     navigate(getPaymentPageUrl(formId, paymentData.paymentId))
                     storePaymentMemory(paymentData.paymentId)
@@ -802,6 +808,7 @@ export const PublicFormProvider = ({
               },
             )
             .catch(async (error) => {
+              postIFrameMessage({ state: 'submitError' })
               // TODO(#5826): Remove when we have resolved the Network Error
               datadogLogs.logger.warn(
                 `handleSubmitForm: submit with virus scan`,

--- a/frontend/src/features/public-form/utils/iframeMessaging.ts
+++ b/frontend/src/features/public-form/utils/iframeMessaging.ts
@@ -1,0 +1,23 @@
+export type PublicFormIFrameMessage =
+  | { state: 'submitting' | 'submitError' }
+  | { state: 'submitted'; submissionId: string }
+
+const TRUSTED_TARGET_ORIGINS = [
+  'https://pay.gov.sg',
+  'https://exp.pay.gov.sg',
+  'https://staging.pay.gov.sg',
+].concat(
+  process.env.NODE_ENV === 'development' ? ['http://localhost:3000'] : [],
+)
+
+export const postIFrameMessage = (message: PublicFormIFrameMessage): void => {
+  // De-risk by wrapping in try-catch even though this is synchronous. This should
+  // never block form submission.
+  try {
+    TRUSTED_TARGET_ORIGINS.forEach((origin) => {
+      window.parent.postMessage(message, origin)
+    })
+  } catch (error) {
+    console.warn('Error while posting form state to iframe parent', error)
+  }
+}

--- a/frontend/src/features/public-form/utils/iframeMessaging.ts
+++ b/frontend/src/features/public-form/utils/iframeMessaging.ts
@@ -6,9 +6,7 @@ const TRUSTED_TARGET_ORIGINS = [
   'https://pay.gov.sg',
   'https://exp.pay.gov.sg',
   'https://staging.pay.gov.sg',
-].concat(
-  process.env.NODE_ENV === 'development' ? ['http://localhost:3000'] : [],
-)
+]
 
 export const postIFrameMessage = (message: PublicFormIFrameMessage): void => {
   // De-risk by wrapping in try-catch even though this is synchronous. This should


### PR DESCRIPTION
# Embedding FormSG in PaySG IFrame for Payment Creation

## Problem Statement
PaySG aims to integrate FormSG within an IFrame to facilitate payment creation. There's a need for real-time communication from FormSG to PaySG regarding form state changes, such as:
- When a user is in the process of submitting a form
- When a form has been successfully submitted

## Proposed Solution
Implement `window.parent.postMessage(message, origin)` to enable communication from FormSG (child frame) to PaySG (parent window).

To maintain security:
- Implement a whitelist of authorized domains (PaySG domains for different environments)
- Only post messages to whitelisted domains

## Implementation Details
1. Create a whitelist of authorized PaySG domains
2. Implement message posting for `Storage Forms` when form state changes during submission and error
3. Ensure messages are only sent to whitelisted domains

## Impact Analysis
**Breaking Changes**: None anticipated

## Remarks
Testing needed to ensure that the message is posted. This is a regression to ensure that Iframe message posting is not removed accidentally.