### PR TITLE
fix: return ExpectedResponseNotFoundError as 4xx

### DIFF
--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -126,6 +126,7 @@ import {
   AttachmentUploadError,
   ConflictError,
   DownloadCleanFileFailedError,
+  ExpectedResponseNotFoundError,
   FeatureDisabledError,
   InvalidEncodingError,
   InvalidFieldIdError,
@@ -342,6 +343,7 @@ const errorMapper: MapRouteError = (
     case AttachmentSizeLimitExceededError:
     case InvalidFileKeyError:
     case MaliciousFileDetectedError:
+    case ExpectedResponseNotFoundError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When the approval logic is hidden from respondent and we reject the submission with a 5xx. The user will be met with something a wrong error instead of something that's more legible.

Closes FRM-1951

## Solution
<!-- How did you solve the problem? -->

As this is purely a configuration issue rather than an action that requires intervention of the service issue it should return 4xx instead of 5xx.

Returning a 4xx also provides context of the failure.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Component | Before | After |
|--------|--------|--------|
| Cell | ![Screenshot 2025-02-20 at 6 42 38 PM](https://github.com/user-attachments/assets/2fd078b3-c57e-4c98-9e9b-e6860bd38785) | ![Screenshot 2025-02-20 at 6 42 11 PM](https://github.com/user-attachments/assets/a62cd87e-cc08-44fc-b2df-1bec3001f8e9) |
| asdasd |![Screenshot 2025-02-20 at 6 42 43 PM](https://github.com/user-attachments/assets/ac9a04bb-b9dc-4cb7-8499-7b1ff6f3ebbe) | ![Screenshot 2025-02-20 at 6 41 26 PM](https://github.com/user-attachments/assets/af699030-4d8c-49fd-a7e8-09943bd1477f)|

## Tests
<!-- What tests should be run to confirm functionality? -->

### Submission of invalid approval fields should return 4xx
- [ ] Create an MRF form with approval field and radio field
- [ ] Set up with logic on radio field to hide approval field
- [ ] Set up 1st step of workflow with no fields to fill in
- [ ] Set up 2nd step of workflow with approval field
- [ ] As a respondent, submit as a first respondent with no fields populated
- [ ] Ensure that 4xx error is returned in the network tab when submitting as a second respondent with no fields populated
- [ ] Ensure that the error dialog appears with "Response for the Yes/No field for this approval step is not found" when submitting as a second respondent with no fields populated