### PR TITLE
fix(submit): reduce log pollution by only logging when email is sent

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -782,11 +782,6 @@ const _createSubmission = async ({
     responseMetadata,
   }
 
-  logger.info({
-    message: 'Sending admin notification mail',
-    meta: logMetaWithSubmission,
-  })
-
   const emailData = new SubmissionEmailObj(
     emailFields,
     new Set(), // the MyInfo prefixes are already inserted in middleware
@@ -806,6 +801,11 @@ const _createSubmission = async ({
   // submissions regardless, the email is more of a notification and shouldn't
   // stop the storage of the data in the db
   if (((form as IEncryptedForm)?.emails || []).length > 0) {
+    logger.info({
+      message: 'Sending admin notification mail',
+      meta: logMetaWithSubmission,
+    })
+
     void MailService.sendSubmissionToAdmin({
       replyToEmails: EmailSubmissionService.extractEmailAnswers(emailFields),
       form,


### PR DESCRIPTION
## Problem
`Sending admin notification mail` is sent even when `MailService.sendSubmissionToAdmin` is not called.

context: was debugging a possible email bounce issue on Lao deployment of Form. got misled by this log.

## Solution
Only log when email is actually sent.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Improvements**:

- Proper logging

## Tests
- No functional logic change (thus no changed test)
- This is an observability change

## Deploy Notes
- This would reduce the number of occurrence of `Sending admin notification mail` in backend logs, since previously it logs on every submission. Now it only logs when only when email list is configured.
- Need to highlight this explicitly to not be surprised of the occurrence drop if this PR does get merged in
