### PR TITLE
feat: improve email mode deprecation banner

### DIFF
--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -17,7 +17,7 @@ import {
 import { useFeatureValue } from '@growthbook/growthbook-react'
 
 import { KILL_EMAIL_MODE_LINK } from '~shared/constants'
-import { FormResponseMode } from '~shared/types'
+import { FormResponseMode, FormStatus } from '~shared/types'
 import { Workspace } from '~shared/types/workspace'
 
 import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
@@ -56,11 +56,13 @@ export const WorkspacePage = (): JSX.Element => {
   const { data: dashboardForms, isLoading: isDashboardLoading } = useDashboard()
   const { data: workspaces, isLoading: isWorkspaceLoading } = useWorkspace()
 
-  const [emailModeForms, hasEmailModeForms] = useMemo(() => {
+  const [openEmailModeForms, hasOpenEmailModeForms] = useMemo(() => {
     const emailModeForms =
       !isDashboardLoading && dashboardForms
         ? dashboardForms.filter(
-            (form) => form.responseMode === FormResponseMode.Email,
+            (form) =>
+              form.responseMode === FormResponseMode.Email &&
+              form.status === FormStatus.Public,
           )
         : undefined
     return emailModeForms
@@ -183,17 +185,12 @@ export const WorkspacePage = (): JSX.Element => {
             defaultWorkspace={DEFAULT_WORKSPACE}
             setCurrentWorkspace={setCurrWorkspaceId}
           >
-            {hasEmailModeForms && (
+            {hasOpenEmailModeForms && (
               <InlineMessage>
                 <Text>
-                  <Link href="/dashboard?filter=email">
-                    {t(
-                      'features.workspace.workspacePage.emailRetirementNotice.description',
-                      {
-                        count: emailModeForms?.length || 0,
-                      },
-                    )}
-                  </Link>{' '}
+                  {t(
+                    'features.workspace.workspacePage.emailRetirementNotice.description',
+                  )}{' '}
                   <Text as="span" fontWeight="bold">
                     {t(
                       'features.workspace.workspacePage.emailRetirementNotice.date',
@@ -204,6 +201,18 @@ export const WorkspacePage = (): JSX.Element => {
                       },
                     )}
                   </Text>
+                  {'. '}
+                  {t(
+                    'features.workspace.workspacePage.emailRetirementNotice.beforeLink',
+                  )}
+                  <Link href="/dashboard?filter=email">
+                    {t(
+                      'features.workspace.workspacePage.emailRetirementNotice.link',
+                      {
+                        count: openEmailModeForms?.length || 0,
+                      },
+                    )}
+                  </Link>
                   {'. ' + emailRetirementNotice.additionalDescription + '.'}{' '}
                   <Link
                     display="inline"
@@ -212,6 +221,7 @@ export const WorkspacePage = (): JSX.Element => {
                   >
                     {emailRetirementNotice.learnMore}
                   </Link>
+                  {'.'}
                 </Text>
               </InlineMessage>
             )}

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -17,6 +17,7 @@ import {
 import { useFeatureValue } from '@growthbook/growthbook-react'
 
 import { KILL_EMAIL_MODE_LINK } from '~shared/constants'
+import { FormResponseMode } from '~shared/types'
 import { Workspace } from '~shared/types/workspace'
 
 import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
@@ -54,6 +55,18 @@ export const WorkspacePage = (): JSX.Element => {
   const { user } = useUser()
   const { data: dashboardForms, isLoading: isDashboardLoading } = useDashboard()
   const { data: workspaces, isLoading: isWorkspaceLoading } = useWorkspace()
+
+  const [emailModeForms, hasEmailModeForms] = useMemo(() => {
+    const emailModeForms =
+      !isDashboardLoading && dashboardForms
+        ? dashboardForms.filter(
+            (form) => form.responseMode === FormResponseMode.Email,
+          )
+        : undefined
+    return emailModeForms
+      ? [emailModeForms, emailModeForms.length > 0]
+      : [undefined, false]
+  }, [dashboardForms, isDashboardLoading])
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
@@ -170,27 +183,38 @@ export const WorkspacePage = (): JSX.Element => {
             defaultWorkspace={DEFAULT_WORKSPACE}
             setCurrentWorkspace={setCurrWorkspaceId}
           >
-            <InlineMessage>
-              <Text>
-                {emailRetirementNotice.description}{' '}
-                <Text as="span" fontWeight="bold">
-                  {t(
-                    'features.workspace.workspacePage.emailRetirementNotice.date',
-                    {
-                      retirementDate: new Date(Date.UTC(2025, 5, 30, 3, 0, 0)),
-                    },
-                  )}
+            {hasEmailModeForms && (
+              <InlineMessage>
+                <Text>
+                  <Link href="/dashboard?filter=email">
+                    {t(
+                      'features.workspace.workspacePage.emailRetirementNotice.description',
+                      {
+                        count: emailModeForms?.length || 0,
+                      },
+                    )}
+                  </Link>{' '}
+                  <Text as="span" fontWeight="bold">
+                    {t(
+                      'features.workspace.workspacePage.emailRetirementNotice.date',
+                      {
+                        retirementDate: new Date(
+                          Date.UTC(2025, 7, 31, 3, 0, 0),
+                        ),
+                      },
+                    )}
+                  </Text>
+                  {'. ' + emailRetirementNotice.additionalDescription + '.'}{' '}
+                  <Link
+                    display="inline"
+                    href={KILL_EMAIL_MODE_LINK}
+                    target="_blank"
+                  >
+                    {emailRetirementNotice.learnMore}
+                  </Link>
                 </Text>
-                {'. ' + emailRetirementNotice.additionalDescription + '.'}{' '}
-                <Link
-                  display="inline"
-                  href={KILL_EMAIL_MODE_LINK}
-                  target="_blank"
-                >
-                  {emailRetirementNotice.learnMore}
-                </Link>
-              </Text>
-            </InlineMessage>
+              </InlineMessage>
+            )}
             <WorkspaceContent />
           </WorkspaceProvider>
         </GridItem>

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -213,7 +213,7 @@ export const WorkspacePage = (): JSX.Element => {
                       },
                     )}
                   </Link>
-                  {'. ' + emailRetirementNotice.additionalDescription + '.'}{' '}
+                  {emailRetirementNotice.additionalDescription}{' '}
                   <Link
                     display="inline"
                     href={KILL_EMAIL_MODE_LINK}

--- a/frontend/src/features/workspace/WorkspaceProvider.tsx
+++ b/frontend/src/features/workspace/WorkspaceProvider.tsx
@@ -1,11 +1,19 @@
-import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react'
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { useSearchParams } from 'react-router-dom'
 import fuzzysort from 'fuzzysort'
 
-import { FormId, FormStatus } from '~shared/types'
+import { FormId, FormResponseMode, FormStatus } from '~shared/types'
 import { Workspace } from '~shared/types/workspace'
 
 import { useDashboard, useWorkspace } from './queries'
-import { FilterOption } from './types'
+import { FilterOption, filterOptionMap, filterOptionReverseMap } from './types'
 import { WorkspaceContext } from './WorkspaceContext'
 
 interface WorkspaceProviderProps {
@@ -21,6 +29,7 @@ export const WorkspaceProvider = ({
   setCurrentWorkspace,
   children,
 }: WorkspaceProviderProps): JSX.Element => {
+  const [searchParams, setSearchParams] = useSearchParams()
   const { data: dashboardForms, isLoading: dashboardIsLoading } = useDashboard()
 
   const { data: workspaces, isLoading: workspaceIsLoading } = useWorkspace()
@@ -29,7 +38,8 @@ export const WorkspaceProvider = ({
 
   const [activeSearch, setActiveSearch] = useState<string>('')
   const [activeFilter, setActiveFilter] = useState<FilterOption>(
-    FilterOption.AllForms,
+    filterOptionMap[searchParams.get('filter') ?? 'none'] ??
+      FilterOption.AllForms,
   )
 
   const activeWorkspace = useMemo(
@@ -71,6 +81,21 @@ export const WorkspaceProvider = ({
           (form) => form.status === FormStatus.Private,
         )
         break
+      case FilterOption.EmailForms:
+        displayedForms = displayedForms.filter(
+          (form) => form.responseMode === FormResponseMode.Email,
+        )
+        break
+      case FilterOption.StorageForms:
+        displayedForms = displayedForms.filter(
+          (form) => form.responseMode === FormResponseMode.Encrypt,
+        )
+        break
+      case FilterOption.MultiRespondentForms:
+        displayedForms = displayedForms.filter(
+          (form) => form.responseMode === FormResponseMode.Multirespondent,
+        )
+        break
       default:
         break
     }
@@ -108,6 +133,16 @@ export const WorkspaceProvider = ({
     },
     [workspaces],
   )
+
+  // Update the URL search params based on the current workspace state
+  useEffect(() => {
+    // Update the URL search params when the filter changes
+    const newSearchParams: Record<string, string> = {}
+    if (activeFilter !== FilterOption.AllForms) {
+      newSearchParams.filter = filterOptionReverseMap[activeFilter] || 'none'
+    }
+    setSearchParams(newSearchParams)
+  }, [activeFilter, setSearchParams])
 
   return (
     <WorkspaceContext.Provider

--- a/frontend/src/features/workspace/types.ts
+++ b/frontend/src/features/workspace/types.ts
@@ -5,8 +5,8 @@ export enum FilterOption {
   AllForms = 'All forms',
   OpenForms = 'Open forms',
   ClosedForms = 'Closed forms',
-  EmailForms = 'Email-mode forms',
-  StorageForms = 'Storage-mode forms',
+  EmailForms = 'Email mode forms',
+  StorageForms = 'Storage mode forms',
   MultiRespondentForms = 'Multi-respondent forms',
 }
 

--- a/frontend/src/features/workspace/types.ts
+++ b/frontend/src/features/workspace/types.ts
@@ -5,4 +5,26 @@ export enum FilterOption {
   AllForms = 'All forms',
   OpenForms = 'Open forms',
   ClosedForms = 'Closed forms',
+  EmailForms = 'Email-mode forms',
+  StorageForms = 'Storage-mode forms',
+  MultiRespondentForms = 'Multi-respondent forms',
 }
+
+export const filterOptionMap: Record<string, FilterOption> = {
+  none: FilterOption.AllForms,
+  open: FilterOption.OpenForms,
+  closed: FilterOption.ClosedForms,
+  email: FilterOption.EmailForms,
+  storage: FilterOption.StorageForms,
+  mrf: FilterOption.MultiRespondentForms,
+}
+
+export const filterOptionReverseMap: Record<FilterOption, string> = Object.keys(
+  filterOptionMap,
+).reduce(
+  (acc, key) => {
+    acc[filterOptionMap[key]] = key
+    return acc
+  },
+  {} as Record<FilterOption, string>,
+)

--- a/frontend/src/features/workspace/utils/dashboardFilter.ts
+++ b/frontend/src/features/workspace/utils/dashboardFilter.ts
@@ -4,4 +4,7 @@ export const FILTER_OPTIONS: FilterOption[] = [
   FilterOption.AllForms,
   FilterOption.OpenForms,
   FilterOption.ClosedForms,
+  FilterOption.EmailForms,
+  FilterOption.StorageForms,
+  FilterOption.MultiRespondentForms,
 ]

--- a/frontend/src/i18n/locales/features/workspace/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/en-sg.ts
@@ -74,11 +74,12 @@ export const enSG: Workspace = {
   workspacePage: {
     defaultTitle: 'All forms',
     emailRetirementNotice: {
-      description: 'Email mode forms will be retired on',
+      description:
+        'These {count, number} email mode forms will be set to CLOSED by',
       date: '{retirementDate, date, long}',
       additionalDescription:
-        'Email functionalities will continue to be available in Storage mode',
-      learnMore: 'Learn what this means for you.',
+        'You will be informed of the exact date separately',
+      learnMore: 'Learn more here',
     },
   },
   sideMenu,

--- a/frontend/src/i18n/locales/features/workspace/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/en-sg.ts
@@ -74,9 +74,10 @@ export const enSG: Workspace = {
   workspacePage: {
     defaultTitle: 'All forms',
     emailRetirementNotice: {
-      description:
-        'These {count, number} email mode forms will be set to CLOSED by',
+      description: 'All Email mode forms will be set to CLOSED by',
       date: '{retirementDate, date, long}',
+      beforeLink: 'You have ',
+      link: '{count, number} OPEN Email mode form(s)',
       additionalDescription:
         'You will be informed of the exact date separately',
       learnMore: 'Learn more here',

--- a/frontend/src/i18n/locales/features/workspace/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/en-sg.ts
@@ -76,10 +76,10 @@ export const enSG: Workspace = {
     emailRetirementNotice: {
       description: 'All Email mode forms will be set to CLOSED by',
       date: '{retirementDate, date, long}',
-      beforeLink: 'You have ',
+      beforeLink: 'You currently have ',
       link: '{count, number} OPEN Email mode form(s)',
       additionalDescription:
-        'You will be informed of the exact date separately',
+        ', and will be informed of the exact closure date separately.',
       learnMore: 'Learn more here',
     },
   },

--- a/frontend/src/i18n/locales/features/workspace/index.ts
+++ b/frontend/src/i18n/locales/features/workspace/index.ts
@@ -76,6 +76,8 @@ export interface Workspace {
     emailRetirementNotice: {
       description: string
       date: string
+      beforeLink: string
+      link: string
       additionalDescription: string
       learnMore: string
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Form admins experience confusion and uncertainty when facing the "Email-mode deprecation" banner.
- This decreases admin satisfaction and impacts trust.
- And increases support ticket volume, which impacts team capacity / bandwidth.

Closes FRM-2052

## Solution
<!-- How did you solve the problem? -->

We implemented a conditional banner which is shown only to affected admins.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3ce2dd81-0ad5-420c-a760-255497064b92" />

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

**Features**:

- Add support for `filter=<mode>` in the Admin Dashboard's search parameters

**Improvements**:

- Improve the copy of the Email mode deprecation banner
- Include the number of OPEN, Email mode forms affected in the copy
- Deep-link to the filtered page with the affected forms

**Considerations**:
- We had issues with pluralisation, so for simplicity we use parentheses in the copy instead
- The filter shows all Email mode forms, and not just OPEN email mode forms, to reduce rework complexity.

## Before & After Screenshots


| Before | After (No Email-mode forms) | After (OPEN Email-mode forms) |
| :--------: |--------|--------|
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/e5dcba0c-cd93-4663-9410-e337864939e2" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/6ef762e5-ee3d-4c77-8803-ae9faddeb1f5" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/35962698-194c-4910-aab8-dfa36793fcd5" /> | 



## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: The banner is shown / hidden correctly based on the number of email mode forms**

- [x] Visit the Admin Dashboard
- [x] Ensure that you have at least one email mode form
- [x] Ensure that the number of affected forms displayed matches the number of actual OPENED email mode forms
- [x] Click on the link on the banner
- [x] Ensure that the filter list is now set to filter by Email Mode
- [x] Set all the email mode forms to CLOSED
- [x] Ensure that the banner is hidden when no email mode forms are OPENED

**TC2: Filtering works in DESKTOP view**
- [x] in the desktop view of the Admin dashboard, click between the different filter modes
- [x] the forms displayed should be updated with the filtered list of forms
- [x] the URL should be updated with the latest filter mode

**TC3: Filtering works in MOBILE view -- special emphasis on filter selection**
- [x] in the mobile view of the Admin dashboard, click between the different filter modes
- [x] the forms displayed should be updated with the filtered list of forms
- [x] the URL should be updated with the latest filter mode
