### PR TITLE
fix: disallow clause to disallow all

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -6,10 +6,12 @@ Allow: /public/
 Disallow: *
 
 User-agent: Googlebot
+Disallow: /*/edit/
 Allow: /
 
 User-agent: Bingbot
+Disallow: /*/edit/
 Allow: /
 
 User-agent: *
-Disallow:
+Disallow: /


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

MRF might be crawled. We don't want that to happen.

## Solution
<!-- How did you solve the problem? -->

Added disallow rule to prevent crawling of `/*/edit/`.
Added disallow rule for crawlers except for `googlebot` and `bingbot`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
