### PR TITLE
fix: hawkeye v1.0 pending response at missing bug

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -166,6 +166,9 @@ export const IndividualResponsePage = (): JSX.Element => {
       )
     : ''
 
+  const workflowCurrentStepNumber = data?.mrf?.workflowCurrentStepNumber
+  const workflowNumTotalSteps = data?.mrf?.workflowNumTotalSteps
+
   return (
     <Flex flexDir="column" marginTop={{ base: '-1.5rem', md: '-3rem' }}>
       <IndividualResponseNavbar />
@@ -191,11 +194,17 @@ export const IndividualResponsePage = (): JSX.Element => {
               />
               <StackRow
                 label={MRF_PENDING_RESPONSE_AT_LABEL}
-                value={getPendingResponseAtString({
-                  workflowCurrentStepNumber:
-                    data?.mrf?.workflowCurrentStepNumber,
-                  workflowNumTotalSteps: data?.mrf?.workflowNumTotalSteps,
-                })}
+                value={
+                  workflowStatus === undefined ||
+                  workflowCurrentStepNumber === undefined ||
+                  workflowNumTotalSteps === undefined
+                    ? ''
+                    : getPendingResponseAtString({
+                        workflowStatus,
+                        workflowCurrentStepNumber,
+                        workflowNumTotalSteps,
+                      })
+                }
                 isLoading={isLoading}
                 isError={isError}
               />

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -220,11 +220,23 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   },
   {
     Header: MRF_PENDING_RESPONSE_AT_LABEL,
-    accessor: ({ mrf }) =>
-      getPendingResponseAtString({
-        workflowCurrentStepNumber: mrf?.workflowCurrentStepNumber,
-        workflowNumTotalSteps: mrf?.workflowNumTotalSteps,
-      }),
+    accessor: ({ mrf }) => {
+      const workflowStatus = mrf?.workflowStatus
+      const workflowCurrentStepNumber = mrf?.workflowCurrentStepNumber
+      const workflowNumTotalSteps = mrf?.workflowNumTotalSteps
+      if (
+        workflowStatus === undefined ||
+        workflowCurrentStepNumber === undefined ||
+        workflowNumTotalSteps === undefined
+      ) {
+        return ''
+      }
+      return getPendingResponseAtString({
+        workflowStatus,
+        workflowCurrentStepNumber,
+        workflowNumTotalSteps,
+      })
+    },
     width: 200,
     minWidth: 180,
     maxWidth: 220,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -409,6 +409,7 @@ describe('EncryptedResponseCsvGenerator', () => {
           mockRecord.submissionId,
           MRF_STATUS.COMPLETED,
           getPendingResponseAtString({
+            workflowStatus: mockRecord.mrfMeta.workflowStatus,
             workflowCurrentStepNumber:
               mockRecord.mrfMeta.workflowCurrentStepNumber,
             workflowNumTotalSteps: mockRecord.mrfMeta.workflowNumTotalSteps,

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -407,7 +407,7 @@ describe('EncryptedResponseCsvGenerator', () => {
         ])
         const expectedSubmissionRow = stringify([
           mockRecord.submissionId,
-          MRF_STATUS.COMPLETED,
+          MRF_STATUS.REJECTED,
           getPendingResponseAtString({
             workflowStatus: mockRecord.mrfMeta.workflowStatus,
             workflowCurrentStepNumber:

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.ts
@@ -144,10 +144,20 @@ export class EncryptedResponseCsvGenerator extends CsvGenerator {
           ? getStatusFromWorkflowStatus(workflowStatus)
           : ''
         row.push(mrfSubmissionStatus)
-        const pendingAtString = getPendingResponseAtString({
-          workflowCurrentStepNumber: up.mrfMeta?.workflowCurrentStepNumber,
-          workflowNumTotalSteps: up.mrfMeta?.workflowNumTotalSteps,
-        })
+
+        const workflowCurrentStepNumber = up.mrfMeta?.workflowCurrentStepNumber
+        const workflowNumTotalSteps = up.mrfMeta?.workflowNumTotalSteps
+
+        const pendingAtString =
+          workflowStatus === undefined ||
+          workflowCurrentStepNumber === undefined ||
+          workflowNumTotalSteps === undefined
+            ? ''
+            : getPendingResponseAtString({
+                workflowStatus,
+                workflowCurrentStepNumber,
+                workflowNumTotalSteps,
+              })
         row.push(pendingAtString)
 
         const lastSubmittedAt = up.mrfMeta?.lastSubmittedAt

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.test.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.test.ts
@@ -1,0 +1,59 @@
+import { WorkflowStatus } from '~shared/types'
+
+import { getPendingResponseAtString } from './mrfSubmissionView'
+
+describe('getPendingResponseAtString', () => {
+  test('should return empty string when workflow status is approved', () => {
+    const result = getPendingResponseAtString({
+      workflowStatus: WorkflowStatus.APPROVED,
+      workflowCurrentStepNumber: 1,
+      workflowNumTotalSteps: 2,
+    })
+    expect(result).toBe('')
+  })
+
+  test('should return empty string when workflow status is rejected', () => {
+    const result = getPendingResponseAtString({
+      workflowStatus: WorkflowStatus.REJECTED,
+      workflowCurrentStepNumber: 1,
+      workflowNumTotalSteps: 2,
+    })
+    expect(result).toBe('')
+  })
+
+  test('should return empty string when workflow status is completed', () => {
+    const result = getPendingResponseAtString({
+      workflowStatus: WorkflowStatus.COMPLETED,
+      workflowCurrentStepNumber: 1,
+      workflowNumTotalSteps: 2,
+    })
+    expect(result).toBe('')
+  })
+
+  test('should return empty string when workflowCurrentStepNumber === workflowNumTotalSteps', () => {
+    const result = getPendingResponseAtString({
+      workflowStatus: WorkflowStatus.PENDING,
+      workflowCurrentStepNumber: 2,
+      workflowNumTotalSteps: 2,
+    })
+    expect(result).toBe('')
+  })
+
+  test('should return empty string when workflowCurrentStepNumber > workflowNumTotalSteps', () => {
+    const result = getPendingResponseAtString({
+      workflowStatus: WorkflowStatus.PENDING,
+      workflowCurrentStepNumber: 3,
+      workflowNumTotalSteps: 2,
+    })
+    expect(result).toBe('')
+  })
+
+  test('should return correct workflowCurrentStepNumber of workflowNumTotalSteps string when workflow status is pending and workflowCurrentStepNumber < workflowNumTotalSteps', () => {
+    const result = getPendingResponseAtString({
+      workflowStatus: WorkflowStatus.PENDING,
+      workflowCurrentStepNumber: 1,
+      workflowNumTotalSteps: 2,
+    })
+    expect(result).toBe('Step 1 of 2')
+  })
+})

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -5,20 +5,19 @@ export enum MRF_STATUS {
   PENDING = 'Pending',
 }
 
-interface CurrentStepInfo {
-  workflowCurrentStepNumber: number | undefined
-  workflowNumTotalSteps: number | undefined
+interface CurrentWorkflowInfo {
+  workflowStatus: WorkflowStatus
+  workflowCurrentStepNumber: number
+  workflowNumTotalSteps: number
 }
 
 /** Gets the business friendly message for the current pending step of the workflow.  */
 export const getPendingResponseAtString = ({
+  workflowStatus,
   workflowCurrentStepNumber,
   workflowNumTotalSteps,
-}: CurrentStepInfo) => {
-  if (!workflowCurrentStepNumber || !workflowNumTotalSteps) {
-    return ''
-  }
-  const isPending = workflowCurrentStepNumber < workflowCurrentStepNumber
+}: CurrentWorkflowInfo) => {
+  const isPending = workflowStatus === WorkflowStatus.PENDING
   if (!isPending) {
     return ''
   }
@@ -32,7 +31,10 @@ export const getPendingResponseAtString = ({
 const getCurrentStepString = ({
   workflowCurrentStepNumber,
   workflowNumTotalSteps,
-}: CurrentStepInfo) => {
+}: Pick<
+  CurrentWorkflowInfo,
+  'workflowNumTotalSteps' | 'workflowCurrentStepNumber'
+>) => {
   return workflowCurrentStepNumber && workflowNumTotalSteps
     ? `Step ${workflowCurrentStepNumber} of ${workflowNumTotalSteps}`
     : ''

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -7,7 +7,7 @@ export enum MRF_STATUS {
 
 interface CurrentWorkflowInfo {
   workflowStatus: WorkflowStatus
-  workflowCurrentStepNumber: number
+  workflowCurrentStepNumber: number // note that this is 1-indexed
   workflowNumTotalSteps: number
 }
 
@@ -17,7 +17,9 @@ export const getPendingResponseAtString = ({
   workflowCurrentStepNumber,
   workflowNumTotalSteps,
 }: CurrentWorkflowInfo) => {
-  const isPending = workflowStatus === WorkflowStatus.PENDING
+  const isPending =
+    workflowStatus === WorkflowStatus.PENDING &&
+    workflowCurrentStepNumber < workflowNumTotalSteps
   if (!isPending) {
     return ''
   }

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -3,6 +3,8 @@ import { WorkflowStatus } from '~shared/types'
 export enum MRF_STATUS {
   COMPLETED = 'Completed',
   PENDING = 'Pending',
+  APPROVED = 'Approved',
+  REJECTED = 'Not approved',
 }
 
 interface CurrentWorkflowInfo {
@@ -48,9 +50,11 @@ export const getStatusFromWorkflowStatus = (
 ): MRF_STATUS => {
   switch (workflowStatus) {
     case WorkflowStatus.COMPLETED:
-    case WorkflowStatus.APPROVED:
-    case WorkflowStatus.REJECTED:
       return MRF_STATUS.COMPLETED
+    case WorkflowStatus.APPROVED:
+      return MRF_STATUS.APPROVED
+    case WorkflowStatus.REJECTED:
+      return MRF_STATUS.REJECTED
     case WorkflowStatus.PENDING:
       return MRF_STATUS.PENDING
     default: {


### PR DESCRIPTION
## Problem 
The pending response at was not showing up for pending status results on the hawkeye dashboard. This was due to a typo in the getResponseAtString function. 

## Solution 
- Pass in workflowStatus and check if is Pending. 
- Prevent re-occurrence by adding automated TCs for the getResponseAtString to expected output for a set of inputs. 
- Prevent passing of wrong props by matching the params in the args. 