### PR TITLE
test: add chromatic screen for email

### DIFF
--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -138,6 +138,60 @@ export const StorageModeAckScreen = () => {
   )
 }
 
+export const EmailModeFeedback = () => {
+  const formMethods = useForm<CreateFormWizardInputProps>()
+
+  const mockHook = useCallback(
+    () =>
+      ({
+        currentStep: CreateFormFlowStates.EmailFeedback,
+        direction: 1,
+        formMethods,
+        handleDetailsSubmit: () => console.log('handle details submit'),
+        handleEmailFeedbackSubmit: () => console.log('handle email feedback'),
+        handleCreateEmailModeForm: () => () => console.log('create email form'),
+        submitEmailModeFeedback: () => () => console.log('submit feedback'),
+        handleCreateStorageModeOrMultirespondentForm: () =>
+          Promise.resolve(console.log('create storage/multi form')),
+        keypair: {
+          publicKey: 'mock-public-key',
+          privateKey: 'mock-private-key',
+        },
+        isFetching: false,
+        isLoading: false,
+        modalHeader: 'Email Mode Creation',
+        isSingpass: false,
+      }) as unknown as CreateFormWizardContextReturn,
+    [formMethods],
+  )
+
+  return (
+    <WorkspaceProvider
+      currentWorkspace={MOCK_DEFAULT_WORKSPACE._id}
+      defaultWorkspace={MOCK_DEFAULT_WORKSPACE}
+      setCurrentWorkspace={() => {
+        return
+      }}
+    >
+      <Modal isOpen onClose={() => console.log('close modal')} size="full">
+        <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
+          <ModalCloseButton />
+          <CreateFormWizardProvider>
+            <EmailModeFeedbackScreen
+              useCreateFormWizardParam={mockHook}
+              useAdminUseEmailModeFormViewParam={() => {
+                return {
+                  data: {},
+                } as unknown as UseQueryResult<PublicFormViewDto, ApiError>
+              }}
+            />
+          </CreateFormWizardProvider>
+        </ModalContent>
+      </Modal>
+    </WorkspaceProvider>
+  )
+}
+
 export const EmailModeCreation = () => {
   const formMethods = useForm<CreateFormWizardInputProps>()
 
@@ -164,8 +218,6 @@ export const EmailModeCreation = () => {
       }) as unknown as CreateFormWizardContextReturn,
     [formMethods],
   )
