### PR TITLE
feat: fail ci if cache miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches-ignore: 
+    branches-ignore:
       - staging
       - staging-alt
       - staging-alt2
@@ -83,6 +83,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          fail-on-cache-miss: true
       - run: npm run build
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
@@ -116,6 +117,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          fail-on-cache-miss: true
       - name: Configure Datadog Test Visibility
         uses: datadog/test-visibility-github-action@v1.0.5
         with:
@@ -149,6 +151,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          fail-on-cache-miss: true
       - run: npm run lint:frontend
 
   backend_test:
@@ -175,6 +178,7 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          fail-on-cache-miss: true
       - run: npm ci --prefix serverless/virus-scanner
       - run: npm ci --prefix serverless/virus-scanner-guardduty
       - name: Configure Datadog Test Visibility
@@ -214,5 +218,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          fail-on-cache-miss: true
       - run: npm run lint-ci
       - run: npm_config_mode=yes npx lockfile-lint --type npm --path package.json --validate-https --allowed-hosts npm

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,7 +2,7 @@ name: Playwright Tests
 
 on:
   push:
-    branches-ignore: 
+    branches-ignore:
       - staging
       - staging-alt
       - staging-alt2
@@ -100,6 +100,7 @@ jobs:
             frontend/.next
             shared/.next
           key: ${{ runner.os }}-build-${{ github.sha }}
+          fail-on-cache-miss: true
       - name: Configure Datadog Test Visibility
         uses: datadog/test-visibility-github-action@v1.0.5
         with:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When cache-misses for some packages, the workflow continues on to fail eventually. This causes the error to be emitted downstream and could be a red herring.

Closes FRM-2038

## Solution
<!-- How did you solve the problem? -->

Short-circuit failures early. If downstream is dependent on cache to be present, then we should `fail-on-cache-miss`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
