### PR TITLE
fix(ui): AttachmentField force override on focus

### DIFF
--- a/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -331,6 +331,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
             {...(!value
               ? { role: 'button', ref: mergedRefs, __css: styles.dropzone }
               : {})}
+            tabIndex={inputProps.disabled ? -1 : 0} // prevent focus capture when disabled
           >
             {value ? (
               <AttachmentFileInfo

--- a/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
+++ b/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
@@ -19,7 +19,7 @@ const DropzoneText = ({ inputProps }: { inputProps: DropzoneInputProps }) => {
   const isDisabled = inputProps.disabled
 
   return (
-    <Text aria-hidden>
+    <Text aria-hidden color="secondary.700">
       {isDisabled ? (
         t('features.publicForm.components.fields.attachment.disabled')
       ) : (
@@ -54,7 +54,9 @@ export const AttachmentDropzone = ({
       <Icon aria-hidden as={BxsCloudUpload} __css={styles.icon} />
 
       {isDragActive ? (
-        <Text aria-hidden>Drop the file here...</Text>
+        <Text aria-hidden color="secondary.700">
+          Drop the file here...
+        </Text>
       ) : (
         <DropzoneText inputProps={inputProps} />
       )}

--- a/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
+++ b/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
@@ -1,6 +1,6 @@
 import { DropzoneInputProps, DropzoneState } from 'react-dropzone'
 import { useTranslation } from 'react-i18next'
-import { chakra, Icon, Text, VisuallyHidden, Box } from '@chakra-ui/react'
+import { chakra, Icon, Text, VisuallyHidden } from '@chakra-ui/react'
 
 import { BxsCloudUpload } from '~assets/icons/BxsCloudUpload'
 import Link from '~components/Link'

--- a/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
+++ b/frontend/src/components/Field/Attachment/AttachmentDropzone.tsx
@@ -1,6 +1,6 @@
 import { DropzoneInputProps, DropzoneState } from 'react-dropzone'
 import { useTranslation } from 'react-i18next'
-import { chakra, Icon, Text, VisuallyHidden } from '@chakra-ui/react'
+import { chakra, Icon, Text, VisuallyHidden, Box } from '@chakra-ui/react'
 
 import { BxsCloudUpload } from '~assets/icons/BxsCloudUpload'
 import Link from '~components/Link'
@@ -14,13 +14,35 @@ interface AttachmentDropzoneProps {
   question?: string
 }
 
+const DropzoneText = ({ inputProps }: { inputProps: DropzoneInputProps }) => {
+  const { t } = useTranslation()
+  const isDisabled = inputProps.disabled
+
+  return (
+    <Text aria-hidden>
+      {isDisabled ? (
+        t('features.publicForm.components.fields.attachment.disabled')
+      ) : (
+        <>
+          <Link>
+            {t(
+              'features.publicForm.components.fields.attachment.fileUploaderLink',
+            )}
+          </Link>
+
+          {t('features.publicForm.components.fields.attachment.dragAndDrop')}
+        </>
+      )}
+    </Text>
+  )
+}
+
 export const AttachmentDropzone = ({
   inputProps,
   isDragActive,
   readableMaxSize,
   question,
 }: AttachmentDropzoneProps): JSX.Element => {
-  const { t } = useTranslation()
   const styles = useAttachmentStyles()
 
   return (
@@ -34,14 +56,7 @@ export const AttachmentDropzone = ({
       {isDragActive ? (
         <Text aria-hidden>Drop the file here...</Text>
       ) : (
-        <Text aria-hidden>
-          <Link isDisabled={inputProps.disabled}>
-            {t(
-              'features.publicForm.components.fields.attachment.fileUploaderLink',
-            )}
-          </Link>
-          {t('features.publicForm.components.fields.attachment.dragAndDrop')}
-        </Text>
+        <DropzoneText inputProps={inputProps} />
       )}
     </>
   )

--- a/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
+++ b/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
@@ -13,6 +13,7 @@ export const enSG: Fields = {
     nothingFound: 'No matching results',
   },
   attachment: {
+    disabled: 'Attachment upload is disabled for you',
     fileUploaderLink: 'Choose file',
     dragAndDrop: ' or drag and drop here',
     dragActive: 'Drop the file here',

--- a/frontend/src/i18n/locales/features/public-form/fields/index.ts
+++ b/frontend/src/i18n/locales/features/public-form/fields/index.ts
@@ -16,6 +16,7 @@ export interface Fields {
     }
   }
   attachment: {
+    disabled: string
     fileUploaderLink: string
     dragAndDrop: string
     dragActive: string

--- a/frontend/src/theme/components/Field/Attachment.ts
+++ b/frontend/src/theme/components/Field/Attachment.ts
@@ -65,6 +65,14 @@ export const Attachment: ComponentMultiStyleConfig<typeof parts> = {
           },
           _disabled: {
             ...inputStyle._disabled,
+            _focus: {
+              border: '1px dashed',
+              borderColor: `neutral.400`,
+              boxShadow: `unset !important`,
+            },
+            _focusVisible: {
+              outline: 'none',
+            },
           },
           _hover: {
             bg: `${c}.100`,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When field is not assigned to user (aka `disabled`)
- On focus, there's a straight line border around the `<AttachmentField />`
- "Placeholder text (Choose file…) and icon" appears which suggests to the user that they should utilise this field

Closes FRM-2129

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
| Component | Before | After |
|--------|--------|--------|
| Attachment on Focus | <img width="990" height="318" alt="Screenshot 2025-08-21 at 6 14 07 PM" src="https://github.com/user-attachments/assets/8ed196fb-fe29-4e13-8b36-dab14166f6d7" /> | <img width="989" height="335" alt="Screenshot 2025-08-21 at 6 13 47 PM" src="https://github.com/user-attachments/assets/4df7bc06-92bd-4bcd-b9a4-fbbaeea880ba" /> |
| Attachment disabled | <img width="972" height="320" alt="Screenshot 2025-08-21 at 6 14 02 PM" src="https://github.com/user-attachments/assets/85bddf88-7c55-42b5-930b-9d88525f00cc" /> |<img width="989" height="335" alt="Screenshot 2025-08-21 at 6 13 47 PM" src="https://github.com/user-attachments/assets/4df7bc06-92bd-4bcd-b9a4-fbbaeea880ba" /> |

## Tests
<!-- What tests should be run to confirm functionality? -->
### Disabled attachments should show disabled text copy
- [x] Create an MRF
- [x] Add Attachment Field
- [x] Assign Attachment for respondent 2
- [x] As respondent, ensure that Attachment Field shows disabled text `'Attachment upload is disabled for you'`

### Disabled attachments should not show focus 
- [x] As respondent, click on Attachment Field
- [x] Ensure that no visual changes on borders are observed

### Disabled attachments should not show focus through keyboard navigation
- [x] Select a prior field, press tab
- [x] Ensure that no visual changes on borders are observed