### PR TITLE
feat: add retry for clamav init

### DIFF
--- a/serverless/virus-scanner/src/__tests/clamscan.service.spec.ts
+++ b/serverless/virus-scanner/src/__tests/clamscan.service.spec.ts
@@ -12,12 +12,8 @@ let scanResult: {
 jest.mock('clamscan', () => {
   return jest.fn().mockImplementation(() => {
     return {
-      init: jest.fn().mockImplementation(() => {
-        return {
-          scanStream: jest.fn().mockImplementation(() => {
-            return scanResult
-          }),
-        }
+      init: jest.fn().mockResolvedValue({
+        scanStream: jest.fn().mockResolvedValue(scanResult),
       }),
     }
   })

--- a/serverless/virus-scanner/src/clamscan.service.ts
+++ b/serverless/virus-scanner/src/clamscan.service.ts
@@ -4,6 +4,33 @@ import internal from 'stream'
 import { getLambdaLogger } from './logger'
 import { ScanFileStreamResult } from './types'
 
+const MAX_RETRIES = 3
+const RETRY_INTERVAL_MS = 1000
+
+const retryFunction = <T>(
+  func: () => Promise<T>,
+  retries: number,
+  interval: number,
+): Promise<T> => {
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      func()
+        .then(resolve)
+        .catch((error) => {
+          if (retries === 0) {
+            reject(error)
+          } else {
+            setTimeout(() => {
+              retries--
+              attempt()
+            }, interval)
+          }
+        })
+    }
+    attempt()
+  })
+}
+
 export async function scanFileStream(
   s3Stream: internal.Readable,
 ): Promise<ScanFileStreamResult> {
@@ -11,11 +38,11 @@ export async function scanFileStream(
 
   logger.info('Scanning file stream')
 
-  const scanner = await new NodeClam().init({
-    clamdscan: {
-      socket: '/tmp/clamd.ctl',
-    },
-  })
+  const scanner = await retryFunction<NodeClam>(
+    () => new NodeClam().init({ clamdscan: { socket: '/tmp/clamd.ctl' } }),
+    MAX_RETRIES,
+    RETRY_INTERVAL_MS,
+  )
 
   const { isInfected: isMalicious, viruses: virusMetadata } =
     await scanner.scanStream(s3Stream)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Our virus-scanner sometimes fails randomly.

## Solution
<!-- How did you solve the problem? -->

Adds retries to re-attempt the upload.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
##### Regression
Non-malicious files does not block submission
- [ ] Create a form with attachments
- [ ] Submit the form with attachments
- [ ] Ensure that form is submitted successfully

Malicious files blocks submission
- [ ] Create a form with attachments
- [ ] Submit the form with malicious attachments (eicar)
- [ ] Ensure that form is submitted *not* successfully