### PR TITLE
wip: detect and deploy staging virus-scanner

### DIFF
--- a/.github/workflows/deploy-virus-scanner-legacy-staging.yml
+++ b/.github/workflows/deploy-virus-scanner-legacy-staging.yml
@@ -1,0 +1,29 @@
+name: Deploy Legacy Virus Scanner to new OGP AWS environment
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - staging
+  # For legacy virus scanner: schedule builds for 12:00AM GMT+8 everyday to get latest ClamAV virus definitions
+  schedule:
+    - cron: '0 16 * * *'
+
+jobs:
+  deploy-scanner:
+    name: Deploy Scanner
+    uses: ./.github/workflows/aws-deploy-scanner-legacy.yml
+    with:
+      checkoutBranch: 'staging'
+      gha-environment: 'staging'
+      environment: 'production'
+      provisionedConcurrency: 10
+    secrets:
+      cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}


### PR DESCRIPTION
# Keeping as open to trigger gh action

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Deployment to `staging` doesn't trigger ClamAV flow to redeploy

## Solution
<!-- How did you solve the problem? -->

Restore script for `staging`.

Note that EC2's `staging`, `staging-*` references `staging` ClamAV flow

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
