### PR TITLE
chore: remove coverage restriction, inspect through datadog instead

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,11 +23,6 @@ module.exports = {
   ],
   coveragePathIgnorePatterns: ['./node_modules/', './tests'],
   coverageReporters: ['lcov', 'text'],
-  coverageThreshold: {
-    global: {
-      statements: 38, // Increase this percentage as test coverage improves
-    },
-  },
   testTimeout: 300000, // Set timeout to be 300s to reduce test flakiness
   maxWorkers: '4',
   globals: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

After we've introduced [datadog test impact analysis](https://docs.datadoghq.com/tests/test_impact_analysis/) a selected set of test files would only be executed which jest's coverage isn't able to properly account for. 

## Solution
<!-- How did you solve the problem? -->

Remove coverage requirements as we should be able to monitor this through datadog and prevent devs from needing to do wasteful work by re-running the pipeline. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
