### PR TITLE
fix: updated dockerfile node version and serverless guardduty

### DIFF
--- a/serverless/virus-scanner-guardduty/Dockerfile
+++ b/serverless/virus-scanner-guardduty/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12-bullseye-slim
+FROM node:22-bookworm-slim
 
 # Install aws-lambda-cpp build dependencies
 RUN apt-get update && \

--- a/serverless/virus-scanner-guardduty/serverless.yml
+++ b/serverless/virus-scanner-guardduty/serverless.yml
@@ -56,7 +56,7 @@ provider:
           # AllowManagedRuleToSendS3EventsToGuardDuty
           - 'events:PutRule'
           Resource:
-            - 'arn:aws:events:::rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*'
+            - 'arn:aws:events:ap-southeast-1:*:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*'
 
   ecr:
     images:


### PR DESCRIPTION
## Problem
- updating guardduty virus scanner node version 
- update iam permissions on `serverless.yml` to specify region and all ids in order to enable guardduty on bucket

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
