### PR TITLE
feat(i18n): move admin forbidden error strings to i18n

### DIFF
--- a/frontend/src/i18n/locales/en-sg.ts
+++ b/frontend/src/i18n/locales/en-sg.ts
@@ -36,5 +36,8 @@ export const enSG: FallbackTranslation = {
     constants: {
       validationConstants,
     },
+    
+
+
   },
 }

--- a/frontend/src/i18n/locales/features/admin-form/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/en-sg.ts
@@ -24,4 +24,16 @@ export const enSG = {
   toasts,
   settings,
   feedback,
+
+  adminForbiddenErrorPage: {
+    title: 'You do not have access to this page.',
+    message: 'Log in, or contact the owner of the form for more information.',
+    button: {
+      text: {
+        back: 'Back',
+        goToDashboard: 'Go to dashboard',
+        login: 'Log in',
+      },
+    },
+  },
 }

--- a/frontend/src/i18n/locales/features/admin-form/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/index.ts
@@ -16,3 +16,16 @@ export {
   type Workflow,
 } from './sidebar'
 export { type Toasts } from './toasts'
+
+export interface AdminForbiddenErrorPage {
+  title: string
+  message: string
+  button: {
+    text: {
+      back: string
+      goToDashboard: string
+      login: string
+    }
+  }
+}
+

--- a/frontend/src/pages/AdminForbiddenError/AdminForbiddenErrorPage.tsx
+++ b/frontend/src/pages/AdminForbiddenError/AdminForbiddenErrorPage.tsx
@@ -11,6 +11,8 @@ import Button from '~components/Button'
 import Link from '~components/Link'
 
 import { ForbiddenSvgr } from './ForbiddenSvgr'
+import { useTranslation } from 'react-i18next'
+
 
 export interface AdminForbiddenErrorPageProps {
   message?: string
@@ -22,6 +24,8 @@ export const AdminForbiddenErrorPage = ({
   const isMobile = useIsMobile()
   const navigate = useNavigate()
   const { isAuthenticated } = useAuth()
+  const { t } = useTranslation()
+
 
   return (
     <>
@@ -57,13 +61,13 @@ export const AdminForbiddenErrorPage = ({
               textAlign="center"
             >
               <Text as="h2" textStyle="h2">
-                You do not have access to this page.
+                t('features["admin-form"].adminForbiddenErrorPage.title')
               </Text>
               <Text textStyle="body-1">
                 {isAuthenticated
                   ? message
-                  : message ??
-                    'Log in, or contact the owner of the form for more information.'}
+                  : message ??  t('features["admin-form"].adminForbiddenErrorPage.message')}
+            
               </Text>
             </Stack>
             <Stack
@@ -74,7 +78,8 @@ export const AdminForbiddenErrorPage = ({
               justify="center"
             >
               <Button isFullWidth={isMobile} onClick={() => navigate(-1)}>
-                Back
+                {t('features["admin-form"].adminForbiddenErrorPage.button.text.back')}
+            
               </Button>
 
               <Link
@@ -82,7 +87,9 @@ export const AdminForbiddenErrorPage = ({
                 as={ReactLink}
                 to={isAuthenticated ? DASHBOARD_ROUTE : LOGIN_ROUTE}
               >
-                {isAuthenticated ? 'Go to dashboard' : 'Log in'}
+                {isAuthenticated 
+                ? t('features["admin-form"].adminForbiddenErrorPage.button.text.goToDashboard')
+                : t('features["admin-form"].adminForbiddenErrorPage.button.text.login')}
               </Link>
             </Stack>
           </Stack>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  

**Features**:

- Details ...
This PR moves hardcoded strings in `AdminForbiddenErrorPage` to `en-sg.ts` under `adminForbiddenErrorPage`.

**Improvements**:
It improves maintainability and prepares the page for multi-language support.

- Details ...

**Bug Fixes**:
- Added `adminForbiddenErrorPage` keys to `en-sg.ts` in i18n/locales/features/admin-form
- Refactored JSX to use `t('...')`
- Updated i18n types in `types.ts`(optional)



