### PR TITLE
fix: admin database query built from user-controlled sources

### DIFF
--- a/src/app/modules/admin-feedback/admin-feedback.service.ts
+++ b/src/app/modules/admin-feedback/admin-feedback.service.ts
@@ -85,8 +85,11 @@ export const updateAdminFeedback = ({
 
   return ResultAsync.fromPromise(
     AdminFeedbackModel.updateOne(
-      { _id: feedbackId, userId: userId },
-      updateObj,
+      { _id: { $eq: feedbackId }, userId: { $eq: userId } },
+      Object.entries(updateObj).reduce((acc, [key, value]) => {
+        acc[key] = { $eq: value };
+        return acc;
+      }, {}),
     ),
     (error) => {
       logger.error({


### PR DESCRIPTION
https://github.com/opengovsg/FormSG/blob/10ffcc6fc6a2eba1d1ab6c1146d90b7ffdfd7858/src/app/modules/admin-feedback/admin-feedback.service.ts#L88-L89

fix an address the vulnerability, the user-provided data (`rating` and `comment`) must be sanitized or validated before inclusion in the database query. Specifically:
1. Use the `$eq` operator in MongoDB queries to ensure user-provided values are treated as literals, preventing them from being interpreted as query objects.
2. Alternatively, validate the user-provided values strictly to ensure they are primitive types (e.g., number or string).

Detailed changes:
- Modify the `updateAdminFeedback` method in the service layer to wrap user-provided values in the `$eq` operator when constructing the query object.
- Ensure that both `rating` and `comment` are validated to avoid potential injection issues.

#### References
[$eq operator](https://docs.mongodb.com/manual/reference/operator/query/eq)
[NoSQL injection](https://owasp.org/www-pdf-archive/GOD16-NOSQL.pdf)


## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  

