### PR TITLE
chore: turn off react-refresh on non-relevant files

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -45,6 +45,12 @@ module.exports = {
         'no-unsafe-optional-chaining': 'off',
       },
     },
+    {
+      files: ['**/*Context.[jt]s?(x)', '**/*Provider.[jt]s?(x)'],
+      rules: {
+        'react-refresh/only-export-components': 'off',
+      },
+    },
   ],
   ignorePatterns: ['!.storybook'],
   rules: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`react-refresh` eslint rule is applied on files which we actually want to have two exports (i.e., Context / Providers should have its hooks close).

This should help to reduce the noise when reviewing PRs.

## Solution
<!-- How did you solve the problem? -->

Detect files that ends with `**/*Context.[jt]s?(x)` or `**/*Provider.[jt]s?(x)`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
