### PR TITLE
hotfix: add forwarded query param to myinfo and sgid joi validators

### DIFF
--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -92,6 +92,7 @@ const validateMyInfoLogin = celebrate({
       .keys({
         code: Joi.string().required(),
         state: Joi.string().required(),
+        forwarded: Joi.string().optional(),
       })
       // MyInfo sends several other params which are not necessary for Form
       .unknown(true),
@@ -100,6 +101,7 @@ const validateMyInfoLogin = celebrate({
         'error-description': Joi.string(),
         error: Joi.string().required(),
         state: Joi.string().required(),
+        forwarded: Joi.string().optional(),
       })
       // Allow other params in case MyInfo adds them in future
       .unknown(true),

--- a/src/app/modules/sgid/sgid.middlewares.ts
+++ b/src/app/modules/sgid/sgid.middlewares.ts
@@ -4,5 +4,6 @@ export const validateLoginRequest = celebrate({
   [Segments.QUERY]: Joi.object({
     code: Joi.string().required(),
     state: Joi.string().required(),
+    forwarded: Joi.string().optional(),
   }),
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Users signing in to FormSG using sgID from a Remote Browser Isolation (RBI) proxy face a 400 Bad Request due to the additional query params.

Related to #8581, which was released to production in #8607 

## Solution
<!-- How did you solve the problem? -->

Add the `forwarded` flag to the Joi validation schema

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Add the `forwarded` flag to the sgID login callback validation schema
- Add the `forwarded` flag to the MyInfo login callback validation schema (did not fail because of the optional provision for future field compatibility)

## Before & After Screenshots

**BEFORE**:

<img width="4032" height="3024" alt="image" src="https://github.com/user-attachments/assets/e3c02081-52e0-4a72-8799-81f953bbe024" />

**AFTER**:

<img width="4032" height="3024" alt="image" src="https://github.com/user-attachments/assets/d4587da2-7d30-4f3c-a3c7-ce2d7105c57d" />

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Login to sgID from non-GSIB / COMET works**
- [x] Login to a FormSG form with sgID configured

**TC2: Validator doesn't fail on a GSIB / COMET**
- [x] Visit the callback URL with `code`, `state`, and `forwarded` query params
- [x] Observe that the `400 Bad Request` validation error message is replaced with a `404 Not Found` error.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

