### PR TITLE
fix: add trimming of input value

### DIFF
--- a/frontend/src/features/admin-form/settings/components/SecretKeyFormModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyFormModal.tsx
@@ -112,6 +112,7 @@ export const SecretKeyFormModal = ({
                         value: SECRET_KEY_REGEX,
                         message: 'The secret key provided is invalid',
                       },
+                      setValueAs: (v) => v.trim(),
                     })}
                     placeholder={
                       dragging


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Our behavior for copying and pasting secret keys into form opening vs results is different. One of them trims white space but not the other. Somehow in the outlook email, there is an additional white space.

Closes FRM-1965

## Solution
<!-- How did you solve the problem? -->

Trim before validate.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  


## Tests
<!-- What tests should be run to confirm functionality? -->
### Regression
- [ ] Create a storage mode form
- [ ] Open the form to bring up `<SecretKeyFormModal />`
- [ ] Input the wrong secret key value (i.e., add `"123"` to the value)
- [ ] Observe that incorrect secret keys is disallowed
- [ ] Input the right secret key value
- [ ] Observe that correct secret keys is allowed

### Space input are trimmed
- [ ] Create a storage mode form
- [ ] Open the form to bring up `<SecretKeyFormModal />`
- [ ] Prepare the secret key with newlines and spaces surrounding the secret key (hint: use notepad to prepare them)
- [ ] Copy and paste the prepared key into `<Input />`
- [ ] Observe that correct secret keys is allowed
