### PR TITLE
feat: use s3 proxy for uploading files

### DIFF
--- a/src/app/modules/submission/submission.controller.ts
+++ b/src/app/modules/submission/submission.controller.ts
@@ -443,7 +443,7 @@ export const getS3PresignedPostData: ControllerHandler<
     ...createReqMeta(req),
   }
 
-  return getQuarantinePresignedPostData(req.body)
+  return getQuarantinePresignedPostData(req.body, req.growthbook)
     .map((presignedUrls) => {
       logger.info({
         message: 'Successfully retrieved quarantine presigned post data.',

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -1,4 +1,5 @@
 import { InvokeCommandOutput } from '@aws-sdk/client-lambda'
+import { GrowthBook } from '@growthbook/growthbook'
 import { Uint8ArrayBlobAdapter } from '@smithy/util-stream/dist-types/blob/Uint8ArrayBlobAdapter'
 import { ManagedUpload } from 'aws-sdk/clients/s3'
 import Bluebird from 'bluebird'
@@ -1180,6 +1181,7 @@ export const validateAttachments = (
 
 export const getQuarantinePresignedPostData = (
   attachmentSizes: AttachmentSizeMapType[],
+  growthbook?: GrowthBook,
 ): ResultAsync<
   AttachmentPresignedPostDataMapType[],
   CreatePresignedPostError
@@ -1222,7 +1224,7 @@ export const getQuarantinePresignedPostData = (
       if (!mongoose.isValidObjectId(id))
         return errAsync(new InvalidFieldIdError())
 
-      return createPresignedPostDataPromise({
+      let results = createPresignedPostDataPromise({
         bucketName: AwsConfig.guarddutyQuarantineS3Bucket,
         expiresSeconds: PRESIGNED_ATTACHMENT_POST_EXPIRY_SECS,
         size,
@@ -1231,6 +1233,34 @@ export const getQuarantinePresignedPostData = (
         id,
         presignedPostData,
       }))
+
+      if (growthbook?.isOn('use-s3-proxy')) {
+        logger.info({
+          message: 'rewriting S3 URLs to use S3 proxy',
+          meta: {
+            action: 'getQuarantinePresignedPostData',
+            featureFlag: 'use-s3-proxy',
+          },
+        })
+        results = results.map((result) => {
+          return {
+            id: result.id,
+            presignedPostData: {
+              ...result.presignedPostData,
+              /** Replace the path-based S3 URLs with the S3 proxy URL
+               * - https://s3.ap-southeast-1.amazonaws.com/
+               * - https://s3-ap-southeast-1.amazonaws.com/
+               */
+              url: result.presignedPostData.url.replace(
+                /^https:\/\/(s3-|s3\.)ap-southeast-1.amazonaws.com\//,
+                'https://upload.form.gov.sg/',
+              ),
+            },
+          }
+        })
+      }
+
+      return results
     }),
   )
 

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -1252,7 +1252,7 @@ export const getQuarantinePresignedPostData = (
                * - https://s3-ap-southeast-1.amazonaws.com/
                */
               url: result.presignedPostData.url.replace(
-                /^https:\/\/(s3-|s3\.)ap-southeast-1.amazonaws.com\//,
+                /^https:\/\/(s3-|s3\.)ap-southeast-1\.amazonaws\.com\//,
                 'https://upload.form.gov.sg/',
               ),
             },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Users from various agencies (PA, ICA, etc.) are reporting issues uploading attachments and other files / downloading form submissions to / from FormSG (among other OGP products e.g. Highway, Plumber).

At time of writing, we haven't been able to identify if this is an issue with:
- **NUCLEUS** -- iasproxy.sgnet.gov.sg 
- **Menlo SIS** -- safe.menlosecurity.com

Addresses incident 560 ([Slack](https://opengovproducts.slack.com/archives/C0924TV8V47) | [DataDog](https://ogp.datadoghq.com/incidents/560))

Closes [insert issue #]

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

> [!IMPORTANT]
> This PR is based on the assumption that **upload.form.gov.sg** is blanket-whitelisted together with ***.form.gov.sg** and **form.gov.sg**

- Add a [GrowthBook feature flag](https://app.growthbook.io/features/use-s3-proxy?new) to enable `use-s3-proxy`
- Add a [CloudFlare CNAME record](https://dash.cloudflare.com/39ed63a4c3545f14aac6ef38ece0e6cc/form.gov.sg/dns/records?recordsSearchSearch=upload.form.gov.sg) (proxied) from **upload.form.gov.sg** to **s3-ap-southeast-1.amazonaws.com**
- When `use-s3-proxy` is enabled, the backend rewrites path-based S3 presigned requests to use the proxy
  - the frontend's **PublicFormService** calls `POST /:formId/submissions/get-s3-presigned-post-data` normally
  - requests are handled normally in the Submission controller on the backend
  - rewriting happens transparently in the backend within the Submission service

When rewriting occurs, the following event is logged to DataDog

```json
{
  "message": "rewriting S3 URLs to use S3 proxy",
  "meta": {
    "action": "getQuarantinePresignedPostData",
    "featureFlag": "use-s3-proxy"
  }
}
```

## Tests
<!-- What tests should be run to confirm functionality? -->

### Regex Test Script

```typescript
[
  "https://s3-ap-southeast-1.amazonaws.com/file/path",
  "https://s3.ap-southeast-1.amazonaws.com/file/path",
].map(url => url.replace(
  /^https:\/\/(s3-|s3\.)ap-southeast-1\.amazonaws\.com\//,
  'https://upload.form.gov.sg/',
))
```

### Output

```typescript
[
  'https://upload.form.gov.sg/file/path',
  'https://upload.form.gov.sg/file/path'
]
```

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New feature flags**:

- `use-s3-proxy` : Toggles the use of **upload.form.gov.sg** as an S3 proxy ([GrowthBook](https://app.growthbook.io/features/use-s3-proxy?new) | [CloudFlare](https://dash.cloudflare.com/39ed63a4c3545f14aac6ef38ece0e6cc/form.gov.sg/dns/records?recordsSearchSearch=upload.form.gov.sg))
