### PR TITLE
feat: email mode post migration removing

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,10 +1,5 @@
 import { Divider } from '@chakra-ui/react'
 
-import { FormResponseMode } from '~shared/types'
-
-import { useUser } from '~features/user/queries'
-
-import { StatusTrackerToggle } from './components/EmailNotificationsSection/StatusTrackerToggle'
 import { FormCaptchaToggle } from './components/FormCaptchaToggle'
 import { FormCustomisationSection } from './components/FormCustomisationSection'
 import { FormDetailsSection } from './components/FormDetailsSection'

--- a/frontend/src/features/admin-form/settings/SettingsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPage.tsx
@@ -86,7 +86,6 @@ export const SettingsPage = (): JSX.Element => {
       icon: BiMailSend,
       component: SettingsEmailsPage,
       path: 'email-notifications',
-      showRedDot: true,
     },
     {
       label: t('features.adminForm.settings.webhooks.title'),

--- a/frontend/src/features/workspace/WorkspaceContent.tsx
+++ b/frontend/src/features/workspace/WorkspaceContent.tsx
@@ -23,7 +23,7 @@ import { useWorkspaceContext } from './WorkspaceContext'
  *
  * Example usage DASHBOARD_MESSAGE = `Introducing payments! Citizens can now pay for fees and services directly on your form. [Learn more](${GUIDE_PAYMENTS_ENTRY})`
  */
-const DASHBOARD_MESSAGE = ``
+const DASHBOARD_MESSAGE = `TEST`
 
 export const WorkspaceContent = (): JSX.Element => {
   const { isLoading, totalFormsCount, isDefaultWorkspace } =

--- a/frontend/src/features/workspace/WorkspaceContent.tsx
+++ b/frontend/src/features/workspace/WorkspaceContent.tsx
@@ -23,7 +23,7 @@ import { useWorkspaceContext } from './WorkspaceContext'
  *
  * Example usage DASHBOARD_MESSAGE = `Introducing payments! Citizens can now pay for fees and services directly on your form. [Learn more](${GUIDE_PAYMENTS_ENTRY})`
  */
-const DASHBOARD_MESSAGE = `TEST`
+const DASHBOARD_MESSAGE = ``
 
 export const WorkspaceContent = (): JSX.Element => {
   const { isLoading, totalFormsCount, isDefaultWorkspace } =

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -11,13 +11,10 @@ import {
   Grid,
   GridItem,
   Stack,
-  Text,
   useDisclosure,
 } from '@chakra-ui/react'
 import { useFeatureValue } from '@growthbook/growthbook-react'
 
-import { KILL_EMAIL_MODE_LINK } from '~shared/constants'
-import { FormResponseMode, FormStatus } from '~shared/types'
 import { Workspace } from '~shared/types/workspace'
 
 import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
@@ -25,8 +22,6 @@ import { AdminNavBar } from '~/app/AdminNavBar/AdminNavBar'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { getBannerProps } from '~utils/getBannerProps'
 import { Banner } from '~components/Banner'
-import InlineMessage from '~components/InlineMessage'
-import Link from '~components/Link'
 
 import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
@@ -40,10 +35,9 @@ import { WorkspaceProvider } from './WorkspaceProvider'
 
 export const WorkspacePage = (): JSX.Element => {
   const { t } = useTranslation()
-  const { defaultTitle, emailRetirementNotice } = t(
-    'features.workspace.workspacePage',
-    { returnObjects: true },
-  )
+  const { defaultTitle } = t('features.workspace.workspacePage', {
+    returnObjects: true,
+  })
   const [currWorkspaceId, setCurrWorkspaceId] = useState<string>('')
   const { data: { siteBannerContent, adminBannerContent } = {} } = useEnv()
   const siteBannerContentGB = useFeatureValue('site-banner-content', '')
@@ -55,20 +49,6 @@ export const WorkspacePage = (): JSX.Element => {
   const { user } = useUser()
   const { data: dashboardForms, isLoading: isDashboardLoading } = useDashboard()
   const { data: workspaces, isLoading: isWorkspaceLoading } = useWorkspace()
-
-  const [openEmailModeForms, hasOpenEmailModeForms] = useMemo(() => {
-    const emailModeForms =
-      !isDashboardLoading && dashboardForms
-        ? dashboardForms.filter(
-            (form) =>
-              form.responseMode === FormResponseMode.Email &&
-              form.status === FormStatus.Public,
-          )
-        : undefined
-    return emailModeForms
-      ? [emailModeForms, emailModeForms.length > 0]
-      : [undefined, false]
-  }, [dashboardForms, isDashboardLoading])
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.
@@ -185,46 +165,6 @@ export const WorkspacePage = (): JSX.Element => {
             defaultWorkspace={DEFAULT_WORKSPACE}
             setCurrentWorkspace={setCurrWorkspaceId}
           >
-            {hasOpenEmailModeForms && (
-              <InlineMessage>
-                <Text>
-                  {t(
-                    'features.workspace.workspacePage.emailRetirementNotice.description',
-                  )}{' '}
-                  <Text as="span" fontWeight="bold">
-                    {t(
-                      'features.workspace.workspacePage.emailRetirementNotice.date',
-                      {
-                        retirementDate: new Date(
-                          Date.UTC(2025, 7, 31, 3, 0, 0),
-                        ),
-                      },
-                    )}
-                  </Text>
-                  {'. '}
-                  {t(
-                    'features.workspace.workspacePage.emailRetirementNotice.beforeLink',
-                  )}
-                  <Link href="/dashboard?filter=email">
-                    {t(
-                      'features.workspace.workspacePage.emailRetirementNotice.link',
-                      {
-                        count: openEmailModeForms?.length || 0,
-                      },
-                    )}
-                  </Link>
-                  {emailRetirementNotice.additionalDescription}{' '}
-                  <Link
-                    display="inline"
-                    href={KILL_EMAIL_MODE_LINK}
-                    target="_blank"
-                  >
-                    {emailRetirementNotice.learnMore}
-                  </Link>
-                  {'.'}
-                </Text>
-              </InlineMessage>
-            )}
             <WorkspaceContent />
           </WorkspaceProvider>
         </GridItem>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -112,7 +112,11 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             ) : null}
           </FormControl>
           <FormControl isRequired isInvalid={!!errors.responseMode} mb="2.5rem">
-            <FormLabel>
+            <FormLabel
+              description={t(
+                'features.workspace.modals.forms.create.details.type.description',
+              )}
+            >
               {t('features.workspace.modals.forms.create.details.type.label')}
             </FormLabel>
             <Skeleton isLoaded={!isFetching}>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -1,13 +1,11 @@
 import { useTranslation } from 'react-i18next'
 import { BiLockAlt } from 'react-icons/bi'
-import { forwardRef, Stack, Text, UnorderedList } from '@chakra-ui/react'
+import { forwardRef, Stack, UnorderedList } from '@chakra-ui/react'
 
 import { FormResponseMode } from '~shared/types/form/form'
 
 import { MultiParty } from '~assets/icons'
 import Badge from '~components/Badge'
-import InlineMessage from '~components/InlineMessage'
-import Link from '~components/Link'
 import Tile from '~components/Tile'
 
 export interface FormResponseOptionsProps {
@@ -51,7 +49,7 @@ const OptionDescription = ({
 export const FormResponseOptions = forwardRef<
   FormResponseOptionsProps,
   'button'
->(({ value, onChange, isSingpass, handleEmailButtonPress }, ref) => {
+>(({ value, onChange, isSingpass }, ref) => {
   const { t } = useTranslation()
   const { storage, mrf } = t(
     'features.workspace.modals.forms.create.details.type',
@@ -75,7 +73,6 @@ export const FormResponseOptions = forwardRef<
             listItems={[
               { text: storage.optionDescriptionItems.supportSingpassMyinfo },
               { text: storage.optionDescriptionItems.supportWebhooks },
-              { text: storage.optionDescriptionItems.sensitivity },
             ]}
           />
         </Tile>
@@ -95,7 +92,6 @@ export const FormResponseOptions = forwardRef<
               {
                 text: mrf.optionDescriptionItems.supportApprovalWorkflow,
               },
-              { text: mrf.optionDescriptionItems.sensitivity },
             ]}
           />
         </Tile>

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -73,7 +73,6 @@ export const FormResponseOptions = forwardRef<
           <Tile.Subtitle>{storage.subtitle}</Tile.Subtitle>
           <OptionDescription
             listItems={[
-              { text: storage.optionDescriptionItems.supportEmailSubmissions },
               { text: storage.optionDescriptionItems.supportSingpassMyinfo },
               { text: storage.optionDescriptionItems.supportWebhooks },
               { text: storage.optionDescriptionItems.sensitivity },
@@ -93,7 +92,6 @@ export const FormResponseOptions = forwardRef<
           <Tile.Subtitle>{mrf.subtitle}</Tile.Subtitle>
           <OptionDescription
             listItems={[
-              { text: mrf.optionDescriptionItems.supportEmailSubmissions },
               {
                 text: mrf.optionDescriptionItems.supportApprovalWorkflow,
               },

--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -76,10 +76,7 @@ export const FormResponseOptions = forwardRef<
               { text: storage.optionDescriptionItems.supportEmailSubmissions },
               { text: storage.optionDescriptionItems.supportSingpassMyinfo },
               { text: storage.optionDescriptionItems.supportWebhooks },
-              {
-                text: storage.optionDescriptionItems.sensitivity,
-                badge: 'new',
-              },
+              { text: storage.optionDescriptionItems.sensitivity },
             ]}
           />
         </Tile>
@@ -100,7 +97,7 @@ export const FormResponseOptions = forwardRef<
               {
                 text: mrf.optionDescriptionItems.supportApprovalWorkflow,
               },
-              { text: mrf.optionDescriptionItems.sensitivity, badge: 'new' },
+              { text: mrf.optionDescriptionItems.sensitivity },
             ]}
           />
         </Tile>

--- a/frontend/src/features/workspace/utils/dashboardFilter.ts
+++ b/frontend/src/features/workspace/utils/dashboardFilter.ts
@@ -4,7 +4,7 @@ export const FILTER_OPTIONS: FilterOption[] = [
   FilterOption.AllForms,
   FilterOption.OpenForms,
   FilterOption.ClosedForms,
-  FilterOption.EmailForms,
   FilterOption.StorageForms,
   FilterOption.MultiRespondentForms,
+  FilterOption.EmailForms,
 ]

--- a/frontend/src/i18n/locales/features/admin-form/toasts/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/toasts/en-sg.ts
@@ -45,6 +45,6 @@ export const enSG: Toasts = {
     successBefore: 'Respondents will',
     disabled: 'not ',
     successAfter:
-      'be able to receive a status tracking link of their submission',
+      'be able to receive a status tracking link of their submission.',
   },
 }

--- a/frontend/src/i18n/locales/features/workspace/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/en-sg.ts
@@ -73,15 +73,6 @@ export const enSG: Workspace = {
   },
   workspacePage: {
     defaultTitle: 'All forms',
-    emailRetirementNotice: {
-      description: 'All Email mode forms will be set to CLOSED by',
-      date: '{retirementDate, date, long}',
-      beforeLink: 'You currently have ',
-      link: '{count, number} OPEN Email mode form(s)',
-      additionalDescription:
-        ', and will be informed of the exact closure date separately.',
-      learnMore: 'Learn more here',
-    },
   },
   sideMenu,
   header,

--- a/frontend/src/i18n/locales/features/workspace/index.ts
+++ b/frontend/src/i18n/locales/features/workspace/index.ts
@@ -73,14 +73,6 @@ export interface Workspace {
   }
   workspacePage: {
     defaultTitle: string
-    emailRetirementNotice: {
-      description: string
-      date: string
-      beforeLink: string
-      link: string
-      additionalDescription: string
-      learnMore: string
-    }
   }
   sideMenu: SideMenu
   header: Header

--- a/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -22,7 +22,8 @@ export const enSG: CreateFormModal = {
     },
     type: {
       label: 'What type of form do you need?',
-      description: 'Both support up to Confidential (Cloud eligible) and Sensitive (High) data.',
+      description:
+        'Both support up to Confidential (Cloud eligible) and Sensitive (High) data.',
       storage: {
         title: 'Storage mode form',
         subtitle:

--- a/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -22,6 +22,7 @@ export const enSG: CreateFormModal = {
     },
     type: {
       label: 'What type of form do you need?',
+      description: 'Both support up to Confidential (Cloud eligible) and Sensitive (High) data.',
       storage: {
         title: 'Storage mode form',
         subtitle:

--- a/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -27,7 +27,6 @@ export const enSG: CreateFormModal = {
         subtitle:
           'Collect responses from individual respondents. Ideal for one-way submissions.',
         optionDescriptionItems: {
-          supportEmailSubmissions: 'Supports email submissions',
           supportSingpassMyinfo: 'Supports Singpass & Myinfo',
           supportWebhooks: 'Supports webhooks for integrations',
           sensitivity:
@@ -39,7 +38,6 @@ export const enSG: CreateFormModal = {
         subtitle:
           'Collect responses from multiple respondents in a single workflow. Ideal for sequential submissions.',
         optionDescriptionItems: {
-          supportEmailSubmissions: 'Supports email submissions',
           supportApprovalWorkflow: 'Supports approval workflows',
           sensitivity:
             'Up to Confidential (Cloud-Eligible) and Sensitive (High) data',

--- a/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
+++ b/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
@@ -20,6 +20,7 @@ export interface CreateFormModal {
     }
     type: {
       label: string
+      description: string
       storage: {
         title: string
         subtitle: string

--- a/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
+++ b/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
@@ -24,7 +24,6 @@ export interface CreateFormModal {
         title: string
         subtitle: string
         optionDescriptionItems: {
-          supportEmailSubmissions: string
           supportSingpassMyinfo: string
           supportWebhooks: string
           sensitivity: string
@@ -34,7 +33,6 @@ export interface CreateFormModal {
         title: string
         subtitle: string
         optionDescriptionItems: {
-          supportEmailSubmissions: string
           supportApprovalWorkflow: string
           sensitivity: string
         }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

After email mode migration have completed (no public email mode forms available anymore), we are removing email-mode related items since they are now redundant. This PR contains changes regarding FE copy changes

Closes FRM-2107

## Solution
<!-- How did you solve the problem? -->

Main changes:
- Remove email mode infobox
- Remove email submissions info bullet from form options
- Remove classification info bullet from form options, shifted above
- Remove “new” badge from Email notifications in settings page
- Move "email mode" to bottom of filter options


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Description | **BEFORE** | **AFTER** |
| --- | --- | --- |
| Remove email mode infobox | <img width="2382" height="308" alt="image" src="https://github.com/user-attachments/assets/0165d598-4e2e-42db-aff9-6fe38514a440" /> | <img width="1453" height="304" alt="image" src="https://github.com/user-attachments/assets/ede465bd-8a98-466f-8751-cc3f5fb259f1" /> |  
| Create form options | <img width="713" height="612" alt="image" src="https://github.com/user-attachments/assets/84d0e684-a979-4a25-9bec-088b4aeb9f3c" /> | <img width="785" height="638" alt="image" src="https://github.com/user-attachments/assets/774e18bc-66f6-4ded-9c9c-4f039d2d037d" /> | 
| Email notifications (settings page) | <img width="630" height="742" alt="image" src="https://github.com/user-attachments/assets/8dfc5eee-55ec-411d-abdb-57943e10b03c" /> | <img width="349" height="333" alt="image" src="https://github.com/user-attachments/assets/a0249f6d-1828-4191-9f90-bce754a75da3" /> |
| Filter options | <img width="321" height="338" alt="image" src="https://github.com/user-attachments/assets/4984c212-f246-4869-b462-3c0647a118ec" /> | <img width="343" height="360" alt="image" src="https://github.com/user-attachments/assets/aaf46a36-9838-4f99-be4e-af5f429422fe" /> |
