### PR TITLE
feat: add error count metric 

### DIFF
--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -7,8 +7,7 @@
         { "containerPort": 4545, "hostPort": 4545, "protocol": "tcp" }
       ],
       "environment": [
-        { "name": "DD_SERVICE", "value": "formsg" }, 
-        { "name": "DD_ENV", "value": "<DD_ENV>" }
+        { "name": "DD_SERVICE", "value": "formsg" }
       ],
       "secrets": [
         { "name": "IS_IAC_MIGRATED", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/IS_IAC_MIGRATED" },

--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -7,7 +7,8 @@
         { "containerPort": 4545, "hostPort": 4545, "protocol": "tcp" }
       ],
       "environment": [
-        { "name": "DD_SERVICE", "value": "formsg" }
+        { "name": "DD_SERVICE", "value": "formsg" }, 
+        { "name": "DD_ENV", "value": "<DD_ENV>" }
       ],
       "secrets": [
         { "name": "IS_IAC_MIGRATED", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/IS_IAC_MIGRATED" },

--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -273,7 +273,10 @@ export class ApplicationError extends Error {
 
     if (this.code) {
       setErrorCode(this)
-      submitErrorCountMetric(this.code)
+      submitErrorCountMetric({
+        errorName: this.name,
+        errorCode: this.code,
+      })
     }
   }
 }

--- a/src/app/modules/core/core.errors.ts
+++ b/src/app/modules/core/core.errors.ts
@@ -1,4 +1,4 @@
-import { setErrorCode } from '../datadog/datadog.utils'
+import { setErrorCode, submitErrorCountMetric } from '../datadog/datadog.utils'
 
 /**
  * Global Error Code Registry
@@ -273,6 +273,7 @@ export class ApplicationError extends Error {
 
     if (this.code) {
       setErrorCode(this)
+      submitErrorCountMetric(this.code)
     }
   }
 }

--- a/src/app/modules/datadog/__mocks__/datadog.utils.ts
+++ b/src/app/modules/datadog/__mocks__/datadog.utils.ts
@@ -16,3 +16,8 @@ export const setFormTags = (_form: IPopulatedForm) => {
 export const setErrorCode = (_error: ApplicationError) => {
   return
 }
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const submitErrorCountMetric = (_errorCode: number) => {
+  return
+}

--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -21,10 +21,20 @@ export const setFormTags = (form: IPopulatedForm) => {
  */
 export const setErrorCode = (error: ApplicationError) => {
   const span = tracer.scope().active()
+
   if (span && error.code) {
-    span.setTag('status', 'error') // RATIONALE: ensures all errors are indexed by DD default error retention filter. This allows for Trace analytic monitors to work on error codes set below.
     span.setTag('span.error.type', error.code)
     span.setTag('span.error.message', `[${error.code}] ${error.message}`)
     if (error.stack) span.setTag('span.error.stack', `${error.stack}`)
   }
+}
+
+/**
+ * Submits an error count metric to Datadog. Used for monitoring errors and dashboard visualizations.
+ * @param errorCode The error code to submit the metric for
+ */
+export const submitErrorCountMetric = (errorCode: number) => {
+  tracer.dogstatsd.increment('error.count', 1, {
+    code: errorCode,
+  })
 }

--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -34,7 +34,7 @@ export const setErrorCode = (error: ApplicationError) => {
  * @param errorCode The error code to submit the metric for
  */
 export const submitErrorCountMetric = (errorCode: number) => {
-  tracer.dogstatsd.increment('error.count', 1, {
+  tracer.dogstatsd.increment('formsg.error.count', 1, {
     code: errorCode,
   })
 }

--- a/src/app/modules/datadog/datadog.utils.ts
+++ b/src/app/modules/datadog/datadog.utils.ts
@@ -33,8 +33,18 @@ export const setErrorCode = (error: ApplicationError) => {
  * Submits an error count metric to Datadog. Used for monitoring errors and dashboard visualizations.
  * @param errorCode The error code to submit the metric for
  */
-export const submitErrorCountMetric = (errorCode: number) => {
+export const submitErrorCountMetric = ({
+  errorName,
+  errorCode,
+}: {
+  errorName: string
+  errorCode: number
+}) => {
   tracer.dogstatsd.increment('formsg.error.count', 1, {
     code: errorCode,
+    // NOTE: since the granularity is the same even when adding name (ie, the name is the same for each error code),
+    // the number and hence cost of custom metrics is the same despite adding the name tag.
+    // Avoid using the error message as it can frequently change, increasing the number and cost of custom metrics.
+    name: `[${errorCode}] ${errorName}`,
   })
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
1. Need to accurately count the number of errors of various codes occurring in FormSG. 

Closes FRM-2028

## Solution
<!-- How did you solve the problem? -->
1. Add a DD custom metric that counts the number of errors with error code tag & remove setTag('status', 'error'). 
3. Include the default DD_ENV env for env tagging in the logs. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  