### PR TITLE
feat: add error span tag for dd retention filter to index

### DIFF
--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -22,6 +22,7 @@ export const setFormTags = (form: IPopulatedForm) => {
 export const setErrorCode = (error: ApplicationError) => {
   const span = tracer.scope().active()
   if (span && error.code) {
+    span.setTag('status', 'error') // RATIONALE: ensures all errors are indexed by DD default error retention filter. This allows for Trace analytic monitors to work on error codes set below.
     span.setTag('span.error.type', error.code)
     span.setTag('span.error.message', `[${error.code}] ${error.message}`)
     if (error.stack) span.setTag('span.error.stack', `${error.stack}`)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, DataDog does not index all spans which include errors (this is due to error spans being marked as `status: ok` which is the default). This leads to some error spans not occurring in trace searches and inability to use APM Trace Analytic monitors as they can only filter indexed spans.

Currently, only our webhook failures are caught by the retention filter. 

Closes FRM-2022 

## Solution
<!-- How did you solve the problem? -->
Set a status: error tag for error spans so that they are indexed by the Default Error retention filter.   

Note: DD costs may increase due to the increased number of indexed spans, but this is only limited to error spans which should be indexed and the $ amount is expected to be marginal (est 2mil/month additional indexed spans) for immediate incident notifications and specific incident messages. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  