### PR TITLE
fix: pending step should refer to n+1

### DIFF
--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.test.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.test.ts
@@ -54,6 +54,6 @@ describe('getPendingResponseAtString', () => {
       workflowCurrentStepNumber: 1,
       workflowNumTotalSteps: 2,
     })
-    expect(result).toBe('Step 1 of 2')
+    expect(result).toBe('Step 2 of 2')
   })
 })

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -25,8 +25,13 @@ export const getPendingResponseAtString = ({
   if (!isPending) {
     return ''
   }
+
+  // The form is currently completed until step N.
+  // Thus, it should mean that it is pending the response of N+1
+  const pendingStep = workflowCurrentStepNumber + 1
+
   return getCurrentStepString({
-    workflowCurrentStepNumber,
+    workflowCurrentStepNumber: pendingStep,
     workflowNumTotalSteps,
   })
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- Off-by-1 for on steps display for MRF
- Affects admins who are viewing MRF status

Closes FRM-1962

## Solution
<!-- How did you solve the problem? -->

As pending here refers to who is to fill in, rather than which step is the form currently filled up till, we have to add 1 to the display text.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  


## Before & After Screenshots

| Component | Before | After |
|--------|--------|--------|
| Response Table | ![Screenshot 2025-02-27 at 12 45 39 PM](https://github.com/user-attachments/assets/6e1029a5-a52d-4b31-96d8-3db017c63e34) | ![Screenshot 2025-02-27 at 12 45 32 PM](https://github.com/user-attachments/assets/5dc500a4-9f3b-4fa3-a48a-b48d92dfa6e4) |
| Individual Results Page | ![Screenshot 2025-02-27 at 12 45 48 PM](https://github.com/user-attachments/assets/3ebb53ae-6dd6-45e4-b703-5816c0003477) | ![Screenshot 2025-02-27 at 12 45 44 PM](https://github.com/user-attachments/assets/4be5618e-9de4-44a6-9346-f658af7ff3a9) | 

## Tests
<!-- What tests should be run to confirm functionality? -->
