### PR TITLE
fix: update clean bucket download and mrf flow of invoking guardduty lambda

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -183,11 +183,12 @@ const asyncVirusScanning = (
           response,
           formId,
         ).mapErr((err) =>
-          logger.info({
-            message: `GuardDuty Scan unsuccessful:, ${err}`,
+          logger.error({
+            message: `GuardDuty Scan unsuccessful`,
             meta: {
               action: 'TriggerGuarddutyScanThenDownloadCleanFileChain',
             },
+            error: err,
           }),
         )
       }

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -6,6 +6,7 @@ import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
 import { IAttachmentInfo } from 'src/types'
 
+import { featureFlags } from '../../../../../shared/constants'
 import {
   BasicField,
   FormDto,
@@ -42,6 +43,7 @@ import {
 } from '../submission.errors'
 import {
   getEncryptedSubmissionData,
+  triggerGuarddutyScanThenDownloadCleanFileChain,
   triggerVirusScanThenDownloadCleanFileChain,
 } from '../submission.service'
 import {
@@ -192,17 +194,34 @@ type IdTaggedParsedClearAttachmentResponseV3 =
 const asyncVirusScanning = (
   responses: IdTaggedParsedClearAttachmentResponseV3[],
   formId: string,
+  enableGuarddutyLambdaInvoke: boolean | undefined,
 ): ResultAsync<
   IdTaggedParsedClearAttachmentResponseV3,
   | VirusScanFailedError
   | DownloadCleanFileFailedError
   | MaliciousFileDetectedError
->[] =>
-  responses.map((response) =>
-    triggerVirusScanThenDownloadCleanFileChain(response.answer, formId).map(
-      (attachmentResponse) => ({ ...response, answer: attachmentResponse }),
-    ),
-  )
+>[] => {
+  return responses.map((response) => {
+    if (enableGuarddutyLambdaInvoke) {
+      triggerGuarddutyScanThenDownloadCleanFileChain(
+        response.answer,
+        formId,
+      ).mapErr((err) =>
+        logger.info({
+          message: `GuardDuty Scan unsuccessful:, ${err}`,
+          meta: {
+            action: 'TriggerGuarddutyScanThenDownloadCleanFileChain',
+          },
+        }),
+      )
+    }
+
+    return triggerVirusScanThenDownloadCleanFileChain(
+      response.answer,
+      formId,
+    ).map((attachmentResponse) => ({ ...response, answer: attachmentResponse }))
+  })
+}
 
 /**
  * Synchronous virus scanning for storage submissions v2.1+. This is used for dev environment.
@@ -248,6 +267,7 @@ export const scanAndRetrieveAttachments = async (
     action: 'scanAndRetrieveAttachments',
     ...createReqMeta(req),
   }
+  const gbGuardduty = req.growthbook?.isOn(featureFlags.guardduty)
 
   // Step 1: Extract attachment responses into an array to prepare for virus scanning.
   const attachmentResponsesToRetrieve: IdTaggedParsedClearAttachmentResponseV3[] =
@@ -286,6 +306,7 @@ export const scanAndRetrieveAttachments = async (
           asyncVirusScanning(
             attachmentResponsesToRetrieve,
             req.formsg.formDef._id.toString(),
+            gbGuardduty,
           ),
         )
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -207,11 +207,12 @@ const asyncVirusScanning = (
         response.answer,
         formId,
       ).mapErr((err) =>
-        logger.info({
-          message: `GuardDuty Scan unsuccessful:, ${err}`,
+        logger.error({
+          message: `GuardDuty Scan unsuccessful`,
           meta: {
             action: 'TriggerGuarddutyScanThenDownloadCleanFileChain',
           },
+          error: err,
         }),
       )
     }

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -351,7 +351,11 @@ export const triggerVirusScanning = (
  * @returns okAsync(buffer) if file has been successfully downloaded from the clean bucket
  * @returns errAsync(DownloadCleanFileFailedError) if file download failed
  */
-export const downloadCleanFile = (cleanFileKey: string, versionId: string) => {
+export const downloadCleanFile = (
+  cleanFileKey: string,
+  versionId: string,
+  bucketName: string,
+) => {
   const logMeta = {
     action: 'downloadCleanFile',
     cleanFileKey,
@@ -378,7 +382,7 @@ export const downloadCleanFile = (cleanFileKey: string, versionId: string) => {
 
   const readStream = AwsConfig.s3
     .getObject({
-      Bucket: AwsConfig.virusScannerCleanS3Bucket,
+      Bucket: bucketName,
       Key: cleanFileKey,
       VersionId: versionId,
     })
@@ -475,6 +479,7 @@ export const triggerVirusScanThenDownloadCleanFileChain = <
         downloadCleanFile(
           cleanAttachment.cleanFileKey,
           cleanAttachment.destinationVersionId,
+          AwsConfig.virusScannerCleanS3Bucket,
         ).map((attachmentBuffer) => ({
           ...response,
           // Replace content with attachmentBuffer and answer with filename.
@@ -1401,6 +1406,7 @@ export const triggerGuarddutyScanThenDownloadCleanFileChain = <
         downloadCleanFile(
           cleanAttachment.cleanFileKey,
           cleanAttachment.destinationVersionId,
+          AwsConfig.guarddutyQuarantineS3Bucket,
         ).map((attachmentBuffer) => ({
           ...response,
           // Replace content with attachmentBuffer and answer with filename.

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -1,4 +1,3 @@
-
 import { Cursor as QueryCursor, Document, Model, QueryOptions } from 'mongoose'
 
 import { EmailSubmissionContent } from 'src/app/modules/submission/email-submission/email-submission.types'

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -1,3 +1,4 @@
+
 import { Cursor as QueryCursor, Document, Model, QueryOptions } from 'mongoose'
 
 import { EmailSubmissionContent } from 'src/app/modules/submission/email-submission/email-submission.types'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- Include invocation of guardduty lambda for MRF attachment submissions. Currently MRF attachment flow is submitting to s3 quarantine bucket, but lambda is not being invoked, causing file to stay in quarantine

## Solution

- Fix the downloading of the cleanFile so that BE can download both from clean virus scanning bucket & clean guardduty bucket

Closes FRM-2001

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
