### PR TITLE
feat: move error to the error object

### DIFF
--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -22,9 +22,8 @@ export const setFormTags = (form: IPopulatedForm) => {
 export const setErrorCode = (error: ApplicationError) => {
   const span = tracer.scope().active()
   if (span && error.code) {
-    span.setTag('status', 'error') // RATIONALE: ensures all errors are indexed by DD default error retention filter. This allows for Trace analytic monitors to work on error codes set below.
-    span.setTag('span.error.type', error.code)
-    span.setTag('span.error.message', `[${error.code}] ${error.message}`)
-    if (error.stack) span.setTag('span.error.stack', `${error.stack}`)
+    span.setTag('error.type', error.code)
+    span.setTag('error.message', `[${error.code}] ${error.message}`)
+    if (error.stack) span.setTag('error.stack', `${error.stack}`)
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Any span with our application defined error codes [100000 TO 99999] should be indexed by the default error retention filter for use in APM Trace analytic monitors and to reflect in our dashboards accurately. 
To index them, `status: error` must be set via setting the [Datadog Error object](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/nodejs/dd-api/?tab=errors). 

Note that previously, `span.error.X` was explicitly chosen in https://github.com/opengovsg/FormSG/pull/7524#issue-2410092620. 
This was for 3 reasons: 
1. to prevent indexing of too many errors to save $. However, upon computation, the cost will be roughly 2 mil spans/month aka $3.85USD/month, which is marginal for the benefits of unlocking APM trace analytics which were previously not fed correct information. 
2. to avoid spans with error.types but with 200 ok codes which contribute to noise. These errors are usually business related errors. However, after further discussion with Ken, we do want to index these business errors as: 
- These business errors can also give insight into our observability (Eg, what if there is a large surge of FormPrivateError across multiple forms? could it point to misconfigurations in the database?)
- The noise problem can be easily solved via filtering (eg, status:error + status != 200 OK). 
3. The `error.type` does not show up in the span tags. This is fine since it is included in the `span.message` and still can be filtered in the filter. 

Closes FRM-2028

## Solution
<!-- How did you solve the problem? -->
Use the default Datadog error object. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  