### PR TITLE
fix(sgid): add guard clause to ensure field is present before formatting

### DIFF
--- a/src/app/modules/sgid/sgid.adapter.ts
+++ b/src/app/modules/sgid/sgid.adapter.ts
@@ -161,6 +161,12 @@ export class SGIDMyInfoData
    */
   _formatFieldValue(attr: ExternalAttr): string | undefined {
     const fieldValue = this.#payload[attr]
+    // returned payload might be empty if the form fields were edited after the initial scope sent to sgid
+    // sgid would then respond only the data initially requested
+    // but the form now expects more fields
+    if (!fieldValue) {
+      return ''
+    }
     switch (attr) {
       case ExternalAttr.RegisteredAddress:
         return formatAddress(fieldValue)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When an initial scope is requested to sgID, the scope could have been outdated if the admin updates the form while the respondent is approving the sgID request. 

This results in sgID returning fields requested in the initial scope. When BE receives and assess scope, there are fields that would be formatted (i.e., requiring and assuming that the fields are rightly returned). These formatters would then fail (and crash the system) since sgID response did not contain the latest form data.

## Solution
<!-- How did you solve the problem? -->

Add undefined check before calling formatX which attempts to manipulates the fields.

Note: The form definition would be checked on submission, which invalidates the submission thereafter.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Updated form when requested with old sgid scope should not crash BE
- [ ] Create a sgid form
- [ ] Open form
- [ ] As a respondent login (but hold at the qrcode scanning) 
- [ ] As an admin add address field to form
- [ ] As a respondent continue with login
- [ ] Ensure that form is loaded
