### PR TITLE
fix: joi validation to allow emails for duplicating forms

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -195,7 +195,7 @@ const duplicateFormValidator = celebrate({
           // When duplicating forms, we reset the `emails` field to be empty
           // Refer to `admin-form.utils.ts`.
           is: FormResponseMode.Encrypt,
-          then: Joi.forbidden(),
+          then: Joi.array().items(Joi.string().email()).required(),
         },
         {
           is: FormResponseMode.Multirespondent,


### PR DESCRIPTION
## Problem

Admins report that they get an error "[emails] is not allowed". This is due to the Joi validation not accounting for the emails being pass to the duplicate form dto. This fixes it by allowing it. 


**Breaking Changes** 
- [x] No - this PR is backwards compatible  