### PR TITLE
fix: bug fix status tracker to strip nextStepRecipientEmails 

### DIFF
--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -1,4 +1,8 @@
-import { FormWorkflowDto, SubmittedStep, WorkflowStatus } from '~shared/types'
+import {
+  StatusTrackerWorkflowDto,
+  SubmittedStep,
+  WorkflowStatus,
+} from '~shared/types'
 
 export enum MRF_STATUS {
   COMPLETED = 'Completed',
@@ -72,7 +76,7 @@ export const getStatusFromWorkflowStatus = (
 
 export type getWorkflowStatusFromFormResponseProps = {
   index: number
-  workflow: FormWorkflowDto
+  workflow: StatusTrackerWorkflowDto
   submittedSteps: SubmittedStep[]
 }
 

--- a/frontend/src/mocks/msw/status-tracker.ts
+++ b/frontend/src/mocks/msw/status-tracker.ts
@@ -8,11 +8,9 @@ const BASE_STATUS_TRACKER_DATA: StatusTrackerData = {
     {
       isApproval: false,
       submittedAt: '2025-05-26T00:23:43.574Z',
-      nextStepRecipientEmails: ['scott@open.gov.sg'],
     },
     {
       submittedAt: '2025-05-26T00:23:57.742Z',
-      nextStepRecipientEmails: ['scott@open.gov.sg'],
       status: WorkflowStatus.APPROVED,
       isApproval: true,
     },
@@ -21,20 +19,17 @@ const BASE_STATUS_TRACKER_DATA: StatusTrackerData = {
     {
       _id: '6825459367829851d459dbc4',
       workflow_type: WorkflowType.Static,
-      emails: [],
       edit: ['6824431c419499b9130367fa'],
       step_name: 'sdfasdhadh',
     },
     {
       _id: '6825467967829851d459dbd4',
       workflow_type: WorkflowType.Static,
-      emails: ['scott@open.gov.sg'],
       edit: ['68244320419499b913036805'],
     },
     {
       _id: '682fe307d29c96acb37efa45',
       workflow_type: WorkflowType.Static,
-      emails: ['scott@open.gov.sg'],
       edit: ['682fe2f1d29c96acb37efa32'],
       approval_field: '682fe2f1d29c96acb37efa32',
     },

--- a/shared/types/form/workflow.ts
+++ b/shared/types/form/workflow.ts
@@ -18,6 +18,11 @@ export interface FormWorkflowStepStatic extends FormWorkflowStepBase {
   emails: string[]
 }
 
+export type FormWorkflowStepStaticNoEmails = Omit<
+  FormWorkflowStepStatic,
+  'emails'
+>
+
 export interface FormWorkflowStepDynamic extends FormWorkflowStepBase {
   workflow_type: WorkflowType.Dynamic
   field: FormFieldDto['_id']
@@ -33,6 +38,11 @@ export type FormWorkflowStep =
   | FormWorkflowStepDynamic
   | FormWorkflowStepConditional
 
+export type StatusTrackerWorkflowStep =
+  | FormWorkflowStepStaticNoEmails
+  | FormWorkflowStepDynamic
+  | FormWorkflowStepConditional
+
 export type FormWorkflow = Array<FormWorkflowStep>
 
 // Additional props to be added for DTOs
@@ -40,3 +50,9 @@ export type FormWorkflow = Array<FormWorkflowStep>
 export type FormWorkflowStepDto = FormWorkflowStep & { _id: string }
 
 export type FormWorkflowDto = Array<FormWorkflowStepDto>
+
+export type StatusTrackerWorkflowStepDto = StatusTrackerWorkflowStep & {
+  _id: string
+}
+
+export type StatusTrackerWorkflowDto = Array<StatusTrackerWorkflowStepDto>

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -7,7 +7,12 @@ import { FormAuthType } from './form/form'
 import { DateString } from './generic'
 import { EmailResponse, FieldResponse, MobileResponse } from './response'
 import { PaymentStatus } from './payment'
-import { FormWorkflowDto, LogicDto, ProductItem } from './form'
+import {
+  FormWorkflowDto,
+  LogicDto,
+  ProductItem,
+  StatusTrackerWorkflowDto,
+} from './form'
 import { ErrorCode } from './errorCodes'
 export type SubmissionId = Opaque<string, 'SubmissionId'>
 export const SubmissionId = z.string() as unknown as z.Schema<SubmissionId>
@@ -358,7 +363,7 @@ export type PaymentSubmissionData = {
 
 export type StatusTrackerData = {
   submittedSteps: SubmittedStep[] | undefined
-  workflow: FormWorkflowDto
+  workflow: StatusTrackerWorkflowDto
   responseId: string | undefined
   form: string
 }

--- a/src/app/modules/status-tracker/status-tracker.controller.ts
+++ b/src/app/modules/status-tracker/status-tracker.controller.ts
@@ -32,8 +32,14 @@ const getStatusTrackerSubmissionData: ControllerHandler<
   return okAsync(submissionId)
     .andThen((submissionId) => getMultirespondentSubmission(submissionId))
     .map((submissionData) => {
+      // strip nextStepRecipientEmails
+      const strippedSubmittedSteps = submissionData.submittedSteps?.map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        ({ nextStepRecipientEmails, ...rest }) => rest,
+      )
+
       const statusTrackerData: StatusTrackerData = {
-        submittedSteps: submissionData.submittedSteps,
+        submittedSteps: strippedSubmittedSteps,
         workflow: submissionData.workflow,
         responseId: submissionData.id,
         form: submissionData.form,

--- a/src/app/modules/status-tracker/status-tracker.controller.ts
+++ b/src/app/modules/status-tracker/status-tracker.controller.ts
@@ -1,8 +1,12 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 import { okAsync } from 'neverthrow'
-import { StatusTrackerData } from 'shared/types'
 
+import { StatusTrackerData } from '../../../../shared/types'
+import {
+  StatusTrackerWorkflowDto,
+  WorkflowType,
+} from '../../../../shared/types/form/workflow'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
@@ -32,15 +36,25 @@ const getStatusTrackerSubmissionData: ControllerHandler<
   return okAsync(submissionId)
     .andThen((submissionId) => getMultirespondentSubmission(submissionId))
     .map((submissionData) => {
-      // strip nextStepRecipientEmails
+      // strip emails from submitted steps and workflow
       const strippedSubmittedSteps = submissionData.submittedSteps?.map(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ nextStepRecipientEmails, ...rest }) => rest,
       )
 
+      const strippedWorkflow: StatusTrackerWorkflowDto =
+        submissionData.workflow.map((step) => {
+          if (step.workflow_type === WorkflowType.Static) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { emails, ...rest } = step
+            return rest
+          }
+          return step
+        })
+
       const statusTrackerData: StatusTrackerData = {
         submittedSteps: strippedSubmittedSteps,
-        workflow: submissionData.workflow,
+        workflow: strippedWorkflow,
         responseId: submissionData.id,
         form: submissionData.form,
       }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently for status tracker api `/api/v3/status/{responseId}`, if workflow is currently ongoing, `submittedSteps` will include information on who the next step is dependent on (`nextStepRecipientEmails`), as well as `emails` if workflow step is `Static`.

This can lead to respondents directly chasing the next step respondent, which may be an undesirable experience for the next step recipients.

Closes FRM-2106

## Solution
<!-- How did you solve the problem? -->

Solution is to strip `nextStepRecipientEmails` from `submittedSteps` and `emails` in workflow steps when returning data from api call. 

Easy to strip since variable is optional in `SubmittedStep` type:
```
const SubmittedNonApprovalStep = z.object({
  isApproval: z.literal(false),
  submittedAt: z.string().datetime({ precision: 3 }),
  nextStepRecipientEmails: z.array(z.string()).optional(),
})

export type SubmittedNonApprovalStep = z.infer<typeof SubmittedNonApprovalStep>

const SubmittedApprovalStep = SubmittedNonApprovalStep.extend({
  isApproval: z.literal(true),
  status: ApprovalStatus,
})

export type SubmittedApprovalStep = z.infer<typeof SubmittedApprovalStep>
```

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- x No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

e.g of api call:
```
{
  "submittedSteps": [
    {
      "isApproval": false,
      "submittedAt": "2025-08-18T05:45:14.624Z",
      "nextStepRecipientEmails": [
        "scott@open.gov.sg"
      ]
    }
  ],
  "workflow": [
    {
      "emails": [],
      "_id": "6892a92e01dd40726309508f",
      "workflow_type": "static",
      "edit": [
        "6892a8eb01dd40726309504f"
      ],
      "step_name": "really long really long  really long step name"
    },
    {
      "emails": [
        "scott@open.gov.sg"
      ],
      "_id": "6892d707efdf483cc6588703",
      "workflow_type": "static",
      "edit": [
        "6892a8ed01dd40726309505a",
        "6892a8f501dd407263095065"
      ]
    }
  ],
  "responseId": "68a2bdeac58033728efb5e77",
  "form": "6892a8e101dd407263095026"
}
```

**AFTER**:
<!-- [insert screenshot here] -->

```
{
  "submittedSteps": [
    {
      "isApproval": false,
      "submittedAt": "2025-08-18T05:45:14.624Z"
    }
  ],
  "workflow": [
    {
      "_id": "6892a92e01dd40726309508f",
      "workflow_type": "static",
      "edit": [
        "6892a8eb01dd40726309504f"
      ],
      "step_name": "really long really long  really long step name"
    },
    {
      "_id": "6892d707efdf483cc6588703",
      "workflow_type": "static",
      "edit": [
        "6892a8ed01dd40726309505a",
        "6892a8f501dd407263095065"
      ]
    }
  ],
  "responseId": "68a2bdeac58033728efb5e77",
  "form": "6892a8e101dd407263095026"
}

```
