### PR TITLE
fix: upated codeql yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [develop, edge, master, release]
+    branches: [develop, release-al2]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [develop]


### PR DESCRIPTION
## Problem

Updating codeql-analysis.yml to run on `develop` and `release-al2` pushes. Removing `master` and `release` since we are not using them currently.
