### PR TITLE
fix: override default retry rate

### DIFF
--- a/serverless/virus-scanner-guardduty/src/s3.service.ts
+++ b/serverless/virus-scanner-guardduty/src/s3.service.ts
@@ -243,7 +243,8 @@ export class S3Service {
           return malwareScanningTag
         },
         {
-          timeout: 40 * 1000, // 9 seconds. FE becomes unresponsive if set to 10s or above
+          retries: 'INFINITELY',
+          timeout: 40 * 1000, // 40 seconds.
           delay: 200, // first delay - 0.2 seconds
           backoff: 'LINEAR',
           maxBackOff: 2 * 1000, // max increment in delay - 2 seconds


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Retries are failing at around 13 seconds instead of the specified 40 seconds. Found to be related to number of retries, which is set to be a default of `10`

Closes FRM-2006

## Solution

Increase number of retries to indefinite so that we can rely on the max timeout of 40s.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  