### PR TITLE
feat: uat iac migration

### DIFF
--- a/.github/workflows/deploy-ecs-uat.yml
+++ b/.github/workflows/deploy-ecs-uat.yml
@@ -24,6 +24,7 @@ jobs:
       react-app-form-sg-sdk-mode: 'staging'
       # AWS configuration
       aws-region: 'ap-southeast-1'
+      ecr-repository: 'formsg'
       # ECS configuration
       ecs-cpu: 1024
       ecs-memory: 2048
@@ -36,14 +37,14 @@ jobs:
       codedeploy-application: 'formsg-uat-ecs-app'
       codedeploy-appspec-path: deploy/appspec.yml
       codedeploy-deployment-group: 'formsg-uat-ecs-dg'
+      # Datadog config 
+      dd-env: 'uat'
     secrets:
       # AWS credentials and configuration
       aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
       cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}
-      ecr-repository: ${{ secrets.ECR_REPO }}
       # Monitoring and analytics configuration
       ga-tracking-id: ${{ secrets.GA_TRACKING_ID }}
-      dd-env: ${{ secrets.DD_ENV }}
       dd-rum-client-token: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
       dd-rum-app-id: ${{ secrets.DD_RUM_APP_ID }}
       dd-sample-rate: ${{ secrets.DD_SAMPLE_RATE }}

--- a/.github/workflows/deploy-ecs-uat.yml
+++ b/.github/workflows/deploy-ecs-uat.yml
@@ -24,26 +24,32 @@ jobs:
     needs: extract-account-id
     uses: ./.github/workflows/deploy-ecs.yml
     with:
+      # Environment configuration
       environment: 'uat'
       environment-site-name: 'uat'
       shortEnv: 'uat'
+      app-version: ${{ github.sha }}
+      app-url: 'https://uat.form.gov.sg'
+      react-app-form-sg-sdk-mode: 'staging'
+      # AWS configuration
+      aws-region: 'ap-southeast-1'
+      # ECS configuration
       ecs-cpu: 1024
       ecs-memory: 2048
-      codedeploy-application: 'formsg-uat-ecs-app'
-      codedeploy-appspec-path: deploy/appspec.yml
-      codedeploy-deployment-group: 'formsg-uat-ecs-dg'
       ecs-cluster-name: 'formsg-uat-ecs'
       ecs-service-name: 'formsg-uat-ecs-service'
       ecs-task-definition: 'formsg-uat-ecs'
       ecs-task-definition-path: 'deploy/ecs-task-definition.json'
       ecs-container-name: 'formsg-app'
-      app-version: ${{ github.sha }}
+      # CodeDeploy configuration
+      codedeploy-application: 'formsg-uat-ecs-app'
+      codedeploy-appspec-path: deploy/appspec.yml
+      codedeploy-deployment-group: 'formsg-uat-ecs-dg'
     secrets:
       # AWS credentials and configuration
       aws-account-id: ${{ secrets.UAT_AWS_ACCOUNT_ID }}
       cicd-role: ${{ secrets.UAT_AWS_CI_ROLE_TO_ASSUME }}
       ecr-repository: ${{ secrets.UAT_ECR_REPOSITORY }}
-
       # Monitoring and analytics configuration
       ga-tracking-id: ${{ secrets.GA_TRACKING_ID }}
       dd-env: ${{ secrets.DD_ENV }}

--- a/.github/workflows/deploy-ecs-uat.yml
+++ b/.github/workflows/deploy-ecs-uat.yml
@@ -10,19 +10,10 @@ on:
       - uat
 
 jobs:
-  extract-account-id:
-    runs-on: ubuntu-latest
-    outputs:
-      aws_account_id: ${{ steps.set-account-id.outputs.aws_account_id }}
-    steps:
-      - id: set-account-id
-        run: |
-          ACCOUNT_ID=$(echo "${{ secrets.AWS_CI_ROLE_TO_ASSUME }}" | cut -d':' -f5)
-          echo "aws_account_id=$ACCOUNT_ID" >> $GITHUB_OUTPUT
   deploy:
     name: Deploy
