### PR TITLE
feat(i18n): field validation rules

### DIFF
--- a/frontend/src/constants/validation.ts
+++ b/frontend/src/constants/validation.ts
@@ -1,18 +1,3 @@
 export const REQUIRED_ERROR = 'This field is required'
 
 export const INVALID_EMAIL_ERROR = 'Please enter a valid email'
-
-export const INVALID_DROPDOWN_OPTION_ERROR =
-  'Entered value is not a valid dropdown option'
-
-export const INVALID_COUNTRY_REGION_OPTION_ERROR =
-  'Please select a valid country/region from the dropdown list'
-
-// local address field errors
-export const INVALID_POSTAL_CODE_ERROR = 'Please enter a valid postal code'
-export const VALID_POSTAL_CODE_NO_ADDRESS_ERROR =
-  'Address cannot be found. Please fill in details manually'
-export const INVALID_BLOCK_UNIT_ERROR = 'Please use numbers and letters only'
-export const INVALID_NON_NUMERICAL_ERROR = 'Please use numbers only'
-export const INVALID_LEVEL_UNIT_ERROR =
-  'Please include both level and unit number'

--- a/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
+++ b/frontend/src/features/verifiable-fields/Mobile/VerifiableMobileField.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Box, VisuallyHidden } from '@chakra-ui/react'
 
 import { baseMobileValidationFn } from '~utils/fieldValidation'
