### PR TITLE
feat: make logs consistent for email type and add bounceSubType

### DIFF
--- a/src/app/modules/bounce/__tests__/bounce-test-helpers.ts
+++ b/src/app/modules/bounce/__tests__/bounce-test-helpers.ts
@@ -64,6 +64,7 @@ export const makeBounceNotification = ({
   recipientList,
   bouncedList,
   bounceType,
+  bounceSubType,
   emailType,
 }: {
   formId?: ObjectId
@@ -71,6 +72,7 @@ export const makeBounceNotification = ({
   recipientList?: string[]
   bouncedList?: string[]
   bounceType?: BounceType
+  bounceSubType?: string
   emailType?: EmailType
 } = {}): IBounceNotification => {
   formId ??= new ObjectId()
@@ -89,6 +91,7 @@ export const makeBounceNotification = ({
     {
       bounce: {
         bounceType,
+        bounceSubType,
         bouncedRecipients: bouncedList.map((emailAddress) => ({
           emailAddress,
         })),

--- a/src/app/modules/bounce/__tests__/bounce.model.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.model.spec.ts
@@ -47,7 +47,12 @@ describe('Bounce Model', () => {
       const params = {
         formId: new ObjectId(),
         bounces: [
-          { email: MOCK_EMAIL, hasBounced: true, bounceType: 'Permanent' },
+          {
+            email: MOCK_EMAIL,
+            hasBounced: true,
+            bounceType: 'Permanent',
+            bounceSubType: 'Suppressed',
+          },
         ],
         expireAt: new Date(Date.now()),
         hasAutoEmailed: true,

--- a/src/app/modules/bounce/__tests__/bounce.service.spec.ts
+++ b/src/app/modules/bounce/__tests__/bounce.service.spec.ts
@@ -23,7 +23,11 @@ import {
 import { DatabaseError } from '../../core/core.errors'
 import { UserWithContactNumber } from '../../user/user.types'
 
-import { makeBounceNotification, MOCK_SNS_BODY } from './bounce-test-helpers'
+import {
+  makeBounceNotification,
+  makeDeliveryNotification,
+  MOCK_SNS_BODY,
+} from './bounce-test-helpers'
 
 jest.mock('sns-validator')
 const MockedSNSMessageValidator = jest.mocked(SNSMessageValidator)
@@ -165,7 +169,7 @@ describe('BounceService', () => {
     ]
     beforeEach(() => jest.resetAllMocks())
 
-    it('should log email confirmations to short-term logs', async () => {
+    it('should log confirmation email bounces to short-term logs', async () => {
       const formId = new ObjectId()
       const submissionId = new ObjectId()
       const notification = makeBounceNotification({
@@ -174,15 +178,22 @@ describe('BounceService', () => {
         recipientList: MOCK_RECIPIENT_LIST,
         bouncedList: MOCK_RECIPIENT_LIST,
         bounceType: BounceType.Transient,
+        bounceSubType: 'General',
         emailType: EmailType.EmailConfirmation,
       })
       BounceService.logEmailNotification(notification)
       expect(mockLogger.info).not.toHaveBeenCalled()
       expect(mockLogger.warn).not.toHaveBeenCalled()
-      expect(mockShortTermLogger.info).toHaveBeenCalledWith(notification)
+      expect(mockShortTermLogger.info).toHaveBeenCalledWith({
+        message: 'Email bounced',
+        meta: {
+          action: 'logEmailNotification',
+          ...notification,
+        },
+      })
     })
 
-    it('should log admin responses to regular logs', async () => {
+    it('should log admin response email bounces to regular logs', async () => {
       const formId = new ObjectId()
       const submissionId = new ObjectId()
       const notification = makeBounceNotification({
@@ -191,11 +202,12 @@ describe('BounceService', () => {
         recipientList: MOCK_RECIPIENT_LIST,
         bouncedList: MOCK_RECIPIENT_LIST,
         bounceType: BounceType.Transient,
+        bounceSubType: 'General',
         emailType: EmailType.AdminResponse,
       })
       BounceService.logEmailNotification(notification)
       expect(mockLogger.info).toHaveBeenCalledWith({
-        message: 'Email notification',
+        message: 'Email bounced',
         meta: {
           action: 'logEmailNotification',
           ...notification,
@@ -205,7 +217,7 @@ describe('BounceService', () => {
       expect(mockShortTermLogger.info).not.toHaveBeenCalled()
     })
 
-    it('should log login OTPs to regular logs', async () => {
+    it('should log login OTP email bounces to regular logs', async () => {
       const formId = new ObjectId()
       const submissionId = new ObjectId()
       const notification = makeBounceNotification({
@@ -214,11 +226,12 @@ describe('BounceService', () => {
         recipientList: MOCK_RECIPIENT_LIST,
         bouncedList: MOCK_RECIPIENT_LIST,
         bounceType: BounceType.Transient,
+        bounceSubType: 'General',
         emailType: EmailType.LoginOtp,
       })
       BounceService.logEmailNotification(notification)
       expect(mockLogger.info).toHaveBeenCalledWith({
-        message: 'Email notification',
+        message: 'Email bounced',
         meta: {
           action: 'logEmailNotification',
           ...notification,
@@ -228,7 +241,7 @@ describe('BounceService', () => {
       expect(mockShortTermLogger.info).not.toHaveBeenCalled()
     })
 
-    it('should log admin notifications to regular logs', async () => {
+    it('should log admin notification email bounces to regular logs', async () => {
       const formId = new ObjectId()
       const submissionId = new ObjectId()
       const notification = makeBounceNotification({
@@ -237,11 +250,12 @@ describe('BounceService', () => {
         recipientList: MOCK_RECIPIENT_LIST,
         bouncedList: MOCK_RECIPIENT_LIST,
         bounceType: BounceType.Transient,
+        bounceSubType: 'General',
         emailType: EmailType.AdminBounce,
       })
       BounceService.logEmailNotification(notification)
       expect(mockLogger.info).toHaveBeenCalledWith({
-        message: 'Email notification',
+        message: 'Email bounced',
         meta: {
           action: 'logEmailNotification',
           ...notification,
@@ -251,7 +265,29 @@ describe('BounceService', () => {
       expect(mockShortTermLogger.info).not.toHaveBeenCalled()
     })
 
-    it('should log verification OTPs to short-term logs', async () => {
+    it('should log admin notification email deliveries to regular logs', async () => {
+      const formId = new ObjectId()
+      const submissionId = new ObjectId()
+      const notification = makeDeliveryNotification({
+        formId,
+        submissionId,
+        recipientList: MOCK_RECIPIENT_LIST,
+        deliveredList: MOCK_RECIPIENT_LIST,
+        emailType: EmailType.AdminBounce,
+      })
+      BounceService.logEmailNotification(notification)
+      expect(mockLogger.info).toHaveBeenCalledWith({
+        message: 'Email delivered',
+        meta: {
+          action: 'logEmailNotification',
+          ...notification,
+        },
+      })
+      expect(mockLogger.warn).not.toHaveBeenCalled()
+      expect(mockShortTermLogger.info).not.toHaveBeenCalled()
+    })
+
+    it('should log verification OTP email bounces to short-term logs', async () => {
       const formId = new ObjectId()
       const submissionId = new ObjectId()
       const notification = makeBounceNotification({
@@ -260,12 +296,41 @@ describe('BounceService', () => {
         recipientList: MOCK_RECIPIENT_LIST,
         bouncedList: MOCK_RECIPIENT_LIST,
         bounceType: BounceType.Transient,
+        bounceSubType: 'General',
         emailType: EmailType.VerificationOtp,
       })
       BounceService.logEmailNotification(notification)
       expect(mockLogger.info).not.toHaveBeenCalled()
       expect(mockLogger.warn).not.toHaveBeenCalled()
-      expect(mockShortTermLogger.info).toHaveBeenCalledWith(notification)
+      expect(mockShortTermLogger.info).toHaveBeenCalledWith({
+        message: 'Email bounced',
+        meta: {
+          action: 'logEmailNotification',
+          ...notification,
+        },
+      })
+    })
+
+    it('should log verification OTP email deliveries to short-term logs', async () => {
+      const formId = new ObjectId()
+      const submissionId = new ObjectId()
+      const notification = makeDeliveryNotification({
+        formId,
+        submissionId,
+        recipientList: MOCK_RECIPIENT_LIST,
+        deliveredList: MOCK_RECIPIENT_LIST,
+        emailType: EmailType.VerificationOtp,
+      })
+      BounceService.logEmailNotification(notification)
+      expect(mockLogger.info).not.toHaveBeenCalled()
+      expect(mockLogger.warn).not.toHaveBeenCalled()
+      expect(mockShortTermLogger.info).toHaveBeenCalledWith({
+        message: 'Email delivered',
+        meta: {
+          action: 'logEmailNotification',
+          ...notification,
+        },
+      })
     })
   })
 

--- a/src/app/modules/bounce/bounce.model.ts
+++ b/src/app/modules/bounce/bounce.model.ts
@@ -64,6 +64,9 @@ const BounceSchema = new Schema<IBounceSchema, IBounceModel>({
           type: String,
           enum: Object.values(BounceType),
         },
+        bounceSubType: {
+          type: String,
+        },
         _id: false,
       },
     ],
@@ -105,6 +108,7 @@ BounceSchema.statics.fromSnsNotification = function (
         email,
         hasBounced: true,
         bounceType: snsInfo.bounce.bounceType,
+        bounceSubType: snsInfo.bounce.bounceSubType,
       }
     } else {
       return { email, hasBounced: false }
@@ -153,6 +157,7 @@ BounceSchema.method<IBounceSchema>(
           email,
           hasBounced: true,
           bounceType: snsInfo.bounce.bounceType,
+          bounceSubType: snsInfo.bounce.bounceSubType,
         }
       } else if (
         hasEmailBeenDelivered(snsInfo, email) ||

--- a/src/app/modules/bounce/bounce.service.ts
+++ b/src/app/modules/bounce/bounce.service.ts
@@ -266,14 +266,22 @@ export const logEmailNotification = (
   // form fillers' information for too long, and everything else goes into the
   // main log group.
   const emailType = extractHeader(notification, EMAIL_HEADERS.emailType)
+  const isBounce = isBounceNotification(notification)
+  const message = isBounce ? 'Email bounced' : 'Email delivered'
   if (
     emailType === EmailType.EmailConfirmation ||
     emailType === EmailType.VerificationOtp
   ) {
-    shortTermLogger.info(notification)
+    shortTermLogger.info({
+      message,
+      meta: {
+        action: 'logEmailNotification',
+        ...notification,
+      },
+    })
   } else {
     logger.info({
-      message: 'Email notification',
+      message,
       meta: {
         action: 'logEmailNotification',
         ...notification,

--- a/src/types/bounce.ts
+++ b/src/types/bounce.ts
@@ -10,6 +10,7 @@ export type ISingleBounce =
       email: string
       hasBounced: true
       bounceType: BounceType
+      bounceSubType: string
     }
   | {
       email: string


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, the logs for different type of emails differ in terms of the search term, making it hard to find the logs when tracing email incidents (which are one of most common incidents experienced). 
For example, when an email verification OTP bounces, it does not have a message to query and logs the notification object directly.  

Also, the bounces doc only stores the bounceType. Adding the bounceSubType (eg, suppressed by acc level suppression list, inbox full etc) can be used for incident investigation. 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Bounces are logged for long term logger
- [ ] Send a login email OTP to a fake email address eg, `xxx@123.com` 
- [ ] Search for the message `email bounced`on Cloudwatch 
- [ ] Assert that the log can be found for corresponding email. 

TC2: Bounces are logged for short term logger
- [ ] Create a form with email OTP verification field 
- [ ] Send the verification email to a fake email address eg, `xxx@123.com` 
- [ ] Search for the message `email bounced`on Cloudwatch 
- [ ] Assert that the log can be found for corresponding email. 

TC2: Deliveries are logged for short term logger
- [ ] Create a form with email OTP verification field 
- [ ] Send the verification email to a valid email address eg, your email address
- [ ] Search for the message `email delivered`on Cloudwatch 
- [ ] Assert that the log can be found for corresponding email. 