-    needs: extract-account-id
     uses: ./.github/workflows/deploy-ecs.yml
+    environment: 'uat'
     with:
       # Environment configuration
       environment: 'uat'
@@ -47,9 +38,9 @@ jobs:
       codedeploy-deployment-group: 'formsg-uat-ecs-dg'
     secrets:
       # AWS credentials and configuration
-      aws-account-id: ${{ secrets.UAT_AWS_ACCOUNT_ID }}
-      cicd-role: ${{ secrets.UAT_AWS_CI_ROLE_TO_ASSUME }}
-      ecr-repository: ${{ secrets.UAT_ECR_REPOSITORY }}
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+      cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}
+      ecr-repository: ${{ secrets.ECR_REPO }}
       # Monitoring and analytics configuration
       ga-tracking-id: ${{ secrets.GA_TRACKING_ID }}
       dd-env: ${{ secrets.DD_ENV }}

--- a/.github/workflows/deploy-ecs-uat.yml
+++ b/.github/workflows/deploy-ecs-uat.yml
@@ -1,7 +1,7 @@
 name: Deploy FormSG app to uat
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -18,7 +18,6 @@ jobs:
       # Environment configuration
       environment: 'uat'
       environment-site-name: 'uat'
-      shortEnv: 'uat'
       app-version: ${{ github.sha }}
       app-url: 'https://uat.form.gov.sg'
       react-app-form-sg-sdk-mode: 'staging'
@@ -37,7 +36,7 @@ jobs:
       codedeploy-application: 'formsg-uat-ecs-app'
       codedeploy-appspec-path: deploy/appspec.yml
       codedeploy-deployment-group: 'formsg-uat-ecs-dg'
-      # Datadog config 
+      # Datadog config
       dd-env: 'uat'
     secrets:
       # AWS credentials and configuration
@@ -45,7 +44,7 @@ jobs:
       cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}
       # Monitoring and analytics configuration
       ga-tracking-id: ${{ secrets.GA_TRACKING_ID }}
-      dd-rum-client-token: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
       dd-rum-app-id: ${{ secrets.DD_RUM_APP_ID }}
+      dd-rum-client-token: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
       dd-sample-rate: ${{ secrets.DD_SAMPLE_RATE }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/deploy-ecs-uat.yml
+++ b/.github/workflows/deploy-ecs-uat.yml
@@ -13,8 +13,8 @@ jobs:
   deploy:
     name: Deploy
     uses: ./.github/workflows/deploy-ecs.yml
-    environment: 'uat'
     with:
+      gha-environment: 'uat'
       # Environment configuration
       environment: 'uat'
       environment-site-name: 'uat'

--- a/.github/workflows/deploy-ecs-uat.yml
+++ b/.github/workflows/deploy-ecs-uat.yml
@@ -1,0 +1,53 @@
+name: Deploy FormSG app to uat
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - uat
+
+jobs:
+  extract-account-id:
+    runs-on: ubuntu-latest
+    outputs:
+      aws_account_id: ${{ steps.set-account-id.outputs.aws_account_id }}
+    steps:
+      - id: set-account-id
+        run: |
+          ACCOUNT_ID=$(echo "${{ secrets.AWS_CI_ROLE_TO_ASSUME }}" | cut -d':' -f5)
+          echo "aws_account_id=$ACCOUNT_ID" >> $GITHUB_OUTPUT
+  deploy:
+    name: Deploy
+    needs: extract-account-id
+    uses: ./.github/workflows/deploy-ecs.yml
+    with:
+      environment: 'uat'
+      environment-site-name: 'uat'
+      shortEnv: 'uat'
+      ecs-cpu: 1024
+      ecs-memory: 2048
+      codedeploy-application: 'formsg-uat-ecs-app'
+      codedeploy-appspec-path: deploy/appspec.yml
+      codedeploy-deployment-group: 'formsg-uat-ecs-dg'
+      ecs-cluster-name: 'formsg-uat-ecs'
+      ecs-service-name: 'formsg-uat-ecs-service'
+      ecs-task-definition: 'formsg-uat-ecs'
+      ecs-task-definition-path: 'deploy/ecs-task-definition.json'
+      ecs-container-name: 'formsg-app'
+      app-version: ${{ github.sha }}
+    secrets:
+      # AWS credentials and configuration
+      aws-account-id: ${{ secrets.UAT_AWS_ACCOUNT_ID }}
+      cicd-role: ${{ secrets.UAT_AWS_CI_ROLE_TO_ASSUME }}
+      ecr-repository: ${{ secrets.UAT_ECR_REPOSITORY }}
+
+      # Monitoring and analytics configuration
+      ga-tracking-id: ${{ secrets.GA_TRACKING_ID }}
+      dd-env: ${{ secrets.DD_ENV }}
+      dd-rum-client-token: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
+      dd-rum-app-id: ${{ secrets.DD_RUM_APP_ID }}
+      dd-sample-rate: ${{ secrets.DD_SAMPLE_RATE }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}

--- a/.github/workflows/deploy-virus-scanner-guardduty-uat.yml
+++ b/.github/workflows/deploy-virus-scanner-guardduty-uat.yml
@@ -19,7 +19,8 @@ jobs:
     uses: ./.github/workflows/aws-deploy-scanner-guardduty-iac.yml
     with:
       checkoutBranch: uat
+      gha-environment: uat
       environment: uat
       provisionedConcurrency: 1
     secrets:
-      cicd-role: ${{ secrets.UAT_AWS_CI_ROLE_TO_ASSUME }}
+      cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}

