### PR TITLE
feat: Add the email input box for encrypt form modal

### DIFF
--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -171,7 +171,7 @@ const addSettings = async (
   await expect(page).toHaveURL(ADMIN_FORM_PAGE_SETTINGS(formId))
 
   await addGeneralSettings(page, formSettings)
-  await addAdminEmails(page, formSettings)
+  // await addAdminEmails(page, formSettings)
   await addAuthSettings(page, formSettings)
   await addCollaborators(page, formSettings)
 

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -120,6 +120,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
               mb="2.25rem"
             >
               <FormLabel
+                isRequired={responseModeValue === FormResponseMode.Email}
                 useMarkdownForDescription
                 description={`All email addresses below will be notified. Learn more on [how to guard against email bounces](${GUIDE_PREVENT_EMAIL_BOUNCE}).`}
               >

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -112,8 +112,13 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
               </InlineMessage>
             )}
           </FormControl>
-          {responseModeValue === FormResponseMode.Email && (
-            <FormControl isRequired isInvalid={!!errors.emails} mb="2.25rem">
+          {(responseModeValue === FormResponseMode.Encrypt ||
+            responseModeValue === FormResponseMode.Email) && (
+            <FormControl
+              isRequired={responseModeValue === FormResponseMode.Email}
+              isInvalid={!!errors.emails}
+              mb="2.25rem"
+            >
               <FormLabel
                 useMarkdownForDescription
                 description={`All email addresses below will be notified. Learn more on [how to guard against email bounces](${GUIDE_PREVENT_EMAIL_BOUNCE}).`}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
@@ -3,7 +3,12 @@ import { Skeleton } from '@chakra-ui/react'
 import { get } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 
-import { REQUIRED_ADMIN_EMAIL_VALIDATION_RULES } from '~utils/formValidation'
+import { FormResponseMode } from '~shared/types/form/form'
+
+import {
+  OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES,
+  REQUIRED_ADMIN_EMAIL_VALIDATION_RULES,
+} from '~utils/formValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Input from '~components/Input'
 import { TagInput } from '~components/TagInput'
@@ -15,6 +20,10 @@ import { useCreateFormWizard } from '../CreateFormWizardContext'
 export const EmailFormRecipientsInput = (): JSX.Element => {
   const { user, isLoading } = useUser()
   const { formMethods } = useCreateFormWizard()
+
+  const { watch } = formMethods
+  const responseModeValue = watch('responseMode')
+
   const {
     control,
     formState: { errors },
@@ -35,7 +44,11 @@ export const EmailFormRecipientsInput = (): JSX.Element => {
         control={control}
         defaultValue={[user.email]}
         name="emails"
-        rules={REQUIRED_ADMIN_EMAIL_VALIDATION_RULES}
+        rules={
+          responseModeValue === FormResponseMode.Email
+            ? REQUIRED_ADMIN_EMAIL_VALIDATION_RULES
+            : OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES
+        }
         render={({ field }) => (
           <TagInput
             placeholder="Separate emails with a comma"

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -72,7 +72,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
   const workspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
 
   const handleCreateStorageModeOrMultirespondentForm = handleSubmit(
-    ({ title, responseMode }) => {
+    ({ title, responseMode, emails }) => {
       switch (responseMode) {
         case FormResponseMode.Encrypt:
           return createStorageModeFormMutation.mutate({
@@ -80,7 +80,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
             responseMode,
             publicKey: keypair.publicKey,
             workspaceId,
-            emails: [],
+            emails: emails.filter(Boolean),
           })
         case FormResponseMode.Email:
           return

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -72,7 +72,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
   const workspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
 
   const handleCreateStorageModeOrMultirespondentForm = handleSubmit(
-    ({ title, responseMode }) => {
+    ({ title, responseMode, emails }) => {
       if (!activeFormMeta?._id) {
         return
       }
@@ -85,6 +85,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
             responseMode,
             publicKey: keypair.publicKey,
             workspaceId,
+            emails: emails.filter(Boolean),
           })
         case FormResponseMode.Email:
           return

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -379,6 +379,7 @@ export type DuplicateFormOverwriteDto = {
   | {
       responseMode: FormResponseMode.Encrypt
       publicKey: string
+      emails: string[]
     }
   | {
       responseMode: FormResponseMode.Multirespondent


### PR DESCRIPTION
## Problem
https://www.notion.so/opengov/Allow-inputting-email-recipients-on-form-creation-13777dbba78880619402dd8d48ab7209

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Before & After Screenshots
| Before    | After |
| -------- | ------- |
| <img width="1214" alt="Screenshot 2025-01-23 at 2 49 26 PM" src="https://github.com/user-attachments/assets/22b5390e-4c62-451c-a4e6-8c00118654a7" /> |  <img width="1209" alt="Screenshot 2025-01-23 at 2 50 47 PM" src="https://github.com/user-attachments/assets/bd089a47-95b7-44b0-b7f1-cbf161eff154" />|

## Tests

**Encrypt forms**
- [ ] 1. Create encrypt mode form
- [ ] 2. Observe that the admin email is inserted by default
- [ ] 3. Observe that the email input field is optional. 
- [ ] 4. Add your email, and create the form. Navigate to the email settings page
- [ ] 5. Observe that the email inputted earlier exists (or empty if not included earlier)
- [ ] 6. Repeat steps 1 to 5, but leave the email empty and observe that the email settings page doesn't show any emails. 

**Duplicated forms**
- [ ] 1. Create an email mode form, with the admin email inside. 
- [ ] 2. Duplicate that form to encrypt mode
- [ ] 3. Observe that the email input is present, and is optional
- [ ] 4. Observe that the emails are **NOT** carried over from the duplicated form. 
- [ ] 5. Repeat for encrypt to encrypt mode duplication. 

**Template workflow**
- [ ] 1. Create an email/encrypt mode form, with any non admin email. 
- [ ] 2. Make the form public and open the link to the template
- [ ] 3. Click on the use as template button, observe that the email inputted in step 1 doesn't exist, and only your admin exists
- [ ] 4. Observe that the emails are not carried over. 

