### PR TITLE
feat: add json collation data to emails

### DIFF
--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -1450,5 +1450,123 @@ describe('encrypt-submission.controller', () => {
         }),
       )
     })
+
+    it('should pass expected dataCollationData to sendSubmissionToAdmin', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockForm = {
+        _id: mockFormId,
+        title: 'Test Form',
+        authType: FormAuthType.NIL,
+        form_fields: [] as FormFieldSchema[],
+        emails: ['test@example.com'],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
+
+      const mockResponses = [
+        {
+          _id: new ObjectId(),
+          question: '[MyInfo] Test Question',
+          answer: 'Test Answer',
+          fieldType: 'text',
+          isVisible: true,
+        },
+      ]
+
+      const mockReq = merge(
+        expressHandler.mockRequest({
+          params: { formId: mockFormId.toHexString() },
+          body: {
+            responses: mockResponses,
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'mockEncryptedContent',
+              version: 1,
+            },
+            formDef: {},
+            encryptedFormDef: mockForm,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitEncryptModeFormForTest(mockReq, mockRes)
+
+      // Assert
+      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dataCollationData: expect.arrayContaining([
+            expect.objectContaining({
+              question: 'Test Question',
+              answer: 'Test Answer',
+            }),
+          ]),
+        }),
+      )
+    })
+
+    it('should strip [MyInfo] prefix from expected dataCollationData to sendSubmissionToAdmin', async () => {
+      // Arrange
+      const mockFormId = new ObjectId()
+      const mockForm = {
+        _id: mockFormId,
+        title: 'Test Form',
+        authType: FormAuthType.NIL,
+        form_fields: [] as FormFieldSchema[],
+        emails: ['test@example.com'],
+        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      } as IPopulatedEncryptedForm
+
+      const mockResponses = [
+        {
+          _id: new ObjectId(),
+          question: '[MyInfo] Name',
+          answer: 'Test Answer',
+          fieldType: 'text',
+          isVisible: true,
+        },
+      ]
+
+      const mockReq = merge(
+        expressHandler.mockRequest({
+          params: { formId: mockFormId.toHexString() },
+          body: {
+            responses: mockResponses,
+          },
+        }),
+        {
+          formsg: {
+            encryptedPayload: {
+              encryptedContent: 'mockEncryptedContent',
+              version: 1,
+            },
+            formDef: {},
+            encryptedFormDef: mockForm,
+          } as unknown as EncryptSubmissionDto,
+        } as unknown as FormCompleteDto,
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitEncryptModeFormForTest(mockReq, mockRes)
+
+      // Assert
+      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dataCollationData: expect.arrayContaining([
+            expect.objectContaining({
+              question: 'Name',
+              answer: 'Test Answer',
+            }),
+          ]),
+        }),
+      )
+    })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -55,6 +55,7 @@ import { SgidService } from '../../sgid/sgid.service'
 import { getOidcService } from '../../spcp/spcp.oidc.service'
 import { getPopulatedUserById } from '../../user/user.service'
 import * as VerifiedContentService from '../../verified-content/verified-content.service'
+import { MYINFO_PREFIX } from '../email-submission/email-submission.constants'
 import * as EmailSubmissionService from '../email-submission/email-submission.service'
 import { SubmissionEmailObj } from '../email-submission/email-submission.util'
 import * as EncryptSubmissionMiddleware from '../encrypt-submission/encrypt-submission.middleware'
@@ -791,6 +792,16 @@ const _createSubmission = async ({
     new Set(), // the MyInfo prefixes are already inserted in middleware
     form.authType,
   )
+
+  // Since we insert the [MyInfo] prefix in `encrypt-submission.middleware.ts`:L434
+  // we want to remove it for the dataCollationData
+  const dataCollationData = emailData.dataCollationData.map((item) => ({
+    question: item.question.startsWith(MYINFO_PREFIX)
+      ? item.question.slice(MYINFO_PREFIX.length)
+      : item.question,
+    answer: item.answer,
+  }))
+
   // We don't await for email submission, as the submission gets saved for encrypt
   // submissions regardless, the email is more of a notification and shouldn't
   // stop the storage of the data in the db
@@ -804,7 +815,7 @@ const _createSubmission = async ({
       },
       attachments: unencryptedAttachments,
       formData: emailData.formData,
-      dataCollationData: emailData.dataCollationData,
+      dataCollationData,
     })
   }
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -804,6 +804,7 @@ const _createSubmission = async ({
       },
       attachments: unencryptedAttachments,
       formData: emailData.formData,
+      dataCollationData: emailData.dataCollationData,
     })
   }
 

--- a/src/app/views/templates/submit-form-email.server.view.html
+++ b/src/app/views/templates/submit-form-email.server.view.html
@@ -36,10 +36,6 @@
     <p>The <%= appName %> Support Team</p>
     <br /><br /><br />
     <% if (typeof dataCollationData !== 'undefined') { %> ===============
-    <p>
-      Please ignore this section. It is meant for the Data Collation Tool to
-      process.
-    </p>
     <p>-- Start of JSON --</p>
     <%= JSON.stringify(dataCollationData) %>
     <p>-- End of JSON --</p>


### PR DESCRIPTION
## Problem

Support JSON in the email summary of responses in order to move large agency use cases over from Email to Storage mode.

Closes FRM-1930

## Solution
Pass the email data collation to the mail service

**Breaking Changes** 
- No - this PR is backwards compatible  

## Before & After Screenshots
| Before | After |
| --- | --- |
| <img width="1229" alt="Screenshot 2025-01-23 at 3 33 20 PM" src="https://github.com/user-attachments/assets/b0832dd2-09c2-4625-9a00-7da01f37b6f9" /> | <img width="1386" alt="Screenshot 2025-01-23 at 3 32 38 PM" src="https://github.com/user-attachments/assets/e9d4b0c5-278f-41ab-b8bd-909d7afa1f3e" /> | 

## Tests

**Encrypt Mode Form**
- [ ] 1. Create Encrypt form
- [ ] 2. Add singpass fields
- [ ] 3. Add admin email and open the form. Enable response pdfs as well. 
- [ ] 4. Create a submission
- [ ] 5. In the email, ensure that teh "[MyInfo]" field is **not** included in the json. 
- [ ] 6. Ensure that the "[MyInfo]" **IS** included in the table in the email.
- [ ] 7. Ensure that the response pdf does contain the "[MyInfo]" prefix
- [ ] 8. In the responses page, ensure that the individual submissions contain the "[MyInfo]" prefix