### PR TITLE
chore: mongoose, nanoid packages update

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14065,9 +14065,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -29121,9 +29121,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true
     },
     "natural-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "celebrate": "^15.0.3",
         "compression": "~1.7.2",
         "connect-datadog": "0.0.9",
-        "connect-mongo": "^4.6.0",
+        "connect-mongo": "^5.1.0",
         "convict": "^6.2.4",
         "convict-format-with-validator": "^6.2.0",
         "cookie-parser": "~1.4.6",
@@ -13280,18 +13280,19 @@
       }
     },
     "node_modules/connect-mongo": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-4.6.0.tgz",
-      "integrity": "sha512-8new4Z7NLP3CGP65Aw6ls3xDBeKVvHRSh39CXuDZTQsvpeeU9oNMzfFgvqmHqZ6gWpxIl663RyoVEmCAGf1yOg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.1.0.tgz",
+      "integrity": "sha512-xT0vxQLqyqoUTxPLzlP9a/u+vir0zNkhiy9uAdHjSCcUUf7TS5b55Icw8lVyYFxfemP3Mf9gdwUOgeF3cxCAhw==",
       "dependencies": {
         "debug": "^4.3.1",
         "kruptein": "^3.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12.9.0"
       },
       "peerDependencies": {
-        "mongodb": "^4.1.0"
+        "express-session": "^1.17.1",
+        "mongodb": ">= 5.1.0 < 7"
       }
     },
     "node_modules/console-control-strings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "moment-timezone": "0.5.41",
         "mongodb-memory-server-core": "^9.5.0",
         "mongodb-uri": "^0.9.7",
-        "mongoose": "^6.12.0",
+        "mongoose": "^6.13.5",
         "multer": "^1.4.5-lts.1",
         "multiparty": ">=4.2.3",
         "nan": "^2.19.0",
@@ -352,460 +352,579 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.433.0.tgz",
-      "integrity": "sha512-42znkBhcLweedtcp+k0Vz4As9FavThrYYGtvuleW82GQqtwyOXSifinXw7xfY2JngqCuCEenFQPsf1hudOWzyw==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.712.0.tgz",
+      "integrity": "sha512-Xb+6S5QzFhKin9gOIKjvFhvP13AffH5oq0v/e0yQO0JckSLuph9+du/CHcobPqkxJpzyreeDltD7+Yu/l9RmIg==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.433.0",
-        "@aws-sdk/credential-provider-node": "3.433.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.433.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/client-sts": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
         "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.433.0.tgz",
