### PR TITLE
fix: checkbox validation bug

### DIFF
--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -104,7 +104,7 @@ export const CheckboxField = ({
           name={checkboxInputName}
           control={control}
           rules={validationRules}
-          render={({ field: { ref, ...field } }) => (
+          render={({ field: { ref, onBlur, ...field } }) => (
             <CheckboxGroup {...field}>
               {fieldOptions.map((o, idx) => (
                 <Checkbox
@@ -117,6 +117,7 @@ export const CheckboxField = ({
                   // of the language of the form.
                   value={englishCheckboxOptions[idx]}
                   aria-label={o}
+                  onBlur={idx === 0 ? onBlur : undefined}
                   {...(idx === 0 ? { ref } : {})}
                   isHighContrast={isHighContrast}
                 >

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -66,7 +66,8 @@ export const CheckboxField = ({
   const englishCheckboxOptions = schema.fieldOptions
   const selectedLanguage = i18n.language as Language
 
-  const { register, getValues, control } = useFormContext<CheckboxFieldInputs>()
+  const { register, getValues, control, trigger } =
+    useFormContext<CheckboxFieldInputs>()
   const { isValid, isSubmitting, errors } = useFormState<CheckboxFieldInputs>({
     name: schema._id,
   })
@@ -144,6 +145,9 @@ export const CheckboxField = ({
                       value={CHECKBOX_OTHERS_INPUT_VALUE}
                       isInvalid={!!get(errors, checkboxInputName)}
                       {...(isHighContrast && { variant: 'highContrast' })}
+                      onChange={() => {
+                        trigger(othersInputName)
+                      }}
                     />
                     <Checkbox.OthersInput
                       colorScheme={fieldColorScheme}


### PR DESCRIPTION
## Problem
Existing bug relating to checkbox field where upon the field has a constraint of min/max checkable options and the current checked options are not within the suitable range, the error message shows only after the user tries to submit a form.

Closes FRM-2034

## Solution
<!-- How did you solve the problem? -->
Force validation check on CheckboxGroup field upon user interaction utilizing `onBlur` to validation & display error message. Error message will show upon user interaction with the field instead of only on submitting of form.

Some details on why this bug occured:
RHF validation is triggered on onChange, onBlur and onSubmit (default)

Chakra's CheckboxGroup is a wrapper managing multiple checkbox inputs which defaults validation to onSubmit if not specified, and doesn't natively have an onBlur event. Without passing `onBlur`, RHF thinks the user never interacted with the field. 

It is not necessary to put `onBlur` to all checkbox fields since RHF treats the entire array field as one field and will call field-level handlers (onBlur) at least one per interaction of the field. Since the first checkbox is always rendered and focusable. Upon user interaction, the first checkbox’s blur event fires and RHF marks the whole field as touched.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

Assume field has been interacted with before the user clicks submit. Also assume a validation contraint of min=1, max=2 for the Checkbox Field.

**BEFORE**:
<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/c6663254-ad7a-496f-a784-66b32d01edfa)


**AFTER**:
<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/e03314f5-61c2-43d0-8874-68afeb48b53e)

## Tests
<!-- What tests should be run to confirm functionality? -->

**Verify error message to display upon user interaction of the field
- [ ] Create a form with a checkbox field with 3 options
- [ ] Set a min=1, max=2 limit for the field
- [ ] After making the form public, try to select all 3 options of the checkbox field
- [ ] Observe that the error message is displayed the instance >2 options are selected
- [ ] Confirm that form is unable to be submitted
- [ ] Remove a selected options (now total of 2)
- [ ] Observe that the error message is now gone
- [ ] Confirm that form is able to be submitted

**Error message refresh for OthersInputField (Text)
- [ ] Create a form with a checkbox field 
- [ ] Enable Toggle On for 'Others'
- [ ] Attempt to make a submission, interact with the 'Others' checkbox option
- [ ] Observe that on selection, empty text error message is displayed
- [ ] With the text field empty, unselect 'Others' checkbox option
- [ ] Observe that the empty text error message is gone
- [ ] Confirm that form is unable to be submitted with 'Others' checkbox option selected & text field is empty
- [ ] Confirm that form is able to be submitted with 'Others' checkbox option selected & text field is not-empty

