### PR TITLE
fix: add emails when duplcating to encrypt forms

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.utils.spec.ts
@@ -287,6 +287,7 @@ describe('admin-form.utils', () => {
         responseMode: FormResponseMode.Encrypt,
         publicKey: 'some public key',
         title: 'some title',
+        emails: ['some@example.com', 'another@example.com'],
       }
 
       // Act
@@ -298,7 +299,7 @@ describe('admin-form.utils', () => {
         title: params.title,
         admin: newAdminId,
         publicKey: params.publicKey,
-        emails: [],
+        emails: params.emails,
         submissionLimit: null,
       }
       expect(actual).toEqual(expected)

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -192,8 +192,6 @@ const duplicateFormValidator = celebrate({
             .required(),
         },
         {
-          // When duplicating forms, we reset the `emails` field to be empty
-          // Refer to `admin-form.utils.ts`.
           is: FormResponseMode.Encrypt,
           then: Joi.array().items(Joi.string().email()).required(),
         },

--- a/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -347,7 +347,7 @@ export const processDuplicateOverrideProps = (
     case FormResponseMode.Encrypt:
       overrideProps.publicKey = params.publicKey
       overrideProps.submissionLimit = null
-      overrideProps.emails = []
+      overrideProps.emails = params.emails
       break
     case FormResponseMode.Multirespondent:
       overrideProps.publicKey = params.publicKey


### PR DESCRIPTION
## Problem

Duplicating a form doesn't copy over  the emails correctly for encrypt forms. 

Closes FRM-2000

**Breaking Changes** 
- [x] No - this PR is backwards compatible  

## Tests

**Duplication from storage to storage**
- [ ] 1. Duplicate a storage form
- [ ] 2. Observe that your email is by default pre-filled in the wizard page
- [ ] 3. Add another email that isnt your admin email
- [ ] 4. Create the form
- [ ] 5. Head to the email notifications settings page
- [ ] 6. Observe that your admin email + other email you added are there

**Duplication from email to storage**
Repeat the above steps
- [ ] 1. Duplicate a storage form
- [ ] 2. Observe that your email is by default pre-filled in the wizard page
- [ ] 3. Add another email that isnt your admin email
- [ ] 4. Create the form
- [ ] 5. Head to the email notifications settings page
- [ ] 6. Observe that your admin email + other email you added are there