-      "integrity": "sha512-L7ksMP7UnYH+w52ly+m+s5vk8662VtyqJ+UduFEMPqKUHTFEm7w+CCw4Xfk3hl5GlVvqPvYWqBqv8eLKSHpCEQ==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.712.0.tgz",
+      "integrity": "sha512-tBo/eW3YpZ9f3Q1qA7aA8uliNFJJX0OP7R2IUJ8t6rqVTk15wWCEPNmXzUZKgruDnKUfCaF4+r9q/Yy4fBc9PA==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.433.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.712.0.tgz",
+      "integrity": "sha512-xNFrG9syrG6pxUP7Ld/nu3afQ9+rbJM9qrE+wDNz4VnNZ3vLiJty4fH85zBFhOQ5OF2DIJTWsFzXGi2FYjsCMA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.712.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.433.0.tgz",
-      "integrity": "sha512-hQ+NLIcA1KRJ2qPdrtkJ3fOEVnehLLMlnB/I5mjg9K2UKjuiOufLao6tc5SyW9fseIL9AdX3fjJ8Unhg+y1RWg==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.712.0.tgz",
+      "integrity": "sha512-gIO6BD+hkEe3GKQhbiFP0zcNQv0EkP1Cl9SOstxS+X9CeudEgVX/xEPUjyoFVkfkntPBJ1g0I1u5xOzzRExl4g==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.433.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-sts": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.433.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.709.0.tgz",
+      "integrity": "sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/signature-v4": "^4.2.4",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
-      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.709.0.tgz",
+      "integrity": "sha512-ZMAp9LSikvHDFVa84dKpQmow6wsg956Um20cKuioPpX2GGreJFur7oduD+tRJT6FtIOHn+64YH+0MwiXLhsaIQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.433.0.tgz",
-      "integrity": "sha512-T+YhCOORyA4+i4T86FfFCmi/jPsmLOP6GAtScHp/K8XzB9XuVvJSZ+T8SUKeW6/9G9z3Az7dqeBVLcMdC6fFDA==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.712.0.tgz",
+      "integrity": "sha512-sTsdQ/Fm/suqMdpjhMuss/5uKL18vcuWnNTQVrG9iGNRqZLbq65MXquwbUpgzfoUmIcH+4CrY6H2ebpTIECIag==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.433.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.712.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.433.0.tgz",
-      "integrity": "sha512-uOTBJszqGJIX5SrH2YdN501cv9rW4ghuSkasxI9DL+sVV5YRMd/bwu6I3PphRyK7z4dosDEbJ1xoIuVR/W04HQ==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.712.0.tgz",
+      "integrity": "sha512-gXrHymW3rMRYORkPVQwL8Gi5Lu92F16SoZR543x03qCi7rm00oL9tRD85ACxkhprS1Wh8lUIUMNoeiwnYWTNuQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.433.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-ini": "3.712.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
-      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.709.0.tgz",
+      "integrity": "sha512-IAC+jPlGQII6jhIylHOwh3RgSobqlgL59nw2qYTURr8hMCI0Z1p5y2ee646HTVt4WeCYyzUAXfxr6YI/Vitv+Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.433.0.tgz",
-      "integrity": "sha512-vuc2X7q/1HUAO/NowfnNMpRDoHw8H2lyZZzUc0lmamy6PDrEFBi/VTm1nStGPuS9egCFrYlkRHsfp50ukYGa5w==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.712.0.tgz",
+      "integrity": "sha512-8lCMxY7Lb9VK9qdlNXRJXE3W1UDVURnJZ3a4XWYNY6yr1TfQaN40mMyXX1oNlXXJtMV0szRvjM8dZj37E/ESAw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.433.0",
-        "@aws-sdk/token-providers": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/token-providers": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
-      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.709.0.tgz",
+      "integrity": "sha512-2lbDfE0IQ6gma/7BB2JpkjW5G0wGe4AS0x80oybYAYYviJmUtIR3Cn2pXun6bnAWElt4wYKl4su7oC36rs5rNA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.709.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
-      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.709.0.tgz",
+      "integrity": "sha512-8gQYCYAaIw4lOCd5WYdf15Y/61MgRsAnrb2eiTl+icMlUOOzl8aOl5iDwm/Idp0oHZTflwxM4XSvGXO83PRWcw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
-      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.709.0.tgz",
+      "integrity": "sha512-jDoGSccXv9zebnpUoisjWd5u5ZPIalrmm6TjvPzZ8UqzQt3Beiz0tnQwmxQD6KRc7ADweWP5Ntiqzbw9xpVajg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
-      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.709.0.tgz",
+      "integrity": "sha512-PObL/wLr4lkfbQ0yXUWaoCWu/jcwfwZzCjsUiXW/H6hW9b/00enZxmx7OhtJYaR6xmh/Lcx5wbhIoDCbzdv0tw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
-      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
-      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.433.0.tgz",
-      "integrity": "sha512-jMgA1jHfisBK4oSjMKrtKEZf0sl2vzADivkFmyZFzORpSZxBnF6hC21RjaI+70LJLcc9rSCzLgcoz5lHb9LLDg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.709.0.tgz",
+      "integrity": "sha512-ooc9ZJvgkjPhi9q05XwSfNTXkEBEIfL4hleo5rQBKwHG3aTHvwOM7LLzhdX56QZVa6sorPBp6fwULuRDSqiQHw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
-      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.709.0.tgz",
+      "integrity": "sha512-/NoCAMEVKAg3kBKOrNtgOfL+ECt6nrl+L7q2SyYmrcY4tVCmwuECVqewQaHc03fTnJijfKLccw0Fj+6wOCnB6w==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.433.0.tgz",
-      "integrity": "sha512-Q6aYVaQKB+CkBLHQQlN8MHVpOzZv9snRfVz7SxIpdbHkRuGEHiLliCY3fg6Sonvu3AKEPERPuHcaC75tnNpOBw==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.709.0.tgz",
+      "integrity": "sha512-q5Ar6k71nci43IbULFgC8a89d/3EHpmd7HvBzqVGRcHnoPwh8eZDBfbBXKH83NGwcS1qPSRYiDbVfeWPm4/1jA==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.433.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.709.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
+      "integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.433.0.tgz",
-      "integrity": "sha512-LFNUh9FH7RMtYjSjPGz9lAJQMzmJ3RcXISzc5X5k2R/9mNwMK7y1k2VAfvx+RbuDbll6xwsXlgv6QHcxVdF2zw==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.709.0.tgz",
+      "integrity": "sha512-Mbc7AtL5WGCTKC16IGeUTz+sjpC3ptBda2t0CcK0kMVw3THDdcSq6ZlNKO747cNqdbwUvW34oHteUiHv4/z88Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-endpoints": "^2.1.7",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
-      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.709.0.tgz",
+      "integrity": "sha512-/rL2GasJzdTWUURCQKFldw2wqBtY4k4kCiA2tVZSKg3y4Ey7zO34SW8ebaeCE2/xoWOyLR2/etdKyphoo4Zrtg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.433.0.tgz",
-      "integrity": "sha512-yT1tO4MbbsUBLl5+S+jVv8wxiAtP5TKjKib9B2KQ2x0OtWWTrIf2o+IZK8va+zQqdV4MVMjezdxdE20hOdB4yQ==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.712.0.tgz",
+      "integrity": "sha512-26X21bZ4FWsVpqs33uOXiB60TOWQdVlr7T7XONDFL/XN7GEpUJkWuuIB4PTok6VOmh1viYcdxZQqekXPuzXexQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -816,11 +935,638 @@
         }
       }
     },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/abort-controller": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/config-resolver": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+      "integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/core": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.5.tgz",
