### PR TITLE
feat(myinfo-children): enable myinfo child on storage admin create page

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -244,8 +244,7 @@ export const MyInfoFieldPanel = ({ searchValue }: { searchValue: string }) => {
           </Box>
         )}
       </Droppable>
-      {user?.betaFlags?.children &&
-      form?.responseMode === FormResponseMode.Email ? (
+      {user?.betaFlags?.children ? (
         <Droppable isDropDisabled droppableId={CREATE_MYINFO_CHILDREN_DROP_ID}>
           {(provided) => (
             <Box ref={provided.innerRef} {...provided.droppableProps}>

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -521,7 +521,7 @@ export const handleMyInfoChildHashResponse = (
     // Validate each answer (child)
     childAnswer.forEach((attrAnswer, subFieldIndex) => {
       const key = getMyInfoChildHashKey(
-        field._id as string,
+        field._id,
         subFields[subFieldIndex],
         childIndex,
         childName,

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -91,7 +91,6 @@ import {
   MyInfoMissingLoginCookieError,
 } from '../myinfo/myinfo.errors'
 import { MyInfoKey } from '../myinfo/myinfo.types'
-import { getMyInfoChildHashKey } from '../myinfo/myinfo.util'
 import {
   InvalidPaymentProductsError,
   PaymentNotFoundError,

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -752,17 +752,12 @@ export const getAnswersForChild = (
     return []
   }
   return response.answerArray.flatMap((arr, childIdx) => {
-    // First array element is always child name
-    const childName = arr[0]
     return arr.map((answer, idx) => {
       const subfield = subFields[idx]
       return {
-        _id: getMyInfoChildHashKey(
-          response._id,
-          subFields[idx],
-          childIdx,
-          childName,
-        ),
+        // Recreates the individual _id of the child field based on the parent field's _id and the subfield
+        // e.g., childrenbirthrecords.67585515e1ced6d790a91e14.childname.0
+        _id: `${MyInfoAttribute.ChildrenBirthRecords}.${response._id}.${subFields[idx]}.${childIdx}`,
         fieldType: response.fieldType,
         // qnChildIdx represents the index of the MyInfo field
         // childIdx represents the index of the child in this MyInfo field


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Enable MyInfo children on Storage mode.

However, the data sent over through webhooks uses `getMyInfoChildHashKey` which contains the childname ie., `_id: childrenbirthrecords.67585683e1ced6d790a91f53.childname.0.Janice Wong`. This prevents downstream automation from reading data consistently as the `field._id` changes every submission.

Closes FRM-1921
## Solution
<!-- How did you solve the problem? -->
Remove `childname` from `_id` after submission.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
