### PR TITLE
fix: status tracker improvements

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -211,7 +211,7 @@ export const IndividualResponsePage = (): JSX.Element => {
                     workflowStatus === undefined ||
                     workflowCurrentStepNumber === undefined ||
                     workflowNumTotalSteps === undefined
-                      ? 'None'
+                      ? '-'
                       : getPendingResponseAtString({
                           workflowStatus,
                           workflowCurrentStepNumber,

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.test.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.test.ts
@@ -2,7 +2,7 @@ import { WorkflowStatus } from '~shared/types'
 
 import { getPendingResponseAtString } from './mrfSubmissionView'
 
-const noneString = 'None'
+const noneString = '-'
 
 describe('getPendingResponseAtString', () => {
   test('should return empty string when workflow status is approved', () => {

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -90,7 +90,11 @@ export const getWorkflowStatusFromFormResponse = ({
   }
 
   // Return the ApprovalStatus of approval steps (either APPROVED or REJECTED)
-  if (workflow[index].approval_field && 'status' in submittedStep) {
+  if (
+    workflow[index].approval_field &&
+    submittedStep !== undefined &&
+    'status' in submittedStep
+  ) {
     return submittedStep.status
   }
 

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -82,12 +82,16 @@ export const getWorkflowStatusFromFormResponse = ({
   workflow,
   submittedSteps,
 }: getWorkflowStatusFromFormResponseProps): WorkflowStatus => {
-  const submittedStep = submittedSteps[index]
-  return index < submittedSteps.length
-    ? workflow[index].approval_field // if this step is an approval step
-      ? 'status' in submittedStep // if status is in submitted step
-        ? submittedStep.status
-        : WorkflowStatus.COMPLETED
-      : WorkflowStatus.COMPLETED
-    : WorkflowStatus.PENDING
+  // Steps that haven't been submitted must be PENDING
+  if (index < submittedSteps.length) {
+    return WorkflowStatus.PENDING
+  }
+  
+  // Return the ApprovalStatus of approval steps (either APPROVED or REJECTED)
+  if (workflow[index].approval_field && 'status' in submittedStep) {
+    return submittedStep.status
+  }
+  
+  // Otherwise, the step is COMPLETED
+  return WorkflowStatus.COMPLETED
 }

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -82,16 +82,18 @@ export const getWorkflowStatusFromFormResponse = ({
   workflow,
   submittedSteps,
 }: getWorkflowStatusFromFormResponseProps): WorkflowStatus => {
+  const submittedStep = submittedSteps[index]
+
   // Steps that haven't been submitted must be PENDING
   if (index < submittedSteps.length) {
     return WorkflowStatus.PENDING
   }
-  
+
   // Return the ApprovalStatus of approval steps (either APPROVED or REJECTED)
   if (workflow[index].approval_field && 'status' in submittedStep) {
     return submittedStep.status
   }
-  
+
   // Otherwise, the step is COMPLETED
   return WorkflowStatus.COMPLETED
 }

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -85,7 +85,7 @@ export const getWorkflowStatusFromFormResponse = ({
   const submittedStep = submittedSteps[index]
 
   // Steps that haven't been submitted must be PENDING
-  if (index < submittedSteps.length) {
+  if (index >= submittedSteps.length) {
     return WorkflowStatus.PENDING
   }
 

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -1,4 +1,4 @@
-import { WorkflowStatus } from '~shared/types'
+import { FormWorkflowDto, SubmittedStep, WorkflowStatus } from '~shared/types'
 
 export enum MRF_STATUS {
   COMPLETED = 'Completed',
@@ -68,4 +68,26 @@ export const getStatusFromWorkflowStatus = (
       throw new Error('Invalid WorkflowStatus encountered.')
     }
   }
+}
+
+export type getWorkflowStatusFromFormResponseProps = {
+  index: number
+  workflow: FormWorkflowDto
+  submittedSteps: SubmittedStep[]
+}
+
+/** Gets a step's workflow status from workflow steps and MRF submmission steps */
+export const getWorkflowStatusFromFormResponse = ({
+  index,
+  workflow,
+  submittedSteps,
+}: getWorkflowStatusFromFormResponseProps): WorkflowStatus => {
+  const submittedStep = submittedSteps[index]
+  return index < submittedSteps.length
+    ? workflow[index].approval_field // if this step is an approval step
+      ? 'status' in submittedStep // if status is in submitted step
+        ? submittedStep.status
+        : WorkflowStatus.COMPLETED
+      : WorkflowStatus.COMPLETED
+    : WorkflowStatus.PENDING
 }

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -23,7 +23,7 @@ export const getPendingResponseAtString = ({
     workflowStatus === WorkflowStatus.PENDING &&
     workflowCurrentStepNumber < workflowNumTotalSteps
   if (!isPending) {
-    return 'None'
+    return '-'
   }
 
   // The form is currently completed until step N.

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -206,11 +206,12 @@ const MrfEmailNotificationsForm = ({
                 <MultiSelect
                   items={formWorkflowStepsWithStepNumber
                     .filter((step) => step.stepNumber > 1)
-                    .map(({ stepNumber, _id: value }) => ({
-                      label: t(
-                        'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.each',
-                        { stepNumber },
-                      ),
+                    .map(({ step_name, stepNumber, _id: value }) => ({
+                      label:
+                        t(
+                          'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.each',
+                          { stepNumber },
+                        ) + (step_name ? ` (${step_name})` : ''),
                       value,
                     }))}
                   values={values}

--- a/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
@@ -101,6 +101,7 @@ export const StatusTrackerPage = (): JSX.Element => {
 
   const { submittedSteps, workflow } = data
 
+  let isWorkFlowRejected = false
   const stepData: StepData[] = workflow.map((step, index) => {
     const name = step.step_name ? step.step_name : `Step ${index + 1}`
     const stepNumber = index + 1
@@ -116,6 +117,10 @@ export const StatusTrackerPage = (): JSX.Element => {
           : WorkflowStatus.COMPLETED
         : WorkflowStatus.PENDING
 
+    if (workflowStatus === WorkflowStatus.REJECTED) {
+      isWorkFlowRejected = true
+    }
+
     if (index < submittedSteps.length) {
       return {
         name: name,
@@ -124,12 +129,14 @@ export const StatusTrackerPage = (): JSX.Element => {
         workflowStatus: workflowStatus,
       }
     }
-
+    console.log(`isWorkFlowRejected: ${isWorkFlowRejected}`)
     return {
       name: name,
       stepNumber: stepNumber,
       workflowStatus: workflowStatus,
-      isCurrentPendingStep: index == submittedSteps.length,
+      ...(isWorkFlowRejected
+        ? {}
+        : { isCurrentPendingStep: index === submittedSteps.length }),
     }
   })
 

--- a/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/StatusTrackerPage.tsx
@@ -10,6 +10,7 @@ import { FCC } from '~typings/react'
 import { AppGrid } from '~templates/AppGrid'
 
 import NotFoundErrorPage from '~pages/NotFoundError'
+import { getWorkflowStatusFromFormResponse } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
 import {
   BackgroundBox,
   BaseGridLayout,
@@ -106,16 +107,11 @@ export const StatusTrackerPage = (): JSX.Element => {
     const name = step.step_name ? step.step_name : `Step ${index + 1}`
     const stepNumber = index + 1
 
-    const submittedStep = submittedSteps[index]
-
-    const workflowStatus =
-      index < submittedSteps.length
-        ? workflow[index].approval_field // if this step is an approval step
-          ? 'status' in submittedStep // if status is in submitted step
-            ? submittedStep.status
-            : WorkflowStatus.COMPLETED
-          : WorkflowStatus.COMPLETED
-        : WorkflowStatus.PENDING
+    const workflowStatus = getWorkflowStatusFromFormResponse({
+      index,
+      workflow,
+      submittedSteps,
+    })
 
     if (workflowStatus === WorkflowStatus.REJECTED) {
       isWorkFlowRejected = true
@@ -129,7 +125,7 @@ export const StatusTrackerPage = (): JSX.Element => {
         workflowStatus: workflowStatus,
       }
     }
-    console.log(`isWorkFlowRejected: ${isWorkFlowRejected}`)
+
     return {
       name: name,
       stepNumber: stepNumber,

--- a/frontend/src/features/public-form/components/StatusTrackerPage/TimelineRunSteps.tsx
+++ b/frontend/src/features/public-form/components/StatusTrackerPage/TimelineRunSteps.tsx
@@ -135,7 +135,11 @@ export const TimelineRunSteps = ({
           h="2rem"
           mx="1rem"
           my="1.5rem"
-          borderColor={statusColor[step.workflowStatus]}
+          borderColor={
+            step.workflowStatus === WorkflowStatus.REJECTED
+              ? statusColor[WorkflowStatus.PENDING]
+              : statusColor[step.workflowStatus]
+          }
           zIndex={1}
           mt="0rem"
           mb="0rem"


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Two issues were found after status tracker release:
1. Status tracker timeline steps reflect 'pending' response after a rejected workflow step
2. Under MRF email notification settings, Steps to notify does not reflect step name if it is present (only step number)
3. 'None' is displayed in admin dashboard, individual response page and csv

## Solution
<!-- How did you solve the problem? -->

- remove isPendingCurrent step variable from subsequent steps after a `WorkflowStatus.REJECTED` step
- Update email notification steps with custom step name if it exists
- Replace 'None' with '-'

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Feature | **BEFORE** | **AFTER** |
| ------- | --------- | --------- |
| Incorrect status tracker timeline steps FE | <img width="483" alt="image" src="https://github.com/user-attachments/assets/4afa55a9-733d-47c5-8bfe-74e1e9c31d9b" /> | <img width="604" alt="image" src="https://github.com/user-attachments/assets/46e43c6b-3944-4dc8-8bbf-13fd9736e80c" /> |
| Custom step name in email notifications workflow step | <img width="794" alt="image" src="https://github.com/user-attachments/assets/51b2131f-f82b-4c56-948d-703231f0606a" /> | <img width="896" alt="image" src="https://github.com/user-attachments/assets/1614c9da-1ebb-4111-86e6-90519474dfa1" /> |
| 'None' replaced with '-' | <img width="794" alt="image" src="https://github.com/user-attachments/assets/d8eed17f-e018-4224-a264-4925ea112d2c" /> <img width="303" alt="image" src="https://github.com/user-attachments/assets/99d56ddf-721b-481d-a83c-47c7f1bbab0e" /> <img width="340" alt="image" src="https://github.com/user-attachments/assets/b6d3e3ae-5b97-4aab-9a47-bc6c53bf3054" /> | <img width="851" alt="image" src="https://github.com/user-attachments/assets/c19d2ad8-80fb-44b7-90fe-15e2d9317a1d" /> <img width="325" alt="image" src="https://github.com/user-attachments/assets/2bbace98-7ee9-4c31-b14e-19a4baf91fc1" /><img width="247" alt="image" src="https://github.com/user-attachments/assets/fa2c700d-2c21-4d3c-b876-6d3e2fb4ba19" />|

## Tests
<!-- What tests should be run to confirm functionality? -->

**Status tracker FE reflects workflow correctly**
- [x] Create a MRF form with 1 basic field & 2 yes/no fields
- [x] Set up a 3 step workflow: assign 1 basic field to step 1 and yes/no field to step 2 and 3 respectively
- [x] Attempt to make a submission of this form, rejecting at step 2
- [x] Observe that the status tracker page shows a 'rejected' step 2 (Red cross icon) and subsequent steps are not the default grey icon

**'None' has been replaced with `-`**
- [x] Referencing the attempted submission just made, return to admin results page
- [x] Observe that on the dashboard under 'Pending response at' column, `-` is displayed
- [x] Click into the submission's individual response page and observe that '-' is also displayed
- [x] Download a CSV of the responses and observe that '-' is displayed

**Renamed steps reflect on workflow email settings**
- [ ] In workflow settings page, rename any number of steps, and save
- [ ] Go to the email settings page, and under `Other respondents in your workflow`, observe that the step names are now reflected after the step number
