### PR TITLE
feat: json support in mrf

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -20,7 +20,6 @@ import {
   updateMultirespondentSubmissionForTest,
 } from '../multirespondent-submission.controller'
 import * as MultiRespondentSubmissionService from '../multirespondent-submission.service'
-import { number } from 'zod'
 
 jest.mock('src/app/modules/datadog/datadog.utils')
 

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -20,6 +20,7 @@ import {
   updateMultirespondentSubmissionForTest,
 } from '../multirespondent-submission.controller'
 import * as MultiRespondentSubmissionService from '../multirespondent-submission.service'
+import { number } from 'zod'
 
 jest.mock('src/app/modules/datadog/datadog.utils')
 
@@ -125,7 +126,7 @@ describe('multiresponodent-submision.controller', () => {
         form: mockSubmitMrfReq.formsg.formDef,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
         submissionId: mockSubmissionId,
-        timestamp: expect.any(String),
+        timestamp: expect.any(Number),
       })
       // Expect 200 ok
       expect(mockRes.status).not.toHaveBeenCalled() // default is 200 ok
@@ -359,7 +360,7 @@ describe('multiresponodent-submision.controller', () => {
         form: mockSubmitMrfReq.formsg.formDef,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
         submissionId: mockSubmissionId,
-        timestamp: expect.any(String),
+        timestamp: expect.any(Number),
       })
       // Expect 200 ok
       expect(mockRes.status).not.toHaveBeenCalled() // default is 200 ok

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -125,6 +125,7 @@ describe('multiresponodent-submision.controller', () => {
         form: mockSubmitMrfReq.formsg.formDef,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
         submissionId: mockSubmissionId,
+        timestamp: expect.any(String),
       })
       // Expect 200 ok
       expect(mockRes.status).not.toHaveBeenCalled() // default is 200 ok
