### PR TITLE
feat: mrf attachment support in confirmation email 

### DIFF
--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -213,9 +213,6 @@ export const createClearSubmissionWithVirusScanningFormDataV3 = (
   )
 
   const attachments = getAttachmentsMap(formFields, formInputs)
-  console.log('here i am')
-  console.log(responses)
-  console.log(attachments)
 
   // Convert content to FormData object.
   const formData = new FormData()
@@ -239,7 +236,6 @@ export const createClearSubmissionWithVirusScanningFormDataV3 = (
       }
     })
   }
-  console.log(formData)
 
   return formData
 }

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -213,6 +213,9 @@ export const createClearSubmissionWithVirusScanningFormDataV3 = (
   )
 
   const attachments = getAttachmentsMap(formFields, formInputs)
+  console.log('here i am')
+  console.log(responses)
+  console.log(attachments)
 
   // Convert content to FormData object.
   const formData = new FormData()
@@ -236,6 +239,7 @@ export const createClearSubmissionWithVirusScanningFormDataV3 = (
       }
     })
   }
+  console.log(formData)
 
   return formData
 }

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -135,6 +135,7 @@ const submitMultirespondentForm = async (
     form,
     encryptedPayload,
     logMeta,
+    attachments: req.formsg.unencryptedAttachments,
   })
 }
 
