### PR TITLE
fix: update findPaymentById to always have primary read preference

### DIFF
--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -50,7 +50,9 @@ export const findPaymentById = (
       paymentId,
       null,
       // readPreference from transaction isn't respected, thus we are setting it on operation
-      session ? { session, readPreference: 'primary' } : null,
+      session
+        ? { session, readPreference: 'primary' }
+        : { readPreference: 'primary' },
     ),
     (error) => {
       logger.error({


### PR DESCRIPTION
## Problem
Stripe is sending us 2 `charge.succeeded` events, causing us to have to handle duplicated events. This is because the 1st `charge.succeeded` event is being failed to process due to (hypothesis) database node replication lag.

`payments.completedPayments` is written into the primary database node, but when attempting to read it again downstream in `performPaymentPostSubmissionActions` in `findPaymentById`, our application is unable to find it because there is a possibility that it spins up a session on a secondary node that does not yet have the updates from the primary node.

Closes FRM-2019

## Solution
Force read of `completedPayments` to always be on the primary node by referencing `readPreference: primary`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

**Make a successful payment submission**
- [ ] Create a form with payment or use an existing payment form
- [ ] Attempt to make a payment submission
- [ ] Observe that you are successfully able to make payment and submit the form 