@@ -358,6 +359,7 @@ describe('multiresponodent-submision.controller', () => {
         form: mockSubmitMrfReq.formsg.formDef,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
         submissionId: mockSubmissionId,
+        timestamp: expect.any(String),
       })
       // Expect 200 ok
       expect(mockRes.status).not.toHaveBeenCalled() // default is 200 ok

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -53,6 +53,9 @@ describe('multirespondent-submission.utils', () => {
     edit: [],
   }
 
+  const mockResponseId = new ObjectId().toHexString()
+  const mockTimestamp = '1708950612345' // Wed, 26 Feb 2025 10:01:30 PM
+
   describe('createMultirespondentSubmissionDto', () => {
     it('should create an encrypted submission DTO sucessfully', () => {
       // Arrange
@@ -278,9 +281,19 @@ describe('multirespondent-submission.utils', () => {
         } as EmailResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionTitleAnswerString({
+        formFields,
+        responses,
+        responseId: mockResponseId,
+        timestamp: mockTimestamp,
+      })
 
       expect(result).toEqual([
+        { question: 'Response ID', answer: mockResponseId },
+        {
+          question: 'Response Timestamp',
+          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+        },
         { question: 'Short Text', answer: 'Test answer' },
         { question: 'Number', answer: '42' },
         { question: 'Email', answer: 'test@example.com' },
@@ -302,9 +315,19 @@ describe('multirespondent-submission.utils', () => {
         } as AttachmentResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionTitleAnswerString({
+        formFields,
+        responses,
+        responseId: mockResponseId,
+        timestamp: mockTimestamp,
+      })
 
       expect(result).toEqual([
+        { question: 'Response ID', answer: mockResponseId },
+        {
+          question: 'Response Timestamp',
+          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+        },
         { question: '[Attachment] File Upload', answer: 'file.pdf' },
       ])
     })
@@ -347,9 +370,19 @@ describe('multirespondent-submission.utils', () => {
         } as TableResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionTitleAnswerString({
+        formFields,
+        responses,
+        responseId: mockResponseId,
+        timestamp: mockTimestamp,
+      })
 
       expect(result).toEqual([
+        { question: 'Response ID', answer: mockResponseId },
+        {
+          question: 'Response Timestamp',
+          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+        },
         {
           question: '[Table] Table of Name and Age (Name; Age)',
           answer: 'Alice; 30',
@@ -387,10 +420,23 @@ describe('multirespondent-submission.utils', () => {
         } as CheckboxResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionTitleAnswerString({
+        formFields,
+        responses,
+        responseId: mockResponseId,
+        timestamp: mockTimestamp,
+      })
 
       expect(result).toEqual([
-        { question: 'Checkbox', answer: 'Option 1,Option 2,Custom Option' },
+        { question: 'Response ID', answer: mockResponseId },
+        {
+          question: 'Response Timestamp',
+          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+        },
+        {
+          question: 'Checkbox',
+          answer: 'Option 1,Option 2,Others: Custom Option',
+        },
       ])
     })
 
@@ -418,9 +464,19 @@ describe('multirespondent-submission.utils', () => {
         } as AddressResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionTitleAnswerString({
+        formFields,
+        responses,
+        responseId: mockResponseId,
+        timestamp: mockTimestamp,
+      })
 
       expect(result).toEqual([
+        { question: 'Response ID', answer: mockResponseId },
+        {
+          question: 'Response Timestamp',
+          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+        },
         {
           question: 'Address',
           answer: '161, BUKIT BATOK STREET 11, #1-1, SINGAPORE 650161',
@@ -645,7 +701,12 @@ describe('multirespondent-submission.utils', () => {
       } as ShortTextResponseV3,
     }
 
-    const result = getQuestionTitleAnswerString({ formFields, responses })
+    const result = getQuestionTitleAnswerString({
+      formFields,
+      responses,
+      responseId: mockResponseId,
+      timestamp: mockTimestamp,
+    })
 
     expect(result).toEqual([])
   })
@@ -662,12 +723,16 @@ describe('multirespondent-submission.utils', () => {
     const undefinedResult = getQuestionTitleAnswerString({
       formFields,
       responses: undefined as unknown as FieldResponsesV3,
+      responseId: mockResponseId,
+      timestamp: mockTimestamp,
     })
     expect(undefinedResult).toEqual([])
 
     const nullResult = getQuestionTitleAnswerString({
       formFields,
       responses: null as unknown as FieldResponsesV3,
+      responseId: mockResponseId,
+      timestamp: mockTimestamp,
     })
     expect(nullResult).toEqual([])
   })

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -54,7 +54,7 @@ describe('multirespondent-submission.utils', () => {
   }
 
   const mockResponseId = new ObjectId().toHexString()
-  const mockTimestamp = 1708950612345 // Wed, 26 Feb 2025 10:01:30 PM
+  const mockTimestamp = 1740607290000 // Wed, 26 Feb 2025 10:01:30 PM
 
   describe('createMultirespondentSubmissionDto', () => {
     it('should create an encrypted submission DTO sucessfully', () => {
@@ -384,20 +384,20 @@ describe('multirespondent-submission.utils', () => {
           answer: 'Wed, 26 Feb 2025 10:01:30 PM',
         },
         {
-          question: '[Table] Table of Name and Age (Name; Age)',
-          answer: 'Alice; 30',
+          question: '[Table] Table of Name and Age (Name, Age)',
+          answer: 'Alice, 30',
         },
         {
-          question: '[Table] Table of Name and Age (Name; Age)',
-          answer: 'Bob; 25',
+          question: '[Table] Table of Name and Age (Name, Age)',
+          answer: 'Bob, 25',
         },
         {
-          question: '[Table] Table of Hobbies (Hobby; Years)',
-          answer: 'Swimming; 5',
+          question: '[Table] Table of Hobbies (Hobby, Years)',
+          answer: 'Swimming, 5',
         },
         {
-          question: '[Table] Table of Hobbies (Hobby; Years)',
-          answer: 'Reading; 10',
+          question: '[Table] Table of Hobbies (Hobby, Years)',
+          answer: 'Reading, 10',
         },
       ])
     })

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -54,7 +54,7 @@ describe('multirespondent-submission.utils', () => {
   }
 
   const mockResponseId = new ObjectId().toHexString()
-  const mockTimestamp = 1740607290000 // Wed, 26 Feb 2025 10:01:30 PM
+  const mockTimestamp = 1740607290000 // Thu, 27 Feb 2025 06:01:30 AM
 
   describe('createMultirespondentSubmissionDto', () => {
     it('should create an encrypted submission DTO sucessfully', () => {
@@ -292,7 +292,7 @@ describe('multirespondent-submission.utils', () => {
         { question: 'Response ID', answer: mockResponseId },
         {
           question: 'Response Timestamp',
-          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+          answer: 'Thu, 27 Feb 2025 06:01:30 AM',
         },
         { question: 'Short Text', answer: 'Test answer' },
         { question: 'Number', answer: '42' },
@@ -326,7 +326,7 @@ describe('multirespondent-submission.utils', () => {
         { question: 'Response ID', answer: mockResponseId },
         {
           question: 'Response Timestamp',
-          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+          answer: 'Thu, 27 Feb 2025 06:01:30 AM',
         },
         { question: '[Attachment] File Upload', answer: 'file.pdf' },
       ])
@@ -381,7 +381,7 @@ describe('multirespondent-submission.utils', () => {
         { question: 'Response ID', answer: mockResponseId },
         {
           question: 'Response Timestamp',
-          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+          answer: 'Thu, 27 Feb 2025 06:01:30 AM',
         },
         {
           question: '[Table] Table of Name and Age (Name, Age)',
@@ -431,7 +431,7 @@ describe('multirespondent-submission.utils', () => {
         { question: 'Response ID', answer: mockResponseId },
         {
           question: 'Response Timestamp',
-          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+          answer: 'Thu, 27 Feb 2025 06:01:30 AM',
         },
         {
           question: 'Checkbox',
@@ -475,7 +475,7 @@ describe('multirespondent-submission.utils', () => {
         { question: 'Response ID', answer: mockResponseId },
         {
           question: 'Response Timestamp',
-          answer: 'Wed, 26 Feb 2025 10:01:30 PM',
+          answer: 'Thu, 27 Feb 2025 06:01:30 AM',
         },
         {
           question: 'Address',

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -54,7 +54,7 @@ describe('multirespondent-submission.utils', () => {
   }
 
   const mockResponseId = new ObjectId().toHexString()
-  const mockTimestamp = '1708950612345' // Wed, 26 Feb 2025 10:01:30 PM
+  const mockTimestamp = 1708950612345 // Wed, 26 Feb 2025 10:01:30 PM
 
   describe('createMultirespondentSubmissionDto', () => {
     it('should create an encrypted submission DTO sucessfully', () => {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -132,7 +132,7 @@ const submitMultirespondentForm = async (
 
   await performMultiRespondentPostSubmissionCreateActions({
     submissionId: submission._id.toString(),
-    timestamp: (submission.created || new Date()).getTime().toString(),
+    timestamp: (submission.created || new Date()).getTime(),
     form,
     encryptedPayload,
     logMeta,
@@ -223,7 +223,7 @@ const updateMultirespondentSubmission = async (
     encryptedPayload,
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
-    timestamp: (submission.created || new Date()).getTime().toString(),
+    timestamp: (submission.created || new Date()).getTime(),
   })
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -132,6 +132,7 @@ const submitMultirespondentForm = async (
 
   await performMultiRespondentPostSubmissionCreateActions({
     submissionId: submission._id.toString(),
+    timestamp: (submission.created || new Date()).getTime().toString(),
     form,
     encryptedPayload,
     logMeta,
@@ -222,6 +223,7 @@ const updateMultirespondentSubmission = async (
     encryptedPayload,
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
+    timestamp: (submission.created || new Date()).getTime().toString(),
   })
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1,5 +1,4 @@
 import { flatten, uniq } from 'lodash'
-import moment from 'moment'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -195,7 +195,7 @@ const sendMrfOutcomeEmails = ({
   isApproval?: boolean
   isRejected?: boolean
   attachments?: IAttachmentInfo[]
-  timestamp: string
+  timestamp: number
 }): ResultAsync<true, InvalidWorkflowTypeError | MailSendError> => {
   const logMeta = {
     action: 'sendMrfOutcomeEmails',
@@ -439,7 +439,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   attachments,
 }: {
   submissionId: string
-  timestamp: string
+  timestamp: number
   form: IPopulatedMultirespondentForm
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
@@ -626,7 +626,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
   attachments?: IAttachmentInfo[]
-  timestamp: string
+  timestamp: number
 }): ResultAsync<
   boolean,
   | InvalidWorkflowTypeError

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -50,6 +50,7 @@ import {
   getQuestionTitleAnswerString,
   retrieveWorkflowStepEmailAddresses,
 } from './multirespondent-submission.utils'
+import moment from 'moment'
 
 const logger = createLoggerWithLabel(module)
 const MultirespondentSubmission = getMultirespondentSubmissionModel(mongoose)
@@ -186,6 +187,7 @@ const sendMrfOutcomeEmails = ({
   isApproval = false,
   isRejected = false,
   attachments,
+  timestamp,
 }: {
   currentStepNumber: number
   form: IPopulatedMultirespondentForm
@@ -194,6 +196,7 @@ const sendMrfOutcomeEmails = ({
   isApproval?: boolean
   isRejected?: boolean
   attachments?: IAttachmentInfo[]
+  timestamp: string
 }): ResultAsync<true, InvalidWorkflowTypeError | MailSendError> => {
   const logMeta = {
     action: 'sendMrfOutcomeEmails',
@@ -269,8 +272,26 @@ const sendMrfOutcomeEmails = ({
           responses,
         })
 
-        // do JSON data here?
-        // const dataCollationData =
+        // thankfully, getQuestionTitleAnswerString works similarly to .dataCollation with the exception of address field
+        let formQuestionAnswersJson = getQuestionTitleAnswerString({
+          formFields: form.form_fields,
+          responses,
+          jsonOutput: true,
+        })
+
+        formQuestionAnswersJson = [
+          {
+            question: 'Response ID',
+            answer: submissionId,
+          },
+          {
+            question: 'Timestamp',
+            answer: moment(timestamp)
+              .tz('Asia/Singapore')
+              .format('ddd, DD MMM YYYY hh:mm:ss A'),
+          },
+          ...formQuestionAnswersJson,
+        ]
 
         if (isApproval) {
           return MailService.sendMrfApprovalEmail({
@@ -280,6 +301,7 @@ const sendMrfOutcomeEmails = ({
             responseId: submissionId,
             isRejected,
             formQuestionAnswers,
+            formQuestionAnswersJson,
           }).orElse((error) => {
             logger.error({
               message: 'Failed to send approval email',
@@ -300,6 +322,7 @@ const sendMrfOutcomeEmails = ({
           responseId: submissionId,
           formQuestionAnswers,
           attachments: attachments,
+          formQuestionAnswersJson,
         }).orElse((error) => {
           logger.error({
             message: 'Failed to send workflow completion email',
@@ -420,12 +443,14 @@ export const createMultiRespondentFormSubmission = ({
 
 export const performMultiRespondentPostSubmissionCreateActions = ({
   submissionId,
+  timestamp,
   form,
   encryptedPayload,
   logMeta,
   attachments,
 }: {
   submissionId: string
+  timestamp: string
   form: IPopulatedMultirespondentForm
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
@@ -470,6 +495,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
         responses,
         submissionId,
         attachments,
+        timestamp,
       })
     })
     .mapErr((error) => {
@@ -603,6 +629,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   encryptedPayload,
   logMeta,
   attachments,
+  timestamp,
 }: {
   submissionId: string
   form: IPopulatedMultirespondentForm
@@ -610,6 +637,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
   attachments?: IAttachmentInfo[]
+  timestamp: string
 }): ResultAsync<
   boolean,
   | InvalidWorkflowTypeError
@@ -660,6 +688,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
       isApproval: true,
       isRejected: true,
       attachments: attachments,
+      timestamp,
     }).mapErr((error) => {
       logger.error({
         message: 'Send mrf outcome email error',
@@ -676,6 +705,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     submissionId,
     isApproval: checkIsFormApproval(form),
     attachments: attachments,
+    timestamp,
   })
     .mapErr((error) => {
       logger.error({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1,4 +1,5 @@
 import { flatten, uniq } from 'lodash'
+import moment from 'moment'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
@@ -50,7 +51,6 @@ import {
   getQuestionTitleAnswerString,
   retrieveWorkflowStepEmailAddresses,
 } from './multirespondent-submission.utils'
-import moment from 'moment'
 
 const logger = createLoggerWithLabel(module)
 const MultirespondentSubmission = getMultirespondentSubmissionModel(mongoose)
@@ -270,28 +270,18 @@ const sendMrfOutcomeEmails = ({
         const formQuestionAnswers = getQuestionTitleAnswerString({
           formFields: form.form_fields,
           responses,
+          responseId: submissionId,
+          timestamp,
         })
 
         // thankfully, getQuestionTitleAnswerString works similarly to .dataCollation with the exception of address field
-        let formQuestionAnswersJson = getQuestionTitleAnswerString({
+        const formQuestionAnswersJson = getQuestionTitleAnswerString({
           formFields: form.form_fields,
           responses,
+          responseId: submissionId,
+          timestamp,
           jsonOutput: true,
         })
-
-        formQuestionAnswersJson = [
-          {
-            question: 'Response ID',
-            answer: submissionId,
-          },
-          {
-            question: 'Timestamp',
-            answer: moment(timestamp)
-              .tz('Asia/Singapore')
-              .format('ddd, DD MMM YYYY hh:mm:ss A'),
-          },
-          ...formQuestionAnswersJson,
-        ]
 
         if (isApproval) {
           return MailService.sendMrfApprovalEmail({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -269,6 +269,9 @@ const sendMrfOutcomeEmails = ({
           responses,
         })
 
+        // do JSON data here?
+        // const dataCollationData =
+
         if (isApproval) {
           return MailService.sendMrfApprovalEmail({
             emails: destinationEmails,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -3,6 +3,7 @@ import { err, ok, Result } from 'neverthrow'
 
 import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from '../../../../../shared/constants/form'
 import {
+  AddressAttributes,
   BasicField,
   FieldResponsesV3,
   FormFieldDto,
@@ -11,7 +12,10 @@ import {
   SubmissionType,
   WorkflowType,
 } from '../../../../../shared/types'
-import { handleAddressResponseDisplay } from '../../../../../shared/utils/address'
+import {
+  answerKey,
+  handleAddressResponseDisplay,
+} from '../../../../../shared/utils/address'
 import {
   FormFieldSchema,
   IPopulatedForm,
@@ -196,6 +200,7 @@ export const validateMrfFieldResponses = ({
 
 /*
  * Extracts question-answer pairs from form fields and responses.
+ * Used for MRF Confirmation email body & JSON, which can be displayed differently (e.g. local address)
  * @param formFields - The form fields schema
  * @param responses - The responses to the form fields
  * @returns An array of QuestionAnswer objects
@@ -203,9 +208,11 @@ export const validateMrfFieldResponses = ({
 export const getQuestionTitleAnswerString = ({
   formFields,
   responses,
+  jsonOutput = false,
 }: {
   formFields: FormFieldSchema[]
   responses: FieldResponsesV3
+  jsonOutput?: boolean
 }): QuestionAnswer[] => {
   const questionAnswerPair = []
   if (!formFields || !responses) {
@@ -228,28 +235,41 @@ export const getQuestionTitleAnswerString = ({
         })
         continue
       case BasicField.Address: {
-        const {
-          postalCode,
-          blockNumber,
-          streetName,
-          buildingName,
-          levelNumber,
-          unitNumber,
-        } = response.answer.addressSubFields
-        answerArray = [
-          blockNumber,
-          streetName,
-          buildingName,
-          levelNumber,
-          unitNumber,
-          postalCode,
-        ] // move postal code to end of array
-        questionAnswerPair.push({
-          question: `${questionTitle}`,
-          answer: handleAddressResponseDisplay(Object.values(answerArray)).join(
-            ', ',
-          ),
-        })
+        if (jsonOutput) {
+          // split address into separate JSON objects
+          answerKey.map((subfield) => {
+            questionAnswerPair.push({
+              question: `${questionTitle} - ${subfield}`,
+              answer:
+                response.answer.addressSubFields[
+                  subfield as keyof AddressAttributes
+                ],
+            })
+          })
+        } else {
+          const {
+            postalCode,
+            blockNumber,
+            streetName,
+            buildingName,
+            levelNumber,
+            unitNumber,
+          } = response.answer.addressSubFields
+          answerArray = [
+            blockNumber,
+            streetName,
+            buildingName,
+            levelNumber,
+            unitNumber,
+            postalCode,
+          ] // move postal code to end of array
+          questionAnswerPair.push({
+            question: `${questionTitle}`,
+            answer: handleAddressResponseDisplay(
+              Object.values(answerArray),
+            ).join(', '),
+          })
+        }
         continue
       }
       case BasicField.Email:
@@ -278,11 +298,11 @@ export const getQuestionTitleAnswerString = ({
               const colTitle = idToColTitleMap[colId]
               return `${colTitle}`
             })
-            .join('; ')
+            .join(', ')
 
           const delimitedColumnAnswers = validColumns
             .map(([, colAns]) => colAns ?? '')
-            .join('; ')
+            .join(', ')
 
           const question = `[Table] ${formField.title} (${delimitedColumnTitles})`
           const answer = delimitedColumnAnswers
@@ -298,14 +318,17 @@ export const getQuestionTitleAnswerString = ({
           'value' in response.answer
             ? response.answer.value
             : 'othersInput' in response.answer
-              ? response.answer.othersInput
+              ? 'Others: ' + response.answer.othersInput
               : ''
         break
       case BasicField.Checkbox:
         // eslint-disable-next-line no-case-declarations
         const selectedAnswers =
           (response.answer.othersInput
-            ? [...response.answer.value, response.answer.othersInput]
+            ? [
+                ...response.answer.value,
+                'Others: ' + response.answer.othersInput,
+              ]
             : [...response.answer.value]
           ).filter((val) => val !== CLIENT_CHECKBOX_OTHERS_INPUT_VALUE) ?? []
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -215,7 +215,7 @@ export const getQuestionTitleAnswerString = ({
   formFields: FormFieldSchema[]
   responses: FieldResponsesV3
   responseId: string
-  timestamp: string
+  timestamp: number
   jsonOutput?: boolean
 }): QuestionAnswer[] => {
   const questionAnswerPair = []

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -208,16 +208,33 @@ export const validateMrfFieldResponses = ({
 export const getQuestionTitleAnswerString = ({
   formFields,
   responses,
+  responseId,
+  timestamp,
   jsonOutput = false,
 }: {
   formFields: FormFieldSchema[]
   responses: FieldResponsesV3
+  responseId: string
+  timestamp: string
   jsonOutput?: boolean
 }): QuestionAnswer[] => {
   const questionAnswerPair = []
   if (!formFields || !responses) {
     return []
   }
+
+  // add responseId & timestamp at the top
+  questionAnswerPair.push({
+    question: `Response ID`,
+    answer: responseId,
+  })
+  questionAnswerPair.push({
+    question: `Response Timestamp`,
+    answer: moment(timestamp)
+      .tz('Asia/Singapore')
+      .format('ddd, DD MMM YYYY hh:mm:ss A'),
+  })
+
   for (const formField of formFields) {
     const questionTitle = formField.title
     const response = responses[formField._id]

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -7,7 +7,11 @@ import Mail from 'nodemailer/lib/mailer'
 import promiseRetry from 'promise-retry'
 import validator from 'validator'
 
-import { FormResponseMode, PaymentChannel } from '../../../../shared/types'
+import {
+  FormResponseMode,
+  PaymentChannel,
+  SubmissionId,
+} from '../../../../shared/types'
 import { centsToDollars } from '../../../../shared/utils/payments'
 import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
 import { HASH_EXPIRE_AFTER_SECONDS } from '../../../../shared/utils/verification'
@@ -871,6 +875,7 @@ export class MailService {
     responseId,
     formQuestionAnswers,
     attachments,
+    formQuestionAnswersJson,
   }: {
     emails: string[]
     formId: string
@@ -878,11 +883,13 @@ export class MailService {
     responseId: string
     formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
+    formQuestionAnswersJson: QuestionAnswer[]
   }) => {
     const htmlData = {
       formTitle,
       responseId: responseId.toString(),
       formQuestionAnswers,
+      formQuestionAnswersJson,
     }
 
     const generatedHtml = fromPromise(
@@ -928,6 +935,7 @@ export class MailService {
     responseId,
     isRejected,
     formQuestionAnswers,
+    formQuestionAnswersJson,
   }: {
     emails: string[]
     formId: string
@@ -935,6 +943,7 @@ export class MailService {
     responseId: string
     isRejected: boolean
     formQuestionAnswers: QuestionAnswer[]
+    formQuestionAnswersJson: QuestionAnswer[]
   }) => {
     const outcome = isRejected
       ? WorkflowOutcome.NOT_APPROVED
@@ -944,6 +953,7 @@ export class MailService {
       responseId: responseId.toString(),
       outcome,
       formQuestionAnswers,
+      formQuestionAnswersJson,
     }
 
     const generatedHtml = fromPromise(

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -887,7 +887,6 @@ export class MailService {
   }) => {
     const htmlData = {
       formTitle,
-      responseId: responseId.toString(),
       formQuestionAnswers,
       formQuestionAnswersJson,
     }
@@ -950,7 +949,6 @@ export class MailService {
       : WorkflowOutcome.APPROVED
     const htmlData = {
       formTitle,
-      responseId: responseId.toString(),
       outcome,
       formQuestionAnswers,
       formQuestionAnswersJson,

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -7,11 +7,7 @@ import Mail from 'nodemailer/lib/mailer'
 import promiseRetry from 'promise-retry'
 import validator from 'validator'
 
-import {
-  FormResponseMode,
-  PaymentChannel,
-  SubmissionId,
-} from '../../../../shared/types'
+import { FormResponseMode, PaymentChannel } from '../../../../shared/types'
 import { centsToDollars } from '../../../../shared/utils/payments'
 import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
 import { HASH_EXPIRE_AFTER_SECONDS } from '../../../../shared/utils/verification'

--- a/src/app/views/templates/MrfWorkflowCompletionEmail.tsx
+++ b/src/app/views/templates/MrfWorkflowCompletionEmail.tsx
@@ -38,6 +38,7 @@ export type WorkflowEmailData = {
   formTitle: string
   responseId: string
   formQuestionAnswers: QuestionAnswer[]
+  formQuestionAnswersJson: QuestionAnswer[]
   outcome?: WorkflowOutcome | undefined 
 }
 
@@ -45,6 +46,7 @@ export const MrfWorkflowCompletionEmail = ({
   formTitle = 'Test form title',
   responseId = '64303c45828035f732088a41', 
   formQuestionAnswers = [], 
+  formQuestionAnswersJson = [],
   outcome
 }: WorkflowEmailData): JSX.Element => {
   const headingText =  
@@ -89,7 +91,7 @@ export const MrfWorkflowCompletionEmail = ({
               -- Start of JSON --
             </Text>
             <Text style={{ ...secondaryTextStyle, ...answerMargin }}>
-              {JSON.stringify(formQuestionAnswers)}
+              {JSON.stringify(formQuestionAnswersJson)}
             </Text>
             <Text style={{...secondaryTextStyle, marginTop: '24px'}}> 
               -- End of JSON --

--- a/src/app/views/templates/MrfWorkflowCompletionEmail.tsx
+++ b/src/app/views/templates/MrfWorkflowCompletionEmail.tsx
@@ -84,6 +84,16 @@ export const MrfWorkflowCompletionEmail = ({
               <Text style={{...secondaryTextStyle, marginTop: '24px'}}> 
                 For more details, please contact the respondent(s) or form administrator. 
               </Text>
+            <Hr style={{ margin: '40px 0' }} />
+            <Text style={{...secondaryTextStyle, marginTop: '24px'}}> 
+              -- Start of JSON --
+            </Text>
+            <Text style={{ ...secondaryTextStyle, ...answerMargin }}>
+              {JSON.stringify(formQuestionAnswers)}
+            </Text>
+            <Text style={{...secondaryTextStyle, marginTop: '24px'}}> 
+              -- End of JSON --
+            </Text>
             </Section> 
           </Container>
       </Body>

--- a/src/app/views/templates/MrfWorkflowCompletionEmail.tsx
+++ b/src/app/views/templates/MrfWorkflowCompletionEmail.tsx
@@ -36,7 +36,6 @@ export type QuestionAnswer = {
 
 export type WorkflowEmailData = {
   formTitle: string
-  responseId: string
   formQuestionAnswers: QuestionAnswer[]
   formQuestionAnswersJson: QuestionAnswer[]
   outcome?: WorkflowOutcome | undefined 
@@ -44,7 +43,6 @@ export type WorkflowEmailData = {
 
 export const MrfWorkflowCompletionEmail = ({
   formTitle = 'Test form title',
-  responseId = '64303c45828035f732088a41', 
   formQuestionAnswers = [], 
   formQuestionAnswersJson = [],
   outcome
@@ -80,8 +78,6 @@ export const MrfWorkflowCompletionEmail = ({
               <Heading style={{...headingTextStyle, marginBottom: '40px'}}>
                 Responses for {formTitle} 
               </Heading>
-              <Text style={{...primaryTextStyle, ...questionMargin}}>Response ID</Text>
-              <Text style={{...secondaryTextStyle, ...answerMargin}}>{responseId}</Text>
               {formQuestionAnswers.map(renderQuestionAnswer)}
               <Text style={{...secondaryTextStyle, marginTop: '24px'}}> 
                 For more details, please contact the respondent(s) or form administrator. 


### PR DESCRIPTION
Description

Enable JSON support for responses in MRF Confirmation Email

Solution

Develop JSON response content in MRF mode

option to utilise emailData.dataCollation (similar to storage/email mode)

utilize GetQuestionTitleAnswerString to be included in JSON response

Screenshots of expected FE

## Problem
JSON Support is available on Storage and Email mode, there is a goal to achieve parity for MRF mode

This is also part of the goal to kill checkpoint, as there are use cases not limited to MOM & ICA that use JSON support.

Closes FRM-1961

## Solution
For development, JSON content for email/storage mode is using emailData.dataCollation function which works with ProcessedFieldResponse and EmilDataCollationTool types. This is different for MRF which has ResponseV3 types.

In .dataCollation , responses are converted to {question: *, answer: *}. This is similar to the getQuestionTitleAnswerString function used for MRF email responses and for JSON output. Decided to utilize the function to generate Json output response

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
![image](https://github.com/user-attachments/assets/b5ca6207-f1f3-4288-8999-b0791b7db705)

**AFTER**:
![image](https://github.com/user-attachments/assets/6fc5e130-59c0-40b8-b565-39ba9bd29cf8)
