### PR TITLE
fix: optional est time taken

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -343,7 +343,6 @@ export const DesignInput = (): JSX.Element | null => {
           name="estTimeTaken"
           control={control}
           rules={{
-            required: 'This field is required', //TODO: why is this field required? Seems a bit strange esp if we don't provide an initial value?
             min: { value: 1, message: 'Cannot be less than 1' },
             max: { value: 1000, message: 'Cannot be more than 1000' },
           }}

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -3215,7 +3215,7 @@ export const handleUpdateStartPage = [
   celebrate({
     [Segments.BODY]: {
       paragraph: Joi.string().allow('').optional(),
-      estTimeTaken: Joi.number().min(1).max(1000).required(),
+      estTimeTaken: Joi.number().min(1).max(1000).optional(),
       colorTheme: Joi.string()
         .valid(...Object.values(FormColorTheme))
         .required(),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

FormSG Admins who want to change their form design (e.g. logo, theme colour), are forced to also provide an estimated time taken.

This could cause admin context-switching and confusion.

Closes FRM-185

## Solution
<!-- How did you solve the problem? -->

Make the estimated time taken field optional.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
    - the API change updates the `estTimeTaken` field from required to optional, which is a non-breaking change

**Improvements**:

- Make the estTimeTaken field optional
- Update the validation logic for react-hook-form

## Before & After Screenshots

**BEFORE**:

<img width="1624" height="980" alt="image" src="https://github.com/user-attachments/assets/e6a117fe-b9b9-442c-a55d-6876a3d43a77" />

**AFTER**:

![formsg-optional-est-time-taken](https://github.com/user-attachments/assets/8aec74af-138b-46c8-9a5d-1aa6c42644b3)


## Tests
<!-- What tests should be run to confirm functionality? -->

**Verify that the estimated time taken can be set and unset**
- [x] Open a Form to update from the Admin Workspace
- [x] Click on the Header, then set the **Time taken to complete form (minutes)** field to a sensible value (e.g. 2 to 5 minutes)
- [x] Click on **Save design** at the bottom of the page -- the new time estimate should be reflected on the header
- [x] Click on the Header, then unset (clear) the **Time taken to complete form (minutes)** field
- [x] Click on **Save design** at the bottom of the page -- the time estimate should be removed from the header

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
