### PR TITLE
feat: add iac tag

### DIFF
--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -138,7 +138,7 @@
         { "name": "DD_APM_NON_LOCAL_TRAFFIC", "value": "true" },
         { "name": "DD_APM_ENABLED", "value": "true" },
         { "name": "DD_SITE", "value": "datadoghq.com" },
-        { "name": "DD_TAGS", "value": "env:<DD_ENV> team:formsg service:formsg" },
+        { "name": "DD_TAGS", "value": "env:<DD_ENV> team:formsg service:formsg iac:true" },
         { "name": "DD_LOGS_INJECTION", "value": "true" },
         { "name": "DD_RUNTIME_METRICS_ENABLED", "value": "true" }
       ],


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, on DD, there is no reliable way to identify spans from pre-IaC and IaC deployments (only can use the log source: kinesis-db, but this is not as reliable and could lead to filtering issues). 

We need a way to distinguish the spans between iac and pre-iac deployments for observability and monitoring in the event of failures. 

FRM-2023

## Solution
<!-- How did you solve the problem? -->
Add a DD tag for filtering spans / logs for iac env. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  