### PR TITLE
feat: add country eswantini

### DIFF
--- a/shared/constants/countryRegion.ts
+++ b/shared/constants/countryRegion.ts
@@ -68,6 +68,7 @@ export enum CountryRegion {
   Equatorial_Guinea = 'Equatorial Guinea',
   Eritrea = 'Eritrea',
   Estonia = 'Estonia',
+  Eswantini = 'Eswantini',
   Ethiopia = 'Ethiopia',
   Faeroe_Islands = 'Faeroe Islands',
   Falkland_Islands = 'Falkland Islands',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Add missing countries from the country field based on SG DRM v5

Closes FRM-2067

## Solution
<!-- How did you solve the problem? -->

- Added `Eswantini` to the `CountryRegion` enum to support this country/region.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Component | Before | After |
|--------|--------|--------|
| Country Field - Eswantini | - | <img width="1020" height="236" alt="Screenshot 2025-08-06 at 12 55 45 AM" src="https://github.com/user-attachments/assets/f77b6d69-cba5-42c3-8d35-5ee6ad12e9bd" /> |


## Tests
<!-- What tests should be run to confirm functionality? -->
#### New countries can be found on the Country Fields
- [ ] Create a new Country Field
- [ ] As a respondent, observe that when typing in `Eswantini` in the country field, `Eswantini` can be selected
- [ ] Ensure that submission is possible