### PR TITLE
fix: resolve bug on radio field bug fix

### DIFF
--- a/shared/utils/logic.ts
+++ b/shared/utils/logic.ts
@@ -1,3 +1,4 @@
+import { CLIENT_RADIO_OTHERS_INPUT_VALUE } from '../constants'
 import {
   BasicField,
   FormDto,
@@ -408,7 +409,14 @@ const isConditionFulfilled = (
           }
         } else {
           // (4) Client-side handling
-          if (currentValue.value === undefined && !!currentValue.othersInput) {
+          // This function is used by (1) FE to display visible fields and (2) BE for logic validation.
+          // For BE validation, we strip currentValue.value away and reintroduce it (above in the same function)
+          // so we also check and validate if .value is undefined
+          if (
+            (currentValue.value === CLIENT_RADIO_OTHERS_INPUT_VALUE ||
+              currentValue.value === undefined) &&
+            !!currentValue.othersInput
+          ) {
             return true
           }
         }

--- a/shared/utils/logic.ts
+++ b/shared/utils/logic.ts
@@ -411,7 +411,7 @@ const isConditionFulfilled = (
           // (4) Client-side handling
           // This function is used by (1) FE to display visible fields and (2) BE for logic validation.
           // For BE validation, we strip currentValue.value away and reintroduce it (above in the same function)
-          // so we also check and validate if .value is undefined
+          // so we also check and validate if .value is undefined (https://github.com/opengovsg/FormSG/pull/8568)
           if (
             (currentValue.value === CLIENT_RADIO_OTHERS_INPUT_VALUE ||
               currentValue.value === undefined) &&


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Because `isConditionalFulfilled` is also used on the FE to display visible fields and it's `.value === CLIENT_RADIO_OTHERS_INPUT_VALUE` on the FE, a radio 'Others: ' input will fail to show/manage logic affected on it

Closes FRM-2063

## Solution
<!-- How did you solve the problem? -->

Update the condition to check if the value is either undefined (BE validation) or CLIENT_RADIO_OTHERS_INPUT_VALUE (FE).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
