### PR TITLE
fix: replace id with _id for saveIfSubmitterIdIsUnique

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -728,7 +728,7 @@ const _createSubmission = async ({
         )
       }
       submission = await EncryptSubmission.saveIfSubmitterIdIsUnique(
-        form.id,
+        form._id,
         submissionContent.submitterId,
         submissionContent,
       )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
- When single submission per nric is enabled, users can still submit twice with responses reflected if they submit simultaneously
- When first submission is made, user will see **submission error** (nric already submitted) but submission is successfully logged as a response (db and admin dashboard)

## Solution
<!-- How did you solve the problem? -->
Since mongoose v7 upgrade, we remove virtual id setting/getting using (_id: false), so code requires calling  _id from mongoose object 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  