### PR TITLE
feat: remove base64 of iac file string content

### DIFF
--- a/src/app/modules/auth/sgid/auth-sgid.service.ts
+++ b/src/app/modules/auth/sgid/auth-sgid.service.ts
@@ -32,7 +32,7 @@ export class AuthSgidServiceClass {
   }: ISgidVarsSchema) {
     this.privateKey = retrieveFileContent({
       preIacFilePath: privateKeyPath,
-      postIacBase64EncodedString: privateKey,
+      postIacFileContentString: privateKey,
     })
     this.client = new SgidClient({
       // If hostname is empty, use the default provided by sgid-client.

--- a/src/app/modules/intranet/intranet.service.ts
+++ b/src/app/modules/intranet/intranet.service.ts
@@ -31,7 +31,7 @@ class IntranetServiceClass {
     try {
       const intranetIpList = retrieveFileContent({
         preIacFilePath: intranetConfig.intranetIpListPath,
-        postIacBase64EncodedString: intranetConfig.intranetIpList,
+        postIacFileContentString: intranetConfig.intranetIpList,
       })
         .split('\n')
         .filter((line) => !line.startsWith('#') && line.trim() !== '')

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -125,11 +125,11 @@ export class MyInfoServiceClass {
       singpassEserviceId: spcpMyInfoConfig.spEsrvcId,
       clientPrivateKey: retrieveFileContent({
         preIacFilePath: spcpMyInfoConfig.myInfoKeyPath,
-        postIacBase64EncodedString: spcpMyInfoConfig.myInfoKey,
+        postIacFileContentString: spcpMyInfoConfig.myInfoKey,
       }),
       myInfoPublicKey: retrieveFileContent({
         preIacFilePath: spcpMyInfoConfig.myInfoCertPath,
-        postIacBase64EncodedString: spcpMyInfoConfig.myInfoCert,
+        postIacFileContentString: spcpMyInfoConfig.myInfoCert,
       }),
       clientId: spcpMyInfoConfig.myInfoClientId,
       clientSecret: spcpMyInfoConfig.myInfoClientSecret,

--- a/src/app/modules/sgid/sgid.service.ts
+++ b/src/app/modules/sgid/sgid.service.ts
@@ -58,7 +58,7 @@ export class SgidServiceClass {
   }: ISgidVarsSchema) {
     this.privateKey = retrieveFileContent({
       preIacFilePath: privateKeyPath,
-      postIacBase64EncodedString: privateKey,
+      postIacFileContentString: privateKey,
     })
     this.client = new SgidClient({
       // If hostname is empty, use the default provided by sgid-client.
@@ -70,7 +70,7 @@ export class SgidServiceClass {
     })
     this.publicKey = retrieveFileContent({
       preIacFilePath: publicKeyPath,
-      postIacBase64EncodedString: publicKey,
+      postIacFileContentString: publicKey,
     })
     this.cookieDomain = cookieDomain
     this.cookieMaxAge = cookieMaxAge

--- a/src/app/utils/iac.ts
+++ b/src/app/utils/iac.ts
@@ -15,18 +15,18 @@ const isIacMigrated = config.iacMigration.isMigrated
  *
  * Relies on convict validation to ensure that the arguments are not null based on the NODE_ENV.
  * @param preIacFilePath - The path to the file in the pre-IaC environment.
- * @param postIacBase64EncodedString - The base64 encoded string of the file in the IaC environment. Files are Base64 encoded since SSM parameters support only string values and do not support binary data.
+ * @param postIacFileContentString - The string contents of the file in the IaC environment. To use, extract out the string content in each pre-IaC file and paste them as value in the SSM param store.
  * @returns The content of the file.
  */
 export const retrieveFileContent = ({
   preIacFilePath,
-  postIacBase64EncodedString,
+  postIacFileContentString,
 }: {
   preIacFilePath: string
-  postIacBase64EncodedString: string
+  postIacFileContentString: string
 }): string => {
   if (isIacMigrated) {
-    return Buffer.from(postIacBase64EncodedString, 'base64').toString('utf-8')
+    return postIacFileContentString
   }
   return fs.readFileSync(preIacFilePath).toString()
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Expectation of base64 encoding of files is unnecessary and causes potential confusion as to why it is needed.  

## Solution
<!-- How did you solve the problem? -->

Remove base64 requirement of SSM strings. 
Since previously, the file contents are extracted and read as string, it is safe to place the file string content directly into the SSM param values without first base64 encoding them. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: Singpass myinfo forms works 
- [ ] Create a singpass form with myinfo 
- [ ] Add 1-2 myinfo fields 
- [ ] Submit as a respondent and assert it works and submission is recorded etc

TC2: Singpass SGID form works 
- [ ] Create a singpass form with SGID 
- [ ] Enable nric collection opt in 
- [ ] Submit as a respondent and assert it works and submission nric is recorded etc

TC3: reCAPTCHA whitelist works for GSIB users
- [ ] Assert that GSIB users are still whitelisted after release and they are not subject to reCAPTCHA issues. 

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
To apply these changes together with IaC envs (VAPT, stg-alt, uat, prod) in https://github.com/opengovsg/formsg-infra/pull/65