### PR TITLE
feat: add friendly message for cf intercepts

### DIFF
--- a/frontend/src/features/turnstile/handleCloudflareChallenge.tsx
+++ b/frontend/src/features/turnstile/handleCloudflareChallenge.tsx
@@ -1,0 +1,17 @@
+import { AxiosResponse } from 'axios'
+
+export const checkIsCloudflareChallengeError = (response: AxiosResponse) => {
+  return (
+    response &&
+    response.status === 403 &&
+    response.headers['server'] === 'cloudflare' &&
+    response.headers['cf-mitigated'] &&
+    response.headers['cf-ray']
+  )
+}
+
+export const handleCloudflareChallengeError = () => {
+  throw new Error(
+    'Your request was blocked due to security reasons. Please try again.',
+  )
+}

--- a/frontend/src/services/ApiService.ts
+++ b/frontend/src/services/ApiService.ts
@@ -8,6 +8,11 @@ import { ApiError } from '~typings/core'
 
 import { LOCAL_STORAGE_EVENT, LOGGED_IN_KEY } from '~constants/localStorage'
 
+import {
+  checkIsCloudflareChallengeError,
+  handleCloudflareChallengeError,
+} from '~features/turnstile/handleCloudflareChallenge'
+
 export const API_BASE_URL = import.meta.env.VITE_APP_BASE_URL ?? '/api/v3'
 export class HttpError extends Error {
   code: number
@@ -90,6 +95,10 @@ export const ApiService = axios.create({
 ApiService.interceptors.response.use(
   (response) => response,
   (error: AxiosError) => {
+    if (error.response && checkIsCloudflareChallengeError(error.response)) {
+      return handleCloudflareChallengeError()
+    }
+
     if (error.response?.status === 401) {
       // Remove logged in state from localStorage
       localStorage.removeItem(LOGGED_IN_KEY)

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
       },
       "devDependencies": {
         "@opengovsg/mockpass": "^4.3.4",
-        "@playwright/test": "^1.52.0",
+        "@playwright/test": "^1.53.0",
         "@types/bcrypt": "^5.0.0",
         "@types/bluebird": "^3.5.42",
         "@types/busboy": "^1.5.4",
@@ -8796,13 +8796,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
-      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
+      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.52.0"
+        "playwright": "1.53.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -22725,13 +22725,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.52.0"
+        "playwright-core": "1.53.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -22744,9 +22744,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
   },
   "devDependencies": {
     "@opengovsg/mockpass": "^4.3.4",
-    "@playwright/test": "^1.52.0",
+    "@playwright/test": "^1.53.0",
     "@types/bcrypt": "^5.0.0",
     "@types/bluebird": "^3.5.42",
     "@types/busboy": "^1.5.4",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
FormSG is proxied by CF's WAF and Super bot fight mode which sends challenges when suspicious requests are detected.
As such, when AJAX requests are made (eg, axios API calls), CF can intercept and return a challenge html as response, which do not match the current expected response of the AJAX request and causes a non-friendly `!DOCTYPE` error to be shown to users.  

<img width="644" alt="doctype" src="https://github.com/user-attachments/assets/eeb73ecd-5b68-4afe-8295-620d3ac950dd" />

Closes FRM-2032

## Solution
<!-- How did you solve the problem? -->
Detect and handle the intercepted challenge responses by showing a business friendly message based on UX writing practices.    

This PR is meant as part of mitigation for incident 546. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests 
TC1: Business friendly error replaces the previous !DOCTYPE error 
- [ ] Set up WAF rule to send challenges to OGP IP and connect to OGP VPN 
- [ ] On staging, go to the submit form page and clear your cookies for staging.form.gov.sg 
- [ ] Assert that the business friendly message pops up instead of the !DOCTYPE error  