### PR TITLE
fix: retain isForceConvertToStorageMode for email mode form converts

### DIFF
--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -122,7 +122,6 @@ export const FormStatusToggle = (): JSX.Element => {
             formId={formId!}
           />
         )}
-        )
         {(formSettings?.responseMode === FormResponseMode.Encrypt ||
           formSettings?.responseMode === FormResponseMode.Multirespondent) && (
           <SecretKeyActivationModal

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -277,6 +277,11 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
       gstRegNo: { type: String, default: '', trim: true },
     },
   },
+
+  isForceConvertToStorageMode: {
+    type: Boolean,
+    required: false,
+  },
 })
 
 const EncryptedFormDocumentSchema =

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1873,7 +1873,7 @@ export const updateFormSettings = (
     ) {
       return errAsync(
         new MalformedParametersError(
-          'Please refresh the page (Ctrl+Shift+R) to convert your form to storage mode and reopen it',
+          'Please refresh your browser (Ctrl+Shift+R) to convert your form to storage mode before opening it to responses. If you encounter issues, please contact FormSG.',
         ),
       )
     }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1873,7 +1873,7 @@ export const updateFormSettings = (
     ) {
       return errAsync(
         new MalformedParametersError(
-          'Operation denied: You must convert your form to storage mode before you may open your form to responses.',
+          'Please refresh the page (Ctrl+Shift+R) to convert your form to storage mode and reopen it',
         ),
       )
     }

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -326,6 +326,7 @@ export interface IEncryptedForm extends IForm {
   business?: FormBusinessField
   emails?: string[]
   whitelistedSubmitterIds?: WhitelistedSubmitterIds
+  isForceConvertToStorageMode?: boolean
 }
 
 export type IEncryptedFormSchema = IEncryptedForm & IFormSchema


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When email mode forms are converted to storage mode, the `isForceConvertToStorageMode` variable gets removed from the form definition, making tracking of conversion progress difficult (We won't know which storage mode forms were previously email mode)

## Solution
<!-- How did you solve the problem? -->

1. Retain `isForceConvertToStorageMode` variable when changing form definition from `email` to `encrypt`
2. Update error toast message copy change 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
