### PR TITLE
fix: only send mrf rc when has respondent emails

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1388,6 +1388,87 @@ describe('multirespondent-submission.service', () => {
   })
 
   describe('sendRespondentCopyEmail', () => {
+    it('should not send respondent copy if respondent emails are not present on performMultiRespondentPostSubmissionCreateActions', async () => {
+      // Arrange
+      const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+        MailService,
+        'sendMrfRespondentCopyEmail',
+      )
+
+      const singleStepWorkflow: FormWorkflowStepDto[] = [
+        {
+          _id: new ObjectId().toHexString(),
+          workflow_type: WorkflowType.Static,
+          emails: [],
+          edit: [],
+        },
+      ]
+
+      const emptyRespondentEmails: string[] = []
+
+      // Act
+      await performMultiRespondentPostSubmissionCreateActions({
+        submissionId: mockSubmissionId,
+        form: {
+          _id: mockFormId,
+          workflow: singleStepWorkflow,
+          emails: ['email1@example.com'],
+        } as IPopulatedMultirespondentForm,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+        respondentEmails: emptyRespondentEmails,
+      })
+
+      // Assert
+      expect(sendMrfRespondentCopyEmailSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not send respondent copy if respondent emails are not present on performMultiRespondentPostSubmissionUpdateActions', async () => {
+      // Arrange
+      const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+        MailService,
+        'sendMrfRespondentCopyEmail',
+      )
+
+      const singleStepWorkflow: FormWorkflowStepDto[] = [
+        {
+          _id: new ObjectId().toHexString(),
+          workflow_type: WorkflowType.Static,
+          emails: [],
+          edit: [],
+        },
+      ]
+
+      const emptyRespondentEmails: string[] = []
+
+      // Act
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submissionId: mockSubmissionId,
+        form: {
+          _id: mockFormId,
+          workflow: singleStepWorkflow,
+          emails: ['email1@example.com'],
+        } as IPopulatedMultirespondentForm,
+        currentStepNumber: 1,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+        respondentEmails: emptyRespondentEmails,
+      })
+
+      // Assert
+      expect(sendMrfRespondentCopyEmailSpy).not.toHaveBeenCalled()
+    })
+
     it('sends respondent copy on first step submission when respondent emails are present', async () => {
       // Arrange
       const sendMrfRespondentCopyEmailSpy = jest.spyOn(

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1538,6 +1538,7 @@ describe('multirespondent-submission.service', () => {
         responseUrl: 'http://test.com',
         formId: 'formId',
         reminderStepNumber: 1,
+        senderEmail: 'senderEmail@example.com',
       })
 
       // Assert

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -626,7 +626,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
     submissionId,
   }
 
-  if (respondentEmails) {
+  if (respondentEmails && respondentEmails.length > 0) {
     sendMrfRespondentCopyEmails({
       form,
       responses,
@@ -635,7 +635,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
       respondentEmails,
     }).mapErr((error) => {
       logger.error({
-        message: 'Send multirespondent respondent copy email error',
+        message: `Send multirespondent respondent copy email error ${respondentEmails} something here ${respondentEmails ? 'HAS' : 'NONE'}`,
         meta: logMeta,
         error,
       })

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -635,7 +635,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
       respondentEmails,
     }).mapErr((error) => {
       logger.error({
-        message: `Send multirespondent respondent copy email error ${respondentEmails} something here ${respondentEmails ? 'HAS' : 'NONE'}`,
+        message: 'Send multirespondent respondent copy email error',
         meta: logMeta,
         error,
       })
@@ -861,7 +861,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     submissionId,
   }
 
-  if (respondentEmails) {
+  if (respondentEmails && respondentEmails.length > 0) {
     sendMrfRespondentCopyEmails({
       form,
       responses,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, if there is an mrf submission without respondent copy emails, an attempt to send out `sendMrfRespondentCopyEmails` will occur because the `respondentEmails` is an empty `[]`, which passes the `if (respondentEmails)` check.

## Solution
Additionally check if respondentEmails has `length > 0`.

More context. Initial attempt was made to set `respondentEmails` defaultValue as `undefined`. However, if a user interacts with the input field (e.g. add an email and then remove it), `respondentEmails` with stick to an empty `[]`; this needs to be handled downstream as well. Therefore check happens right before respondent copy emails are sent out.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
