### PR TITLE
feat: ssm keys iac style

### DIFF
--- a/.ebextensions/03env-file-aws-ssm-iac-compat.config
+++ b/.ebextensions/03env-file-aws-ssm-iac-compat.config
@@ -36,9 +36,9 @@ files:
         fi
 
         echo "Creating config for ${ENV_SITE_NAME} in ${AWS_REGION}"
-        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/GUARDDUTY_QUARANTINE_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/GUARDDUTY_CLEAN_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/GUARDDUTY_LAMBDA_FUNCTION_NAME" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_QUARANTINE_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_CLEAN_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_LAMBDA_FUNCTION_NAME" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
 
 packages:
   yum: 

--- a/.ebextensions/03env-file-aws-ssm-iac-compat.config
+++ b/.ebextensions/03env-file-aws-ssm-iac-compat.config
@@ -1,0 +1,44 @@
+# Pulls additional config from AWS SSM Parameter Store for compatibility with IAC (key-value pairs)
+
+commands:
+  03-update-env:
+    command: "/tmp/update-env.sh"
+
+files:
+  "/tmp/create-env.sh":
+      mode: "000755"
+      content : |
+        #!/bin/bash
+        # Reach into the undocumented container config
+        AWS_REGION='`{"Ref": "AWS::Region"}`'
+        ENV_TYPE=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
+        ENV_SITE_NAME=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_ENV_SITE_NAME)
+        TARGET_DIR=/etc/formsg
+
+        echo "Checking if ${TARGET_DIR} exists..."
+        if [ ! -d ${TARGET_DIR} ]; then
+            echo "Creating directory ${TARGET_DIR} ..."
+            mkdir -p ${TARGET_DIR}
+            if [ $? -ne 0 ]; then
+                echo 'ERROR: Directory creation failed!'
+                exit 1
+            fi
+        else
+            echo "Directory ${TARGET_DIR} already exists!"
+        fi
+
+        echo "Setting ENV_SITE_NAME config for payment credentials..."
+        if [ -z "${ENV_SITE_NAME}" ]; then
+            echo "setting ENV_SITE_NAME as ENV_TYPE (${ENV_TYPE})"
+            ENV_SITE_NAME=${ENV_TYPE}
+        else
+          echo "ENV_SITE_NAME already set as ${ENV_SITE_NAME} using SSM_ENV_SITE_NAME"
+        fi
+
+        echo "Creating config for ${ENV_SITE_NAME} in ${AWS_REGION}"
+        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/VIRUS_SCANNER_CLEAN_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/VIRUS_SCANNER_QUARANTINE_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+
+packages:
+  yum: 
+    jq: []

--- a/.ebextensions/03env-file-aws-ssm-iac-compat.config
+++ b/.ebextensions/03env-file-aws-ssm-iac-compat.config
@@ -36,8 +36,9 @@ files:
         fi
 
         echo "Creating config for ${ENV_SITE_NAME} in ${AWS_REGION}"
-        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/VIRUS_SCANNER_CLEAN_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/VIRUS_SCANNER_QUARANTINE_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/GUARDDUTY_QUARANTINE_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/GUARDDUTY_CLEAN_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "${ENV_SITE_NAME}/virus-scanner-guardduty/GUARDDUTY_LAMBDA_FUNCTION_NAME" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
 
 packages:
   yum: 

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -50,7 +50,7 @@ async function saveAllParameters() {
     exit(0)
   }
   const client = new SSMClient({ region: 'ap-southeast-1' })
