### PR TITLE
fix: increase guarduty polling timeout to 40

### DIFF
--- a/serverless/virus-scanner-guardduty/src/s3.service.ts
+++ b/serverless/virus-scanner-guardduty/src/s3.service.ts
@@ -243,7 +243,7 @@ export class S3Service {
           return malwareScanningTag
         },
         {
-          timeout: 18 * 1000, // 9 seconds. FE becomes unresponsive if set to 10s or above
+          timeout: 40 * 1000, // 9 seconds. FE becomes unresponsive if set to 10s or above
           delay: 200, // first delay - 0.2 seconds
           backoff: 'LINEAR',
           maxBackOff: 2 * 1000, // max increment in delay - 2 seconds


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- GuardDuty virus scanning sometimes times out while polling and waiting to obtain Tag on s3 Object
- This happens ~0.5% of the time, with time taken for s3 GuardDuty to tag files to be about 30-35s

## Solution
<!-- How did you solve the problem? -->

- Increase polling timeout to 40s 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- No - this PR is backwards compatible  