-
-  console.log(`${mockHook}`)
 
   return (
     <WorkspaceProvider

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { SyntheticEvent, useCallback, useState } from 'react'
+import { SyntheticEvent, useCallback } from 'react'
 import { useForm } from 'react-hook-form'
+import { UseQueryResult } from 'react-query'
 import { MemoryRouter } from 'react-router-dom'
 import {
   Modal,
@@ -11,18 +12,30 @@ import {
 import { Meta, StoryFn } from '@storybook/react'
 
 import { UserId } from '~shared/types'
+import { PublicFormViewDto } from '~shared/types/form'
 import { Workspace, WorkspaceId } from '~shared/types/workspace'
 
 import { userHandlers } from '~/mocks/msw/handlers/user'
+
+import { ApiError } from '~typings/core'
 
 import { fullScreenDecorator, LoggedInDecorator } from '~utils/storybook'
 import { ModalCloseButton } from '~components/Modal'
 
 import { WorkspaceProvider } from '~features/workspace/WorkspaceProvider'
 
+import {
+  EmailModeCreationScreen,
+  EmailModeFeedbackScreen,
+} from './CreateFormModalContent/EmailModeFeedbackAndCreateScreen'
 import { SaveSecretKeyScreen } from './CreateFormModalContent/SaveSecretKeyScreen'
 import { CreateFormModal, CreateFormModalProps } from './CreateFormModal'
-import { CreateFormWizardInputProps } from './CreateFormWizardContext'
+import {
+  CreateFormFlowStates,
+  CreateFormWizardContext,
+  CreateFormWizardContextReturn,
+  CreateFormWizardInputProps,
+} from './CreateFormWizardContext'
 import { CreateFormWizardProvider } from './CreateFormWizardProvider'
 
 const MOCK_DEFAULT_WORKSPACE = {
@@ -118,6 +131,62 @@ export const StorageModeAckScreen = () => {
           <ModalCloseButton />
           <CreateFormWizardProvider>
             <SaveSecretKeyScreen useSaveSecretKey={mockHook} />
+          </CreateFormWizardProvider>
+        </ModalContent>
+      </Modal>
+    </WorkspaceProvider>
+  )
+}
+
+export const EmailModeCreation = () => {
+  const formMethods = useForm<CreateFormWizardInputProps>()
+
+  const mockHook = useCallback(
+    () =>
+      ({
+        currentStep: CreateFormFlowStates.EmailModeCreation,
+        direction: 1,
+        formMethods,
+        handleDetailsSubmit: () => console.log('handle details submit'),
+        handleEmailFeedbackSubmit: () => console.log('handle email feedback'),
+        handleCreateEmailModeForm: () => () => console.log('create email form'),
+        submitEmailModeFeedback: () => () => console.log('submit feedback'),
+        handleCreateStorageModeOrMultirespondentForm: () =>
+          Promise.resolve(console.log('create storage/multi form')),
+        keypair: {
+          publicKey: 'mock-public-key',
+          privateKey: 'mock-private-key',
+        },
+        isFetching: false,
+        isLoading: false,
+        modalHeader: 'Email Mode Creation',
+        isSingpass: false,
+      }) as unknown as CreateFormWizardContextReturn,
+    [formMethods],
+  )
+
+  console.log(`${mockHook}`)
+
+  return (
+    <WorkspaceProvider
+      currentWorkspace={MOCK_DEFAULT_WORKSPACE._id}
+      defaultWorkspace={MOCK_DEFAULT_WORKSPACE}
+      setCurrentWorkspace={() => {
+        return
+      }}
+    >
+      <Modal isOpen onClose={console.log} size="full">
+        <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
+          <ModalCloseButton />
+          <CreateFormWizardProvider>
+            <EmailModeCreationScreen
+              useCreateFormWizardParam={mockHook}
+              useAdminUseEmailModeFormViewParam={() => {
+                return {
+                  data: {},
+                } as unknown as UseQueryResult<PublicFormViewDto, ApiError>
+              }}
+            />
           </CreateFormWizardProvider>
         </ModalContent>
       </Modal>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
@@ -120,9 +120,6 @@ export const EmailModeCreationScreen = ({
   const mergedRef = useMergeRefs(formTitleRegister.ref, inputRef)
 
   const { data: feedbackForm } = useAdminUseEmailModeFormViewParam()
-  // print type  of data
-  console.log(`${typeof feedbackForm}`)
-  console.log(`${JSON.stringify(feedbackForm)}`)
   if (!feedbackForm) return <></>
 
   return (

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
@@ -40,14 +40,20 @@ const CHECKBOX_FIELD_SCHEMA: CheckboxFieldSchema = {
 }
 
 // TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented.
-export const EmailModeFeedbackScreen = (): JSX.Element => {
+export const EmailModeFeedbackScreen = ({
+  useCreateFormWizardParam = useCreateFormWizard,
+  useAdminUseEmailModeFormViewParam = useAdminUseEmailModeFormView,
+}: {
+  useCreateFormWizardParam?: typeof useCreateFormWizard
+  useAdminUseEmailModeFormViewParam?: typeof useAdminUseEmailModeFormView
+}): JSX.Element => {
   const { formMethods, submitEmailModeFeedback, isLoading, isFetching } =
-    useCreateFormWizard()
+    useCreateFormWizardParam()
   const {
     formState: { errors },
   } = formMethods
 
-  const { data: feedbackForm } = useAdminUseEmailModeFormView()
+  const { data: feedbackForm } = useAdminUseEmailModeFormViewParam()
   if (!feedbackForm) return <></>
 
   return (

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
@@ -86,14 +86,20 @@ export const EmailModeFeedbackScreen = (): JSX.Element => {
   )
 }
 
-export const EmailModeCreationScreen = (): JSX.Element => {
+export const EmailModeCreationScreen = ({
+  useCreateFormWizardParam = useCreateFormWizard,
+  useAdminUseEmailModeFormViewParam = useAdminUseEmailModeFormView,
+}: {
+  useCreateFormWizardParam?: typeof useCreateFormWizard
+  useAdminUseEmailModeFormViewParam?: typeof useAdminUseEmailModeFormView
+}): JSX.Element => {
   const {
     formMethods,
 
     handleCreateEmailModeForm,
     isLoading,
     isFetching,
-  } = useCreateFormWizard()
+  } = useCreateFormWizardParam()
   const {
     register,
     formState: { errors },
@@ -107,7 +113,10 @@ export const EmailModeCreationScreen = (): JSX.Element => {
   const formTitleRegister = register('title', FORM_TITLE_VALIDATION_RULES)
   const mergedRef = useMergeRefs(formTitleRegister.ref, inputRef)
 
-  const { data: feedbackForm } = useAdminUseEmailModeFormView()
+  const { data: feedbackForm } = useAdminUseEmailModeFormViewParam()
+  // print type  of data
+  console.log(`${typeof feedbackForm}`)
+  console.log(`${JSON.stringify(feedbackForm)}`)
   if (!feedbackForm) return <></>
 
   return (


### PR DESCRIPTION
## Problem
As we create e2e tests programmatically (https://github.com/opengovsg/FormSG/pull/8143) now, we want to cover this with added chromatic tests. These are the new screens for the new email mode workflow

Closes FRM-1979

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests
**Email Mode Feedback**
- [ ] 1. Create an email mode form
- [ ] 2. Observe that the feedback submission is successful, and there are no errors in console + network tab
- [ ] 3. Observe that form creation is successful.

