### PR TITLE
fix: also match amount paid

### DIFF
--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -507,6 +507,10 @@ export const convertToProofOfPaymentFormat = (
           '<strong>Amount charged</strong>',
           `<strong>Amount charged</strong> <i>(includes GST)</i>`,
         )
+        .replace(
+          '<strong>Amount paid</strong>',
+          `<strong>Amount paid</strong> <i>(includes GST)</i>`,
+        )
     : paymentByProductsEdits
         .replace(
           /Receipt (#[0-9-]+)/,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We have received reports that `includes GST` is not shown on the invoice. 

## Solution
<!-- How did you solve the problem? -->

Stripe has changed their receipt wording from "Amount charged" to "Amount paid".
We will match both `Amount charged` and `Amount paid`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
### Regression
- [ ] Find an existing payment form with existing payments that has GST enabled
- [ ] Click download payment invoice
- [ ] Observe that it should reflect "Amount paid (includes GST)"
