### PR TITLE
fix: admin forms download path

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesService.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesService.ts
@@ -27,7 +27,7 @@ const generateDownloadUrl = (
 
   // Stringify all values in params.
   const uriEncodedParams = new URLSearchParams(mapValues(params, String))
-  return `${API_BASE_URL}/${ADMIN_FORM_ENDPOINT}/${formId}/submissions/download?${uriEncodedParams}`
+  return `${API_BASE_URL}${ADMIN_FORM_ENDPOINT}/${formId}/submissions/download?${uriEncodedParams}`
 }
 
 export const getEncryptedResponsesStream = async (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The FormSG Admin's download attachment button incorrectly concatenates the path with an extra `/`.

<img width="640" alt="image" src="https://github.com/user-attachments/assets/800491aa-fa73-4325-b5ba-97296da54d25" />

### Backstory

In the past, `axios` wasn't suitable for use with streaming data needed for downloading large numbers of attachments.
```typescript
  // Unable to use axios for streams, and thus using native fetch instead.
  return fetch(generateDownloadUrl(formId, params), {
  ...
```

To overcome this, native `fetch` was used instead. This introduced two complexities:
- [generation of the download URL api call was done using string concatenation](https://github.com/opengovsg/FormSG/blob/8a3499eec20f6bc5aa35c46b15b333a5321d3ab1/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesService.ts#L30)
- because **ApiService**'s basePath isn't applicable

Usage of Fetch also affects [these other API calls](https://github.com/search?q=repo%3Aopengovsg%2FFormSG+%22%24%7BAPI_BASE_URL%7D%24%7B%22&type=code) at this time:
- preview submissions email ([link](https://github.com/opengovsg/FormSG/blob/8a3499eec20f6bc5aa35c46b15b333a5321d3ab1/frontend/src/features/admin-form/common/AdminViewFormService.ts#L210))
- preview submissions storage ([link](https://github.com/opengovsg/FormSG/blob/8a3499eec20f6bc5aa35c46b15b333a5321d3ab1/frontend/src/features/admin-form/common/AdminViewFormService.ts#L234))
- submission of email forms ([link](https://github.com/opengovsg/FormSG/blob/8a3499eec20f6bc5aa35c46b15b333a5321d3ab1/frontend/src/features/public-form/PublicFormService.ts#L268))
- submission of storage forms ([link](https://github.com/opengovsg/FormSG/blob/8a3499eec20f6bc5aa35c46b15b333a5321d3ab1/frontend/src/features/public-form/PublicFormService.ts#L359))

One other place using [string concatenation in the API path](https://github.com/search?q=repo%3Aopengovsg%2FFormSG+%22%24%7BAPI_BASE_URL%7D%2F%24%7B%22&type=code) (correctly):
- [getPaymentInvoiceDownloadUrl](https://github.com/opengovsg/FormSG/blob/8a3499eec20f6bc5aa35c46b15b333a5321d3ab1/frontend/src/features/public-form/utils/urls.ts#L13)

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Remove the extraneous `/` in the API request
- Aligns with other uses of the `ADMIN_FORM_ENDPOINT` configuration variable

## Tests
<!-- What tests should be run to confirm functionality? -->

**Verify that downloading responses as an Admin works correctly**
- [ ] navigate to the FormSG Admin page
- [ ] select a form with responses and attachments
- [ ] open the Network tab in the Inspect Element pane
- [ ] click "Download" and select "Download with Attachments"
- [ ] verify that the network request to `download?downloadAttachments=true` has just one `/` between **/api/v3** and **/admin/forms**
