### PR TITLE
feat: enable mrf webhooks

### DIFF
--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -1,5 +1,5 @@
 import {
-  StatusTrackerWorkflowDto,
+  StrippedFormWorkflowDto,
   SubmittedStep,
   WorkflowStatus,
 } from '~shared/types'
@@ -76,7 +76,7 @@ export const getStatusFromWorkflowStatus = (
 
 export type getWorkflowStatusFromFormResponseProps = {
   index: number
-  workflow: StatusTrackerWorkflowDto
+  workflow: StrippedFormWorkflowDto
   submittedSteps: SubmittedStep[]
 }
 

--- a/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { Skeleton } from '@chakra-ui/react'
 import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants'
@@ -32,13 +33,17 @@ export const SettingsWebhooksPage = (): JSX.Element => {
 
   // Webhooks are only supported in storage mode; show message if form response mode is not storage
   if (!enableWebhooks) {
-    return <WebhooksUnsupportedMsg />
+    return (
+      <Skeleton isLoaded={!isLoading}>
+        <WebhooksUnsupportedMsg />
+      </Skeleton>
+    )
   }
 
   return (
-    <>
+    <Skeleton isLoaded={!isLoading}>
       <CategoryHeader>Webhooks</CategoryHeader>
       <WebhooksSection />
-    </>
+    </Skeleton>
   )
 }

--- a/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -1,4 +1,10 @@
+import { useEffect } from 'react'
+import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
+
+import { featureFlags } from '~shared/constants'
 import { FormResponseMode } from '~shared/types/form'
+
+import { useUser } from '~features/user/queries'
 
 import { CategoryHeader } from './components/CategoryHeader'
 import { WebhooksSection } from './components/WebhooksSection'
@@ -6,10 +12,26 @@ import { WebhooksUnsupportedMsg } from './components/WebhooksSection/WebhooksUns
 import { useAdminFormSettings } from './queries'
 
 export const SettingsWebhooksPage = (): JSX.Element => {
+  const gb = useGrowthBook()
   const { data: settings, isLoading } = useAdminFormSettings()
+  const userRes = useUser()
+
+  useEffect(() => {
+    gb?.setAttributes({
+      adminEmail: userRes.user?.email,
+    })
+  }, [userRes.user?.email, gb])
+
+  const enableMrfWebhooks = useFeatureIsOn(featureFlags.enableMrfWebhooks)
+
+  const enableWebhooks =
+    !isLoading &&
+    (settings?.responseMode == FormResponseMode.Encrypt ||
+      (settings?.responseMode === FormResponseMode.Multirespondent &&
+        enableMrfWebhooks))
 
   // Webhooks are only supported in storage mode; show message if form response mode is not storage
-  if (!isLoading && settings?.responseMode !== FormResponseMode.Encrypt) {
+  if (!enableWebhooks) {
     return <WebhooksUnsupportedMsg />
   }
 

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -20,4 +20,5 @@ export const featureFlags = {
   signatureField: 'signature-field' as const,
   ogpSuiteSso: 'ogp-suite-sso' as const,
   enableIntranetSgidLogin: 'enable-intranet-sgid-login' as const,
+  enableMrfWebhooks: 'enable-mrf-webhooks' as const,
 }

--- a/shared/types/form/workflow.ts
+++ b/shared/types/form/workflow.ts
@@ -38,7 +38,7 @@ export type FormWorkflowStep =
   | FormWorkflowStepDynamic
   | FormWorkflowStepConditional
 
-export type StatusTrackerWorkflowStep =
+export type StrippedFormWorkflowStep =
   | FormWorkflowStepStaticNoEmails
   | FormWorkflowStepDynamic
   | FormWorkflowStepConditional
@@ -51,8 +51,8 @@ export type FormWorkflowStepDto = FormWorkflowStep & { _id: string }
 
 export type FormWorkflowDto = Array<FormWorkflowStepDto>
 
-export type StatusTrackerWorkflowStepDto = StatusTrackerWorkflowStep & {
+export type StrippedFormWorkflowStepDto = StrippedFormWorkflowStep & {
   _id: string
 }
 
-export type StatusTrackerWorkflowDto = Array<StatusTrackerWorkflowStepDto>
+export type StrippedFormWorkflowDto = Array<StrippedFormWorkflowStepDto>

--- a/shared/types/submission.ts
+++ b/shared/types/submission.ts
@@ -11,7 +11,7 @@ import {
   FormWorkflowDto,
   LogicDto,
   ProductItem,
-  StatusTrackerWorkflowDto,
+  StrippedFormWorkflowDto,
 } from './form'
 import { ErrorCode } from './errorCodes'
 export type SubmissionId = Opaque<string, 'SubmissionId'>
@@ -363,7 +363,7 @@ export type PaymentSubmissionData = {
 
 export type StatusTrackerData = {
   submittedSteps: SubmittedStep[] | undefined
-  workflow: StatusTrackerWorkflowDto
+  workflow: StrippedFormWorkflowDto
   responseId: string | undefined
   form: string
 }

--- a/shared/utils/strip-workflow-emails.ts
+++ b/shared/utils/strip-workflow-emails.ts
@@ -1,0 +1,18 @@
+import {
+  FormWorkflowDto,
+  StrippedFormWorkflowDto,
+  WorkflowType,
+} from '../types'
+
+export function stripWorkflowEmails(
+  workflow: FormWorkflowDto,
+): StrippedFormWorkflowDto {
+  return workflow.map((step) => {
+    if (step.workflow_type === WorkflowType.Static) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { emails, ...rest } = step
+      return rest
+    }
+    return step
+  })
+}

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1426,11 +1426,12 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     // Webhooks only allowed if encrypt mode
     if (
       this.responseMode !== FormResponseMode.Encrypt &&
+      this.responseMode !== FormResponseMode.Multirespondent &&
       (this.webhook?.url?.length ?? 0) > 0
     ) {
       const validationError = this.invalidate(
         'webhook',
-        'Webhook only allowed on storage mode form',
+        'Webhook only allowed on storage and multirespondent mode form',
       ) as mongoose.Error.ValidationError
       return next(validationError)
     }

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -600,6 +600,7 @@ MultirespondentSubmissionSchema.methods.getWebhookView = async function (
     workflowContent: {
       workflow: this.workflow,
       workflowStep: this.workflowStep,
+      submittedSteps: this.submittedSteps,
     },
   }
 

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -597,6 +597,10 @@ MultirespondentSubmissionSchema.methods.getWebhookView = async function (
     created: this.created,
     attachmentDownloadUrls: attachmentRecords,
     paymentContent,
+    workflowContent: {
+      workflow: this.workflow,
+      workflowStep: this.workflowStep,
+    },
   }
 
   return {

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -567,6 +567,43 @@ type MultiRespondentAggregates = Pick<
 type MultiRespondentAggregateResult = MetadataAggregateResult &
   MultiRespondentAggregates
 
+/**
+ * Returns an object which represents the encrypted submission
+ * which will be posted to the webhook URL.
+ */
+MultirespondentSubmissionSchema.methods.getWebhookView = async function (
+  this: IMultirespondentSubmissionSchema,
+): Promise<WebhookView> {
+  const formId = this.populated('form')
+    ? String((this as IMultirespondentSubmissionSchema).form._id)
+    : String(this.form)
+  const attachmentRecords = Object.fromEntries(
+    this.attachmentMetadata ?? new Map(),
+  )
+
+  if (this.paymentId) {
+    await (this as IMultirespondentSubmissionSchema).populate('paymentId')
+  }
+  const paymentContent = this.populated('paymentId')
+    ? getPaymentWebhookEventObject(this.paymentId)
+    : {}
+
+  const webhookData: WebhookData = {
+    formId,
+    submissionId: String(this._id),
+    encryptedContent: this.encryptedContent,
+    verifiedContent: '',
+    version: this.version,
+    created: this.created,
+    attachmentDownloadUrls: attachmentRecords,
+    paymentContent,
+  }
+
+  return {
+    data: webhookData,
+  }
+}
+
 MultirespondentSubmissionSchema.statics.findSingleMetadata = function (
   formId: string,
   submissionId: string,

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -16,6 +16,7 @@ import getAgencyModel from 'src/app/models/agency.server.model'
 import getFormModel, {
   getEmailFormModel,
   getEncryptedFormModel,
+  getMultirespondentFormModel,
 } from 'src/app/models/form.server.model'
 import getFormWhitelistSubmitterIdsModel from 'src/app/models/form_whitelist.server.model'
 import { getWorkspaceModel } from 'src/app/models/workspace.server.model'
@@ -92,6 +93,7 @@ import * as AdminFormUtils from '../admin-form.utils'
 const FormModel = getFormModel(mongoose)
 const EmailFormModel = getEmailFormModel(mongoose)
 const EncryptFormModel = getEncryptedFormModel(mongoose)
+const MultirespondentFormModel = getMultirespondentFormModel(mongoose)
 const AgencyModel = getAgencyModel(mongoose)
 const WorkspaceModel = getWorkspaceModel(mongoose)
 const FormWhitelistedSubmitterIdsModel =
@@ -1371,6 +1373,13 @@ describe('admin-form.service', () => {
       .mockReturnValue({
         exec: jest.fn().mockResolvedValue(MOCK_UPDATED_FORM),
       })
+    const MULTIRESPONDENT_UPDATE_SPY = jest
+      .spyOn(MultirespondentFormModel, 'findByIdAndUpdate')
+
+      // @ts-ignore
+      .mockReturnValue({
+        exec: jest.fn().mockResolvedValue(MOCK_UPDATED_FORM),
+      })
 
     beforeEach(() => jest.clearAllMocks())
 
@@ -1453,7 +1462,7 @@ describe('admin-form.service', () => {
       expect(MOCK_UPDATED_FORM.getSettings).toHaveBeenCalledTimes(0)
     })
 
-    it('should not allow webhooks updates for MRF', async () => {
+    it('should allow webhooks updates for MRF', async () => {
       const MOCK_MULTIRESPONDENT_FORM = jest.mocked({
         _id: new ObjectId(),
         status: FormStatus.Public,
@@ -1461,7 +1470,7 @@ describe('admin-form.service', () => {
       } as unknown as IPopulatedForm)
       const settingsToUpdate: SettingsUpdateDto = {
         webhook: {
-          url: 'does not matter',
+          url: 'https://example.com',
         },
       }
 
@@ -1472,9 +1481,14 @@ describe('admin-form.service', () => {
       )
 
       // Assert
-      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
-        MalformedParametersError,
+      expect(actualResult._unsafeUnwrap()).toEqual(MOCK_UPDATED_SETTINGS)
+      expect(MULTIRESPONDENT_UPDATE_SPY).toHaveBeenCalledWith(
+        MOCK_MULTIRESPONDENT_FORM._id,
+        // Should be dotified
+        { 'webhook.url': 'https://example.com' },
+        { new: true, runValidators: true },
       )
+      expect(MOCK_UPDATED_FORM.getSettings).toHaveBeenCalledTimes(1)
     })
 
     it('should allow webhooks updates for encrypt form', async () => {

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1857,15 +1857,6 @@ export const updateFormSettings = (
     return errAsync(new MalformedParametersError('Invalid authentication type'))
   }
 
-  if (
-    originalForm.responseMode === FormResponseMode.Multirespondent &&
-    Boolean(body.webhook?.url)
-  ) {
-    return errAsync(
-      new MalformedParametersError('Webhooks not supported on MRF'),
-    )
-  }
-
   if (isFormEmailMode(originalForm)) {
     if (
       originalForm.isForceConvertToStorageMode &&

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1834,7 +1834,6 @@ export const deleteFormWorkflowStep = (
  * @param body the subset of form settings to update
  * @returns ok(updated form settings) on success
  * @returns err(MalformedParametersError) if auth type update is attempted for a multi-respondent form
- * @returns err(MalformedParametersError) if webhook update is attempted for a multi-respondent form
  * @returns err(database errors) if db error is thrown during form setting update
  */
 export const updateFormSettings = (

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -7,13 +7,17 @@ import {
   ErrorCode,
   ErrorDto,
   FormAuthType,
-  FormFieldDto, FormResponseMode,
+  FormFieldDto,
+  FormResponseMode,
   PrivateFormErrorDto,
   PublicFormAuthLogoutDto,
   PublicFormAuthRedirectDto,
   PublicFormDto,
   PublicFormViewDto,
+  StrippedFormWorkflowDto,
 } from '../../../../../shared/types'
+import { stripWorkflowEmails } from '../../../../../shared/utils/strip-workflow-emails'
+import { IPopulatedMultirespondentForm } from '../../../../types'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { isMongoError } from '../../../utils/handle-mongo-error'
 import { createReqMeta, getRequestIp } from '../../../utils/request'
@@ -64,10 +68,6 @@ import * as FormService from '../form.service'
 
 import * as PublicFormService from './public-form.service'
 import { mapFormAuthError, mapRouteError } from './public-form.utils'
-import {
-  PublicMultiRespondentForm
-} from "../../../../../frontend/src/features/admin-form/settings/SettingsEmailsPage.stories";
-import {IPopulatedMultirespondentForm} from "../../../../types";
 
 const logger = createLoggerWithLabel(module)
 
@@ -548,7 +548,7 @@ export const handleGetPublicFormSampleSubmission: ControllerHandler<
   { formId: string },
   | {
       responses: ReturnType<typeof FormService.createSampleSubmissionResponses>
-      workflowContent?: { workflow: IPopulatedMultirespondentForm['workflow'] }
+      workflowContent?: { workflow: StrippedFormWorkflowDto }
     }
   | ErrorDto
   | PrivateFormErrorDto
@@ -618,16 +618,16 @@ export const handleGetPublicFormSampleSubmission: ControllerHandler<
 
   // Include workflow if form is a multirespondent form
   if (form.responseMode === FormResponseMode.Multirespondent) {
-    let mrfForm  = form as IPopulatedMultirespondentForm
+    const mrfForm = form as IPopulatedMultirespondentForm
     res.json({
       responses: sampleData,
       workflowContent: {
-        workflow: mrfForm.workflow,
-      }
+        workflow: stripWorkflowEmails(mrfForm.toObject().workflow),
+      },
     })
+  } else {
+    return res.json({ responses: sampleData })
   }
-
-  return res.json({ responses: sampleData })
 }
 /**
  * NOTE: This is exported only for testing

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -7,7 +7,7 @@ import {
   ErrorCode,
   ErrorDto,
   FormAuthType,
-  FormFieldDto,
+  FormFieldDto, FormResponseMode,
   PrivateFormErrorDto,
   PublicFormAuthLogoutDto,
   PublicFormAuthRedirectDto,
@@ -64,6 +64,10 @@ import * as FormService from '../form.service'
 
 import * as PublicFormService from './public-form.service'
 import { mapFormAuthError, mapRouteError } from './public-form.utils'
+import {
+  PublicMultiRespondentForm
+} from "../../../../../frontend/src/features/admin-form/settings/SettingsEmailsPage.stories";
+import {IPopulatedMultirespondentForm} from "../../../../types";
 
 const logger = createLoggerWithLabel(module)
 
@@ -544,6 +548,7 @@ export const handleGetPublicFormSampleSubmission: ControllerHandler<
   { formId: string },
   | {
       responses: ReturnType<typeof FormService.createSampleSubmissionResponses>
+      workflowContent?: { workflow: IPopulatedMultirespondentForm['workflow'] }
     }
   | ErrorDto
   | PrivateFormErrorDto
@@ -609,6 +614,17 @@ export const handleGetPublicFormSampleSubmission: ControllerHandler<
       error,
     })
     return res.sendStatus(HttpStatusCode.InternalServerError)
+  }
+
+  // Include workflow if form is a multirespondent form
+  if (form.responseMode === FormResponseMode.Multirespondent) {
+    let mrfForm  = form as IPopulatedMultirespondentForm
+    res.json({
+      responses: sampleData,
+      workflowContent: {
+        workflow: mrfForm.workflow,
+      }
+    })
   }
 
   return res.json({ responses: sampleData })

--- a/src/app/modules/status-tracker/status-tracker.controller.ts
+++ b/src/app/modules/status-tracker/status-tracker.controller.ts
@@ -2,11 +2,11 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 import { okAsync } from 'neverthrow'
 
-import { StatusTrackerData } from '../../../../shared/types'
 import {
-  StatusTrackerWorkflowDto,
-  WorkflowType,
-} from '../../../../shared/types/form/workflow'
+  StatusTrackerData,
+  StrippedFormWorkflowDto,
+} from '../../../../shared/types'
+import { stripWorkflowEmails } from '../../../../shared/utils/strip-workflow-emails'
 import { createLoggerWithLabel } from '../../config/logger'
 import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
@@ -42,15 +42,9 @@ const getStatusTrackerSubmissionData: ControllerHandler<
         ({ nextStepRecipientEmails, ...rest }) => rest,
       )
 
-      const strippedWorkflow: StatusTrackerWorkflowDto =
-        submissionData.workflow.map((step) => {
-          if (step.workflow_type === WorkflowType.Static) {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { emails, ...rest } = step
-            return rest
-          }
-          return step
-        })
+      const strippedWorkflow: StrippedFormWorkflowDto = stripWorkflowEmails(
+        submissionData.workflow,
+      )
 
       const statusTrackerData: StatusTrackerData = {
         submittedSteps: strippedSubmittedSteps,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -154,6 +154,9 @@ describe('multirespondent-submision.controller', () => {
         form: mockSubmitMrfReq.formsg.formDef,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
         submissionId: mockSubmissionId,
+        submission: {
+          _id: mockSubmissionId,
+        },
       })
       // Expect 200 ok
       expect(mockRes.status).not.toHaveBeenCalled() // default is 200 ok
@@ -437,6 +440,9 @@ describe('multirespondent-submision.controller', () => {
         snapshottedFormDef: mockSubmitMrfReq.formsg.snapshottedFormDef,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
         submissionId: mockSubmissionId,
+        submission: {
+          _id: mockSubmissionId,
+        },
       })
       // Expect 200 ok
       expect(mockRes.status).not.toHaveBeenCalled() // default is 200 ok

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -178,6 +178,7 @@ describe('createFormsgAndRetrieveForm', () => {
       title: MOCK_FORM.title,
       form_fields: MOCK_MRF_SUBMISSION.form_fields, // Should use snapshot from submission
       form_logics: MOCK_MRF_SUBMISSION.form_logics, // Should use snapshot from submission
+      webhook: MOCK_FORM.webhook, // Should use current form data
       workflow: MOCK_MRF_SUBMISSION.workflow, // Should use snapshot from submission
       hasRespondentCopy: MOCK_FORM.hasRespondentCopy, // Should use current form data
       emails: MOCK_FORM.emails, // Should use current form data

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -149,6 +149,7 @@ const submitMultirespondentForm = async (
   })
 
   await performMultiRespondentPostSubmissionCreateActions({
+    submission,
     submissionId: submission._id.toString(),
     form,
     encryptedPayload,
@@ -243,6 +244,7 @@ const updateMultirespondentSubmission = async (
   const currentStepNumber = submission.workflowStep
 
   await performMultiRespondentPostSubmissionUpdateActions({
+    submission,
     submissionId,
     snapshottedFormDef,
     currentStepNumber,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -126,6 +126,7 @@ const getSnapshottedFormDef = (
   form_fields: mrfSubmission.form_fields,
   form_logics: mrfSubmission.form_logics,
   workflow: mrfSubmission.workflow,
+  webhook: currentFormDef.webhook,
   hasRespondentCopy: currentFormDef.hasRespondentCopy,
   emails: currentFormDef.emails,
   stepOneEmailNotificationFieldId:

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -40,6 +40,7 @@ import { convertToSignaturePngBuffer } from '../../../utils/convert-vector-array
 import { transformMongoError } from '../../../utils/handle-mongo-error'
 import { DatabaseError } from '../../core/core.errors'
 import { isFormMultirespondent } from '../../form/form.utils'
+import { WebhookFactory } from '../../webhook/webhook.factory'
 import {
   AttachmentUploadError,
   ExpectedResponseNotFoundError,
@@ -652,6 +653,7 @@ export const createMultiRespondentFormSubmission = ({
 }
 
 export const performMultiRespondentPostSubmissionCreateActions = ({
+  submission,
   submissionId,
   form,
   encryptedPayload,
@@ -659,6 +661,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   attachments,
   respondentEmails,
 }: {
+  submission: IMultirespondentSubmissionSchema
   submissionId: string
   form: IPopulatedMultirespondentForm
   encryptedPayload: MultirespondentSubmissionDto
@@ -692,6 +695,28 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
       })
       return error
     })
+  }
+
+  const webhookUrl = form.webhook?.url
+  if (webhookUrl) {
+    logger.info({
+      message: 'Sending initial webhook for multirespondent submission',
+      meta: logMeta,
+    })
+
+    WebhookFactory.sendInitialWebhook(
+      submission,
+      webhookUrl,
+      !!form.webhook?.isRetryEnabled,
+    )
+      .andThen(() => okAsync(form))
+      .mapErr((error) => {
+        logger.error({
+          message: 'Multirespondent submission webhook error',
+          meta: logMeta,
+          error,
+        })
+      })
   }
 
   return sendNextStepEmail({
@@ -880,6 +905,7 @@ export const updateMultiRespondentFormSubmission = ({
 }
 
 export const performMultiRespondentPostSubmissionUpdateActions = ({
+  submission,
   submissionId,
   snapshottedFormDef,
   currentStepNumber,
@@ -888,6 +914,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   attachments,
   respondentEmails,
 }: {
+  submission: IMultirespondentSubmissionSchema
   submissionId: string
   snapshottedFormDef: SnapshottedFormDef
   currentStepNumber: number
@@ -951,6 +978,28 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   }
 
   const isStepRejected = isStepRejectedResult.value
+
+  const webhookUrl = form.webhook?.url
+  if (webhookUrl) {
+    logger.info({
+      message: 'Sending update webhook for multirespondent submission',
+      meta: logMeta,
+    })
+
+    WebhookFactory.sendInitialWebhook(
+      submission,
+      webhookUrl,
+      !!form.webhook?.isRetryEnabled,
+    )
+      .andThen(() => okAsync(form))
+      .mapErr((error) => {
+        logger.error({
+          message: 'Multirespondent submission webhook error',
+          meta: logMeta,
+          error,
+        })
+      })
+  }
 
   if (isStepRejected) {
     return sendMrfOutcomeEmails({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -979,7 +979,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
 
   const isStepRejected = isStepRejectedResult.value
 
-  const webhookUrl = form.webhook?.url
+  const webhookUrl = snapshottedFormDef.webhook?.url
   if (webhookUrl) {
     logger.info({
       message: 'Sending update webhook for multirespondent submission',
@@ -989,9 +989,9 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     WebhookFactory.sendInitialWebhook(
       submission,
       webhookUrl,
-      !!form.webhook?.isRetryEnabled,
+      !!snapshottedFormDef.webhook?.isRetryEnabled,
     )
-      .andThen(() => okAsync(form))
+      .andThen(() => okAsync(undefined))
       .mapErr((error) => {
         logger.error({
           message: 'Multirespondent submission webhook error',

--- a/src/app/modules/webhook/webhook.service.ts
+++ b/src/app/modules/webhook/webhook.service.ts
@@ -7,6 +7,7 @@ import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { WebhookResponse } from '../../../../shared/types'
 import {
   IEncryptedSubmissionSchema,
+  IMultirespondentSubmissionSchema,
   ISubmissionSchema,
   WebhookView,
 } from '../../../types'
@@ -246,7 +247,7 @@ export const getWebhookType = (webhookUrl: string) => {
 export const createInitialWebhookSender =
   (producer?: WebhookProducer) =>
   (
-    submission: IEncryptedSubmissionSchema,
+    submission: IEncryptedSubmissionSchema | IMultirespondentSubmissionSchema,
     webhookUrl: string,
     isRetryEnabled: boolean,
   ): ResultAsync<

--- a/src/app/modules/webhook/webhook.types.ts
+++ b/src/app/modules/webhook/webhook.types.ts
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
-import { FormWorkflowDto, FormWorkflowStepDto } from '../../../../shared/types'
+import { FormWorkflowDto, SubmittedStep } from '../../../../shared/types'
 import { IFormSchema, ISubmissionSchema, WebhookView } from '../../../types'
 
 export interface WebhookParams {
@@ -64,5 +64,6 @@ export type PaymentWebhookEventObject = {
 
 export type WorkflowWebhookEventObject = {
   workflow: FormWorkflowDto
-  workflowSteps: FormWorkflowStepDto[]
+  workflowStep: number
+  submittedSteps: SubmittedStep[]
 }

--- a/src/app/modules/webhook/webhook.types.ts
+++ b/src/app/modules/webhook/webhook.types.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod'
 
+import { FormWorkflowDto, FormWorkflowStepDto } from '../../../../shared/types'
 import { IFormSchema, ISubmissionSchema, WebhookView } from '../../../types'
 
 export interface WebhookParams {
@@ -59,4 +60,9 @@ export type PaymentWebhookEventType = 'payment_charge'
 export type PaymentWebhookEventObject = {
   type: PaymentWebhookEventType
   [key: string]: unknown
+}
+
+export type WorkflowWebhookEventObject = {
+  workflow: FormWorkflowDto
+  workflowSteps: FormWorkflowStepDto[]
 }

--- a/src/types/api/multirespondent_submission.ts
+++ b/src/types/api/multirespondent_submission.ts
@@ -23,6 +23,7 @@ export type SnapshottedFormDef = Pick<
   | 'stepOneEmailNotificationFieldId'
   | 'stepsToNotify'
   | 'hasRespondentCopy'
+  | 'webhook'
   | 'title'
   | 'workflow'
 > & {

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -2,7 +2,10 @@ import { Cursor as QueryCursor, Document, Model, QueryOptions } from 'mongoose'
 
 import { EmailSubmissionContent } from 'src/app/modules/submission/email-submission/email-submission.types'
 import { EncryptSubmissionContent } from 'src/app/modules/submission/encrypt-submission/encrypt-submission.types'
-import { PaymentWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
+import {
+  PaymentWebhookEventObject,
+  WorkflowWebhookEventObject,
+} from 'src/app/modules/webhook/webhook.types'
 
 import {
   EmailModeSubmissionBase,
@@ -26,6 +29,7 @@ export interface WebhookData {
   created: IEncryptedSubmissionSchema['created']
   attachmentDownloadUrls: Record<string, string>
   paymentContent?: PaymentWebhookEventObject | object
+  workflowContent?: WorkflowWebhookEventObject | object
 }
 
 export interface WebhookView {

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -120,7 +120,7 @@ export interface IMultirespondentSubmissionSchema
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   form: any
   submissionType: SubmissionType.Multirespondent
-  getWebhookView(): Promise<null>
+  getWebhookView(): Promise<WebhookView>
   mrfVersion: number
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Users want to configure webhooks as destinations for their Multi-Respondent Form.
At present, only Storage (Encrypt) mode forms can have Webhooks configured as a notification destination.

Closes FRM-1679

## Solution
<!-- How did you solve the problem? -->

> [!IMPORTANT]
> This pull request will allow any FormSG Admin to configure webhooks for their Multi-Respondent Form.
> The Feature Flag only affects the front-end visibility of the Webhooks section in the Settings Page.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Enable Webhooks for Multi-Respondent Forms
- Add a `workflowContent` field which contains the `workflowStep` counter and the `workflow` configuration

## Before & After Screenshots

**BEFORE**:

<img width="1624" height="980" alt="image" src="https://github.com/user-attachments/assets/cb3cd951-54a3-4971-a1e0-6a8fe4ae5cd4" />

**AFTER**:

<img width="1624" height="980" alt="image" src="https://github.com/user-attachments/assets/afc5973b-b4c7-41f4-ad12-0e56fbb7a4d6" />

<img width="992" height="1274" alt="image" src="https://github.com/user-attachments/assets/052e19f7-cabf-491e-82a1-2d40120dbe6c" />

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Verify that Multi-Respondent Forms can now be configured with a Webhook**

- [ ] Create a new Form with "Multi-Respondent" mode selected
- [ ] Create a simple form (e.g. a Short Text field called "Name")
- [ ] Add a Yes / No field for approval use
- [ ] In the Workflows tab, configure a simple Workflow with two steps:
  - [ ] Step 1: Application -- all the simple form fields should be assigned to this step.
  - [ ] Step 2: Approval -- the approval field should be assigned to this step. Use your email as the approver email.
- [ ] In the Settings page, select the Webhooks tab, then configure a Webhook URL from [https://webhook.site](https://webhook.site)
- [ ] Click outside the Webhook URL field: the URL should be saved.

**TC2: Receive a Webhook from a Multi-Respondent Form**

- [ ] Visit and fill up the form in Test Case 1
- [ ] Submit the form
- [ ] Observe that the webhook was successfully received at the Webhook URL (TC1)
- [ ] Open the approval request email, Click on "Yes" / "No", and submit the approval / rejection
- [ ] Observe that the webhook was successfully received at the Webhook URL (TC1)

**TC3: Check that MRF Form Settings can be modified**

- [ ] Visit the form in Test Case 1
- [ ] Set the Form to CLOSED.
- [ ] Set the Form to OPEN.
- [ ] Add `form@open.gov.sg` as a collaborator to the form.
- [ ] All of the operations should succeed without error.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New feature flags**:

- `enable-mrf-webhooks` : [enable / disable MRF webhooks for specified user segments](https://app.growthbook.io/features/enable-mrf-webhooks)
