### PR TITLE
chore: remove email from playwright projects

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,10 +71,8 @@ jobs:
         project:
           [
             'chromium-login',
-            'chromium-email-submission',
             'chromium-encrypt-submission',
             'firefox-login',
-            'firefox-email-submission',
             'firefox-encrypt-submission',
           ]
     env:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -50,13 +50,6 @@ export default defineConfig({
       },
     },
     {
-      name: 'chromium-email-submission',
-      testMatch: /email-submission\.spec\.ts$/,
-      use: {
-        ...devices['Desktop Chrome'],
-      },
-    },
-    {
       name: 'chromium-encrypt-submission',
       testMatch: /encrypt-submission\.spec\.ts$/,
       use: {
@@ -66,13 +59,6 @@ export default defineConfig({
     {
       name: 'firefox-login',
       testMatch: /login\.spec\.ts$/,
-      use: {
-        ...devices['Desktop Firefox'],
-      },
-    },
-    {
-      name: 'firefox-email-submission',
-      testMatch: /email-submission\.spec\.ts$/,
       use: {
         ...devices['Desktop Firefox'],
       },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We have concluded our migration of public email mode forms and there will no longer be any email mode forms available. This is part of our efforts to deprecate email mode.

However, it is noted that we have some existing test suites that is still testing email mode form which is unnecessary.

1. E2E playwright tests 👈 this PR
2. FE Chromatic stories
3. BE tests

## Solution
<!-- How did you solve the problem? -->

Remove E2E playwright for email mode.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

