### PR TITLE
feat(iframe): add frame messaging for paysg

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -69,6 +69,7 @@ import {
 
 import { FormNotFound } from './components/FormNotFound'
 import { decryptAttachment, decryptSubmission } from './utils/decryptSubmission'
+import { postIFrameMessage } from './utils/iframeMessaging'
 import { usePublicAuthMutations, usePublicFormMutations } from './mutations'
 import { PublicFormContext, SubmissionData } from './PublicFormContext'
 import { useEncryptedSubmission, usePublicFormView } from './queries'
@@ -629,6 +630,8 @@ export const PublicFormProvider = ({
         }
       }
 
+      postIFrameMessage({ state: 'submitting' })
+
       switch (form.responseMode) {
         case FormResponseMode.Email: {
           // Using mutateAsync so react-hook-form goes into loading state.
@@ -762,6 +765,7 @@ export const PublicFormProvider = ({
                     paymentData,
                   }) => {
                     trackSubmitForm(form)
+                    postIFrameMessage({ state: 'submitted', submissionId })
 
                     if (paymentData) {
                       navigate(getPaymentPageUrl(formId, paymentData.paymentId))
@@ -784,6 +788,7 @@ export const PublicFormProvider = ({
                 },
               )
               .catch(async (error) => {
+                postIFrameMessage({ state: 'submitError' })
                 datadogLogs.logger.warn(`handleSubmitForm: ${error.message}`, {
                   meta: {
                     ...logMeta,
@@ -826,6 +831,7 @@ export const PublicFormProvider = ({
                   paymentData,
                 }) => {
                   trackSubmitForm(form)
+                  postIFrameMessage({ state: 'submitted', submissionId })
                   if (paymentData) {
                     navigate(getPaymentPageUrl(formId, paymentData.paymentId))
                     storePaymentMemory(paymentData.paymentId)
@@ -847,6 +853,7 @@ export const PublicFormProvider = ({
               },
             )
             .catch(async (error) => {
+              postIFrameMessage({ state: 'submitError' })
               // TODO(#5826): Remove when we have resolved the Network Error
               datadogLogs.logger.warn(
                 `handleSubmitForm: submit with virus scan`,

--- a/frontend/src/features/public-form/utils/iframeMessaging.ts
+++ b/frontend/src/features/public-form/utils/iframeMessaging.ts
@@ -1,0 +1,23 @@
+export type PublicFormIFrameMessage =
+  | { state: 'submitting' | 'submitError' }
+  | { state: 'submitted'; submissionId: string }
+
+const TRUSTED_TARGET_ORIGINS = [
+  'https://pay.gov.sg',
+  'https://exp.pay.gov.sg',
+  'https://staging.pay.gov.sg',
+].concat(
+  process.env.NODE_ENV === 'development' ? ['http://localhost:3000'] : [],
+)
+
+export const postIFrameMessage = (message: PublicFormIFrameMessage): void => {
+  // De-risk by wrapping in try-catch even though this is synchronous. This should
+  // never block form submission.
+  try {
+    TRUSTED_TARGET_ORIGINS.forEach((origin) => {
+      window.parent.postMessage(message, origin)
+    })
+  } catch (error) {
+    console.warn('Error while posting form state to iframe parent', error)
+  }
+}

--- a/frontend/src/features/public-form/utils/iframeMessaging.ts
+++ b/frontend/src/features/public-form/utils/iframeMessaging.ts
@@ -6,9 +6,7 @@ const TRUSTED_TARGET_ORIGINS = [
   'https://pay.gov.sg',
   'https://exp.pay.gov.sg',
   'https://staging.pay.gov.sg',
-].concat(
-  process.env.NODE_ENV === 'development' ? ['http://localhost:3000'] : [],
-)
+]
 
 export const postIFrameMessage = (message: PublicFormIFrameMessage): void => {
   // De-risk by wrapping in try-catch even though this is synchronous. This should


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
PaySG aims to integrate FormSG within an IFrame to facilitate payment creation. There's a need for real-time communication from FormSG to PaySG regarding form state changes, such as:
- When a user is in the process of submitting a form
- When a form has been successfully submitted

See #7978 for original PR

## Solution
<!-- How did you solve the problem? -->
Implement `window.parent.postMessage(message, origin)` to enable communication from FormSG (child frame) to PaySG (parent window).

To maintain security:
- Implement a whitelist of authorized domains (PaySG domains for different environments)
- Only post messages to whitelisted domains

## Implementation Details
1. Create a whitelist of authorized PaySG domains
2. Implement message posting for `Storage Forms` when form state changes during submission and error
3. Ensure messages are only sent to whitelisted domains

Testing needed to ensure that the message is posted. This is a regression to ensure that Iframe message posting is not removed accidentally.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
#### Payment form can be submitted
- [ ] Create a payment form
- [ ] As a respondent fill up the payment section
- [ ] Ensure that payment form can be successfully submitted