### PR TITLE
fix: update renamed envkey

### DIFF
--- a/.ebextensions/03env-file-aws-ssm-iac-compat.config
+++ b/.ebextensions/03env-file-aws-ssm-iac-compat.config
@@ -36,9 +36,9 @@ files:
         fi
 
         echo "Creating config for ${ENV_SITE_NAME} in ${AWS_REGION}"
-        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_QUARANTINE_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_CLEAN_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
-        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_LAMBDA_FUNCTION_NAME" --with-decryption --region $AWS_REGION | jq -r '"\(.Parameter.Name)=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_QUARANTINE_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"GUARDDUTY_CLEAN_S3_BUCKET=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_CLEAN_S3_BUCKET" --with-decryption --region $AWS_REGION | jq -r '"GUARDDUTY_CLEAN_S3_BUCKET=\(.Parameter.Value)"' >> $TARGET_DIR/.env
+        aws ssm get-parameter --name "/virus-scanner-guardduty/${ENV_SITE_NAME}/GUARDDUTY_LAMBDA_FUNCTION_NAME" --with-decryption --region $AWS_REGION | jq -r '"GUARDDUTY_LAMBDA_FUNCTION_NAME=\(.Parameter.Value)"' >> $TARGET_DIR/.env
 
 packages:
   yum: 

--- a/serverless/virus-scanner-guardduty/.env.development
+++ b/serverless/virus-scanner-guardduty/.env.development
@@ -1,4 +1,4 @@
 NODE_ENV=development
 
-VIRUS_SCANNER_QUARANTINE_S3_BUCKET='local-virus-scanner-quarantine-bucket'
-VIRUS_SCANNER_CLEAN_S3_BUCKET='local-virus-scanner-clean-bucket'
+GUARDDUTY_QUARANTINE_S3_BUCKET='local-virus-scanner-quarantine-bucket'
+GUARDDUTY_CLEAN_S3_BUCKET='local-virus-scanner-clean-bucket'

--- a/serverless/virus-scanner-guardduty/.env.development
+++ b/serverless/virus-scanner-guardduty/.env.development
@@ -1,4 +1,4 @@
 NODE_ENV=development
 
-GUARDDUTY_QUARANTINE_S3_BUCKET='local-virus-scanner-quarantine-bucket'
-GUARDDUTY_CLEAN_S3_BUCKET='local-virus-scanner-clean-bucket'
+GUARDDUTY_QUARANTINE_S3_BUCKET='local-guardduty-quarantine-bucket'
+GUARDDUTY_CLEAN_S3_BUCKET='local-guardduty-clean-bucket'

--- a/serverless/virus-scanner-guardduty/.env.example
+++ b/serverless/virus-scanner-guardduty/.env.example
@@ -1,4 +1,4 @@
 NODE_ENV=development
 
-VIRUS_SCANNER_QUARANTINE_S3_BUCKET='local-virus-scanner-quarantine-bucket'
-VIRUS_SCANNER_CLEAN_S3_BUCKET='local-virus-scanner-clean-bucket'
+GUARDDUTY_QUARANTINE_S3_BUCKET='local-virus-scanner-quarantine-bucket'
+GUARDDUTY_CLEAN_S3_BUCKET='local-virus-scanner-clean-bucket'

--- a/serverless/virus-scanner-guardduty/.env.example
+++ b/serverless/virus-scanner-guardduty/.env.example
@@ -1,4 +1,4 @@
 NODE_ENV=development
 