@@ -221,6 +222,7 @@ const updateMultirespondentSubmission = async (
     currentStepNumber,
     encryptedPayload,
     logMeta,
+    attachments: req.formsg.unencryptedAttachments,
   })
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -4,6 +4,8 @@ import { NextFunction } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
+import { IAttachmentInfo } from 'src/types'
+
 import {
   BasicField,
   FormDto,
@@ -44,6 +46,7 @@ import {
 } from '../submission.service'
 import {
   getEncryptedAttachmentsMapFromAttachmentsMap,
+  isAttachmentResponseV3,
   mapRouteError,
 } from '../submission.utils'
 
@@ -637,6 +640,8 @@ export const encryptSubmission = async (
     ParsedClearFormFieldResponseV3 | StrippedAttachmentResponseV3
   > = {}
 
+  const unencryptedAttachments: IAttachmentInfo[] = []
+
   // Populate attachment map
   for (const id of Object.keys(responses)) {
     const response = responses[id]
@@ -649,6 +654,19 @@ export const encryptSubmission = async (
       ...response,
       answer: { ...response.answer, filename: undefined, content: undefined },
     }
+
+    // collect unencrypted attachments to include in email notifications
+    if (isAttachmentResponseV3(response)) {
+      unencryptedAttachments.push({
+        filename: response.answer.filename,
+        content: response.answer.content,
+        fieldId: id,
+      })
+    }
+  }
+
+  if (req.formsg) {
+    req.formsg.unencryptedAttachments = unencryptedAttachments
   }
 
   const {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -11,6 +11,7 @@ import {
 import { getMultirespondentSubmissionEditPath } from '../../../../../shared/utils/urls'
 import {
   Environment,
+  IAttachmentInfo,
   IMultirespondentSubmissionSchema,
   IPopulatedForm,
   IPopulatedMultirespondentForm,
@@ -181,6 +182,7 @@ const sendMrfOutcomeEmails = ({
   submissionId,
   isApproval = false,
   isRejected = false,
+  attachments,
 }: {
   currentStepNumber: number
   form: IPopulatedMultirespondentForm
@@ -188,12 +190,15 @@ const sendMrfOutcomeEmails = ({
   submissionId: string
   isApproval?: boolean
   isRejected?: boolean
+  attachments?: IAttachmentInfo[]
 }): ResultAsync<true, InvalidWorkflowTypeError | MailSendError> => {
   const logMeta = {
     action: 'sendMrfOutcomeEmails',
     formId: form._id?.toString(),
     submissionId,
   }
+  // console.log('here i am')
+  // console.log(responses)
   const emailsToNotify =
     form.emails && Array.isArray(form.emails) ? form.emails : []
 
@@ -290,6 +295,7 @@ const sendMrfOutcomeEmails = ({
           formTitle: form.title,
           responseId: submissionId,
           formQuestionAnswers,
+          attachments: attachments,
         }).orElse((error) => {
           logger.error({
             message: 'Failed to send workflow completion email',
@@ -407,11 +413,13 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   form,
   encryptedPayload,
   logMeta,
+  attachments,
 }: {
   submissionId: string
   form: IPopulatedMultirespondentForm
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
+  attachments?: IAttachmentInfo[]
 }): ResultAsync<boolean, InvalidWorkflowTypeError | MailSendError> => {
   const { submissionSecretKey, responses } = encryptedPayload
   const currentStepNumber = 0
@@ -451,6 +459,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
         form,
         responses,
         submissionId,
+        attachments,
       })
     })
     .mapErr((error) => {
@@ -549,12 +558,14 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   currentStepNumber,
   encryptedPayload,
   logMeta,
+  attachments,
 }: {
   submissionId: string
   form: IPopulatedMultirespondentForm
   currentStepNumber: number
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
+  attachments?: IAttachmentInfo[]
 }): ResultAsync<
   boolean,
   | InvalidWorkflowTypeError
@@ -604,6 +615,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
       submissionId,
       isApproval: true,
       isRejected: true,
+      attachments: attachments,
     }).mapErr((error) => {
       logger.error({
         message: 'Send mrf outcome email error',
@@ -619,6 +631,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     responses,
     submissionId,
     isApproval: checkIsFormApproval(form),
+    attachments: attachments,
   })
     .mapErr((error) => {
       logger.error({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -197,8 +197,6 @@ const sendMrfOutcomeEmails = ({
     formId: form._id?.toString(),
     submissionId,
   }
-  // console.log('here i am')
-  // console.log(responses)
   const emailsToNotify =
     form.emails && Array.isArray(form.emails) ? form.emails : []
 

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -561,6 +561,15 @@ export const isAttachmentResponse = (
   )
 }
 
+export const isAttachmentResponseV3 = (
+  response: ParsedClearFormFieldResponseV3,
+): response is ParsedClearAttachmentResponseV3 => {
+  return (
+    response.fieldType === BasicField.Attachment &&
+    response.answer.content !== undefined
+  )
+}
+
 /**
  * Checks if a response is a quarantined attachment response to be processed by the virus scanner.
  */

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -547,7 +547,8 @@ export class MailService {
     const submissionTime = moment(submission.created)
       .tz('Asia/Singapore')
       .format('ddd, DD MMM YYYY hh:mm:ss A')
-
+    console.log('here i am storage')
+    console.log(attachments)
     // Add in additional metadata to dataCollationData.
     // Unshift is not used as it mutates the array.
     const htmlData: SubmissionToAdminHtmlData = {
@@ -870,12 +871,14 @@ export class MailService {
     formTitle,
     responseId,
     formQuestionAnswers,
+    attachments,
   }: {
     emails: string[]
     formId: string
     formTitle: string
     responseId: string
     formQuestionAnswers: QuestionAnswer[]
+    attachments?: Mail.Attachment[]
   }) => {
     const htmlData = {
       formTitle,
@@ -906,6 +909,7 @@ export class MailService {
         from: this.#senderFromString,
         subject: `Completed - ${formTitle} (${responseId})`,
         html: mailHtml,
+        attachments,
         headers: {
           [EMAIL_HEADERS.emailType]: EmailType.WorkflowNotification,
         },

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -547,8 +547,7 @@ export class MailService {
     const submissionTime = moment(submission.created)
       .tz('Asia/Singapore')
       .format('ddd, DD MMM YYYY hh:mm:ss A')
-    console.log('here i am storage')
-    console.log(attachments)
+
     // Add in additional metadata to dataCollationData.
     // Unshift is not used as it mutates the array.
     const htmlData: SubmissionToAdminHtmlData = {

--- a/src/types/vendor/express.d.ts
+++ b/src/types/vendor/express.d.ts
@@ -46,6 +46,7 @@ declare global {
             formDef?: IPopulatedMultirespondentForm
             featureFlags?: string[]
             encryptedPayload?: MultirespondentSubmissionDto
+            unencryptedAttachments?: IAttachmentInfo[]
           }
     }
   }


### PR DESCRIPTION
## Problem
MRF mode forms do not include attachments as part of the confirmation email workflow.

## Solution
- pass in unencrypted attachments data during 'encryptSubmission' flow in controller (similar to storage/email mode)
- req.formsg.unencryptedAttachments will have attachments data which then is passed into in `sendMrfOutcomes emails`, and included in `sendMrfWorkflowCompletionEmail`
- include attachments in MRF confirmation emails


**Breaking Changes** 
- [X] No - this PR is backwards compatible  

TCs:
#### Submission of attachments in step 1 of multi-step
- [ ] Create a MRF mode form, add 1 attachment field and 1 other basic field
- [ ] Set up a workflow, assign attachment field to step 1, other basic field to step 2
   (you can specify your own email for nextWorkflowEmail)
- [ ] Attempt a submission for step 1 (attachment field active here) and step 2
- [ ] Verify that confirmation email contains the attachment

#### Submission of attachments in step 2 of multi-step
- [ ] Reuse form from previous test
- [ ] Edit workflow to assign attachment field to step 2, and basic field to step 1
- [ ] Attempt a submission for step 1 and step 2 (attachment field active here)
- [ ] Verify that confirmation email contains the attachment

#### Submission of different attachments in step 1 & 2 of multi-step
- [ ] Re-use form from previous test
- [ ] Edit workflow to assign attachment field to step 1 & 2
- [ ] Attempt a submission for step 1
- [ ] Attempt a submission for step 2 (use a different attachment than the one uploaded in step 1)
- [ ] Verify that confirmation email contains the attachment uploaded in step 2, **NOT step 1**

#### Submission of attachment (same field) in step 1 & 2
- [ ] Re-use form from previous test
- [ ] Add an additional attachment field into form
- [ ] Include an additional workflow step (step 3), assign new attachment field to step 3
- [ ] Attempt a submission for step 1, step 2 and step 3
- [ ] Verify that confirmation email contains both attachments

Check for expected behaviour:
- If there are 2 attachment fields, split across 2 different workflow steps, if I submit the exact same attachment in them, only 1 will show up.
- This is different from if 2 attachment fields are in the same step and i submit the same attachment in them, both will show up in the email.
