### PR TITLE
chore: remove ts-essentials package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,6 @@
         "stripe": "^12.5.0",
         "text-encoding": "^0.7.0",
         "triple-beam": "^1.3.0",
-        "ts-essentials": "^10.0.1",
         "tweetnacl": "^1.0.1",
         "tweetnacl-util": "^0.15.1",
         "uid-generator": "^2.0.0",
@@ -24421,19 +24420,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
-      }
-    },
-    "node_modules/ts-essentials": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.1.tgz",
-      "integrity": "sha512-HPH+H2bkkO8FkMDau+hFvv7KYozzned9Zr1Urn7rRPXMF4mZmCKOq+u4AI1AAW+2bofIOXTuSdKo9drQuni2dQ==",
-      "peerDependencies": {
-        "typescript": ">=4.5.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "stripe": "^12.5.0",
     "text-encoding": "^0.7.0",
     "triple-beam": "^1.3.0",
-    "ts-essentials": "^10.0.1",
     "tweetnacl": "^1.0.1",
     "tweetnacl-util": "^0.15.1",
     "uid-generator": "^2.0.0",

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -2,7 +2,6 @@ import { HttpStatusCode } from 'axios'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 import { err, ok, Result } from 'neverthrow'
-import { UnreachableCaseError } from 'ts-essentials'
 
 import {
   ErrorCode,
@@ -324,8 +323,18 @@ export const handleGetPublicForm: ControllerHandler<
       break
     }
     default: {
-      return new UnreachableCaseError(authType)
+      // Force TS to emit an error if the cases above are not exhaustive
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const exhaustiveCheck: never = authType
     }
+  }
+
+  if (!spcpSession) {
+    logger.error({
+      message: 'spcpSession is undefined',
+      meta: logMeta,
+    })
+    return res.sendStatus(HttpStatusCode.InternalServerError)
   }
 
   // for consistency with whitelist lookup which also uppercases all submitterIds when saving
@@ -521,8 +530,11 @@ export const handleGetPublicForm: ControllerHandler<
           isIntranetUser,
         })
     }
-    default:
-      return new UnreachableCaseError(authType)
+    default: {
+      // Force TS to emit an error if the cases above are not exhaustive
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const exhaustiveCheck: never = authType
+    }
   }
 }
 

--- a/src/app/modules/payments/__tests__/stripe.controller.spec.ts
+++ b/src/app/modules/payments/__tests__/stripe.controller.spec.ts
@@ -5,7 +5,7 @@ import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
 import { errAsync, ok, okAsync } from 'neverthrow'
 import Stripe from 'stripe'
-import { MarkRequired } from 'ts-essentials'
+import { SetRequired } from 'type-fest'
 
 import getPaymentModel from 'src/app/models/payment.server.model'
 import { getEncryptPendingSubmissionModel } from 'src/app/models/pending_submission.server.model'
@@ -121,7 +121,7 @@ describe('stripe.controller', () => {
       const mockStripeToken = {
         stripe_user_id: 'user_id',
         stripe_publishable_key: 'publishable_key',
-      } as MarkRequired<
+      } as SetRequired<
         Stripe.OAuthToken,
         'stripe_user_id' | 'stripe_publishable_key'
       >

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -4,7 +4,7 @@ import cuid from 'cuid'
 import mongoose from 'mongoose'
 import { errAsync, ok, okAsync, ResultAsync } from 'neverthrow'
 import Stripe from 'stripe'
-import { MarkRequired } from 'ts-essentials'
+import { SetRequired } from 'type-fest'
 import isURL from 'validator/lib/isURL'
 
 import { featureFlags } from '../../../../shared/constants'
@@ -633,7 +633,7 @@ export const getStripeOauthUrl = (form: IPopulatedEncryptedForm) => {
 export const exchangeCodeForAccessToken = (
   code: string,
 ): ResultAsync<
-  MarkRequired<Stripe.OAuthToken, 'stripe_user_id' | 'stripe_publishable_key'>,
+  SetRequired<Stripe.OAuthToken, 'stripe_user_id' | 'stripe_publishable_key'>,
   StripeAccountError | StripeFetchError
 > => {
   return ResultAsync.fromPromise(
@@ -656,7 +656,7 @@ export const exchangeCodeForAccessToken = (
       return errAsync(new StripeAccountError('Stripe account ID is missing'))
     }
     return okAsync(
-      token as MarkRequired<
+      token as SetRequired<
         Stripe.OAuthToken,
         'stripe_user_id' | 'stripe_publishable_key'
       >,

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -5,8 +5,7 @@ import {
   Model,
   ToObjectOptions,
 } from 'mongoose'
-import { DeepRequired } from 'ts-essentials'
-import type { Merge, SetOptional } from 'type-fest'
+import type { Merge, RequiredDeep, SetOptional } from 'type-fest'
 
 import {
   AdminDashboardFormMetaDto,
@@ -238,7 +237,7 @@ export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
   }: {
     accountId: FormPaymentsChannel['target_account_id']
     publishableKey: FormPaymentsChannel['publishable_key']
-  }): Promise<T & DeepRequired<Pick<IEncryptedFormSchema, 'payments_channel'>>>
+  }): Promise<T & RequiredDeep<Pick<IEncryptedFormSchema, 'payments_channel'>>>
 
   /**
    * Remove payment account ID from the form.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`type-fest` and `ts-essentials` are typechecking libraries that does the same thing. Our codebase heavier on `type-fest` thus making a call to remove the use of `ts-essentials`.

## Solution
<!-- How did you solve the problem? -->

- Replaced `MarkRequired` from `ts-essentials` with `SetRequired` from `type-fest`
- Replaced `DeepRequired` from `ts-essentials` with `RequiredDeep` from `type-fest`
- Removed the import of `UnreachableCaseError` from `ts-essentials` and replace with typescript's exhaustive check pattern


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
**New dependencies**:

- `ts-essentials`: removed
