### PR TITLE
feat(i18n): extract text from payment settings section

### DIFF
--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/BusinessInfoSection.tsx
@@ -5,6 +5,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FormControl } from '@chakra-ui/react'
 
 import {
@@ -75,6 +76,9 @@ const BusinessInfoBlock = ({
   settings: StorageFormSettings
   agencyDefaults: AgencyBase['business']
 }) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.payments',
+  })
   const { mutateFormBusiness } = useMutateFormSettings()
   const handleAddressMutation = (newAddress: string) => {
     mutateFormBusiness.mutate({ address: newAddress })
@@ -86,7 +90,9 @@ const BusinessInfoBlock = ({
     <>
       {settings.payments_field.gst_enabled ? (
         <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
-          <FormLabel isRequired>GST Registration Number</FormLabel>
+          <FormLabel isRequired>
+            {t('businessInfo.gstRegistrationNumber')}
+          </FormLabel>
           <BusinessFieldInput
             initialValue={
               settings.business?.gstRegNo || agencyDefaults?.gstRegNo || ''
@@ -96,7 +102,7 @@ const BusinessInfoBlock = ({
         </FormControl>
       ) : null}
       <FormControl mb="2.5rem" isReadOnly={mutateFormBusiness.isLoading}>
-        <FormLabel isRequired>Business Address</FormLabel>
+        <FormLabel isRequired>{t('businessInfo.businessAddress')}</FormLabel>
         <BusinessFieldInput
           initialValue={
             settings.business?.address || agencyDefaults?.address || ''

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/GstToggleSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/GstToggleSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Skeleton } from '@chakra-ui/react'
 
 import { FormResponseMode } from '~shared/types'
@@ -9,6 +10,9 @@ import { useMutateFormSettings } from '../../mutations'
 import { useAdminFormSettings } from '../../queries'
 
 export const GstToggleSection = (): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.payments.gstToggle',
+  })
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -41,8 +45,8 @@ export const GstToggleSection = (): JSX.Element => {
         mb="2.5rem"
         isLoading={mutateGST.isLoading}
         isChecked={hasGST}
-        label="GST applicable"
-        description="GST will be mentioned in proof of payment"
+        label={t('label')}
+        description={t('description')}
         onChange={() => handleToggleGST()}
       />
     </Skeleton>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentSettingsSection.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Link as ReactLink, useParams, useSearchParams } from 'react-router-dom'
 import {
   As,
@@ -51,6 +52,9 @@ const PaymentsDisabledRationaleText = ({
   isSingleSubmission: boolean
   isPDFResponseEnabled: boolean
 }): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.payments.disabledRationaleText',
+  })
   const disabledCount = [
     isAdminEmailsPresent,
     isSingleSubmission,
@@ -63,26 +67,26 @@ const PaymentsDisabledRationaleText = ({
   if (disabledCount > 1) {
     return (
       <Text>
-        To enable payment fields,
+        {t('genericRationale.toEnable')}
         <UnorderedList spacing="0.5rem" mt="1rem">
           {isAdminEmailsPresent ? (
             <ListItem>
               <Link as={ReactLink} to={'email-notifications'}>
-                Remove all recipients from email notifications
+                {t('genericRationale.removeAdminEmail')}
               </Link>
             </ListItem>
           ) : undefined}
           {isPDFResponseEnabled ? (
             <ListItem>
               <Link as={ReactLink} to={`/admin/form/${formId}`}>
-                Turn off "Include PDF responses" in all email fields
+                {t('genericRationale.turnOffPdfResponses')}
               </Link>
             </ListItem>
           ) : undefined}
           {isSingleSubmission ? (
             <ListItem>
               <Link as={ReactLink} to={'singpass'}>
-                Disable only one submission per NRIC/FIN/UEN
+                {t('genericRationale.disableSingleSubmission')}
               </Link>
             </ListItem>
           ) : undefined}
@@ -94,9 +98,9 @@ const PaymentsDisabledRationaleText = ({
   if (isAdminEmailsPresent) {
     return (
       <Text>
-        To enable payment fields, remove all recipients from{' '}
+        {t('adminEmailsPresent.removeToEnable')}{' '}
         <Link as={ReactLink} to={'email-notifications'}>
-          email notifications
+          {t('adminEmailsPresent.emailNotifications')}
         </Link>
         .
       </Text>
@@ -105,9 +109,9 @@ const PaymentsDisabledRationaleText = ({
   if (isSingleSubmission) {
     return (
       <Text>
-        To enable payment fields, disable{' '}
+        {t('singleSubmission.disableSingleSubmission')}{' '}
         <Link as={ReactLink} to={'singpass'}>
-          only one submission per NRIC/FIN/UEN
+          {t('singleSubmission.singleSubmissionPerNricFinUen')}
         </Link>
         .
       </Text>
@@ -116,9 +120,9 @@ const PaymentsDisabledRationaleText = ({
   if (isPDFResponseEnabled) {
     return (
       <Text>
-        To enable payment fields,{' '}
+        {t('pdfResponseEnabled.toEnable')}{' '}
         <Link as={ReactLink} to={`/admin/form/${formId}`}>
-          turn off "Include PDF Responses" in all email fields.
+          {t('pdfResponseEnabled.disablePdfResponses')}
         </Link>
       </Text>
     )
@@ -131,6 +135,10 @@ const BeforeConnectionInstructions = ({
 }: {
   isProductionEnv: boolean
 }): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix:
+      'features.adminForm.settings.payments.beforeConnectionInstructions',
+  })
   const [allowConnect, setAllowConnect] = useState(false)
   const { data: paymentGuideLink } = usePaymentGuideLink()
   const [searchParams] = useSearchParams()
@@ -169,11 +177,7 @@ const BeforeConnectionInstructions = ({
     return (
       <>
         <InlineMessage variant="error" my="2rem">
-          <Text>
-            Your Stripe account could not be connected because it was created
-            with a non-whitelisted email domain. Try reconnecting an account
-            that was created with a whitelisted email domain.
-          </Text>
+          <Text>{t('invalidDomain')}</Text>
         </InlineMessage>
         <StripeConnectButton connectState={StripeConnectButtonStates.ENABLED} />
       </>
@@ -193,22 +197,28 @@ const BeforeConnectionInstructions = ({
             </InlineMessage>
           </Box>
         ) : (
-          <InlineMessage useMarkdown>
-            {`Read [our guide](${paymentGuideLink}) to set up a Stripe account. If your agency already has a Stripe account, you can connect it to this form.`}
+          <InlineMessage>
+            <Text>
+              {t('setupGuide.read')}{' '}
+              <Link isExternal variant="inline" href={paymentGuideLink}>
+                {t('setupGuide.ourGuide')}
+              </Link>{' '}
+              {t('setupGuide.setupOrConnectStripeText')}
+            </Text>
           </InlineMessage>
         )}
 
         <Text textStyle="h3" color="secondary.500">
-          Bulk transaction rates
+          {t('bulkTransactionText.bulkTransactionRate')}
         </Text>
         <Text>
-          To request bulk transaction rates for your payments, use{' '}
+          {t('bulkTransactionText.useBulkTransactionRates')}{' '}
           <Link href={GUIDE_STRIPE_ONBOARDING} target="_blank">
-            this form
+            {t('bulkTransactionText.thisForm')}
           </Link>{' '}
-          to contact us for assistance.{' '}
+          {t('bulkTransactionText.contactForAssistance')}{' '}
           <Text as="b">
-            Without this step, you will be charged default transaction rates.
+            {t('bulkTransactionText.defaultTransactionRatesWarning')}
           </Text>
         </Text>
 
@@ -218,8 +228,7 @@ const BeforeConnectionInstructions = ({
           mb="2rem"
           onChange={(e) => setAllowConnect(e.target.checked)}
         >
-          I understand that I will be paying default transaction rates, unless I
-          have requested bulk transaction rates and received confirmation
+          {t('bulkTransactionText.acknowledgeWarningText')}
         </Checkbox>
         <StripeConnectButton
           connectState={
@@ -247,10 +256,7 @@ const BeforeConnectionInstructions = ({
           </Box>
         ) : (
           <InlineMessage variant="info">
-            <Text>
-              You are currently in test mode. You can choose to skip connecting
-              a Stripe account after clicking the button below.
-            </Text>
+            <Text>{t('testMode')}</Text>
           </InlineMessage>
         )}
         <StripeConnectButton
@@ -297,6 +303,9 @@ const AfterConnectionInfo = ({
   hasPaymentCapabilities: boolean
   adminFormPaymentsError: boolean
 }): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.payments.afterConnectionInfo',
+  })
   let connectionInfo: JSX.Element
 
   if (adminFormPaymentsError) {
@@ -305,7 +314,7 @@ const AfterConnectionInfo = ({
       <ConnectionStatusText
         color="danger.500"
         icon={BxsError}
-        text="Something went wrong when validating the connected Stripe account."
+        text={t('genericPaymentsError')}
       />
     )
   } else if (isProductionEnv) {
@@ -315,7 +324,7 @@ const AfterConnectionInfo = ({
         <ConnectionStatusText
           color="success.700"
           icon={BxsCheckCircle}
-          text="Your Stripe account is connected to this Form."
+          text={t('stripeAccountConnected')}
         />
       )
     } else {
@@ -324,7 +333,7 @@ const AfterConnectionInfo = ({
         <ConnectionStatusText
           color="warning.500"
           icon={BxsInfoCircle}
-          text="The connected account does not have the ability to process payments."
+          text={t('noPaymentCapabilities')}
         />
       )
     }
@@ -335,7 +344,7 @@ const AfterConnectionInfo = ({
         <ConnectionStatusText
           color="success.700"
           icon={BxsCheckCircle}
-          text="Stripe account connected. Payments made on this form will only show in test mode in your Stripe account."
+          text={t('testModeStripeAccountConnected')}
         />
       )
     } else {
@@ -344,7 +353,7 @@ const AfterConnectionInfo = ({
         <ConnectionStatusText
           color="success.700"
           icon={BxsCheckCircle}
-          text="You are connected to a test account."
+          text={t('testModeStripeConnectionSkipped')}
         />
       )
     }
@@ -360,13 +369,14 @@ const PaymentsAccountInformation = ({
   account_id: string
   isLoading: boolean
 }) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix:
+      'features.adminForm.settings.payments.paymentsAccountInformation',
+  })
   return (
     <FormControl mb="2.5rem">
-      <FormLabel
-        description="This is the account ID connected to this form."
-        isRequired
-      >
-        Target Account ID
+      <FormLabel description={t('labelDescription')} isRequired>
+        {t('label')}
       </FormLabel>
       <Skeleton isLoaded={!isLoading}>
         <Input isDisabled={true} value={account_id}></Input>

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentsUnsupportedMsg.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/PaymentsUnsupportedMsg.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Flex, Text } from '@chakra-ui/react'
 
 import Link from '~components/Link'
@@ -7,17 +8,19 @@ import { SettingsUnsupportedSvgr } from '~features/admin-form/settings/svgrs/Set
 import { usePaymentGuideLink } from './queries'
 
 export const PaymentsUnsupportedMsg = (): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.payments.paymentUnsupportedMsg',
+  })
   const { data: paymentGuideLink } = usePaymentGuideLink()
   return (
     <Flex justify="center" flexDir="column" textAlign="center">
       <Text textStyle="h2" as="h2" color="primary.500" mb="1rem">
-        Payments are only available in storage mode
+        {t('shortDescription')}
       </Text>
       <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
-        Respondents can now make payment for fees or services directly on your
-        form. This feature is only available in storage mode.&nbsp;
+        {t('longDescription')}&nbsp;
         <Link isExternal href={paymentGuideLink}>
-          Learn more about payments
+          {t('learnMore')}
         </Link>
       </Text>
       <SettingsUnsupportedSvgr />

--- a/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
+++ b/frontend/src/features/admin-form/settings/components/PaymentSettingsSection/StripeConnectButton.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import Button from '~components/Button'
 
@@ -15,6 +16,9 @@ export const StripeConnectButton = ({
 }: {
   connectState: StripeConnectButtonStates
 }): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.payments.stripeConnectBtn',
+  })
   const { linkStripeAccountMutation, unlinkStripeAccountMutation } =
     useMutateStripeAccount()
 
@@ -41,7 +45,7 @@ export const StripeConnectButton = ({
         onClick={onLinkAccountClick}
         colorScheme="primary"
       >
-        Connect my Stripe account
+        {t('connect')}
       </Button>
     )
   } else {
@@ -51,7 +55,7 @@ export const StripeConnectButton = ({
         onClick={onUnlinkAccountClick}
         isLoading={unlinkStripeAccountMutation.isLoading}
       >
-        Disconnect Stripe
+        {t('disconnect')}
       </Button>
     )
   }

--- a/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
@@ -1,5 +1,6 @@
 import { enSG as emailNotifications } from './email-notifications'
 import { enSG as general } from './general'
+import { enSG as payments } from './payments'
 import { enSG as webhooks } from './webhooks'
 
 export const enSG = {
@@ -9,7 +10,5 @@ export const enSG = {
   },
   emailNotifications,
   webhooks,
-  payments: {
-    title: 'Payments',
-  },
+  payments,
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/index.ts
@@ -1,5 +1,6 @@
 import { EmailNotifications } from './email-notifications'
 import { General } from './general'
+import { Payments } from './payments'
 import { Webhooks } from './webhooks'
 
 export * from './en-sg'
@@ -13,5 +14,5 @@ export interface Settings {
   singpass: HasTitle
   emailNotifications: EmailNotifications
   webhooks: Webhooks
-  payments: HasTitle
+  payments: Payments
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/payments/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/payments/en-sg.ts
@@ -1,0 +1,82 @@
+import { Payments } from '.'
+
+export const enSG: Payments = {
+  title: 'Payments',
+  businessInfo: {
+    gstRegistrationNumber: 'GST Registration Number',
+    businessAddress: 'Business Address',
+  },
+  gstToggle: {
+    label: 'GST applicable',
+    description: 'GST will be mentioned in proof of payment',
+  },
+  paymentUnsupportedMsg: {
+    shortDescription: 'Payments are only available in storage mode',
+    longDescription:
+      'Respondents can now make payment for fees or services directly on your form. This feature is only available in storage mode.',
+    learnMore: 'Learn more about payments',
+  },
+  stripeConnectBtn: {
+    connect: 'Connect my Stripe account',
+    disconnect: 'Disconnect Stripe',
+  },
+  disabledRationaleText: {
+    genericRationale: {
+      toEnable: 'To enable payment fields,',
+      removeAdminEmail: 'Remove all recipients from email notifications',
+      turnOffPdfResponses:
+        'Turn off "Include PDF responses" in all email fields',
+      disableSingleSubmission: 'Disable only one submission per NRIC/FIN/UEN',
+    },
+    adminEmailsPresent: {
+      removeToEnable: 'To enable payment fields, remove all recipients from',
+      emailNotifications: 'email notifications',
+    },
+    singleSubmission: {
+      disableSingleSubmission: 'To enable payment fields, disable',
+      singleSubmissionPerNricFinUen: 'only one submission per NRIC/FIN/UEN',
+    },
+    pdfResponseEnabled: {
+      toEnable: 'To enable payment fields,',
+      disablePdfResponses:
+        'turn off "Include PDF Responses" in all email fields.',
+    },
+  },
+  beforeConnectionInstructions: {
+    invalidDomain:
+      'Your Stripe account could not be connected because it was created with a non-whitelisted email domain. Try reconnecting an account that was created with a whitelisted email domain.',
+    testMode:
+      'You are currently in test mode. You can choose to skip connecting a Stripe account after clicking the button below.',
+    setupGuide: {
+      read: 'Read',
+      ourGuide: 'our guide',
+      setupOrConnectStripeText:
+        'to set up a Stripe account. If your agency already has a Stripe account, you can connect it to this form.',
+    },
+    bulkTransactionText: {
+      bulkTransactionRate: 'Bulk transaction rates',
+      useBulkTransactionRates:
+        'To request bulk transaction rates for your payments, use',
+      thisForm: 'this form',
+      contactForAssistance: 'to contact us for assistance.',
+      defaultTransactionRatesWarning:
+        'Without this step, you will be charged default transaction rates.',
+      acknowledgeWarningText:
+        'I understand that I will be paying default transaction rates, unless I have requested bulk transaction rates and received confirmation',
+    },
+  },
+  afterConnectionInfo: {
+    genericPaymentsError:
+      'Something went wrong when validating the connected Stripe account.',
+    stripeAccountConnected: 'Your Stripe account is connected to this Form.',
+    noPaymentCapabilities:
+      'The connected account does not have the ability to process payments.',
+    testModeStripeAccountConnected:
+      'Stripe account connected. Payments made on this form will only show in test mode in your Stripe account.',
+    testModeStripeConnectionSkipped: 'You are connected to a test account.',
+  },
+  paymentsAccountInformation: {
+    label: 'Target Account ID',
+    labelDescription: 'This is the account ID connected to this form.',
+  },
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/payments/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/payments/index.ts
@@ -1,0 +1,71 @@
+import { HasTitle } from '..'
+
+export * from './en-sg'
+
+export interface Payments extends HasTitle {
+  disabledRationaleText: {
+    genericRationale: {
+      toEnable: string
+      removeAdminEmail: string
+      turnOffPdfResponses: string
+      disableSingleSubmission: string
+    }
+    adminEmailsPresent: {
+      removeToEnable: string
+      emailNotifications: string
+    }
+    singleSubmission: {
+      disableSingleSubmission: string
+      singleSubmissionPerNricFinUen: string
+    }
+    pdfResponseEnabled: {
+      toEnable: string
+      disablePdfResponses: string
+    }
+  }
+  beforeConnectionInstructions: {
+    invalidDomain: string
+    testMode: string
+    setupGuide: {
+      read: string
+      ourGuide: string
+      setupOrConnectStripeText: string
+    }
+    bulkTransactionText: {
+      bulkTransactionRate: string
+      useBulkTransactionRates: string
+      thisForm: string
+      contactForAssistance: string
+      defaultTransactionRatesWarning: string
+      acknowledgeWarningText: string
+    }
+  }
+  afterConnectionInfo: {
+    genericPaymentsError: string
+    stripeAccountConnected: string
+    noPaymentCapabilities: string
+    testModeStripeAccountConnected: string
+    testModeStripeConnectionSkipped: string
+  }
+  paymentsAccountInformation: {
+    label: string
+    labelDescription: string
+  }
+  businessInfo: {
+    gstRegistrationNumber: string
+    businessAddress: string
+  }
+  gstToggle: {
+    label: string
+    description: string
+  }
+  paymentUnsupportedMsg: {
+    shortDescription: string
+    longDescription: string
+    learnMore: string
+  }
+  stripeConnectBtn: {
+    connect: string
+    disconnect: string
+  }
+}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #8395 

## Solution
- Extracted all text within the issue's scope

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

## Tests
- Important to note that a stripe account in test mode should be set up on the form to cover all cases
### Regression
- Create a Storage Mode form and MRF in the platform
- [ ] MRF payments section should have its text extracted properly, displaying that payments are only available in storage mode
- [ ] PaymentsDisabledRationaleText
  - [ ] Add an email field with PDF response enabled - payments section should have warning extracted properly
  - [ ] Add email address for notification - payments section should have instructions extracted properly
  - [ ] Enable single submission - payments section should have warning extracted properly
  - [ ] Add or remove conditions to make sure the appropriate instructions are properly extracted/displayed
- [ ] Test Mode
  - [ ] Ensure inline message for test mode is extracted properly (before connecting stripe account)
  - [ ] Connect account
    - [ ] Ensure all text in all sections/fields (target account id, disconnect/connect stripe button, gst applicable, business address) and their texts are properly extracted
    - [ ] Ensure test mode specific text is extracted properly
- [ ] Production Environment
  - [ ] Ensure the inline message and bulk transaction rates section for production environment is extracted properly (before connecting stripe account)
  - [ ] Connect account
    - [ ] Ensure all text in all sections/fields (target account id, disconnect/connect stripe button, gst applicable, business address) and their texts are properly extracted
- [ ] Stripe Connect Errors (and ensure text is extracted) - change boolean conditions in code to true to ensure text is extracted (im honestly not sure how to trigger both errors)
  - [ ] Connect to an account with no payment capabilities
  - [ ] Trigger a generic stripe error