### PR TITLE
fix: replace id with _id for text and vision mfb prompts

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.assistance.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.assistance.service.ts
@@ -311,7 +311,7 @@ export const createFormFieldsUsingTextPrompt = ({
 > => {
   return generateAndsendTextPromptToModel({
     userPrompt,
-    formId: form.id,
+    formId: form._id,
   })
     .andThen((modelResponse) => {
       if (!modelResponse) {
@@ -496,7 +496,7 @@ export const createFormFieldsUsingVisionPrompt = ({
   | FieldNotFoundError
 > => {
   return generateAndSendVisionPromptToModel({
-    formId: form.id,
+    formId: form._id,
     imageDataUrls,
   })
     .andThen((modelResponse) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

form.id is returning undefined due to `_id: false` setting change for form definitions as a result of our Mongoose v7 upgrade.

## Solution
<!-- How did you solve the problem? -->

Replace `.id` with `_.id` so that logs for text and vision prompts can be tagged with the right formId (instead of undefined).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  