### PR TITLE
chore: use npm workspaces for repo-wide npm install and better management

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ nvm use
 To install the relevant npm packages (frontend, backend and virus-scanner), run the following in the root direcory:
 
 ```bash
-npm install && npm --prefix serverless/virus-scanner install
+npm install
 ```
 
 If you are on Mac OS X, you may want to allow Docker to use more RAM (minimum of 4GB) by clicking on the Docker icon on the toolbar, clicking on the "Preferences" menu item, then clicking on the "Resources" link on the left.
@@ -239,7 +239,7 @@ Please contact FormSG (support@form.gov.sg) for any details.
 ### Migrating from MongoDB to FerretDB
 [FerretDB](https://ferretdb.io) is an open source MongoDB alternative built on PostgreSQL. MongoDB can be swapped out of FormSG for FerretDB. In order for this to be done, certain changes to the code should be made as described below:
 
-- Add postgres to the list of services in the `docker.compose` file e.g. 
+- Add postgres to the list of services in the `docker.compose` file e.g.
   ```  pg:
     image: postgres:15.3-alpine3.18
     environment:
@@ -251,7 +251,7 @@ Please contact FormSG (support@form.gov.sg) for any details.
     ports:
       - '5432:5432'
 - In the same file, change the "database" image from MongoDB to FerretDB and update the database section to include the lines below:
-    ``` 
+    ```
      image: ghcr.io/ferretdb/ferretdb:1.17.0
      environment:
        - FERRETDB_TELEMETRY=disable
@@ -261,19 +261,19 @@ Please contact FormSG (support@form.gov.sg) for any details.
      depends_on:
        - pg
 - Lastly, add the *pgdata* volume
-    ``` 
+    ```
         volumes:
             mongodb_data:
                 driver: local
             pgdata:
-- FerretDB currently has some limitations and [certain database features are not supported](https://docs.ferretdb.io/reference/supported-commands/), these include TTL, database transactions and some aggregration pipelines which are all features used by FormSG. 
+- FerretDB currently has some limitations and [certain database features are not supported](https://docs.ferretdb.io/reference/supported-commands/), these include TTL, database transactions and some aggregration pipelines which are all features used by FormSG.
 
     The following changes can be made to mitigate the limitations of FerretDB:
-    
+
     - Add the *autoRemove: 'interval'* property to the initializing of the session object in the `session.ts` file.
     - Remove the unsupported [aggregration pipeline stages](https://docs.ferretdb.io/reference/supported-commands/#aggregation-pipeline-stages) e.g. *lookup* and *project*, in the `submission.server.model.ts` file.
     - Replace the *findOneAndUpdate* code block in the `user.server.model.ts` file with code similar to the one below:
-        ```  
+        ```
          const user = await this.exists({ email: upsertParams.email })
          if (!user) {
           await this.create(upsertParams)
@@ -329,12 +329,12 @@ Refer to this [guide](https://www.couchbase.com/blog/migrate-mongodb-mongoose-co
 
 FormSG acknowledges the work done by [Arielle Baldwynn](https://github.com/whitef0x0) to build and maintain [TellForm](https://github.com/tellform), on which FormSG is based.
 
-Contributions have also been made by:  
-[@RyanAngJY](https://github.com/RyanAngJY)  
-[@jeantanzy](https://github.com/jeantanzy)  
-[@pregnantboy](https://github.com/pregnantboy)  
-[@namnguyen08](https://github.com/namnguyen08)  
-[@zioul123](https://github.com/zioul123)  
-[@JoelWee](https://github.com/JoelWee)  
-[@limli](https://github.com/limli)  
+Contributions have also been made by:
+[@RyanAngJY](https://github.com/RyanAngJY)
+[@jeantanzy](https://github.com/jeantanzy)
+[@pregnantboy](https://github.com/pregnantboy)
+[@namnguyen08](https://github.com/namnguyen08)
+[@zioul123](https://github.com/zioul123)
+[@JoelWee](https://github.com/JoelWee)
+[@limli](https://github.com/limli)
 [@tankevan](https://github.com/tankevan)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
   "name": "FormSG",
   "description": "Form Manager for Government",
+  "workspaces": [
+    "frontend",
+    "shared",
+    "serverless/virus-scanner",
+    "serverless/virus-scanner-guardduty",
+    "functions/form-payment-reconciliation",
+    "react-email-p,review"
+  ],
   "version": "6.217.0",
   "homepage": "https://form.gov.sg",
   "authors": [
@@ -24,7 +32,6 @@
     ]
   },
   "scripts": {
-    "postinstall": "npm run postinstall:frontend && npm run postinstall:shared",
     "test": "npm run test:backend && npm run test:frontend",
     "test:backend": "env-cmd -f __tests__/setup/.test-env node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:backend:ci": "env-cmd -f __tests__/setup/.test-env node --experimental-vm-modules node_modules/jest/bin/jest.js --maxWorkers=2 --logHeapUsage --workerIdleMemoryLimit=0.2",
@@ -51,9 +58,7 @@
     "version": "auto-changelog -p && git add CHANGELOG.md",
     "prepare": "husky",
     "pre-commit": "lint-staged",
-    "storybook": "npm run --prefix frontend storybook",
-    "postinstall:frontend": "npm --prefix frontend install",
-    "postinstall:shared": "npm --prefix shared install"
+    "storybook": "npm run --prefix frontend storybook"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.758.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "serverless/virus-scanner",
     "serverless/virus-scanner-guardduty",
     "functions/form-payment-reconciliation",
-    "react-email-p,review"
+    "react-email-preview"
   ],
   "version": "6.217.0",
   "homepage": "https://form.gov.sg",


### PR DESCRIPTION
## Problem
This original install instruction in the readme...

```
To install the relevant npm packages (frontend, backend and virus-scanner), run the following in the root direcory:
npm install && npm --prefix serverless/virus-scanner install
```

...implies the command will run npm install to each folder having a `package.json`. While it is very obvious and trivial what needs to be done (e.g. just run `npm --prefix <your intended folder> install` lol), it can be easily missed.

Example: the "Running locally" section states
```
First, build the frontend for local development:

npm run build:frontend

Run the following shell commands to build the Docker image. The first time will usually take 10 or so minutes. These commands runs the backend services specified under docker-compose.yml and the React frontend on the native host.

npm run dev
```
If
1. someone forgot to run `npm --prefix frontend install`
2. `npm run build:frontend` will fail, since it needs `vite` as the build tool, but the error message is non-obvious as it's a bunch of word vomit
3. then continue to proceed to `npm run dev`, only to find out backend fails to run since one of the [controller](https://github.com/opengovsg/FormSG/blob/develop/src/app/modules/frontend/frontend.controller.ts#L16) needs to resolve the built frontend.

Found this out when piloting the FormSG self-hosting guide with someone.

## Solution
A simple solution is just write this in the readme.
```
npm install && \
  npm --prefix frontend install && \
  npm --prefix shared install && \
  npm --prefix serverless/virus-scanner install && \
  ...
```

But alternatively, I'm trying to see if we can leverage [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) for this, considering the monorepo structure of the repo.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Improvements**:

- Simplified `npm i` to install `node_modules` on each listed folder.
- The usual behavior of `npm i` at root can still be achieved with `npm install --ignore-scripts --no-workspaces` if needed.

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] `npm i` at project root installs `node_modules` in all folders listed in `workspaces` section of root's `package.json`

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
- Make sure backward-compatible with existing `Dockerfile.development` and `Dockerfile.production`


**New scripts**:

- `script` : Removes `postinstall` scripts