### PR TITLE
fix: add define global

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -61,5 +61,10 @@ export default defineConfig(() => {
       plugins: () => [tsconfigPaths()],
       format: 'es' as const,
     },
+    define: {
+      // On local dev, global is undefined, causing decryption workers to fail.
+      // This is a workaround based on https://github.com/vitejs/vite/discussions/5912.
+      global: 'globalThis',
+    },
   }
 })


### PR DESCRIPTION
## Problem
When downloading responses as csv on local, an error seen `global is undefined` is shown. This prevents the download as csv functionality from working on local development. 


Closes FRM-1917

## Solution
<!-- How did you solve the problem? -->
This is caused since vite does not add polyfills for nodejs builtins (of which `global` is a nodejs builtin) and the web workers are accessing `global`. 
Hence, the `global` is explicitly defined as `globalThis` to fix this issue (sourced from [here](https://github.com/vitejs/vite/discussions/5912#discussioncomment-6115736)) which allows standard access to global across different environments. 
> The globalThis property provides a standard way of accessing the global this value (and hence the global object itself) across environments. Unlike similar properties such as window and self, it's guaranteed to work in window and non-window contexts. In this way, you can access the global object in a consistent manner without having to know which environment the code is being run in.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: can download responses as CSV on staging and prod
- [ ] Download responses as CSV 
- [ ] Ensure it downloads correctly with the correct # of rows 
- [ ] Download responses as CSV with attachments  
- [ ] Ensure all attachments are downloaded successfully and the csv has the correct # of rows. 