### PR TITLE
feat: Update workspace and mode selector infobox

### DIFF
--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -147,7 +147,7 @@ const addForm = async (
 
     await page.getByRole('button', { name: 'Create form' }).click()
   } else {
-    await page.getByText('storage mode').click()
+    await page.getByText('Storage mode form').click()
     await page.getByRole('button', { name: 'Next step' }).click()
 
     // Download the secret key and save it for the test.

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@chakra-ui/react'
 import { useFeatureValue } from '@growthbook/growthbook-react'
 
-import { PAPERLESS_FORMSG_RESEARCH_LINK } from '~shared/constants'
+import { KILL_EMAIL_MODE_LINK } from '~shared/constants'
 import { Workspace } from '~shared/types/workspace'
 
 import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
@@ -166,13 +166,18 @@ export const WorkspacePage = (): JSX.Element => {
           >
             <InlineMessage>
               <Text>
-                Do you still have paper forms in your agency?{' '}
+                Email mode forms will be retired on{' '}
+                <>
+                  <strong>30 June 2025</strong>
+                </>
+                . Email functionalities will continue to be available in Storage
+                mode.{' '}
                 <Link
                   display="inline"
-                  href={PAPERLESS_FORMSG_RESEARCH_LINK}
+                  href={KILL_EMAIL_MODE_LINK}
                   target="_blank"
                 >
-                  Tell us more so that we can help you digitalise them.
+                  Learn what this means for you.
                 </Link>
               </Text>
             </InlineMessage>

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -167,9 +167,9 @@ export const WorkspacePage = (): JSX.Element => {
             <InlineMessage>
               <Text>
                 Email mode forms will be retired on{' '}
-                <>
-                  <strong>30 June 2025</strong>
-                </>
+                <Text as="span" fontWeight="bold">
+                  30 June 2025
+                </Text>
                 . Email functionalities will continue to be available in Storage
                 mode.{' '}
                 <Link

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -70,9 +70,8 @@ export const FormResponseOptions = forwardRef<
           <Tile.Subtitle>{storage.subtitle}</Tile.Subtitle>
           <OptionDescription
             listItems={[
-              { text: 'Supports webhooks for integrations' },
-              { text: 'Supports payments' },
               { text: 'Supports Singpass & Myinfo' },
+              { text: 'Supports webhooks for integrations' },
               { text: 'Up to Restricted and Sensitive (Normal) data' },
             ]}
           />
@@ -99,8 +98,8 @@ export const FormResponseOptions = forwardRef<
       {/* TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented. */}
       <InlineMessage mt="1rem">
         <Text>
-          We're phasing out Email mode in the coming months. Don't worry! You
-          can still{' '}
+          We're phasing out Email mode in the coming months. Don't worry!
+          Storage Mode already supports email functionalities. You can still{' '}
           <Link onClick={() => handleEmailButtonPress()}>use it for now</Link>,
           but we'd love to hear why.
         </Text>

--- a/shared/constants/links.ts
+++ b/shared/constants/links.ts
@@ -10,5 +10,5 @@ export const SGID_VALID_ORG_PAGE =
 // Growthbook proxy set up on cloudflare workers. For more info, see Worker script: https://github.com/opengovsg/formsg-private/pull/171.
 export const GROWTHBOOK_DEV_PROXY =
   'https://proxy-growthbook-stg.formsg.workers.dev'
-export const PAPERLESS_FORMSG_RESEARCH_LINK =
-  'https://go.gov.sg/paperformsresearch'
+export const KILL_EMAIL_MODE_LINK =
+  'https://go.gov.sg/formsg-email-mode-phase-out'


### PR DESCRIPTION
## Problem
We want to update the workspace and mode selector copy to inform our users about retiring Email mode. 

## Solution

- Change the workspace infobox copy and link
- Change the form mode selector infobox copy 
- Rearrange Storage mode form copy (removed payments and adjusted Singpass Myinfo above webhooks)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:

<img width="975" alt="image" src="https://github.com/user-attachments/assets/79540833-9437-4f52-aa88-6e9755723c50" />

<img width="744" alt="image" src="https://github.com/user-attachments/assets/e1a16007-a074-473b-9bdd-727209e11d9d" />


**AFTER**:
<img width="992" alt="image" src="https://github.com/user-attachments/assets/32aaa89c-59da-4a3b-a1cc-96ab7674db65" />

<img width="736" alt="image" src="https://github.com/user-attachments/assets/f88a4b82-a0d5-437b-b0a9-db6536fc8dc9" />
