### PR TITLE
feat: allow field type change

### DIFF
--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -535,8 +535,9 @@ const addBasicField = async (
       }
     // Fall through to set "Options".
     case BasicField.Dropdown:
+      // Wait for the textarea to be available and fill it with options
       await page
-        .getByLabel('Options')
+        .getByRole('textbox', { name: 'Options' })
         .first()
         .fill(field.fieldOptions.join('\n'))
       break

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAddress/EditAddress.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAddress/EditAddress.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { FormControl } from '@chakra-ui/react'
+import { t } from 'i18next'
 import { extend, pick } from 'lodash'
 
 import { AddressCompoundFieldBase } from '~shared/types/field'
@@ -28,15 +29,10 @@ export const EditAddress = ({ field }: EditAddressProps): JSX.Element => {
   const {
     register,
     formState: { errors },
-    getValues,
     buttonText,
     handleUpdateField,
-    watch,
-    control,
-    clearErrors,
     isLoading,
     handleCancel,
-    setValue,
   } = useEditFieldForm<EditAddressInputs, AddressCompoundFieldBase>({
     field,
     transform: {
@@ -53,9 +49,11 @@ export const EditAddress = ({ field }: EditAddressProps): JSX.Element => {
     [],
   )
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
-        <FormLabel>Field Name</FormLabel>
+        <FormLabel>
+          {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}
+        </FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAttachment/EditAttachment.tsx
@@ -155,7 +155,7 @@ export const EditAttachment = ({ field }: EditAttachmentProps): JSX.Element => {
   }, [form, validateAttachmentSize])
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
@@ -224,7 +224,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
   }, [clearErrors, watchedInputs.validateByValue])
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCountryRegion/EditCountryRegion.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCountryRegion/EditCountryRegion.tsx
@@ -73,7 +73,7 @@ export const EditCountryRegion = ({
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -262,7 +262,7 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
   const { drawerWidth } = useCreatePageSidebarLayout()
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDecimal/EditDecimal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDecimal/EditDecimal.tsx
@@ -99,7 +99,7 @@ export const EditDecimal = ({ field }: EditDecimalProps): JSX.Element => {
   }, [getValues, t])
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
@@ -88,7 +88,7 @@ export const EditDropdown = ({ field }: EditDropdownProps): JSX.Element => {
   }, [formWorkflow, field._id])
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -156,7 +156,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     !field.autoReplyOptions.hasAutoReply
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHeader.tsx
@@ -48,7 +48,7 @@ export const EditHeader = ({ field }: EditHeaderProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.section.heading')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHomeno/EditHomeno.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHomeno/EditHomeno.tsx
@@ -55,7 +55,7 @@ export const EditHomeno = ({ field }: EditHomenoProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditImage/EditImage.tsx
@@ -159,7 +159,7 @@ export const EditImage = ({ field }: EditImageProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl
         isRequired
         isReadOnly={isLoading || isSubmitting}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -134,7 +134,7 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
@@ -69,7 +69,7 @@ export const EditMobile = ({ field }: EditMobileProps): JSX.Element => {
 
   return (
     <>
-      <CreatePageDrawerContentContainer>
+      <CreatePageDrawerContentContainer isFieldTypeChangeable>
         <FormControl
           isRequired
           isReadOnly={isLoading}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/EditMyInfo.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/EditMyInfo.tsx
@@ -1,10 +1,9 @@
 import { BiCheck, BiData, BiX } from 'react-icons/bi'
-import { Box, HStack, Icon, Text, VStack } from '@chakra-ui/react'
+import { HStack, Icon, Text, VStack } from '@chakra-ui/react'
 
 import { MyInfoField } from '~shared/types'
 
 import { SINGPASS_FAQ } from '~constants/links'
-import InlineMessage from '~components/InlineMessage'
 import Link from '~components/Link'
 
 import {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
@@ -7,7 +7,6 @@ import { MyInfoChildAttributes } from '~shared/types'
 
 import { SINGPASS_FAQ } from '~constants/links'
 import { MultiSelect } from '~components/Dropdown'
-import InlineMessage from '~components/InlineMessage'
 import Link from '~components/Link'
 import { Toggle } from '~components/Toggle/Toggle'
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNric.tsx
@@ -51,7 +51,7 @@ export const EditNric = ({ field }: EditNricProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
@@ -296,7 +296,7 @@ export const EditNumber = ({ field }: EditNumberProps): JSX.Element => {
   }, [clearErrors, setValue, watchedSelectedValidation])
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditParagraph.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditParagraph.tsx
@@ -50,7 +50,7 @@ export const EditParagraph = ({ field }: EditParagraphProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl
         isRequired
         isReadOnly={isLoading}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRadio/EditRadio.tsx
@@ -94,7 +94,7 @@ export const EditRadio = ({ field }: EditRadioProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditRating/EditRating.tsx
@@ -66,7 +66,7 @@ export const EditRating = ({ field }: EditRatingProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -178,7 +178,7 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
   }, [clearErrors, setValue, watchedSelectedValidation])
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTable.tsx
@@ -123,7 +123,7 @@ export const EditTable = ({ field }: EditTableProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditUen.tsx
@@ -48,7 +48,7 @@ export const EditUen = ({ field }: EditUenProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditYesNo.tsx
@@ -54,7 +54,7 @@ export const EditYesNo = ({ field }: EditYesNoProps): JSX.Element => {
   )
 
   return (
-    <CreatePageDrawerContentContainer>
+    <CreatePageDrawerContentContainer isFieldTypeChangeable>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
         <FormLabel>
           {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -37,6 +37,7 @@ import {
   updateEditStateSelector,
   useFieldBuilderStore,
 } from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
+import { filterValidFieldTypeProperties } from '~features/admin-form/create/builder-and-design/utils/fieldCreation'
 import { isMyInfo } from '~features/myinfo/utils'
 
 import { EditFieldProps } from './types'
@@ -161,6 +162,10 @@ export const useEditFieldForm = <
         updatedFormField,
       )
     }
+
+    updatedFormField = filterValidFieldTypeProperties(
+      updatedFormField,
+    ) as FieldShape
 
     // if field to be updated is MyInfo, enable admin feedback
     if (isMyInfo(updatedFormField)) setIsAdminFeedbackEligible(true)

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { Box } from '@chakra-ui/react'
 import { Droppable } from '@hello-pangea/dnd'
 

--- a/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
@@ -1,4 +1,4 @@
-import { isEqual, pick } from 'lodash'
+import { isEqual, merge } from 'lodash'
 import create from 'zustand'
 import { devtools } from 'zustand/middleware'
 
@@ -63,9 +63,10 @@ const getChangedFieldValues = ({
 }): FormFieldDto => {
   const newFieldMeta = getFieldCreationMeta(fieldTypeToChangeTo)
 
+  const changedFieldValues = merge(newFieldMeta, existingFieldValues)
+
   return {
-    ...newFieldMeta,
-    ...existingFieldValues,
+    ...changedFieldValues,
     fieldType: fieldTypeToChangeTo,
     _id,
   } as FormFieldDto

--- a/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
@@ -1,8 +1,10 @@
-import { isEqual } from 'lodash'
+import { isEqual, pick } from 'lodash'
 import create from 'zustand'
 import { devtools } from 'zustand/middleware'
 
-import { FieldCreateDto, FormFieldDto } from '~shared/types/field'
+import { BasicField, FieldCreateDto, FormFieldDto } from '~shared/types/field'
+
+import { getFieldCreationMeta } from './utils/fieldCreation'
 
 export enum FieldBuilderState {
   CreatingField,
@@ -28,6 +30,7 @@ export type FieldBuilderStore = {
     holding?: boolean,
   ) => void
   updateEditState: (field: FormFieldDto, holding?: boolean) => void
+  changeFieldType: (fieldTypeToChangeTo: BasicField) => void
   setToInactive: (holding?: boolean) => void
   stateData:
     | FieldBuilderCreateEditStateData
@@ -40,6 +43,32 @@ export type FieldBuilderStore = {
     | null
   clearHoldingStateData: () => void
   moveFromHolding: () => void
+}
+
+/*
+ * Used to generate the required new field properties when changing between basic field types.
+ * Note that the new field values includes all current values including properties not required by the new field type.
+ * This allows us to retain user-defined values for subsequent field type changes.
+ * For example, suppose a user-defined options for radio field type and then changes the field type to short text,
+ * the user-defined options is retained so if the user changes to checkbox next, the options will be retained and applied to the checkbox field.
+ */
+const getChangedFieldValues = ({
+  existingFieldValues,
+  fieldTypeToChangeTo,
+  _id,
+}: {
+  existingFieldValues: FieldCreateDto | FormFieldDto
+  fieldTypeToChangeTo: BasicField
+  _id?: string
+}): FormFieldDto => {
+  const newFieldMeta = getFieldCreationMeta(fieldTypeToChangeTo)
+
+  return {
+    ...newFieldMeta,
+    ...existingFieldValues,
+    fieldType: fieldTypeToChangeTo,
+    _id,
+  } as FormFieldDto
 }
 
 export const useFieldBuilderStore = create<FieldBuilderStore>()(
@@ -95,6 +124,36 @@ export const useFieldBuilderStore = create<FieldBuilderStore>()(
         set({ stateData })
       }
     },
+    changeFieldType: (fieldTypeToChangeTo) => {
+      const current = get()
+
+      if (current.stateData.state === FieldBuilderState.CreatingField) {
+        const changedField = getChangedFieldValues({
+          existingFieldValues: current.stateData.field,
+          fieldTypeToChangeTo,
+        })
+
+        set({
+          stateData: {
+            state: FieldBuilderState.CreatingField,
+            field: changedField,
+            insertionIndex: current.stateData.insertionIndex,
+          },
+        })
+      } else if (current.stateData.state === FieldBuilderState.EditingField) {
+        const changedField = getChangedFieldValues({
+          existingFieldValues: current.stateData.field,
+          fieldTypeToChangeTo,
+          _id: current.stateData.field._id,
+        })
+        set({
+          stateData: {
+            state: FieldBuilderState.EditingField,
+            field: changedField,
+          },
+        })
+      }
+    },
     setToInactive: (holding?: boolean) => {
       const nextState: FieldBuilderStore['holdingStateData'] = {
         state: FieldBuilderState.Inactive,
@@ -107,6 +166,18 @@ export const useFieldBuilderStore = create<FieldBuilderStore>()(
     },
   })),
 )
+
+export const fieldTypeSelector = (
+  state: FieldBuilderStore,
+): BasicField | undefined => {
+  if (
+    state.stateData.state === FieldBuilderState.CreatingField ||
+    state.stateData.state === FieldBuilderState.EditingField
+  ) {
+    return state.stateData.field.fieldType
+  }
+  return undefined
+}
 
 export const stateDataSelector = (
   state: FieldBuilderStore,
@@ -127,3 +198,7 @@ export const updateEditStateSelector = (
 export const setToInactiveSelector = (
   state: FieldBuilderStore,
 ): FieldBuilderStore['setToInactive'] => state.setToInactive
+
+export const changeFieldTypeSelector = (
+  state: FieldBuilderStore,
+): FieldBuilderStore['changeFieldType'] => state.changeFieldType

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -1,9 +1,13 @@
+import { pick } from 'lodash'
+
 import { MYINFO_ATTRIBUTE_MAP } from '~shared/constants/field/myinfo'
 import {
   AllowedMyInfoFieldOption,
   AttachmentSize,
   BasicField,
+  FieldBase,
   FieldCreateDto,
+  FormField,
   MyInfoAttribute,
   MyInfoField,
   RatingShape,
@@ -312,4 +316,142 @@ export const getMyInfoFieldCreationMeta = (
       throw new Error(`MyInfo type is not implemented: ${exception}`)
     }
   }
+}
+
+/**
+ * Gets valid properties for a given BasicField field type
+ */
+const getValidPropertiesForFieldType = (fieldType: BasicField): string[] => {
+  const baseProperties = [
+    'fieldType',
+    'title',
+    'description',
+    'required',
+    'disabled',
+    'titleTranslations',
+    'descriptionTranslations',
+    'globalId',
+  ]
+
+  const fieldTypeProperties = {
+    [BasicField.Section]: baseProperties,
+    [BasicField.Statement]: baseProperties,
+    [BasicField.Email]: [
+      ...baseProperties,
+      'isVerifiable',
+      'hasAllowedEmailDomains',
+      'allowedEmailDomains',
+      'autoReplyOptions',
+    ],
+    [BasicField.Mobile]: [
+      ...baseProperties,
+      'isVerifiable',
+      'allowIntlNumbers',
+    ],
+    [BasicField.HomeNo]: [...baseProperties, 'allowIntlNumbers', 'myInfo'],
+    [BasicField.Number]: [
+      ...baseProperties,
+      'ValidationOptions',
+      'ValidationOptions.selectedValidation',
+      'ValidationOptions.LengthValidationOptions',
+      'ValidationOptions.LengthValidationOptions.selectedLengthValidation',
+      'ValidationOptions.LengthValidationOptions.customVal',
+      'ValidationOptions.RangeValidationOptions',
+      'ValidationOptions.RangeValidationOptions.customMin',
+      'ValidationOptions.RangeValidationOptions.customMax',
+    ],
+    [BasicField.Decimal]: [
+      ...baseProperties,
+      'validateByValue',
+      'ValidationOptions',
+      'ValidationOptions.customMin',
+      'ValidationOptions.customMax',
+    ],
+    [BasicField.Image]: [
+      ...baseProperties,
+      'fileMd5Hash',
+      'name',
+      'url',
+      'size',
+    ],
+    [BasicField.ShortText]: [
+      ...baseProperties,
+      'ValidationOptions',
+      'ValidationOptions.selectedValidation',
+      'ValidationOptions.customVal',
+      'allowPrefill',
+      'lockPrefill',
+    ],
+    [BasicField.LongText]: [
+      ...baseProperties,
+      'ValidationOptions',
+      'ValidationOptions.selectedValidation',
+      'ValidationOptions.customVal',
+    ],
+    [BasicField.Dropdown]: [
+      ...baseProperties,
+      'fieldOptions',
+      'fieldOptionsTranslations',
+    ],
+    [BasicField.CountryRegion]: [...baseProperties, 'fieldOptions', 'myInfo'],
+    [BasicField.YesNo]: [...baseProperties, 'myInfo'],
+    [BasicField.Checkbox]: [
+      ...baseProperties,
+      'fieldOptions',
+      'fieldOptionsTranslations',
+      'othersRadioButton',
+      'ValidationOptions',
+      'ValidationOptions.customMin',
+      'ValidationOptions.customMax',
+      'validateByValue',
+    ],
+    [BasicField.Radio]: [
+      ...baseProperties,
+      'fieldOptions',
+      'fieldOptionsTranslations',
+      'othersRadioButton',
+    ],
+    [BasicField.Attachment]: [...baseProperties, 'attachmentSize'],
+    [BasicField.Date]: [
+      ...baseProperties,
+      'dateValidation',
+      'dateValidation.customMaxDate',
+      'dateValidation.customMinDate',
+      'dateValidation.selectedDateValidation',
+    ],
+    [BasicField.Rating]: [
+      ...baseProperties,
+      'ratingOptions',
+      'ratingOptions.shape',
+      'ratingOptions.steps',
+    ],
+    [BasicField.Nric]: [...baseProperties, 'myInfo'],
+    [BasicField.Table]: [
+      ...baseProperties,
+      'columns',
+      'minimumRows',
+      'addMoreRows',
+      'maximumRows',
+    ],
+    [BasicField.Uen]: [...baseProperties, 'myInfo'],
+    [BasicField.Children]: [
+      ...baseProperties,
+      'childrenSubFields',
+      'allowMultiple',
+    ],
+    [BasicField.Address]: [...baseProperties, 'addressSubFields'],
+  }
+
+  return fieldTypeProperties[fieldType] || baseProperties
+}
+
+/**
+ * Filters an field object to only include properties valid for its field type.
+ */
+export const filterValidFieldTypeProperties = (field: FormField): FieldBase => {
+  const validPropertyKeyPaths = getValidPropertiesForFieldType(field.fieldType)
+
+  const filteredField = pick(field, validPropertyKeyPaths) as FieldBase
+
+  return filteredField as FieldBase
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
+++ b/frontend/src/features/admin-form/create/builder-and-design/utils/fieldCreation.ts
@@ -347,6 +347,7 @@ const getValidPropertiesForFieldType = (fieldType: BasicField): string[] => {
       ...baseProperties,
       'isVerifiable',
       'allowIntlNumbers',
+      'myInfo',
     ],
     [BasicField.HomeNo]: [...baseProperties, 'allowIntlNumbers', 'myInfo'],
     [BasicField.Number]: [
@@ -381,6 +382,7 @@ const getValidPropertiesForFieldType = (fieldType: BasicField): string[] => {
       'ValidationOptions.customVal',
       'allowPrefill',
       'lockPrefill',
+      'myInfo',
     ],
     [BasicField.LongText]: [
       ...baseProperties,
@@ -392,6 +394,7 @@ const getValidPropertiesForFieldType = (fieldType: BasicField): string[] => {
       ...baseProperties,
       'fieldOptions',
       'fieldOptionsTranslations',
+      'myInfo',
     ],
     [BasicField.CountryRegion]: [...baseProperties, 'fieldOptions', 'myInfo'],
     [BasicField.YesNo]: [...baseProperties, 'myInfo'],
@@ -418,6 +421,7 @@ const getValidPropertiesForFieldType = (fieldType: BasicField): string[] => {
       'dateValidation.customMaxDate',
       'dateValidation.customMinDate',
       'dateValidation.selectedDateValidation',
+      'myInfo',
     ],
     [BasicField.Rating]: [
       ...baseProperties,
@@ -450,8 +454,6 @@ const getValidPropertiesForFieldType = (fieldType: BasicField): string[] => {
  */
 export const filterValidFieldTypeProperties = (field: FormField): FieldBase => {
   const validPropertyKeyPaths = getValidPropertiesForFieldType(field.fieldType)
-
   const filteredField = pick(field, validPropertyKeyPaths) as FieldBase
-
   return filteredField as FieldBase
 }

--- a/frontend/src/features/admin-form/create/common/CreatePageDrawer/CreatePageDrawerContentContainer.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageDrawer/CreatePageDrawerContentContainer.tsx
@@ -1,8 +1,17 @@
 import { Children } from 'react'
 import { Box, Divider, Stack, StackProps } from '@chakra-ui/layout'
 
+import { FieldTypeSelect } from './FieldTypeSelect'
+
+const InputContainer = ({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element => <Box px="1.5rem">{children}</Box>
+
 export interface DrawerContentContainerProps extends StackProps {
   children: React.ReactNode
+  isFieldTypeChangeable?: boolean
 }
 /**
  * Component to provide consistent padding to rendered builder/edit field drawer
@@ -10,6 +19,7 @@ export interface DrawerContentContainerProps extends StackProps {
  */
 export const CreatePageDrawerContentContainer = ({
   children,
+  isFieldTypeChangeable = false,
   ...props
 }: DrawerContentContainerProps): JSX.Element => {
   return (
@@ -23,9 +33,14 @@ export const CreatePageDrawerContentContainer = ({
       spacing="2rem"
       {...props}
     >
+      {isFieldTypeChangeable && (
+        <InputContainer>
+          <FieldTypeSelect />
+        </InputContainer>
+      )}
       {Children.map(
         children,
-        (child) => child && <Box px="1.5rem">{child}</Box>,
+        (child) => child && <InputContainer>{child}</InputContainer>,
       )}
     </Stack>
   )

--- a/frontend/src/features/admin-form/create/common/CreatePageDrawer/FieldTypeSelect.tsx
+++ b/frontend/src/features/admin-form/create/common/CreatePageDrawer/FieldTypeSelect.tsx
@@ -1,0 +1,46 @@
+import { FormControl, FormLabel } from '@chakra-ui/react'
+
+import { BasicField } from '~shared/types'
+
+import { SingleSelect } from '~components/Dropdown/SingleSelect'
+
+import {
+  changeFieldTypeSelector,
+  fieldTypeSelector,
+  useFieldBuilderStore,
+} from '../../builder-and-design/useFieldBuilderStore'
+import { BASICFIELD_TO_DRAWER_META } from '../../constants'
+
+export const FieldTypeSelect = (): JSX.Element => {
+  const changeFieldType = useFieldBuilderStore(changeFieldTypeSelector)
+  const fieldType = useFieldBuilderStore(fieldTypeSelector)
+
+  const fieldOptions = Object.entries(BASICFIELD_TO_DRAWER_META)
+    .filter(([, meta]) => meta.isUsed !== false)
+    .map(([fieldType, meta]) => ({
+      value: fieldType,
+      label: meta.label,
+      icon: meta.icon,
+    }))
+
+  const isFieldTypeChangeable =
+    fieldType !== undefined &&
+    fieldOptions.map((f) => f.value).includes(fieldType)
+
+  return isFieldTypeChangeable ? (
+    <FormControl>
+      <FormLabel>Field Type</FormLabel>
+      <SingleSelect
+        items={fieldOptions}
+        onChange={(value) => {
+          changeFieldType(value as BasicField)
+        }}
+        value={fieldType as BasicField}
+        name="fieldType"
+        isClearable={false}
+      />
+    </FormControl>
+  ) : (
+    <></>
+  )
+}

--- a/frontend/src/features/admin-form/create/common/FieldTypeSelect.stories.tsx
+++ b/frontend/src/features/admin-form/create/common/FieldTypeSelect.stories.tsx
@@ -1,0 +1,128 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { expect, screen, userEvent, within } from '@storybook/test'
+
+import { BasicField, FormFieldDto } from '~shared/types'
+
+import {
+  FieldBuilderState,
+  useFieldBuilderStore,
+} from '../builder-and-design/useFieldBuilderStore'
+import { getFieldCreationMeta } from '../builder-and-design/utils/fieldCreation'
+
+import { FieldTypeSelect } from './CreatePageDrawer/FieldTypeSelect'
+
+const meta = {
+  title: 'Features/AdminForm/Create/Common/FieldTypeSelect',
+  component: FieldTypeSelect,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof FieldTypeSelect>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// export const Default: Story = {
+//   args: {},
+// }
+
+export const WithLongTextFieldType: Story = {
+  decorators: [
+    (Story) => {
+      const store = useFieldBuilderStore.getState()
+      store.updateCreateState(getFieldCreationMeta(BasicField.LongText), 0)
+      return <Story />
+    },
+  ],
+}
+
+export const WithUnsupportedFieldType: Story = {
+  decorators: [
+    (Story) => {
+      const store = useFieldBuilderStore.getState()
+      store.updateCreateState(
+        {
+          fieldType: 'undefined',
+          title: '',
+          description: '',
+          required: true,
+          disabled: false,
+        } as unknown as FormFieldDto,
+        0,
+      )
+      return <Story />
+    },
+  ],
+}
+
+export const WithFieldTypeSearch: Story = {
+  decorators: [
+    (Story) => {
+      const store = useFieldBuilderStore.getState()
+      store.updateCreateState(getFieldCreationMeta(BasicField.ShortText), 0)
+      return <Story />
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Click the select dropdown
+    const selectButton = canvas.getByRole('combobox')
+    await userEvent.click(selectButton)
+
+    // Filter for number field
+    await userEvent.type(selectButton, 'number')
+
+    // Wait for the dropdown menu to appear and verify filtered options
+    // The menu is rendered in a portal, so we need to look for it in the document
+    const options = await screen.findAllByRole('option')
+    expect(options.length).toBe(3)
+    expect(options[0]).toHaveTextContent(/number/i)
+    expect(options[1]).toHaveTextContent(/home number/i)
+    expect(options[2]).toHaveTextContent(/mobile number/i)
+  },
+}
+
+export const WithFieldTypeChange: Story = {
+  decorators: [
+    (Story) => {
+      const store = useFieldBuilderStore.getState()
+      store.updateCreateState(getFieldCreationMeta(BasicField.ShortText), 0)
+      return <Story />
+    },
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Verify initial field type is ShortText
+    const initialStore = useFieldBuilderStore.getState()
+    expect(initialStore.stateData.state).toBe(FieldBuilderState.CreatingField)
+    expect(
+      (initialStore.stateData as { field: { fieldType: BasicField } }).field
+        .fieldType,
+    ).toBe(BasicField.ShortText)
+
+    // Click the select dropdown
+    const selectButton = canvas.getByRole('combobox')
+    await userEvent.click(selectButton)
+
+    // Filter for email field
+    await userEvent.type(selectButton, 'email')
+
+    // Wait for the dropdown menu to appear and verify filtered options
+    // The menu is rendered in a portal, so we need to look for it in the document
+    const options = await screen.findAllByRole('option')
+    expect(options.length).toBe(1)
+    expect(options[0]).toHaveTextContent(/email/i)
+
+    // Click the Email option
+    await userEvent.click(options[0])
+
+    // Verify changeFieldType was called with Email
+    const store = useFieldBuilderStore.getState()
+    expect(store.stateData.state).toBe(FieldBuilderState.CreatingField)
+    expect(
+      (store.stateData as { field: { fieldType: BasicField } }).field.fieldType,
+    ).toBe(BasicField.Email)
+  },
+}

--- a/frontend/src/features/admin-form/create/constants.ts
+++ b/frontend/src/features/admin-form/create/constants.ts
@@ -54,6 +54,7 @@ export type BuilderSidebarFieldMeta = {
   // Is this fieldType included in submissions?
   isSubmitted: boolean
   searchAliases?: string[]
+  isUsed?: boolean // Used to mark field type as deprecated / not currently being used. For example, Children basic field is not being used but still kept in the codebase for legacy reasons.
 }
 
 // !!! Do not use this to reference field titles for MyInfo fields. !!!
@@ -266,6 +267,7 @@ export const BASICFIELD_TO_DRAWER_META: {
     label: 'Children',
     icon: BiGroup,
     isSubmitted: true,
+    isUsed: false, // For legacy reasons, Children basic field is not being used
   },
 
   [BasicField.Address]: {

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -2668,7 +2668,7 @@ describe('Form Model', () => {
         })
       })
 
-      it('should return updated form when successfully updating form field', async () => {
+      it('should return updated form when successfully updating form field without changing field type', async () => {
         // Arrange
         const originalFormFields = (
           form.form_fields as Types.DocumentArray<IFieldSchema>
@@ -2707,7 +2707,50 @@ describe('Form Model', () => {
         expect(actual).toBeNull()
       })
 
-      it('should return validation error if field type of new field does not match the field to update', async () => {
+      it('should successfully update form field and ignore extra properties not in field type schema', async () => {
+        // Arrange
+        const originalFormFields = (
+          form.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        const newField: FormFieldDto = {
+          ...originalFormFields[0], // Checkbox field
+          title: 'updated checkbox',
+          // Add extra property that doesn't exist in CheckboxFieldBase
+          extraProperty: 'this should not be saved',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            autoReplySubject: 'auto reply subject',
+            autoReplySender: 'auto reply sender',
+            autoReplyMessage: 'auto reply message',
+            includeFormSummary: true,
+          },
+          validateByValue: true,
+          fieldOptions: ['option 1', 'option 2'],
+        }
+
+        // Act
+        const actual = await form.updateFormFieldById(newField._id, newField)
+
+        // Assert
+        expect(actual).not.toBeNull()
+        const updatedFields = (
+          actual?.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        // Updated field should only contain valid checkbox properties
+        expect(updatedFields[0].title).toEqual('updated checkbox')
+        expect(updatedFields[0].fieldOptions).toEqual(['option 1', 'option 2'])
+        expect(updatedFields[0].validateByValue).toEqual(true)
+        // Does not save extra properties not in field type schema
+        expect('extraProperty' in updatedFields[0]).toBeFalse()
+        expect(updatedFields[0].autoReplyOptions).toBeUndefined()
+        // Second and third fields should remain unchanged
+        expect(updatedFields[1]).toEqual(originalFormFields[1])
+        expect(updatedFields[2]).toEqual(originalFormFields[2])
+      })
+
+      it('should successfully update form field when changing field type from HomeNo to Mobile', async () => {
         // Arrange
         const originalFormFields = (
           form.form_fields as Types.DocumentArray<IFieldSchema>
@@ -2721,14 +2764,148 @@ describe('Form Model', () => {
         }
 
         // Act
-        const actual = await form
-          .updateFormFieldById(newField._id, newField)
-          .catch((err) => err)
+        const actual = await form.updateFormFieldById(newField._id, newField)
 
         // Assert
-        expect(actual).toBeInstanceOf(mongoose.Error.ValidationError)
-        expect(actual.message).toEqual(
-          expect.stringContaining('Changing form field type is not allowed'),
+        expect(actual).not.toBeNull()
+        const updatedFields = (
+          actual?.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        // First and third fields should remain unchanged
+        expect(updatedFields[0]).toEqual(originalFormFields[0])
+        expect(updatedFields[2]).toEqual(originalFormFields[2])
+
+        // Second field should be updated with new field type and properties
+        expect(updatedFields[1].fieldType).toEqual(BasicField.Mobile)
+        expect(updatedFields[1].title).toEqual('another mock title')
+        expect(updatedFields[1]._id).toEqual(newField._id)
+      })
+
+      it('should successfully update form field when changing field type from Email to ShortText', async () => {
+        // Arrange
+        const originalFormFields = (
+          form.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        const newField: FormFieldDto = {
+          ...originalFormFields[2], // Email field
+          // Updating field type from Email to ShortText.
+          fieldType: BasicField.ShortText,
+          title: 'short text field',
+          description: 'new description',
+        }
+
+        // Act
+        const actual = await form.updateFormFieldById(newField._id, newField)
+
+        // Assert
+        expect(actual).not.toBeNull()
+        const updatedFields = (
+          actual?.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        // First and second fields should remain unchanged
+        expect(updatedFields[0]).toEqual(originalFormFields[0])
+        expect(updatedFields[1]).toEqual(originalFormFields[1])
+
+        // Third field should be updated with new field type and properties
+        expect(updatedFields[2].fieldType).toEqual(BasicField.ShortText)
+        expect(updatedFields[2].title).toEqual('short text field')
+        expect(updatedFields[2].description).toEqual('new description')
+        expect(updatedFields[2]._id).toEqual(newField._id)
+      })
+
+      it('should successfully update form field when changing field type from Checkbox to Radio', async () => {
+        // Arrange
+        const originalFormFields = (
+          form.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        const newField: FormFieldDto = {
+          ...originalFormFields[0], // Checkbox field
+          // Updating field type from Checkbox to Radio.
+          fieldType: BasicField.Radio,
+          title: 'radio field',
+          fieldOptions: ['Option 1', 'Option 2', 'Option 3'],
+        }
+
+        // Act
+        const actual = await form.updateFormFieldById(newField._id, newField)
+
+        // Assert
+        expect(actual).not.toBeNull()
+        const updatedFields = (
+          actual?.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        // Second and third fields should remain unchanged
+        expect(updatedFields[1]).toEqual(originalFormFields[1])
+        expect(updatedFields[2]).toEqual(originalFormFields[2])
+
+        // First field should be updated with new field type and properties
+        expect(updatedFields[0].fieldType).toEqual(BasicField.Radio)
+        expect(updatedFields[0].title).toEqual('radio field')
+        expect(updatedFields[0].fieldOptions).toEqual([
+          'Option 1',
+          'Option 2',
+          'Option 3',
+        ])
+        expect(updatedFields[0]._id).toEqual(newField._id)
+      })
+
+      it('should maintain field order when changing field type', async () => {
+        // Arrange
+        const originalFormFields = (
+          form.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        const newField: FormFieldDto = {
+          ...originalFormFields[1], // HomeNo field at index 1
+          fieldType: BasicField.Number,
+          title: 'number field',
+        }
+
+        // Act
+        const actual = await form.updateFormFieldById(newField._id, newField)
+
+        // Assert
+        expect(actual).not.toBeNull()
+        const updatedFields = (
+          actual?.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        // Field order should be maintained
+        expect(updatedFields[0].fieldType).toEqual(BasicField.Checkbox)
+        expect(updatedFields[1].fieldType).toEqual(BasicField.Number)
+        expect(updatedFields[2].fieldType).toEqual(BasicField.Email)
+      })
+
+      it('should preserve field ID when changing field type', async () => {
+        // Arrange
+        const originalFormFields = (
+          form.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+        const originalFieldId = originalFormFields[1]._id
+
+        const newField: FormFieldDto = {
+          ...originalFormFields[1],
+          fieldType: BasicField.LongText,
+          title: 'long text field',
+        }
+
+        // Act
+        const actual = await form.updateFormFieldById(newField._id, newField)
+
+        // Assert
+        expect(actual).not.toBeNull()
+        const updatedFields = (
+          actual?.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        // Field ID should be preserved
+        expect(updatedFields[1]._id.toString()).toEqual(
+          originalFieldId.toString(),
         )
       })
 
@@ -2752,6 +2929,83 @@ describe('Form Model', () => {
 
         // Assert
         expect(actual).toBeInstanceOf(mongoose.Error.ValidationError)
+      })
+
+      it('should return CastError if boolean cast fails when changing field type', async () => {
+        // Arrange
+        const originalFormFields = (
+          form.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        const newField: FormFieldDto = {
+          ...originalFormFields[1],
+          fieldType: BasicField.Email,
+          // Invalid value for email field.
+          isVerifiable: 'some string, but this should be boolean',
+        }
+
+        // Act
+        let actual: mongoose.Error.CastError
+        try {
+          await form.updateFormFieldById(newField._id, newField)
+          throw new Error('Expected error but got success')
+        } catch (err) {
+          actual = err as mongoose.Error.CastError
+        }
+
+        // Assert
+        expect(actual).toBeInstanceOf(mongoose.Error.CastError)
+        expect(actual.message).toBe(
+          'Cast to Boolean failed for value "some string, but this should be boolean" (type string) at path "isVerifiable" because of "CastError"',
+        )
+        expect(actual.path).toBe('isVerifiable')
+        expect(actual.kind).toBe('Boolean')
+      })
+
+      it('should handle field type change with complex field properties', async () => {
+        // Arrange
+        const originalFormFields = (
+          form.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        const newField: FormFieldDto = {
+          ...originalFormFields[1],
+          fieldType: BasicField.Checkbox,
+          title: 'checkbox field',
+          fieldOptions: ['Option A', 'Option B', 'Option C'],
+          othersRadioButton: true,
+          required: false,
+          disabled: true,
+          ValidationOptions: {
+            customMax: 3,
+            customMin: 2,
+          },
+        }
+
+        // Act
+        const actual = await form.updateFormFieldById(newField._id, newField)
+
+        // Assert
+        expect(actual).not.toBeNull()
+        const updatedFields = (
+          actual?.form_fields as Types.DocumentArray<IFieldSchema>
+        ).toObject()
+
+        // Field should be updated with new type and properties
+        expect(updatedFields[1].fieldType).toEqual(BasicField.Checkbox)
+        expect(updatedFields[1].title).toEqual('checkbox field')
+        expect(updatedFields[1].fieldOptions).toEqual([
+          'Option A',
+          'Option B',
+          'Option C',
+        ])
+        expect(updatedFields[1].othersRadioButton).toEqual(true)
+        expect(updatedFields[1].required).toEqual(false)
+        expect(updatedFields[1].disabled).toEqual(true)
+        expect(updatedFields[1].ValidationOptions).toEqual({
+          customMax: 3,
+          customMin: 2,
+        })
       })
     })
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1093,7 +1093,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       const formFieldsDocumentArray = this
         .form_fields as Types.DocumentArray<IFieldSchema>
       const fieldIndex = this.form_fields.findIndex(
-        (f: { _id: string }) => String(f._id) === fieldId,
+        (f: { _id: string }) => f._id.toString() === fieldId.toString(),
       )
       const fieldToUpdateFound = fieldIndex !== -1
       if (!fieldToUpdateFound) return Promise.resolve(null)

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1098,7 +1098,6 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       const fieldToUpdateFound = fieldIndex !== -1
       if (!fieldToUpdateFound) return Promise.resolve(null)
 
-      // Creates a new field with only the properties that are valid for the changed target field type
       const newFieldWithChangedTypeProperties = formFieldsDocumentArray.create(
         newField,
       ) as FormFieldSchema

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1088,8 +1088,22 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     const fieldToUpdate = getFormFieldById(this.form_fields, fieldId)
     if (!fieldToUpdate) return Promise.resolve(null)
 
-    if (fieldToUpdate.fieldType !== newField.fieldType) {
-      this.invalidate('form_fields', 'Changing form field type is not allowed')
+    const isFieldTypeChange = fieldToUpdate.fieldType !== newField.fieldType
+    if (isFieldTypeChange) {
+      const formFieldsDocumentArray = this
+        .form_fields as Types.DocumentArray<IFieldSchema>
+      const fieldIndex = this.form_fields.findIndex(
+        (f: { _id: string }) => String(f._id) === fieldId,
+      )
+      const fieldToUpdateFound = fieldIndex !== -1
+      if (!fieldToUpdateFound) return Promise.resolve(null)
+
+      // Creates a new field with only the properties that are valid for the changed target field type
+      const newFieldWithChangedTypeProperties = formFieldsDocumentArray.create(
+        newField,
+      ) as FormFieldSchema
+      // This is required so that the field type schema discriminator is updated.
+      this.form_fields.splice(fieldIndex, 1, newFieldWithChangedTypeProperties)
     } else {
       fieldToUpdate.set(newField)
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When users generate a first draft of their forms (eg, using MFB PDF generation), they face inconveniences changing the field type to their desired state. For example, MFB generates a `shorttext` field for phone number, but respondents want it to be a `phone number` field instead.  

## Solution
Introduce a quick way to convert between field types. 

<img width="535" height="661" alt="image" src="https://github.com/user-attachments/assets/719f1580-19ba-4858-af49-8310abc2cec6" />
Ability to switch types 
It retains properties for the field type which have been set previously.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

In the same form: 
TC1: Able to convert newly created field types 
- [ ] Create a new field (choose any field type eg, email, number etc)  
- [ ] Edit the field settings (eg, title), try to edit as many properties as possible 
- [ ] Change field type in the dropdown toggle 
- [ ] Assert that the previously edited properties are carried over. 
- [ ] Try and edit any additional field types the new field has 
- [ ] Save the field
- [ ] Assert the field can be created successfully  

TC2: Able to convert edited field types 
- [ ] Select an existing field (choose any field type eg, email, number etc)  
- [ ] Edit the field settings (eg, title), try to edit as many properties as possible 
- [ ] Change field type in the dropdown toggle 
- [ ] Assert that the previously edited properties are carried over. 
- [ ] Try and edit any additional field types the new field has 
- [ ] Save the field
- [ ] Assert the field type can be edited successfully  

TC3: Able to remember previous edited field 
- [ ] Choose a field with field specific properties eg, dropdown 
- [ ] Change to short answer 
- [ ] Change back to dropdown 
- [ ] Assert that dropdown specific properties such options is retained. 
- [ ] Save the field
- [ ] Assert that the field can be saved successfully. 

TC4: Able to create myinfo field 
- [ ] Create any myinfo field 
- [ ] Assert it can be created 

TC5: Able to create payment field
- [ ] Create a payment field 
- [ ] Assert it can be created 

TC5: Form can be submitted 
- [ ] Set the form as public 
- [ ] Make a submission to the form 
- [ ] Assert that the form can be submitted and response can be found with correct values in the results page. 