### PR TITLE
fix(payment): remove dedup event

### DIFF
--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -485,7 +485,9 @@ export const handleStripeEvent = (
             if (processedEventType === ProcessEventType.DuplicateEvent) {
               // If the event was a duplicate, we do not need to send the
               // confirmation email again.
-              return okAsync(undefined)
+              // TODO: FRM-2017 Removing this temporarily as we found that there were
+              // instances where webhooks were not sent as a result
+              // return okAsync(undefined)
             }
 
             return PaymentsService.performPaymentPostSubmissionActions(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The fix introduced in #8326 resulted in some payment webhooks to be not sent.

Closes FRM-2017

## Solution
<!-- How did you solve the problem? -->

Not sure what’s the root cause yet, but we think that having duplicated webhook is better than having no webhooks fired.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Create a payment form
- [ ] Make a payment on a payment form
- [ ] Observe that payment is confirmed on Dedicated Payment Page
- [ ] Observe that payment receipt is received
- [ ] As an admin, ensure that submission is found on Results Page