### PR TITLE
fix: remove use of explicit any and fix failing UI test

### DIFF
--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -139,6 +139,7 @@ Empty.parameters = {
         return res(ctx.json([]))
       },
     ),
+    ...BASE_MSW_HANDLERS,
   ],
 }
 

--- a/frontend/src/templates/Field/Radio/RadioField.stories.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.stories.tsx
@@ -61,7 +61,9 @@ const Template: StoryFn<StoryRadioFieldProps> = ({ defaultValue, ...args }) => {
 
   const [submitValues, setSubmitValues] = useState<string>()
 
-  const onSubmit = (values: Record<string, any>) => {
+  const onSubmit = (
+    values: Record<string, { value: string; othersInput?: string }>,
+  ) => {
     setSubmitValues(
       JSON.stringify(values[args.schema._id]) || 'Nothing was selected',
     )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
In the latest push for `fix/mrf-prefill`, the CI linter did not run before merging into dev branch. As a result, code that failed the CI lint check was merged in. 

Also, a UI test on chromatic is failing due to infinite network call loop and recently detected by Chromatic. This has likely been happening for a while. 
See: 
<img width="1017" alt="image" src="https://github.com/user-attachments/assets/38d35603-5362-4749-b869-1f541c83bf12" />

## Solution
<!-- How did you solve the problem? -->
Fix the failing lint line, which involves explciit use of `any`. 

Fix by adding the missing base msw handlers, which was missing (likely due to accidental removal or it had been failing from the start). 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  