### PR TITLE
fix: added attachments to approval workflow end email

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -393,6 +393,7 @@ const sendMrfOutcomeEmails = ({
             responseId: submissionId,
             isRejected,
             formQuestionAnswers,
+            attachments: attachments,
           }).orElse((error) => {
             logger.error({
               message: 'Failed to send approval email',

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -935,6 +935,7 @@ export class MailService {
     responseId,
     isRejected,
     formQuestionAnswers,
+    attachments,
   }: {
     emails: string[]
     formId: string
@@ -942,6 +943,7 @@ export class MailService {
     responseId: string
     isRejected: boolean
     formQuestionAnswers: QuestionAnswer[]
+    attachments?: Mail.Attachment[]
   }) => {
     const outcome = isRejected
       ? WorkflowOutcome.NOT_APPROVED
@@ -976,6 +978,7 @@ export class MailService {
         from: this.#senderFromString,
         subject: `${outcome} - ${formTitle} (${responseId})`,
         html: mailHtml,
+        attachments,
         headers: {
           [EMAIL_HEADERS.emailType]: EmailType.WorkflowNotification,
         },


### PR DESCRIPTION
## Problem
Part of the work of attachment support in MRF emails

## Solution
Including attachments in the email response for approval/rejection outcome emails, similar to MRF workflow completion emails (not approvals).

Attachments are only included for email responses upon outcome fulfilment:
- When MRF is approved all the way (if there are multiple approvals)
- If MRF is rejected (and workflow stops there)
