### PR TITLE
chore: remove user beta flag checking for mfbVision for GA release

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
@@ -25,7 +25,6 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Skeleton,
   Tab,
   TabList,
   TabPanel,
@@ -41,8 +40,6 @@ import { featureFlags, MFB_VISION_MAX_IMAGES_COUNT } from '~shared/constants'
 import Badge from '~components/Badge'
 import { NextAndBackButtonGroup } from '~components/Button'
 import Attachment from '~components/Field/Attachment'
-
-import { useUser } from '~features/user/queries'
 
 import { pdfBinaryToImageDataUrls } from '../utils'
 
@@ -247,9 +244,6 @@ const MagicFormBuilderCreateFormPrompt = ({
     isVisionPromptSubmitLoading ? PROMPT_TYPE.VISION : PROMPT_TYPE.TEXT,
   )
 
-  const { user, isLoading: isUserLoading } = useUser()
-  const isComponentLoading = isUserLoading
-
   const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
 
   const isMfbTextEnabled = useFeatureIsOn(featureFlags.mfb)
@@ -269,12 +263,8 @@ const MagicFormBuilderCreateFormPrompt = ({
         </Badge>
       </ModalHeader>
       <ModalBody>
-        <Skeleton isLoaded={!isComponentLoading}>
-          {isTest ||
-          (isMfbTextEnabled &&
-            isMfbVisionEnabled &&
-            !isUserLoading &&
-            user?.betaFlags?.mfbVision) ? (
+        <>
+          {isTest || (isMfbTextEnabled && isMfbVisionEnabled) ? (
             <Tabs isFitted index={selectedTab} onChange={setSelectedTab}>
               <TabList px="2px" mb="1rem">
                 <Tab
@@ -315,7 +305,7 @@ const MagicFormBuilderCreateFormPrompt = ({
               setValue={setValue}
               errors={errors}
             />
-          ) : isMfbVisionEnabled && user?.betaFlags?.mfbVision ? (
+          ) : isMfbVisionEnabled ? (
             <VisionPromptModalBodyContent
               control={visionControl}
               errors={visionErrors}
@@ -324,7 +314,7 @@ const MagicFormBuilderCreateFormPrompt = ({
               isVisionPromptSubmitLoading={isVisionPromptSubmitLoading}
             />
           ) : null}
-        </Skeleton>
+        </>
       </ModalBody>
       <ModalFooter justifyContent="flex-end">
         <NextAndBackButtonGroup
@@ -357,7 +347,6 @@ const MagicFormBuilderCreateFormPrompt = ({
                   }
                 })
           }
-          isNextDisabled={isComponentLoading}
           isNextLoading={
             isTextPromptSubmitLoading || isVisionPromptSubmitLoading
           }

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -25,7 +25,7 @@ export const UserBase = z.object({
       mrfAdminSubmissionKey: z.boolean().optional(),
       mrfConditionalRouting: z.boolean().optional(),
       mfb: z.boolean().optional(), // Previously used for MFB private beta, not currently used
-      mfbVision: z.boolean().optional(),
+      mfbVision: z.boolean().optional(), // Previously used for MFB Vision private beta, not currently used
       multiLangTranslation: z.boolean().optional(),
     })
     .optional(),

--- a/src/app/models/user.server.model.ts
+++ b/src/app/models/user.server.model.ts
@@ -79,7 +79,7 @@ const compileUserModel = (db: Mongoose) => {
         mrfAdminSubmissionKey: Boolean,
         mrfConditionalRouting: Boolean,
         mfb: Boolean, // Previously used for MFB private beta, not currently used
-        mfbVision: Boolean,
+        mfbVision: Boolean, // Previously used for MFB Vision private beta, not currently used
         multiLangTranslation: Boolean,
       },
       flags: {

--- a/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
@@ -17,7 +17,7 @@ import {
   createFormFieldsUsingVisionPrompt,
 } from './admin-form.assistance.service'
 import { PermissionLevel } from './admin-form.types'
-import { mapRouteError, verifyUserBetaflag } from './admin-form.utils'
+import { mapRouteError } from './admin-form.utils'
 
 const logger = createLoggerWithLabel(module)
 
@@ -150,9 +150,6 @@ const _handleVisionPrompt: ControllerHandler<
   // Step 1: Retrieve currently logged in user.
   return (
     UserService.getPopulatedUserById(sessionUserId)
-      .andThen((user) => {
-        return verifyUserBetaflag(user, 'mfbVision')
-      })
       .andThen((user) =>
         // Step 2: Retrieve form with write permission check.
         AuthService.getFormAfterPermissionChecks({


### PR DESCRIPTION
## Problem
Grant public GA access for all admins for MFB vision.  

## Solution
<!-- How did you solve the problem? -->

Remove user beta flags for mfbVision. Note that the growthbook feature flag is still in-place. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: Can access MFB pdf even without user beta flag for mfbVision 
- [ ] Log in using an account without a beta flag. 
- [ ] Try to access MFB vision. 
- [ ] Assert it is accessible.  

TC2: GB flagging still works 
- [ ] Turn off the GB flag. 
- [ ] Assert that MFB vision is no longer accessible. 