### PR TITLE
feat: move banner to growthbook

### DIFF
--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 import { get } from 'lodash'
 
 import { fillHeightCss } from '~utils/fillHeightCss'
@@ -9,8 +10,8 @@ import { Banner } from '~components/Banner'
 
 import AdminForbiddenErrorPage from '~pages/AdminForbiddenError'
 import NotFoundErrorPage from '~pages/NotFoundError'
-import { useEnv } from '~features/env/queries'
 
+// import { useEnv } from '~features/env/queries'
 import { StorageResponsesProvider } from '../responses/ResponsesPage/storage/StorageResponsesProvider'
 
 import AdminFormNavbar from './components/AdminFormNavbar'
@@ -23,7 +24,9 @@ export const AdminFormLayout = (): JSX.Element => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  // const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  const siteBannerContent = useFeatureValue('site-banner-content', '')
+  const adminBannerContent = useFeatureValue('admin-banner-content', '')
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.

--- a/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -10,8 +10,8 @@ import { Banner } from '~components/Banner'
 
 import AdminForbiddenErrorPage from '~pages/AdminForbiddenError'
 import NotFoundErrorPage from '~pages/NotFoundError'
+import { useEnv } from '~features/env/queries'
 
-// import { useEnv } from '~features/env/queries'
 import { StorageResponsesProvider } from '../responses/ResponsesPage/storage/StorageResponsesProvider'
 
 import AdminFormNavbar from './components/AdminFormNavbar'
@@ -24,9 +24,9 @@ export const AdminFormLayout = (): JSX.Element => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  // const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
-  const siteBannerContent = useFeatureValue('site-banner-content', '')
-  const adminBannerContent = useFeatureValue('admin-banner-content', '')
+  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  const siteBannerContentGB = useFeatureValue('site-banner-content', '')
+  const adminBannerContentGB = useFeatureValue('admin-banner-content', '')
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
@@ -34,9 +34,14 @@ export const AdminFormLayout = (): JSX.Element => {
     [adminBannerContent, siteBannerContent],
   )
 
+  const bannerContentGB = useMemo(
+    () => siteBannerContentGB || adminBannerContentGB,
+    [adminBannerContentGB, siteBannerContentGB],
+  )
+
   const bannerProps = useMemo(
-    () => getBannerProps(bannerContent),
-    [bannerContent],
+    () => getBannerProps(bannerContent || bannerContentGB),
+    [bannerContent, bannerContentGB],
   )
 
   const { error } = useAdminForm()

--- a/frontend/src/features/login/LoginPageTemplate.tsx
+++ b/frontend/src/features/login/LoginPageTemplate.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link as ReactLink } from 'react-router-dom'
 import { Box, chakra, Flex, GridItem, GridProps, Text } from '@chakra-ui/react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 
 import { AppFooter } from '~/app/AppFooter'
 
