### PR TITLE
feat(i18n): extract text from form validation rules

### DIFF
--- a/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
@@ -3,7 +3,7 @@ import { Controller, RegisterOptions, useForm } from 'react-hook-form'
 import { FormControl, Skeleton, Stack } from '@chakra-ui/react'
 import { get, isEmpty } from 'lodash'
 
-import { FORM_TITLE_VALIDATION_RULES } from '~utils/formValidation'
+import { useFormTitleValidationRules } from '~utils/formValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import Input from '~components/Input'
@@ -41,6 +41,7 @@ const FormTitleInput = ({ initialTitle }: FormTitleInputProps): JSX.Element => {
   })
 
   const { mutateFormTitle } = useMutateFormSettings()
+  const formTitleValidationRules = useFormTitleValidationRules()
 
   const handleBlur = useCallback(() => {
     return handleSubmit(
@@ -73,9 +74,7 @@ const FormTitleInput = ({ initialTitle }: FormTitleInputProps): JSX.Element => {
       <Controller<{ title: string }>
         control={control}
         name="title"
-        rules={
-          FORM_TITLE_VALIDATION_RULES as RegisterOptions<{ title: string }>
-        }
+        rules={formTitleValidationRules as RegisterOptions<{ title: string }>}
         render={({ field }) => (
           <Input {...field} onBlur={handleBlur} onKeyDown={handleKeyDown} />
         )}

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -19,8 +19,8 @@ import {
 
 import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
 import {
-  OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES,
-  REQUIRED_ADMIN_EMAIL_VALIDATION_RULES,
+  useOptionalAdminEmailValidationRules,
+  useRequiredAdminEmailValidationRules,
 } from '~utils/formValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -50,6 +50,11 @@ const AdminEmailRecipientsInput = ({
 
   const { data: settings } = useAdminFormSettings()
 
+  const requiredAdminEmailValidationRules =
+    useRequiredAdminEmailValidationRules()
+  const optionalAdminEmailValidationRules =
+    useOptionalAdminEmailValidationRules()
+
   const handleBlur = useCallback(() => {
     // Get rid of bad tags before submitting.
     setValue(
@@ -68,8 +73,8 @@ const AdminEmailRecipientsInput = ({
       name={EMAILS_FIELD_NAME}
       rules={
         (settings?.responseMode === FormResponseMode.Email
-          ? REQUIRED_ADMIN_EMAIL_VALIDATION_RULES
-          : OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES) as RegisterOptions<{
+          ? requiredAdminEmailValidationRules
+          : optionalAdminEmailValidationRules) as RegisterOptions<{
           emails: string[]
           isRequired: boolean
         }>

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -13,7 +13,7 @@ import isEmail from 'validator/lib/isEmail'
 
 import { MultirespondentFormSettings } from '~shared/types/form'
 
-import { OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES } from '~utils/formValidation'
+import { useOptionalAdminEmailValidationRules } from '~utils/formValidation'
 import { MultiSelect, SingleSelect } from '~components/Dropdown'
 import FormLabel from '~components/FormControl/FormLabel'
 import { TagInput } from '~components/TagInput'
@@ -142,6 +142,9 @@ const MrfEmailNotificationsForm = ({
       ? undefined
       : 'me@example.com'
 
+  const optionalAdminEmailValidationRules =
+    useOptionalAdminEmailValidationRules()
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Box>
@@ -240,7 +243,7 @@ const MrfEmailNotificationsForm = ({
             name={OTHER_PARTIES_EMAIL_INPUT_NAME}
             control={control}
             rules={
-              OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES as RegisterOptions<FormData>
+              optionalAdminEmailValidationRules as RegisterOptions<FormData>
             }
             render={({ field }) => (
               <TagInput

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -13,7 +13,7 @@ import {
 import { FormResponseMode } from '~shared/types/form/form'
 
 import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
-import { FORM_TITLE_VALIDATION_RULES } from '~utils/formValidation'
+import { useFormTitleValidationRules } from '~utils/formValidation'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormFieldMessage from '~components/FormControl/FormFieldMessage'
@@ -75,6 +75,8 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     handleEmailFeedbackSubmit()
   }
 
+  const formTitleValidationRules = useFormTitleValidationRules()
+
   return (
     <>
       <ModalHeader color="secondary.700">
@@ -93,7 +95,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
                 autoFocus
                 {...register(
                   'title',
-                  FORM_TITLE_VALIDATION_RULES as RegisterOptions<
+                  formTitleValidationRules as RegisterOptions<
                     CreateFormWizardInputProps,
                     'title'
                   >,

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailFormRecipientsInput.tsx
@@ -6,8 +6,8 @@ import isEmail from 'validator/lib/isEmail'
 import { FormResponseMode } from '~shared/types/form/form'
 
 import {
-  OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES,
-  REQUIRED_ADMIN_EMAIL_VALIDATION_RULES,
+  useOptionalAdminEmailValidationRules,
+  useRequiredAdminEmailValidationRules,
 } from '~utils/formValidation'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Input from '~components/Input'
@@ -26,6 +26,11 @@ export const EmailFormRecipientsInput = (): JSX.Element => {
 
   const { watch } = formMethods
   const responseModeValue = watch('responseMode')
+
+  const requiredAdminEmailValidationRules =
+    useRequiredAdminEmailValidationRules()
+  const optionalAdminEmailValidationRules =
+    useOptionalAdminEmailValidationRules()
 
   const {
     control,
@@ -49,8 +54,8 @@ export const EmailFormRecipientsInput = (): JSX.Element => {
         name="emails"
         rules={
           (responseModeValue === FormResponseMode.Email
-            ? REQUIRED_ADMIN_EMAIL_VALIDATION_RULES
-            : OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES) as RegisterOptions<CreateFormWizardInputProps>
+            ? requiredAdminEmailValidationRules
+            : optionalAdminEmailValidationRules) as RegisterOptions<CreateFormWizardInputProps>
         }
         render={({ field }) => (
           <TagInput

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EmailModeFeedbackAndCreateScreen.tsx
@@ -15,7 +15,7 @@ import {
 import { BasicField } from '~shared/types'
 
 import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
-import { FORM_TITLE_VALIDATION_RULES } from '~utils/formValidation'
+import { useFormTitleValidationRules } from '~utils/formValidation'
 import Button from '~components/Button'
 import FormLabel from '~components/FormControl/FormLabel'
 import { CheckboxField, CheckboxFieldSchema } from '~templates/Field'
@@ -114,6 +114,8 @@ export const EmailModeCreationScreen = ({
     formState: { errors },
   } = formMethods
 
+  const formTitleValidationRules = useFormTitleValidationRules()
+
   const inputRef = useRef<HTMLInputElement>(null)
   useEffect(() => {
     setTimeout(() => inputRef.current?.focus(), 200)
@@ -121,7 +123,7 @@ export const EmailModeCreationScreen = ({
 
   const formTitleRegister = register(
     'title',
-    FORM_TITLE_VALIDATION_RULES as RegisterOptions<
+    formTitleValidationRules as RegisterOptions<
       CreateFormWizardInputProps,
       'title'
     >,

--- a/frontend/src/i18n/locales/en-sg.ts
+++ b/frontend/src/i18n/locales/en-sg.ts
@@ -5,6 +5,7 @@ import { enSG as landingPage } from './features/landing-page'
 import { enSG as login } from './features/login'
 import { enSG as publicForm } from './features/public-form'
 import { enSG as workspace } from './features/workspace'
+import { enSG as formValidation } from './utils/form-validation'
 import { FallbackTranslation } from './types'
 
 export const enSG: FallbackTranslation = {
@@ -17,6 +18,9 @@ export const enSG: FallbackTranslation = {
       login,
       publicForm,
       workspace,
+    },
+    utils: {
+      formValidation,
     },
   },
 }

--- a/frontend/src/i18n/locales/types.ts
+++ b/frontend/src/i18n/locales/types.ts
@@ -18,6 +18,7 @@ import {
   Workflow,
   Workspace,
 } from './features'
+import { FormValidation } from './utils'
 
 interface Translation {
   translation: {
@@ -43,12 +44,16 @@ interface Translation {
       login?: Login
       workspace?: Workspace
     }
+    utils: {
+      formValidation?: FormValidation
+    }
   }
 }
 
 export interface FallbackTranslation extends Translation {
   translation: {
     features: RequiredDeep<Translation['translation']['features']>
+    utils: RequiredDeep<Translation['translation']['utils']>
   }
 }
 

--- a/frontend/src/i18n/locales/utils/form-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/form-validation/en-sg.ts
@@ -1,0 +1,25 @@
+import { FormValidation } from '.'
+
+export const enSG: FormValidation = {
+  titleValidationRules: {
+    required: 'Form name is required',
+    minLength: {
+      message: 'Form name must be at least {minTitleLength} characters',
+    },
+    maxLength: {
+      message: 'Form name must be at most {maxTitleLength} characters',
+    },
+    validate: {
+      trimMinLength: 'Form name must be at least {minTitleLength} characters',
+    },
+  },
+  requiredEmailAdminValidationRules: {
+    validate: {
+      required: 'You must at least enter one email to receive responses',
+      valid:
+        'Please enter valid email(s) (e.g. me@example.com) separated by commas, as invalid emails will not be saved',
+      duplicate: 'Please remove duplicate emails',
+      maxLength: 'Please limit number of emails to {maxEmailLength}',
+    },
+  },
+}

--- a/frontend/src/i18n/locales/utils/form-validation/index.ts
+++ b/frontend/src/i18n/locales/utils/form-validation/index.ts
@@ -1,0 +1,24 @@
+export interface FormValidation {
+  titleValidationRules: {
+    required: string
+    minLength: {
+      message: string
+    }
+    maxLength: {
+      message: string
+    }
+    validate: {
+      trimMinLength: string
+    }
+  }
+  requiredEmailAdminValidationRules: {
+    validate: {
+      required: string
+      valid: string
+      duplicate: string
+      maxLength: string
+    }
+  }
+}
+
+export * from './en-sg'

--- a/frontend/src/i18n/locales/utils/index.ts
+++ b/frontend/src/i18n/locales/utils/index.ts
@@ -1,0 +1,1 @@
+export { type FormValidation } from './form-validation'

--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -2,9 +2,9 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import validator from 'validator'
 
-const maxEmailLength = 30
-const maxTitleLength = 200
-const minTitleLength = 4
+const MAX_EMAIL_LENGTH = 30
+const MAX_TITLE_LENGTH = 200
+const MIN_TITLE_LENGTH = 4
 
 export const useFormTitleValidationRules = () => {
   const { t } = useTranslation()
@@ -13,25 +13,25 @@ export const useFormTitleValidationRules = () => {
     () => ({
       required: t('utils.formValidation.titleValidationRules.required'),
       minLength: {
-        value: minTitleLength,
+        value: MIN_TITLE_LENGTH,
         message: t(
           'utils.formValidation.titleValidationRules.minLength.message',
-          { minTitleLength },
+          { MIN_TITLE_LENGTH },
         ),
       },
       maxLength: {
-        value: maxTitleLength,
+        value: MAX_TITLE_LENGTH,
         message: t(
           'utils.formValidation.titleValidationRules.maxLength.message',
-          { maxTitleLength },
+          { MAX_TITLE_LENGTH },
         ),
       },
       validate: {
         trimMinLength: (value: string) =>
-          value.trim().length >= minTitleLength ||
+          value.trim().length >= MIN_TITLE_LENGTH ||
           t(
             'utils.formValidation.titleValidationRules.validate.trimMinLength',
-            { minTitleLength },
+            { MIN_TITLE_LENGTH },
           ),
       },
     }),
@@ -72,10 +72,10 @@ export const useRequiredAdminEmailValidationRules = () => {
         },
         maxLength: (emails: string[]) => {
           return (
-            emails.filter(Boolean).length <= maxEmailLength ||
+            emails.filter(Boolean).length <= MAX_EMAIL_LENGTH ||
             t(
               'utils.formValidation.requiredEmailAdminValidationRules.validate.maxLength',
-              { maxEmailLength },
+              { MAX_EMAIL_LENGTH },
             )
           )
         },

--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -1,67 +1,102 @@
-import { UseControllerProps } from 'react-hook-form'
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import validator from 'validator'
 
-const MAX_EMAIL_LENGTH = 30
+const maxEmailLength = 30
+const maxTitleLength = 200
+const minTitleLength = 4
 
-const MAX_TITLE_LENGTH = 200
-const MIN_TITLE_LENGTH = 4
+export const useFormTitleValidationRules = () => {
+  const { t } = useTranslation()
 
-export const FORM_TITLE_VALIDATION_RULES: UseControllerProps['rules'] = {
-  required: 'Form name is required',
-  minLength: {
-    value: MIN_TITLE_LENGTH,
-    message: `Form name must be at least ${MIN_TITLE_LENGTH} characters`,
-  },
-  maxLength: {
-    value: MAX_TITLE_LENGTH,
-    message: `Form name must be at most ${MAX_TITLE_LENGTH} characters`,
-  },
-  validate: {
-    trimMinLength: (value: string) => {
-      return (
-        value.trim().length >= MIN_TITLE_LENGTH ||
-        `Form name must be at least ${MIN_TITLE_LENGTH} characters`
-      )
-    },
-  },
+  return useMemo(
+    () => ({
+      required: t('utils.formValidation.titleValidationRules.required'),
+      minLength: {
+        value: minTitleLength,
+        message: t(
+          'utils.formValidation.titleValidationRules.minLength.message',
+          { minTitleLength },
+        ),
+      },
+      maxLength: {
+        value: maxTitleLength,
+        message: t(
+          'utils.formValidation.titleValidationRules.maxLength.message',
+          { maxTitleLength },
+        ),
+      },
+      validate: {
+        trimMinLength: (value: string) =>
+          value.trim().length >= minTitleLength ||
+          t(
+            'utils.formValidation.titleValidationRules.validate.trimMinLength',
+            { minTitleLength },
+          ),
+      },
+    }),
+    [t],
+  )
 }
 
-export const REQUIRED_ADMIN_EMAIL_VALIDATION_RULES: UseControllerProps['rules'] =
-  {
-    validate: {
-      required: (emails: string[]) => {
-        return (
-          emails.filter(Boolean).length > 0 ||
-          'You must at least enter one email to receive responses'
-        )
-      },
-      valid: (emails: string[]) => {
-        return (
-          emails.filter(Boolean).every((e) => validator.isEmail(e)) ||
-          'Please enter valid email(s) (e.g. me@example.com) separated by commas, as invalid emails will not be saved'
-        )
-      },
-      duplicate: (emails: string[]) => {
-        const truthyEmails = emails.filter(Boolean)
-        return (
-          new Set(truthyEmails).size === truthyEmails.length ||
-          'Please remove duplicate emails'
-        )
-      },
-      maxLength: (emails: string[]) => {
-        return (
-          emails.filter(Boolean).length <= MAX_EMAIL_LENGTH ||
-          `Please limit number of emails to ${MAX_EMAIL_LENGTH}`
-        )
-      },
-    },
-  }
+export const useRequiredAdminEmailValidationRules = () => {
+  const { t } = useTranslation()
 
-export const OPTIONAL_ADMIN_EMAIL_VALIDATION_RULES: UseControllerProps['rules'] =
-  {
-    ...REQUIRED_ADMIN_EMAIL_VALIDATION_RULES,
-    validate: {
-      ...REQUIRED_ADMIN_EMAIL_VALIDATION_RULES.validate,
-      required: () => true,
-    },
-  }
+  return useMemo(
+    () => ({
+      validate: {
+        required: (emails: string[]) => {
+          return (
+            emails.filter(Boolean).length > 0 ||
+            t(
+              'utils.formValidation.requiredEmailAdminValidationRules.validate.required',
+            )
+          )
+        },
+        valid: (emails: string[]) => {
+          return (
+            emails.filter(Boolean).every((e) => validator.isEmail(e)) ||
+            t(
+              'utils.formValidation.requiredEmailAdminValidationRules.validate.valid',
+            )
+          )
+        },
+        duplicate: (emails: string[]) => {
+          const truthyEmails = emails.filter(Boolean)
+          return (
+            new Set(truthyEmails).size === truthyEmails.length ||
+            t(
+              'utils.formValidation.requiredEmailAdminValidationRules.validate.duplicate',
+            )
+          )
+        },
+        maxLength: (emails: string[]) => {
+          return (
+            emails.filter(Boolean).length <= maxEmailLength ||
+            t(
+              'utils.formValidation.requiredEmailAdminValidationRules.validate.maxLength',
+              { maxEmailLength },
+            )
+          )
+        },
+      },
+    }),
+    [t],
+  )
+}
+
+export const useOptionalAdminEmailValidationRules = () => {
+  const requiredAdminEmailValidationRules =
+    useRequiredAdminEmailValidationRules()
+
+  return useMemo(
+    () => ({
+      ...requiredAdminEmailValidationRules,
+      validate: {
+        ...requiredAdminEmailValidationRules.validate,
+        required: () => true,
+      },
+    }),
+    [requiredAdminEmailValidationRules],
+  )
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
_Follows on from #8310, creating a PR on @shagrirse behalf so that chromatic can be ran and reviewed.
Have vetted the code change in 8310 comments, please feel free to run through again if you're keen._

Extracting texts on the form-level validation rules to i18n locales. 

We're pulling more human readable texts to locale files. Motivation: so future forks (eg other countries wanting to adopt and translate) can just create `their-locale.ts` and reference how it's structured in `en-SG.ts`

Closes #8167.

## Solution
<!-- How did you solve the problem? -->
We're using [react-i18next](https://react.i18next.com/), which provides the `useTranslation()` hook to pull translated strings. Since it's a hook, it's meant to be used inside react components.

The form validation rule fns have been modified to facilitate it.

PS: There is a way to use pull human-readable strings for objects outside of react components (such as using the global `i18n.t()`, and other means). But this is generally not recommended [1] (the text will not update if in the future we have a language switcher) and we should strive for using the `useTranslation()` hook wherever possible.

[1] considerations
- https://www.locize.com/blog/how-to-use-i18next-t-outside-react-components (happy to attach more github issues related to this if need. I feel `Solution 3` in the blog is a bit messy)
- https://github.com/opengovsg/FormSG/pull/8310#discussion_r2043847311

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Improvements**:

- Converted constants in `src/utils/formValidation` to hooks
  - New hooks named accordingly
  - Hook invocation on respective components that use the form validation rules
- Add `useTranslation()` hook invocation
- Created locale files for human-readable text

## Tests
<!-- What tests should be run to confirm functionality? -->

### Regression
- [ ] Make a form
- [ ] Go to `Settings` > `General`
- [ ] Change form title below min or below max
- [ ] Go to `Settings` > `Email notifications`
- [ ] Add falsy emails
- [ ] Test that the form validation is working (for both email and title validation rules)
- [ ] Make sure it doesn't necessarily rerender (as we're using `useMemo` already)
