### PR TITLE
feat: add missing dd env

### DIFF
--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -7,7 +7,8 @@
         { "containerPort": 4545, "hostPort": 4545, "protocol": "tcp" }
       ],
       "environment": [
-        { "name": "DD_SERVICE", "value": "formsg" }
+        { "name": "DD_SERVICE", "value": "formsg" }, 
+        { "name": "DD_ENV", "value": "<DD_ENV>" }
       ],
       "secrets": [
         { "name": "IS_IAC_MIGRATED", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/IS_IAC_MIGRATED" },

--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -139,7 +139,8 @@
         { "name": "DD_APM_NON_LOCAL_TRAFFIC", "value": "true" },
         { "name": "DD_APM_ENABLED", "value": "true" },
         { "name": "DD_SITE", "value": "datadoghq.com" },
-        { "name": "DD_TAGS", "value": "env:<DD_ENV> team:formsg service:formsg iac:true" },
+        { "name": "DD_SERVICE", "value": "formsg" },
+        { "name": "DD_ENV", "value": "<DD_ENV>" },
         { "name": "DD_LOGS_INJECTION", "value": "true" },
         { "name": "DD_RUNTIME_METRICS_ENABLED", "value": "true" }
       ],


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
DD logs for iac env are missing the env tag used for filtering logs. 

## Solution
<!-- How did you solve the problem? -->
Add `DD_ENV` so that the env tag is instrumented. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  