### PR TITLE
feat: add formurl to otp email

### DIFF
--- a/react-email-preview/emails/EmailAddressVerificationOtp.stories.tsx
+++ b/react-email-preview/emails/EmailAddressVerificationOtp.stories.tsx
@@ -20,4 +20,5 @@ Default.args = {
   otp: '123456',
   minutesToExpiry: 30,
   appName: 'FormSG',
+  formUrl: 'https://form.gov.sg/645b5f5372deb40012fe98123',
 }

--- a/src/app/modules/verification/__tests__/verification.service.spec.ts
+++ b/src/app/modules/verification/__tests__/verification.service.spec.ts
@@ -477,6 +477,7 @@ describe('Verification service', () => {
           MOCK_LOCAL_RECIPIENT,
           MOCK_OTP,
           MOCK_OTP_PREFIX,
+          new ObjectId(mockFormId),
         )
         expect(
           MockFormsgSdk.verification.generateSignature,
@@ -597,6 +598,7 @@ describe('Verification service', () => {
           MOCK_EMAIL_RECIPIENT,
           MOCK_OTP,
           MOCK_OTP_PREFIX,
+          new ObjectId(mockFormId),
         )
         expect(
           MockFormsgSdk.verification.generateSignature,
@@ -741,6 +743,7 @@ describe('Verification service', () => {
           MOCK_EMAIL_RECIPIENT,
           MOCK_OTP,
           MOCK_OTP_PREFIX,
+          new ObjectId(mockFormId),
         )
         expect(
           MockFormsgSdk.verification.generateSignature,
@@ -761,6 +764,7 @@ describe('Verification service', () => {
           MOCK_EMAIL_RECIPIENT,
           MOCK_OTP,
           MOCK_OTP_PREFIX,
+          new ObjectId(mockFormId),
         )
         expect(
           MockFormsgSdk.verification.generateSignature,

--- a/src/app/modules/verification/verification.service.ts
+++ b/src/app/modules/verification/verification.service.ts
@@ -470,7 +470,7 @@ const sendOtpForField = (
         : errAsync(new MalformedParametersError('Field id not present'))
     case BasicField.Email:
       // call email - it should validate the recipient
-      return MailService.sendVerificationOtp(recipient, otp, otpPrefix)
+      return MailService.sendVerificationOtp(recipient, otp, otpPrefix, formId)
     default:
       return errAsync(new NonVerifiedFieldTypeError(fieldType))
   }

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -78,6 +78,8 @@ describe('mail.service', () => {
 
   describe('sendVerificationOtp', () => {
     const MOCK_OTP = '123456'
+    const MOCK_FORM_ID = 'mockFormId'
+    const MOCK_FORM_URL = `${MOCK_APP_URL}/${MOCK_FORM_ID}`
 
     const expectedArg = expect.objectContaining({
       to: MOCK_VALID_EMAIL,
@@ -96,6 +98,7 @@ describe('mail.service', () => {
         MOCK_VALID_EMAIL,
         MOCK_OTP,
         MOCK_OTP_PREFIX,
+        MOCK_FORM_URL,
       )
 
       // Assert
@@ -114,6 +117,7 @@ describe('mail.service', () => {
         invalidEmail,
         MOCK_OTP,
         MOCK_OTP_PREFIX,
+        MOCK_FORM_URL,
       )
 
       // Assert
@@ -138,6 +142,7 @@ describe('mail.service', () => {
         MOCK_VALID_EMAIL,
         MOCK_OTP,
         MOCK_OTP_PREFIX,
+        MOCK_FORM_URL,
       )
 
       // Assert
@@ -162,6 +167,7 @@ describe('mail.service', () => {
         MOCK_VALID_EMAIL,
         MOCK_OTP,
         MOCK_OTP_PREFIX,
+        MOCK_FORM_URL,
       )
 
       // Assert
@@ -192,6 +198,7 @@ describe('mail.service', () => {
         MOCK_VALID_EMAIL,
         MOCK_OTP,
         MOCK_OTP_PREFIX,
+        MOCK_FORM_URL,
       )
 
       // Assert

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -338,15 +338,20 @@ export class MailService {
     recipient: string,
     otp: string,
     otpPrefix: string,
+    formId: string,
   ): ResultAsync<true, MailSendError> => {
     const minutesToExpiry = Math.floor(HASH_EXPIRE_AFTER_SECONDS / 60)
+
+    const formUrl = this.#appUrl + `/${formId}`
 
     const htmlData: EmailAddressVerificationOtpHtmlData = {
       appName: this.#appName,
       minutesToExpiry,
       otp,
       otpPrefix,
+      formUrl,
     }
+
     const generatedHtml = fromPromise(
       render(EmailAddressVerificationOtp(htmlData)),
       (e) => {

--- a/src/app/views/templates/EmailAddressVerificationOtp.tsx
+++ b/src/app/views/templates/EmailAddressVerificationOtp.tsx
@@ -5,6 +5,7 @@ export type EmailAddressVerificationOtpHtmlData = {
   otp: string
   minutesToExpiry: number
   appName: string
+  formUrl: string
 }
 
 export const EmailAddressVerificationOtp = ({
@@ -12,15 +13,19 @@ export const EmailAddressVerificationOtp = ({
   otp,
   minutesToExpiry,
   appName,
+  formUrl,
 }: EmailAddressVerificationOtpHtmlData): JSX.Element => {
   return (
     <Html>
       <Head />
       <Body>
-        <Text>You are currently submitting a form on {appName}.</Text>
+        <Text>
+          You are trying to verify your email address on the following form:{' '}
+          <a href={formUrl}>{formUrl}</a>.
+        </Text>
         <Text>
           Your OTP is {otpPrefix}-<b>{otp}</b>. It will expire in{' '}
-          {minutesToExpiry} minutes. Please use this to verify your submission.
+          {minutesToExpiry} minutes.
         </Text>
         <Text>
           Never share your OTP with anyone else. If you did not request this


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Provide more information to link back to form during verification.

## Solution
<!-- How did you solve the problem? -->
Show form url on form.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Components | Before | After |
|--------|--------|--------|
| OTP Email |<img width="1009" alt="Screenshot 2024-12-13 at 3 54 43 PM" src="https://github.com/user-attachments/assets/e3415770-c21b-4849-9b02-77956ea712a7" /> | <img width="697" alt="Screenshot 2024-12-13 at 3 53 55 PM" src="https://github.com/user-attachments/assets/b3c22929-50c6-4a57-8fbf-a6143702f1e2" />| 

## Tests
<!-- What tests should be run to confirm functionality? -->
**Regression**
#### Email address OTP verification should be received by user
 - [ ] Create an admin form
 - [ ] Add email address and enable verification
 - [ ] Trigger email verification
 - [ ] Ensure that email is received