### PR TITLE
feat: reduce virus scanner lambda size to 128MB

### DIFF
--- a/serverless/virus-scanner-guardduty/serverless.yml
+++ b/serverless/virus-scanner-guardduty/serverless.yml
@@ -72,7 +72,7 @@ functions:
       name: virus-scanner-guardduty
     # max timeout per invocation
     timeout: 300
-    memorySize: 128
+    memorySize: 128 # Usage of the smallest memory size is possible since the lambda function does not load the file content into memory and simply makes API calls to S3.
     # Provision concurrency so at least one instance always hot
     # https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml/#provisioned-concurrency
     # 1 for staging, 5 for prod

--- a/serverless/virus-scanner-guardduty/serverless.yml
+++ b/serverless/virus-scanner-guardduty/serverless.yml
@@ -72,8 +72,7 @@ functions:
       name: virus-scanner-guardduty
     # max timeout per invocation
     timeout: 300
-    # allocate more memory as the default 1028 MB size will cause lambda to crash
-    memorySize: 2048
+    memorySize: 128
     # Provision concurrency so at least one instance always hot
     # https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml/#provisioned-concurrency
     # 1 for staging, 5 for prod

--- a/serverless/virus-scanner-guardduty/src/__tests/index.spec.ts
+++ b/serverless/virus-scanner-guardduty/src/__tests/index.spec.ts
@@ -71,15 +71,15 @@ describe('handler', () => {
       }),
     )
   })
-  it('should return 404 and log if file not found', async () => {
+
+  it('should return 404 if versionId not found', async () => {
     // Arrange
     const mockUUID = crypto.randomUUID()
     const mockEvent = { key: mockUUID }
 
-    // Mock rejection of getS3FileStreamWithVersionId
-    MockS3Service.prototype.getS3FileStreamWithVersionId = jest
+    MockS3Service.prototype.getS3ObjectVersionId = jest
       .fn()
-      .mockRejectedValueOnce(new Error('File not found'))
+      .mockRejectedValueOnce(new Error('VersionId is empty'))
 
     // Act
     const result = await handler(mockEvent as unknown as APIGatewayProxyEvent)
@@ -87,13 +87,46 @@ describe('handler', () => {
     // Assert
     expect(result.statusCode).toBe(StatusCodes.NOT_FOUND)
     expect(result.body).toBe(
-      JSON.stringify({ message: 'File not found', fileKey: mockUUID }),
+      JSON.stringify({
+        message: 'File not found or its content is empty',
+        fileKey: mockUUID,
+      }),
     )
     expect(mockLoggerWarn).toHaveBeenCalledTimes(1)
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: 'File not found',
-        err: new Error('File not found'),
+        message: 'File not found or its content is empty',
+        err: new Error('VersionId is empty'),
+        quarantineFileKey: mockUUID,
+      }),
+    )
+  })
+
+  it('should return 404 if body content length is empty', async () => {
+    // Arrange
+    const mockUUID = crypto.randomUUID()
+    const mockEvent = { key: mockUUID }
+
+    MockS3Service.prototype.getS3ObjectVersionId = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('Body is empty'))
+
+    // Act
+    const result = await handler(mockEvent as unknown as APIGatewayProxyEvent)
+
+    // Assert
+    expect(result.statusCode).toBe(StatusCodes.NOT_FOUND)
+    expect(result.body).toBe(
+      JSON.stringify({
+        message: 'File not found or its content is empty',
+        fileKey: mockUUID,
+      }),
+    )
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1)
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'File not found or its content is empty',
+        err: new Error('Body is empty'),
         quarantineFileKey: mockUUID,
       }),
     )
