### PR TITLE
chore: update virus-scanner node version

### DIFF
--- a/serverless/virus-scanner/Dockerfile
+++ b/serverless/virus-scanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.20-bullseye-slim
+FROM node:18.12-bullseye-slim
 
 # Install aws-lambda-cpp build dependencies
 RUN apt-get update && \


### PR DESCRIPTION
## Problem

Node on virus-scanner is outdated.

## Solution

Update node version to 18.

**Breaking Changes** 
- No - this PR is backwards compatible  


## Tests
##### Regression
Non-malicious files does not block submission
- [ ] Create a form with attachments
- [ ] Submit the form with attachments
- [ ] Ensure that form is submitted successfully

Malicious files blocks submission
- [ ] Create a form with attachments
- [ ] Submit the form with malicious attachments (eicar)
- [ ] Ensure that form is submitted *not* successfully