@@ -90,7 +91,11 @@ export const NonMobileSidebarGridArea: FCC = ({ children }) => (
 )
 
 export const LoginPageTemplate: FCC = ({ children }) => {
-  const { data: { siteBannerContent, isLoginBanner } = {} } = useEnv()
+  // const { data: { siteBannerContent, isLoginBanner } = {} } = useEnv()
+
+  const siteBannerContent = useFeatureValue('site-banner-content', '')
+  const isLoginBanner = useFeatureValue('is-login-banner', '')
+
   const { t } = useTranslation()
 
   const bannerContent = useMemo(

--- a/frontend/src/features/login/LoginPageTemplate.tsx
+++ b/frontend/src/features/login/LoginPageTemplate.tsx
@@ -91,10 +91,10 @@ export const NonMobileSidebarGridArea: FCC = ({ children }) => (
 )
 
 export const LoginPageTemplate: FCC = ({ children }) => {
-  // const { data: { siteBannerContent, isLoginBanner } = {} } = useEnv()
+  const { data: { siteBannerContent, isLoginBanner } = {} } = useEnv()
 
-  const siteBannerContent = useFeatureValue('site-banner-content', '')
-  const isLoginBanner = useFeatureValue('is-login-banner', '')
+  const siteBannerContentGB = useFeatureValue('site-banner-content', '')
+  const isLoginBannerGB = useFeatureValue('is-login-banner', '')
 
   const { t } = useTranslation()
 
@@ -104,9 +104,14 @@ export const LoginPageTemplate: FCC = ({ children }) => {
     [siteBannerContent, isLoginBanner],
   )
 
+  const bannerContentGB = useMemo(
+    () => siteBannerContentGB || isLoginBannerGB,
+    [siteBannerContentGB, isLoginBannerGB],
+  )
+
   const bannerProps = useMemo(
-    () => getBannerProps(bannerContent),
-    [bannerContent],
+    () => getBannerProps(bannerContent || bannerContentGB),
+    [bannerContent, bannerContentGB],
   )
 
   const bannerColorIntensity = 600

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -1,24 +1,30 @@
 import { useMemo } from 'react'
+import { useFeatureValue, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { FormAuthType } from '~shared/types'
 
 import { getBannerProps } from '~utils/getBannerProps'
 import { Banner } from '~components/Banner'
 
-import { useEnv } from '~features/env/queries'
-
+// import { useEnv } from '~features/env/queries'
 import { usePublicFormContext } from '../PublicFormContext'
 
 export const FormBanner = (): JSX.Element | null => {
-  const {
-    data: {
-      siteBannerContent,
-      isGeneralMaintenance,
-      isSPMaintenance,
-      isCPMaintenance,
-      myInfoBannerContent,
-    } = {},
-  } = useEnv()
+  // const {
+  //   data: {
+  //     siteBannerContent,
+  //     isGeneralMaintenance,
+  //     isSPMaintenance,
+  //     isCPMaintenance,
+  //     myInfoBannerContent,
+  //   } = {},
+  // } = useEnv()
+  const siteBannerContent = useFeatureValue('site-banner-content', '')
+  console.log('siteBannerContent: ', siteBannerContent)
+  const isGeneralMaintenance = useFeatureValue('is-general-maintenance', '')
+  const isSPMaintenance = useFeatureValue('is-sp-maintenance', '')
+  const isCPMaintenance = useFeatureValue('is-cp-maintenance', '')
+  const myInfoBannerContent = useFeatureValue('myinfo-banner-content', '')
   const { form } = usePublicFormContext()
 
   const bannerContent = useMemo(

--- a/frontend/src/features/public-form/components/FormBanner.tsx
+++ b/frontend/src/features/public-form/components/FormBanner.tsx
@@ -1,30 +1,30 @@
 import { useMemo } from 'react'
-import { useFeatureValue, useGrowthBook } from '@growthbook/growthbook-react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 
 import { FormAuthType } from '~shared/types'
 
 import { getBannerProps } from '~utils/getBannerProps'
 import { Banner } from '~components/Banner'
 
-// import { useEnv } from '~features/env/queries'
+import { useEnv } from '~features/env/queries'
+
 import { usePublicFormContext } from '../PublicFormContext'
 
 export const FormBanner = (): JSX.Element | null => {
-  // const {
-  //   data: {
-  //     siteBannerContent,
-  //     isGeneralMaintenance,
-  //     isSPMaintenance,
-  //     isCPMaintenance,
-  //     myInfoBannerContent,
-  //   } = {},
-  // } = useEnv()
-  const siteBannerContent = useFeatureValue('site-banner-content', '')
-  console.log('siteBannerContent: ', siteBannerContent)
-  const isGeneralMaintenance = useFeatureValue('is-general-maintenance', '')
-  const isSPMaintenance = useFeatureValue('is-sp-maintenance', '')
-  const isCPMaintenance = useFeatureValue('is-cp-maintenance', '')
-  const myInfoBannerContent = useFeatureValue('myinfo-banner-content', '')
+  const {
+    data: {
+      siteBannerContent,
+      isGeneralMaintenance,
+      isSPMaintenance,
+      isCPMaintenance,
+      myInfoBannerContent,
+    } = {},
+  } = useEnv()
+  const siteBannerContentGB = useFeatureValue('site-banner-content', '')
+  const isGeneralMaintenanceGB = useFeatureValue('is-general-maintenance', '')
+  const isSPMaintenanceGB = useFeatureValue('is-sp-maintenance', '')
+  const isCPMaintenanceGB = useFeatureValue('is-cp-maintenance', '')
+  const myInfoBannerContentGB = useFeatureValue('myinfo-banner-content', '')
   const { form } = usePublicFormContext()
 
   const bannerContent = useMemo(
@@ -46,9 +46,28 @@ export const FormBanner = (): JSX.Element | null => {
     ],
   )
 
+  const bannerContentGB = useMemo(
+    // Use || instead of ?? so that we fall through even if previous banners are empty string.
+    () =>
+      siteBannerContentGB ||
+      isGeneralMaintenanceGB ||
+      (form?.authType === FormAuthType.SP && isSPMaintenanceGB) ||
+      (form?.authType === FormAuthType.CP && isCPMaintenanceGB) ||
+      (form?.authType === FormAuthType.MyInfo && myInfoBannerContentGB) ||
+      undefined,
+    [
+      form?.authType,
+      isCPMaintenanceGB,
+      isGeneralMaintenanceGB,
+      isSPMaintenanceGB,
+      myInfoBannerContentGB,
+      siteBannerContentGB,
+    ],
+  )
+
   const bannerProps = useMemo(
-    () => getBannerProps(bannerContent),
-    [bannerContent],
+    () => getBannerProps(bannerContent || bannerContentGB),
+    [bannerContent, bannerContentGB],
   )
 
   if (!bannerProps) return null

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -26,7 +26,7 @@ import { Banner } from '~components/Banner'
 import InlineMessage from '~components/InlineMessage'
 import Link from '~components/Link'
 
-// import { useEnv } from '~features/env/queries'
+import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
 import { WorkspaceContent } from '~features/workspace/WorkspaceContent'
 
@@ -38,9 +38,9 @@ import { WorkspaceProvider } from './WorkspaceProvider'
 
 export const WorkspacePage = (): JSX.Element => {
   const [currWorkspaceId, setCurrWorkspaceId] = useState<string>('')
-  // const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
-  const siteBannerContent = useFeatureValue('site-banner-content', '')
-  const adminBannerContent = useFeatureValue('admin-banner-content', '')
+  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  const siteBannerContentGB = useFeatureValue('site-banner-content', '')
+  const adminBannerContentGB = useFeatureValue('admin-banner-content', '')
 
   const mobileDrawer = useDisclosure()
   const isMobile = useIsMobile()
@@ -54,9 +54,15 @@ export const WorkspacePage = (): JSX.Element => {
     () => siteBannerContent || adminBannerContent,
     [adminBannerContent, siteBannerContent],
   )
+
+  const bannerContentGB = useMemo(
+    () => siteBannerContentGB || adminBannerContentGB,
+    [adminBannerContentGB, siteBannerContentGB],
+  )
+
   const bannerProps = useMemo(
-    () => getBannerProps(bannerContent),
-    [bannerContent],
+    () => getBannerProps(bannerContent || bannerContentGB),
+    [bannerContent, bannerContentGB],
   )
 
   const DEFAULT_WORKSPACE = useMemo(() => {

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 
 import { PAPERLESS_FORMSG_RESEARCH_LINK } from '~shared/constants'
 import { Workspace } from '~shared/types/workspace'
@@ -25,7 +26,7 @@ import { Banner } from '~components/Banner'
 import InlineMessage from '~components/InlineMessage'
 import Link from '~components/Link'
 
-import { useEnv } from '~features/env/queries'
+// import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
 import { WorkspaceContent } from '~features/workspace/WorkspaceContent'
 
@@ -37,7 +38,9 @@ import { WorkspaceProvider } from './WorkspaceProvider'
 
 export const WorkspacePage = (): JSX.Element => {
   const [currWorkspaceId, setCurrWorkspaceId] = useState<string>('')
-  const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  // const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
+  const siteBannerContent = useFeatureValue('site-banner-content', '')
+  const adminBannerContent = useFeatureValue('admin-banner-content', '')
 
   const mobileDrawer = useDisclosure()
   const isMobile = useIsMobile()


### PR DESCRIPTION
## Problem

Closes FRM-1956

https://www.notion.so/opengov/Migration-of-Banners-to-Growthbook-18377dbba788800e8dfcdf1544d9f41f?pvs=4

As for the banner hierarchy, SSM > growthbook. Any truthy value set in SSM will override the growthbook values. 
For example,


## Solution
- Buy pro plan
- Reduce TTL for cloudflare caching by worker. 

Currently verifying that the caching is done a the CDN level and not the browser level by monitoring the API requests after reducing the TTL. 

**Breaking Changes** 
- [x] No - this PR does not contain breaking changes
    - AWS SSM is still used as fallback for this initial phase out period. If SSM has a truthy value ,then its value is used instead, and growthbook is overriden. 


## Tests
- [ ] 1. Ensure that SSM has empty banner values for staging
- [ ] 2. On GB, add override value for staging banner,
- [ ] 3. Wait for cache to expire, Observe that the staging website shows updated banner info, and is formatted correctly (info warning error)
- [ ] 4. Add banner content to SSM, with a different value from GB.
- [ ] 5. Wait for cache expire
- [ ] 6. Observe that staging shows new banner value on `staging` and is formatted correctly. 