-GUARDDUTY_QUARANTINE_S3_BUCKET='local-virus-scanner-quarantine-bucket'
-GUARDDUTY_CLEAN_S3_BUCKET='local-virus-scanner-clean-bucket'
+GUARDDUTY_QUARANTINE_S3_BUCKET='local-guardduty-quarantine-bucket'
+GUARDDUTY_CLEAN_S3_BUCKET='local-guardduty-clean-bucket'

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -55,12 +55,11 @@ async function saveAllParameters() {
   const requests = SSM_PARAMETER_STORE_KEYS.map((key) => {
     console.log('fetching', `${parameterNamePrefix}${key}`)
 
-    return {
-      key,
-      res: client.send(
-        new GetParameterCommand({ Name: `${parameterNamePrefix}${key}` }),
-      ),
-    }
+    return client
+      .send(new GetParameterCommand({ Name: `${parameterNamePrefix}${key}` }))
+      .then((res) => {
+        return { key, res }
+      })
   })
 
   const resolvedResponses = await Promise.all(requests)

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -63,7 +63,9 @@ async function saveAllParameters() {
     (res) => `${res.Parameter.Name}=${res.Parameter.Value}`,
   )
 
+  
   const parameterString = parameters.join('\n')
+  console.log(parameterString)
 
   // Add on NODE_ENV
   const parameterStringWithNodeEnv = [
@@ -76,5 +78,5 @@ async function saveAllParameters() {
     parameterStringWithNodeEnv,
   )
 }
-
+`.env.staging`
 await saveAllParameters()

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -52,18 +52,22 @@ async function saveAllParameters() {
   const client = new SSMClient({ region: 'ap-southeast-1' })
   const parameterNamePrefix = `/virus-scanner-guardduty/${SHORT_ENV_MAP[process.env.ENV]}/`
 
-  const requests = SSM_PARAMETER_STORE_KEYS.map((key) =>
-  ({
+  const requests = SSM_PARAMETER_STORE_KEYS.map((key) => {
+    console.log('fetching', `${parameterNamePrefix}${key}`)
+
+    return {
       key,
       res: client.send(
-      new GetParameterCommand({ Name: `${parameterNamePrefix}${key}` }),
-    )}),
-  )
+        new GetParameterCommand({ Name: `${parameterNamePrefix}${key}` }),
+      ),
+    }
+  })
 
   const resolvedResponses = await Promise.all(requests)
-  const parameterString = resolvedResponses.map(
-    ({key, res}) => `${key}=${res.Parameter.Value}`,
-  )
+  const parameterString = resolvedResponses.map(({ key, res }) => {
+    console.log({ res })
+    return `${key}=${res.Parameter.Value}`
+  })
 
   console.log(parameterString)
 
@@ -78,5 +82,5 @@ async function saveAllParameters() {
     parameterStringWithNodeEnv,
   )
 }
