### PR TITLE
fix: omit signature field from mfb creation

### DIFF
--- a/src/app/modules/form/admin-form/admin-form.assistance.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.assistance.service.ts
@@ -112,7 +112,9 @@ const mapSuggestedFormFieldToFieldCreateDto = (
   })
 }
 
-const BASIC_FIELD_NAMES = Object.keys(omit(BasicField, ['Children', 'Image']))
+const BASIC_FIELD_NAMES = Object.keys(
+  omit(BasicField, ['Children', 'Image', 'Signature']),
+)
   .map((fieldType) => `"${fieldType}"`)
   .toString()
 
@@ -175,7 +177,7 @@ const generateFormCreationPrompt = (userPrompt: string) => {
  * Field types supported by Mfb.
  */
 const supportedFieldTypes = Object.keys(
-  omit(BasicField, ['Children', 'Image']),
+  omit(BasicField, ['Children', 'Image', 'Signature']),
 ) as [string, ...string[]]
 
 /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Admins can create forms with signature field without being whitelisted through Magic Form Builder

## Solution
<!-- How did you solve the problem? -->

Omit Signature field from possible field types during prompt generation

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible
