### PR TITLE
feat: Attachment support in email responses for storage mode forms

### DIFF
--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -29,7 +29,11 @@ import {
   SpVerifiedContent,
 } from 'src/app/modules/verified-content/verified-content.types'
 import MailService from 'src/app/services/mail/mail.service'
-import { FormFieldSchema, IPopulatedEncryptedForm } from 'src/types'
+import {
+  FormFieldSchema,
+  IAttachmentInfo,
+  IPopulatedEncryptedForm,
+} from 'src/types'
 import { EncryptSubmissionDto, FormCompleteDto } from 'src/types/api'
 
 import { SubmissionEmailObj } from '../../email-submission/email-submission.util'
@@ -1327,6 +1331,71 @@ describe('encrypt-submission.controller', () => {
       // Assert
       expect(performEncryptPostSubmissionActionsSpy.mock.calls[0][2]).toEqual(
         emailData,
+      )
+    })
+  })
+
+  describe('submitEncryptModeForm', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+      MockMailService.sendSubmissionToAdmin.mockReturnValue(okAsync(true))
+    })
+
+    it('should call sendSubmissionToAdmin with the attachments', async () => {
+      // Arrange
+      jest
+        .spyOn(MailService, 'sendSubmissionToAdmin')
+        .mockReturnValue(okAsync(true))
+
+      const mockFormId = new ObjectId()
+      const mockForm = {
+        _id: mockFormId,
+        title: 'Test Form',
+        authType: FormAuthType.NIL,
+        form_fields: [] as FormFieldSchema[],
+        emails: ['test@example.com'],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
+
+      const mockAttachments: IAttachmentInfo[] = [
+        {
+          filename: 'test.pdf',
+          content: Buffer.from('this is a test file'),
+          fieldId: 'test-field-id',
+        },
+      ]
+
+      const mockReq = merge(
+        expressHandler.mockRequest({
+          params: { formId: mockFormId.toHexString() },
+          body: {
+            responses: [],
+            attachments: mockAttachments,
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'mockEncryptedContent',
+              version: 1,
+            },
+            formDef: {},
+            encryptedFormDef: mockForm,
+            unencryptedAttachments: mockAttachments,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitEncryptModeFormForTest(mockReq, mockRes)
+
+      // Assert (done)
+      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: mockAttachments,
+        }),
       )
     })
   })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -1341,6 +1341,58 @@ describe('encrypt-submission.controller', () => {
       MockMailService.sendSubmissionToAdmin.mockReturnValue(okAsync(true))
     })
 
+    it('should call sendSubmissionToAdmin with no attachments', async () => {
+      // Arrange
+      jest
+        .spyOn(MailService, 'sendSubmissionToAdmin')
+        .mockReturnValue(okAsync(true))
+
+      const mockFormId = new ObjectId()
+      const mockForm = {
+        _id: mockFormId,
+        title: 'Test Form',
+        authType: FormAuthType.NIL,
+        form_fields: [] as FormFieldSchema[],
+        emails: ['test@example.com'],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
+
+      const mockAttachments: IAttachmentInfo[] = []
+
+      const mockReq = merge(
+        expressHandler.mockRequest({
+          params: { formId: mockFormId.toHexString() },
+          body: {
+            responses: [],
+            attachments: mockAttachments,
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'mockEncryptedContent',
+              version: 1,
+            },
+            formDef: {},
+            encryptedFormDef: mockForm,
+            unencryptedAttachments: mockAttachments,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitEncryptModeFormForTest(mockReq, mockRes)
+
+      // Assert (done)
+      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: mockAttachments,
+        }),
+      )
+    })
+
     it('should call sendSubmissionToAdmin with the attachments', async () => {
       // Arrange
       jest

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -802,7 +802,7 @@ const _createSubmission = async ({
         created: createdTime,
         id: submission.id,
       },
-      attachments: undefined, // Don't send attachments in the email notifications
+      attachments: unencryptedAttachments,
       formData: emailData.formData,
     })
   }

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -379,7 +379,13 @@ describe('mail.service', () => {
         id: 'mockSubmissionId',
         created: new Date(),
       },
-      attachments: [],
+      attachments: [
+        {
+          filename: 'test.pdf',
+          content: Buffer.from('this is a test file'),
+          fieldId: 'test-field-id',
+        },
+      ],
       dataCollationData: [
         {
           question: 'some question',


### PR DESCRIPTION
## Problem

https://www.notion.so/opengov/Attachment-support-in-email-responses-12177dbba788805eb502cc56ec46de45


## Solution
Change from undefined to `unencryptedAttachments`

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
- [ ] Create form with no attachment fields, enable email notifs and ensure no attachment
- [ ] Create form with one attachment fields, enable email notifs and ensure attachment is received, and is open-able
- [ ] Create form with multiple attachment fields, enable email notifs and ensure both attachments are received
- [ ] Create form with multiple attachment fields all with the same name, enable email notifs and ensure all attachments are received