### PR TITLE
fix: status tracker header, footer and copy changes

### DIFF
--- a/frontend/src/components/FormEndPage/StatusTrackerLink.tsx
+++ b/frontend/src/components/FormEndPage/StatusTrackerLink.tsx
@@ -32,7 +32,7 @@ export const StatusTrackerLink = ({
           isRequired
           description={'Track the status of your response through this link'}
         >
-          Status Tracking link
+          Status tracking link
         </FormLabel>
       </Box>
       <Skeleton isLoaded={!!formId}>

--- a/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
@@ -29,7 +29,7 @@ export const TimelineGridArea: FCC = ({ children }) => (
     gridColumn={{ md: '1 / 12', lg: '7 / 12' }}
     py={{ base: '0rem', lg: '4rem' }}
     display="flex"
-    alignItems={{ base: 'initial', md: 'initial,', lg: 'center' }}
+    alignItems={{ base: 'initial', md: 'initial', lg: 'center' }}
     justifyContent={{ lg: 'center' }}
     children={children}
   />

--- a/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
@@ -26,11 +26,11 @@ import { TimelineRunSteps } from './TimelineRunSteps'
 // Grid area styling for the login form.
 export const TimelineGridArea: FCC = ({ children }) => (
   <GridItem
-    gridColumn={{ md: '1 / 5', lg: '7 / 12' }}
+    gridColumn={{ md: '1 / 12', lg: '7 / 12' }}
     py={{ base: '0rem', lg: '4rem' }}
     display="flex"
     alignItems={{ base: 'initial', md: 'initial,', lg: 'center' }}
-    justifyContent="center"
+    justifyContent={{ lg: 'center' }}
     children={children}
   />
 )

--- a/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
@@ -38,7 +38,7 @@ export const TimelineGridArea: FCC = ({ children }) => (
 // Grid area styling for the left sidebar that only displays on tablet and desktop breakpoints
 export const StatusTrackerFormInfoGridArea: FCC = ({ children }) => (
   <GridItem
-    mt={{ base: '1rem', lg: '7.125rem', md: '1.125rem' }}
+    mt={{ lg: '7.125rem' }}
     display={{ base: 'flex', md: 'flex' }}
     gridColumn={{ base: '1 / -1', md: '1 / 13', lg: '2 / 5' }}
     pl={{ base: '1.5rem', lg: '0%' }}
@@ -143,7 +143,7 @@ export const StatusTrackerPage = (): JSX.Element => {
           </StatusTrackerFormInfoGridArea>
           <TimelineGridArea>
             <Box
-              mt={{ base: '1rem', lg: '2.33rem' }}
+              mt={{ base: '1rem', lg: '2rem' }}
               mb={{ base: '2rem', md: '2rem' }}
             >
               <Flex direction="column" align="flex-start">

--- a/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
@@ -142,7 +142,10 @@ export const StatusTrackerPage = (): JSX.Element => {
             <StatusTrackerFormInfo />
           </StatusTrackerFormInfoGridArea>
           <TimelineGridArea>
-            <Box mt={{ base: '1rem', lg: '2.33rem' }}>
+            <Box
+              mt={{ base: '1rem', lg: '2.33rem' }}
+              mb={{ base: '2rem', md: '2rem' }}
+            >
               <Flex direction="column" align="flex-start">
                 {/* manually transforming horizontal positioning left because publicFormLogo has column layout */}
                 <Box ml="-1.5rem">

--- a/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
@@ -26,7 +26,7 @@ import { TimelineRunSteps } from './TimelineRunSteps'
 // Grid area styling for the login form.
 export const TimelineGridArea: FCC = ({ children }) => (
   <GridItem
-    gridColumn={{ lg: '7 / 12' }}
+    gridColumn={{ md: '1 / 5', lg: '7 / 12' }}
     py={{ base: '0rem', lg: '4rem' }}
     display="flex"
     alignItems={{ base: 'initial', md: 'initial,', lg: 'center' }}
@@ -151,7 +151,7 @@ export const StatusTrackerPage = (): JSX.Element => {
                 <Box ml="-1.5rem">
                   <PublicFormLogo />
                 </Box>
-                <Text mb="2rem" textStyle="h4" isTruncated>
+                <Text mb="2rem" textStyle="h4">
                   Response ID: {data.responseId}
                 </Text>
                 <TimelineRunSteps steps={stepData} />

--- a/frontend/src/features/public-form/components/StatusTrackerPage/TimelineRunSteps.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/TimelineRunSteps.tsx
@@ -87,7 +87,7 @@ const TimelineStep = ({
   isCurrentPendingStep,
 }: StepData) => {
   const submissionTimestamp = timestamp
-    ? format(new Date(timestamp), 'dd MMM yyyy, HH:mm:ss z')
+    ? format(new Date(timestamp), 'do MMM yyyy, h:mm:ss a')
     : timestamp
 
   const approvalText = isCurrentPendingStep


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Some copy changes and layout fixes related to the recently released status tracker on beta

**Respondent status tracking page**

- Masthead and footer have white padding on the left when scaling below 440px width on desktop 
- Response ID text should wrap downwards in small width 
- Last step and footer should have at least 32px/2rem padding 
- Can we follow time format of responses view (1st Jul 2025, 4:47:51 pm) 

**Thank you page**

- “Status tracking link” not “Status Tracking link”  


Changes are tracked in feature PRD: https://www.notion.so/opengov/Rename-steps-Status-tracking-v1-1-21777dbba788801c8053d195087f011e?source=copy_link

## Solution
<!-- How did you solve the problem? -->

- Updated grid layout settings for base/md breakpoints
- Updated copy changes and timestamp format

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | --- | --- |
| Masthead white padding (<440px). Response ID text wrap on mobile, Timestamp format, Last step footer padding | ![image](https://github.com/user-attachments/assets/01aac11f-0040-472a-bdfa-266932e21b5a) | ![image](https://github.com/user-attachments/assets/a38a19f0-221f-4c87-a482-bc5273331329) |
| Status tracking link copy change | ![image](https://github.com/user-attachments/assets/6a6b78dd-0b6d-4fa2-a133-70c6656cb6f0) | ![image](https://github.com/user-attachments/assets/15ace631-ba79-4aa2-bd50-df59ed0fe0a3) |


