### PR TITLE
feat(mrf): mask key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -170,6 +170,7 @@
         "lint-staged": "^15.2.10",
         "maildev": "^2.2.1",
         "mockdate": "^3.0.5",
+        "node-mocks-http": "^1.16.2",
         "prettier": "^3.5.3",
         "rimraf": "^5.0.5",
         "stripe-event-types": "^3.1.0",
@@ -21642,6 +21643,48 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/node-mocks-http": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.16.2.tgz",
+      "integrity": "sha512-2Sh6YItRp1oqewZNlck3LaFp5vbyW2u51HX2p1VLxQ9U/bG90XV8JY9O7Nk+HDd6OOn/oV3nA5Tx5k4Rki0qlg==",
+      "dev": true,
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-disposition": "^0.5.3",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.21 || ^5.0.0",
+        "@types/node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-mocks-http/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
     "lint-staged": "^15.2.10",
     "maildev": "^2.2.1",
     "mockdate": "^3.0.5",
+    "node-mocks-http": "^1.16.2",
     "prettier": "^3.5.3",
     "rimraf": "^5.0.5",
     "stripe-event-types": "^3.1.0",

--- a/src/app/utils/__tests__/request.spec.ts
+++ b/src/app/utils/__tests__/request.spec.ts
@@ -1,0 +1,52 @@
+import { ObjectId } from 'bson'
+import { createRequest } from 'node-mocks-http'
+
+import { createReqMeta } from 'src/app/utils/request'
+
+describe('request', () => {
+  it('should mask referer headers', () => {
+    it('should replace captured mrf keys with *', () => {
+      // Arrange
+      const mockObjectId = new ObjectId()
+      const mockSubmissionId = new ObjectId()
+      const req = createRequest({
+        url: '/mockEndpoint',
+        headers: {
+          referer: `https://form.gov.sg/${mockObjectId}/edit/${mockSubmissionId}?key=aHf3OiQ64U6Sj%2FkSUlmJRsG0OsJdIayGrv0vjCxHk5Y%3D`,
+          'cf-ray': 'cf-ray',
+          'x-request-id': 'x-request-id',
+        },
+        baseUrl: '/mockBaseUrl',
+        path: '/mockPath',
+      })
+
+      // Act
+      const filteredReq = createReqMeta(req)
+
+      // Assert
+      expect(filteredReq).toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            referer: expect.not.stringContaining(
+              'aHf3OiQ64U6Sj%2FkSUlmJRsG0OsJdIayGrv0vjCxHk5Y%3D',
+            ),
+          }),
+        }),
+      )
+      expect(filteredReq).toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            referer: expect.stringContaining(mockObjectId.toHexString()),
+          }),
+        }),
+      )
+      expect(filteredReq).toEqual(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            referer: expect.stringContaining(mockSubmissionId.toHexString()),
+          }),
+        }),
+      )
+    })
+  })
+})

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -35,12 +35,43 @@ export const getTrace = <R extends LooseRequest>(
   return req.get('cf-ray') ?? req.id // trace using cloudflare cf-ray header, with x-request-id header as backup
 }
 
+const HEADERS_RULES = {
+  referer: {
+    // Match the referer URL and replace the last 24 characters of the key with asterisks
+    // e.g.                  /edit/<form_id>/?key=12345678901234567890123456789012345678901234567890
+    // will be replaced with /edit/<form_id>/?key=12345678901234567890123456************************
+    regex: /\/edit\/[a-zA-Z0-9]{24}\?key=.+(.{24})$/i,
+    replacement: '************************',
+  },
+}
+
+const maskRefererHeaders = (
+  headers: ReqMeta['headers'],
+): ReqMeta['headers'] => {
+  if (typeof headers === 'string') {
+    return headers
+  }
+  if (!headers.referer) {
+    return headers
+  }
+
+  for (const [headerKey, { regex, replacement }] of Object.entries(
+    HEADERS_RULES,
+  )) {
+    const value = headers[headerKey]
+    if (typeof value === 'string') {
+      headers[headerKey] = value.replace(regex, replacement)
+    }
+  }
+  return headers
+}
+
 export const createReqMeta = <R extends LooseRequest>(req: R): ReqMeta => {
   return {
     ip: getRequestIp(req),
     trace: getTrace(req), // trace using cloudflare cf-ray header, with x-request-id header as backup
     url: req.baseUrl + req.path,
     urlWithQueryParams: req.originalUrl,
-    headers: req.headers,
+    headers: maskRefererHeaders(req.headers),
   }
 }

--- a/src/app/utils/request.ts
+++ b/src/app/utils/request.ts
@@ -40,7 +40,7 @@ const HEADERS_RULES = {
     // Match the referer URL and replace the last 24 characters of the key with asterisks
     // e.g.                  /edit/<form_id>/?key=12345678901234567890123456789012345678901234567890
     // will be replaced with /edit/<form_id>/?key=12345678901234567890123456************************
-    regex: /\/edit\/[a-zA-Z0-9]{24}\?key=.+(.{24})$/i,
+    regex: /(?<=\/edit\/[a-zA-Z0-9]{24}\?key=.+).{24}$/i,
     replacement: '************************',
   },
 }
@@ -51,10 +51,9 @@ const maskRefererHeaders = (
   if (typeof headers === 'string') {
     return headers
   }
-  if (!headers.referer) {
+  if (!headers?.referer) {
     return headers
   }
-
   for (const [headerKey, { regex, replacement }] of Object.entries(
     HEADERS_RULES,
   )) {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We are no longer requiring to debug keys for MRF. This should now be sanitised before the logs are sent to cloudwatch.

Closes FRM-2010

## Solution
<!-- How did you solve the problem? -->

On request buildup, we will run through an additional filter to explicitly mask the pattern.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

