### PR TITLE
fix: restore original behaviour for robots.txt

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -5,13 +5,5 @@ Allow: /
 Allow: /public/
 Disallow: *
 
-User-agent: Googlebot
-Disallow: /*/edit/
-Allow: /
-
-User-agent: Bingbot
-Disallow: /*/edit/
-Allow: /
-
 User-agent: *
-Disallow: /
+Disallow:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Usage of `robots.txt` can be counter intuitive. `robots.txt` should be read as an accessibility instructions for the crawlers rather than index-ability instruction.

1. There's no need to prevent crawlers from accessing our pages, we allow them to do so.
2. We want them to be able to access the page to read the `X-Robots-Tag` header config for the specific path rather than dropping the read.

## Solution
<!-- How did you solve the problem? -->

Reverting changes on #8334 and #8336.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible