### PR TITLE
feat: magic form builder remove beta badge

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
@@ -37,7 +37,6 @@ import { useFeatureIsOn } from '@growthbook/growthbook-react'
 
 import { featureFlags, MFB_VISION_MAX_IMAGES_COUNT } from '~shared/constants'
 
-import Badge from '~components/Badge'
 import { NextAndBackButtonGroup } from '~components/Button'
 import Attachment from '~components/Field/Attachment'
 
@@ -253,14 +252,6 @@ const MagicFormBuilderCreateFormPrompt = ({
     <>
       <ModalHeader display="flex" alignItems="center">
         <Text textStyle="h2">Create fields with AI</Text>
-        <Badge
-          colorScheme="primary"
-          variant="subtle"
-          color="secondary.500"
-          ml="0.5rem"
-        >
-          Beta
-        </Badge>
       </ModalHeader>
       <ModalBody>
         <>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Magic Form Builder is sufficiently mature to graduate from Beta access

Closes FRM-2033

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

**Improvements**:

- Remove the **Beta** badge from the Magic Form Builder modal

## Before & After Screenshots

| Component | Before | After |
| :--------: |--------|--------|
| **Beta** badge | <img width="300" alt="Screenshot 2025-06-16 at 3 43 28 PM" src="https://github.com/user-attachments/assets/3211bfa3-98fb-4ba2-a301-2ad7c46d3c38" /> | <img width="300" alt="Screenshot 2025-06-16 at 3 43 35 PM" src="https://github.com/user-attachments/assets/8daf0c2c-e090-47fd-8de6-3b1b73f20546" /> | 

## Tests
<!-- What tests should be run to confirm functionality? -->

**Quick Check on the User Experience for the Magic Form Builder**
- [ ] Begin by creating a new Storage mode form
- [ ] On the empty form screen's central placeholder, Click on **Create fields with AI**
- [ ] Verify that the Magic Form Builder modal displays correctly.
- [ ] Ensure that the Beta badge to the right of the modal title "Create fields with AI" is no longer displayed.
