### PR TITLE
feat(i18n): extract text from feedback page

### DIFF
--- a/frontend/src/components/Pagination/PaginationDesktop.tsx
+++ b/frontend/src/components/Pagination/PaginationDesktop.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
 import {
   Box,
@@ -62,6 +63,8 @@ export const PaginationDesktop = ({
   currentPage,
   isDisabled,
 }: PaginationProps): JSX.Element => {
+  const { t } = useTranslation()
+
   const paginationRange = usePaginationRange<typeof SEPARATOR>({
     totalCount,
     pageSize,
@@ -90,7 +93,7 @@ export const PaginationDesktop = ({
     <Box __css={styles.container}>
       <IconButton
         sx={styles.stepper}
-        aria-label="Previous page"
+        aria-label={t('components.pagination.paginationDesktop.previousPage')}
         isDisabled={isDisablePrevPage}
         onClick={handlePageBack}
         icon={<BiChevronLeft />}
@@ -108,7 +111,7 @@ export const PaginationDesktop = ({
       </HStack>
       <IconButton
         sx={styles.stepper}
-        aria-label="Next page"
+        aria-label={t('components.pagination.paginationDesktop.nextPage')}
         isDisabled={isDisableNextPage}
         onClick={handlePageNext}
         icon={<BiChevronRight />}

--- a/frontend/src/components/Pagination/PaginationMobile.tsx
+++ b/frontend/src/components/Pagination/PaginationMobile.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiChevronLeft, BiChevronRight } from 'react-icons/bi'
 import { Box, IconButton, Text, useMultiStyleConfig } from '@chakra-ui/react'
 
@@ -19,6 +20,8 @@ export const PaginationMobile = ({
   currentPage,
   isDisabled,
 }: PaginationMobileProps): JSX.Element => {
+  const { t } = useTranslation()
+
   const styles = useMultiStyleConfig(PAGINATION_THEME_KEY, { isDisabled })
 
   const totalPageCount = Math.ceil(totalCount / pageSize)
@@ -39,17 +42,20 @@ export const PaginationMobile = ({
     <Box __css={styles.container}>
       <IconButton
         sx={styles.stepper}
-        aria-label="Previous page"
+        aria-label={t('components.pagination.paginationMobile.previousPage')}
         isDisabled={isDisablePrevPage}
         onClick={handlePageBack}
         icon={<BiChevronLeft />}
       />
       <Text sx={styles.text} aria-disabled={isDisabled}>
-        Page {currentPage} of {totalPageCount}
+        {t('components.pagination.paginationMobile.currentPageCount', {
+          currentPage,
+          totalPageCount,
+        })}
       </Text>
       <IconButton
         sx={styles.stepper}
-        aria-label="Next page"
+        aria-label={t('components.pagination.paginationMobile.nextPage')}
         isDisabled={isDisableNextPage}
         onClick={handlePageNext}
         icon={<BiChevronRight />}

--- a/frontend/src/features/admin-form/common/mutations.ts
+++ b/frontend/src/features/admin-form/common/mutations.ts
@@ -495,7 +495,7 @@ export const usePreviewFormMutations = (formId: string) => {
   }
 }
 
-export const useFormFeedbackMutations = () => {
+export const useFormFeedbackMutations = (headers: string[]) => {
   const toast = useToast({ status: 'success', isClosable: true })
 
   const handleError = useCallback(
@@ -511,7 +511,7 @@ export const useFormFeedbackMutations = () => {
 
   const downloadFormFeedbackMutation = useMutation(
     ({ formId, formTitle }: DownloadFormFeedbackMutationArgs) =>
-      downloadFormReview(formId, formTitle),
+      downloadFormReview(formId, formTitle, headers),
     {
       onSuccess: () => {
         toast({
@@ -525,7 +525,7 @@ export const useFormFeedbackMutations = () => {
   return { downloadFormFeedbackMutation }
 }
 
-export const useFormIssueMutations = () => {
+export const useFormIssueMutations = (headers: string[]) => {
   const toast = useToast({ status: 'success', isClosable: true })
 
   const handleError = useCallback(
@@ -541,7 +541,7 @@ export const useFormIssueMutations = () => {
 
   const downloadFormIssuesMutation = useMutation(
     ({ formId, formTitle, count }: DownloadFormIssuesMutationArgs) =>
-      downloadFormIssue(formId, formTitle, count || 0),
+      downloadFormIssue(formId, formTitle, count || 0, headers),
     {
       onSuccess: () => {
         toast({

--- a/frontend/src/features/admin-form/responses/FeedbackPage/EmptyFeedback/EmptyFeedback.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/EmptyFeedback/EmptyFeedback.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Flex, Text } from '@chakra-ui/react'
 
 import { OGP_POSTMAN } from '~constants/links'
@@ -6,17 +7,19 @@ import Link from '~components/Link'
 import { EmptyFeedbackSvgr } from './EmptyFeedbackSvgr'
 
 export const EmptyFeedback = (): JSX.Element => {
+  const { t } = useTranslation()
+
   return (
     <Flex justify="center" flexDir="column" align="center" px="2rem" py="4rem">
       <Text as="h2" textStyle="h2" color="primary.500" mb="1rem">
-        You don't have any feedback yet
+        {t('features.adminForm.feedback.emptyFeedback.noFeedbackYet')}
       </Text>
       <Text textStyle="body-1" color="secondary.500">
-        Try using{' '}
+        {t('features.adminForm.feedback.emptyFeedback.tryUsing')}{' '}
         <Link isExternal href={OGP_POSTMAN}>
           Postman.gov.sg
         </Link>{' '}
-        to send out your forms!
+        {t('features.adminForm.feedback.emptyFeedback.toSendOutForms')}
       </Text>
       <EmptyFeedbackSvgr mt="1.5rem" w="380px" maxW="100%" />
     </Flex>

--- a/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackDownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackDownloadButton.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { BiDownload } from 'react-icons/bi'
 
 import Button from '~components/Button'
@@ -16,13 +17,15 @@ export const FeedbackDownloadButton = ({
   handleClick,
   isMobile,
 }: FeedbackDownloadButtonProps) => {
+  const { t } = useTranslation()
+
   if (isMobile) {
     return (
       <IconButton
         isDisabled={isDisabled}
         isLoading={isLoading}
         onClick={handleClick}
-        aria-label="Export"
+        aria-label={t('features.adminForm.feedback.downloadButton.export')}
         icon={<BiDownload />}
         variant="outline"
         colorScheme="primary"
@@ -36,7 +39,7 @@ export const FeedbackDownloadButton = ({
       onClick={handleClick}
       leftIcon={<BiDownload fontSize="1.5rem" />}
     >
-      Export
+      {t('features.adminForm.feedback.downloadButton.export')}
     </Button>
   )
 }

--- a/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { UseMutationResult } from 'react-query'
 import { useParams } from 'react-router-dom'
 import {
@@ -10,7 +11,6 @@ import {
   Icon,
   Text,
 } from '@chakra-ui/react'
-import simplur from 'simplur'
 
 import { ProcessedFeedbackMeta, ProcessedIssueMeta } from '~shared/types'
 
@@ -31,8 +31,8 @@ import { useAdminForm } from '~features/admin-form/common/queries'
 
 import { useFormFeedback, useFormIssues } from '../queries'
 
-import { ISSUE_TABLE_COLUMNS } from './issue/IssueTable'
-import { REVIEW_TABLE_COLUMNS } from './review/ReviewTable'
+import { useIssueTableColumns } from './issue/IssueTable'
+import { useReviewTableColumns } from './review/ReviewTable'
 import { EmptyFeedback } from './EmptyFeedback'
 import { FeedbackDownloadButton } from './FeedbackDownloadButton'
 import {
@@ -62,7 +62,54 @@ interface Review extends Feedback {
   download: UseMutationResult<void, Error, DownloadFormFeedbackMutationArgs>
 }
 
+interface ReviewInformationTranslations {
+  averageScore: string
+  reviewsToDate: (reviewCount: number) => string
+}
+
+interface IssueInformationTranslations {
+  tooltip: string
+  issuesToDate: (issueCount: number) => string
+}
+
+interface FeedbackPageTranslations {
+  issues: string
+  reviews: string
+  reviewInformation: ReviewInformationTranslations
+  issueInformation: IssueInformationTranslations
+}
+
 export const FeedbackPage = (): JSX.Element => {
+  // Translations to be parsed into helper functions
+  const { t } = useTranslation()
+
+  const translations: FeedbackPageTranslations = useMemo(
+    () => ({
+      issues: t('features.adminForm.feedback.feedbackPage.issues'),
+      reviews: t('features.adminForm.feedback.feedbackPage.reviews'),
+      reviewInformation: {
+        averageScore: t(
+          'features.adminForm.feedback.feedbackPage.reviewInformation.averageScore',
+        ),
+        reviewsToDate: (reviewCount: number) =>
+          t(
+            'features.adminForm.feedback.feedbackPage.reviewInformation.reviewsToDate',
+            { reviewCount },
+          ),
+      },
+      issueInformation: {
+        tooltip: t(
+          'features.adminForm.feedback.feedbackPage.issueInformation.tooltip',
+        ),
+        issuesToDate: (issueCount: number) =>
+          t(
+            'features.adminForm.feedback.feedbackPage.issueInformation.issuesToDate',
+            { issueCount },
+          ),
+      },
+    }),
+    [t],
+  )
   // Extract form information
   const { data: form } = useAdminForm()
   const { formId } = useParams()
@@ -94,6 +141,10 @@ export const FeedbackPage = (): JSX.Element => {
     download: issueDownload,
     isGetLoading: isIssueLoading,
   }
+
+  // Table column hooks for issue and review tables
+  const issueTableColumns = useIssueTableColumns()
+  const reviewTableColumns = useReviewTableColumns()
 
   // Download button handler
   const handleFeedbackDownloadClick = useCallback(() => {
@@ -154,6 +205,7 @@ export const FeedbackPage = (): JSX.Element => {
             currentFeedbackType,
             issueProps,
             reviewProps,
+            translations,
           )}
         </Box>
         <ButtonGroup gridArea="feedbackType" isAttached variant="outline">
@@ -165,7 +217,7 @@ export const FeedbackPage = (): JSX.Element => {
             sx={{ borderRightWidth: '0px' }}
             onClick={() => setCurrentFeedbackType(FeedbackType.Issues)}
           >
-            Issues
+            {translations.issues}
           </Button>
           <Button
             {...getFeedbackTypeButtonProps(
@@ -174,7 +226,7 @@ export const FeedbackPage = (): JSX.Element => {
             )}
             onClick={() => setCurrentFeedbackType(FeedbackType.Reviews)}
           >
-            Reviews
+            {translations.reviews}
           </Button>
         </ButtonGroup>
         <Box gridArea="export" justifySelf="flex-end">
@@ -198,8 +250,8 @@ export const FeedbackPage = (): JSX.Element => {
           }
           feedbackColumns={
             currentFeedbackType === FeedbackType.Issues
-              ? ISSUE_TABLE_COLUMNS
-              : REVIEW_TABLE_COLUMNS
+              ? issueTableColumns
+              : reviewTableColumns
           }
           currentPage={currentPage - 1}
         />
@@ -229,6 +281,7 @@ export const FeedbackPage = (): JSX.Element => {
 const getReviewInformationComponent = (
   average: string | undefined,
   count: number | undefined,
+  translations: ReviewInformationTranslations,
 ): JSX.Element => {
   return (
     <Grid
@@ -241,7 +294,7 @@ const getReviewInformationComponent = (
     >
       <Flex gridArea="score" flexDir="column">
         <Text textStyle="caption-2" color="secondary.400">
-          Average Score
+          {translations.averageScore}
         </Text>
         <Text textStyle="display-2">
           {average ? Number(average).toPrecision(2) : '-.--'}
@@ -251,8 +304,8 @@ const getReviewInformationComponent = (
         <Text textStyle="h4" mb="0.5rem">
           <Text as="span" color="primary.500">
             {count}
-          </Text>
-          {simplur` ${[count || 0]}review[|s] to date`}
+          </Text>{' '}
+          {translations.reviewsToDate(count ?? 0)}
         </Text>
       </Box>
     </Grid>
@@ -261,20 +314,17 @@ const getReviewInformationComponent = (
 
 const getIssueInformationComponent = (
   count: number | undefined,
+  translations: IssueInformationTranslations,
 ): JSX.Element => {
   return (
     <Box display="flex" alignItems="center" mb="0.5rem">
       <Text textStyle="h4">
         <Text as="span" color="primary.500">
           {count}
-        </Text>
-        {simplur` ${[count || 0]}issue[|s] to date`}
+        </Text>{' '}
+        {translations.issuesToDate(count ?? 0)}
       </Text>
-      <Tooltip
-        label={`Feedback displayed here relates to form submission issues`}
-        placement="top"
-        textAlign="center"
-      >
+      <Tooltip label={translations.tooltip} placement="top" textAlign="center">
         <Icon as={BxsInfoCircle} aria-hidden marginX="0.5rem" />
       </Tooltip>
     </Box>
@@ -285,11 +335,19 @@ const getInformationGridComponent = (
   currentFeedbackType: FeedbackType,
   issueProps: Issue,
   reviewProps: Review,
+  translations: FeedbackPageTranslations,
 ): JSX.Element => {
   if (currentFeedbackType === FeedbackType.Issues) {
-    return getIssueInformationComponent(issueProps.count)
+    return getIssueInformationComponent(
+      issueProps.count,
+      translations.issueInformation,
+    )
   }
-  return getReviewInformationComponent(reviewProps.average, reviewProps.count)
+  return getReviewInformationComponent(
+    reviewProps.average,
+    reviewProps.count,
+    translations.reviewInformation,
+  )
 }
 
 const getFeedbackTypeButtonProps = (

--- a/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
@@ -77,6 +77,8 @@ interface FeedbackPageTranslations {
   reviews: string
   reviewInformation: ReviewInformationTranslations
   issueInformation: IssueInformationTranslations
+  feedbackHeaders: string[]
+  issueHeaders: string[]
 }
 
 export const FeedbackPage = (): JSX.Element => {
@@ -107,6 +109,16 @@ export const FeedbackPage = (): JSX.Element => {
             { issueCount },
           ),
       },
+      feedbackHeaders: [
+        t('features.adminForm.feedback.feedbackCsvGenerator.date'),
+        t('features.adminForm.feedback.feedbackCsvGenerator.comment'),
+        t('features.adminForm.feedback.feedbackCsvGenerator.rating'),
+      ],
+      issueHeaders: [
+        t('features.adminForm.feedback.issueCsvGenerator.date'),
+        t('features.adminForm.feedback.issueCsvGenerator.issue'),
+        t('features.adminForm.feedback.issueCsvGenerator.email'),
+      ],
     }),
     [t],
   )
@@ -123,7 +135,9 @@ export const FeedbackPage = (): JSX.Element => {
 
   // Hooks for form reviews
   const { data: reviewData, isLoading: isReviewLoading } = useFormFeedback()
-  const reviewDownload = useFormFeedbackMutations().downloadFormFeedbackMutation
+  const reviewDownload = useFormFeedbackMutations(
+    translations.feedbackHeaders,
+  ).downloadFormFeedbackMutation
   const reviewProps: Review = {
     count: reviewData?.count,
     data: reviewData?.feedback,
@@ -134,7 +148,9 @@ export const FeedbackPage = (): JSX.Element => {
 
   // Hooks for form issues
   const { data: issueData, isLoading: isIssueLoading } = useFormIssues()
-  const issueDownload = useFormIssueMutations().downloadFormIssueMutation
+  const issueDownload = useFormIssueMutations(
+    translations.issueHeaders,
+  ).downloadFormIssueMutation
   const issueProps: Issue = {
     count: issueData?.count,
     data: issueData?.issues,

--- a/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { UseMutationResult } from 'react-query'
 import { useParams } from 'react-router-dom'
@@ -54,73 +54,49 @@ interface Feedback {
 interface Issue extends Feedback {
   data: ProcessedIssueMeta[] | undefined
   download: UseMutationResult<void, Error, DownloadFormIssuesMutationArgs>
+  translations: IssueInformationTranslations
 }
 
 interface Review extends Feedback {
   data: ProcessedFeedbackMeta[] | undefined
   average: string | undefined
   download: UseMutationResult<void, Error, DownloadFormFeedbackMutationArgs>
+  translations: ReviewInformationTranslations
 }
 
 interface ReviewInformationTranslations {
   averageScore: string
-  reviewsToDate: (reviewCount: number) => string
+  reviewsToDate: string
 }
 
 interface IssueInformationTranslations {
   tooltip: string
-  issuesToDate: (issueCount: number) => string
+  issuesToDate: string
 }
-
 interface FeedbackPageTranslations {
   issues: string
   reviews: string
   reviewInformation: ReviewInformationTranslations
   issueInformation: IssueInformationTranslations
-  feedbackHeaders: string[]
-  issueHeaders: string[]
+  feedbackCsvGenerator: {
+    date: string
+    comment: string
+    rating: string
+  }
+  issueCsvGenerator: {
+    date: string
+    issue: string
+    email: string
+  }
 }
 
 export const FeedbackPage = (): JSX.Element => {
-  // Translations to be parsed into helper functions
   const { t } = useTranslation()
-
-  const translations: FeedbackPageTranslations = useMemo(
-    () => ({
-      issues: t('features.adminForm.feedback.feedbackPage.issues'),
-      reviews: t('features.adminForm.feedback.feedbackPage.reviews'),
-      reviewInformation: {
-        averageScore: t(
-          'features.adminForm.feedback.feedbackPage.reviewInformation.averageScore',
-        ),
-        reviewsToDate: (reviewCount: number) =>
-          t(
-            'features.adminForm.feedback.feedbackPage.reviewInformation.reviewsToDate',
-            { reviewCount },
-          ),
-      },
-      issueInformation: {
-        tooltip: t(
-          'features.adminForm.feedback.feedbackPage.issueInformation.tooltip',
-        ),
-        issuesToDate: (issueCount: number) =>
-          t(
-            'features.adminForm.feedback.feedbackPage.issueInformation.issuesToDate',
-            { issueCount },
-          ),
-      },
-      feedbackHeaders: [
-        t('features.adminForm.feedback.feedbackCsvGenerator.date'),
-        t('features.adminForm.feedback.feedbackCsvGenerator.comment'),
-        t('features.adminForm.feedback.feedbackCsvGenerator.rating'),
-      ],
-      issueHeaders: [
-        t('features.adminForm.feedback.issueCsvGenerator.date'),
-        t('features.adminForm.feedback.issueCsvGenerator.issue'),
-        t('features.adminForm.feedback.issueCsvGenerator.email'),
-      ],
-    }),
-    [t],
+  const translations: FeedbackPageTranslations = t(
+    'features.adminForm.feedback.feedbackPage',
+    {
+      returnObjects: true,
+    },
   )
   // Extract form information
   const { data: form } = useAdminForm()
@@ -135,27 +111,45 @@ export const FeedbackPage = (): JSX.Element => {
 
   // Hooks for form reviews
   const { data: reviewData, isLoading: isReviewLoading } = useFormFeedback()
-  const reviewDownload = useFormFeedbackMutations(
-    translations.feedbackHeaders,
-  ).downloadFormFeedbackMutation
+  const reviewDownload = useFormFeedbackMutations([
+    translations.feedbackCsvGenerator.date,
+    translations.feedbackCsvGenerator.comment,
+    translations.feedbackCsvGenerator.rating,
+  ]).downloadFormFeedbackMutation
   const reviewProps: Review = {
     count: reviewData?.count,
     data: reviewData?.feedback,
     average: reviewData?.average,
     download: reviewDownload,
     isGetLoading: isReviewLoading,
+    translations: {
+      averageScore: translations.reviewInformation.averageScore,
+      reviewsToDate: t(
+        'features.adminForm.feedback.feedbackPage.reviewInformation.reviewsToDate',
+        { reviewCount: reviewData?.count ?? 0 },
+      ),
+    },
   }
 
   // Hooks for form issues
   const { data: issueData, isLoading: isIssueLoading } = useFormIssues()
-  const issueDownload = useFormIssueMutations(
-    translations.issueHeaders,
-  ).downloadFormIssueMutation
+  const issueDownload = useFormIssueMutations([
+    translations.issueCsvGenerator.date,
+    translations.issueCsvGenerator.issue,
+    translations.issueCsvGenerator.email,
+  ]).downloadFormIssueMutation
   const issueProps: Issue = {
     count: issueData?.count,
     data: issueData?.issues,
     download: issueDownload,
     isGetLoading: isIssueLoading,
+    translations: {
+      tooltip: translations.issueInformation.tooltip,
+      issuesToDate: t(
+        'features.adminForm.feedback.feedbackPage.issueInformation.issuesToDate',
+        { issueCount: issueData?.count ?? 0 },
+      ),
+    },
   }
 
   // Table column hooks for issue and review tables
@@ -221,7 +215,6 @@ export const FeedbackPage = (): JSX.Element => {
             currentFeedbackType,
             issueProps,
             reviewProps,
-            translations,
           )}
         </Box>
         <ButtonGroup gridArea="feedbackType" isAttached variant="outline">
@@ -321,7 +314,7 @@ const getReviewInformationComponent = (
           <Text as="span" color="primary.500">
             {count}
           </Text>{' '}
-          {translations.reviewsToDate(count ?? 0)}
+          {translations.reviewsToDate}
         </Text>
       </Box>
     </Grid>
@@ -338,7 +331,7 @@ const getIssueInformationComponent = (
         <Text as="span" color="primary.500">
           {count}
         </Text>{' '}
-        {translations.issuesToDate(count ?? 0)}
+        {translations.issuesToDate}
       </Text>
       <Tooltip label={translations.tooltip} placement="top" textAlign="center">
         <Icon as={BxsInfoCircle} aria-hidden marginX="0.5rem" />
@@ -351,18 +344,17 @@ const getInformationGridComponent = (
   currentFeedbackType: FeedbackType,
   issueProps: Issue,
   reviewProps: Review,
-  translations: FeedbackPageTranslations,
 ): JSX.Element => {
   if (currentFeedbackType === FeedbackType.Issues) {
     return getIssueInformationComponent(
       issueProps.count,
-      translations.issueInformation,
+      issueProps.translations,
     )
   }
   return getReviewInformationComponent(
     reviewProps.average,
     reviewProps.count,
-    translations.reviewInformation,
+    reviewProps.translations,
   )
 }
 

--- a/frontend/src/features/admin-form/responses/FeedbackPage/issue/IssueService.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/issue/IssueService.tsx
@@ -24,11 +24,12 @@ export const downloadFormIssue = async (
   formId: string,
   formTitle: string,
   count: number,
+  headers: string[],
 ): Promise<void> => {
   return ApiService.get<FormIssueDto[]>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/issues/download`,
   ).then(({ data }) => {
-    const csvGenerator = new IssueCsvGenerator(count)
+    const csvGenerator = new IssueCsvGenerator(count, headers)
 
     data.forEach((issue) => {
       csvGenerator.addLineFromIssue(issue)

--- a/frontend/src/features/admin-form/responses/FeedbackPage/issue/IssueTable.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/issue/IssueTable.tsx
@@ -1,39 +1,48 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Column } from 'react-table'
 
 import { DateCell } from '~features/admin-form/responses/FeedbackPage/DateCell'
 
-export const ISSUE_TABLE_COLUMNS: Column[] = [
-  {
-    Header: '#',
-    accessor: (_row, i) => i + 1,
-    sortType: 'number',
-    minWidth: 50, // minWidth is only used as a limit for resizing
-    width: 50, // width is used for both the flex-basis and flex-grow
-    maxWidth: 100, // maxWidth is only used as a limit for resizing
-  },
-  {
-    Header: 'Date',
-    accessor: 'timestamp',
-    sortType: 'number',
-    Cell: DateCell,
-    minWidth: 80, // minWidth is only used as a limit for resizing
-    width: 80, // width is used for both the flex-basis and flex-grow
-    maxWidth: 120, // maxWidth is only used as a limit for resizing
-  },
-  {
-    Header: 'Issue',
-    accessor: 'issue',
-    sortType: 'basic',
-    minWidth: 200,
-    width: 300,
-    maxWidth: 600,
-  },
-  {
-    Header: 'Contact',
-    accessor: 'email',
-    sortType: 'basic',
-    minWidth: 120,
-    width: 120,
-    maxWidth: 300,
-  },
-]
+export const useIssueTableColumns = () => {
+  const { t } = useTranslation()
+
+  return useMemo(
+    (): Column[] => [
+      {
+        Header: '#',
+        accessor: (_row, i) => i + 1,
+        sortType: 'number',
+        minWidth: 50, // minWidth is only used as a limit for resizing
+        width: 50, // width is used for both the flex-basis and flex-grow
+        maxWidth: 100, // maxWidth is only used as a limit for resizing
+      },
+      {
+        Header: t('features.adminForm.feedback.issueTable.dateHeader'),
+        accessor: 'timestamp',
+        sortType: 'number',
+        Cell: DateCell,
+        minWidth: 80, // minWidth is only used as a limit for resizing
+        width: 80, // width is used for both the flex-basis and flex-grow
+        maxWidth: 120, // maxWidth is only used as a limit for resizing
+      },
+      {
+        Header: t('features.adminForm.feedback.issueTable.issueHeader'),
+        accessor: 'issue',
+        sortType: 'basic',
+        minWidth: 200,
+        width: 300,
+        maxWidth: 600,
+      },
+      {
+        Header: t('features.adminForm.feedback.issueTable.contactHeader'),
+        accessor: 'email',
+        sortType: 'basic',
+        minWidth: 120,
+        width: 120,
+        maxWidth: 300,
+      },
+    ],
+    [t],
+  )
+}

--- a/frontend/src/features/admin-form/responses/FeedbackPage/review/ReviewService.ts
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/review/ReviewService.ts
@@ -33,13 +33,14 @@ export const getFormFeedbackCount = async (formId: string): Promise<number> => {
 export const downloadFormReview = async (
   formId: string,
   formTitle: string,
+  headers: string[],
 ): Promise<void> => {
   const expectedNumResponses = await getFormFeedbackCount(formId)
 
   return ApiService.get<FormFeedbackDto[]>(
     `${ADMIN_FORM_ENDPOINT}/${formId}/feedback/download`,
   ).then(({ data }) => {
-    const csvGenerator = new FeedbackCsvGenerator(expectedNumResponses)
+    const csvGenerator = new FeedbackCsvGenerator(expectedNumResponses, headers)
 
     data.forEach((feedback) => {
       csvGenerator.addLineFromFeedback(feedback)

--- a/frontend/src/features/admin-form/responses/FeedbackPage/review/ReviewTable.tsx
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/review/ReviewTable.tsx
@@ -1,39 +1,48 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Column } from 'react-table'
 
 import { DateCell } from '~features/admin-form/responses/FeedbackPage/DateCell'
 
-export const REVIEW_TABLE_COLUMNS: Column[] = [
-  {
-    Header: '#',
-    accessor: (_row, i) => i + 1,
-    sortType: 'number',
-    minWidth: 50, // minWidth is only used as a limit for resizing
-    width: 50, // width is used for both the flex-basis and flex-grow
-    maxWidth: 100, // maxWidth is only used as a limit for resizing
-  },
-  {
-    Header: 'Date',
-    accessor: 'timestamp',
-    sortType: 'number',
-    Cell: DateCell,
-    minWidth: 80, // minWidth is only used as a limit for resizing
-    width: 80, // width is used for both the flex-basis and flex-grow
-    maxWidth: 120, // maxWidth is only used as a limit for resizing
-  },
-  {
-    Header: 'Feedback',
-    accessor: 'comment',
-    sortType: 'basic',
-    minWidth: 200,
-    width: 300,
-    maxWidth: 600,
-  },
-  {
-    Header: 'Rating',
-    accessor: 'rating',
-    sortType: 'number',
-    minWidth: 90,
-    width: 90,
-    disableResizing: true,
-  },
-]
+export const useReviewTableColumns = () => {
+  const { t } = useTranslation()
+
+  return useMemo(
+    (): Column[] => [
+      {
+        Header: '#',
+        accessor: (_row, i) => i + 1,
+        sortType: 'number',
+        minWidth: 50, // minWidth is only used as a limit for resizing
+        width: 50, // width is used for both the flex-basis and flex-grow
+        maxWidth: 100, // maxWidth is only used as a limit for resizing
+      },
+      {
+        Header: t('features.adminForm.feedback.reviewTable.dateHeader'),
+        accessor: 'timestamp',
+        sortType: 'number',
+        Cell: DateCell,
+        minWidth: 80, // minWidth is only used as a limit for resizing
+        width: 80, // width is used for both the flex-basis and flex-grow
+        maxWidth: 120, // maxWidth is only used as a limit for resizing
+      },
+      {
+        Header: t('features.adminForm.feedback.reviewTable.feedbackHeader'),
+        accessor: 'comment',
+        sortType: 'basic',
+        minWidth: 200,
+        width: 300,
+        maxWidth: 600,
+      },
+      {
+        Header: t('features.adminForm.feedback.reviewTable.ratingHeader'),
+        accessor: 'rating',
+        sortType: 'number',
+        minWidth: 90,
+        width: 90,
+        disableResizing: true,
+      },
+    ],
+    [t],
+  )
+}

--- a/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
@@ -1,7 +1,5 @@
-import { withTranslation } from 'react-i18next'
 import { isValid, parseISO } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
-import i18next from 'i18next'
 
 import { FormFeedbackDto } from '~shared/types'
 
@@ -11,13 +9,9 @@ import { processFormulaInjectionText } from '../../ResponsesPage/storage/utils/p
  * Class to encapsulate the FeedbackCsv and its attributes
  */
 export class FeedbackCsvGenerator extends CsvGenerator {
-  constructor(expectedNumberOfRecords: number) {
+  constructor(expectedNumberOfRecords: number, headers: string[]) {
     super(expectedNumberOfRecords, 0)
-    this.setHeader([
-      i18next.t('features.adminForm.feedback.feedbackCsvGenerator.date'),
-      i18next.t('features.adminForm.feedback.feedbackCsvGenerator.comment'),
-      i18next.t('features.adminForm.feedback.feedbackCsvGenerator.rating'),
-    ])
+    this.setHeader(headers)
   }
 
   /**

--- a/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/utils/FeedbackCsvGenerator.ts
@@ -1,5 +1,7 @@
+import { withTranslation } from 'react-i18next'
 import { isValid, parseISO } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
+import i18next from 'i18next'
 
 import { FormFeedbackDto } from '~shared/types'
 
@@ -11,7 +13,11 @@ import { processFormulaInjectionText } from '../../ResponsesPage/storage/utils/p
 export class FeedbackCsvGenerator extends CsvGenerator {
   constructor(expectedNumberOfRecords: number) {
     super(expectedNumberOfRecords, 0)
-    this.setHeader(['Date', 'Comment', 'Rating'])
+    this.setHeader([
+      i18next.t('features.adminForm.feedback.feedbackCsvGenerator.date'),
+      i18next.t('features.adminForm.feedback.feedbackCsvGenerator.comment'),
+      i18next.t('features.adminForm.feedback.feedbackCsvGenerator.rating'),
+    ])
   }
 
   /**

--- a/frontend/src/features/admin-form/responses/FeedbackPage/utils/IssueCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/utils/IssueCsvGenerator.ts
@@ -1,6 +1,5 @@
 import { isValid } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
-import i18next from 'i18next'
 
 import { FormIssueDto } from '~shared/types'
 
@@ -11,13 +10,9 @@ import { processFormulaInjectionText } from '../../ResponsesPage/storage/utils/p
  * Class to encapsulate the IssueCsv and its attributes
  */
 export class IssueCsvGenerator extends CsvGenerator {
-  constructor(expectedNumberOfRecords: number) {
+  constructor(expectedNumberOfRecords: number, headers: string[]) {
     super(expectedNumberOfRecords, 0)
-    this.setHeader([
-      i18next.t('features.adminForm.feedback.issueCsvGenerator.date'),
-      i18next.t('features.adminForm.feedback.issueCsvGenerator.issue'),
-      i18next.t('features.adminForm.feedback.issueCsvGenerator.email'),
-    ])
+    this.setHeader(headers)
   }
 
   /**

--- a/frontend/src/features/admin-form/responses/FeedbackPage/utils/IssueCsvGenerator.ts
+++ b/frontend/src/features/admin-form/responses/FeedbackPage/utils/IssueCsvGenerator.ts
@@ -1,5 +1,6 @@
 import { isValid } from 'date-fns'
 import { formatInTimeZone } from 'date-fns-tz'
+import i18next from 'i18next'
 
 import { FormIssueDto } from '~shared/types'
 
@@ -12,7 +13,11 @@ import { processFormulaInjectionText } from '../../ResponsesPage/storage/utils/p
 export class IssueCsvGenerator extends CsvGenerator {
   constructor(expectedNumberOfRecords: number) {
     super(expectedNumberOfRecords, 0)
-    this.setHeader(['Date', 'Issue', 'Email'])
+    this.setHeader([
+      i18next.t('features.adminForm.feedback.issueCsvGenerator.date'),
+      i18next.t('features.adminForm.feedback.issueCsvGenerator.issue'),
+      i18next.t('features.adminForm.feedback.issueCsvGenerator.email'),
+    ])
   }
 
   /**

--- a/frontend/src/i18n/locales/components/index.ts
+++ b/frontend/src/i18n/locales/components/index.ts
@@ -1,0 +1,1 @@
+export { type Pagination } from './pagination'

--- a/frontend/src/i18n/locales/components/pagination/en-sg.ts
+++ b/frontend/src/i18n/locales/components/pagination/en-sg.ts
@@ -1,0 +1,13 @@
+import { Pagination } from '.'
+
+export const enSG: Pagination = {
+  paginationDesktop: {
+    previousPage: 'Previous page',
+    nextPage: 'Next page',
+  },
+  paginationMobile: {
+    currentPageCount: 'Page {currentPage} of {totalPageCount}',
+    previousPage: 'Previous page',
+    nextPage: 'Next page',
+  },
+}

--- a/frontend/src/i18n/locales/components/pagination/index.ts
+++ b/frontend/src/i18n/locales/components/pagination/index.ts
@@ -1,0 +1,13 @@
+export interface Pagination {
+  paginationDesktop: {
+    previousPage: string
+    nextPage: string
+  }
+  paginationMobile: {
+    previousPage: string
+    nextPage: string
+    currentPageCount: string
+  }
+}
+
+export * from './en-sg'

--- a/frontend/src/i18n/locales/en-sg.ts
+++ b/frontend/src/i18n/locales/en-sg.ts
@@ -1,3 +1,4 @@
+import { enSG as pagination } from './components/pagination'
 import { enSG as adminForm } from './features/admin-form'
 import { enSG as app } from './features/app'
 import { enSG as common } from './features/common'
@@ -21,6 +22,9 @@ export const enSG: FallbackTranslation = {
     },
     utils: {
       formValidation,
+    },
+    components: {
+      pagination,
     },
   },
 }

--- a/frontend/src/i18n/locales/features/admin-form/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/en-sg.ts
@@ -1,3 +1,4 @@
+import { enSG as feedback } from './feedback'
 import { enSG as meta } from './meta'
 import { enSG as modals } from './modals'
 import { enSG as navbar } from './navbar'
@@ -12,4 +13,5 @@ export const enSG = {
   modals,
   toasts,
   settings,
+  feedback,
 }

--- a/frontend/src/i18n/locales/features/admin-form/feedback/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/feedback/en-sg.ts
@@ -1,0 +1,46 @@
+import { Feedback } from '.'
+
+export const enSG: Feedback = {
+  emptyFeedback: {
+    noFeedbackYet: "You don't have any feedback yet",
+    tryUsing: 'Try using',
+    toSendOutForms: 'to send out your forms!',
+  },
+  issueTable: {
+    dateHeader: 'Date',
+    issueHeader: 'Issue',
+    contactHeader: 'Contact',
+  },
+  reviewTable: {
+    dateHeader: 'Date',
+    feedbackHeader: 'Feedback',
+    ratingHeader: 'Rating',
+  },
+  downloadButton: {
+    export: 'Export',
+  },
+  feedbackPage: {
+    issues: 'Issues',
+    reviews: 'Reviews',
+    reviewInformation: {
+      averageScore: 'Average Score',
+      reviewsToDate:
+        '{reviewCount, plural, =1 {review to date} other {reviews to date}}',
+    },
+    issueInformation: {
+      issuesToDate:
+        '{issueCount, plural, =1 {issue to date} other {issues to date}}',
+      tooltip: 'Feedback displayed here relates to form submission issues',
+    },
+  },
+  feedbackCsvGenerator: {
+    date: 'Date',
+    comment: 'Comment',
+    rating: 'Rating',
+  },
+  issueCsvGenerator: {
+    date: 'Date',
+    issue: 'Issue',
+    email: 'Email',
+  },
+}

--- a/frontend/src/i18n/locales/features/admin-form/feedback/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/feedback/en-sg.ts
@@ -32,15 +32,15 @@ export const enSG: Feedback = {
         '{issueCount, plural, =1 {issue to date} other {issues to date}}',
       tooltip: 'Feedback displayed here relates to form submission issues',
     },
-  },
-  feedbackCsvGenerator: {
-    date: 'Date',
-    comment: 'Comment',
-    rating: 'Rating',
-  },
-  issueCsvGenerator: {
-    date: 'Date',
-    issue: 'Issue',
-    email: 'Email',
+    feedbackCsvGenerator: {
+      date: 'Date',
+      comment: 'Comment',
+      rating: 'Rating',
+    },
+    issueCsvGenerator: {
+      date: 'Date',
+      issue: 'Issue',
+      email: 'Email',
+    },
   },
 }

--- a/frontend/src/i18n/locales/features/admin-form/feedback/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/feedback/index.ts
@@ -1,0 +1,44 @@
+export * from './en-sg'
+
+export interface Feedback {
+  emptyFeedback: {
+    noFeedbackYet: string
+    tryUsing: string
+    toSendOutForms: string
+  }
+  issueTable: {
+    dateHeader: string
+    issueHeader: string
+    contactHeader: string
+  }
+  reviewTable: {
+    dateHeader: string
+    feedbackHeader: string
+    ratingHeader: string
+  }
+  downloadButton: {
+    export: string
+  }
+  feedbackPage: {
+    issues: string
+    reviews: string
+    reviewInformation: {
+      averageScore: string
+      reviewsToDate: string
+    }
+    issueInformation: {
+      issuesToDate: string
+      tooltip: string
+    }
+  }
+  feedbackCsvGenerator: {
+    date: string
+    comment: string
+    rating: string
+  }
+  issueCsvGenerator: {
+    date: string
+    issue: string
+    email: string
+  }
+}

--- a/frontend/src/i18n/locales/features/admin-form/feedback/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/feedback/index.ts
@@ -30,15 +30,15 @@ export interface Feedback {
       issuesToDate: string
       tooltip: string
     }
-  }
-  feedbackCsvGenerator: {
-    date: string
-    comment: string
-    rating: string
-  }
-  issueCsvGenerator: {
-    date: string
-    issue: string
-    email: string
+    feedbackCsvGenerator: {
+      date: string
+      comment: string
+      rating: string
+    }
+    issueCsvGenerator: {
+      date: string
+      issue: string
+      email: string
+    }
   }
 }

--- a/frontend/src/i18n/locales/features/admin-form/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/index.ts
@@ -1,4 +1,5 @@
 export * from './en-sg'
+export { type Feedback } from './feedback'
 export { type Meta } from './meta'
 export { type Modals } from './modals'
 export { type Navbar } from './navbar'

--- a/frontend/src/i18n/locales/features/index.ts
+++ b/frontend/src/i18n/locales/features/index.ts
@@ -1,4 +1,5 @@
 export {
+  type Feedback,
   type Fields,
   type HeaderAndInstructions,
   type Logic,

--- a/frontend/src/i18n/locales/types.ts
+++ b/frontend/src/i18n/locales/types.ts
@@ -1,8 +1,10 @@
 import { RequiredDeep } from 'type-fest'
 
+import { Pagination } from './components'
 import {
   App,
   Common,
+  Feedback,
   Fields,
   HeaderAndInstructions,
   LandingPage,
@@ -36,6 +38,7 @@ interface Translation {
         modals?: Modals
         toasts?: Toasts
         settings?: Settings
+        feedback?: Feedback
       }
       app?: App
       common?: Common
@@ -47,6 +50,9 @@ interface Translation {
     utils: {
       formValidation?: FormValidation
     }
+    components: {
+      pagination?: Pagination
+    }
   }
 }
 
@@ -54,6 +60,7 @@ export interface FallbackTranslation extends Translation {
   translation: {
     features: RequiredDeep<Translation['translation']['features']>
     utils: RequiredDeep<Translation['translation']['utils']>
+    components: RequiredDeep<Translation['translation']['components']>
   }
 }
 


### PR DESCRIPTION
## Problem

Closes #8161 

## Solution
- Extracted text from feedback form and related components. `useTranslation` is used in react components.
- The constants for the issues and reviews in `frontend/src/features/admin-form/responses/FeedbackPage/issue/IssueTable.tsx` and  `frontend/src/features/admin-form/responses/FeedbackPage/review/ReviewTable.tsx` are converted into hooks similar to the work done in https://github.com/opengovsg/FormSG/pull/8310#issue-2994292842.
- Created locale files for human-readable text
- The headers of the CSV generated files have also been extracted [1]

[1] Considerations
- the CSV generator class is not a react component, so I used i18next instead (same locales and configuration as what we've already been doing as react-i18next is just a wrapper of i18next)
- As mentioned by @littlemight in https://github.com/opengovsg/FormSG/pull/8311#issue-2995753872, it might cause some issues down the line when a language switcher is implemented. Would like some input on whether this implementation is valid, or if there are any other alternatives available (edit: perhaps checking for language and parsing it into the class when called?).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

## Tests

### Regression
- [ ] Create form
- [ ] Leave review(s) and issue(s) for the form
- [ ] Ensure that ICU is properly implemented for plurals
- [ ] Ensure all text fields are in human-readable format for:
  - [ ] ARIA labels
  - [ ] Exported CSV file headers
  - [ ] All texts throughout the feedback page