### PR TITLE
feat: remove whiteout

### DIFF
--- a/.github/workflows/deploy-ecs-prod.yml
+++ b/.github/workflows/deploy-ecs-prod.yml
@@ -48,3 +48,4 @@ jobs:
       dd-rum-client-token: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
       dd-sample-rate: ${{ secrets.DD_SAMPLE_RATE }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      S3_STATIC_ASSETS_BUCKET_NAME: ${{ secrets.S3_STATIC_ASSETS_BUCKET_NAME }}

--- a/.github/workflows/deploy-ecs-stg-alt3.yml
+++ b/.github/workflows/deploy-ecs-stg-alt3.yml
@@ -48,3 +48,4 @@ jobs:
       dd-rum-client-token: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
       dd-sample-rate: ${{ secrets.DD_SAMPLE_RATE }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      S3_STATIC_ASSETS_BUCKET_NAME: ${{ secrets.S3_STATIC_ASSETS_BUCKET_NAME }}

--- a/.github/workflows/deploy-ecs-uat.yml
+++ b/.github/workflows/deploy-ecs-uat.yml
@@ -48,3 +48,4 @@ jobs:
       dd-rum-client-token: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
       dd-sample-rate: ${{ secrets.DD_SAMPLE_RATE }}
       DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      S3_STATIC_ASSETS_BUCKET_NAME: ${{ secrets.S3_STATIC_ASSETS_BUCKET_NAME }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -102,6 +102,9 @@ on:
       DD_API_KEY:
         description: 'Datadog API key'
         required: true
+      S3_STATIC_ASSETS_BUCKET_NAME:
+        description: 'S3 domain style bucket name for static assets'
+        required: true
 
 # used to configure IAM to trust Github's OIDC provider
 permissions:
@@ -200,6 +203,17 @@ jobs:
           environment-variables: |
             ENV_TYPE=${{ inputs.environment }}
             ENV_SITE_NAME=${{ inputs.environment-site-name }}
+
+      - name: Copy Static Assets from Docker Image and Push to S3
+        env:
+          S3_STATIC_ASSETS_BUCKET_NAME: ${{ secrets.S3_STATIC_ASSETS_BUCKET_NAME }}
+          ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          mkdir -p /tmp/s3static
+          chmod 777 /tmp/s3static
+          docker run --rm -v /tmp/s3static:/tmp/s3static $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG cp -r ./dist/frontend/. /tmp/s3static
+          aws s3 sync /tmp/s3static s3://$S3_STATIC_ASSETS_BUCKET_NAME
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When a new release is deployed, some of our tests will fail.

**Symptoms**
- new ECS pushes made which updates static files (essentially any FE components)
- Datadog alarms rings due to element not found as page is a whiteout
- Datadog alarms notes of failure to load `/asset/XYZ.js`
- Datadog alarm passes after a while
- Can be sporadic

**Hypothesis**
1. ECS deployment flow doesn’t upload files over to S3, all files are expected to be served from container (or cache)
2. As ECS deployment update is in progress, some Containers (FormSG does a rolling deployment) will be loaded with a later version of `index.html/js` which also dynamically loads other resources.
3. As the browser requests are assigned in a RR manner, some containers will not possess resources.
4. Normally, under EB flow, resources will be attempted to be served from S3
    
    ```java
    app.use(express.static(path.resolve('dist/frontend'), { index: false }))
    ...
    app.get(/^\/[^/]+\.[a-z]+$/, catchNonExistentStaticRoutesMiddleware)
    
    ```
    
5. Since the resources only existed on the newer containers, this fails as the requests hits the older resources.

## Solution
<!-- How did you solve the problem? -->

Store FE artifacts on S3 that will be caught by `catchNonExistentStaticRoutesMiddleware`.
Note this is already done on EB, but not added when we moved to ECS.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

Tests for this PR should be generally regressive nature to determine if we should go ahead with the release.
### Regression
FE page can be loaded
- [ ] Go to the main webpage
- [ ] Ensure that the webpage can be loaded 

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
