### PR TITLE
fix: add delete perms for guardduty lambda

### DIFF
--- a/serverless/virus-scanner-guardduty/serverless.yml
+++ b/serverless/virus-scanner-guardduty/serverless.yml
@@ -20,7 +20,7 @@ provider:
             - 's3:GetObject'
             - 's3:GetObjectVersion'
             - 's3:DeleteObject'
-				    - 's3:DeleteObjectVersion'
+            - 's3:DeleteObjectVersion'
           Resource:
             - 'arn:aws:s3:::${env:GUARDDUTY_QUARANTINE_S3_BUCKET}/*'
         - Effect: Allow

--- a/serverless/virus-scanner-guardduty/serverless.yml
+++ b/serverless/virus-scanner-guardduty/serverless.yml
@@ -19,6 +19,8 @@ provider:
             # AllowMalwareScan
             - 's3:GetObject'
             - 's3:GetObjectVersion'
+            - 's3:DeleteObject',
+				    - 's3:DeleteObjectVersion'
           Resource:
             - 'arn:aws:s3:::${env:GUARDDUTY_QUARANTINE_S3_BUCKET}/*'
         - Effect: Allow

--- a/serverless/virus-scanner-guardduty/serverless.yml
+++ b/serverless/virus-scanner-guardduty/serverless.yml
@@ -19,7 +19,7 @@ provider:
             # AllowMalwareScan
             - 's3:GetObject'
             - 's3:GetObjectVersion'
-            - 's3:DeleteObject',
+            - 's3:DeleteObject'
 				    - 's3:DeleteObjectVersion'
           Resource:
             - 'arn:aws:s3:::${env:GUARDDUTY_QUARANTINE_S3_BUCKET}/*'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

s3 Guardduty lambda when invoked, upon successful check of clean file, will move file from quarantine to clean and delete file from quarantine bucket. Fix is to give lambda permissions to delete the file.


