### PR TITLE
fix: use forwardRef

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -1,4 +1,11 @@
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { BiCog, BiDuplicate, BiGridHorizontal, BiTrash } from 'react-icons/bi'
@@ -102,32 +109,28 @@ export interface FieldRowContainerProps {
 /**
  * Used for highlighting fields that were created by Magic Form Builder.
  */
-const HighlightableFlex = ({
-  isHighlighted,
-  ref,
-  ...props
-}: {
-  isHighlighted?: boolean
-  ref?: React.RefObject<HTMLDivElement>
-} & FlexProps) => {
-  const { children } = props
+type HighlightableFlexProps = FlexProps & { isHighlighted?: boolean }
+const HighlightableFlex = forwardRef<HTMLDivElement, HighlightableFlexProps>(
+  (props, ref) => {
+    const { children, isHighlighted } = props
 
-  const augmentedProps = isHighlighted
-    ? {
-        ...props,
-        borderColor: 'primary.500',
-        borderRadius: '0.25rem',
-        borderWidth: '0.125rem',
-        bg: 'secondary.100',
-      }
-    : props
+    const augmentedProps = isHighlighted
+      ? {
+          ...props,
+          borderColor: 'primary.500',
+          borderRadius: '0.25rem',
+          borderWidth: '0.125rem',
+          bg: 'secondary.100',
+        }
+      : props
 
-  return (
-    <Flex {...augmentedProps} ref={ref}>
-      {children}
-    </Flex>
-  )
-}
+    return (
+      <Flex {...augmentedProps} ref={ref}>
+        {children}
+      </Flex>
+    )
+  },
+)
 
 const FieldRowContainer = ({
   responseMode,
@@ -234,6 +237,7 @@ const FieldRowContainer = ({
     )
   }, [isActive, isDirty, numFormFieldMutations, fieldBuilderState])
 
+  console.log({ ref2: ref })
   return (
     <Draggable
       index={index}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -237,7 +237,6 @@ const FieldRowContainer = ({
     )
   }, [isActive, isDirty, numFormFieldMutations, fieldBuilderState])
 
-  console.log({ ref2: ref })
   return (
     <Draggable
       index={index}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Tooltip is shown on the top left (0,0) instead of the component that they are supposed to be near with.

Closes FRM-2008

## Solution
<!-- How did you solve the problem? -->

`ref`s needs to be passed over through `forwardRef` as they are a special type of react prop.

## Before & After Screenshots

| Component | Before | After |
|--------|--------|--------|
| Tooltip | <img width="1004" alt="Screenshot 2025-04-04 at 5 54 07 PM" src="https://github.com/user-attachments/assets/52cc6722-aae9-4c12-a400-a8f0b66242e7" /> | <img width="1007" alt="Screenshot 2025-04-04 at 5 41 38 PM" src="https://github.com/user-attachments/assets/edd9f647-e340-480c-9eaa-a1421a772c0e" /> | 

## Tests
<!-- What tests should be run to confirm functionality? -->

### Regression Tests
**Tooltip appears above FormField**
- [ ] Create a form field
- [ ] Add form logic to hide field
- [ ] Observe that on mouse over, the tooltip appears just above the form field