### PR TITLE
fix: failing backend lint and tests

### DIFF
--- a/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -2237,7 +2237,6 @@ describe('submission.service', () => {
         [
           {
             ...expectedCalledWithSubset,
-            Bucket: aws.guarddutyQuarantineS3Bucket,
             Fields: { key: uuid2 },
             Conditions: [['content-length-range', 0, 2]],
           },

--- a/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -2188,6 +2188,8 @@ describe('submission.service', () => {
 
     const REGEX_UUID =
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    const uuid1 = expect.stringMatching(REGEX_UUID)
+    const uuid2 = expect.stringMatching(REGEX_UUID)
 
     it('should return presigned post data', async () => {
       // Arrange
@@ -2227,6 +2229,7 @@ describe('submission.service', () => {
         [
           {
             ...expectedCalledWithSubset,
+            Fields: { key: uuid1 },
             Conditions: [['content-length-range', 0, 1]],
           },
           expect.any(Function), // anonymous error handling function
@@ -2234,6 +2237,8 @@ describe('submission.service', () => {
         [
           {
             ...expectedCalledWithSubset,
+            Bucket: aws.guarddutyQuarantineS3Bucket,
+            Fields: { key: uuid2 },
             Conditions: [['content-length-range', 0, 2]],
           },
           expect.any(Function), // anonymous error handling function
@@ -2241,6 +2246,8 @@ describe('submission.service', () => {
         [
           {
             ...expectedCalledWithSubset,
+            Bucket: aws.guarddutyQuarantineS3Bucket,
+            Fields: { key: uuid1 },
             Conditions: [['content-length-range', 0, 1]],
           },
           expect.any(Function), // anonymous error handling function
@@ -2248,6 +2255,8 @@ describe('submission.service', () => {
         [
           {
             ...expectedCalledWithSubset,
+            Bucket: aws.guarddutyQuarantineS3Bucket,
+            Fields: { key: uuid2 },
             Conditions: [['content-length-range', 0, 2]],
           },
           expect.any(Function), // anonymous error handling function

--- a/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -2238,6 +2238,20 @@ describe('submission.service', () => {
           },
           expect.any(Function), // anonymous error handling function
         ],
+        [
+          {
+            ...expectedCalledWithSubset,
+            Conditions: [['content-length-range', 0, 1]],
+          },
+          expect.any(Function), // anonymous error handling function
+        ],
+        [
+          {
+            ...expectedCalledWithSubset,
+            Conditions: [['content-length-range', 0, 2]],
+          },
+          expect.any(Function), // anonymous error handling function
+        ],
       ])
       const actualResultValue = actualResult._unsafeUnwrap()
       expect(actualResultValue).toEqual(

--- a/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -2206,6 +2206,15 @@ describe('submission.service', () => {
         }),
       })
 
+      const expectedPresignedPostDataGuardDuty = expect.objectContaining({
+        url: `${aws.endPoint}/${aws.guarddutyQuarantineS3Bucket}`,
+        fields: expect.objectContaining({
+          key: expect.stringMatching(REGEX_UUID),
+          bucket: aws.guarddutyQuarantineS3Bucket,
+          'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+        }),
+      })
+
       // Act
       const actualResult = await getQuarantinePresignedPostData(
         MOCK_ATTACHMENT_SIZES,
@@ -2213,7 +2222,7 @@ describe('submission.service', () => {
 
       // Assert
       expect(actualResult.isOk()).toEqual(true)
-      expect(awsSpy).toHaveBeenCalledTimes(2)
+      expect(awsSpy).toHaveBeenCalledTimes(4)
       expect(awsSpy.mock.calls).toEqual([
         [
           {
@@ -2235,6 +2244,14 @@ describe('submission.service', () => {
         expect.objectContaining([
           { id: fieldId1, presignedPostData: expectedPresignedPostData },
           { id: fieldId2, presignedPostData: expectedPresignedPostData },
+          {
+            id: fieldId1,
+            presignedPostData: expectedPresignedPostDataGuardDuty,
+          },
+          {
+            id: fieldId2,
+            presignedPostData: expectedPresignedPostDataGuardDuty,
+          },
         ]),
       )
     })

--- a/src/app/modules/submission/submission.controller.ts
+++ b/src/app/modules/submission/submission.controller.ts
@@ -443,12 +443,8 @@ export const getS3PresignedPostData: ControllerHandler<
     action: 'getS3PresignedPostData',
     ...createReqMeta(req),
   }
-  const gbGuardduty = req.growthbook?.isOn(featureFlags.guardduty)
-  logger.info({
-    message: `guardduty growthbook tag is: ${gbGuardduty}`,
-    meta: logMeta,
-  })
-  return getQuarantinePresignedPostData(req.body, gbGuardduty)
+
+  return getQuarantinePresignedPostData(req.body)
     .map((presignedUrls) => {
       logger.info({
         message: 'Successfully retrieved quarantine presigned post data.',

--- a/src/app/modules/submission/submission.controller.ts
+++ b/src/app/modules/submission/submission.controller.ts
@@ -5,7 +5,6 @@ import { StatusCodes } from 'http-status-codes'
 import JSONStream from 'JSONStream'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 
-import { featureFlags } from '../../../../shared/constants'
 import {
   AttachmentPresignedPostDataMapType,
   AttachmentSizeMapType,

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -1162,7 +1162,6 @@ export const validateAttachments = (
 
 export const getQuarantinePresignedPostData = (
   attachmentSizes: AttachmentSizeMapType[],
-  enableGuarddutyBucketPost?: boolean | undefined,
 ): ResultAsync<
   AttachmentPresignedPostDataMapType[],
   CreatePresignedPostError

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.submissions.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.submissions.routes.spec.ts
@@ -1150,6 +1150,14 @@ describe('public-form.submissions.routes', () => {
           id: VALID_PAYLOAD[1].id,
           presignedPostData: expectedPresignedPostData,
         }),
+        expect.objectContaining({
+          id: VALID_PAYLOAD[0].id,
+          presignedPostData: expectedPresignedPostData,
+        }),
+        expect.objectContaining({
+          id: VALID_PAYLOAD[1].id,
+          presignedPostData: expectedPresignedPostData,
+        }),
       ])
     })
   })


### PR DESCRIPTION
## Problem
- backend lint and some tests are failing due to a change in defaulting attachment upload to s3 to both quarantine buckets (existing and guardDuty) and removing the feature flag logic

Closes FRM-2005

## Solution
- Resolved the tests to expect calls & return values to reflect this change

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- No - this PR is backwards compatible  

