### PR TITLE
fix: downgrade from server error to client error

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -204,7 +204,7 @@ export const mapRouteError = (
     case ModelResponseInvalidSchemaFormatError:
     case ModelResponseInvalidSyntaxError:
       return {
-        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'Something went wrong when generating your form. Please change your prompt and try again.',
       }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

5xx error class refers to errors where the BE should make a configuration correction to accept requests. Since we require the user to reword the prompt to generate the right response, it should be a client-side error.

Closes FRM-1973

## Solution
<!-- How did you solve the problem? -->

Change the error returned to `400 BAD REQUEST` which implies that "Clients that receive a 400 response should expect that repeating the request without modification will fail with the same error."

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