@@ -69,7 +70,14 @@ export const VerifiableMobileField = ({
   schema,
   ...props
 }: VerifiableMobileFieldProps) => {
-  const validateInputForVfn = baseMobileValidationFn(schema)
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'utils.fieldValidation',
+  })
+  const validateInputForVfn = useMemo(
+    () => baseMobileValidationFn(schema, t),
+    [schema, t],
+  )
+
   return (
     <VerifiableFieldProvider
       schema={schema}

--- a/frontend/src/i18n/locales/constants/validation/en-sg.ts
+++ b/frontend/src/i18n/locales/constants/validation/en-sg.ts
@@ -1,14 +1,3 @@
 export const enSG = {
-  requiredError: 'This field is required',
-  invalidEmailError: 'Please enter a valid email',
-  invalidDropdownOptionError: 'Entered value is not a valid dropdown option',
   cannotTransferOwnershipToSelf: 'You cannot transfer ownership to yourself',
-  invalidCountryRegionOptionError:
-    'Please select a valid country/region from the dropdown list',
-  invalidPostalCodeError: 'Please enter a valid postal code',
-  validPostalCodeNoAddressError:
-    'Address cannot be found. Please fill in details manually',
-  invalidBlockUnitError: 'Please use numbers and letters only',
-  invalidNonNumericalError: 'Please use numbers only',
-  invalidLevelUnitError: 'Please include both level and unit number',
 }

--- a/frontend/src/i18n/locales/constants/validation/index.ts
+++ b/frontend/src/i18n/locales/constants/validation/index.ts
@@ -1,14 +1,5 @@
 export interface ValidationConstants {
-  requiredError: string
-  invalidEmailError: string
-  invalidDropdownOptionError: string
   cannotTransferOwnershipToSelf: string
-  invalidCountryRegionOptionError: string
-  invalidPostalCodeError: string
-  validPostalCodeNoAddressError: string
-  invalidBlockUnitError: string
-  invalidNonNumericalError: string
-  invalidLevelUnitError: string
 }
 
 export * from './en-sg'

--- a/frontend/src/i18n/locales/en-sg.ts
+++ b/frontend/src/i18n/locales/en-sg.ts
@@ -11,7 +11,10 @@ import { enSG as whatsNew } from './features/whats-new'
 import { enSG as workspace } from './features/workspace'
 import { enSG as fieldValidation } from './utils/field-validation'
 import { enSG as formValidation } from './utils/form-validation'
+<<<<<<< HEAD
 import { enSG as workspaceValidation } from './utils/workspace-validation'
+=======
+>>>>>>> 44b5baa0f (chore: lint)
 import { FallbackTranslation } from './types'
 
 export const enSG: FallbackTranslation = {

--- a/frontend/src/i18n/locales/en-sg.ts
+++ b/frontend/src/i18n/locales/en-sg.ts
@@ -11,10 +11,7 @@ import { enSG as whatsNew } from './features/whats-new'
 import { enSG as workspace } from './features/workspace'
 import { enSG as fieldValidation } from './utils/field-validation'
 import { enSG as formValidation } from './utils/form-validation'
-<<<<<<< HEAD
 import { enSG as workspaceValidation } from './utils/workspace-validation'
-=======
->>>>>>> 44b5baa0f (chore: lint)
 import { FallbackTranslation } from './types'
 
 export const enSG: FallbackTranslation = {

--- a/frontend/src/i18n/locales/en-sg.ts
+++ b/frontend/src/i18n/locales/en-sg.ts
@@ -9,6 +9,7 @@ import { enSG as publicForm } from './features/public-form'
 import { enSG as user } from './features/user'
 import { enSG as whatsNew } from './features/whats-new'
 import { enSG as workspace } from './features/workspace'
+import { enSG as fieldValidation } from './utils/field-validation'
 import { enSG as formValidation } from './utils/form-validation'
 import { enSG as workspaceValidation } from './utils/workspace-validation'
 import { FallbackTranslation } from './types'
@@ -29,6 +30,7 @@ export const enSG: FallbackTranslation = {
     utils: {
       formValidation,
       workspaceValidation,
+      fieldValidation,
     },
     components: {
       pagination,

--- a/frontend/src/i18n/locales/types.ts
+++ b/frontend/src/i18n/locales/types.ts
@@ -27,7 +27,7 @@ import {
   Workflow,
   Workspace,
 } from './features'
-import { FormValidation, WorkspaceValidation } from './utils'
+import { FieldValidation, FormValidation, WorkspaceValidation } from './utils'
 
 interface Translation {
   translation: {
@@ -65,6 +65,7 @@ interface Translation {
       }
     }
     utils: {
+      fieldValidation?: FieldValidation
       formValidation?: FormValidation
       workspaceValidation?: WorkspaceValidation
     }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -104,6 +104,21 @@ const dropdownFieldValidation: DropdownFieldValidation = {
     'Please select a valid country/region from the dropdown list',
 }
 
+interface TextFieldValidation {
+  exactCharacters: string
+  minCharacters: string
+  maxCharacters: string
+}
+
+const textFieldValidation: TextFieldValidation = {
+  exactCharacters:
+    'Please enter {threshold} {threshold, plural, =1 {character} other {characters}} ({current}/{threshold})',
+  minCharacters:
+    'Please enter at least {threshold} {threshold, plural, =1 {character} other {characters}} ({current}/{threshold})',
+  maxCharacters:
+    'Please enter at most {threshold} {threshold, plural, =1 {character} other {characters}} ({current}/{threshold})',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
@@ -111,7 +126,8 @@ export type FieldValidation = BaseValidation &
   DateFieldValidation &
   NricFieldValidation &
   CheckboxFieldValidation &
-  DropdownFieldValidation
+  DropdownFieldValidation &
+  TextFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
@@ -123,4 +139,5 @@ export const enSG: FieldValidation = {
   ...checkboxFieldValidation,
   ...checkboxFieldValidation,
   ...dropdownFieldValidation,
+  ...textFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -93,13 +93,25 @@ const checkboxFieldValidation: CheckboxFieldValidation = {
     'Please select at most {threshold} {threshold, plural, =1 {option} other {options}} ({current}/{threshold})',
 }
 
+interface DropdownFieldValidation {
+  invalidDropdownOption: string
+  invalidCountryRegion: string
+}
+
+const dropdownFieldValidation: DropdownFieldValidation = {
+  invalidDropdownOption: 'Entered value is not a valid dropdown option',
+  invalidCountryRegion:
+    'Please select a valid country/region from the dropdown list',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
   UenFieldValidation &
   DateFieldValidation &
   NricFieldValidation &
-  CheckboxFieldValidation
+  CheckboxFieldValidation &
+  DropdownFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
@@ -109,4 +121,6 @@ export const enSG: FieldValidation = {
   ...dateFieldValidation,
   ...nricFieldValidation,
   ...checkboxFieldValidation,
+  ...checkboxFieldValidation,
+  ...dropdownFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -70,11 +70,20 @@ const dateFieldValidation: DateFieldValidation = {
   invalidDay: 'This date is not allowed by the form admin',
 }
 
+interface NricFieldValidation {
+  validNric: string
+}
+
+const nricFieldValidation: NricFieldValidation = {
+  validNric: 'Please enter a valid NRIC/FIN',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
   UenFieldValidation &
-  DateFieldValidation
+  DateFieldValidation &
+  NricFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
@@ -82,4 +91,5 @@ export const enSG: FieldValidation = {
   ...decimalFieldValidation,
   ...uenFieldValidation,
   ...dateFieldValidation,
+  ...nricFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -1,7 +1,12 @@
-export interface FieldValidation {
+interface BaseValidation {
   required: string
+}
 
-  // number field
+const baseValidation: BaseValidation = {
+  required: 'This field is required',
+}
+
+interface NumberFieldValidation {
   exactDigits: string
   minDigits: string
   maxDigits: string
@@ -9,20 +14,9 @@ export interface FieldValidation {
   numbersRange: string
   numberMinimum: string
   numberMaximum: string
-
-  // decimal field
-  validDecimal: string
-  validDecimalNoLeadingZeros: string
-  decimalRange: string
-  decimalMinimum: string
-  decimalMaximum: string
-
-  // UEN field
-  validUen: string
 }
 
-export const enSG: FieldValidation = {
-  required: 'This field is required',
+const numberFieldValidation: NumberFieldValidation = {
   exactDigits:
     'Please enter {threshold} {threshold, plural, =1 {digit} other {digits}} ({current}/{threshold})',
   minDigits:
@@ -33,13 +27,41 @@ export const enSG: FieldValidation = {
   numbersRange: 'Please enter a number between {min} and {max}',
   numberMinimum: 'Please enter a number that is at least {min}',
   numberMaximum: 'Please enter a number that is at most {max}',
+}
 
+interface DecimalFieldValidation {
+  validDecimal: string
+  validDecimalNoLeadingZeros: string
+  decimalRange: string
+  decimalMinimum: string
+  decimalMaximum: string
+}
+
+const decimalFieldValidation: DecimalFieldValidation = {
   validDecimal: 'Please enter a valid decimal',
   validDecimalNoLeadingZeros:
     'Please enter a valid decimal without leading zeros',
   decimalRange: 'Please enter a decimal between {min} and {max} (inclusive)',
   decimalMinimum: 'Please enter a decimal greater than or equal to {min}',
   decimalMaximum: 'Please enter a decimal less than or equal to {max}',
+}
 
+interface UenFieldValidation {
+  validUen: string
+}
+
+const uenFieldValidation: UenFieldValidation = {
   validUen: 'Please enter a valid UEN',
+}
+
+export type FieldValidation = BaseValidation &
+  NumberFieldValidation &
+  DecimalFieldValidation &
+  UenFieldValidation
+
+export const enSG: FieldValidation = {
+  ...baseValidation,
+  ...numberFieldValidation,
+  ...decimalFieldValidation,
+  ...uenFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -9,6 +9,13 @@ export interface FieldValidation {
   numbersRange: string
   numberMinimum: string
   numberMaximum: string
+
+  // decimal field
+  validDecimal: string
+  validDecimalNoLeadingZeros: string
+  decimalRange: string
+  decimalMinimum: string
+  decimalMaximum: string
 }
 
 export const enSG: FieldValidation = {
@@ -23,4 +30,11 @@ export const enSG: FieldValidation = {
   numbersRange: 'Please enter a number between {min} and {max}',
   numberMinimum: 'Please enter a number that is at least {min}',
   numberMaximum: 'Please enter a number that is at most {max}',
+
+  validDecimal: 'Please enter a valid decimal',
+  validDecimalNoLeadingZeros:
+    'Please enter a valid decimal without leading zeros',
+  decimalRange: 'Please enter a decimal between {min} and {max} (inclusive)',
+  decimalMinimum: 'Please enter a decimal greater than or equal to {min}',
+  decimalMaximum: 'Please enter a decimal less than or equal to {max}',
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -155,6 +155,7 @@ interface AddressFieldValidation {
   invalidPostalCode: string
   invalidBlockUnit: string
   invalidLevelUnit: string
+  validPostalCodeNoAddress: string
 }
 
 const addressFieldValidation: AddressFieldValidation = {
@@ -162,6 +163,8 @@ const addressFieldValidation: AddressFieldValidation = {
   invalidPostalCode: 'Please enter a valid postal code',
   invalidBlockUnit: 'Please use numbers and letters only',
   invalidLevelUnit: 'Please include both level and unit number',
+  validPostalCodeNoAddress:
+    'Address cannot be found. Please fill in details manually',
 }
 
 export type FieldValidation = BaseValidation &

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -142,6 +142,14 @@ const mobileFieldValidation: MobileFieldValidation = {
   pleaseVerifyMobile: 'Please verify your mobile number',
 }
 
+interface HomeNoFieldValidation {
+  validHomeNo: string
+}
+
+const homeNoFieldValidation: HomeNoFieldValidation = {
+  validHomeNo: 'Please enter a valid landline number',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
@@ -152,7 +160,8 @@ export type FieldValidation = BaseValidation &
   DropdownFieldValidation &
   TextFieldValidation &
   EmailFieldValidation &
-  MobileFieldValidation
+  MobileFieldValidation &
+  HomeNoFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
@@ -167,4 +176,5 @@ export const enSG: FieldValidation = {
   ...textFieldValidation,
   ...emailFieldValidation,
   ...mobileFieldValidation,
+  ...homeNoFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -1,0 +1,26 @@
+export interface FieldValidation {
+  required: string
+
+  // number field
+  exactDigits: string
+  minDigits: string
+  maxDigits: string
+  validNumber: string
+  numbersRange: string
+  numberMinimum: string
+  numberMaximum: string
+}
+
+export const enSG: FieldValidation = {
+  required: 'This field is required',
+  exactDigits:
+    'Please enter {threshold} {threshold, plural, =1 {digit} other {digits}} ({current}/{threshold})',
+  minDigits:
+    'Please enter at least {threshold} {threshold, plural, =1 {digit} other {digits}} ({current}/{threshold})',
+  maxDigits:
+    'Please enter at most {threshold} {threshold, plural, =1 {digit} other {digits}} ({current}/{threshold})',
+  validNumber: 'Please enter a valid number',
+  numbersRange: 'Please enter a number between {min} and {max}',
+  numberMinimum: 'Please enter a number that is at least {min}',
+  numberMaximum: 'Please enter a number that is at most {max}',
+}

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -54,14 +54,32 @@ const uenFieldValidation: UenFieldValidation = {
   validUen: 'Please enter a valid UEN',
 }
 
+interface DateFieldValidation {
+  validDate: string
+  noFutureDate: string
+  noPastDate: string
+  dateOutOfRange: string
+  invalidDay: string
+}
+
+const dateFieldValidation: DateFieldValidation = {
+  validDate: 'Please enter a valid date',
+  noFutureDate: 'Only dates today or before are allowed',
+  noPastDate: 'Only dates today or after are allowed',
+  dateOutOfRange: 'Selected date is not within the allowed date range',
+  invalidDay: 'This date is not allowed by the form admin',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
-  UenFieldValidation
+  UenFieldValidation &
+  DateFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
   ...numberFieldValidation,
   ...decimalFieldValidation,
   ...uenFieldValidation,
+  ...dateFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -150,6 +150,20 @@ const homeNoFieldValidation: HomeNoFieldValidation = {
   validHomeNo: 'Please enter a valid landline number',
 }
 
+interface AddressFieldValidation {
+  invalidNonNumerical: string
+  invalidPostalCode: string
+  invalidBlockUnit: string
+  invalidLevelUnit: string
+}
+
+const addressFieldValidation: AddressFieldValidation = {
+  invalidNonNumerical: 'Please use numbers only',
+  invalidPostalCode: 'Please enter a valid postal code',
+  invalidBlockUnit: 'Please use numbers and letters only',
+  invalidLevelUnit: 'Please include both level and unit number',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
@@ -161,7 +175,8 @@ export type FieldValidation = BaseValidation &
   TextFieldValidation &
   EmailFieldValidation &
   MobileFieldValidation &
-  HomeNoFieldValidation
+  HomeNoFieldValidation &
+  AddressFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
@@ -177,4 +192,6 @@ export const enSG: FieldValidation = {
   ...emailFieldValidation,
   ...mobileFieldValidation,
   ...homeNoFieldValidation,
+  ...addressFieldValidation,
+  // NOTE: excluding MyInfo fields for now.
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -132,6 +132,16 @@ const emailFieldValidation: EmailFieldValidation = {
   domainDisallowed: 'Domain disallowed',
 }
 
+interface MobileFieldValidation {
+  validMobile: string
+  pleaseVerifyMobile: string
+}
+
+const mobileFieldValidation: MobileFieldValidation = {
+  validMobile: 'Please enter a valid mobile number',
+  pleaseVerifyMobile: 'Please verify your mobile number',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
@@ -141,7 +151,8 @@ export type FieldValidation = BaseValidation &
   CheckboxFieldValidation &
   DropdownFieldValidation &
   TextFieldValidation &
-  EmailFieldValidation
+  EmailFieldValidation &
+  MobileFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
@@ -155,4 +166,5 @@ export const enSG: FieldValidation = {
   ...dropdownFieldValidation,
   ...textFieldValidation,
   ...emailFieldValidation,
+  ...mobileFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -119,6 +119,19 @@ const textFieldValidation: TextFieldValidation = {
     'Please enter at most {threshold} {threshold, plural, =1 {character} other {characters}} ({current}/{threshold})',
 }
 
+interface EmailFieldValidation {
+  invalidEmail: string
+  pleaseVerifyEmail: string
+  domainDisallowed: string
+}
+
+const emailFieldValidation: EmailFieldValidation = {
+  invalidEmail: 'Please enter a valid email',
+  pleaseVerifyEmail: 'Please verify your email address',
+  // TODO: decide how to combine with src/i18n/locales/features/public-form/fields/en-sg.ts
+  domainDisallowed: 'Domain disallowed',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
@@ -127,7 +140,8 @@ export type FieldValidation = BaseValidation &
   NricFieldValidation &
   CheckboxFieldValidation &
   DropdownFieldValidation &
-  TextFieldValidation
+  TextFieldValidation &
+  EmailFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
@@ -140,4 +154,5 @@ export const enSG: FieldValidation = {
   ...checkboxFieldValidation,
   ...dropdownFieldValidation,
   ...textFieldValidation,
+  ...emailFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -16,6 +16,9 @@ export interface FieldValidation {
   decimalRange: string
   decimalMinimum: string
   decimalMaximum: string
+
+  // UEN field
+  validUen: string
 }
 
 export const enSG: FieldValidation = {
@@ -37,4 +40,6 @@ export const enSG: FieldValidation = {
   decimalRange: 'Please enter a decimal between {min} and {max} (inclusive)',
   decimalMinimum: 'Please enter a decimal greater than or equal to {min}',
   decimalMaximum: 'Please enter a decimal less than or equal to {max}',
+
+  validUen: 'Please enter a valid UEN',
 }

--- a/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/en-sg.ts
@@ -78,12 +78,28 @@ const nricFieldValidation: NricFieldValidation = {
   validNric: 'Please enter a valid NRIC/FIN',
 }
 
+interface CheckboxFieldValidation {
+  exactOptions: string
+  minOptions: string
+  maxOptions: string
+}
+
+const checkboxFieldValidation: CheckboxFieldValidation = {
+  exactOptions:
+    'Please select exactly {threshold} {threshold, plural, =1 {option} other {options}} ({current}/{threshold})',
+  minOptions:
+    'Please select at least {threshold} {threshold, plural, =1 {option} other {options}} ({current}/{threshold})',
+  maxOptions:
+    'Please select at most {threshold} {threshold, plural, =1 {option} other {options}} ({current}/{threshold})',
+}
+
 export type FieldValidation = BaseValidation &
   NumberFieldValidation &
   DecimalFieldValidation &
   UenFieldValidation &
   DateFieldValidation &
-  NricFieldValidation
+  NricFieldValidation &
+  CheckboxFieldValidation
 
 export const enSG: FieldValidation = {
   ...baseValidation,
@@ -92,4 +108,5 @@ export const enSG: FieldValidation = {
   ...uenFieldValidation,
   ...dateFieldValidation,
   ...nricFieldValidation,
+  ...checkboxFieldValidation,
 }

--- a/frontend/src/i18n/locales/utils/field-validation/index.ts
+++ b/frontend/src/i18n/locales/utils/field-validation/index.ts
@@ -1,0 +1,1 @@
+export * from './en-sg'

--- a/frontend/src/i18n/locales/utils/index.ts
+++ b/frontend/src/i18n/locales/utils/index.ts
@@ -1,2 +1,3 @@
+export { type FieldValidation } from './field-validation'
 export { type FormValidation } from './form-validation'
 export { type WorkspaceValidation } from './workspace-validation'

--- a/frontend/src/templates/Field/Address/AddressField.test.tsx
+++ b/frontend/src/templates/Field/Address/AddressField.test.tsx
@@ -84,7 +84,7 @@ describe('validation required', () => {
 
     await user.click(verifyButton)
     const error = screen.getAllByText(
-      fieldValidationTranslation.invalidPostalCode,
+      fieldValidationTranslation.validPostalCodeNoAddress,
     )
     expect(error).toHaveLength(2)
   })

--- a/frontend/src/templates/Field/Address/AddressField.test.tsx
+++ b/frontend/src/templates/Field/Address/AddressField.test.tsx
@@ -3,14 +3,10 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 
+import { enSG as fieldValidationTranslation } from '~/i18n/locales/utils/field-validation/en-sg'
 import { verifyAddress } from '~/services/OneMapService'
 
-import {
-  INVALID_BLOCK_UNIT_ERROR,
-  INVALID_NON_NUMERICAL_ERROR,
-  REQUIRED_ERROR,
-  VALID_POSTAL_CODE_NO_ADDRESS_ERROR,
-} from '~constants/validation'
+import { REQUIRED_ERROR } from '~constants/validation'
 
 import * as stories from './AddressField.stories'
 
@@ -60,7 +56,9 @@ describe('validation required', () => {
     const submitButton = screen.getByText('Submit')
 
     await user.click(submitButton)
-    const error = screen.queryByText(INVALID_NON_NUMERICAL_ERROR)
+    const error = screen.queryByText(
+      fieldValidationTranslation.invalidNonNumerical,
+    )
     expect(error).not.toBeNull()
   })
 
@@ -70,7 +68,9 @@ describe('validation required', () => {
     const submitButton = screen.getByText('Submit')
 
     await user.click(submitButton)
-    const error = screen.queryByText(INVALID_BLOCK_UNIT_ERROR)
+    const error = screen.queryByText(
+      fieldValidationTranslation.invalidBlockUnit,
+    )
     expect(error).not.toBeNull()
   })
 
@@ -83,7 +83,9 @@ describe('validation required', () => {
     const verifyButton = screen.getByRole('button', { name: /Find Address/i })
 
     await user.click(verifyButton)
-    const error = screen.getAllByText(VALID_POSTAL_CODE_NO_ADDRESS_ERROR)
+    const error = screen.getAllByText(
+      fieldValidationTranslation.invalidPostalCode,
+    )
     expect(error).toHaveLength(2)
   })
 })

--- a/frontend/src/templates/Field/Address/AddressField.tsx
+++ b/frontend/src/templates/Field/Address/AddressField.tsx
@@ -112,11 +112,11 @@ export const AddressCompoundField = ({
         if (!result.success) {
           setError(`${schema._id}.addressSubFields.blockNumber`, {
             type: 'manual',
-            message: t('invalidPostalCode'),
+            message: t('validPostalCodeNoAddress'),
           })
           setError(`${schema._id}.addressSubFields.streetName`, {
             type: 'manual',
-            message: t('invalidPostalCode'),
+            message: t('validPostalCodeNoAddress'),
           })
           setValue(`${schema._id}.addressSubFields.blockNumber`, '') // reset values if verification failure
           setValue(`${schema._id}.addressSubFields.streetName`, '')

--- a/frontend/src/templates/Field/Address/AddressField.tsx
+++ b/frontend/src/templates/Field/Address/AddressField.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Controller, useFormContext, useFormState } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Box, Flex, FormControl, Stack } from '@chakra-ui/react'
 
 import { validatePostalCode } from '~shared/utils/address-validation'
 
-import { VALID_POSTAL_CODE_NO_ADDRESS_ERROR } from '~constants/validation'
 import {
   useBlockNumberValidationRules,
   useLevelNumberValidationRules,
@@ -53,6 +53,10 @@ export const AddressCompoundField = ({
     schema,
     disableRequiredValidation,
   )
+
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'utils.fieldValidation',
+  })
 
   const unitNumber = watch(`${schema._id}.addressSubFields.unitNumber`)
   const levelNumber = watch(`${schema._id}.addressSubFields.levelNumber`)
@@ -108,11 +112,11 @@ export const AddressCompoundField = ({
         if (!result.success) {
           setError(`${schema._id}.addressSubFields.blockNumber`, {
             type: 'manual',
-            message: VALID_POSTAL_CODE_NO_ADDRESS_ERROR,
+            message: t('invalidPostalCode'),
           })
           setError(`${schema._id}.addressSubFields.streetName`, {
             type: 'manual',
-            message: VALID_POSTAL_CODE_NO_ADDRESS_ERROR,
+            message: t('invalidPostalCode'),
           })
           setValue(`${schema._id}.addressSubFields.blockNumber`, '') // reset values if verification failure
           setValue(`${schema._id}.addressSubFields.streetName`, '')

--- a/frontend/src/templates/Field/Address/AddressField.tsx
+++ b/frontend/src/templates/Field/Address/AddressField.tsx
@@ -6,11 +6,11 @@ import { validatePostalCode } from '~shared/utils/address-validation'
 
 import { VALID_POSTAL_CODE_NO_ADDRESS_ERROR } from '~constants/validation'
 import {
-  createBlockNumberValidationRules,
-  createLevelNumberValidationRules,
-  createPostalCodeValidationRules,
-  createUnitNumberValidationRules,
+  useBlockNumberValidationRules,
+  useLevelNumberValidationRules,
+  usePostalCodeValidationRules,
   useStreetNameValidationRules,
+  useUnitNumberValidationRules,
 } from '~utils/fieldValidation'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -39,14 +39,14 @@ export const AddressCompoundField = ({
     })
   const addressSubFieldErrors = errors?.[schema._id]?.addressSubFields
 
-  const postalCodeValidationRules = useMemo(
-    () => createPostalCodeValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const postalCodeValidationRules = usePostalCodeValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
-  const blockNumberValidationRules = useMemo(
-    () => createBlockNumberValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const blockNumberValidationRules = useBlockNumberValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const streetNameValidationRules = useStreetNameValidationRules(
@@ -57,13 +57,15 @@ export const AddressCompoundField = ({
   const unitNumber = watch(`${schema._id}.addressSubFields.unitNumber`)
   const levelNumber = watch(`${schema._id}.addressSubFields.levelNumber`)
 
-  const levelNumberValidationRules = useMemo(() => {
-    return createLevelNumberValidationRules(schema, getValues)
-  }, [schema, getValues])
+  const levelNumberValidationRules = useLevelNumberValidationRules(
+    schema,
+    getValues,
+  )
 
-  const unitNumberValidationRules = useMemo(() => {
-    return createUnitNumberValidationRules(schema, getValues)
-  }, [schema, getValues])
+  const unitNumberValidationRules = useUnitNumberValidationRules(
+    schema,
+    getValues,
+  )
 
   useEffect(() => {
     if (unitNumber && levelNumber) {

--- a/frontend/src/templates/Field/Address/AddressField.tsx
+++ b/frontend/src/templates/Field/Address/AddressField.tsx
@@ -9,8 +9,8 @@ import {
   createBlockNumberValidationRules,
   createLevelNumberValidationRules,
   createPostalCodeValidationRules,
-  createStreetNameValidationRules,
   createUnitNumberValidationRules,
+  useStreetNameValidationRules,
 } from '~utils/fieldValidation'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -49,9 +49,9 @@ export const AddressCompoundField = ({
     [schema, disableRequiredValidation],
   )
 
-  const streetNameValidationRules = useMemo(
-    () => createStreetNameValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const streetNameValidationRules = useStreetNameValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const unitNumber = watch(`${schema._id}.addressSubFields.unitNumber`)

--- a/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -10,7 +10,7 @@ import { MB } from '~shared/constants/file'
 import { FormColorTheme } from '~shared/types'
 import { VALID_EXTENSIONS } from '~shared/utils/file-validation'
 
-import { createAttachmentValidationRules } from '~utils/fieldValidation'
+import { useAttachmentValidationRules } from '~utils/fieldValidation'
 import fileArrayBuffer from '~utils/fileArrayBuffer'
 import Attachment from '~components/Field/Attachment'
 
@@ -34,9 +34,9 @@ export const AttachmentField = ({
   isHighContrast,
 }: AttachmentFieldProps): JSX.Element => {
   const fieldName = schema._id
-  const validationRules = useMemo(
-    () => createAttachmentValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useAttachmentValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const { clearErrors, setError, control } =

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -12,7 +12,7 @@ import {
 import { FormColorTheme, Language } from '~shared/types'
 
 import { CHECKBOX_THEME_KEY } from '~theme/components/Checkbox'
-import { createCheckboxValidationRules } from '~utils/fieldValidation'
+import { useCheckboxValidationRules } from '~utils/fieldValidation'
 import { getFieldOptionsInSelectedLanguage } from '~utils/multiLanguage'
 import Checkbox from '~components/Checkbox'
 import { CheckboxProps } from '~components/Checkbox/Checkbox'
@@ -58,9 +58,9 @@ export const CheckboxField = ({
     [schema._id],
   )
 
-  const validationRules = useMemo(
-    () => createCheckboxValidationRules(schema, disableRequiredValidation),
-    [disableRequiredValidation, schema],
+  const validationRules = useCheckboxValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const englishCheckboxOptions = schema.fieldOptions

--- a/frontend/src/templates/Field/CountryRegionField/CountryRegionField.tsx
+++ b/frontend/src/templates/Field/CountryRegionField/CountryRegionField.tsx
@@ -5,7 +5,7 @@ import { CountryRegion } from '~shared/constants/countryRegion'
 import { FormColorTheme } from '~shared/types'
 import { CountryRegionFieldBase, FormFieldWithId } from '~shared/types/field'
 
-import { createCountryRegionValidationRules } from '~utils/fieldValidation'
+import { useCountryRegionValidationRules } from '~utils/fieldValidation'
 import { SingleSelect } from '~components/Dropdown'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
@@ -40,12 +40,10 @@ export const CountryRegionField = ({
     }
   }, [schema])
 
-  const rules = useMemo(() => {
-    return createCountryRegionValidationRules(
-      schemaWithFieldOptions,
-      disableRequiredValidation,
-    )
-  }, [schemaWithFieldOptions, disableRequiredValidation])
+  const rules = useCountryRegionValidationRules(
+    schemaWithFieldOptions,
+    disableRequiredValidation,
+  )
 
   const { control } = useFormContext<SingleAnswerFieldInput>()
 

--- a/frontend/src/templates/Field/Date/DateField.tsx
+++ b/frontend/src/templates/Field/Date/DateField.tsx
@@ -12,7 +12,7 @@ import {
   isDateOutOfRange,
   loadDateFromNormalizedDate,
 } from '~utils/date'
-import { createDateValidationRules } from '~utils/fieldValidation'
+import { useDateValidationRules } from '~utils/fieldValidation'
 import { DatePicker } from '~components/DatePicker'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
@@ -33,9 +33,9 @@ export const DateField = ({
   isHighContrast,
   ...fieldContainerProps
 }: DateFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createDateValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useDateValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const isDateUnavailable = useCallback(

--- a/frontend/src/templates/Field/Decimal/DecimalField.tsx
+++ b/frontend/src/templates/Field/Decimal/DecimalField.tsx
@@ -1,7 +1,6 @@
-import { useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
-import { createDecimalValidationRules } from '~utils/fieldValidation'
+import { useDecimalValidationRules } from '~utils/fieldValidation'
 import NumberInput from '~components/NumberInput'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
@@ -20,9 +19,9 @@ export const DecimalField = ({
   disableRequiredValidation,
   isHighContrast,
 }: DecimalFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createDecimalValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useDecimalValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const { control } = useFormContext<SingleAnswerFieldInput>()

--- a/frontend/src/templates/Field/Dropdown/DropdownField.tsx
+++ b/frontend/src/templates/Field/Dropdown/DropdownField.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { FormColorTheme, Language } from '~shared/types'
 
-import { createDropdownValidationRules } from '~utils/fieldValidation'
+import { useDropdownValidationRules } from '~utils/fieldValidation'
 import { SingleSelect } from '~components/Dropdown/SingleSelect'
 import { ComboboxItem } from '~components/Dropdown/types'
 
@@ -27,9 +27,7 @@ export const DropdownField = ({
   ...fieldContainerProps
 }: DropdownFieldProps): JSX.Element => {
   const { i18n } = useTranslation()
-  const rules = useMemo(() => {
-    return createDropdownValidationRules(schema, disableRequiredValidation)
-  }, [schema, disableRequiredValidation])
+  const rules = useDropdownValidationRules(schema, disableRequiredValidation)
 
   const { control } = useFormContext<SingleAnswerFieldInput>()
 

--- a/frontend/src/templates/Field/Email/EmailFieldInput.tsx
+++ b/frontend/src/templates/Field/Email/EmailFieldInput.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import {
   Controller,
   ControllerRenderProps,
@@ -8,7 +7,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Language } from '~shared/types'
 
-import { createEmailValidationRules } from '~utils/fieldValidation'
+import { useEmailValidationRules } from '~utils/fieldValidation'
 import Input, { InputProps } from '~components/Input'
 
 import { EmailFieldSchema, VerifiableFieldInput } from '../types'
@@ -39,18 +38,16 @@ export const EmailFieldInput = ({
   isHighContrast,
 }: EmailFieldInputProps): JSX.Element => {
   const { t } = useTranslation()
+  // TODO: decide how to combine with field-validations en-sg.ts
   const validationErrorMessages = t(
     'features.publicForm.components.fields.email.validation',
     { allowObjects: true },
   )
-  const validationRules = useMemo(
-    () =>
-      createEmailValidationRules(
-        schema,
-        disableRequiredValidation,
-        validationErrorMessages,
-      ),
-    [schema, disableRequiredValidation, validationErrorMessages],
+
+  const validationRules = useEmailValidationRules(
+    schema,
+    disableRequiredValidation,
+    validationErrorMessages,
   )
 
   const { control } = useFormContext<VerifiableFieldInput>()

--- a/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
+++ b/frontend/src/templates/Field/HomeNo/HomeNoField.tsx
@@ -1,7 +1,6 @@
-import { useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
-import { createHomeNoValidationRules } from '~utils/fieldValidation'
+import { useHomeNoValidationRules } from '~utils/fieldValidation'
 import PhoneNumberInput from '~components/PhoneNumberInput'
 import landlineExamples from '~components/PhoneNumberInput/resources/examples.landline.json'
 
@@ -18,9 +17,9 @@ export const HomeNoField = ({
   disableRequiredValidation,
   isHighContrast,
 }: HomeNoFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createHomeNoValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useHomeNoValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const { control } = useFormContext<SingleAnswerFieldInput>()

--- a/frontend/src/templates/Field/LongText/LongTextField.tsx
+++ b/frontend/src/templates/Field/LongText/LongTextField.tsx
@@ -1,10 +1,9 @@
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-import { useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { createTextValidationRules } from '~utils/fieldValidation'
+import { useTextValidationRules } from '~utils/fieldValidation'
 import Textarea from '~components/Textarea'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
@@ -20,9 +19,9 @@ export const LongTextField = ({
   disableRequiredValidation,
   isHighContrast,
 }: LongTextFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createTextValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useTextValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const { register } = useFormContext<SingleAnswerFieldInput>()

--- a/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
+++ b/frontend/src/templates/Field/Mobile/MobileFieldInput.tsx
@@ -5,7 +5,7 @@ import {
   useFormContext,
 } from 'react-hook-form'
 
-import { createMobileValidationRules } from '~utils/fieldValidation'
+import { useMobileValidationRules } from '~utils/fieldValidation'
 import PhoneNumberInput, {
   PhoneNumberInputProps,
 } from '~components/PhoneNumberInput'
@@ -36,9 +36,9 @@ export const MobileFieldInput = ({
   phoneNumberInputProps = {},
   isHighContrast,
 }: MobileFieldInputProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createMobileValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useMobileValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const { control } = useFormContext<VerifiableFieldInput>()

--- a/frontend/src/templates/Field/Nric/NricField.tsx
+++ b/frontend/src/templates/Field/Nric/NricField.tsx
@@ -1,10 +1,9 @@
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-import { useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { createNricValidationRules } from '~utils/fieldValidation'
+import { useNricValidationRules } from '~utils/fieldValidation'
 import Input from '~components/Input'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
@@ -20,9 +19,9 @@ export const NricField = ({
   disableRequiredValidation,
   isHighContrast,
 }: NricFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createNricValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useNricValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const { register, setValue } = useFormContext<SingleAnswerFieldInput>()

--- a/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/frontend/src/templates/Field/Number/NumberField.tsx
@@ -1,9 +1,8 @@
-import { useMemo } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 
 import { FormColorTheme } from '~shared/types'
 
-import { createNumberValidationRules } from '~utils/fieldValidation'
+import { useNumberValidationRules } from '~utils/fieldValidation'
 import NumberInput from '~components/NumberInput'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
@@ -20,11 +19,10 @@ export const NumberField = ({
   colorTheme = FormColorTheme.Blue,
   isHighContrast,
 }: NumberFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createNumberValidationRules(schema, disableRequiredValidation),
-    [disableRequiredValidation, schema],
+  const validationRules = useNumberValidationRules(
+    schema,
+    disableRequiredValidation,
   )
-
   const { control } = useFormContext<SingleAnswerFieldInput>()
 
   return (

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -7,7 +7,7 @@ import { get } from 'lodash'
 import { FormColorTheme, Language } from '~shared/types'
 
 import { RADIO_THEME_KEY } from '~theme/components/Radio'
-import { createRadioValidationRules } from '~utils/fieldValidation'
+import { useRadioValidationRules } from '~utils/fieldValidation'
 import { getFieldOptionsInSelectedLanguage } from '~utils/multiLanguage'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Radio, { OthersInput } from '~components/Radio'
@@ -49,9 +49,9 @@ export const RadioField = ({
     [schema._id],
   )
 
-  const validationRules = useMemo(
-    () => createRadioValidationRules(schema, disableRequiredValidation),
-    [disableRequiredValidation, schema],
+  const validationRules = useRadioValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const englishRadioOptions = schema.fieldOptions

--- a/frontend/src/templates/Field/Rating/RatingField.tsx
+++ b/frontend/src/templates/Field/Rating/RatingField.tsx
@@ -8,7 +8,7 @@ import { get } from 'lodash'
 import { FormColorTheme } from '~shared/types'
 import { RatingShape } from '~shared/types/field'
 
-import { createRatingValidationRules } from '~utils/fieldValidation'
+import { useRatingValidationRules } from '~utils/fieldValidation'
 import Rating from '~components/Field/Rating'
 import { RatingProps } from '~components/Field/Rating/Rating'
 
@@ -34,9 +34,9 @@ export const RatingField = ({
   colorTheme = FormColorTheme.Blue,
   isHighContrast,
 }: RatingFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createRatingValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useRatingValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const ratingVariant: RatingProps['variant'] = useMemo(() => {

--- a/frontend/src/templates/Field/ShortText/ShortTextField.tsx
+++ b/frontend/src/templates/Field/ShortText/ShortTextField.tsx
@@ -1,10 +1,9 @@
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-import { useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { createTextValidationRules } from '~utils/fieldValidation'
+import { useTextValidationRules } from '~utils/fieldValidation'
 import Input from '~components/Input'
 
 import { PrefillMap } from '../../../features/public-form/components/FormFields/FormFields'
@@ -23,9 +22,9 @@ export const ShortTextField = ({
   isHighContrast,
   ...fieldContainerProps
 }: ShortTextFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createTextValidationRules(schema, disableRequiredValidation),
-    [disableRequiredValidation, schema],
+  const validationRules = useTextValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const { register } = useFormContext<SingleAnswerFieldInput>()

--- a/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -18,7 +18,7 @@ import { useIsMobile } from '~hooks/useIsMobile'
 import { useIsPrint } from '~hooks/useIsPrint'
 import {
   createBaseValidationRules,
-  createDropdownValidationRules,
+  useDropdownValidationRules,
 } from '~utils/fieldValidation'
 import { SingleSelect } from '~components/Dropdown'
 import { ComboboxItem } from '~components/Dropdown/types'
@@ -95,10 +95,7 @@ const DropdownColumnCell = ({
 }: FieldColumnCellProps<DropdownColumnBase>) => {
   const { i18n } = useTranslation()
   const { control } = useFormContext<TableFieldInputs>()
-  const rules = useMemo(
-    () => createDropdownValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
-  )
+  const rules = useDropdownValidationRules(schema, disableRequiredValidation)
 
   const selectedLanguage = i18n.language as Language
 

--- a/frontend/src/templates/Field/Uen/UenField.tsx
+++ b/frontend/src/templates/Field/Uen/UenField.tsx
@@ -1,10 +1,9 @@
 /**
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
-import { useMemo } from 'react'
 import { useFormContext } from 'react-hook-form'
 
-import { createUenValidationRules } from '~utils/fieldValidation'
+import { useUenValidationRules } from '~utils/fieldValidation'
 import Input from '~components/Input'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
@@ -20,9 +19,9 @@ export const UenField = ({
   disableRequiredValidation,
   isHighContrast,
 }: UenFieldProps): JSX.Element => {
-  const validationRules = useMemo(
-    () => createUenValidationRules(schema, disableRequiredValidation),
-    [schema, disableRequiredValidation],
+  const validationRules = useUenValidationRules(
+    schema,
+    disableRequiredValidation,
   )
 
   const { register, setValue } = useFormContext<SingleAnswerFieldInput>()

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -576,26 +576,29 @@ export const useUenValidationRules = (
   }, [schema, disableRequiredValidation, t])
 }
 
-export const createNricValidationRules: ValidationRuleFn<NricFieldBase> = (
-  schema,
-  disableRequiredValidation,
+export const useNricValidationRules = (
+  schema: NricFieldBase,
+  disableRequiredValidation?: boolean,
 ): RegisterOptions => {
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validNric: (val?: string) => {
-        if (!val) return true
-        return (
-          isNricValid(val) ||
-          isMFinSeriesValid(val) ||
-          'Please enter a valid NRIC/FIN'
-        )
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validNric: (val?: string) => {
+          if (!val) return true
+          return isNricValid(val) || isMFinSeriesValid(val) || t('validNric')
+        },
       },
-    },
-  }
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 export const createCheckboxValidationRules: ValidationRuleFn<

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -661,75 +661,76 @@ const parseDate = (val: string) => {
   return parse(val, DATE_PARSE_FORMAT, new Date())
 }
 
-export const createDateValidationRules: ValidationRuleFn<DateFieldBase> = (
-  schema,
-  disableRequiredValidation,
+export const useDateValidationRules = (
+  schema: DateFieldBase,
+  disableRequiredValidation?: boolean,
 ): RegisterOptions => {
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validDate: (val) => {
-        if (!val) return true
-        if (val === DATE_PARSE_FORMAT.toLowerCase()) {
-          return REQUIRED_ERROR
-        }
-        return isValid(parseDate(val)) || 'Please enter a valid date'
-      },
-      noFuture: (val) => {
-        if (
-          !val ||
-          schema.dateValidation.selectedDateValidation !==
-            DateSelectedValidation.NoFuture
-        ) {
-          return true
-        }
-        return (
-          !isDateAfterToday(parseDate(val)) ||
-          'Only dates today or before are allowed'
-        )
-      },
-      noPast: (val) => {
-        if (
-          !val ||
-          schema.dateValidation.selectedDateValidation !==
-            DateSelectedValidation.NoPast
-        ) {
-          return true
-        }
-        return (
-          !isDateBeforeToday(parseDate(val)) ||
-          'Only dates today or after are allowed'
-        )
-      },
-      range: (val) => {
-        if (
-          !val ||
-          schema.dateValidation.selectedDateValidation !==
-            DateSelectedValidation.Custom
-        ) {
-          return true
-        }
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
 
-        const { customMinDate, customMaxDate } = schema.dateValidation ?? {}
-        return (
-          !isDateOutOfRange(
-            parseDate(val),
-            loadDateFromNormalizedDate(customMinDate),
-            loadDateFromNormalizedDate(customMaxDate),
-          ) || 'Selected date is not within the allowed date range'
-        )
+  return useMemo(() => {
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validDate: (val) => {
+          if (!val) return true
+          if (val === DATE_PARSE_FORMAT.toLowerCase()) {
+            return t('required')
+          }
+          return isValid(parseDate(val)) || t('validDate')
+        },
+        noFuture: (val) => {
+          if (
+            !val ||
+            schema.dateValidation.selectedDateValidation !==
+              DateSelectedValidation.NoFuture
+          ) {
+            return true
+          }
+          return !isDateAfterToday(parseDate(val)) || t('noFutureDate')
+        },
+        noPast: (val) => {
+          if (
+            !val ||
+            schema.dateValidation.selectedDateValidation !==
+              DateSelectedValidation.NoPast
+          ) {
+            return true
+          }
+          return !isDateBeforeToday(parseDate(val)) || t('noPastDate')
+        },
+        range: (val) => {
+          if (
+            !val ||
+            schema.dateValidation.selectedDateValidation !==
+              DateSelectedValidation.Custom
+          ) {
+            return true
+          }
+
+          const { customMinDate, customMaxDate } = schema.dateValidation ?? {}
+          return (
+            !isDateOutOfRange(
+              parseDate(val),
+              loadDateFromNormalizedDate(customMinDate),
+              loadDateFromNormalizedDate(customMaxDate),
+            ) || t('dateOutOfRange')
+          )
+        },
+        invalidDays: (val) =>
+          !val ||
+          !schema.invalidDays ||
+          !schema.invalidDays.length ||
+          !isDateAnInvalidDay(parseDate(val), schema.invalidDays) ||
+          t('invalidDay'),
       },
-      invalidDays: (val) =>
-        !val ||
-        !schema.invalidDays ||
-        !schema.invalidDays.length ||
-        !isDateAnInvalidDay(parseDate(val), schema.invalidDays) ||
-        'This date is not allowed by the form admin',
-    },
-  }
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 export const createRadioValidationRules: ValidationRuleFn<RadioFieldBase> = (

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -2,13 +2,16 @@
  * This utility file creates validation rules for `react-hook-form` according
  * to the field schema.
  */
+import { useMemo } from 'react'
 import {
   FieldValues,
   Path,
   RegisterOptions,
   UseFormGetValues,
 } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { isValid, parse } from 'date-fns'
+import { TFunction } from 'i18next'
 import { identity } from 'lodash'
 import simplur from 'simplur'
 import validator from 'validator'
@@ -112,11 +115,19 @@ type ValidationRuleFnUnitAndLevelNo<T extends FieldBase = FieldBase> = (
   getValues: UseFormGetValues<AddressCompoundFieldInput>,
 ) => RegisterOptions
 
+const I18N_KEY_PREFIX = 'utils.fieldValidation'
+
 const requiredSingleAnswerValidationFn =
-  (schema: Pick<FieldBase, 'required'>, disableRequiredValidation?: boolean) =>
+  (
+    schema: Pick<FieldBase, 'required'>,
+    disableRequiredValidation?: boolean,
+    t?: TFunction,
+  ) =>
   (value?: SingleAnswerValue) => {
     if (disableRequiredValidation || !schema.required) return true
-    return !!value?.trim() || REQUIRED_ERROR
+    // TODO: migrate REQUIRED_ERROR to point to 'required' instead
+    const errorMessage = t ? t('required') : REQUIRED_ERROR
+    return !!value?.trim() || errorMessage
   }
 
 /**
@@ -347,77 +358,96 @@ export const createMobileValidationRules: ValidationRuleFnEmailAndMobile<
   }
 }
 
-export const createNumberValidationRules: ValidationRuleFn<NumberFieldBase> = (
-  schema,
-  disableRequiredValidation,
+export const useNumberValidationRules = (
+  schema: NumberFieldBase,
+  disableRequiredValidation?: boolean,
 ): RegisterOptions => {
-  const { selectedValidation } = schema.ValidationOptions
-  const { selectedLengthValidation, customVal } =
-    schema.ValidationOptions.LengthValidationOptions
-  const { customMin, customMax } =
-    schema.ValidationOptions.RangeValidationOptions
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
 
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validNumberLength: (val: string) => {
-        if (
-          selectedValidation !== NumberSelectedValidation.Length ||
-          !val ||
-          !customVal
-        )
-          return true
+  return useMemo(() => {
+    const { selectedValidation } = schema.ValidationOptions
+    const { selectedLengthValidation, customVal } =
+      schema.ValidationOptions.LengthValidationOptions
+    const { customMin, customMax } =
+      schema.ValidationOptions.RangeValidationOptions
 
-        const currLen = val.trim().length
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validNumberLength: (val: string) => {
+          if (
+            selectedValidation !== NumberSelectedValidation.Length ||
+            !val ||
+            !customVal
+          )
+            return true
 
-        switch (selectedLengthValidation) {
-          case NumberSelectedLengthValidation.Exact:
-            return (
-              currLen === customVal ||
-              simplur`Please enter ${customVal} digit[|s] (${currLen}/${customVal})`
-            )
-          case NumberSelectedLengthValidation.Min:
-            return (
-              currLen >= customVal ||
-              simplur`Please enter at least ${customVal} digit[|s] (${currLen}/${customVal})`
-            )
-          case NumberSelectedLengthValidation.Max:
-            return (
-              currLen <= customVal ||
-              simplur`Please enter at most ${customVal} digit[|s] (${currLen}/${customVal})`
-            )
-        }
+          const currLen = val.trim().length
+
+          switch (selectedLengthValidation) {
+            case NumberSelectedLengthValidation.Exact:
+              return (
+                currLen === customVal ||
+                t('exactDigits', {
+                  current: currLen,
+                  threshold: customVal,
+                })
+              )
+            case NumberSelectedLengthValidation.Min:
+              return (
+                currLen >= customVal ||
+                t('minDigits', {
+                  current: currLen,
+                  threshold: customVal,
+                })
+              )
+            case NumberSelectedLengthValidation.Max:
+              return (
+                currLen <= customVal ||
+                t('maxDigits', {
+                  current: currLen,
+                  threshold: customVal,
+                })
+              )
+          }
+        },
+        validNumberRange: (val: string) => {
+          if (selectedValidation !== NumberSelectedValidation.Range || !val)
+            return true
+
+          const numVal = parseInt(val)
+          if (Number.isNaN(numVal)) {
+            return t('validNumber')
+          }
+
+          const hasMinimum = customMin !== null
+          const hasMaximum = customMax !== null
+          const satisfiesMinimum = !hasMinimum || customMin <= numVal
+          const satisfiesMaximum = !hasMaximum || numVal <= customMax
+          const isInRange = satisfiesMinimum && satisfiesMaximum
+
+          if (isInRange) {
+            return true
+          } else if (hasMinimum && hasMaximum) {
+            return t('numbersRange', {
+              min: customMin,
+              max: customMax,
+            })
+          } else if (hasMinimum) {
+            return t('numberMinimum', { min: customMin })
+          } else if (hasMaximum) {
+            return t('numberMaximum', { max: customMax })
+          }
+        },
       },
-      validNumberRange: (val: string) => {
-        if (selectedValidation !== NumberSelectedValidation.Range || !val)
-          return true
-
-        const numVal = parseInt(val)
-        if (Number.isNaN(numVal)) {
-          return 'Please enter a valid number'
-        }
-
-        const hasMinimum = customMin !== null
-        const hasMaximum = customMax !== null
-        const satisfiesMinimum = !hasMinimum || customMin <= numVal
-        const satisfiesMaximum = !hasMaximum || numVal <= customMax
-        const isInRange = satisfiesMinimum && satisfiesMaximum
-
-        if (isInRange) {
-          return true
-        } else if (hasMinimum && hasMaximum) {
-          return `Please enter a number between ${customMin} and ${customMax}`
-        } else if (hasMinimum) {
-          return `Please enter a number that is at least ${customMin}`
-        } else if (hasMaximum) {
-          return `Please enter a number that is at most ${customMax}`
-        }
-      },
-    },
-  }
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 export const createDecimalValidationRules: ValidationRuleFn<

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -184,7 +184,7 @@ const useBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
             return true
           }
           if (schema.fieldType === BasicField.Mobile) {
-            return 'Please verify your mobile number'
+            return t('pleaseVerifyMobile')
           }
           if (schema.fieldType === BasicField.Email) {
             return t('pleaseVerifyEmail')
@@ -195,7 +195,7 @@ const useBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
   }, [schema, disableRequiredValidation, t])
 }
 
-// TODO: remove after useBaseValidationRules is used instead. keeping this for backward compatibility
+// TODO: remove after useBaseValidationRules is used instead. keeping this for backward compatibility. this is being used in 52 other occurences at the moment.
 export const createBaseValidationRules = <
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends Path<TFieldValues> = never,
@@ -406,18 +406,28 @@ export const createUnitNumberValidationRules: ValidationRuleFnUnitAndLevelNo<
   }
 }
 
-export const createMobileValidationRules: ValidationRuleFnEmailAndMobile<
+export const useMobileValidationRules: ValidationRuleFnEmailAndMobile<
   MobileFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
-  return {
-    validate: {
-      baseValidations: (val?: VerifiableFieldValues) => {
-        return baseMobileValidationFn(schema)(val?.value)
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  const baseVfnRules = useBaseVfnFieldValidationRules(
+    schema,
+    disableRequiredValidation,
+  )
+
+  return useMemo(() => {
+    return {
+      validate: {
+        baseValidations: (val?: VerifiableFieldValues) => {
+          return baseMobileValidationFn(schema, t)(val?.value)
+        },
+        ...baseVfnRules.validate,
       },
-      ...createBaseVfnFieldValidationRules(schema, disableRequiredValidation)
-        .validate,
-    },
-  }
+    }
+  }, [baseVfnRules.validate, schema, t])
 }
 
 export const useNumberValidationRules = (
@@ -891,14 +901,12 @@ export const baseEmailValidationFn =
   }
 
 export const baseMobileValidationFn =
-  (_schema: MinimumFieldValidationProps<MobileFieldBase>) =>
-  (inputValue?: string) => {
+  (_schema: MinimumFieldValidationProps<MobileFieldBase>, t: TFunction) =>
+  (inputValue?: string): true | string => {
     if (!inputValue) return true
 
     // Valid mobile check
-    return (
-      isMobilePhoneNumber(inputValue) || 'Please enter a valid mobile number'
-    )
+    return isMobilePhoneNumber(inputValue) || (t('validMobile') as string)
   }
 
 export const createChildrenValidationRules: ValidationRuleFn<

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -450,58 +450,68 @@ export const useNumberValidationRules = (
   }, [schema, disableRequiredValidation, t])
 }
 
-export const createDecimalValidationRules: ValidationRuleFn<
-  DecimalFieldBase
-> = (schema, disableRequiredValidation): RegisterOptions => {
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validDecimal: (val: string) => {
-        const {
-          ValidationOptions: { customMax, customMin },
-          validateByValue,
-        } = schema
-        if (!val) return true
+export const useDecimalValidationRules = (
+  schema: DecimalFieldBase,
+  disableRequiredValidation?: boolean,
+): RegisterOptions => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
 
-        const numVal = Number(val)
-        if (isNaN(numVal)) {
-          return 'Please enter a valid decimal'
-        }
+  return useMemo(() => {
+    const {
+      ValidationOptions: { customMax, customMin },
+      validateByValue,
+    } = schema
 
-        // Validate leading zeros
-        if (/^0[0-9]/.test(val)) {
-          return 'Please enter a valid decimal without leading zeros'
-        }
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validDecimal: (val: string) => {
+          if (!val) return true
 
-        if (!validateByValue) return true
+          const numVal = Number(val)
+          if (isNaN(numVal)) {
+            return t('validDecimal')
+          }
 
-        if (
-          customMin !== null &&
-          customMax !== null &&
-          (numVal < customMin || numVal > customMax)
-        ) {
-          return `Please enter a decimal between ${formatNumberToLocaleString(
-            customMin,
-          )} and ${formatNumberToLocaleString(customMax)} (inclusive)`
-        }
-        if (customMin !== null && numVal < customMin) {
-          return `Please enter a decimal greater than or equal to ${formatNumberToLocaleString(
-            customMin,
-          )}`
-        }
-        if (customMax !== null && numVal > customMax) {
-          return `Please enter a decimal less than or equal to ${formatNumberToLocaleString(
-            customMax,
-          )}`
-        }
+          // Validate leading zeros
+          if (/^0[0-9]/.test(val)) {
+            return t('validDecimalNoLeadingZeros')
+          }
 
-        return true
+          if (!validateByValue) return true
+
+          if (
+            customMin !== null &&
+            customMax !== null &&
+            (numVal < customMin || numVal > customMax)
+          ) {
+            return t('decimalRange', {
+              min: formatNumberToLocaleString(customMin),
+              max: formatNumberToLocaleString(customMax),
+            })
+          }
+          if (customMin !== null && numVal < customMin) {
+            return t('decimalMinimum', {
+              min: formatNumberToLocaleString(customMin),
+            })
+          }
+          if (customMax !== null && numVal > customMax) {
+            return t('decimalMaximum', {
+              max: formatNumberToLocaleString(customMax),
+            })
+          }
+
+          return true
+        },
       },
-    },
-  }
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 export const createTextValidationRules: ValidationRuleFn<

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -13,7 +13,6 @@ import { useTranslation } from 'react-i18next'
 import { isValid, parse } from 'date-fns'
 import { TFunction } from 'i18next'
 import { identity } from 'lodash'
-import simplur from 'simplur'
 import validator from 'validator'
 
 import { DATE_PARSE_FORMAT } from '~shared/constants/dates'
@@ -255,7 +254,16 @@ export const useRatingValidationRules: ValidationRuleFn<RatingFieldBase> = (
 export const useAttachmentValidationRules: ValidationRuleFn<
   AttachmentFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
-  return useBaseValidationRules(schema, disableRequiredValidation)
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+  return {
+    validate: (value?: File) => {
+      if (disableRequiredValidation || !schema.required) return true
+      const errorMessage = t ? t('required') : REQUIRED_ERROR
+      return !!value || errorMessage
+    },
+  }
 }
 
 export const useHomeNoValidationRules = (

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -160,6 +160,41 @@ const createBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
   }
 }
 
+const useBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
+  VerifiableFieldBase
+> = (schema, disableRequiredValidation): RegisterOptions => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        required: (value?: VerifiableFieldValues) => {
+          return requiredSingleAnswerValidationFn(
+            schema,
+            disableRequiredValidation,
+            t,
+          )(value?.value)
+        },
+        hasSignature: (val?: VerifiableFieldValues) => {
+          if (!schema.isVerifiable) return true
+          // Either signature is filled, or both fields have no input.
+          if (!!val?.signature || (!val?.value && !val?.signature)) {
+            return true
+          }
+          if (schema.fieldType === BasicField.Mobile) {
+            return 'Please verify your mobile number'
+          }
+          if (schema.fieldType === BasicField.Email) {
+            return t('pleaseVerifyEmail')
+          }
+        },
+      },
+    }
+  }, [schema, disableRequiredValidation, t])
+}
+
 // TODO: remove after useBaseValidationRules is used instead. keeping this for backward compatibility
 export const createBaseValidationRules = <
   TFieldValues extends FieldValues = FieldValues,
@@ -787,24 +822,36 @@ export const useRadioValidationRules: ValidationRuleFn<RadioFieldBase> = (
   return useBaseValidationRules(schema, disableRequiredValidation)
 }
 
-export const createEmailValidationRules: ValidationRuleFnEmailAndMobile<
+export const useEmailValidationRules: ValidationRuleFnEmailAndMobile<
   EmailFieldBase
 > = (
   schema,
   disableRequiredValidation,
   validationErrorMessages,
 ): RegisterOptions => {
-  return {
-    validate: {
-      baseValidations: (val?: VerifiableFieldValues) => {
-        return baseEmailValidationFn({ schema, validationErrorMessages })(
-          val?.value,
-        )
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  const baseVfnRules = useBaseVfnFieldValidationRules(
+    schema,
+    disableRequiredValidation,
+  )
+
+  return useMemo(() => {
+    return {
+      validate: {
+        baseValidations: (val?: VerifiableFieldValues) => {
+          return baseEmailValidationFn({
+            schema,
+            t,
+            validationErrorMessages,
+          })(val?.value)
+        },
+        ...baseVfnRules.validate,
       },
-      ...createBaseVfnFieldValidationRules(schema, disableRequiredValidation)
-        .validate,
-    },
-  }
+    }
+  }, [baseVfnRules.validate, schema, t, validationErrorMessages])
 }
 
 /**
@@ -814,9 +861,11 @@ export const createEmailValidationRules: ValidationRuleFnEmailAndMobile<
 export const baseEmailValidationFn =
   ({
     schema,
+    t,
     validationErrorMessages = { domainDisallowed: 'Domain disallowed' },
   }: {
     schema: MinimumFieldValidationProps<EmailFieldBase>
+    t?: TFunction
     validationErrorMessages?: EmailValidationErrorMessages
   }) =>
   (inputValue?: string) => {
@@ -825,7 +874,8 @@ export const baseEmailValidationFn =
     const trimmedInputValue = inputValue.trim()
 
     // Valid email check
-    if (!validator.isEmail(trimmedInputValue)) return INVALID_EMAIL_ERROR
+    if (!validator.isEmail(trimmedInputValue))
+      return t ? t('invalidEmail') : INVALID_EMAIL_ERROR
 
     // Valid domain check
     const allowedDomains = new Set(schema.allowedEmailDomains)

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -251,15 +251,10 @@ export const useRatingValidationRules: ValidationRuleFn<RatingFieldBase> = (
   return useBaseValidationRules(schema, disableRequiredValidation)
 }
 
-export const createAttachmentValidationRules: ValidationRuleFn<
+export const useAttachmentValidationRules: ValidationRuleFn<
   AttachmentFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
-  return {
-    validate: (value?: File) => {
-      if (disableRequiredValidation || !schema.required) return true
-      return !!value || REQUIRED_ERROR
-    },
-  }
+  return useBaseValidationRules(schema, disableRequiredValidation)
 }
 
 export const createHomeNoValidationRules: ValidationRuleFn<HomenoFieldBase> = (

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -569,6 +569,31 @@ export const createUenValidationRules: ValidationRuleFn<UenFieldBase> = (
   }
 }
 
+export const useUenValidationRules = (
+  schema: UenFieldBase,
+  disableRequiredValidation?: boolean,
+): RegisterOptions => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validUen: (val?: string) => {
+          if (!val) return true
+          return isUenValid(val) || t('validUen')
+        },
+      },
+    }
+  }, [schema, disableRequiredValidation, t])
+}
+
 export const createNricValidationRules: ValidationRuleFn<NricFieldBase> = (
   schema,
   disableRequiredValidation,

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -601,45 +601,62 @@ export const useNricValidationRules = (
   }, [schema, disableRequiredValidation, t])
 }
 
-export const createCheckboxValidationRules: ValidationRuleFn<
-  CheckboxFieldBase
-> = (schema, disableRequiredValidation): RegisterOptions => {
-  return {
-    validate: {
-      required: (val?: CheckboxFieldValues['value']) => {
-        if (disableRequiredValidation || !schema.required) return true
-        if (!val) return REQUIRED_ERROR
-        // Trim strings before checking for emptiness
-        return val.map((v) => v.trim()).some(identity) || REQUIRED_ERROR
+export const useCheckboxValidationRules = (
+  schema: CheckboxFieldBase,
+  disableRequiredValidation?: boolean,
+): RegisterOptions => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    const {
+      ValidationOptions: { customMin, customMax },
+      validateByValue,
+    } = schema
+
+    return {
+      validate: {
+        required: (val?: CheckboxFieldValues['value']) => {
+          if (disableRequiredValidation || !schema.required) return true
+          if (!val) return t('required')
+          // Trim strings before checking for emptiness
+          return val.map((v) => v.trim()).some(identity) || t('required')
+        },
+        validOptions: (val?: CheckboxFieldValues['value']) => {
+          if (!val || val.length === 0 || !validateByValue) return true
+
+          if (
+            customMin &&
+            customMax &&
+            customMin === customMax &&
+            val.length !== customMin
+          ) {
+            return t('exactOptions', {
+              current: val.length,
+              threshold: customMin,
+            })
+          }
+
+          if (customMin && val.length < customMin) {
+            return t('minOptions', {
+              current: val.length,
+              threshold: customMin,
+            })
+          }
+
+          if (customMax && val.length > customMax) {
+            return t('maxOptions', {
+              current: val.length,
+              threshold: customMax,
+            })
+          }
+
+          return true
+        },
       },
-      validOptions: (val?: CheckboxFieldValues['value']) => {
-        const {
-          ValidationOptions: { customMin, customMax },
-          validateByValue,
-        } = schema
-        if (!val || val.length === 0 || !validateByValue) return true
-
-        if (
-          customMin &&
-          customMax &&
-          customMin === customMax &&
-          val.length !== customMin
-        ) {
-          return simplur`Please select exactly ${customMin} option[|s] (${val.length}/${customMin})`
-        }
-
-        if (customMin && val.length < customMin) {
-          return simplur`Please select at least ${customMin} option[|s] (${val.length}/${customMin})`
-        }
-
-        if (customMax && val.length > customMax) {
-          return simplur`Please select at most ${customMax} option[|s] (${val.length}/${customMax})`
-        }
-
-        return true
-      },
-    },
-  }
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 const parseDate = (val: string) => {

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -132,34 +132,6 @@ const requiredSingleAnswerValidationFn =
  * @param schema verifiable field schema
  * @returns base verifiable fields' validation rules
  */
-const createBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
-  VerifiableFieldBase
-> = (schema, disableRequiredValidation): RegisterOptions => {
-  return {
-    validate: {
-      required: (value?: VerifiableFieldValues) => {
-        return requiredSingleAnswerValidationFn(
-          schema,
-          disableRequiredValidation,
-        )(value?.value)
-      },
-      hasSignature: (val?: VerifiableFieldValues) => {
-        if (!schema.isVerifiable) return true
-        // Either signature is filled, or both fields have no input.
-        if (!!val?.signature || (!val?.value && !val?.signature)) {
-          return true
-        }
-        if (schema.fieldType === BasicField.Mobile) {
-          return 'Please verify your mobile number'
-        }
-        if (schema.fieldType === BasicField.Email) {
-          return 'Please verify your email address'
-        }
-      },
-    },
-  }
-}
-
 const useBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
   VerifiableFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -520,41 +520,59 @@ export const useDecimalValidationRules = (
   }, [schema, disableRequiredValidation, t])
 }
 
-export const createTextValidationRules: ValidationRuleFn<
-  ShortTextFieldBase | LongTextFieldBase
-> = (schema, disableRequiredValidation): RegisterOptions => {
-  const { selectedValidation, customVal } = schema.ValidationOptions
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validText: (val?: string) => {
-        if (!val || !customVal) return true
+export const useTextValidationRules = (
+  schema: ShortTextFieldBase | LongTextFieldBase,
+  disableRequiredValidation?: boolean,
+): RegisterOptions => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
 
-        const currLen = val.trim().length
+  return useMemo(() => {
+    const { selectedValidation, customVal } = schema.ValidationOptions
 
-        switch (selectedValidation) {
-          case TextSelectedValidation.Exact:
-            return (
-              currLen === customVal ||
-              simplur`Please enter ${customVal} character[|s] (${currLen}/${customVal})`
-            )
-          case TextSelectedValidation.Minimum:
-            return (
-              currLen >= customVal ||
-              simplur`Please enter at least ${customVal} character[|s] (${currLen}/${customVal})`
-            )
-          case TextSelectedValidation.Maximum:
-            return (
-              currLen <= customVal ||
-              simplur`Please enter at most ${customVal} character[|s] (${currLen}/${customVal})`
-            )
-        }
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validText: (val?: string) => {
+          if (!val || !customVal) return true
+
+          const currLen = val.trim().length
+
+          switch (selectedValidation) {
+            case TextSelectedValidation.Exact:
+              return (
+                currLen === customVal ||
+                t('exactCharacters', {
+                  current: currLen,
+                  threshold: customVal,
+                })
+              )
+            case TextSelectedValidation.Minimum:
+              return (
+                currLen >= customVal ||
+                t('minCharacters', {
+                  current: currLen,
+                  threshold: customVal,
+                })
+              )
+            case TextSelectedValidation.Maximum:
+              return (
+                currLen <= customVal ||
+                t('maxCharacters', {
+                  current: currLen,
+                  threshold: customVal,
+                })
+              )
+          }
+        },
       },
-    },
-  }
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 export const useUenValidationRules = (

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -341,6 +341,26 @@ export const createStreetNameValidationRules: ValidationRuleFn<
   }
 }
 
+export const useStreetNameValidationRules: ValidationRuleFn<
+  AddressCompoundFieldBase
+> = (schema, disableRequiredValidation): RegisterOptions => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+      },
+    }
+  }, [schema, disableRequiredValidation, t])
+}
+
 export const createLevelNumberValidationRules: ValidationRuleFnUnitAndLevelNo<
   AddressCompoundFieldBase
 > = (

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -175,41 +175,47 @@ export const createBaseValidationRules = <
   }
 }
 
-// i18n this next
-export const createDropdownValidationRules: ValidationRuleFn<
-  DropdownFieldBase
-> = (schema, disableRequiredValidation): RegisterOptions => {
+export const useDropdownValidationRules: ValidationRuleFn<DropdownFieldBase> = (
+  schema,
+  disableRequiredValidation,
+): RegisterOptions => {
   return createDropdownValidationRulesWithCustomErrorMessage(
-    'Entered value is not a valid dropdown option',
+    'invalidDropdownOption',
   )(schema, disableRequiredValidation)
 }
 
-// i18n this next
-export const createCountryRegionValidationRules: ValidationRuleFn<
+export const useCountryRegionValidationRules: ValidationRuleFn<
   DropdownFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
   return createDropdownValidationRulesWithCustomErrorMessage(
-    'Please select a valid country/region from the dropdown list',
+    'invalidCountryRegion',
   )(schema, disableRequiredValidation)
 }
 
-export const createDropdownValidationRulesWithCustomErrorMessage: (
-  errorMessage: string,
+const createDropdownValidationRulesWithCustomErrorMessage: (
+  errorKey: 'invalidDropdownOption' | 'invalidCountryRegion',
 ) => ValidationRuleFn<DropdownFieldBase> =
-  (errorMessage) =>
+  (errorKey) =>
   (schema, disableRequiredValidation): RegisterOptions => {
-    return {
-      validate: {
-        required: requiredSingleAnswerValidationFn(
-          schema,
-          disableRequiredValidation,
-        ),
-        validOptions: (value: string) => {
-          if (!value) return
-          return schema.fieldOptions.includes(value) || errorMessage
+    const { t } = useTranslation('translation', {
+      keyPrefix: I18N_KEY_PREFIX,
+    })
+
+    return useMemo(() => {
+      return {
+        validate: {
+          required: requiredSingleAnswerValidationFn(
+            schema,
+            disableRequiredValidation,
+            t,
+          ),
+          validOptions: (value: string) => {
+            if (!value) return true
+            return schema.fieldOptions.includes(value) || t(errorKey)
+          },
         },
-      },
-    }
+      }
+    }, [schema, disableRequiredValidation, t])
   }
 
 export const createRatingValidationRules: ValidationRuleFn<RatingFieldBase> = (

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -122,7 +122,7 @@ const requiredSingleAnswerValidationFn =
   ) =>
   (value?: SingleAnswerValue) => {
     if (disableRequiredValidation || !schema.required) return true
-    // TODO: migrate REQUIRED_ERROR to point to 'required' instead
+    // TODO: migrate REQUIRED_ERROR to point to 'required' instead of 'This field is required'
     const errorMessage = t ? t('required') : REQUIRED_ERROR
     return !!value?.trim() || errorMessage
   }
@@ -160,6 +160,7 @@ const createBaseVfnFieldValidationRules: ValidationRuleFnEmailAndMobile<
   }
 }
 
+// TODO: remove after useBaseValidationRules is used instead. keeping this for backward compatibility
 export const createBaseValidationRules = <
   TFieldValues extends FieldValues = FieldValues,
   TFieldName extends Path<TFieldValues> = never,
@@ -173,6 +174,31 @@ export const createBaseValidationRules = <
       disableRequiredValidation,
     ),
   }
+}
+
+// Hook version using i18n
+const useBaseValidationRules = <
+  TFieldValues extends FieldValues = FieldValues,
+  TFieldName extends Path<TFieldValues> = never,
+>(
+  schema: Pick<FieldBase, 'required'>,
+  disableRequiredValidation?: boolean,
+): RegisterOptions<TFieldValues, TFieldName> => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+      },
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 export const useDropdownValidationRules: ValidationRuleFn<DropdownFieldBase> = (
@@ -218,11 +244,11 @@ const createDropdownValidationRulesWithCustomErrorMessage: (
     }, [schema, disableRequiredValidation, t])
   }
 
-export const createRatingValidationRules: ValidationRuleFn<RatingFieldBase> = (
+export const useRatingValidationRules: ValidationRuleFn<RatingFieldBase> = (
   schema,
   disableRequiredValidation,
 ): RegisterOptions => {
-  return createBaseValidationRules(schema, disableRequiredValidation)
+  return useBaseValidationRules(schema, disableRequiredValidation)
 }
 
 export const createAttachmentValidationRules: ValidationRuleFn<
@@ -759,11 +785,11 @@ export const useDateValidationRules = (
   }, [schema, disableRequiredValidation, t])
 }
 
-export const createRadioValidationRules: ValidationRuleFn<RadioFieldBase> = (
+export const useRadioValidationRules: ValidationRuleFn<RadioFieldBase> = (
   schema,
   disableRequiredValidation,
 ): RegisterOptions => {
-  return createBaseValidationRules(schema, disableRequiredValidation)
+  return useBaseValidationRules(schema, disableRequiredValidation)
 }
 
 export const createEmailValidationRules: ValidationRuleFnEmailAndMobile<

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -551,24 +551,6 @@ export const createTextValidationRules: ValidationRuleFn<
   }
 }
 
-export const createUenValidationRules: ValidationRuleFn<UenFieldBase> = (
-  schema,
-  disableRequiredValidation,
-): RegisterOptions => {
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validUen: (val?: string) => {
-        if (!val) return true
-        return isUenValid(val) || 'Please enter a valid UEN'
-      },
-    },
-  }
-}
-
 export const useUenValidationRules = (
   schema: UenFieldBase,
   disableRequiredValidation?: boolean,

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -58,13 +58,7 @@ import { isUenValid } from '~shared/utils/uen-validation'
 
 import { Fields } from '~/i18n/locales/features/public-form/fields'
 
-import {
-  INVALID_BLOCK_UNIT_ERROR,
-  INVALID_EMAIL_ERROR,
-  INVALID_LEVEL_UNIT_ERROR,
-  INVALID_NON_NUMERICAL_ERROR,
-  REQUIRED_ERROR,
-} from '~constants/validation'
+import { INVALID_EMAIL_ERROR, REQUIRED_ERROR } from '~constants/validation'
 import {
   AddressCompoundFieldInput,
   CheckboxFieldValues,
@@ -289,56 +283,56 @@ export const useHomeNoValidationRules = (
   }, [schema, disableRequiredValidation, t])
 }
 
-// i18n this next
-export const createPostalCodeValidationRules: ValidationRuleFn<
+export const usePostalCodeValidationRules: ValidationRuleFn<
   AddressCompoundFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validOnlyNumbers: (value: string) => {
-        if (value === '') return true
-        return validateNoNonNumerical(value) || INVALID_NON_NUMERICAL_ERROR
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validOnlyNumbers: (value: string) => {
+          if (value === '') return true
+          return validateNoNonNumerical(value) || t('invalidNonNumerical')
+        },
+        validPostalCode: (value: string) => {
+          if (value === '') return true
+          return validatePostalCode(value) || t('invalidPostalCode')
+        },
       },
-      validPostalCode: (value: string) => {
-        if (value === '') return true
-        return validatePostalCode(value) || 'Please enter a valid postal code'
-      },
-    },
-  }
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
-export const createBlockNumberValidationRules: ValidationRuleFn<
+export const useBlockNumberValidationRules: ValidationRuleFn<
   AddressCompoundFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validBlock: (value: string) => {
-        if (value === '') return true
-        return validateNoSpecialCharacters(value) || INVALID_BLOCK_UNIT_ERROR
-      },
-    },
-  }
-}
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
 
-export const createStreetNameValidationRules: ValidationRuleFn<
-  AddressCompoundFieldBase
-> = (schema, disableRequiredValidation): RegisterOptions => {
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-    },
-  }
+  return useMemo(() => {
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validBlock: (value: string) => {
+          if (value === '') return true
+          return validateNoSpecialCharacters(value) || t('invalidBlockUnit')
+        },
+      },
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 export const useStreetNameValidationRules: ValidationRuleFn<
@@ -361,48 +355,64 @@ export const useStreetNameValidationRules: ValidationRuleFn<
   }, [schema, disableRequiredValidation, t])
 }
 
-export const createLevelNumberValidationRules: ValidationRuleFnUnitAndLevelNo<
+export const useLevelNumberValidationRules: ValidationRuleFnUnitAndLevelNo<
   AddressCompoundFieldBase
 > = (
   schema,
   getValues: UseFormGetValues<AddressCompoundFieldInput>,
 ): RegisterOptions => {
-  return {
-    validate: {
-      validLevel: (value: string) => {
-        if (value === '') return true
-        return validateNoNonNumerical(value) || INVALID_NON_NUMERICAL_ERROR
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        validLevel: (value: string) => {
+          if (value === '') return true
+          return validateNoNonNumerical(value) || t('invalidNonNumerical')
+        },
+        validInput: () => {
+          if (!getValues) return true
+          const levelNo = getValues(
+            `${schema._id}.addressSubFields.levelNumber`,
+          )
+          const unitNo = getValues(`${schema._id}.addressSubFields.unitNumber`)
+          return validateLevelUnit(levelNo, unitNo) || t('invalidLevelUnit')
+        },
       },
-      validInput: () => {
-        if (!getValues) return true
-        const levelNo = getValues(`${schema._id}.addressSubFields.levelNumber`)
-        const unitNo = getValues(`${schema._id}.addressSubFields.unitNumber`)
-        return validateLevelUnit(levelNo, unitNo) || INVALID_LEVEL_UNIT_ERROR
-      },
-    },
-  }
+    }
+  }, [schema, getValues, t])
 }
 
-export const createUnitNumberValidationRules: ValidationRuleFnUnitAndLevelNo<
+export const useUnitNumberValidationRules: ValidationRuleFnUnitAndLevelNo<
   AddressCompoundFieldBase
 > = (
   schema,
   getValues: UseFormGetValues<AddressCompoundFieldInput>,
 ): RegisterOptions => {
-  return {
-    validate: {
-      validUnit: (value: string) => {
-        if (value === '') return true
-        return validateNoSpecialCharacters(value) || INVALID_BLOCK_UNIT_ERROR
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        validUnit: (value: string) => {
+          if (value === '') return true
+          return validateNoSpecialCharacters(value) || t('invalidBlockUnit')
+        },
+        validInput: () => {
+          if (!getValues) return true
+          const unitNo = getValues(`${schema._id}.addressSubFields.unitNumber`)
+          const levelNo = getValues(
+            `${schema._id}.addressSubFields.levelNumber`,
+          )
+          return validateLevelUnit(unitNo, levelNo) || t('invalidLevelUnit')
+        },
       },
-      validInput: () => {
-        if (!getValues) return true
-        const unitNo = getValues(`${schema._id}.addressSubFields.unitNumber`)
-        const levelNo = getValues(`${schema._id}.addressSubFields.levelNumber`)
-        return validateLevelUnit(unitNo, levelNo) || INVALID_LEVEL_UNIT_ERROR
-      },
-    },
-  }
+    }
+  }, [schema, getValues, t])
 }
 
 export const useMobileValidationRules: ValidationRuleFnEmailAndMobile<

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -264,22 +264,29 @@ export const useAttachmentValidationRules: ValidationRuleFn<
   return useBaseValidationRules(schema, disableRequiredValidation)
 }
 
-export const createHomeNoValidationRules: ValidationRuleFn<HomenoFieldBase> = (
-  schema,
-  disableRequiredValidation,
+export const useHomeNoValidationRules = (
+  schema: HomenoFieldBase,
+  disableRequiredValidation?: boolean,
 ): RegisterOptions => {
-  return {
-    validate: {
-      required: requiredSingleAnswerValidationFn(
-        schema,
-        disableRequiredValidation,
-      ),
-      validHomeNo: (val?: string) => {
-        if (!val) return true
-        return isHomePhoneNumber(val) || 'Please enter a valid landline number'
+  const { t } = useTranslation('translation', {
+    keyPrefix: I18N_KEY_PREFIX,
+  })
+
+  return useMemo(() => {
+    return {
+      validate: {
+        required: requiredSingleAnswerValidationFn(
+          schema,
+          disableRequiredValidation,
+          t,
+        ),
+        validHomeNo: (val?: string) => {
+          if (!val) return true
+          return isHomePhoneNumber(val) || t('validHomeNo')
+        },
       },
-    },
-  }
+    }
+  }, [schema, disableRequiredValidation, t])
 }
 
 // i18n this next

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -60,12 +60,9 @@ import { Fields } from '~/i18n/locales/features/public-form/fields'
 
 import {
   INVALID_BLOCK_UNIT_ERROR,
-  INVALID_COUNTRY_REGION_OPTION_ERROR,
-  INVALID_DROPDOWN_OPTION_ERROR,
   INVALID_EMAIL_ERROR,
   INVALID_LEVEL_UNIT_ERROR,
   INVALID_NON_NUMERICAL_ERROR,
-  INVALID_POSTAL_CODE_ERROR,
   REQUIRED_ERROR,
 } from '~constants/validation'
 import {
@@ -178,19 +175,21 @@ export const createBaseValidationRules = <
   }
 }
 
+// i18n this next
 export const createDropdownValidationRules: ValidationRuleFn<
   DropdownFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
   return createDropdownValidationRulesWithCustomErrorMessage(
-    INVALID_DROPDOWN_OPTION_ERROR,
+    'Entered value is not a valid dropdown option',
   )(schema, disableRequiredValidation)
 }
 
+// i18n this next
 export const createCountryRegionValidationRules: ValidationRuleFn<
   DropdownFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
   return createDropdownValidationRulesWithCustomErrorMessage(
-    INVALID_COUNTRY_REGION_OPTION_ERROR,
+    'Please select a valid country/region from the dropdown list',
   )(schema, disableRequiredValidation)
 }
 
@@ -249,6 +248,7 @@ export const createHomeNoValidationRules: ValidationRuleFn<HomenoFieldBase> = (
   }
 }
 
+// i18n this next
 export const createPostalCodeValidationRules: ValidationRuleFn<
   AddressCompoundFieldBase
 > = (schema, disableRequiredValidation): RegisterOptions => {
@@ -264,7 +264,7 @@ export const createPostalCodeValidationRules: ValidationRuleFn<
       },
       validPostalCode: (value: string) => {
         if (value === '') return true
-        return validatePostalCode(value) || INVALID_POSTAL_CODE_ERROR
+        return validatePostalCode(value) || 'Please enter a valid postal code'
       },
     },
   }


### PR DESCRIPTION
## Problem

Partially closes https://github.com/opengovsg/FormSG/issues/8168
Many more field hooks are yet to be converted since some constants are intertwined with tests, non-react code, etc. Have already drafted a change but a bit messy, will commit it after I'm back from my leave.

## Solution
- Convert rule to hooks using `t()`
- Delete single use constants for convenience (since they'll be referenced in `en-sg.ts` anyway)
- For constants used in > 2 places, the constants will be refactored to store the key path pointing to `en-sg.ts` instead, so that it's both reusable in the codebase and also in test (for assertions)
- TBA: add a i18n config for tests so that it can reuse the same constants everywhere, pending tidying up, will be committed after
- Refactors....

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Improvements**:

- Extraction of text as i18next interpolation values


