### PR TITLE
chore: update actions/cache to v4

### DIFF
--- a/.github/workflows/aws-deploy-scanner.yml
+++ b/.github/workflows/aws-deploy-scanner.yml
@@ -37,7 +37,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Cache Node.js modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.OS }}-node-scanner-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
       - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -67,7 +67,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       # Load cached node_modules
       - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -100,7 +100,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       # Load cached node_modules
       - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -133,7 +133,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       # Load cached node_modules
       - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -159,7 +159,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       # Load cached node_modules
       - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
@@ -197,7 +197,7 @@ jobs:
           cache-dependency-path: '**/package-lock.json'
       # Load cached node_modules
       - name: Cache Node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Github is closing down [actions/cachev1-v2](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down).

Closes FRM-1937

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