-`.env.staging`
+;`.env.staging`
 await saveAllParameters()

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -72,7 +72,7 @@ async function saveAllParameters() {
   ].join('\n')
 
   await fs.promises.writeFile(
-    `.env.${process.env.ENV}`,
+    `.env.${SHORT_ENV_MAP[process.env.ENV]}`,
     parameterStringWithNodeEnv,
   )
 }

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -53,8 +53,6 @@ async function saveAllParameters() {
   const parameterNamePrefix = `/virus-scanner-guardduty/${SHORT_ENV_MAP[process.env.ENV]}/`
 
   const requests = SSM_PARAMETER_STORE_KEYS.map((key) => {
-    console.log('fetching', `${parameterNamePrefix}${key}`)
-
     return client
       .send(new GetParameterCommand({ Name: `${parameterNamePrefix}${key}` }))
       .then((res) => {
@@ -63,12 +61,9 @@ async function saveAllParameters() {
   })
 
   const resolvedResponses = await Promise.all(requests)
-  const parameterString = resolvedResponses.map(({ key, res }) => {
-    console.log({ res })
-    return `${key}=${res.Parameter.Value}`
-  })
-
-  console.log(parameterString)
+  const parameterString = resolvedResponses.map(
+    ({ key, res }) => `${key}=${res.Parameter.Value}`,
+  )
 
   // Add on NODE_ENV
   const parameterStringWithNodeEnv = [
@@ -81,5 +76,5 @@ async function saveAllParameters() {
     parameterStringWithNodeEnv,
   )
 }
-;`.env.staging`
+
 await saveAllParameters()

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -53,18 +53,18 @@ async function saveAllParameters() {
   const parameterNamePrefix = `/virus-scanner-guardduty/${SHORT_ENV_MAP[process.env.ENV]}/`
 
   const requests = SSM_PARAMETER_STORE_KEYS.map((key) =>
-    client.send(
+  ({
+      key,
+      res: client.send(
       new GetParameterCommand({ Name: `${parameterNamePrefix}${key}` }),
-    ),
+    )}),
   )
 
   const resolvedResponses = await Promise.all(requests)
-  const parameters = resolvedResponses.map(
-    (res) => `${res.Parameter.Name}=${res.Parameter.Value}`,
+  const parameterString = resolvedResponses.map(
+    ({key, res}) => `${key}=${res.Parameter.Value}`,
   )
 
-  
-  const parameterString = parameters.join('\n')
   console.log(parameterString)
 
   // Add on NODE_ENV
@@ -74,7 +74,7 @@ async function saveAllParameters() {
   ].join('\n')
 
   await fs.promises.writeFile(
-    `.env.${SHORT_ENV_MAP[process.env.ENV]}`,
+    `.env.${process.env.ENV}`,
     parameterStringWithNodeEnv,
   )
 }

--- a/serverless/virus-scanner-guardduty/serverless.yml
+++ b/serverless/virus-scanner-guardduty/serverless.yml
@@ -20,7 +20,7 @@ provider:
             - 's3:GetObject'
             - 's3:GetObjectVersion'
           Resource:
-            - 'arn:aws:s3:::${env:VIRUS_SCANNER_QUARANTINE_S3_BUCKET}/*'
+            - 'arn:aws:s3:::${env:GUARDDUTY_QUARANTINE_S3_BUCKET}/*'
         - Effect: Allow
           Action:
             # AllowCheckBucketOwnership
@@ -29,13 +29,13 @@ provider:
             - 's3:PutBucketNotification'
             - 's3:GetBucketNotification'
           Resource:
-            - 'arn:aws:s3:::${env:VIRUS_SCANNER_QUARANTINE_S3_BUCKET}'
+            - 'arn:aws:s3:::${env:GUARDDUTY_QUARANTINE_S3_BUCKET}'
         - Effect: Allow
           Action:
             # AllowPutValidationObject
             - 's3:PutObject'
           Resource:
-            - 'arn:aws:s3:::${env:VIRUS_SCANNER_QUARANTINE_S3_BUCKET}/malware-protection-resource-validation-object'
+            - 'arn:aws:s3:::${env:GUARDDUTY_QUARANTINE_S3_BUCKET}/malware-protection-resource-validation-object'
         - Effect: Allow
           Action:
             # Both PutObject* required for copy
@@ -43,7 +43,7 @@ provider:
             - 's3:PutObjectTagging'
             - 's3:PutObjectVersionTagging'
           Resource:
-            - 'arn:aws:s3:::${env:VIRUS_SCANNER_CLEAN_S3_BUCKET}/*'
+            - 'arn:aws:s3:::${env:GUARDDUTY_CLEAN_S3_BUCKET}/*'
         - Effect: Allow
           Action:
           # AllowGuardDutyToMonitorEventBridgeManagedRule

--- a/serverless/virus-scanner-guardduty/src/__tests/index.spec.ts
+++ b/serverless/virus-scanner-guardduty/src/__tests/index.spec.ts
@@ -247,7 +247,7 @@ describe('handler', () => {
       expect.objectContaining({
         message: 'Failed to move file to clean bucket',
         err: new Error('Failed to move file'),
-        bucket: 'local-virus-scanner-quarantine-bucket',
+        bucket: 'local-guardduty-quarantine-bucket',
         key: mockUUID,
       }),
     )

--- a/serverless/virus-scanner-guardduty/src/config.ts
+++ b/serverless/virus-scanner-guardduty/src/config.ts
@@ -14,12 +14,12 @@ export const config = convict({
     default: isDev || isTest,
   },
   virusScannerQuarantineS3Bucket: {
-    env: 'VIRUS_SCANNER_QUARANTINE_S3_BUCKET',
+    env: 'GUARDDUTY_QUARANTINE_S3_BUCKET',
     format: String,
     default: '',
   },
   virusScannerCleanS3Bucket: {
-    env: 'VIRUS_SCANNER_CLEAN_S3_BUCKET',
+    env: 'GUARDDUTY_CLEAN_S3_BUCKET',
     format: String,
     default: '',
   },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Keys have been renamed in #8218 but not retroactively addressed.

## Solution
<!-- How did you solve the problem? -->

All guardduty env keys should be named `GUARDDUTY_*`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