+      "integrity": "sha512-G8G/sDDhXA7o0bOvkc7bgai6POuSld/+XhNnWAbpQTpLv2OZPvyqQ58tLPPlz0bSNsXktldDDREIv1LczFeNEw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+      "integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.2.tgz",
+      "integrity": "sha512-R7rU7Ae3ItU4rC0c5mB2sP5mJNbCfoDc8I5XlYjIZnquyUwec7fEo78F6DA3SmgJgkU1qTMcZJuGblxZsl10ZA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+      "integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+      "integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+      "integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.5.tgz",
+      "integrity": "sha512-VhJNs/s/lyx4weiZdXSloBgoLoS8osV0dKIain8nGmx7of3QFKu5BSdEuk1z/U8x9iwes1i+XCiNusEvuK1ijg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.30.tgz",
+      "integrity": "sha512-6323RL2BvAR3VQpTjHpa52kH/iSHyxd/G9ohb2MkBk2Ucu+oMtRXT8yi7KTSIS9nb58aupG6nO0OlXnQOAcvmQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-http-handler": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.2.tgz",
+      "integrity": "sha512-t4ng1DAd527vlxvOfKFYEe6/QFBcsj7WpNlWTyjorwXXcKw3XlltBGbyHfSJ24QT84nF+agDha9tNYpzmSRZPA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/property-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/protocol-http": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/signature-v4": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
+      "integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/smithy-client": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.0.tgz",
+      "integrity": "sha512-Y8FeOa7gbDfCWf7njrkoRATPa5eNLUEjlJS5z5rXatYuGkCb80LbHcu8AQR8qgAZZaNHCLyo2N+pxPsV7l+ivg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/url-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.30.tgz",
+      "integrity": "sha512-nLuGmgfcr0gzm64pqF2UT4SGWVG8UGviAdayDlVzJPNa6Z4lqvpDzdRXmLxtOdEjVlTOEdpZ9dd3ZMMu488mzg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.30.tgz",
+      "integrity": "sha512-OD63eWoH68vp75mYcfYyuVH+p7Li/mY4sYOROnauDrtObo1cS4uWfsy/zhOTW8F8ZPxQC1ZXZKVxoxvMGUv2Ow==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-endpoints": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+      "integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.2.tgz",
+      "integrity": "sha512-sInAqdiVeisUGYAv/FrXpmJ0b4WTFmciTRqzhb7wVuem9BHvhIG7tpiYHLDWrl2stOokNZpTTGqz3mzB2qFwXg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "optional": true
+    },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@aws-sdk/client-lambda": {
       "version": "3.693.0",