--- a/.github/workflows/deploy-virus-scanner-guardduty-uat.yml
+++ b/.github/workflows/deploy-virus-scanner-guardduty-uat.yml
@@ -1,0 +1,25 @@
+name: Deploy Virus Scanner GuardDuty to new OGP AWS production account
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - uat 
+
+jobs:
+  deploy-scanner-guardduty:
+    name: Deploy Scanner Guardduty
+    uses: ./.github/workflows/aws-deploy-scanner-guardduty-iac.yml
+    with:
+      checkoutBranch: uat
+      environment: uat
+      provisionedConcurrency: 1
+    secrets:
+      cicd-role: ${{ secrets.UAT_AWS_CI_ROLE_TO_ASSUME }}

--- a/.github/workflows/deploy-virus-scanner-legacy-uat.yml
+++ b/.github/workflows/deploy-virus-scanner-legacy-uat.yml
@@ -23,7 +23,8 @@ jobs:
     uses: ./.github/workflows/aws-deploy-scanner-legacy.yml
     with:
       checkoutBranch: uat
+      gha-environment: uat
       environment: uat
       provisionedConcurrency: 1
     secrets:
-      cicd-role: ${{ secrets.UAT_AWS_CI_ROLE_TO_ASSUME }}
+      cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}

--- a/.github/workflows/deploy-virus-scanner-legacy-uat.yml
+++ b/.github/workflows/deploy-virus-scanner-legacy-uat.yml
@@ -1,0 +1,29 @@
+name: Deploy Legacy Virus Scanner to new OGP AWS production account
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - uat
+  # For legacy virus scanner: schedule builds for 12:00AM GMT+8 everyday to get latest ClamAV virus definitions
+  schedule:
+    - cron: '0 16 * * *'
+
+
+jobs:
+  deploy-scanner:
+    name: Deploy Scanner
+    uses: ./.github/workflows/aws-deploy-scanner-legacy.yml
+    with:
+      checkoutBranch: uat
+      environment: uat
+      provisionedConcurrency: 1
+    secrets:
+      cicd-role: ${{ secrets.UAT_AWS_CI_ROLE_TO_ASSUME }}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Migrate our UAT environment to support dual-boot IaC and pre-IaC environments as rehearsal for production IaC migration.  

Closes [insert issue #]

## Solution
<!-- How did you solve the problem? -->
Setup the necessary infra resources via IaC + GH actions scripts to deploy to the new infra resources.  

This PR only contains scripts to deploy UAT to new IaC provisioned resources. 
- formsg app and dd agent to ECS
- set up isolated virus scanner lambdas for uat (instead of using a shared lambda previously) 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  