### PR TITLE
feat: secret key file enhancements

### DIFF
--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -136,7 +136,10 @@ const addForm = async (
   await page.getByText('Storage mode form').click()
   await page.getByRole('button', { name: 'Create form' }).click()
 
-  await page.waitForTimeout(1000)
+  await page.getByRole('button', { name: 'Cancel' }).click()
+
+  await page.getByRole('button', { name: 'Close' }).click()
+
   const downloadButton = page.getByRole('button', { name: 'Download key' })
   await expect(downloadButton).toBeEnabled({ timeout: 15000 })
   const downloadPromise = page.waitForEvent('download')

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -133,47 +133,33 @@ const addForm = async (
 
   await page.getByLabel('Form name').fill(`e2e-test-${cuid()}`)
 
-  let formResponseMode: E2eFormResponseMode
+  await page.getByText('Storage mode form').click()
+  await page.getByRole('button', { name: 'Create form' }).click()
 
-  if (responseMode === FormResponseMode.Email) {
-    await page.getByText('use it for now').click()
-
-    formResponseMode = {
-      responseMode: FormResponseMode.Email,
-    }
-
-    await page.getByText('I need to collect Sensitive High data').click()
-    await page.getByRole('button', { name: 'Next: Set up your form' }).click()
-
-    await page.getByRole('button', { name: 'Create form' }).click()
-  } else {
-    await page.getByText('Storage mode form').click()
-    await page.getByRole('button', { name: 'Next step' }).click()
-
-    // Download the secret key and save it for the test.
-    const downloadPromise = page.waitForEvent('download')
-    await page.getByRole('button', { name: 'Download key' }).click()
-    const download = await downloadPromise
-    const path = await download.path()
-    if (!path) throw new Error('Secret key download failed')
-    formResponseMode = {
-      responseMode: FormResponseMode.Encrypt,
-      secretKey: readFileSync(path).toString(),
-    }
-
-    // Double check that the secret key exists on the screen.
-    await expect(
-      page.getByText(formResponseMode.secretKey, { exact: true }),
-    ).toBeVisible()
-
-    // Click acknowledgement buttons
-    await page.getByText(/If I lose my Secret Key/).click()
-    await page
-      .getByRole('button', {
-        name: 'I have saved my Secret Key safely',
-      })
-      .click()
+  // Download the secret key and save it for the test.
+  const downloadPromise = page.waitForEvent('download')
+  await page.getByRole('button', { name: 'Download key' }).click()
+  const download = await downloadPromise
+  const path = await download.path()
+  if (!path) throw new Error('Secret key download failed')
+  const formResponseMode: E2eFormResponseMode = {
+    responseMode: FormResponseMode.Encrypt,
+    secretKey: readFileSync(path).toString(),
   }
+
+  // Double check that the secret key exists on the screen.
+  await expect(
+    page.getByText(formResponseMode.secretKey, { exact: true }),
+  ).toBeVisible()
+
+  // Click acknowledgement buttons
+  await page.getByText(/If I lose my Secret Key/).click()
+  await page
+    .getByRole('button', {
+      name: 'I have saved my Secret Key safely',
+    })
+    .click()
+
   await expect(page).toHaveURL(new RegExp(`${ADMIN_FORM_PAGE_PREFIX}/.*`, 'i'))
 
   const l = ADMIN_FORM_PAGE_PREFIX.length + 1

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -136,9 +136,13 @@ const addForm = async (
   await page.getByText('Storage mode form').click()
   await page.getByRole('button', { name: 'Create form' }).click()
 
-  // Download the secret key and save it for the test.
+  await page.waitForTimeout(1000)
+  const downloadButton = page.getByRole('button', { name: 'Download key' })
+  await expect(downloadButton).toBeEnabled({ timeout: 15000 })
   const downloadPromise = page.waitForEvent('download')
-  await page.getByRole('button', { name: 'Download key' }).click()
+  await downloadButton.click()
+
+  // Download the secret key and save it for the test.
   const download = await downloadPromise
   const path = await download.path()
   if (!path) throw new Error('Secret key download failed')

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -197,7 +197,7 @@ const addSettings = async (
   await expect(page).toHaveURL(ADMIN_FORM_PAGE_SETTINGS(formId))
 
   await addGeneralSettings(page, formSettings)
-  // await addAdminEmails(page, formSettings)
+  await addAdminEmails(page, formSettings)
   await addAuthSettings(page, formSettings)
   await addCollaborators(page, formSettings)
 
@@ -398,9 +398,6 @@ const addAdminEmails = async (
   if (formSettings.emails) {
     const emailInput = page.getByLabel('Notifications for new responses')
     await emailInput.focus()
-
-    // Clear the current admin email
-    await page.keyboard.press('Backspace')
 
     await emailInput.fill(formSettings.emails.join(', '))
 

--- a/__tests__/e2e/utils/settings.ts
+++ b/__tests__/e2e/utils/settings.ts
@@ -1,6 +1,5 @@
 import { FormAuthType, FormResponseMode, FormStatus } from 'shared/types'
 
-import { ADMIN_EMAIL } from '../constants'
 import { E2eSettingsOptions } from '../constants/settings'
 
 export const getEncryptSettings = (
@@ -47,8 +46,9 @@ const _getSettings = (
     ...custom,
   }
 
+  // Admin email is added by default for both encrypt and email forms, this is just to test the email page
   if (responseMode === FormResponseMode.Encrypt) {
-    settings.emails = [ADMIN_EMAIL]
+    settings.emails = ['test2@open.gov.sg']
   }
 
   return settings

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -61,7 +61,7 @@
         "react-focus-lock": "^2.7.1",
         "react-google-charts": "^4.0.1",
         "react-helmet-async": "^2.0.4",
-        "react-hook-form": "^7.28.0",
+        "react-hook-form": "^7.54.2",
         "react-i18next": "^11.16.7",
         "react-icons": "^5.3.0",
         "react-input-mask": "^3.0.0-alpha.2",
@@ -15700,18 +15700,18 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.28.0.tgz",
-      "integrity": "sha512-mmLpT86BkMGPr0r6ca8zxV0WH4Y1FW5MKs7Rq1+uHLVeeg5pSWbF5Z/qLCnM5vPVblHNM6lRBRRotnfEAf0ALA==",
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17"
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-i18next": {
@@ -30152,9 +30152,9 @@
       }
     },
     "react-hook-form": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.28.0.tgz",
-      "integrity": "sha512-mmLpT86BkMGPr0r6ca8zxV0WH4Y1FW5MKs7Rq1+uHLVeeg5pSWbF5Z/qLCnM5vPVblHNM6lRBRRotnfEAf0ALA=="
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg=="
     },
     "react-i18next": {
       "version": "11.16.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,7 @@
     "react-focus-lock": "^2.7.1",
     "react-google-charts": "^4.0.1",
     "react-helmet-async": "^2.0.4",
-    "react-hook-form": "^7.28.0",
+    "react-hook-form": "^7.54.2",
     "react-i18next": "^11.16.7",
     "react-icons": "^5.3.0",
     "react-input-mask": "^3.0.0-alpha.2",

--- a/frontend/src/components/Checkbox/Checkbox.stories.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.stories.tsx
@@ -136,7 +136,7 @@ export const Playground: StoryFn = ({
           />
         </Checkbox.OthersWrapper>
         <FormErrorMessage>
-          {errors[name]?.message ?? errors[othersInputName]?.message}
+          {String(errors[name]?.message ?? errors[othersInputName]?.message)}
         </FormErrorMessage>
       </FormControl>
       <Button type="submit">Submit</Button>

--- a/frontend/src/components/Field/Attachment/Attachment.stories.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.stories.tsx
@@ -108,7 +108,7 @@ export const Playground: StoryFn<AttachmentProps> = ({
           control={control}
         />
         <FormErrorMessage>
-          {errors[args.name] && errors[args.name].message}
+          {String(errors[args.name]?.message)}
         </FormErrorMessage>
       </FormControl>
       <Button type="submit">Submit</Button>

--- a/frontend/src/components/Field/Rating/Rating.stories.tsx
+++ b/frontend/src/components/Field/Rating/Rating.stories.tsx
@@ -238,9 +238,7 @@ export const Playground: StoryFn = ({
           isDisabled={isDisabled}
           {...field}
         />
-        <FormErrorMessage>
-          {errors[name] && errors[name].message}
-        </FormErrorMessage>
+        <FormErrorMessage>{String(errors[name]?.message)}</FormErrorMessage>
       </FormControl>
       <Button type="submit" colorScheme={args.colorScheme}>
         Submit

--- a/frontend/src/components/Field/YesNo/YesNo.stories.tsx
+++ b/frontend/src/components/Field/YesNo/YesNo.stories.tsx
@@ -132,9 +132,7 @@ export const Playground: StoryFn = ({
             <YesNo {...args} isDisabled={isDisabled} {...field} />
           )}
         />
-        <FormErrorMessage>
-          {errors[name] && errors[name].message}
-        </FormErrorMessage>
+        <FormErrorMessage>{String(errors[name]?.message)}</FormErrorMessage>
       </FormControl>
       <Button type="submit">Submit</Button>
     </form>

--- a/frontend/src/components/Input/Input.stories.tsx
+++ b/frontend/src/components/Input/Input.stories.tsx
@@ -89,9 +89,7 @@ export const Playground: StoryFn = ({
               : false,
           })}
         />
-        <FormErrorMessage>
-          {errors[name] && errors[name].message}
-        </FormErrorMessage>
+        <FormErrorMessage>{String(errors[name]?.message)}</FormErrorMessage>
       </FormControl>
       <Button variant="solid" type="submit">
         Submit

--- a/frontend/src/components/MoneyInput/MoneyInput.stories.tsx
+++ b/frontend/src/components/MoneyInput/MoneyInput.stories.tsx
@@ -81,9 +81,7 @@ export const Playground: StoryFn = ({
           }}
           render={({ field }) => <MoneyInput {...field} {...args} />}
         />
-        <FormErrorMessage>
-          {errors[name] && errors[name].message}
-        </FormErrorMessage>
+        <FormErrorMessage>{String(errors[name]?.message)}</FormErrorMessage>
       </FormControl>
       <Button variant="solid" type="submit">
         Submit

--- a/frontend/src/components/NumberInput/NumberInput.stories.tsx
+++ b/frontend/src/components/NumberInput/NumberInput.stories.tsx
@@ -86,9 +86,7 @@ export const Playground: StoryFn = ({
           }}
           render={({ field }) => <NumberInput {...field} {...args} />}
         />
-        <FormErrorMessage>
-          {errors[name] && errors[name].message}
-        </FormErrorMessage>
+        <FormErrorMessage>{String(errors[name]?.message)}</FormErrorMessage>
       </FormControl>
       <Button variant="solid" type="submit">
         Submit

--- a/frontend/src/components/PhoneNumberInput/IntlPhoneNumberInput.stories.tsx
+++ b/frontend/src/components/PhoneNumberInput/IntlPhoneNumberInput.stories.tsx
@@ -99,9 +99,7 @@ export const Playground: StoryFn = ({
           render={({ field }) => <PhoneNumberInput {...args} {...field} />}
         />
 
-        <FormErrorMessage>
-          {errors[name] && errors[name].message}
-        </FormErrorMessage>
+        <FormErrorMessage>{String(errors[name]?.message)}</FormErrorMessage>
       </FormControl>
       <Button variant="solid" type="submit">
         Submit

--- a/frontend/src/components/Radio/Radio.stories.tsx
+++ b/frontend/src/components/Radio/Radio.stories.tsx
@@ -87,7 +87,10 @@ const PlaygroundTemplate: StoryFn = ({
     register,
     getValues,
   } = useForm()
-  const othersInputError: FieldError | undefined = get(errors, othersInputName)
+  const othersInputError: FieldError | undefined = get(
+    errors,
+    othersInputName,
+  ) as FieldError | undefined
 
   const othersInputValue = '!!FORMSG_INTERNAL_CHECKBOX_OTHERS_VALUE!!'
 
@@ -148,7 +151,7 @@ const PlaygroundTemplate: StoryFn = ({
           )}
         </Radio.RadioGroup>
         <FormErrorMessage>
-          {errors[name]?.message ?? errors[othersInputName]?.message}
+          {String(errors[name]?.message ?? errors[othersInputName]?.message)}
         </FormErrorMessage>
       </FormControl>
       <Button type="submit">Submit</Button>

--- a/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
+++ b/frontend/src/components/SecretKeyVerificationInput/SecretKeyVerificationInput.tsx
@@ -66,7 +66,10 @@ export const SecretKeyVerificationInput = ({
 
   const fileUploadRef = useRef<HTMLInputElement | null>(null)
 
-  const secretKeyValidationRules: RegisterOptions = useMemo(() => {
+  const secretKeyValidationRules: RegisterOptions<
+    SecretKeyFormInputs,
+    'secretKey'
+  > = useMemo(() => {
     return {
       required: "Please enter the form's secret key",
       validate: (secretKey: string) => {

--- a/frontend/src/components/Textarea/Textarea.stories.tsx
+++ b/frontend/src/components/Textarea/Textarea.stories.tsx
@@ -82,9 +82,7 @@ export const Playground: StoryFn = ({
               : false,
           })}
         />
-        <FormErrorMessage>
-          {errors[name] && errors[name].message}
-        </FormErrorMessage>
+        <FormErrorMessage>{String(errors[name]?.message)}</FormErrorMessage>
       </FormControl>
       <Button variant="solid" type="submit">
         Submit

--- a/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/AddCollaboratorInput.tsx
+++ b/frontend/src/features/admin-form/common/components/CollaboratorModal/CollaboratorListScreen/AddCollaboratorInput.tsx
@@ -73,25 +73,26 @@ const useAddCollaboratorInput = () => {
     return handleAddCollaborator(inputs)
   })
 
-  const validationRules: RegisterOptions = useMemo(() => {
-    return {
-      required: 'Collaborator email is required',
-      validate: {
-        validEmail: (value: string) =>
-          !value || isEmail(value) || 'Please enter a valid email',
-        duplicateEmail: (value: string) =>
-          !value ||
-          !collaborators?.find(
-            (c) => c.email.toLowerCase() === value.toLowerCase(),
-          ) ||
-          'This user is an existing collaborator. Edit role below.',
-        ownerEmail: (value: string) =>
-          !value ||
-          form?.admin.email?.toLowerCase() !== value.toLowerCase() ||
-          'You cannot add the form owner as a collaborator',
-      },
-    }
-  }, [collaborators, form?.admin.email])
+  const validationRules: RegisterOptions<AddCollaboratorInputs, 'email'> =
+    useMemo(() => {
+      return {
+        required: 'Collaborator email is required',
+        validate: {
+          validEmail: (value: string) =>
+            !value || isEmail(value) || 'Please enter a valid email',
+          duplicateEmail: (value: string) =>
+            !value ||
+            !collaborators?.find(
+              (c) => c.email.toLowerCase() === value.toLowerCase(),
+            ) ||
+            'This user is an existing collaborator. Edit role below.',
+          ownerEmail: (value: string) =>
+            !value ||
+            form?.admin.email?.toLowerCase() !== value.toLowerCase() ||
+            'You cannot add the form owner as a collaborator',
+        },
+      }
+    }, [collaborators, form?.admin.email])
 
   const isMobile = useIsMobile()
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAddress/EditAddress.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAddress/EditAddress.tsx
@@ -48,7 +48,8 @@ export const EditAddress = ({ field }: EditAddressProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditAddressInputs, 'title'>({ required: true }),
     [],
   )
   return (

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -84,7 +84,10 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditAttachmentInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 
@@ -126,7 +129,7 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
   }, [form])
 
   const attachmentSizeValidationRule = useMemo(
-    (): RegisterOptions => ({
+    (): RegisterOptions<EditAttachmentInputs, 'attachmentSize'> => ({
       validate: (val) => {
         return (
           maxTotalSizeMb - otherAttachmentsSize >= Number(val) ||

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
@@ -100,7 +100,10 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditCheckboxInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 
@@ -118,7 +121,10 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
     [watchedInputs.othersRadioButton],
   )
 
-  const customMinValidationOptions: RegisterOptions = useMemo(
+  const customMinValidationOptions: RegisterOptions<
+    EditCheckboxInputs,
+    'ValidationOptions.customMin'
+  > = useMemo(
     () => ({
       required: {
         value:
@@ -152,7 +158,9 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
             numOptions += 1
           }
           return (
-            !val || val <= numOptions || 'Cannot be more than number of options'
+            !val ||
+            Number(val) <= numOptions ||
+            'Cannot be more than number of options'
           )
         },
       },
@@ -160,7 +168,10 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
     [watchedInputs],
   )
 
-  const customMaxValidationOptions: RegisterOptions = useMemo(
+  const customMaxValidationOptions: RegisterOptions<
+    EditCheckboxInputs,
+    'ValidationOptions.customMax'
+  > = useMemo(
     () => ({
       required: {
         value:
@@ -195,7 +206,9 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
             numOptions += 1
           }
           return (
-            !val || val <= numOptions || 'Cannot be more than number of options'
+            !val ||
+            Number(val) <= numOptions ||
+            'Cannot be more than number of options'
           )
         },
       },

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCountryRegion/EditCountryRegion.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCountryRegion/EditCountryRegion.tsx
@@ -65,7 +65,10 @@ export const EditCountryRegion = ({
   const { t } = useTranslation()
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditCountryRegionInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -207,7 +207,10 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditDateInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDecimal/EditDecimal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDecimal/EditDecimal.tsx
@@ -74,7 +74,10 @@ export const EditDecimal = ({ field }: EditDecimalProps): JSX.Element => {
   const watchValidateByValue = watch('validateByValue')
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditDecimalInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
@@ -72,7 +72,10 @@ export const EditDropdown = ({ field }: EditDropdownProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditDropdownInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -88,7 +88,10 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
   const watchedHasAutoReply = watch('autoReplyOptions.hasAutoReply')
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditEmailInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -40,7 +40,10 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditHeaderInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHomeno/EditHomeno.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHomeno/EditHomeno.tsx
@@ -47,7 +47,10 @@ export const EditHomeno = ({ field }: EditHomenoProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditHomenoInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
@@ -141,7 +141,10 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditImageInputs, 'description'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -91,7 +91,10 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
   const { t } = useTranslation()
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditLongTextInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
@@ -48,7 +48,10 @@ export const EditMobile = ({ field }: EditMobileProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditMobileInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
@@ -43,7 +43,10 @@ export const EditNric = ({ field }: EditNricProps): JSX.Element => {
   const { t } = useTranslation()
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditNricInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
@@ -163,7 +163,10 @@ export const EditNumber = ({ field }: EditNumberProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditNumberInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditParagraph.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditParagraph.tsx
@@ -42,7 +42,10 @@ export const EditParagraph = ({ field }: EditParagraphProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditParagraphInputs, 'description'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
@@ -75,7 +75,10 @@ export const EditRadio = ({ field }: EditRadioProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditRadioInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
@@ -58,7 +58,10 @@ export const EditRating = ({ field }: EditRatingProps): JSX.Element => {
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditRatingInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -106,7 +106,10 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
   const { t } = useTranslation()
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditShortTextInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -115,7 +115,10 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
   const { errors } = useFormState({ control })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditTableInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTableColumns.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTableColumns.tsx
@@ -63,7 +63,21 @@ export const EditTableColumns = ({
   })
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditTableInputs, `columns.${number}.title`>({
+        required: true,
+      }),
+    [],
+  )
+
+  const columnTypeValidationRule = useMemo(
+    () =>
+      createBaseValidationRules<
+        EditTableInputs,
+        `columns.${number}.columnType`
+      >({
+        required: true,
+      }),
     [],
   )
 
@@ -120,7 +134,7 @@ export const EditTableColumns = ({
             <Controller
               name={`columns.${index}.columnType`}
               control={control}
-              rules={requiredValidationRule}
+              rules={columnTypeValidationRule}
               render={({ field }) => (
                 <SingleSelect
                   isClearable={false}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
@@ -43,7 +43,7 @@ export const EditUen = ({ field }: EditUenProps): JSX.Element => {
   const { t } = useTranslation()
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () => createBaseValidationRules<EditUenInputs, 'title'>({ required: true }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
@@ -46,7 +46,10 @@ export const EditYesNo = ({ field }: EditYesNoProps): JSX.Element => {
   const { t } = useTranslation()
 
   const requiredValidationRule = useMemo(
-    () => createBaseValidationRules({ required: true }),
+    () =>
+      createBaseValidationRules<EditYesNoInputs, 'title'>({
+        required: true,
+      }),
     [],
   )
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import {
   DeepPartial,
+  DefaultValues,
   FieldValues,
   Mode,
   UnpackNestedValue,
@@ -110,7 +111,7 @@ export const useEditFieldForm = <
   )
 
   const defaultValues = useMemo(
-    () => transform.input(field),
+    () => transform.input(field) as DefaultValues<FormShape>,
     [field, transform],
   )
   const editForm = useForm<FormShape>({
@@ -130,7 +131,7 @@ export const useEditFieldForm = <
 
   const watchedInputs = useWatch({
     control: editForm.control,
-  }) as UnpackNestedValue<FormShape>
+  }) as FormShape
 
   // Cloning is required so any nested references are not pointing to the same object,
   // which would prevent rerenders.
@@ -141,16 +142,24 @@ export const useEditFieldForm = <
 
   const onSaveSuccess = useCallback(
     (newField: FormField) => {
-      editForm.reset(transform.input(newField as FieldShape))
+      editForm.reset(
+        transform.input(newField as FieldShape) as DefaultValues<FormShape>,
+      )
       setToInactive()
     },
     [editForm, transform, setToInactive],
   )
 
   const handleUpdateField = editForm.handleSubmit(async (inputs) => {
-    let updatedFormField = transform.output(inputs, field)
+    let updatedFormField = transform.output(
+      inputs as UnpackNestedValue<FormShape>,
+      field,
+    )
     if (transform.preSubmit) {
-      updatedFormField = await transform.preSubmit(inputs, updatedFormField)
+      updatedFormField = await transform.preSubmit(
+        inputs as UnpackNestedValue<FormShape>,
+        updatedFormField,
+      )
     }
 
     // if field to be updated is MyInfo, enable admin feedback
@@ -187,7 +196,13 @@ export const useEditFieldForm = <
   }, [setToInactive])
 
   useDebounce(
-    () => handleChange(transform.output(clonedWatchedInputs, field)),
+    () =>
+      handleChange(
+        transform.output(
+          clonedWatchedInputs as UnpackNestedValue<FormShape>,
+          field,
+        ),
+      ),
     300,
     Object.values(clonedWatchedInputs),
   )

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/ProductModal.tsx
@@ -139,12 +139,11 @@ export const ProductModal = ({
     onClose()
   })
 
-  const minQtyValidation: RegisterOptions = {
-    validate: (valStr: string) => {
+  const minQtyValidation: RegisterOptions<ProductInput, typeof MIN_QTY_KEY> = {
+    validate: (val: number) => {
       if (!getValues(MULTI_QTY_KEY)) return true
 
-      const valNumber = parseIntElseNull(valStr)
-      if (!valNumber || valNumber <= 0) {
+      if (!val || val <= 0) {
         return 'Enter a value greater than 0'
       }
 
@@ -152,24 +151,23 @@ export const ProductModal = ({
         parseIntElseNull(getValues(MAX_QTY_KEY) as unknown as string) ||
         Number.MAX_SAFE_INTEGER
 
-      if (valNumber > maxNumber) {
+      if (val > maxNumber) {
         return 'Enter a value smaller than the maximum quantity'
       }
       return true
     },
   }
-  const maxQtyValidation: RegisterOptions = {
-    validate: (valStr: string) => {
+  const maxQtyValidation: RegisterOptions<ProductInput, typeof MAX_QTY_KEY> = {
+    validate: (val: number) => {
       if (!getValues(MULTI_QTY_KEY)) return true
 
-      const valNumber = parseIntElseNull(valStr)
-      if (!valNumber || valNumber <= 0) {
+      if (!val || val <= 0) {
         return 'Enter a value greater than 0'
       }
 
       const amount = dollarsToCents(getValues(DISPLAY_AMOUNT_KEY) ?? '')
 
-      if (valNumber * amount > maxPaymentAmountCents) {
+      if (val * amount > maxPaymentAmountCents) {
         const maxQty = Math.floor(maxPaymentAmountCents / amount)
         if (maxQty <= 0) {
           return `Quantity limit could not be set because amount is above S${formatCurrency(
@@ -182,7 +180,7 @@ export const ProductModal = ({
         parseIntElseNull(getValues(MIN_QTY_KEY) as unknown as string) ||
         Number.MIN_SAFE_INTEGER
 
-      if (valNumber < minNumber) {
+      if (val < minNumber) {
         return 'Enter a value greater than the minimum quantity'
       }
       return true

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
@@ -194,7 +194,8 @@ export const EditConditionBlock = ({
   }, [ifValueTypeValue])
 
   const validateValueInputComponent: Validate<
-    string | number | string[] | number[]
+    string | number | string[] | number[],
+    EditLogicInputs
   > = useCallback(
     (val) => {
       switch (ifValueTypeValue) {

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
@@ -3,6 +3,8 @@ import { useFieldArray, useForm } from 'react-hook-form'
 import { Stack } from '@chakra-ui/react'
 import { merge } from 'lodash'
 
+import { LogicConditionState } from '~shared/types'
+
 import {
   setToInactiveSelector,
   useAdminLogicStore,
@@ -65,6 +67,8 @@ export const useEditLogicBlock = ({
         // Cannot be undefined or the default value will be used.
         // This may cause old values to be shown when appending.
         field: '',
+        state: LogicConditionState.Equal,
+        value: '',
       }),
     [append],
   )

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
@@ -67,7 +67,7 @@ export const useEditLogicBlock = ({
         // Cannot be undefined or the default value will be used.
         // This may cause old values to be shown when appending.
         field: '',
-        state: LogicConditionState.Equal,
+        state: LogicConditionState.Empty,
         value: '',
       }),
     [append],

--- a/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
@@ -1,5 +1,5 @@
 import { KeyboardEventHandler, useCallback } from 'react'
-import { Controller, useForm } from 'react-hook-form'
+import { Controller, RegisterOptions, useForm } from 'react-hook-form'
 import { FormControl, Skeleton, Stack } from '@chakra-ui/react'
 import { get, isEmpty } from 'lodash'
 
@@ -70,15 +70,17 @@ const FormTitleInput = ({ initialTitle }: FormTitleInputProps): JSX.Element => {
     <FormControl isInvalid={!isEmpty(errors)}>
       <FormLabel isRequired>Form name</FormLabel>
 
-      <Controller
+      <Controller<{ title: string }>
         control={control}
         name="title"
-        rules={FORM_TITLE_VALIDATION_RULES}
+        rules={
+          FORM_TITLE_VALIDATION_RULES as RegisterOptions<{ title: string }>
+        }
         render={({ field }) => (
           <Input {...field} onBlur={handleBlur} onKeyDown={handleKeyDown} />
         )}
       />
-      <FormErrorMessage>{get(errors, 'title.message')}</FormErrorMessage>
+      <FormErrorMessage>{String(errors.title?.message)}</FormErrorMessage>
     </FormControl>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 import {
   Controller,
   FormProvider,
+  RegisterOptions,
   useForm,
   useFormContext,
 } from 'react-hook-form'
@@ -62,18 +63,22 @@ const AdminEmailRecipientsInput = ({
     getValues(EMAILS_FIELD_NAME)?.length > 0 ? undefined : 'me@example.com'
 
   return (
-    <Controller
+    <Controller<{ emails: string[]; isRequired: boolean }>
       control={control}
       name={EMAILS_FIELD_NAME}
       rules={
-        settings?.responseMode === FormResponseMode.Email
+        (settings?.responseMode === FormResponseMode.Email
           ? REQUIRED_ADMIN_EMAIL_VALIDATION_RULES
-          : OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES
+          : OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES) as RegisterOptions<{
+          emails: string[]
+          isRequired: boolean
+        }>
       }
       render={({ field }) => (
         <TagInput
           placeholder={emailsFieldPlaceholder}
           {...field}
+          value={field.value as string[]}
           tagValidation={isEmail}
           onBlur={handleBlur}
         />

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { Controller, useForm } from 'react-hook-form'
+import { Controller, RegisterOptions, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import {
   Box,
@@ -236,14 +236,17 @@ const MrfEmailNotificationsForm = ({
               'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
             )}
           </FormLabel>
-          <Controller
+          <Controller<FormData>
             name={OTHER_PARTIES_EMAIL_INPUT_NAME}
             control={control}
-            rules={OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES}
+            rules={
+              OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES as RegisterOptions<FormData>
+            }
             render={({ field }) => (
               <TagInput
                 placeholder={otherPartiesEmailInputPlaceholder}
                 {...field}
+                value={field.value as string[]}
                 isDisabled={isDisabled}
                 onBlur={handleOtherPartiesEmailInputBlur}
                 tagValidation={isEmail}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormFieldTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormFieldTranslationContainer.tsx
@@ -100,7 +100,11 @@ export const FormFieldTranslationContainer = ({
             unicodeLocale={unicodeLocale}
             language={capitalisedLanguage}
             columns={formFieldData.columns}
-            errors={formState.errors.tableColumnDropdownTranslations}
+            errors={
+              Array.isArray(formState.errors.tableColumnDropdownTranslations)
+                ? formState.errors.tableColumnDropdownTranslations
+                : undefined
+            }
           />
         </>
       )}

--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateModal.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateModal.tsx
@@ -34,7 +34,6 @@ export const UseTemplateModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-        <ModalCloseButton />
         <UseTemplateWizardProvider formId={formId}>
           <CreateFormModalContent />
         </UseTemplateWizardProvider>

--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateModal.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateModal.tsx
@@ -32,7 +32,7 @@ export const UseTemplateModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-        <UseTemplateWizardProvider formId={formId}>
+        <UseTemplateWizardProvider formId={formId} onClose={onClose}>
           <CreateFormModalContent />
         </UseTemplateWizardProvider>
       </ModalContent>

--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateModal.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateModal.tsx
@@ -5,8 +5,6 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
-import { ModalCloseButton } from '~components/Modal'
-
 // Explicit import to avoid circular dependency warnings by rollup
 import { CreateFormModalContent } from '~features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent'
 

--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -132,19 +132,6 @@ export const useUseTemplateWizardContext = (
       })
     })
 
-  const handleDetailsSubmit = handleSubmit((inputs) => {
-    if (!formId) return
-    if (inputs.responseMode === FormResponseMode.Email) {
-      return useEmailModeFormTemplateMutation.mutate({
-        formIdToDuplicate: formId,
-        emails: inputs.emails.filter(Boolean),
-        title: inputs.title,
-        responseMode: inputs.responseMode,
-      })
-    }
-    setCurrentStep([CreateFormFlowStates.Landing, 1])
-  })
-
   return {
     isFetching: isTemplateFormLoading,
     isLoading:
@@ -155,7 +142,6 @@ export const useUseTemplateWizardContext = (
     currentStep,
     direction,
     formMethods,
-    handleDetailsSubmit,
     handleCreateStorageModeOrMultirespondentForm,
     handleEmailFeedbackSubmit,
     handleCreateEmailModeForm,

--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -63,21 +63,35 @@ export const useUseTemplateWizardContext = (
       if (!formId) return
       switch (responseMode) {
         case FormResponseMode.Encrypt: {
-          return useStorageModeFormTemplateMutation.mutate({
-            formIdToDuplicate: formId,
-            title,
-            responseMode,
-            publicKey: keypair.publicKey,
-            emails: [],
-          })
+          return useStorageModeFormTemplateMutation.mutate(
+            {
+              formIdToDuplicate: formId,
+              title,
+              responseMode,
+              publicKey: keypair.publicKey,
+              emails: [],
+            },
+            {
+              onSuccess: () => {
+                setCurrentStep([CreateFormFlowStates.Landing, 1])
+              },
+            },
+          )
         }
         case FormResponseMode.Multirespondent: {
-          return useMultirespondentFormTemplateMutation.mutate({
-            formIdToDuplicate: formId,
-            title,
-            responseMode,
-            publicKey: keypair.publicKey,
-          })
+          return useMultirespondentFormTemplateMutation.mutate(
+            {
+              formIdToDuplicate: formId,
+              title,
+              responseMode,
+              publicKey: keypair.publicKey,
+            },
+            {
+              onSuccess: () => {
+                setCurrentStep([CreateFormFlowStates.Landing, 1])
+              },
+            },
+          )
         }
         case FormResponseMode.Email: {
           return

--- a/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -17,6 +17,7 @@ import { useUseTemplateMutations } from '../mutation'
 
 export const useUseTemplateWizardContext = (
   formId: string,
+  onClose: () => void,
 ): CreateFormWizardContextReturn => {
   const { t } = useTranslation()
   const { data: templateFormData, isLoading: isTemplateFormLoading } =
@@ -162,12 +163,14 @@ export const useUseTemplateWizardContext = (
     submitEmailModeFeedback,
     isSingpass,
     modalHeader: t('features.workspace.modals.create.title.duplicate'),
+    onClose,
   }
 }
 
 interface UseTemplateWizardProviderProps {
   formId: string
   children: React.ReactNode
+  onClose: () => void
 }
 
 /**
@@ -177,8 +180,9 @@ interface UseTemplateWizardProviderProps {
 export const UseTemplateWizardProvider = ({
   formId,
   children,
+  onClose,
 }: UseTemplateWizardProviderProps): JSX.Element => {
-  const values = useUseTemplateWizardContext(formId)
+  const values = useUseTemplateWizardContext(formId, onClose)
   return (
     <CreateFormWizardContext.Provider value={values}>
       {children}

--- a/frontend/src/features/admin-form/template/mutation.ts
+++ b/frontend/src/features/admin-form/template/mutation.ts
@@ -37,6 +37,14 @@ const useCommonHooks = () => {
     [navigate, queryClient],
   )
 
+  const handleSuccessWithoutRedirect = useCallback(
+    (data: FormDto) => {
+      queryClient.invalidateQueries(workspaceKeys.dashboard)
+      queryClient.invalidateQueries(workspaceKeys.workspaces)
+      return data
+    },
+    [queryClient],
+  )
   const handleError = useCallback(
     (error: ApiError) => {
       toast({
@@ -49,6 +57,7 @@ const useCommonHooks = () => {
 
   return {
     handleSuccess,
+    handleSuccessWithoutRedirect,
     handleError,
   }
 }
@@ -58,7 +67,10 @@ const useCommonHooks = () => {
  * "UseTemplate" is a FormSG functionality referring to the FormSG feature of utilising another form as a starting template.
  */
 export const useUseTemplateMutations = () => {
-  const { handleSuccess, handleError } = useCommonHooks()
+  const { handleSuccess, handleSuccessWithoutRedirect, handleError } =
+    useCommonHooks()
+
+  const queryClient = useQueryClient()
 
   const useEmailModeFormTemplateMutation = useMutation<
     FormDto,
@@ -83,7 +95,10 @@ export const useUseTemplateMutations = () => {
     ({ formIdToDuplicate, ...params }) =>
       createStorageModeTemplateForm(formIdToDuplicate, params),
     {
-      onSuccess: handleSuccess,
+      onSuccess: (data) => {
+        handleSuccessWithoutRedirect(data)
+        queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
+      },
       onError: handleError,
     },
   )
@@ -98,7 +113,10 @@ export const useUseTemplateMutations = () => {
     ({ formIdToDuplicate, ...params }) =>
       createMultirespondentTemplateForm(formIdToDuplicate, params),
     {
-      onSuccess: handleSuccess,
+      onSuccess: (data) => {
+        handleSuccessWithoutRedirect(data)
+        queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
+      },
       onError: handleError,
     },
   )

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
@@ -100,7 +100,9 @@ export const ProductPaymentItemDetailsBlock = ({
             />
           ))}
         </Stack>
-        <FormErrorMessage>{String(errors?.payment_products?.message)}</FormErrorMessage>
+        <FormErrorMessage>
+          {String(errors?.payment_products?.message)}
+        </FormErrorMessage>
       </FormControl>
       <Divider />
       <Flex justifyContent="end" alignItems="baseline">

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/ProductPaymentItemDetailsBlock.tsx
@@ -100,7 +100,7 @@ export const ProductPaymentItemDetailsBlock = ({
             />
           ))}
         </Stack>
-        <FormErrorMessage>{errors?.payment_products?.message}</FormErrorMessage>
+        <FormErrorMessage>{String(errors?.payment_products?.message)}</FormErrorMessage>
       </FormControl>
       <Divider />
       <Flex justifyContent="end" alignItems="baseline">

--- a/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailsBlock.tsx
+++ b/frontend/src/features/public-form/components/FormPaymentPage/components/VariablePaymentItemDetailsBlock.tsx
@@ -1,4 +1,4 @@
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller, RegisterOptions, useFormContext } from 'react-hook-form'
 import { Box, FormControl, Text } from '@chakra-ui/react'
 
 import { PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID } from '~shared/constants'
@@ -25,7 +25,7 @@ export const VariablePaymentItemDetailsBlock = ({
   const {
     control,
     formState: { errors },
-  } = useFormContext()
+  } = useFormContext<{ payment_variable_input_amount_field_id: string }>()
 
   const {
     data: {
@@ -63,7 +63,11 @@ export const VariablePaymentItemDetailsBlock = ({
         <Controller
           name={PAYMENT_VARIABLE_INPUT_AMOUNT_FIELD_ID}
           control={control}
-          rules={amountValidation}
+          rules={
+            amountValidation as RegisterOptions<{
+              payment_variable_input_amount_field_id: string
+            }>
+          }
           render={({ field }) => (
             <MoneyInput
               flex={1}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -107,6 +107,7 @@ export const StorageModeAckScreen = () => {
       handleDownloadKey: () => console.log('download key'),
       handleEmailKey: () => console.log('email key'),
       mailToHref: 'mailto:?subject=&body=',
+      handleDownloadAndNavigate: () => console.log('download and navigate'),
       handleCreateStorageModeForm: () =>
         Promise.resolve(console.log('create storage mode form')),
       secretKey,

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -128,8 +128,8 @@ export const StorageModeAckScreen = () => {
     >
       <Modal isOpen onClose={() => console.log('close modal')} size="full">
         <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-          <ModalCloseButton />
           <CreateFormWizardProvider>
+            <ModalCloseButton />
             <SaveSecretKeyScreen useSaveSecretKey={mockHook} />
           </CreateFormWizardProvider>
         </ModalContent>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -129,7 +129,7 @@ export const StorageModeAckScreen = () => {
     >
       <Modal isOpen onClose={() => console.log('close modal')} size="full">
         <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-          <CreateFormWizardProvider>
+          <CreateFormWizardProvider onClose={() => console.log('close modal')}>
             <ModalCloseButton />
             <SaveSecretKeyScreen useSaveSecretKey={mockHook} />
           </CreateFormWizardProvider>
@@ -177,7 +177,7 @@ export const EmailModeFeedback = () => {
       <Modal isOpen onClose={() => console.log('close modal')} size="full">
         <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
           <ModalCloseButton />
-          <CreateFormWizardProvider>
+          <CreateFormWizardProvider onClose={() => console.log('close modal')}>
             <EmailModeFeedbackScreen
               useCreateFormWizardParam={mockHook}
               useAdminUseEmailModeFormViewParam={() => {
@@ -231,7 +231,7 @@ export const EmailModeCreation = () => {
       <Modal isOpen onClose={console.log} size="full">
         <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
           <ModalCloseButton />
-          <CreateFormWizardProvider>
+          <CreateFormWizardProvider onClose={() => console.log('close modal')}>
             <EmailModeCreationScreen
               useCreateFormWizardParam={mockHook}
               useAdminUseEmailModeFormViewParam={() => {

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.tsx
@@ -5,8 +5,6 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
-import { ModalCloseButton } from '~components/Modal'
-
 // Explicit import to avoid circular dependency warnings by rollup
 import { CreateFormModalContent } from './CreateFormModalContent/CreateFormModalContent'
 import { CreateFormWizardProvider } from './CreateFormWizardProvider'
@@ -29,7 +27,6 @@ export const CreateFormModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-        <ModalCloseButton />
         {isOpen && (
           <CreateFormWizardProvider>
             <CreateFormModalContent />

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.tsx
@@ -28,7 +28,7 @@ export const CreateFormModal = ({
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
         {isOpen && (
-          <CreateFormWizardProvider>
+          <CreateFormWizardProvider onClose={onClose}>
             <CreateFormModalContent />
           </CreateFormWizardProvider>
         )}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -52,8 +52,8 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
   const { t } = useTranslation()
   const {
     formMethods,
-    handleDetailsSubmit,
     handleEmailFeedbackSubmit,
+    handleCreateStorageModeOrMultirespondentForm,
     isLoading,
     isFetching,
     modalHeader,
@@ -156,7 +156,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             type="submit"
             isLoading={isLoading}
             isDisabled={isFetching}
-            onClick={handleDetailsSubmit}
+            onClick={handleCreateStorageModeOrMultirespondentForm}
             isFullWidth
             data-dd-action-name={getTrackingSubmissionActionName(
               responseModeValue,

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -163,7 +163,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             )}
           >
             <Text lineHeight="1.5rem">
-              {t('features.workspace.modals.create.details.next')}
+              {t('features.workspace.modals.create.details.create')}
             </Text>
           </Button>
         </Container>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -1,4 +1,4 @@
-import { Controller } from 'react-hook-form'
+import { Controller, RegisterOptions } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { BiRightArrowAlt } from 'react-icons/bi'
 import {
@@ -22,7 +22,10 @@ import InlineMessage from '~components/InlineMessage'
 import Input from '~components/Input'
 
 import { WorkspaceRowsProvider } from '../../WorkspaceFormRow/WorkspaceRowsContext'
-import { useCreateFormWizard } from '../CreateFormWizardContext'
+import {
+  CreateFormWizardInputProps,
+  useCreateFormWizard,
+} from '../CreateFormWizardContext'
 
 import { EmailFormRecipientsInput } from './EmailFormRecipientsInput'
 import { FormResponseOptions } from './FormResponseOptions'
@@ -88,7 +91,13 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             <Skeleton isLoaded={!isFetching}>
               <Input
                 autoFocus
-                {...register('title', FORM_TITLE_VALIDATION_RULES)}
+                {...register(
+                  'title',
+                  FORM_TITLE_VALIDATION_RULES as RegisterOptions<
+                    CreateFormWizardInputProps,
+                    'title'
+                  >,
+                )}
               />
             </Skeleton>
             <FormErrorMessage>{errors.title?.message}</FormErrorMessage>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
@@ -1,3 +1,5 @@
+import { ModalCloseButton } from '@chakra-ui/react'
+
 import { XMotionBox } from '~templates/MotionBox'
 
 import {
@@ -20,18 +22,23 @@ export const CreateFormModalContent = () => {
   const { direction, currentStep } = useCreateFormWizard()
 
   return (
-    <XMotionBox keyProp={currentStep} custom={direction}>
-      {currentStep === CreateFormFlowStates.Details && (
-        <CreateFormDetailsScreen />
-      )}
-      {currentStep === CreateFormFlowStates.Landing && <SaveSecretKeyScreen />}
-      {/* TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented. */}
-      {currentStep === CreateFormFlowStates.EmailFeedback && (
-        <EmailModeFeedbackScreen />
-      )}
-      {currentStep === CreateFormFlowStates.EmailModeCreation && (
-        <EmailModeCreationScreen />
-      )}
-    </XMotionBox>
+    <>
+      {currentStep !== CreateFormFlowStates.Landing && <ModalCloseButton />}
+      <XMotionBox keyProp={currentStep} custom={direction}>
+        {currentStep === CreateFormFlowStates.Details && (
+          <CreateFormDetailsScreen />
+        )}
+        {currentStep === CreateFormFlowStates.Landing && (
+          <SaveSecretKeyScreen />
+        )}
+        {/* TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented. */}
+        {currentStep === CreateFormFlowStates.EmailFeedback && (
+          <EmailModeFeedbackScreen />
+        )}
+        {currentStep === CreateFormFlowStates.EmailModeCreation && (
+          <EmailModeCreationScreen />
+        )}
+      </XMotionBox>
+    </>
   )
 }

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
@@ -1,4 +1,4 @@
-import { Controller } from 'react-hook-form'
+import { Control, Controller, RegisterOptions } from 'react-hook-form'
 import { Skeleton } from '@chakra-ui/react'
 import { get } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
@@ -15,7 +15,10 @@ import { TagInput } from '~components/TagInput'
 
 import { useUser } from '~features/user/queries'
 
-import { useCreateFormWizard } from '../CreateFormWizardContext'
+import {
+  CreateFormWizardInputProps,
+  useCreateFormWizard,
+} from '../CreateFormWizardContext'
 
 export const EmailFormRecipientsInput = (): JSX.Element => {
   const { user, isLoading } = useUser()
@@ -40,19 +43,20 @@ export const EmailFormRecipientsInput = (): JSX.Element => {
 
   return (
     <>
-      <Controller
+      <Controller<CreateFormWizardInputProps>
         control={control}
         defaultValue={[user.email]}
         name="emails"
         rules={
-          responseModeValue === FormResponseMode.Email
+          (responseModeValue === FormResponseMode.Email
             ? REQUIRED_ADMIN_EMAIL_VALIDATION_RULES
-            : OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES
+            : OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES) as RegisterOptions<CreateFormWizardInputProps>
         }
         render={({ field }) => (
           <TagInput
             placeholder="Separate emails with a comma"
             {...field}
+            value={field.value as string[]}
             tagValidation={isEmail}
           />
         )}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { FormProvider } from 'react-hook-form'
+import { FormProvider, RegisterOptions } from 'react-hook-form'
 import { BiRightArrowAlt } from 'react-icons/bi'
 import {
   Container,
@@ -22,7 +22,10 @@ import { CheckboxField, CheckboxFieldSchema } from '~templates/Field'
 
 import { useAdminUseEmailModeFormView } from '~features/public-form/queries'
 
-import { useCreateFormWizard } from '../CreateFormWizardContext'
+import {
+  CreateFormWizardInputProps,
+  useCreateFormWizard,
+} from '../CreateFormWizardContext'
 
 import { EmailFormRecipientsInput } from './EmailFormRecipientsInput'
 
@@ -116,7 +119,13 @@ export const EmailModeCreationScreen = ({
     setTimeout(() => inputRef.current?.focus(), 200)
   }, [])
 
-  const formTitleRegister = register('title', FORM_TITLE_VALIDATION_RULES)
+  const formTitleRegister = register(
+    'title',
+    FORM_TITLE_VALIDATION_RULES as RegisterOptions<
+      CreateFormWizardInputProps,
+      'title'
+    >,
+  )
   const mergedRef = useMergeRefs(formTitleRegister.ref, inputRef)
 
   const { data: feedbackForm } = useAdminUseEmailModeFormViewParam()

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -181,47 +181,39 @@ export const SaveSecretKeyScreen = ({
               </Text>
             </Stack>
             <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
-            <UnorderedList>
-              <ListItem>
-                {t('features.workspace.modals.create.secretKey.message.preamble1')}
-              </ListItem>
-              <ListItem>
-                <Text textStyle="body-1" color="secondary.500">
-                  {t('features.workspace.modals.create.secretKey.message.preamble2.prefix')}
-                  <Text color="danger.500" textStyle="subhead-1" as="span">
-                    {t('features.workspace.modals.create.secretKey.message.preamble2.warning')}
+              <UnorderedList>
+                <ListItem>
+                  {t(
+                    'features.workspace.modals.create.secretKey.message.preamble1',
+                  )}
+                </ListItem>
+                <ListItem>
+                  <Text textStyle="body-1" color="secondary.500">
+                    {t(
+                      'features.workspace.modals.create.secretKey.message.preamble2.prefix',
+                    )}
+                    <Text color="danger.500" textStyle="subhead-1" as="span">
+                      {t(
+                        'features.workspace.modals.create.secretKey.message.preamble2.warning',
+                      )}
+                    </Text>
                   </Text>
-                </Text>
-              </ListItem>
-              <ListItem>
-                {t('features.workspace.modals.create.secretKey.message.preamble3.prefix')}
-                <Link variant="inline" href={mailToHref}>
-                  {t('features.workspace.modals.create.secretKey.message.preamble3.link')}
-                </Link>
-                {t('features.workspace.modals.create.secretKey.message.preamble3.suffix')}
-              </ListItem>
-            </UnorderedList>
+                </ListItem>
+                <ListItem>
+                  {t(
+                    'features.workspace.modals.create.secretKey.message.preamble3.prefix',
+                  )}
+                  <Link variant="inline" href={mailToHref}>
+                    {t(
+                      'features.workspace.modals.create.secretKey.message.preamble3.link',
+                    )}
+                  </Link>
+                  {t(
+                    'features.workspace.modals.create.secretKey.message.preamble3.suffix',
+                  )}
+                </ListItem>
+              </UnorderedList>
             </Text>
-            {/* <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
-              {t('features.workspace.modals.create.secretKey.message.preamble')}{' '}
-              <Text color="danger.500" textStyle="subhead-1" as="span">
-                {t(
-                  'features.workspace.modals.create.secretKey.message.warning',
-                )}
-              </Text>
-              .{' '}
-              {t(
-                'features.workspace.modals.create.secretKey.message.email.prefix',
-              )}{' '}
-              <Link variant="inline" href={mailToHref}>
-                {t(
-                  'features.workspace.modals.create.secretKey.message.email.link',
-                )}
-              </Link>{' '}
-              {t(
-                'features.workspace.modals.create.secretKey.message.email.suffix',
-              )}
-            </Text> */}
             <Stack direction={{ base: 'column', md: 'row' }}>
               <Tooltip
                 mt={0}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -117,10 +117,27 @@ const useSaveSecretKeyDefault = () => {
       }
     }
 
-    window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [hasDownloaded])
+    const handlePopState = (e: PopStateEvent) => {
+      if (!hasDownloaded) {
+        e.preventDefault();
+        window.history.pushState(null, '', window.location.href);
+        const confirmMessage = 'You have not downloaded your Secret Key yet. You won\'t be able to access your form responses without it. Are you sure you want to leave?';
+        if (!window.confirm(confirmMessage)) {
+          return;
+        }
+      }
+    }
 
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+    
+    window.history.pushState(null, '', window.location.href);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+    }
+  }, [hasDownloaded]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -119,37 +119,38 @@ const useSaveSecretKeyDefault = () => {
 
     const handlePopState = (e: PopStateEvent) => {
       if (!hasDownloaded) {
-        e.preventDefault();
-        window.history.pushState(null, '', window.location.href);
-        const confirmMessage = 'You have not downloaded your Secret Key yet. You won\'t be able to access your form responses without it. Are you sure you want to leave?';
+        e.preventDefault()
+        window.history.pushState(null, '', window.location.href)
+        const confirmMessage =
+          "You have not downloaded your Secret Key yet. You won't be able to access your form responses without it. Are you sure you want to leave?"
         if (!window.confirm(confirmMessage)) {
-          return;
+          return
         }
       }
     }
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
-    window.addEventListener('popstate', handlePopState);
-    
-    window.history.pushState(null, '', window.location.href);
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    window.addEventListener('popstate', handlePopState)
+
+    window.history.pushState(null, '', window.location.href)
 
     return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-      window.removeEventListener('popstate', handlePopState);
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      window.removeEventListener('popstate', handlePopState)
     }
-  }, [hasDownloaded]);
+  }, [hasDownloaded])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && !hasDownloaded) {
-        e.preventDefault();
-        e.stopPropagation();
+        e.preventDefault()
+        e.stopPropagation()
       }
-    };
+    }
 
-    document.addEventListener('keydown', handleKeyDown, true);
-    return () => document.removeEventListener('keydown', handleKeyDown, true);
-  }, [hasDownloaded]);
+    document.addEventListener('keydown', handleKeyDown, true)
+    return () => document.removeEventListener('keydown', handleKeyDown, true)
+  }, [hasDownloaded])
 
   return {
     isLoading,
@@ -228,19 +229,6 @@ export const SaveSecretKeyScreen = ({
                       )}
                     </Text>
                   </Text>
-                </ListItem>
-                <ListItem>
-                  {t(
-                    'features.workspace.modals.create.secretKey.message.preamble3.prefix',
-                  )}
-                  <Link variant="inline" href={mailToHref}>
-                    {t(
-                      'features.workspace.modals.create.secretKey.message.preamble3.link',
-                    )}
-                  </Link>
-                  {t(
-                    'features.workspace.modals.create.secretKey.message.preamble3.suffix',
-                  )}
                 </ListItem>
               </UnorderedList>
             </Text>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -52,15 +52,14 @@ const useSaveSecretKeyDefault = () => {
 
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const formId = queryClient.getQueryData(workspaceKeys.lastCreatedForm)
 
   const handleDownloadAndNavigate = useCallback(() => {
-    // Retrieve stored form ID and navigate
-    const formId = queryClient.getQueryData(workspaceKeys.lastCreatedForm)
     if (formId) {
       queryClient.invalidateQueries(workspaceKeys.lastCreatedForm)
       navigate(`${ADMINFORM_ROUTE}/${formId}`)
     }
-  }, [queryClient, navigate])
+  }, [queryClient, navigate, formId])
 
   const [hasDownloaded, setHasDownloaded] = useState(false)
 
@@ -92,10 +91,11 @@ const useSaveSecretKeyDefault = () => {
       new Blob([secretKey], { type: 'text/plain;charset=utf-8' }),
       t('features.workspace.modals.create.secretKey.email.filename', {
         titleInputValue,
+        formId,
       }),
     )
     setHasDownloaded(true)
-  }, [secretKey, titleInputValue, t])
+  }, [t, secretKey, titleInputValue, formId])
 
   const handleCopyKey = useCallback(
     (e?: SyntheticEvent) => {

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -1,4 +1,10 @@
-import { SyntheticEvent, useCallback, useMemo, useState } from 'react'
+import {
+  SyntheticEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import { useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { BiMailSend, BiRightArrowAlt } from 'react-icons/bi'
@@ -84,6 +90,19 @@ const useSaveSecretKeyDefault = () => {
     },
     [onCopy],
   )
+
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!hasDownloaded) {
+        e.preventDefault() // if event doesn't get explicitly handled, default action WILL not be taken
+        // returnValue is deprecated, but we return it regardless to support legacy cases (e.g. Chrome/Edge < 119)
+        e.returnValue = 'You have not downloaded your Secret Key yet'
+      }
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [hasDownloaded])
 
   return {
     isLoading,

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -8,6 +8,8 @@ import {
 import { useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { BiMailSend, BiRightArrowAlt } from 'react-icons/bi'
+import { useQueryClient } from 'react-query'
+import { useNavigate } from 'react-router-dom'
 import {
   Box,
   ButtonGroup,
@@ -24,12 +26,14 @@ import dedent from 'dedent'
 import FileSaver from 'file-saver'
 
 import { BxsError } from '~assets/icons'
+import { ADMINFORM_ROUTE } from '~constants/routes'
 import Button from '~components/Button'
 import Checkbox from '~components/Checkbox'
 import IconButton from '~components/IconButton'
 import Tooltip from '~components/Tooltip'
 
 import { trackClickSecretKeyMailTo } from '~features/analytics/AnalyticsService'
+import { workspaceKeys } from '~features/workspace/queries'
 
 import { useCreateFormWizard } from '../CreateFormWizardContext'
 
@@ -42,10 +46,21 @@ const useSaveSecretKeyDefault = () => {
       register,
       formState: { isValid },
     },
-    handleCreateStorageModeOrMultirespondentForm,
     isLoading,
     keypair: { secretKey },
   } = useCreateFormWizard()
+
+  const queryClient = useQueryClient()
+  const navigate = useNavigate()
+
+  const handleDownloadAndNavigate = useCallback(() => {
+    // Retrieve stored form ID and navigate
+    const formId = queryClient.getQueryData(workspaceKeys.lastCreatedForm)
+    if (formId) {
+      queryClient.invalidateQueries(workspaceKeys.lastCreatedForm)
+      navigate(`${ADMINFORM_ROUTE}/${formId}`)
+    }
+  }, [queryClient, navigate])
 
   const [hasDownloaded, setHasDownloaded] = useState(false)
 
@@ -112,7 +127,7 @@ const useSaveSecretKeyDefault = () => {
     handleCopyKey,
     handleDownloadKey,
     mailToHref,
-    handleCreateStorageModeOrMultirespondentForm,
+    handleDownloadAndNavigate,
     secretKey,
     register,
   }
@@ -129,7 +144,7 @@ export const SaveSecretKeyScreen = ({
   const {
     isLoading,
     handleCopyKey,
-    handleCreateStorageModeOrMultirespondentForm,
+    handleDownloadAndNavigate,
     handleDownloadKey,
     mailToHref,
     hasDownloaded,
@@ -250,7 +265,7 @@ export const SaveSecretKeyScreen = ({
             rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}
             type="submit"
             isLoading={isLoading}
-            onClick={handleCreateStorageModeOrMultirespondentForm}
+            onClick={handleDownloadAndNavigate}
             isFullWidth
           >
             <Text lineHeight="1.5rem">

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -17,15 +17,17 @@ import {
   Container,
   Icon,
   Link,
+  ListItem,
   ModalBody,
   Stack,
   Text,
+  UnorderedList,
   useClipboard,
 } from '@chakra-ui/react'
 import dedent from 'dedent'
 import FileSaver from 'file-saver'
 
-import { BxsError } from '~assets/icons'
+import { BxsCheckCircle } from '~assets/icons'
 import { ADMINFORM_ROUTE } from '~constants/routes'
 import Button from '~components/Button'
 import Checkbox from '~components/Checkbox'
@@ -169,16 +171,38 @@ export const SaveSecretKeyScreen = ({
           >
             <Stack direction="column" spacing="1rem" mb="1rem">
               <Icon
-                as={BxsError}
+                as={BxsCheckCircle}
                 fontSize="3rem"
                 aria-hidden
-                color="danger.500"
+                color="primary.500"
               />
               <Text as="header" textStyle="h2" color="secondary.700">
                 {t('features.workspace.modals.create.secretKey.title')}
               </Text>
             </Stack>
             <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
+            <UnorderedList>
+              <ListItem>
+                {t('features.workspace.modals.create.secretKey.message.preamble1')}
+              </ListItem>
+              <ListItem>
+                <Text textStyle="body-1" color="secondary.500">
+                  {t('features.workspace.modals.create.secretKey.message.preamble2.prefix')}
+                  <Text color="danger.500" textStyle="subhead-1" as="span">
+                    {t('features.workspace.modals.create.secretKey.message.preamble2.warning')}
+                  </Text>
+                </Text>
+              </ListItem>
+              <ListItem>
+                {t('features.workspace.modals.create.secretKey.message.preamble3.prefix')}
+                <Link variant="inline" href={mailToHref}>
+                  {t('features.workspace.modals.create.secretKey.message.preamble3.link')}
+                </Link>
+                {t('features.workspace.modals.create.secretKey.message.preamble3.suffix')}
+              </ListItem>
+            </UnorderedList>
+            </Text>
+            {/* <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
               {t('features.workspace.modals.create.secretKey.message.preamble')}{' '}
               <Text color="danger.500" textStyle="subhead-1" as="span">
                 {t(
@@ -197,7 +221,7 @@ export const SaveSecretKeyScreen = ({
               {t(
                 'features.workspace.modals.create.secretKey.message.email.suffix',
               )}
-            </Text>
+            </Text> */}
             <Stack direction={{ base: 'column', md: 'row' }}>
               <Tooltip
                 mt={0}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -121,6 +121,19 @@ const useSaveSecretKeyDefault = () => {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
   }, [hasDownloaded])
 
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !hasDownloaded) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [hasDownloaded]);
+
   return {
     isLoading,
     hasDownloaded,

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyScreen.tsx
@@ -50,6 +50,7 @@ const useSaveSecretKeyDefault = () => {
     },
     isLoading,
     keypair: { secretKey },
+    onClose,
   } = useCreateFormWizard()
 
   const queryClient = useQueryClient()
@@ -119,12 +120,11 @@ const useSaveSecretKeyDefault = () => {
 
     const handlePopState = (e: PopStateEvent) => {
       if (!hasDownloaded) {
-        e.preventDefault()
         window.history.pushState(null, '', window.location.href)
         const confirmMessage =
           "You have not downloaded your Secret Key yet. You won't be able to access your form responses without it. Are you sure you want to leave?"
-        if (!window.confirm(confirmMessage)) {
-          return
+        if (window.confirm(confirmMessage)) {
+          onClose()
         }
       }
     }
@@ -138,7 +138,7 @@ const useSaveSecretKeyDefault = () => {
       window.removeEventListener('beforeunload', handleBeforeUnload)
       window.removeEventListener('popstate', handlePopState)
     }
-  }, [hasDownloaded])
+  }, [hasDownloaded, onClose])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -211,27 +211,27 @@ export const SaveSecretKeyScreen = ({
                 {t('features.workspace.modals.create.secretKey.title')}
               </Text>
             </Stack>
-            <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
-              <UnorderedList>
-                <ListItem>
+            <UnorderedList mb="2.5rem" styleType="disc" spacing={2}>
+              <ListItem>
+                <Text textStyle="body-1" color="secondary.500">
                   {t(
                     'features.workspace.modals.create.secretKey.message.preamble1',
                   )}
-                </ListItem>
-                <ListItem>
-                  <Text textStyle="body-1" color="secondary.500">
+                </Text>
+              </ListItem>
+              <ListItem>
+                <Text textStyle="body-1" color="secondary.500">
+                  {t(
+                    'features.workspace.modals.create.secretKey.message.preamble2.prefix',
+                  )}
+                  <Text color="danger.500" textStyle="subhead-1" as="span">
                     {t(
-                      'features.workspace.modals.create.secretKey.message.preamble2.prefix',
+                      'features.workspace.modals.create.secretKey.message.preamble2.warning',
                     )}
-                    <Text color="danger.500" textStyle="subhead-1" as="span">
-                      {t(
-                        'features.workspace.modals.create.secretKey.message.preamble2.warning',
-                      )}
-                    </Text>
                   </Text>
-                </ListItem>
-              </UnorderedList>
-            </Text>
+                </Text>
+              </ListItem>
+            </UnorderedList>
             <Stack direction={{ base: 'column', md: 'row' }}>
               <Tooltip
                 mt={0}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -31,9 +31,6 @@ export type CreateFormWizardContextReturn = {
   currentStep: CreateFormFlowStates
   direction: number
   formMethods: UseFormReturn<CreateFormWizardInputProps>
-  handleDetailsSubmit: ReturnType<
-    UseFormHandleSubmit<CreateFormWizardInputProps>
-  >
   handleEmailFeedbackSubmit: () => void
   handleCreateEmailModeForm: () => () => void
   submitEmailModeFeedback: (feedbackForm: PublicFormViewDto) => () => void

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -43,6 +43,7 @@ export type CreateFormWizardContextReturn = {
   isLoading: boolean
   modalHeader: string
   isSingpass: boolean
+  onClose: () => void
 }
 
 export const CreateFormWizardContext = createContext<

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -87,22 +87,36 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
     ({ title, responseMode, emails }) => {
       switch (responseMode) {
         case FormResponseMode.Encrypt:
-          return createStorageModeFormMutation.mutate({
-            title,
-            responseMode,
-            publicKey: keypair.publicKey,
-            workspaceId,
-            emails: emails.filter(Boolean),
-          })
+          return createStorageModeFormMutation.mutate(
+            {
+              title,
+              responseMode,
+              publicKey: keypair.publicKey,
+              workspaceId,
+              emails: emails.filter(Boolean),
+            },
+            {
+              onSuccess: () => {
+                setCurrentStep([CreateFormFlowStates.Landing, 1])
+              },
+            },
+          )
         case FormResponseMode.Email:
           return
         case FormResponseMode.Multirespondent:
-          return createMultirespondentModeFormMutation.mutate({
-            title,
-            responseMode,
-            publicKey: keypair.publicKey,
-            workspaceId,
-          })
+          return createMultirespondentModeFormMutation.mutate(
+            {
+              title,
+              responseMode,
+              publicKey: keypair.publicKey,
+              workspaceId,
+            },
+            {
+              onSuccess: () => {
+                setCurrentStep([CreateFormFlowStates.Landing, 1])
+              },
+            },
+          )
         default: {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const _: never = responseMode
@@ -157,10 +171,6 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
     })
   }
 
-  const handleDetailsSubmit = handleSubmit(() => {
-    setCurrentStep([CreateFormFlowStates.Landing, 1])
-  })
-
   return {
     isFetching: false,
     isLoading:
@@ -171,7 +181,6 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
     currentStep,
     direction,
     formMethods,
-    handleDetailsSubmit,
     handleCreateEmailModeForm,
     submitEmailModeFeedback,
     handleEmailFeedbackSubmit,

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -55,7 +55,9 @@ export const useCommonFormWizardProvider = ({
   }
 }
 
-const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
+const useCreateFormWizardContext = (
+  onClose: () => void,
+): CreateFormWizardContextReturn => {
   const { t } = useTranslation()
   const { formMethods, currentStep, direction, keypair, setCurrentStep } =
     useCommonFormWizardProvider({
@@ -187,15 +189,18 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
     handleCreateStorageModeOrMultirespondentForm,
     isSingpass: false,
     modalHeader: t('features.workspace.modals.create.title.setup'),
+    onClose,
   }
 }
 
 export const CreateFormWizardProvider = ({
   children,
+  onClose,
 }: {
   children: React.ReactNode
+  onClose: () => void
 }): JSX.Element => {
-  const values = useCreateFormWizardContext()
+  const values = useCreateFormWizardContext(onClose)
   return (
     <CreateFormWizardContext.Provider value={values}>
       {children}

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -10,6 +10,7 @@ import formsgSdk from '~utils/formSdk'
 import { useUser } from '~features/user/queries'
 import {
   useCreateFormMutations,
+  useCreateFormMutationsWithoutRedirect,
   useEmailModeFeedbackMutation,
 } from '~features/workspace/mutations'
 import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
@@ -66,11 +67,12 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
 
   const { handleSubmit, setValue } = formMethods
 
+  const { createEmailModeFormMutation } = useCreateFormMutations()
+
   const {
-    createEmailModeFormMutation,
     createStorageModeFormMutation,
     createMultirespondentModeFormMutation,
-  } = useCreateFormMutations()
+  } = useCreateFormMutationsWithoutRedirect()
 
   const { user } = useUser()
   const adminEmail = user?.email

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -10,7 +10,6 @@ import formsgSdk from '~utils/formSdk'
 import { useUser } from '~features/user/queries'
 import {
   useCreateFormMutations,
-  useCreateFormMutationsWithoutRedirect,
   useEmailModeFeedbackMutation,
 } from '~features/workspace/mutations'
 import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
@@ -67,12 +66,11 @@ const useCreateFormWizardContext = (): CreateFormWizardContextReturn => {
 
   const { handleSubmit, setValue } = formMethods
 
-  const { createEmailModeFormMutation } = useCreateFormMutations()
-
   const {
+    createEmailModeFormMutation,
     createStorageModeFormMutation,
     createMultirespondentModeFormMutation,
-  } = useCreateFormMutationsWithoutRedirect()
+  } = useCreateFormMutations()
 
   const { user } = useUser()
   const adminEmail = user?.email

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -21,7 +21,9 @@ import {
 import { useCommonFormWizardProvider } from '../CreateFormModal/CreateFormWizardProvider'
 import { useWorkspaceRowsContext } from '../WorkspaceFormRow/WorkspaceRowsContext'
 
-export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
+export const useDupeFormWizardContext = (
+  onClose: () => void,
+): CreateFormWizardContextReturn => {
   const { t } = useTranslation()
   const { data: dashboardForms, isLoading: isWorkspaceLoading } = useDashboard()
   const { activeFormMeta } = useWorkspaceRowsContext()
@@ -192,15 +194,18 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
     submitEmailModeFeedback,
     isSingpass,
     modalHeader: t('features.workspace.modals.create.title.duplicate'),
+    onClose,
   }
 }
 
 export const DupeFormWizardProvider = ({
   children,
+  onClose,
 }: {
   children: React.ReactNode
+  onClose: () => void
 }): JSX.Element => {
-  const values = useDupeFormWizardContext()
+  const values = useDupeFormWizardContext(onClose)
   return (
     <CreateFormWizardContext.Provider value={values}>
       {children}

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -90,24 +90,38 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
 
       switch (responseMode) {
         case FormResponseMode.Encrypt:
-          return dupeStorageModeFormMutation.mutate({
-            formIdToDuplicate: activeFormMeta._id,
-            title,
-            responseMode,
-            publicKey: keypair.publicKey,
-            workspaceId,
-            emails: emails.filter(Boolean),
-          })
+          return dupeStorageModeFormMutation.mutate(
+            {
+              formIdToDuplicate: activeFormMeta._id,
+              title,
+              responseMode,
+              publicKey: keypair.publicKey,
+              workspaceId,
+              emails: emails.filter(Boolean),
+            },
+            {
+              onSuccess: () => {
+                setCurrentStep([CreateFormFlowStates.Landing, 1])
+              },
+            },
+          )
         case FormResponseMode.Email:
           return
         case FormResponseMode.Multirespondent:
-          return dupeMultirespondentModeFormMutation.mutate({
-            formIdToDuplicate: activeFormMeta._id,
-            title,
-            responseMode,
-            publicKey: keypair.publicKey,
-            workspaceId,
-          })
+          return dupeMultirespondentModeFormMutation.mutate(
+            {
+              formIdToDuplicate: activeFormMeta._id,
+              title,
+              responseMode,
+              publicKey: keypair.publicKey,
+              workspaceId,
+            },
+            {
+              onSuccess: () => {
+                setCurrentStep([CreateFormFlowStates.Landing, 1])
+              },
+            },
+          )
         default: {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const _: never = responseMode
@@ -162,10 +176,6 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
       })
     })
 
-  const handleDetailsSubmit = handleSubmit(() => {
-    setCurrentStep([CreateFormFlowStates.Landing, 1])
-  })
-
   return {
     isFetching: isWorkspaceLoading || isPreviewFormLoading,
     isLoading:
@@ -176,7 +186,6 @@ export const useDupeFormWizardContext = (): CreateFormWizardContextReturn => {
     currentStep,
     direction,
     formMethods,
-    handleDetailsSubmit,
     handleCreateStorageModeOrMultirespondentForm,
     handleEmailFeedbackSubmit,
     handleCreateEmailModeForm,

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -6,8 +6,6 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
-import { ModalCloseButton } from '~components/Modal'
-
 import { CreateFormModalContent } from '../CreateFormModal/CreateFormModalContent'
 
 import { DupeFormWizardProvider } from './DupeFormWizardProvider'

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -34,7 +34,6 @@ export const DuplicateFormModal = ({
       */}
       <RemoveScroll>
         <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-          <ModalCloseButton />
           <DupeFormWizardProvider>
             <CreateFormModalContent />
           </DupeFormWizardProvider>

--- a/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -32,7 +32,7 @@ export const DuplicateFormModal = ({
       */}
       <RemoveScroll>
         <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-          <DupeFormWizardProvider>
+          <DupeFormWizardProvider onClose={onClose}>
             <CreateFormModalContent />
           </DupeFormWizardProvider>
         </ModalContent>

--- a/frontend/src/features/workspace/components/WorkspaceModals/CreateWorkspaceModal.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceModals/CreateWorkspaceModal.tsx
@@ -1,4 +1,4 @@
-import { useForm } from 'react-hook-form'
+import { RegisterOptions, useForm } from 'react-hook-form'
 import {
   FormControl,
   Modal,
@@ -69,7 +69,13 @@ export const CreateWorkspaceModal = ({
             <Input
               mt="0.75rem"
               autoFocus
-              {...register('title', WORKSPACE_TITLE_VALIDATION_RULES)}
+              {...register(
+                'title',
+                WORKSPACE_TITLE_VALIDATION_RULES as RegisterOptions<
+                  CreateWorkspaceInputProps,
+                  'title'
+                >,
+              )}
             />
             <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
           </FormControl>

--- a/frontend/src/features/workspace/components/WorkspaceModals/RenameWorkspaceModal.tsx
+++ b/frontend/src/features/workspace/components/WorkspaceModals/RenameWorkspaceModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useForm } from 'react-hook-form'
+import { RegisterOptions, useForm } from 'react-hook-form'
 import {
   FormControl,
   Modal,
@@ -84,7 +84,13 @@ export const RenameWorkspaceModal = ({
             <Input
               mt="0.75rem"
               autoFocus
-              {...register('title', WORKSPACE_TITLE_VALIDATION_RULES)}
+              {...register(
+                'title',
+                WORKSPACE_TITLE_VALIDATION_RULES as RegisterOptions<
+                  RenameWorkspaceInputProps,
+                  'title'
+                >,
+              )}
             />
             <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
           </FormControl>

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -158,7 +158,6 @@ export const useDuplicateFormMutations = () => {
     {
       onSuccess: (data) => {
         handleSuccessWithoutRedirect(data)
-        console.log(`dupe form worfklow: set query data done on ${data._id}`)
         queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
       },
       onError: handleError,
@@ -175,7 +174,6 @@ export const useDuplicateFormMutations = () => {
     {
       onSuccess: (data) => {
         handleSuccessWithoutRedirect(data)
-        console.log(`dupe form worfklow: set query data done on ${data._id}`)
         queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
       },
       onError: handleError,

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -57,6 +57,15 @@ const useCommonHooks = () => {
     [navigate, queryClient],
   )
 
+  const handleSuccessWithoutRedirect = useCallback(
+    (data: FormDto) => {
+      queryClient.invalidateQueries(workspaceKeys.dashboard)
+      queryClient.invalidateQueries(workspaceKeys.workspaces)
+      return data
+    },
+    [queryClient],
+  )
+
   const handleError = useCallback(
     (error: ApiError) => {
       toast({
@@ -69,11 +78,58 @@ const useCommonHooks = () => {
 
   return {
     handleSuccess,
+    handleSuccessWithoutRedirect,
     handleError,
   }
 }
 
 export const useCreateFormMutations = () => {
+  const { handleSuccess, handleError, handleSuccessWithoutRedirect } =
+    useCommonHooks()
+
+  const queryClient = useQueryClient()
+
+  const createEmailModeFormMutation = useMutation<
+    FormDto,
+    ApiError,
+    CreateEmailFormBodyDto
+  >((params) => createEmailModeForm(params), {
+    onSuccess: handleSuccess, // we want to redirect on this, as we have no secret key to download
+    onError: handleError,
+  })
+
+  const createStorageModeFormMutation = useMutation<
+    FormDto,
+    ApiError,
+    CreateStorageFormBodyDto
+  >((params) => createStorageModeForm(params), {
+    onSuccess: (data) => {
+      handleSuccessWithoutRedirect(data)
+      queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
+    },
+    onError: handleError,
+  })
+
+  const createMultirespondentModeFormMutation = useMutation<
+    FormDto,
+    ApiError,
+    CreateMultirespondentFormBodyDto
+  >((params) => createMultirespondentModeForm(params), {
+    onSuccess: (data) => {
+      handleSuccessWithoutRedirect(data)
+      queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
+    },
+    onError: handleError,
+  })
+
+  return {
+    createEmailModeFormMutation,
+    createStorageModeFormMutation,
+    createMultirespondentModeFormMutation,
+  }
+}
+
+export const useCreateFormMutationsWithoutRedirect = () => {
   const { handleSuccess, handleError } = useCommonHooks()
 
   const createEmailModeFormMutation = useMutation<
@@ -126,6 +182,7 @@ export const useDuplicateFormMutations = () => {
     },
   )
 
+  // TODO (tejas): remember to change this!
   const dupeStorageModeFormMutation = useMutation<
     FormDto,
     ApiError,

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -83,20 +83,10 @@ const useCommonHooks = () => {
   }
 }
 
-export const useCreateFormMutations = () => {
-  const { handleSuccess, handleError, handleSuccessWithoutRedirect } =
-    useCommonHooks()
+export const useCreateFormMutationsWithoutRedirect = () => {
+  const { handleError, handleSuccessWithoutRedirect } = useCommonHooks()
 
   const queryClient = useQueryClient()
-
-  const createEmailModeFormMutation = useMutation<
-    FormDto,
-    ApiError,
-    CreateEmailFormBodyDto
-  >((params) => createEmailModeForm(params), {
-    onSuccess: handleSuccess, // we want to redirect on this, as we have no secret key to download
-    onError: handleError,
-  })
 
   const createStorageModeFormMutation = useMutation<
     FormDto,
@@ -123,13 +113,12 @@ export const useCreateFormMutations = () => {
   })
 
   return {
-    createEmailModeFormMutation,
     createStorageModeFormMutation,
     createMultirespondentModeFormMutation,
   }
 }
 
-export const useCreateFormMutationsWithoutRedirect = () => {
+export const useCreateFormMutations = () => {
   const { handleSuccess, handleError } = useCommonHooks()
 
   const createEmailModeFormMutation = useMutation<

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -83,43 +83,11 @@ const useCommonHooks = () => {
   }
 }
 
-export const useCreateFormMutationsWithoutRedirect = () => {
-  const { handleError, handleSuccessWithoutRedirect } = useCommonHooks()
+export const useCreateFormMutations = () => {
+  const { handleError, handleSuccess, handleSuccessWithoutRedirect } =
+    useCommonHooks()
 
   const queryClient = useQueryClient()
-
-  const createStorageModeFormMutation = useMutation<
-    FormDto,
-    ApiError,
-    CreateStorageFormBodyDto
-  >((params) => createStorageModeForm(params), {
-    onSuccess: (data) => {
-      handleSuccessWithoutRedirect(data)
-      queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
-    },
-    onError: handleError,
-  })
-
-  const createMultirespondentModeFormMutation = useMutation<
-    FormDto,
-    ApiError,
-    CreateMultirespondentFormBodyDto
-  >((params) => createMultirespondentModeForm(params), {
-    onSuccess: (data) => {
-      handleSuccessWithoutRedirect(data)
-      queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
-    },
-    onError: handleError,
-  })
-
-  return {
-    createStorageModeFormMutation,
-    createMultirespondentModeFormMutation,
-  }
-}
-
-export const useCreateFormMutations = () => {
-  const { handleSuccess, handleError } = useCommonHooks()
 
   const createEmailModeFormMutation = useMutation<
     FormDto,
@@ -135,7 +103,11 @@ export const useCreateFormMutations = () => {
     ApiError,
     CreateStorageFormBodyDto
   >((params) => createStorageModeForm(params), {
-    onSuccess: handleSuccess,
+    onSuccess: (data) => {
+      handleSuccessWithoutRedirect(data)
+      console.log(`create form worfklow: set query data done on ${data._id}`)
+      queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
+    },
     onError: handleError,
   })
 
@@ -144,7 +116,11 @@ export const useCreateFormMutations = () => {
     ApiError,
     CreateMultirespondentFormBodyDto
   >((params) => createMultirespondentModeForm(params), {
-    onSuccess: handleSuccess,
+    onSuccess: (data) => {
+      handleSuccessWithoutRedirect(data)
+      console.log(`create form worfklow: set query data done on ${data._id}`)
+      queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
+    },
     onError: handleError,
   })
 
@@ -184,6 +160,7 @@ export const useDuplicateFormMutations = () => {
     {
       onSuccess: (data) => {
         handleSuccessWithoutRedirect(data)
+        console.log(`dupe form worfklow: set query data done on ${data._id}`)
         queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
       },
       onError: handleError,
@@ -200,6 +177,7 @@ export const useDuplicateFormMutations = () => {
     {
       onSuccess: (data) => {
         handleSuccessWithoutRedirect(data)
+        console.log(`dupe form worfklow: set query data done on ${data._id}`)
         queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
       },
       onError: handleError,

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -105,7 +105,6 @@ export const useCreateFormMutations = () => {
   >((params) => createStorageModeForm(params), {
     onSuccess: (data) => {
       handleSuccessWithoutRedirect(data)
-      console.log(`create form worfklow: set query data done on ${data._id}`)
       queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
     },
     onError: handleError,
@@ -118,7 +117,6 @@ export const useCreateFormMutations = () => {
   >((params) => createMultirespondentModeForm(params), {
     onSuccess: (data) => {
       handleSuccessWithoutRedirect(data)
-      console.log(`create form worfklow: set query data done on ${data._id}`)
       queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
     },
     onError: handleError,

--- a/frontend/src/features/workspace/mutations.ts
+++ b/frontend/src/features/workspace/mutations.ts
@@ -156,7 +156,10 @@ export const useCreateFormMutations = () => {
 }
 
 export const useDuplicateFormMutations = () => {
-  const { handleSuccess, handleError } = useCommonHooks()
+  const { handleSuccess, handleSuccessWithoutRedirect, handleError } =
+    useCommonHooks()
+
+  const queryClient = useQueryClient()
 
   const dupeEmailModeFormMutation = useMutation<
     FormDto,
@@ -171,7 +174,6 @@ export const useDuplicateFormMutations = () => {
     },
   )
 
-  // TODO (tejas): remember to change this!
   const dupeStorageModeFormMutation = useMutation<
     FormDto,
     ApiError,
@@ -180,7 +182,10 @@ export const useDuplicateFormMutations = () => {
     ({ formIdToDuplicate, ...params }) =>
       dupeStorageModeForm(formIdToDuplicate, params),
     {
-      onSuccess: handleSuccess,
+      onSuccess: (data) => {
+        handleSuccessWithoutRedirect(data)
+        queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
+      },
       onError: handleError,
     },
   )
@@ -193,7 +198,10 @@ export const useDuplicateFormMutations = () => {
     ({ formIdToDuplicate, ...params }) =>
       dupeMultirespondentModeForm(formIdToDuplicate, params),
     {
-      onSuccess: handleSuccess,
+      onSuccess: (data) => {
+        handleSuccessWithoutRedirect(data)
+        queryClient.setQueryData(workspaceKeys.lastCreatedForm, data._id)
+      },
       onError: handleError,
     },
   )

--- a/frontend/src/features/workspace/queries.ts
+++ b/frontend/src/features/workspace/queries.ts
@@ -10,6 +10,7 @@ import { getDashboardView, getWorkspacesView } from './WorkspaceService'
 export const workspaceKeys = {
   dashboard: ['dashboard'] as const,
   workspaces: ['workspaces'] as const,
+  lastCreatedForm: ['lastCreatedForm'] as const,
 }
 
 export const useDashboard = (): UseQueryResult<

--- a/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
@@ -59,7 +59,7 @@ export const enSG: CreateModal = {
       'If I lose my Secret Key, I cannot activate my form or access any responses to it',
     confirm: 'I have saved my Secret Key safely',
     email: {
-      filename: 'Form Secret Key - {titleInputValue} - FormID(${formId}).txt',
+      filename: 'Form Secret Key - {titleInputValue} - FormID({formId}).txt',
       subject: 'Shared Secret Key for {titleInputValue}',
       body: `
         Dear collaborator,

--- a/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
@@ -44,7 +44,7 @@ export const enSG: CreateModal = {
     title: 'Your form has been created! Download your Secret Key to proceed.',
     message: {
       preamble1:
-        "You'll need your secret key every time you access your responses to this form.",
+        "You will need this secret key to access this form's responses.",
       preamble2: {
         prefix: 'If you lose it, ',
         warning: 'all responses will be permanently lost',

--- a/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
@@ -41,15 +41,18 @@ export const enSG: CreateModal = {
     create: 'Create form',
   },
   secretKey: {
-    title: 'Download Secret Key to proceed',
+    title: 'Your form has been created! Download your Secret Key to proceed.',
     message: {
-      preamble:
-        "You'll need it every time you access your responses to this form. If you lose it,",
-      warning: 'all responses will be permanently lost',
-      email: {
-        prefix: 'You can also',
+      preamble1:
+        "You'll need your secret key every time you access your responses to this form.",
+      preamble2: {
+        prefix: 'If you lose it, ',
+        warning: 'all responses will be permanently lost',
+      },
+      preamble3: {
+        prefix: 'You can also ',
         link: 'email it',
-        suffix: 'for safekeeping.',
+        suffix: ' for safekeeping.',
       },
     },
     tooltip: {

--- a/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
@@ -49,11 +49,6 @@ export const enSG: CreateModal = {
         prefix: 'If you lose it, ',
         warning: 'all responses will be permanently lost',
       },
-      preamble3: {
-        prefix: 'You can also ',
-        link: 'email it',
-        suffix: ' for safekeeping.',
-      },
     },
     tooltip: {
       copyKey: 'Copy key',

--- a/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
@@ -61,7 +61,7 @@ export const enSG: CreateModal = {
       'If I lose my Secret Key, I cannot activate my form or access any responses to it',
     confirm: 'I have saved my Secret Key safely',
     email: {
-      filename: 'Form Secret Key - {titleInputValue}.txt',
+      filename: 'Form Secret Key - {titleInputValue} - FormID(${formId}).txt',
       subject: 'Shared Secret Key for {titleInputValue}',
       body: `
         Dear collaborator,

--- a/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/en-sg.ts
@@ -38,7 +38,7 @@ export const enSG: CreateModal = {
       description:
         'All email addresses below will be notified. Learn more on [how to guard against email bounces]({GUIDE_PREVENT_EMAIL_BOUNCE}).',
     },
-    next: 'Next step',
+    create: 'Create form',
   },
   secretKey: {
     title: 'Download Secret Key to proceed',

--- a/frontend/src/i18n/locales/features/workspace/create/index.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/index.ts
@@ -32,7 +32,7 @@ export interface CreateModal {
       label: string
       description: string
     }
-    next: string
+    create: string
   }
   secretKey: {
     title: string

--- a/frontend/src/i18n/locales/features/workspace/create/index.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/index.ts
@@ -37,9 +37,12 @@ export interface CreateModal {
   secretKey: {
     title: string
     message: {
-      preamble: string
-      warning: string
-      email: {
+      preamble1: string
+      preamble2: {
+        prefix: string
+        warning: string
+      }
+      preamble3: {
         prefix: string
         link: string
         suffix: string

--- a/frontend/src/i18n/locales/features/workspace/create/index.ts
+++ b/frontend/src/i18n/locales/features/workspace/create/index.ts
@@ -42,11 +42,6 @@ export interface CreateModal {
         prefix: string
         warning: string
       }
-      preamble3: {
-        prefix: string
-        link: string
-        suffix: string
-      }
     }
     tooltip: {
       copyKey: string

--- a/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -81,7 +81,9 @@ export const ChildrenCompoundField = ({
   const { isSubmitting, errors } = useFormState<ChildrenCompoundFieldInputs>({
     name: schema._id,
   })
-  const error: FieldError[][] | undefined = get(errors, schema._id)?.child
+  const error: FieldError[][] | undefined = get(errors, schema._id)?.child as
+    | FieldError[][]
+    | undefined
   const childError: FieldError[] | undefined = error ? error[0] : undefined
 
   const { fields, append, remove } = useFieldArray<ChildrenCompoundFieldInputs>(

--- a/frontend/src/templates/Field/FieldContainer.tsx
+++ b/frontend/src/templates/Field/FieldContainer.tsx
@@ -70,7 +70,9 @@ export const FieldContainer = ({
   const { i18n } = useTranslation()
   const { errors, isSubmitting, isValid } = useFormState({ name: schema._id })
 
-  const error: FieldError | undefined = get(errors, errorKey ?? schema._id)
+  const error: FieldError | undefined = get(errors, errorKey ?? schema._id) as
+    | FieldError
+    | undefined
   const selectedLanguage = i18n.language as Language
 
   const title = getValueInSelectedLanguage({

--- a/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -54,7 +54,11 @@ const ShortTextColumnCell = ({
   colorTheme,
 }: FieldColumnCellProps<ShortTextColumnBase>) => {
   const rules = useMemo(
-    () => createBaseValidationRules(schema, disableRequiredValidation),
+    () =>
+      createBaseValidationRules<
+        TableFieldInputs,
+        `${string}.${number}.${string}`
+      >(schema, disableRequiredValidation),
     [schema, disableRequiredValidation],
   )
 

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -84,7 +84,9 @@ export const TableField = ({
     // would not need to be shown in the table field itself.
     if (isMobile) return
     // Get first available error amongst all column cell errors.
-    return head(uniq(tableErrors?.flatMap((err = {}) => Object.values(err))))
+    return head(
+      uniq([tableErrors].flat().flatMap((err = {}) => Object.values(err))),
+    )
   }, [isMobile, tableErrors])
 
   const { fields, append, remove } = useFieldArray<TableFieldInputs>({
@@ -267,7 +269,7 @@ export const TableField = ({
       </Box>
       {uniqTableError ? (
         <FormErrorMessage my="0.75rem">
-          {uniqTableError.message}
+          {String(uniqTableError)}
         </FormErrorMessage>
       ) : null}
       {schema.addMoreRows && schema.maximumRows !== undefined ? (

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -83,10 +83,28 @@ export const TableField = ({
     // On mobile, errors are shown directly in the individual table cells and
     // would not need to be shown in the table field itself.
     if (isMobile) return
-    // Get first available error amongst all column cell errors.
-    return head(
-      uniq([tableErrors].flat().flatMap((err = {}) => Object.values(err))),
-    )
+    if (!tableErrors) return null
+
+    if (typeof tableErrors === 'object' && tableErrors?.message) {
+      return tableErrors.message
+    }
+
+    // If tableErrors is an array, find the first error message
+    if (Array.isArray(tableErrors)) {
+      // Look for the first object with a message property
+      for (const err of tableErrors) {
+        if (err?.message) return err.message
+
+        // Check if any property of the error object has a message
+        for (const val of Object.values(err || {})) {
+          if (typeof val === 'object' && val !== null && 'message' in val) {
+            return val.message
+          }
+        }
+      }
+    }
+
+    return String(tableErrors)
   }, [isMobile, tableErrors])
 
   const { fields, append, remove } = useFieldArray<TableFieldInputs>({

--- a/frontend/src/templates/Field/YesNo/YesNoField.tsx
+++ b/frontend/src/templates/Field/YesNo/YesNoField.tsx
@@ -24,7 +24,11 @@ export const YesNoField = ({
   colorTheme = FormColorTheme.Blue,
 }: YesNoFieldProps): JSX.Element => {
   const validationRules = useMemo(
-    () => createBaseValidationRules(schema, disableRequiredValidation),
+    () =>
+      createBaseValidationRules<YesNoFieldInput, string>(
+        schema,
+        disableRequiredValidation,
+      ),
     [schema, disableRequiredValidation],
   )
 

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -2,7 +2,12 @@
  * This utility file creates validation rules for `react-hook-form` according
  * to the field schema.
  */
-import { RegisterOptions, UseFormGetValues } from 'react-hook-form'
+import {
+  FieldValues,
+  Path,
+  RegisterOptions,
+  UseFormGetValues,
+} from 'react-hook-form'
 import { isValid, parse } from 'date-fns'
 import { identity } from 'lodash'
 import simplur from 'simplur'
@@ -147,10 +152,13 @@ const createBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
   }
 }
 
-export const createBaseValidationRules = (
+export const createBaseValidationRules = <
+  TFieldValues extends FieldValues = FieldValues,
+  TFieldName extends Path<TFieldValues> = never,
+>(
   schema: Pick<FieldBase, 'required'>,
   disableRequiredValidation?: boolean,
-): RegisterOptions => {
+): RegisterOptions<TFieldValues, TFieldName> => {
   return {
     validate: requiredSingleAnswerValidationFn(
       schema,

--- a/shared/types/form/form_logic.ts
+++ b/shared/types/form/form_logic.ts
@@ -1,6 +1,7 @@
 import { BasicField, FormFieldDto, TranslationMapping } from '../field'
 
 export enum LogicConditionState {
+  Empty = '',
   Equal = 'is equals to',
   Lte = 'is less than or equal to',
   Gte = 'is more than or equal to',


### PR DESCRIPTION
## Problem

Closes FRM-1959, closes FRM-1971

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
**Encrypt form creation workflow**
- [ ] 1. Press on create form, enter title
- [ ] 2. Pick encrypt mode
- [ ] 3. Click create form button, which should bring you to the secrets page
- [ ] 4. Observe that the cross button at the top right is no longer visible
- [ ] 5. Before downloading, try to refresh / go back a page / close the page. 
- [ ] 6. Observe that the browser download box appears with "Reload site" text. Press no / cancel the action. 
- [ ] 7. Download the key
- [ ] 8. Click checkbox and proceed button
- [ ] 9. Observe that the encrypt form is created successfully
- [ ] 10. Repeat steps 1 - 5. Instead, now press ok. Observe that it should let you do the destructive action.

**MRF creation workflow**
- [ ] 1. Press on create form, enter title
- [ ] 2. Pick encrypt mode
- [ ] 3. Click create form button, which should bring you to the secrets page
- [ ] 4. Observe that the cross button at the top right is no longer visible
- [ ] 5. Before downloading, try to refresh / go back a page / close the page. 
- [ ] 6. Observe that the browser download box appears with "Reload site" text.
- [ ] 7. Download the key
- [ ] 8. Click checkbox and proceed button
- [ ] 9. Observe that the encrypt form is created successfully
- [ ] 10. Repeat steps 1 - 5. Instead, now press ok. Observe that it should let you do the destructive action.

**Email mode creation workflow**
Repeat the above steps for email mode, except there's no secret key saving and it should send you to the admin dashboard.

**Repeat for `Duplicate` + `UseTemplate` workflow**
