### PR TITLE
refactor(i18n): enforce locale enums

### DIFF
--- a/frontend/src/i18n/i18n.ts
+++ b/frontend/src/i18n/i18n.ts
@@ -3,6 +3,8 @@ import i18n from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import ICU from 'i18next-icu'
 
+import { Language } from '~shared/types'
+
 import { locales } from './locales'
 
 i18n
@@ -11,7 +13,7 @@ i18n
   .use(initReactI18next) // passes i18n down to react-i18next
   .init({
     resources: locales,
-    fallbackLng: 'en-SG',
+    fallbackLng: Language.ENGLISH,
     debug: false,
     interpolation: {
       escapeValue: false, // react already safes from xss

--- a/shared/utils/payments.ts
+++ b/shared/utils/payments.ts
@@ -1,4 +1,4 @@
-import { PaymentsUpdateDto, PaymentType } from '../types'
+import { Language, PaymentsUpdateDto, PaymentType } from '../types'
 
 export const centsToDollars = (amountCents: number) => {
   const decimalPlaces = 2
@@ -14,7 +14,7 @@ export const dollarsToCents = (dollarStr: string) => {
   return Number(`${tokens[0]}${(tokens[1] ?? '').padEnd(2, '0')}`)
 }
 
-export const formatCurrency = new Intl.NumberFormat('en-SG', {
+export const formatCurrency = new Intl.NumberFormat(Language.ENGLISH, {
   style: 'currency',
   currency: 'SGD',
   minimumFractionDigits: 2,

--- a/src/app/modules/form/form.service.ts
+++ b/src/app/modules/form/form.service.ts
@@ -10,6 +10,7 @@ import {
   FormFieldDto,
   FormResponseMode,
   FormStatus,
+  Language,
   PublicFormDto,
 } from '../../../../shared/types'
 import { encryptString } from '../../../../shared/utils/crypto'
@@ -601,11 +602,13 @@ export const createSingleSampleSubmissionAnswer = (field: FormFieldDto) => {
       }
     }
     case BasicField.Date: {
-      const sampleValue = faker.date.anytime().toLocaleDateString('en-SG', {
-        day: '2-digit',
-        month: 'short',
-        year: 'numeric',
-      })
+      const sampleValue = faker.date
+        .anytime()
+        .toLocaleDateString(Language.ENGLISH, {
+          day: '2-digit',
+          month: 'short',
+          year: 'numeric',
+        })
       return {
         id: field._id,
         question: field.title,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Some dangling `en-SG` strings, it should be using the already available enums.

## Solution 
Use enums.

**Breaking Changes** 
- [x] No - this PR is backwards compatible  