### PR TITLE
feat: remove active and hover styles for send reminder button

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/SendReminderButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/SendReminderButton.tsx
@@ -41,6 +41,8 @@ export const SendReminderButton = ({
       variant="clear"
       leftIcon={<BiBell />}
       _focus={{}}
+      _hover={{}}
+      _active={{}}
       onClick={(e) => {
         e.stopPropagation()
         if (!submissionSecretKey) {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
There is a visual issue where the hover and active state triggers a background color of the send reminder button to change. This affects the polish and visual quality of how the button looks.   

## Solution
<!-- How did you solve the problem? -->
Remove the hover and active state styles of the send reminder button. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  