### PR TITLE
fix(workflow): set approval toggle header size to h4

### DIFF
--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/ApprovalsBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/ApprovalsBlock.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { Controller, UseFormReturn } from 'react-hook-form'
 import { FormControl } from '@chakra-ui/react'
 
+import { textStyles } from '~theme/textStyles'
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -89,6 +90,7 @@ export const ApprovalsBlock = ({
         isLoading={isLoading}
         onChange={onApprovalToggleChange}
         isChecked={isApprovalToggleChecked}
+        labelStyles={textStyles.h4}
         label="This respondent is an approver"
         description="If they select Yes, the form continues to the next step. If they select No, it stops here."
         tooltipText="Use this for steps that involve any type of decision, such as reviews or endorsements"


### PR DESCRIPTION
## Problem

**Background**
Approval toggle header is a size smaller than headers of similar hierarchy. We previously dropped this as it was not blocking the release.

After some thinking, and consideration that we're likely to conclude with MRF admins features (i.e., not going to add more configurations), we should treat the Approval toggle to be the only header, and thus promote it to be of the same hierarchy. 

Closes FRM-1916

## Solution
Set Approval toggle header to be of the same size as other header-level text (h4).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
