### PR TITLE
fix: softblock of FRM-2017 to stop duplicate firing of payment webhooks

### DIFF
--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -485,7 +485,13 @@ export const handleStripeEvent = (
             if (processedEventType === ProcessEventType.DuplicateEvent) {
               // If the event was a duplicate, we do not need to send the
               // confirmation email again.
-              return okAsync(undefined)
+              // TODO: FRM-2017 Removing this temporarily as we found that there were
+              // instances where webhooks were not sent as a result
+              logger.warn({
+                message: 'Duplicated Event found',
+                meta: logMeta,
+              })
+              // return okAsync(undefined)
             }
 
             return PaymentsService.performPaymentPostSubmissionActions(

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -485,9 +485,7 @@ export const handleStripeEvent = (
             if (processedEventType === ProcessEventType.DuplicateEvent) {
               // If the event was a duplicate, we do not need to send the
               // confirmation email again.
-              // TODO: FRM-2017 Removing this temporarily as we found that there were
-              // instances where webhooks were not sent as a result
-              // return okAsync(undefined)
+              return okAsync(undefined)
             }
 
             return PaymentsService.performPaymentPostSubmissionActions(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Original issue was related to FormSG firing 2 duplicated payment webhooks due to a scenario of a pending payments submission + cron job check overlapping. A fix was introduced FRM-2017 to check for a duplicated event and skip firing the second webhook.

After introducing this fix, it was found that FormSG was occasionally not firing payment webhooks. Fix was reverted because it was deemed better to fire duplicated webhooks than not firing at all. 

Why no webhooks were fired:
- webhooks are fired on handling `charge.succeeded` stripe events.
- On the handling 1st event, we were receiving `Submission ID from completed payment could not be found`, leading to no webhooks being fired by FormSG and a firing of 2nd of the `charge.succeeded` event by stripe on their end.
- Upon handling second `charge.succeeded` event, event is deemed as a `DuplicatedEvent`, skipping the webhook firing by FormSG, resulting in no webhooks being fired at all.
- Root cause of submission ID not being able to be found was due to replication lag. Another fix was implemented to always read from primary and this resolved handling 1st event failure

![image](https://github.com/user-attachments/assets/ace289d1-065e-48af-a182-e4e49c26020c)

## Solution
<!-- How did you solve the problem? -->

Now that webhooks are successfully handled on first try, reintroducing a soft block from original fix to check when/if we are firing duplicated payments webhooks.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

- [ ] Create a form and include a payments field
- [ ] Successfully submit payments form