### PR TITLE
fix: remove nested tests

### DIFF
--- a/src/app/utils/__tests__/request.spec.ts
+++ b/src/app/utils/__tests__/request.spec.ts
@@ -4,7 +4,7 @@ import { createRequest } from 'node-mocks-http'
 import { createReqMeta } from 'src/app/utils/request'
 
 describe('request', () => {
-  it('should mask referer headers', () => {
+  describe('maskRefererHeaders', () => {
     it('should replace captured mrf keys with *', () => {
       // Arrange
       const mockObjectId = new ObjectId()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

> Tests cannot be nested. Test "should replace captured mrf keys with *" cannot run because it is nested within "should mask referer headers".

## Solution
<!-- How did you solve the problem? -->

Use `jest.describe` instead of `jest.it`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