@@ -104,9 +137,9 @@ describe('handler', () => {
     const mockUUID = crypto.randomUUID()
     const mockEvent = { key: mockUUID }
 
-    MockS3Service.prototype.getS3FileStreamWithVersionId = jest
+    MockS3Service.prototype.getS3ObjectVersionId = jest
       .fn()
-      .mockResolvedValueOnce({ body: 'mockBody', versionId: 'mockVersionId' })
+      .mockResolvedValueOnce('mockVersionId')
 
     MockS3Service.prototype.deleteS3File = jest.fn().mockResolvedValueOnce('ok')
 
@@ -143,9 +176,9 @@ describe('handler', () => {
     const mockUUID = crypto.randomUUID()
     const mockEvent = { key: mockUUID }
 
-    MockS3Service.prototype.getS3FileStreamWithVersionId = jest
+    MockS3Service.prototype.getS3ObjectVersionId = jest
       .fn()
-      .mockResolvedValueOnce({ body: 'mockBody', versionId: 'mockVersionId' })
+      .mockResolvedValueOnce('mockVersionId')
 
     MockS3Service.prototype.getS3ObjectScanTag = jest
       .fn()
@@ -178,9 +211,9 @@ describe('handler', () => {
     const mockUUID = crypto.randomUUID()
     const mockEvent = { key: mockUUID }
 
-    MockS3Service.prototype.getS3FileStreamWithVersionId = jest
+    MockS3Service.prototype.getS3ObjectVersionId = jest
       .fn()
-      .mockResolvedValueOnce({ body: 'mockBody', versionId: 'mockVersionId' })
+      .mockResolvedValueOnce('mockVersionId')
 
     MockS3Service.prototype.moveS3File = jest.fn().mockResolvedValueOnce('ok')
 
@@ -216,9 +249,9 @@ describe('handler', () => {
     const mockUUID = crypto.randomUUID()
     const mockEvent = { key: mockUUID }
 
-    MockS3Service.prototype.getS3FileStreamWithVersionId = jest
+    MockS3Service.prototype.getS3ObjectVersionId = jest
       .fn()
-      .mockResolvedValueOnce({ body: 'mockBody', versionId: 'mockVersionId' })
+      .mockResolvedValueOnce('mockVersionId')
 
     MockS3Service.prototype.moveS3File = jest
       .fn()

--- a/serverless/virus-scanner-guardduty/src/__tests/s3.service.spec.ts
+++ b/serverless/virus-scanner-guardduty/src/__tests/s3.service.spec.ts
@@ -106,22 +106,19 @@ describe('S3Service', () => {
       )
     })
   })
-  describe('getS3FileStreamWithVersionId', () => {
-    it('should return file stream with version id', async () => {
+  describe('getS3ObjectVersionId', () => {
+    it('should return version id', async () => {
       // Arrange
       const mockS3Service = new S3Service(true, mockLogger)
 
       // Act
-      const result = await mockS3Service.getS3FileStreamWithVersionId({
+      const versionIdResult = await mockS3Service.getS3ObjectVersionId({
         bucketName: 'bucketName',
         objectKey: 'objectKey',
       })
 
       // Assert
-      expect(result).toEqual({
-        body: 'mockBody',
-        versionId: 'mockObjectVersionId',
-      })
+      expect(versionIdResult).toEqual('mockObjectVersionId')
     })
 
     it('should throw error and log if body is empty', async () => {
@@ -134,7 +131,7 @@ describe('S3Service', () => {
 
       // Act + assert
       await expect(
-        mockS3Service.getS3FileStreamWithVersionId({
+        mockS3Service.getS3ObjectVersionId({
           bucketName: 'bucketName',
           objectKey: 'objectKey',
         }),
@@ -161,7 +158,7 @@ describe('S3Service', () => {
 
       // Act + assert
       await expect(
-        mockS3Service.getS3FileStreamWithVersionId({
+        mockS3Service.getS3ObjectVersionId({
           bucketName: 'bucketName',
           objectKey: 'objectKey',
         }),

--- a/serverless/virus-scanner-guardduty/src/__tests/s3.service.spec.ts
+++ b/serverless/virus-scanner-guardduty/src/__tests/s3.service.spec.ts
@@ -144,7 +144,7 @@ describe('S3Service', () => {
           objectKey: 'objectKey',
           err: new Error('Body is empty'),
         }),
-        'Failed to get object from s3',
+        'Failed to get object version ID from s3',
       )
     })
 
@@ -171,7 +171,7 @@ describe('S3Service', () => {
           objectKey: 'objectKey',
           err: new Error('VersionId is empty'),
         }),
-        'Failed to get object from s3',
+        'Failed to get object version ID from s3',
       )
     })
   })

--- a/serverless/virus-scanner-guardduty/src/__tests/s3.service.spec.ts
+++ b/serverless/virus-scanner-guardduty/src/__tests/s3.service.spec.ts
@@ -8,7 +8,7 @@ import { S3Service } from '../s3.service'
 const VersionId = 'mockObjectVersionId'
 // Mock S3Client
 let getResult = {
-  Body: 'mockBody',
+  ContentLength: 100,
   VersionId,
 }
 jest.mock('@aws-sdk/client-s3', () => {
@@ -26,7 +26,7 @@ jest.mock('@aws-sdk/client-s3', () => {
     DeleteObjectCommand: jest.fn().mockImplementation(() => {
       return
     }),
-    GetObjectCommand: jest.fn().mockImplementation(() => {
+    HeadObjectCommand: jest.fn().mockImplementation(() => {
       return getResult
     }),
   }
@@ -125,7 +125,7 @@ describe('S3Service', () => {
       // Arrange
       const mockS3Service = new S3Service(true, mockLogger)
       getResult = {
-        Body: '',
+        ContentLength: 0,
         VersionId: 'mockObjectVersionId',
       }
 
@@ -152,7 +152,7 @@ describe('S3Service', () => {
       // Arrange
       const mockS3Service = new S3Service(true, mockLogger)
       getResult = {
-        Body: 'mockBody',
+        ContentLength: 100,
         VersionId: '',
       }
 

--- a/serverless/virus-scanner-guardduty/src/index.ts
+++ b/serverless/virus-scanner-guardduty/src/index.ts
@@ -59,9 +59,9 @@ export const handler = async (
   // Retrieve from S3
   const s3Client = new S3Service(config.isTestOrDev, logger)
 
-  let s3ReadableStream
+  let versionId: string
   try {
-    s3ReadableStream = await s3Client.getS3FileStreamWithVersionId({
+    versionId = await s3Client.getS3ObjectVersionId({
       bucketName: quarantineBucket,
       objectKey: quarantineFileKey,
     })
@@ -79,10 +79,6 @@ export const handler = async (
       }),
     }
   }
-
-  // Scan file
-
-  const { versionId } = s3ReadableStream
 
   let tagResult
   try {

--- a/serverless/virus-scanner-guardduty/src/index.ts
+++ b/serverless/virus-scanner-guardduty/src/index.ts
@@ -67,14 +67,14 @@ export const handler = async (
     })
   } catch (err) {
     logger.warn({
-      message: 'File not found',
+      message: 'File not found or its content is empty',
       err,
       quarantineFileKey,
     })
     return {
       statusCode: StatusCodes.NOT_FOUND,
       body: JSON.stringify({
-        message: 'File not found',
+        message: 'File not found or its content is empty',
         fileKey: quarantineFileKey,
       }),
     }

--- a/serverless/virus-scanner-guardduty/src/s3.service.ts
+++ b/serverless/virus-scanner-guardduty/src/s3.service.ts
@@ -253,7 +253,7 @@ export class S3Service {
       }
 
       if (!ContentLength || ContentLength === 0) {
-        throw new Error('Object is empty')
+        throw new Error('Body is empty')
       }
 
       this.logger.info(

--- a/serverless/virus-scanner-guardduty/src/s3.service.ts
+++ b/serverless/virus-scanner-guardduty/src/s3.service.ts
@@ -1,8 +1,8 @@
 import {
   CopyObjectCommand,
   DeleteObjectCommand,
-  GetObjectCommand,
   GetObjectTaggingCommand,
+  HeadObjectCommand,
   S3Client,
   Tag,
 } from '@aws-sdk/client-s3'
@@ -12,7 +12,6 @@ import { retry } from 'ts-retry-promise'
 import {
   DeleteS3FileParams,
   GetS3FileStreamParams,
-  GetS3FileStreamResult,
   GUARD_DUTY_MALWARE_SCAN_TAG,
   MoveS3FileParams,
 } from './types'
@@ -39,57 +38,6 @@ export class S3Service {
       this.s3Client = new S3Client({
         region: 'ap-southeast-1',
       })
-    }
-  }
-
-  async getS3FileStreamWithVersionId({
-    bucketName,
-    objectKey,
-  }: GetS3FileStreamParams): Promise<GetS3FileStreamResult> {
-    this.logger.info(
-      {
-        bucketName,
-        objectKey,
-      },
-      'Getting document from s3',
-    )
-
-    try {
-      const { Body: body, VersionId: versionId } = await this.s3Client.send(
-        new GetObjectCommand({
-          Key: objectKey,
-          Bucket: bucketName,
-        }),
-      )
-
-      if (!body) {
-        throw new Error('Body is empty')
-      }
-
-      if (!versionId) {
-        throw new Error('VersionId is empty')
-      }
-
-      this.logger.info(
-        {
-          bucketName,
-          objectKey,
-        },
-        'Retrieved document from s3',
-      )
-
-      return { body, versionId } as GetS3FileStreamResult
-    } catch (err) {
-      this.logger.error(
-        {
-          bucketName,
-          objectKey,
-          err,
-        },
-        'Failed to get object from s3',
-      )
-
-      throw err
     }
   }
 
@@ -270,6 +218,66 @@ export class S3Service {
         })
         throw e
       }
+    }
+  }
+
+  /**
+   * Gets the version ID metadata without loading file content into lambda memory.
+   * RATIONALE: This aims to reduce the memory usage and hence reduce the memory requirement for the lambda function, saving monetary cost.
+   * In the event that the object is empty, an error is thrown.
+   * @param params GetS3FileStreamParams
+   * @returns Promise<{ versionId: string }>
+   */
+  async getS3ObjectVersionId({
+    bucketName,
+    objectKey,
+  }: GetS3FileStreamParams): Promise<string> {
+    this.logger.info(
+      {
+        bucketName,
+        objectKey,
+      },
+      'Getting object version ID from s3',
+    )
+
+    try {
+      const { VersionId: versionId, ContentLength } = await this.s3Client.send(
+        new HeadObjectCommand({
+          Key: objectKey,
+          Bucket: bucketName,
+        }),
+      )
+
+      if (!versionId) {
+        throw new Error('VersionId is empty')
+      }
+
+      if (!ContentLength || ContentLength === 0) {
+        throw new Error('Object is empty')
+      }
+
+      this.logger.info(
+        {
+          bucketName,
+          objectKey,
+          versionId,
+          contentLength: ContentLength,
+        },
+        'Retrieved object version ID from s3',
+      )
+
+      return versionId
+    } catch (err) {
+      this.logger.error(
+        {
+          bucketName,
+          objectKey,
+          err,
+        },
+        'Failed to get object version ID from s3',
+      )
+
+      throw err
     }
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, the guard duty virus scanner consumes 2048MB of memory. However, the cost of lambda virus scanner invocations can be reduced 16x per month by reducing the memory size to 128MB with some optimizations. 

## Solution
<!-- How did you solve the problem? -->

Prevent loading of file content into lambda memory - by only loading the metadata to save memory usage. 
Change the virus scanner lambda to 128MB. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Virus scanner works to scan files 
- [x] Create a form with 20MB file attachment fields totaling up to 20mb
- [x] Upload files to the attachment field - aiming to upload as large file size as possible
- [x] Assert virus scanner works and form can be submitted