### PR TITLE
fix(i18n): replacement values

### DIFF
--- a/frontend/src/i18n/locales/utils/form-validation/en-sg.ts
+++ b/frontend/src/i18n/locales/utils/form-validation/en-sg.ts
@@ -4,13 +4,13 @@ export const enSG: FormValidation = {
   titleValidationRules: {
     required: 'Form name is required',
     minLength: {
-      message: 'Form name must be at least {minTitleLength} characters',
+      message: 'Form name must be at least {MIN_TITLE_LENGTH} characters',
     },
     maxLength: {
-      message: 'Form name must be at most {maxTitleLength} characters',
+      message: 'Form name must be at most {MAX_TITLE_LENGTH} characters',
     },
     validate: {
-      trimMinLength: 'Form name must be at least {minTitleLength} characters',
+      trimMinLength: 'Form name must be at least {MIN_TITLE_LENGTH} characters',
     },
   },
   requiredEmailAdminValidationRules: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Replacement reference value introduced in #8311 was incorrectly mapped resulting in the templated value displaying raw keys.

## Solution
<!-- How did you solve the problem? -->

Use the correct values.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Component | Before | After |
|--------|--------|--------|
| Title - less than | ![image](https://github.com/user-attachments/assets/1fc98906-330c-41ee-a891-b17a32b1bf26) | <img width="705" alt="Screenshot 2025-04-28 at 2 02 48 PM" src="https://github.com/user-attachments/assets/3000cc7d-3e0b-4950-9620-d48417ed4362" />|
| Title - more than | <img width="805" alt="Screenshot 2025-04-28 at 2 03 18 PM" src="https://github.com/user-attachments/assets/3f35714a-9aef-4db0-8bc1-46f3a7ca02b5" /> | <img width="703" alt="Screenshot 2025-04-28 at 2 03 37 PM" src="https://github.com/user-attachments/assets/12e5fa3e-ec1a-46d0-b3d4-4587859ee285" /> | 

## Tests
<!-- What tests should be run to confirm functionality? -->
### Regression
- [ ] Make a form
- [ ] Go to `Settings` > `General`
- [ ] Change form title below min or below max
- [ ] Go to `Settings` > `Email notifications`
- [ ] Add falsy emails
- [ ] Test that the form validation is working (for both email and title validation rules)
- [ ] Make sure it doesn't necessarily rerender (as we're using `useMemo` already)