### PR TITLE
chore(otp): replace hardcoded app name

### DIFF
--- a/src/app/views/templates/otp-email.server.view.html
+++ b/src/app/views/templates/otp-email.server.view.html
@@ -13,7 +13,7 @@
     <br />
     <p>
       This login attempt was made from the IP: <%= ipAddress %>. If you did not
-      attempt to log in to FormSG, you may choose to investigate this IP address
+      attempt to log in to <%= appName %>, you may choose to investigate this IP address
       further.
     </p>
     <br />


### PR DESCRIPTION
## Problem and Solution
One-line change that removes hardcoded FormSG app name and replaces it with parameter in OTP email body