@@ -2288,38 +3034,63 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.433.0.tgz",
-      "integrity": "sha512-zBTrVbruYkPY4/YrUNP11mHbuVwGx7lxfo/Hlul7iUFhRbVhd/Xg3EYi6fgdTojEWEhY4SltFwVFUrzVAm8V5g==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.712.0.tgz",
+      "integrity": "sha512-sUUaw4PK9LQNGGytVpz659w4rWwdhfsZ4AMns0smnWfNVmmDAOtDMUTzNUxYmXhWt4+iS4cXfQqmUAdKqIhlsw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-cognito-identity": "3.712.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
+      "integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/property-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "optional": true
     },
     "node_modules/@aws-sdk/credential-provider-env": {
@@ -2342,41 +3113,451 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.433.0.tgz",
-      "integrity": "sha512-HA3Op+tT/EvJnRTzeURFbygNUX5wx5wlD84h4RgWpDa6x3G0lhI1wxCUR5/+qzIpF5vC7E3Q9/yu7ln07RmZlg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.709.0.tgz",
+      "integrity": "sha512-lIS7XLwCOyJnLD70f+VIRr8DNV1HPQe9oN6aguYrhoczqz7vDiVZLe3lh714cJqq9rdxzFypK5DqKHmcscMEPQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/core": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.709.0.tgz",
+      "integrity": "sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/signature-v4": "^4.2.4",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
+      "integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/abort-controller": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/core": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.5.tgz",
+      "integrity": "sha512-G8G/sDDhXA7o0bOvkc7bgai6POuSld/+XhNnWAbpQTpLv2OZPvyqQ58tLPPlz0bSNsXktldDDREIv1LczFeNEw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.2.tgz",
+      "integrity": "sha512-R7rU7Ae3ItU4rC0c5mB2sP5mJNbCfoDc8I5XlYjIZnquyUwec7fEo78F6DA3SmgJgkU1qTMcZJuGblxZsl10ZA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.5.tgz",
+      "integrity": "sha512-VhJNs/s/lyx4weiZdXSloBgoLoS8osV0dKIain8nGmx7of3QFKu5BSdEuk1z/U8x9iwes1i+XCiNusEvuK1ijg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.2.tgz",
+      "integrity": "sha512-t4ng1DAd527vlxvOfKFYEe6/QFBcsj7WpNlWTyjorwXXcKw3XlltBGbyHfSJ24QT84nF+agDha9tNYpzmSRZPA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/property-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/protocol-http": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/signature-v4": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
+      "integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/smithy-client": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.0.tgz",
+      "integrity": "sha512-Y8FeOa7gbDfCWf7njrkoRATPa5eNLUEjlJS5z5rXatYuGkCb80LbHcu8AQR8qgAZZaNHCLyo2N+pxPsV7l+ivg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/url-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-stream": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.2.tgz",
+      "integrity": "sha512-sInAqdiVeisUGYAv/FrXpmJ0b4WTFmciTRqzhb7wVuem9BHvhIG7tpiYHLDWrl2stOokNZpTTGqz3mzB2qFwXg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "optional": true
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
@@ -2514,439 +3695,568 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.433.0.tgz",
-      "integrity": "sha512-GKsdnFiab+uiwUCzEZKRVa0/h2Ov/Lft/69DJQtFqkM+RHT/XXhAOA9noZmCOyta6UlRbj3P5ep28oQOTc1czw==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.712.0.tgz",
+      "integrity": "sha512-7U/pIx1T2IjysoskFRglZAThoxewKw6HoZS/SJT3hLusa/uuYuno1Y1nmCr0ojsl9NB7Jm4PIK3yJUZDDgy+Ng==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.433.0",
-        "@aws-sdk/client-sso": "3.433.0",
-        "@aws-sdk/client-sts": "3.433.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.433.0",
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-http": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.433.0",
-        "@aws-sdk/credential-provider-node": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.433.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-cognito-identity": "3.712.0",
+        "@aws-sdk/client-sso": "3.712.0",
+        "@aws-sdk/client-sts": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.712.0",
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-ini": "3.712.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.433.0.tgz",
-      "integrity": "sha512-L7ksMP7UnYH+w52ly+m+s5vk8662VtyqJ+UduFEMPqKUHTFEm7w+CCw4Xfk3hl5GlVvqPvYWqBqv8eLKSHpCEQ==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.712.0.tgz",
+      "integrity": "sha512-tBo/eW3YpZ9f3Q1qA7aA8uliNFJJX0OP7R2IUJ8t6rqVTk15wWCEPNmXzUZKgruDnKUfCaF4+r9q/Yy4fBc9PA==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.433.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.712.0.tgz",
+      "integrity": "sha512-xNFrG9syrG6pxUP7Ld/nu3afQ9+rbJM9qrE+wDNz4VnNZ3vLiJty4fH85zBFhOQ5OF2DIJTWsFzXGi2FYjsCMA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.712.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.433.0.tgz",
-      "integrity": "sha512-hQ+NLIcA1KRJ2qPdrtkJ3fOEVnehLLMlnB/I5mjg9K2UKjuiOufLao6tc5SyW9fseIL9AdX3fjJ8Unhg+y1RWg==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.712.0.tgz",
+      "integrity": "sha512-gIO6BD+hkEe3GKQhbiFP0zcNQv0EkP1Cl9SOstxS+X9CeudEgVX/xEPUjyoFVkfkntPBJ1g0I1u5xOzzRExl4g==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/credential-provider-node": "3.433.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-sdk-sts": "3.433.0",
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/region-config-resolver": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.433.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.5.0"
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/client-sso-oidc": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-node": "3.712.0",
+        "@aws-sdk/middleware-host-header": "3.709.0",
+        "@aws-sdk/middleware-logger": "3.709.0",
+        "@aws-sdk/middleware-recursion-detection": "3.709.0",
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/region-config-resolver": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@aws-sdk/util-user-agent-browser": "3.709.0",
+        "@aws-sdk/util-user-agent-node": "3.712.0",
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/core": "^2.5.5",
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/hash-node": "^3.0.11",
+        "@smithy/invalid-dependency": "^3.0.11",
+        "@smithy/middleware-content-length": "^3.0.13",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-retry": "^3.0.30",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-body-length-node": "^3.0.0",
+        "@smithy/util-defaults-mode-browser": "^3.0.30",
+        "@smithy/util-defaults-mode-node": "^3.0.30",
+        "@smithy/util-endpoints": "^2.1.7",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.709.0.tgz",
+      "integrity": "sha512-7kuSpzdOTAE026j85wq/fN9UDZ70n0OHw81vFqMWwlEFtm5IQ/MRCLKcC4HkXxTdfy1PqFlmoXxWqeBa15tujw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/signature-v4": "^4.2.4",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.433.0.tgz",
-      "integrity": "sha512-Vl7Qz5qYyxBurMn6hfSiNJeUHSqfVUlMt0C1Bds3tCkl3IzecRWwyBOlxtxO3VCrgVeW3HqswLzCvhAFzPH6nQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.709.0.tgz",
+      "integrity": "sha512-ZMAp9LSikvHDFVa84dKpQmow6wsg956Um20cKuioPpX2GGreJFur7oduD+tRJT6FtIOHn+64YH+0MwiXLhsaIQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.433.0.tgz",
-      "integrity": "sha512-T+YhCOORyA4+i4T86FfFCmi/jPsmLOP6GAtScHp/K8XzB9XuVvJSZ+T8SUKeW6/9G9z3Az7dqeBVLcMdC6fFDA==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.712.0.tgz",
+      "integrity": "sha512-sTsdQ/Fm/suqMdpjhMuss/5uKL18vcuWnNTQVrG9iGNRqZLbq65MXquwbUpgzfoUmIcH+4CrY6H2ebpTIECIag==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.433.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.712.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.433.0.tgz",
-      "integrity": "sha512-uOTBJszqGJIX5SrH2YdN501cv9rW4ghuSkasxI9DL+sVV5YRMd/bwu6I3PphRyK7z4dosDEbJ1xoIuVR/W04HQ==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.712.0.tgz",
+      "integrity": "sha512-gXrHymW3rMRYORkPVQwL8Gi5Lu92F16SoZR543x03qCi7rm00oL9tRD85ACxkhprS1Wh8lUIUMNoeiwnYWTNuQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.433.0",
-        "@aws-sdk/credential-provider-ini": "3.433.0",
-        "@aws-sdk/credential-provider-process": "3.433.0",
-        "@aws-sdk/credential-provider-sso": "3.433.0",
-        "@aws-sdk/credential-provider-web-identity": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/credential-provider-imds": "^2.0.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/credential-provider-env": "3.709.0",
+        "@aws-sdk/credential-provider-http": "3.709.0",
+        "@aws-sdk/credential-provider-ini": "3.712.0",
+        "@aws-sdk/credential-provider-process": "3.709.0",
+        "@aws-sdk/credential-provider-sso": "3.712.0",
+        "@aws-sdk/credential-provider-web-identity": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.433.0.tgz",
-      "integrity": "sha512-W7FcGlQjio9Y/PepcZGRyl5Bpwb0uWU7qIUCh+u4+q2mW4D5ZngXg8V/opL9/I/p4tUH9VXZLyLGwyBSkdhL+A==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.709.0.tgz",
+      "integrity": "sha512-IAC+jPlGQII6jhIylHOwh3RgSobqlgL59nw2qYTURr8hMCI0Z1p5y2ee646HTVt4WeCYyzUAXfxr6YI/Vitv+Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.433.0.tgz",
-      "integrity": "sha512-vuc2X7q/1HUAO/NowfnNMpRDoHw8H2lyZZzUc0lmamy6PDrEFBi/VTm1nStGPuS9egCFrYlkRHsfp50ukYGa5w==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.712.0.tgz",
+      "integrity": "sha512-8lCMxY7Lb9VK9qdlNXRJXE3W1UDVURnJZ3a4XWYNY6yr1TfQaN40mMyXX1oNlXXJtMV0szRvjM8dZj37E/ESAw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/client-sso": "3.433.0",
-        "@aws-sdk/token-providers": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/client-sso": "3.712.0",
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/token-providers": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.433.0.tgz",
-      "integrity": "sha512-RlwjP1I5wO+aPpwyCp23Mk8nmRbRL33hqRASy73c4JA2z2YiRua+ryt6MalIxehhwQU6xvXUKulJnPG9VaMFZg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.709.0.tgz",
+      "integrity": "sha512-2lbDfE0IQ6gma/7BB2JpkjW5G0wGe4AS0x80oybYAYYviJmUtIR3Cn2pXun6bnAWElt4wYKl4su7oC36rs5rNA==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.709.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.433.0.tgz",
-      "integrity": "sha512-mBTq3UWv1UzeHG+OfUQ2MB/5GEkt5LTKFaUqzL7ESwzW8XtpBgXnjZvIwu3Vcd3sEetMwijwaGiJhY0ae/YyaA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.709.0.tgz",
+      "integrity": "sha512-8gQYCYAaIw4lOCd5WYdf15Y/61MgRsAnrb2eiTl+icMlUOOzl8aOl5iDwm/Idp0oHZTflwxM4XSvGXO83PRWcw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.433.0.tgz",
-      "integrity": "sha512-We346Fb5xGonTGVZC9Nvqtnqy74VJzYuTLLiuuftA5sbNzftBDy/22QCfvYSTOAl3bvif+dkDUzQY2ihc5PwOQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.709.0.tgz",
+      "integrity": "sha512-jDoGSccXv9zebnpUoisjWd5u5ZPIalrmm6TjvPzZ8UqzQt3Beiz0tnQwmxQD6KRc7ADweWP5Ntiqzbw9xpVajg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.433.0.tgz",
-      "integrity": "sha512-HEvYC9PQlWY/ccUYtLvAlwwf1iCif2TSAmLNr3YTBRVa98x6jKL0hlCrHWYklFeqOGSKy6XhE+NGJMUII0/HaQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.709.0.tgz",
+      "integrity": "sha512-PObL/wLr4lkfbQ0yXUWaoCWu/jcwfwZzCjsUiXW/H6hW9b/00enZxmx7OhtJYaR6xmh/Lcx5wbhIoDCbzdv0tw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.433.0.tgz",
-      "integrity": "sha512-ORYbJnBejUyonFl5FwIqhvI3Cq6sAp9j+JpkKZtFNma9tFPdrhmYgfCeNH32H/wGTQV/tUoQ3luh0gA4cuk6DA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.433.0.tgz",
-      "integrity": "sha512-jxPvt59NZo/epMNLNTu47ikmP8v0q217I6bQFGJG7JVFnfl36zDktMwGw+0xZR80qiK47/2BWrNpta61Zd2FxQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/signature-v4": "^2.0.0",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.433.0.tgz",
-      "integrity": "sha512-jMgA1jHfisBK4oSjMKrtKEZf0sl2vzADivkFmyZFzORpSZxBnF6hC21RjaI+70LJLcc9rSCzLgcoz5lHb9LLDg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.709.0.tgz",
+      "integrity": "sha512-ooc9ZJvgkjPhi9q05XwSfNTXkEBEIfL4hleo5rQBKwHG3aTHvwOM7LLzhdX56QZVa6sorPBp6fwULuRDSqiQHw==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/core": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@aws-sdk/util-endpoints": "3.709.0",
+        "@smithy/core": "^2.5.5",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.433.0.tgz",
-      "integrity": "sha512-xpjRjCZW+CDFdcMmmhIYg81ST5UAnJh61IHziQEk0FXONrg4kjyYPZAOjEdzXQ+HxJQuGQLKPhRdzxmQnbX7pg==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.709.0.tgz",
+      "integrity": "sha512-/NoCAMEVKAg3kBKOrNtgOfL+ECt6nrl+L7q2SyYmrcY4tVCmwuECVqewQaHc03fTnJijfKLccw0Fj+6wOCnB6w==",
       "optional": true,
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "@smithy/util-config-provider": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.5",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.433.0.tgz",
-      "integrity": "sha512-Q6aYVaQKB+CkBLHQQlN8MHVpOzZv9snRfVz7SxIpdbHkRuGEHiLliCY3fg6Sonvu3AKEPERPuHcaC75tnNpOBw==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.709.0.tgz",
+      "integrity": "sha512-q5Ar6k71nci43IbULFgC8a89d/3EHpmd7HvBzqVGRcHnoPwh8eZDBfbBXKH83NGwcS1qPSRYiDbVfeWPm4/1jA==",
       "optional": true,
       "dependencies": {
-        "@aws-crypto/sha256-browser": "3.0.0",
-        "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/middleware-host-header": "3.433.0",
-        "@aws-sdk/middleware-logger": "3.433.0",
-        "@aws-sdk/middleware-recursion-detection": "3.433.0",
-        "@aws-sdk/middleware-user-agent": "3.433.0",
-        "@aws-sdk/types": "3.433.0",
-        "@aws-sdk/util-endpoints": "3.433.0",
-        "@aws-sdk/util-user-agent-browser": "3.433.0",
-        "@aws-sdk/util-user-agent-node": "3.433.0",
-        "@smithy/config-resolver": "^2.0.16",
-        "@smithy/fetch-http-handler": "^2.2.4",
-        "@smithy/hash-node": "^2.0.12",
-        "@smithy/invalid-dependency": "^2.0.12",
-        "@smithy/middleware-content-length": "^2.0.14",
-        "@smithy/middleware-endpoint": "^2.1.3",
-        "@smithy/middleware-retry": "^2.0.18",
-        "@smithy/middleware-serde": "^2.0.12",
-        "@smithy/middleware-stack": "^2.0.6",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/node-http-handler": "^2.1.8",
-        "@smithy/property-provider": "^2.0.0",
-        "@smithy/protocol-http": "^3.0.8",
-        "@smithy/shared-ini-file-loader": "^2.0.6",
-        "@smithy/smithy-client": "^2.1.12",
-        "@smithy/types": "^2.4.0",
-        "@smithy/url-parser": "^2.0.12",
-        "@smithy/util-base64": "^2.0.0",
-        "@smithy/util-body-length-browser": "^2.0.0",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.16",
-        "@smithy/util-defaults-mode-node": "^2.0.21",
-        "@smithy/util-retry": "^2.0.5",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "^3.709.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
-      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.709.0.tgz",
+      "integrity": "sha512-ArtLTMxgjf13Kfu3gWH3Ez9Q5TkDdcRZUofpKH3pMGB/C6KAbeSCtIIDKfoRTUABzyGlPyCrZdnFjKyH+ypIpg==",
       "optional": true,
       "dependencies": {
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.433.0.tgz",
-      "integrity": "sha512-LFNUh9FH7RMtYjSjPGz9lAJQMzmJ3RcXISzc5X5k2R/9mNwMK7y1k2VAfvx+RbuDbll6xwsXlgv6QHcxVdF2zw==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.709.0.tgz",
+      "integrity": "sha512-Mbc7AtL5WGCTKC16IGeUTz+sjpC3ptBda2t0CcK0kMVw3THDdcSq6ZlNKO747cNqdbwUvW34oHteUiHv4/z88Q==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-endpoints": "^2.1.7",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.433.0.tgz",
-      "integrity": "sha512-2Cf/Lwvxbt5RXvWFXrFr49vXv0IddiUwrZoAiwhDYxvsh+BMnh+NUFot+ZQaTrk/8IPZVDeLPWZRdVy00iaVXQ==",
+      "version": "3.709.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.709.0.tgz",
+      "integrity": "sha512-/rL2GasJzdTWUURCQKFldw2wqBtY4k4kCiA2tVZSKg3y4Ey7zO34SW8ebaeCE2/xoWOyLR2/etdKyphoo4Zrtg==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/types": "^2.4.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/types": "^3.7.2",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.433.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.433.0.tgz",
-      "integrity": "sha512-yT1tO4MbbsUBLl5+S+jVv8wxiAtP5TKjKib9B2KQ2x0OtWWTrIf2o+IZK8va+zQqdV4MVMjezdxdE20hOdB4yQ==",
+      "version": "3.712.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.712.0.tgz",
+      "integrity": "sha512-26X21bZ4FWsVpqs33uOXiB60TOWQdVlr7T7XONDFL/XN7GEpUJkWuuIB4PTok6VOmh1viYcdxZQqekXPuzXexQ==",
       "optional": true,
       "dependencies": {
-        "@aws-sdk/types": "3.433.0",
-        "@smithy/node-config-provider": "^2.1.3",
-        "@smithy/types": "^2.4.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/middleware-user-agent": "3.709.0",
+        "@aws-sdk/types": "3.709.0",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -2957,11 +4267,651 @@
         }
       }
     },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/abort-controller": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.9.tgz",
+      "integrity": "sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/config-resolver": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.13.tgz",
+      "integrity": "sha512-Gr/qwzyPaTL1tZcq8WQyHhTZREER5R1Wytmz4WnVGL4onA3dNk6Btll55c8Vr58pLdvWZmtG8oZxJTw3t3q7Jg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-config-provider": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/core": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.5.5.tgz",
+      "integrity": "sha512-G8G/sDDhXA7o0bOvkc7bgai6POuSld/+XhNnWAbpQTpLv2OZPvyqQ58tLPPlz0bSNsXktldDDREIv1LczFeNEw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-body-length-browser": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-stream": "^3.3.2",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/credential-provider-imds": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.2.8.tgz",
+      "integrity": "sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-4.1.2.tgz",
+      "integrity": "sha512-R7rU7Ae3ItU4rC0c5mB2sP5mJNbCfoDc8I5XlYjIZnquyUwec7fEo78F6DA3SmgJgkU1qTMcZJuGblxZsl10ZA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.11.tgz",
+      "integrity": "sha512-emP23rwYyZhQBvklqTtwetkQlqbNYirDiEEwXl2v0GYWMnCzxst7ZaRAnWuy28njp5kAH54lvkdG37MblZzaHA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/invalid-dependency": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.11.tgz",
+      "integrity": "sha512-NuQmVPEJjUX6c+UELyVz8kUx8Q539EDeNwbRyu4IIF8MeV7hUtq1FB3SHVyki2u++5XLMFqngeMKk7ccspnNyQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/is-array-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
+      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-content-length": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.13.tgz",
+      "integrity": "sha512-zfMhzojhFpIX3P5ug7jxTjfUcIPcGjcQYzB9t+rv0g1TX7B0QdwONW+ATouaLoD7h7LOw/ZlXfkq4xJ/g2TrIw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-endpoint": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.2.5.tgz",
+      "integrity": "sha512-VhJNs/s/lyx4weiZdXSloBgoLoS8osV0dKIain8nGmx7of3QFKu5BSdEuk1z/U8x9iwes1i+XCiNusEvuK1ijg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-serde": "^3.0.11",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "@smithy/url-parser": "^3.0.11",
+        "@smithy/util-middleware": "^3.0.11",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-retry": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.30.tgz",
+      "integrity": "sha512-6323RL2BvAR3VQpTjHpa52kH/iSHyxd/G9ohb2MkBk2Ucu+oMtRXT8yi7KTSIS9nb58aupG6nO0OlXnQOAcvmQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-retry": "^3.0.11",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-serde": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.11.tgz",
+      "integrity": "sha512-KzPAeySp/fOoQA82TpnwItvX8BBURecpx6ZMu75EZDkAcnPtO6vf7q4aH5QHs/F1s3/snQaSFbbUMcFFZ086Mw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-stack": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.11.tgz",
+      "integrity": "sha512-1HGo9a6/ikgOMrTrWL/WiN9N8GSVYpuRQO5kjstAq4CvV59bjqnh7TbdXGQ4vxLD3xlSjfBjq5t1SOELePsLnA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-config-provider": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.12.tgz",
+      "integrity": "sha512-O9LVEu5J/u/FuNlZs+L7Ikn3lz7VB9hb0GtPT9MQeiBmtK8RSY3ULmsZgXhe6VAlgTw0YO+paQx4p8xdbs43vQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/shared-ini-file-loader": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-http-handler": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.3.2.tgz",
+      "integrity": "sha512-t4ng1DAd527vlxvOfKFYEe6/QFBcsj7WpNlWTyjorwXXcKw3XlltBGbyHfSJ24QT84nF+agDha9tNYpzmSRZPA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/abort-controller": "^3.1.9",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/querystring-builder": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/property-provider": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.11.tgz",
+      "integrity": "sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/protocol-http": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.1.8.tgz",
+      "integrity": "sha512-hmgIAVyxw1LySOwkgMIUN0kjN8TG9Nc85LJeEmEE/cNEe2rkHDUWhnJf2gxcSRFLWsyqWsrZGw40ROjUogg+Iw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-builder": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.11.tgz",
+      "integrity": "sha512-u+5HV/9uJaeLj5XTb6+IEF/dokWWkEqJ0XiaRRogyREmKGUgZnNecLucADLdauWFKUNbQfulHFEZEdjwEBjXRg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.11.tgz",
+      "integrity": "sha512-Je3kFvCsFMnso1ilPwA7GtlbPaTixa3WwC+K21kmMZHsBEOZYQaqxcMqeFFoU7/slFjKDIpiiPydvdJm8Q/MCw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/service-error-classification": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.11.tgz",
+      "integrity": "sha512-QnYDPkyewrJzCyaeI2Rmp7pDwbUETe+hU8ADkXmgNusO1bgHBH7ovXJiYmba8t0fNfJx75fE8dlM6SEmZxheog==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.12.tgz",
+      "integrity": "sha512-1xKSGI+U9KKdbG2qDvIR9dGrw3CNx+baqJfyr0igKEpjbHL5stsqAesYBzHChYHlelWtb87VnLWlhvfCz13H8Q==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-4.2.4.tgz",
+      "integrity": "sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-middleware": "^3.0.11",
+        "@smithy/util-uri-escape": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/smithy-client": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.5.0.tgz",
+      "integrity": "sha512-Y8FeOa7gbDfCWf7njrkoRATPa5eNLUEjlJS5z5rXatYuGkCb80LbHcu8AQR8qgAZZaNHCLyo2N+pxPsV7l+ivg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^2.5.5",
+        "@smithy/middleware-endpoint": "^3.2.5",
+        "@smithy/middleware-stack": "^3.0.11",
+        "@smithy/protocol-http": "^4.1.8",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-stream": "^3.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.7.2.tgz",
+      "integrity": "sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/url-parser": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.11.tgz",
+      "integrity": "sha512-TmlqXkSk8ZPhfc+SQutjmFr5FjC0av3GZP4B/10caK1SbRwe/v+Wzu/R6xEKxoNqL+8nY18s1byiy6HqPG37Aw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/querystring-parser": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
+      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
+      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
+      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
+      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-config-provider": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
+      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.30.tgz",
+      "integrity": "sha512-nLuGmgfcr0gzm64pqF2UT4SGWVG8UGviAdayDlVzJPNa6Z4lqvpDzdRXmLxtOdEjVlTOEdpZ9dd3ZMMu488mzg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-node": {
+      "version": "3.0.30",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.30.tgz",
+      "integrity": "sha512-OD63eWoH68vp75mYcfYyuVH+p7Li/mY4sYOROnauDrtObo1cS4uWfsy/zhOTW8F8ZPxQC1ZXZKVxoxvMGUv2Ow==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/config-resolver": "^3.0.13",
+        "@smithy/credential-provider-imds": "^3.2.8",
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/property-provider": "^3.1.11",
+        "@smithy/smithy-client": "^3.5.0",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-endpoints": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.1.7.tgz",
+      "integrity": "sha512-tSfcqKcN/Oo2STEYCABVuKgJ76nyyr6skGl9t15hs+YaiU06sgMkN7QYjo0BbVw+KT26zok3IzbdSOksQ4YzVw==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/node-config-provider": "^3.1.12",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-hex-encoding": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
+      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-middleware": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.11.tgz",
+      "integrity": "sha512-dWpyc1e1R6VoXrwLoLDd57U1z6CwNSdkM69Ie4+6uYh2GC7Vg51Qtan7ITzczuVpqezdDTKJGJB95fFvvjU/ow==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-retry": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.11.tgz",
+      "integrity": "sha512-hJUC6W7A3DQgaee3Hp9ZFcOxVDZzmBIRBPlUAk8/fSOEl7pE/aX7Dci0JycNOnm9Mfr0KV2XjIlUOcGWXQUdVQ==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/service-error-classification": "^3.0.11",
+        "@smithy/types": "^3.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.3.2.tgz",
+      "integrity": "sha512-sInAqdiVeisUGYAv/FrXpmJ0b4WTFmciTRqzhb7wVuem9BHvhIG7tpiYHLDWrl2stOokNZpTTGqz3mzB2qFwXg==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^4.1.2",
+        "@smithy/node-http-handler": "^3.3.2",
+        "@smithy/types": "^3.7.2",
+        "@smithy/util-base64": "^3.0.0",
+        "@smithy/util-buffer-from": "^3.0.0",
+        "@smithy/util-hex-encoding": "^3.0.0",
+        "@smithy/util-utf8": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
+      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^3.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-uri-escape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
+      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/fast-xml-parser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "optional": true
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.535.0",
@@ -19774,13 +21724,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.12.1.tgz",
-      "integrity": "sha512-VEawZMiMaclKrR5q8rj+Bu95PfUmx0ld+dk/poi37fqPlSd93sE4TlIPSqBY9GKY9tZPxu0aDEtgFDuHoI8sOg==",
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.13.5.tgz",
+      "integrity": "sha512-podJEaIF/5N2mQymkyyUzN2NeL/68MOyYjf3O0zsgCU2B2Omnhg6NhGHVavt9ZH/VxOrwKE9XphbuHDFK+T06g==",
       "dependencies": {
         "bson": "^4.7.2",
         "kareem": "2.5.1",
-        "mongodb": "4.17.1",
+        "mongodb": "4.17.2",
         "mpath": "0.9.0",
         "mquery": "4.0.3",
         "ms": "2.1.3",
@@ -19795,9 +21745,9 @@
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.1.tgz",
-      "integrity": "sha512-MBuyYiPUPRTqfH2dV0ya4dcr2E5N52ocBuZ8Sgg/M030nGF78v855B3Z27mZJnp8PxjnUquEnAtjOsphgMZOlQ==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.17.2.tgz",
+      "integrity": "sha512-mLV7SEiov2LHleRJPMPrK2PMyhXFZt2UQLC4VD4pnth3jMjYKHhtqfwwkkvS/NXuo/Fp3vbhaNcXrIDaLRb9Tg==",
       "dependencies": {
         "bson": "^4.7.2",
         "mongodb-connection-string-url": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "moment-timezone": "0.5.41",
     "mongodb-memory-server-core": "^9.5.0",
     "mongodb-uri": "^0.9.7",
-    "mongoose": "^6.12.0",
+    "mongoose": "^6.13.5",
     "multer": "^1.4.5-lts.1",
     "multiparty": ">=4.2.3",
     "nan": "^2.19.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "celebrate": "^15.0.3",
     "compression": "~1.7.2",
     "connect-datadog": "0.0.9",
-    "connect-mongo": "^4.6.0",
+    "connect-mongo": "^5.1.0",
     "convict": "^6.2.4",
     "convict-format-with-validator": "^6.2.0",
     "cookie-parser": "~1.4.6",

--- a/react-email-preview/package-lock.json
+++ b/react-email-preview/package-lock.json
@@ -4089,9 +4089,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Package updates.
- `mongoose`: `6.12.0` -> `6.13.5`
- `nanoid`: `3.3.7` -> `3.3.8`
- `connect-mongo`: `4.6.0` -> `5.1.0`

Closes #7991, #7990, #7999

Note: the large LOC changes are mainly from `@aws-sdk` that was used by `connect-mongo -> mongodb`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible
