### PR TITLE
fix: mongoose issues

### DIFF
--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -2548,7 +2548,7 @@ describe('Form Model', () => {
         // Previous user should now be in permissionList with editor
         // permissions.
         expect(actual.toObject().permissionList).toEqual([
-          { email: populatedAdmin.email, write: true, _id: expect.anything() },
+          { email: populatedAdmin.email, write: true },
         ])
       })
     })

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1122,10 +1122,12 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     function (fieldId: string, insertionIndex: number) {
       const fieldToDuplicate = getFormFieldById(this.form_fields, fieldId)
       if (!fieldToDuplicate) return Promise.resolve(null)
-      const duplicatedField = omit(fieldToDuplicate, [
-        '_id',
-        'globalId',
-      ]) as FormFieldSchema
+
+      const formFieldsDocumentArray = this
+        .form_fields as Types.DocumentArray<IFieldSchema>
+      const duplicatedField = formFieldsDocumentArray.create(
+        omit(fieldToDuplicate.toObject(), ['_id', 'globalId']),
+      ) as FormFieldSchema
 
       this.form_fields.splice(insertionIndex, 0, duplicatedField)
       return this.save()

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -562,19 +562,22 @@ const compileFormModel = (db: Mongoose): IFormModel => {
 
       permissionList: {
         type: [
-          {
-            email: {
-              type: String,
-              trim: true,
-              required: true,
-              // Set email to lowercase for consistency
-              set: (v: string) => v.toLowerCase(),
+          new Schema(
+            {
+              email: {
+                type: String,
+                trim: true,
+                required: true,
+                // Set email to lowercase for consistency
+                set: (v: string) => v.toLowerCase(),
+              },
+              write: {
+                type: Boolean,
+                default: false,
+              },
             },
-            write: {
-              type: Boolean,
-              default: false,
-            },
-          },
+            { _id: false },
+          ),
         ],
         validate: {
           validator: (users: FormPermission[]) =>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Some bugs were found during release of mongoose upgrade
1. Cannot add more than 2 collaborators
![image](https://github.com/user-attachments/assets/4a296149-915c-4e57-ba7b-29f215739a36)

2. When duplicating field, duplicated field has the same _id 
![image](https://github.com/user-attachments/assets/133d202d-2e8e-4a97-9e39-bcb3e96abd3f)
## Solution
<!-- How did you solve the problem? -->
**Cannot add more than 2 collaborators**

- `permissionList` is returning a Dto with `_id` and `id`
- by default, **each subdocument gets its own `_id` field**. Mongoose also adds a **virtual `id` getter**, which is just `this._id.toString()`.
- setting `id: false` will disable the virtual setting of id
- To do that, creating a new schema for `permissionList`  is needed

**When duplicating field, duplicated field has the same `_id`** 

- `omit` creates a **plain JavaScript object**, not a proper Mongoose subdocument. In Mongoose v6, this works due to implicit casting. In v7, casting is stricter POJOs don’t automatically become subdocuments with new `_ids`
- Ids will then be duplicated, causing 2 fields to have the same `_id`
- Creating a new field while omit the previous `_id` will create a new subdocument with a new `_id`
- Then this needs to be casted back to a FormFieldSchema for it to be spliced into `this.form_fields`


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

## Tests
<!-- What tests should be run to confirm functionality? -->

**Adding 2+ Collaborators to a form**
- [x] Create a form/use an existing form
- [x] Try to add 2+ collaborators to the form. Observe the ability to do so.
- [x] Try changing collaborator access to viewer, and owner. Observe the ability to do so.

**Duplicating a form field**
- [x] Create a form and add any 1 field to the form
- [x] Attempt duplicating the form
- [x] Observe the ability to do so
- [x] Observe that you can independently update the original and duplicated field.
- [x] Make the form public and successfully make a submission 
- [x] Observe in admin portal responses that answers for both original and duplicated field are reflected