-  const parameterNamePrefix = `${SHORT_ENV_MAP[process.env.ENV]}/virus-scanner-guardduty/`
+  const parameterNamePrefix = `/virus-scanner-guardduty/${SHORT_ENV_MAP[process.env.ENV]}/`
 
   const requests = SSM_PARAMETER_STORE_KEYS.map((key) =>
     client.send(

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -23,8 +23,8 @@ const SHORT_ENV_MAP = {
 }
 
 const SSM_PARAMETER_STORE_KEYS = [
-  'VIRUS_SCANNER_CLEAN_S3_BUCKET',
-  'VIRUS_SCANNER_QUARANTINE_S3_BUCKET',
+  'GUARDDUTY_CLEAN_S3_BUCKET',
+  'GUARDDUTY_QUARANTINE_S3_BUCKET',
 ]
 
 // This is a helper for local file runs or jest, as specified in package.json

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -8,22 +8,34 @@ const SHORT_ENV_MAP = {
   development: 'dev',
   prod: 'prod',
   production: 'prod',
-  stg: 'staging',
-  staging: 'staging',
+  stg: 'stg',
+  staging: 'stg',
+  'stg-alt': 'stg-alt',
+  'staging-alt': 'stg-alt',
+  'stg-alt2': 'stg-alt2',
+  'staging-alt2': 'stg-alt2',
+  'stg-alt3': 'stg-alt3',
+  'staging-alt3': 'stg-alt3',
   test: 'test',
   testing: 'test',
   uat: 'uat',
   vapt: 'vapt',
 }
 
+const SSM_PARAMETER_STORE_KEYS = [
+  'VIRUS_SCANNER_CLEAN_S3_BUCKET',
+  'VIRUS_SCANNER_QUARANTINE_S3_BUCKET',
+]
+
 // This is a helper for local file runs or jest, as specified in package.json
 // It emulates the loading of SSM which Lambda will do.
 // This file is not meant to be used in a deployment and is .mjs so we can use top-level await
 async function saveAllParameters() {
-
   // If process.env.ENV is not a key in SHORT_ENV_MAP, then it is not a valid environment
   if (!Object.keys(SHORT_ENV_MAP).includes(process.env.ENV)) {
-    console.log(`Invalid ENV=${process.env.ENV}. Must be a valid env in SHORT_ENV_MAP`)
+    console.log(
+      `Invalid ENV=${process.env.ENV}. Must be a valid env in SHORT_ENV_MAP`,
+    )
     exit(1)
   }
 
@@ -38,20 +50,30 @@ async function saveAllParameters() {
     exit(0)
   }
   const client = new SSMClient({ region: 'ap-southeast-1' })
-  const parameterName = `/virus-scanner-guardduty/${SHORT_ENV_MAP[process.env.ENV]}`
+  const parameterNamePrefix = `${SHORT_ENV_MAP[process.env.ENV]}/virus-scanner-guardduty/`
 
-  const res = await client.send(
-    new GetParameterCommand({
-      Name: parameterName,
-    }),
+  const requests = SSM_PARAMETER_STORE_KEYS.map((key) =>
+    client.send(
+      new GetParameterCommand({ Name: `${parameterNamePrefix}${key}` }),
+    ),
   )
 
-  const parameterString = (res.Parameter?.Value ?? '')
+  const resolvedParameters = Promise.all(requests).map(
+    (res) => `${res.Parameter.Name}=${res.Parameter.Value}`,
+  )
+
+  const parameterString = resolvedParameters.join('\n')
 
   // Add on NODE_ENV
-  const parameterStringWithNodeEnv = parameterString.concat(`\nNODE_ENV=${process.env.ENV}`)
+  const parameterStringWithNodeEnv = [
+    ...parameterString,
+    `NODE_ENV=${process.env.ENV}`,
+  ].join('\n')
 
-  await fs.promises.writeFile(`.env.${process.env.ENV}`, parameterStringWithNodeEnv)
+  await fs.promises.writeFile(
+    `.env.${process.env.ENV}`,
+    parameterStringWithNodeEnv,
+  )
 }
 
 await saveAllParameters()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We are moving to IAC-style code in #8025, thus we should avoid using `key: {key-value} pairs` in our SSM configs.

## Solution
<!-- How did you solve the problem? -->

**FormSG Application**
Added `.ebextensions/03env-file-aws-ssm-iac-compat.config` to GET and format predefined parameters. Formats through `jq` into `key=value` pairs and **append** into `.env`
- this file can be safely removed after we transit into full IAC-ed params

**Lambda envLoader**


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `/virus-scanner-guardduty/$ENV/GUARDDUTY_CLEAN_S3_BUCKET` : s3 clean bucket string
- `/virus-scanner-guardduty/$ENV/GUARDDUTY_QUARANTINE_S3_BUCKET` : s3 quarantine bucket string
- `/virus-scanner-guardduty/$ENV/GUARDDUTY_LAMBDA_FUNCTION_NAME` : lambda function name

On elastic beanstalk
- `SSM_ENV_SITE_NAME_SHORT`: short name as per defined in IaC (stg, stg-alt, stg-alt2, uat, prod)

**New scripts**:

- `03env-file-aws-ssm-iac-compat.config` : compatibility script to extract during eb setup