### PR TITLE
fix: eb script to use short name

### DIFF
--- a/.ebextensions/03env-file-aws-ssm-iac-compat.config
+++ b/.ebextensions/03env-file-aws-ssm-iac-compat.config
@@ -12,7 +12,7 @@ files:
         # Reach into the undocumented container config
         AWS_REGION='`{"Ref": "AWS::Region"}`'
         ENV_TYPE=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_PREFIX)
-        ENV_SITE_NAME=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_ENV_SITE_NAME)
+        ENV_SITE_NAME=$(/opt/elasticbeanstalk/bin/get-config environment -k SSM_ENV_SITE_NAME_SHORT)
         TARGET_DIR=/etc/formsg
 
         echo "Checking if ${TARGET_DIR} exists..."
@@ -25,14 +25,6 @@ files:
             fi
         else
             echo "Directory ${TARGET_DIR} already exists!"
-        fi
-
-        echo "Setting ENV_SITE_NAME config for payment credentials..."
-        if [ -z "${ENV_SITE_NAME}" ]; then
-            echo "setting ENV_SITE_NAME as ENV_TYPE (${ENV_TYPE})"
-            ENV_SITE_NAME=${ENV_TYPE}
-        else
-          echo "ENV_SITE_NAME already set as ${ENV_SITE_NAME} using SSM_ENV_SITE_NAME"
         fi
 
         echo "Creating config for ${ENV_SITE_NAME} in ${AWS_REGION}"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

EB is failing to setup due to SSM param fetched being incorrect. Was fetching through the full site name instead of short name.

## Solution
<!-- How did you solve the problem? -->

Use short name defined.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  