### PR TITLE
feat: add admin email as a reply-to

### DIFF
--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { FormResponseMode, PublicFormViewDto } from '~shared/types'
 
 import { useFormTemplate } from '~features/admin-form/common/queries'
+import { useUser } from '~features/user/queries'
 import {
   CreateFormFlowStates,
   CreateFormWizardContext,
@@ -49,6 +50,9 @@ export const useUseTemplateWizardContext = (
     useStorageModeFormTemplateMutation,
     useMultirespondentFormTemplateMutation,
   } = useUseTemplateMutations()
+
+  const { user } = useUser()
+  const adminEmail = user?.email
 
   const { emailModeFeedbackMutation } = useEmailModeFeedbackMutation()
 
@@ -102,7 +106,7 @@ export const useUseTemplateWizardContext = (
 
       emailModeFeedbackMutation.mutate(
         {
-          body: { reason: inputs.reason },
+          body: { reason: inputs.reason, adminEmail },
           feedbackForm,
         },
         {

--- a/frontend/src/features/workspace/WorkspaceService.ts
+++ b/frontend/src/features/workspace/WorkspaceService.ts
@@ -123,6 +123,7 @@ export const createMultirespondentModeForm = async (
   )
 }
 
+// TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented.
 const createFeedbackResponses = (
   formInputs: AdminUseEmailModeFeedbackDto,
   feedbackForm: PublicFormViewDto,
@@ -156,7 +157,18 @@ const createFeedbackResponses = (
       answerArray,
       fieldType,
     },
+    ...(formInputs.adminEmail && feedbackForm.form.form_fields.length > 1
+      ? [
+          {
+            _id: feedbackForm.form.form_fields[1]._id,
+            question: feedbackForm.form.form_fields[1].title,
+            answer: formInputs.adminEmail,
+            fieldType: feedbackForm.form.form_fields[1].fieldType,
+          },
+        ]
+      : []),
   ]
+
   return responses
 }
 
@@ -166,6 +178,7 @@ const createAdminEmailModeUseFeedback = (
 ) => {
   const responses = createFeedbackResponses(formInputs, feedbackForm)
   // convert content to FormData object
+  // TODO(tejas): do we need the responseMetadata?
   const formData = new FormData()
   formData.append('body', JSON.stringify({ responses, version: 2.1 }))
 

--- a/frontend/src/features/workspace/WorkspaceService.ts
+++ b/frontend/src/features/workspace/WorkspaceService.ts
@@ -178,7 +178,6 @@ const createAdminEmailModeUseFeedback = (
 ) => {
   const responses = createFeedbackResponses(formInputs, feedbackForm)
   // convert content to FormData object
-  // TODO(tejas): do we need the responseMetadata?
   const formData = new FormData()
   formData.append('body', JSON.stringify({ responses, version: 2.1 }))
 

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -6,6 +6,7 @@ import { FormResponseMode, PublicFormViewDto } from '~shared/types'
 
 import formsgSdk from '~utils/formSdk'
 
+import { useUser } from '~features/user/queries'
 import {
   useCreateFormMutations,
   useEmailModeFeedbackMutation,
@@ -69,6 +70,9 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
     createMultirespondentModeFormMutation,
   } = useCreateFormMutations()
 
+  const { user } = useUser()
+  const adminEmail = user?.email
+
   const { emailModeFeedbackMutation } = useEmailModeFeedbackMutation()
 
   const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
@@ -124,7 +128,7 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
 
       emailModeFeedbackMutation.mutate(
         {
-          body: { reason: inputs.reason },
+          body: { reason: inputs.reason, adminEmail },
           feedbackForm,
         },
         {

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { FormResponseMode, PublicFormViewDto } from '~shared/types'
 
 import { usePreviewForm } from '~features/admin-form/common/queries'
+import { useUser } from '~features/user/queries'
 import {
   useDuplicateFormMutations,
   useEmailModeFeedbackMutation,
@@ -68,6 +69,9 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
     dupeMultirespondentModeFormMutation,
   } = useDuplicateFormMutations()
 
+  const { user } = useUser()
+  const adminEmail = user?.email
+
   const { emailModeFeedbackMutation } = useEmailModeFeedbackMutation()
 
   const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
@@ -129,7 +133,7 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
 
       emailModeFeedbackMutation.mutate(
         {
-          body: { reason: inputs.reason },
+          body: { reason: inputs.reason, adminEmail },
           feedbackForm,
         },
         {

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -358,4 +358,5 @@ export type AdminUseEmailModeFeedbackDto = {
     value: string[] | false
     othersInput?: string
   }
+  adminEmail?: string
 }


### PR DESCRIPTION
## Problem
FRM-1964

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
**Form creation workflow**
- [ ] 1. Without modifying the email depr feedback form, try to create a email form
- [ ] 2. Observe that email forms can be created without errors. Check console tab as well. Observe in the network tab, that you get 200 for the feedback submission
- [ ] 3. Modify the email depr feedback form, to add the email field **AFTER** the checkbox field. IT MUST BE THE LAST ONE. Make it not required
- [ ] 4. Repeat step 2.
- [ ] 5. ??
- [ ] 6. Profit

**Repeat the above, for both duplication + use template workflow**

## Deploy Notes
- Before deploying, create an email field, turn off required for the email depr feedback form
