### PR TITLE
fix: ongoing mrf not using snapshotted mrf values

### DIFF
--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -17,6 +17,7 @@ import { MissingUserError } from 'src/app/modules/user/user.errors'
 import * as UserService from 'src/app/modules/user/user.service'
 import { MailSendError } from 'src/app/services/mail/mail.errors'
 import { IMultirespondentSubmissionSchema } from 'src/types'
+import { SnapshottedFormDef } from 'src/types/api'
 
 import {
   AttachmentUploadError,
@@ -323,6 +324,45 @@ describe('multirespondent-submision.controller', () => {
   })
 
   describe('updateMultirespondentSubmission', () => {
+    it('returns 400 bad request if snapshottedFormDef is not provided when updating mrf submission', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        params: {
+          formId: mockFormId,
+          submissionId: mockSubmissionId,
+        },
+        body: {} as any,
+      })
+      const mockSubmitMrfReq = merge(mockReq, {
+        formsg: {
+          formDef: {
+            _id: mockFormId,
+            authType: FormAuthType.NIL,
+            getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+          },
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {},
+            workflowStep: 0,
+          },
+        } as any,
+      })
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await updateMultirespondentSubmissionForTest(mockSubmitMrfReq, mockRes)
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(400)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message:
+          'The form submission could not be processed. Please try again.',
+      })
+    })
+
     it('returns 200 ok when form validation passes and invokes updateMultiRespondentFormSubmission and performMultiRespondentPostSubmissionUpdateActions', async () => {
       // Arrange
       const mockReq = expressHandler.mockRequest({
@@ -339,6 +379,17 @@ describe('multirespondent-submision.controller', () => {
             authType: FormAuthType.NIL,
             getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
           },
+          snapshottedFormDef: {
+            _id: mockFormId,
+            form_fields: [],
+            form_logics: [],
+            workflow: [],
+            emails: [],
+            stepOneEmailNotificationFieldId: '',
+            stepsToNotify: [],
+            hasRespondentCopy: false,
+            title: 'Mock snapshotted form def',
+          } as SnapshottedFormDef,
           encryptedPayload: {
             encryptedContent: 'encryptedContent',
             version: 1,
@@ -410,6 +461,17 @@ describe('multirespondent-submision.controller', () => {
             authType: FormAuthType.NIL,
             getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
           },
+          snapshottedFormDef: {
+            _id: mockFormId,
+            form_fields: [],
+            form_logics: [],
+            workflow: [],
+            emails: [],
+            stepOneEmailNotificationFieldId: '',
+            stepsToNotify: [],
+            hasRespondentCopy: false,
+            title: 'Mock snapshotted form def',
+          } as SnapshottedFormDef,
           encryptedPayload: {
             encryptedContent: 'encryptedContent',
             version: 1,
@@ -452,6 +514,17 @@ describe('multirespondent-submision.controller', () => {
             authType: FormAuthType.NIL,
             getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
           },
+          snapshottedFormDef: {
+            _id: mockFormId,
+            form_fields: [],
+            form_logics: [],
+            workflow: [],
+            emails: [],
+            stepOneEmailNotificationFieldId: '',
+            stepsToNotify: [],
+            hasRespondentCopy: false,
+            title: 'Mock snapshotted form def',
+          } as SnapshottedFormDef,
           encryptedPayload: {
             encryptedContent: 'encryptedContent',
             version: 1,
@@ -494,6 +567,17 @@ describe('multirespondent-submision.controller', () => {
             authType: FormAuthType.NIL,
             getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
           },
+          snapshottedFormDef: {
+            _id: mockFormId,
+            form_fields: [],
+            form_logics: [],
+            workflow: [],
+            emails: [],
+            stepOneEmailNotificationFieldId: '',
+            stepsToNotify: [],
+            hasRespondentCopy: false,
+            title: 'Mock snapshotted form def',
+          } as SnapshottedFormDef,
           encryptedPayload: {
             encryptedContent: 'encryptedContent',
             version: 1,
@@ -536,6 +620,17 @@ describe('multirespondent-submision.controller', () => {
             authType: FormAuthType.NIL,
             getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
           },
+          snapshottedFormDef: {
+            _id: mockFormId,
+            form_fields: [],
+            form_logics: [],
+            workflow: [],
+            emails: [],
+            stepOneEmailNotificationFieldId: '',
+            stepsToNotify: [],
+            hasRespondentCopy: false,
+            title: 'Mock snapshotted form def',
+          } as SnapshottedFormDef,
           encryptedPayload: {
             encryptedContent: 'encryptedContent',
             version: 1,
@@ -575,6 +670,17 @@ describe('multirespondent-submision.controller', () => {
             authType: FormAuthType.NIL,
             getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
           },
+          snapshottedFormDef: {
+            _id: mockFormId,
+            form_fields: [],
+            form_logics: [],
+            workflow: [],
+            emails: [],
+            stepOneEmailNotificationFieldId: '',
+            stepsToNotify: [],
+            hasRespondentCopy: false,
+            title: 'Mock snapshotted form def',
+          } as SnapshottedFormDef,
           encryptedPayload: {
             encryptedContent: 'encryptedContent',
             version: 1,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -420,7 +420,7 @@ describe('multirespondent-submision.controller', () => {
       ).toEqual({
         submissionId: mockSubmissionId,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
-        form: mockSubmitMrfReq.formsg.formDef,
+        snapshottedFormDef: mockSubmitMrfReq.formsg.snapshottedFormDef,
       })
 
       // Assert post save actions are invoked with correct args
@@ -434,7 +434,7 @@ describe('multirespondent-submision.controller', () => {
           'logMeta',
         ),
       ).toEqual({
-        form: mockSubmitMrfReq.formsg.formDef,
+        snapshottedFormDef: mockSubmitMrfReq.formsg.snapshottedFormDef,
         encryptedPayload: mockSubmitMrfReq.formsg.encryptedPayload,
         submissionId: mockSubmissionId,
       })

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -1,0 +1,267 @@
+import { ObjectId } from 'bson'
+import { errAsync, ok, okAsync } from 'neverthrow'
+
+import { FormResponseMode } from '../../../../../../shared/types'
+import * as FeatureFlagService from '../../../feature-flags/feature-flags.service'
+import * as FormService from '../../../form/form.service'
+import { SubmissionNotFoundError } from '../../submission.errors'
+import { createFormsgAndRetrieveForm } from '../multirespondent-submission.middleware'
+import {
+  checkFormIsMultirespondent,
+  getMultirespondentSubmission,
+} from '../multirespondent-submission.service'
+
+jest.mock('../../../feature-flags/feature-flags.service')
+jest.mock('../../../form/form.service')
+jest.mock('../multirespondent-submission.service')
+
+describe('createFormsgAndRetrieveForm', () => {
+  const MOCK_FORM_ID = new ObjectId().toHexString()
+  const MOCK_SUBMISSION_ID = new ObjectId().toHexString()
+  const MOCK_FEATURE_FLAGS = ['flag1', 'flag2']
+
+  const MOCK_FORM = {
+    _id: MOCK_FORM_ID,
+    responseMode: FormResponseMode.Multirespondent,
+    title: 'mock form title',
+    publicKey: 'mockPublicKey',
+    form_fields: [
+      { _id: 'field1', fieldType: 'textfield', title: 'Field 1' },
+      { _id: 'field2', fieldType: 'email', title: 'Field 2' },
+    ],
+    form_logics: [{ _id: 'logic1', logicType: 'showFields' }],
+    workflow: [{ step: 1, edit: ['field1', 'field2'] }],
+    hasRespondentCopy: true,
+    emails: ['test@example.com'],
+    stepOneEmailNotificationFieldId: 'field1',
+    stepsToNotify: [new ObjectId().toHexString()],
+    toObject: jest.fn().mockReturnValue({
+      _id: MOCK_FORM_ID,
+      responseMode: FormResponseMode.Multirespondent,
+      title: 'mock form title',
+      publicKey: 'mockPublicKey',
+      form_fields: [
+        { _id: 'field1', fieldType: 'textfield', title: 'Field 1' },
+        { _id: 'field2', fieldType: 'email', title: 'Field 2' },
+      ],
+      form_logics: [{ _id: 'logic1', logicType: 'showFields' }],
+      workflow: [{ step: 1, edit: ['field1', 'field2'] }],
+      hasRespondentCopy: true,
+      emails: ['test@example.com'],
+      stepOneEmailNotificationFieldId: 'field1',
+      stepsToNotify: [new ObjectId().toHexString()],
+    }),
+    // Add other required properties to satisfy IPopulatedForm interface
+    admin: { _id: new ObjectId() },
+    permissionList: [],
+    startPage: { title: 'Start', paragraph: 'Start page' },
+    endPage: { title: 'End', paragraph: 'End page' },
+    hasCaptcha: false,
+    hasIssueNotification: false,
+    authType: FormResponseMode.Multirespondent,
+    isSubmitterIdCollectionEnabled: false,
+    isSingleSubmission: false,
+    status: 'ACTIVE',
+    inactiveMessage: '',
+    submissionLimit: null,
+    isListed: true,
+    webhook: { url: '', isRetryEnabled: false },
+    getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+  } as any
+
+  const MOCK_MRF_SUBMISSION = {
+    form: MOCK_FORM_ID,
+    form_fields: [
+      {
+        _id: 'snapshot_field1',
+        fieldType: 'textfield',
+        title: 'Snapshot Field 1',
+      },
+      { _id: 'snapshot_field2', fieldType: 'email', title: 'Snapshot Field 2' },
+    ],
+    form_logics: [{ _id: 'snapshot_logic1', logicType: 'hideFields' }],
+    workflow: [
+      { step: 1, edit: ['snapshot_field1'] },
+      { step: 2, edit: ['snapshot_field2'] },
+    ],
+    encryptedContent: 'encrypted-content',
+    version: 1,
+    workflowStep: 0,
+    // Add other required properties to satisfy IMultirespondentSubmissionSchema interface
+    submissionType: 'Multirespondent',
+    _id: new ObjectId(),
+    created: new Date(),
+    modified: new Date(),
+    getWebhookView: jest.fn(),
+    mrfVersion: 1,
+    authType: FormResponseMode.Multirespondent,
+  } as any
+
+  // Helper function to create fresh mockReq objects for each test
+  const createMockReq = (params: { formId: string; submissionId?: string }) =>
+    ({
+      params,
+      body: {
+        respondentEmails: ['test@example.com'],
+      },
+      formsg: undefined,
+      // Add Express request methods and properties
+      get: jest.fn((name: string) => {
+        if (name === 'cf-connecting-ip') return '127.0.0.1'
+        if (name === 'cf-ray') return 'mock-cf-ray'
+        return undefined
+      }),
+      ip: '127.0.0.1',
+      id: 'mock-request-id',
+      headers: {
+        'cf-connecting-ip': '127.0.0.1',
+        'cf-ray': 'mock-cf-ray',
+        'x-request-id': 'mock-request-id',
+      },
+      baseUrl: '/api/v3',
+      path: '/forms/mock-form-id/submissions',
+      originalUrl: '/api/v3/forms/mock-form-id/submissions?param=value',
+    }) as any
+
+  // Helper function to create fresh mockRes objects for each test
+  const createMockRes = () => ({
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  })
+
+  const mockNext = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetAllMocks()
+  })
+
+  it('should set formsg.mrfSubmission and formsg.snapshottedFormDef when submissionId exists and mrfSubmission is found', async () => {
+    // Arrange - Set up mocks for this specific test
+    jest
+      .mocked(FeatureFlagService.getEnabledFlags)
+      .mockReturnValue(okAsync(MOCK_FEATURE_FLAGS))
+
+    jest
+      .mocked(FormService.retrieveFullFormById)
+      .mockReturnValue(okAsync(MOCK_FORM))
+
+    jest
+      .mocked(getMultirespondentSubmission)
+      .mockReturnValue(okAsync(MOCK_MRF_SUBMISSION))
+
+    jest.mocked(checkFormIsMultirespondent).mockReturnValue(ok(MOCK_FORM))
+
+    const mockReq = createMockReq({
+      formId: MOCK_FORM_ID,
+      submissionId: MOCK_SUBMISSION_ID,
+    })
+    const mockRes = createMockRes()
+
+    // Act
+    await createFormsgAndRetrieveForm(mockReq, mockRes as any, mockNext)
+
+    // Assert
+    expect(mockNext).toHaveBeenCalled()
+    expect(mockReq).toHaveProperty('formsg')
+
+    // Verify that mrfSubmission is set
+    expect(mockReq.formsg.mrfSubmission).toEqual(MOCK_MRF_SUBMISSION)
+
+    // Verify that formDef (latestFormDef) is set
+    expect(mockReq.formsg.formDef).toEqual(MOCK_FORM)
+
+    // Verify that snapshottedFormDef is set with correct structure
+    expect(mockReq.formsg.snapshottedFormDef).toEqual({
+      _id: MOCK_FORM_ID,
+      title: MOCK_FORM.title,
+      form_fields: MOCK_MRF_SUBMISSION.form_fields, // Should use snapshot from submission
+      form_logics: MOCK_MRF_SUBMISSION.form_logics, // Should use snapshot from submission
+      workflow: MOCK_MRF_SUBMISSION.workflow, // Should use snapshot from submission
+      hasRespondentCopy: MOCK_FORM.hasRespondentCopy, // Should use current form data
+      emails: MOCK_FORM.emails, // Should use current form data
+      stepOneEmailNotificationFieldId:
+        MOCK_FORM.stepOneEmailNotificationFieldId, // Should use current form data
+      stepsToNotify: MOCK_FORM.stepsToNotify, // Should use current form data
+    })
+
+    // Verify that getMultirespondentSubmission was called with the correct submissionId
+    expect(getMultirespondentSubmission).toHaveBeenCalledWith(
+      MOCK_SUBMISSION_ID,
+    )
+  })
+
+  it('should return error response when submissionId exists but mrfSubmission is not found', async () => {
+    // Arrange - Set up mocks for this specific test
+    jest
+      .mocked(FeatureFlagService.getEnabledFlags)
+      .mockReturnValue(okAsync(MOCK_FEATURE_FLAGS))
+
+    jest
+      .mocked(FormService.retrieveFullFormById)
+      .mockReturnValue(okAsync(MOCK_FORM))
+
+    const mockError = new SubmissionNotFoundError()
+    jest
+      .mocked(getMultirespondentSubmission)
+      .mockReturnValue(errAsync(mockError))
+
+    jest.mocked(checkFormIsMultirespondent).mockReturnValue(ok(MOCK_FORM))
+
+    const mockReq = createMockReq({
+      formId: MOCK_FORM_ID,
+      submissionId: MOCK_SUBMISSION_ID,
+    })
+    const mockRes = createMockRes()
+
+    // Act
+    await createFormsgAndRetrieveForm(mockReq, mockRes as any, mockNext)
+
+    // Assert
+    expect(mockNext).not.toHaveBeenCalled() // Should NOT call next on error
+    expect(mockRes.status).toHaveBeenCalledWith(404) // SubmissionNotFoundError maps to 404
+    expect(mockRes.json).toHaveBeenCalledWith({
+      message: 'Submission not found for given ID',
+    })
+    expect(mockReq.formsg).toBeUndefined() // formsg should not be set on error
+  })
+
+  it('should not set snapshottedFormDef and mrfSubmission when submissionId does not exist', async () => {
+    // Arrange - Set up mocks for this specific test
+    jest
+      .mocked(FeatureFlagService.getEnabledFlags)
+      .mockReturnValue(okAsync(MOCK_FEATURE_FLAGS))
+
+    jest
+      .mocked(FormService.retrieveFullFormById)
+      .mockReturnValue(okAsync(MOCK_FORM))
+
+    jest.mocked(checkFormIsMultirespondent).mockReturnValue(ok(MOCK_FORM))
+
+    const mockReq = createMockReq({
+      formId: MOCK_FORM_ID,
+      // No submissionId
+    })
+    const mockRes = createMockRes()
+
+    // Act
+    await createFormsgAndRetrieveForm(mockReq, mockRes as any, mockNext)
+
+    // Assert
+    expect(mockNext).toHaveBeenCalled()
+    expect(mockReq).toHaveProperty('formsg')
+
+    // Verify that mrfSubmission is undefined (since retrieveMultirespondentSubmissionIfExists returns undefined)
+    expect(mockReq.formsg.mrfSubmission).toBeUndefined()
+
+    // Verify that formDef is still set
+    expect(mockReq.formsg.formDef).toEqual(MOCK_FORM)
+
+    // Verify that snapshottedFormDef is undefined
+    expect(mockReq.formsg.snapshottedFormDef).toBeUndefined()
+
+    // Verify that getMultirespondentSubmission was NOT called
+    expect(getMultirespondentSubmission).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -14,7 +14,7 @@ import {
   IMultirespondentSubmissionSchema,
   IPopulatedMultirespondentForm,
 } from 'src/types'
-import { MultirespondentSubmissionDto } from 'src/types/api'
+import { MultirespondentSubmissionDto, SnapshottedFormDef } from 'src/types/api'
 
 import {
   MrfReminderInvalidWorkflowStepError,
@@ -126,12 +126,12 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[0]],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -235,12 +235,12 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -350,13 +350,13 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[3]],
           stepsToNotify: [stepTwoId, stepThreeId],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -461,12 +461,12 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -567,12 +567,12 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -691,13 +691,13 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: fiveStepApprovalWorkflow,
           emails: [expectedEmails[1], expectedEmails[2]],
           stepsToNotify: [stepThreeId, stepFourId, stepFiveId],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -802,12 +802,12 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -948,13 +948,13 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: fourStepWorkflow,
           emails: [expectedEmails[3]],
           stepsToNotify: [stepFourId],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -1047,13 +1047,13 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: fourStepWorkflow,
           emails: [selectedEmails[3]],
           stepsToNotify: [stepFourId],
           stepOneEmailNotificationFieldId: emailFieldId1,
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -1113,13 +1113,13 @@ describe('multirespondent-submission.service', () => {
         },
       ]
 
-      const form: IPopulatedMultirespondentForm = {
+      const snapshottedFormDef = {
         _id: mockFormId,
         workflow,
         emails: [expectedStaticEmail],
         stepsToNotify: [stepOneId, stepTwoId], // Including step one in stepsToNotify
         stepOneEmailNotificationFieldId,
-      } as IPopulatedMultirespondentForm
+      } as SnapshottedFormDef
 
       const submissionResponses: FieldResponsesV3 = {
         [stepOneEmailNotificationFieldId]: {
@@ -1139,7 +1139,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form,
+        snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -1195,17 +1195,17 @@ describe('multirespondent-submission.service', () => {
         },
       ]
 
-      const form: IPopulatedMultirespondentForm = {
+      const snapshottedFormDef = {
         _id: mockFormId,
         workflow,
         emails: [staticEmail],
         stepsToNotify: [stepTwoId],
-      } as IPopulatedMultirespondentForm
+      } as SnapshottedFormDef
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form,
+        snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -1256,13 +1256,13 @@ describe('multirespondent-submission.service', () => {
         },
       ]
 
-      const form: IPopulatedMultirespondentForm = {
+      const snapshottedFormDef = {
         _id: mockFormId,
         workflow,
         emails: [staticEmail],
         stepsToNotify: [stepTwoId],
         stepOneEmailNotificationFieldId,
-      } as IPopulatedMultirespondentForm
+      } as SnapshottedFormDef
 
       const submissionResponses: FieldResponsesV3 = {
         // stepOneEmailNotificationFieldId is not present in responses
@@ -1271,7 +1271,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form,
+        snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -1332,13 +1332,13 @@ describe('multirespondent-submission.service', () => {
         },
       ]
 
-      const form: IPopulatedMultirespondentForm = {
+      const snapshottedFormDef = {
         _id: mockFormId,
         workflow,
         emails: [expectedStaticEmail],
         stepsToNotify: [stepOneId, stepTwoId], // Including step one in stepsToNotify
         stepOneEmailNotificationFieldId,
-      } as IPopulatedMultirespondentForm
+      } as SnapshottedFormDef
 
       const submissionResponses: FieldResponsesV3 = {
         [stepOneEmailNotificationFieldId]: {
@@ -1358,7 +1358,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form,
+        snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -1449,11 +1449,11 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form: {
+        snapshottedFormDef: {
           _id: mockFormId,
           workflow: singleStepWorkflow,
           emails: ['email1@example.com'],
-        } as IPopulatedMultirespondentForm,
+        } as SnapshottedFormDef,
         currentStepNumber: 1,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
@@ -1551,13 +1551,13 @@ describe('multirespondent-submission.service', () => {
         },
       ]
 
-      const form: IPopulatedMultirespondentForm = {
+      const snapshottedFormDef = {
         _id: mockFormId,
         workflow,
         emails: [expectedStaticEmail],
         stepsToNotify: [stepOneId, stepTwoId], // Including step one in stepsToNotify
         stepOneEmailNotificationFieldId,
-      } as IPopulatedMultirespondentForm
+      } as SnapshottedFormDef
       const respondentEmails = ['test@example.com', 'test1@example.com']
 
       const submissionResponses: FieldResponsesV3 = {
@@ -1578,7 +1578,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submissionId: mockSubmissionId,
-        form,
+        snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -172,9 +172,16 @@ const updateMultirespondentSubmission = async (
     formId,
   }
 
-  const form = req.formsg.formDef
+  const { formDef: currentForm, snapshottedFormDef } = req.formsg
 
-  setFormTags(form)
+  if (!snapshottedFormDef) {
+    const { errorMessage, statusCode } = mapRouteError(
+      new SubmissionFailedError(),
+    )
+    return res.status(statusCode).json({ message: errorMessage })
+  }
+
+  setFormTags(currentForm)
 
   const ensurePipeline = new Pipeline(
     ensurePublicForm,
@@ -183,7 +190,7 @@ const updateMultirespondentSubmission = async (
   )
 
   const hasEnsuredAll = await ensurePipeline.execute({
-    form,
+    form: currentForm,
     logMeta,
     req,
     res,
@@ -204,7 +211,7 @@ const updateMultirespondentSubmission = async (
   const updateMultiRespondentFormSubmissionResult =
     await updateMultiRespondentFormSubmission({
       submissionId,
-      form,
+      snapshottedFormDef,
       encryptedPayload,
       logMeta,
     })
@@ -237,7 +244,7 @@ const updateMultirespondentSubmission = async (
 
   await performMultiRespondentPostSubmissionUpdateActions({
     submissionId,
-    form,
+    snapshottedFormDef,
     currentStepNumber,
     encryptedPayload,
     logMeta,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -4,7 +4,7 @@ import { NextFunction } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
-import { IAttachmentInfo } from 'src/types'
+import { IAttachmentInfo, IMultirespondentSubmissionSchema } from 'src/types'
 
 import { featureFlags } from '../../../../../shared/constants'
 import {
@@ -20,7 +20,10 @@ import {
   ParsedClearFormFieldResponsesV3,
   ParsedClearFormFieldResponseV3,
 } from '../../../../types/api'
-import { MultirespondentFormLoadedDto } from '../../../../types/api/multirespondent_submission'
+import {
+  MultirespondentFormLoadedDto,
+  SnapshottedFormDef,
+} from '../../../../types/api/multirespondent_submission'
 import formsgSdk from '../../../config/formsg-sdk'
 import { createLoggerWithLabel } from '../../../config/logger'
 import {
@@ -29,6 +32,7 @@ import {
 } from '../../../utils/logic-adaptor'
 import { createReqMeta } from '../../../utils/request'
 import { isFieldResponseV3Equal } from '../../../utils/response-v3'
+import { DatabaseError } from '../../core/core.errors'
 import * as FeatureFlagService from '../../feature-flags/feature-flags.service'
 import { assertFormAvailable } from '../../form/admin-form/admin-form.utils'
 import * as FormService from '../../form/form.service'
@@ -37,6 +41,7 @@ import { CreateFormsgAndRetrieveFormMiddlewareHandlerType } from '../encrypt-sub
 import {
   InvalidSubmissionTypeError,
   ProcessingError,
+  SubmissionNotFoundError,
 } from '../submission.errors'
 import * as SubmissionService from '../submission.service'
 import {
@@ -95,6 +100,18 @@ export const validateMultirespondentRemindBody = celebrate({
   [Segments.BODY]: Joi.object({ submissionSecretKey: Joi.string().required() }),
 })
 
+const retrieveMultirespondentSubmissionIfExists = (
+  submissionId?: string,
+): ResultAsync<
+  IMultirespondentSubmissionSchema | undefined,
+  DatabaseError | SubmissionNotFoundError
+> => {
+  if (submissionId) {
+    return getMultirespondentSubmission(submissionId)
+  }
+  return okAsync(undefined)
+}
+
 /**
  * Creates formsg namespace in req.body and populates it with featureFlags, formDef and encryptedFormDef.
  */
@@ -103,7 +120,7 @@ export const createFormsgAndRetrieveForm = async (
   res: Parameters<CreateFormsgAndRetrieveFormMiddlewareHandlerType>[1],
   next: NextFunction,
 ) => {
-  const { formId } = req.params
+  const { formId, submissionId } = req.params
 
   const logMeta = {
     action: 'createFormsgAndRetrieveForm',
@@ -130,38 +147,74 @@ export const createFormsgAndRetrieveForm = async (
     .map((featureFlags) => {
       // Step 2b: Set formsg.featureFlags
       formsg.featureFlags = featureFlags
-
-      // Step 3: Retrieve form
-      return FormService.retrieveFullFormById(formId)
+      // Step 3: Retrieve mrf submission if exists
+      return retrieveMultirespondentSubmissionIfExists(submissionId)
         .mapErr((error) => {
-          logger.warn({
-            message: 'Failed to retrieve form from database',
+          logger.error({
+            message: 'Error occurred whilst retrieving mrf submission',
             meta: logMeta,
             error,
           })
-          const { errorMessage, statusCode } = mapRouteError(error)
+          const { statusCode, errorMessage } = mapRouteError(error)
           return res.status(statusCode).json({ message: errorMessage })
         })
-        .map((formDef) =>
-          // Step 4a: Check form is multirespondent form
-          checkFormIsMultirespondent(formDef)
+        .map((mrfSubmission) => {
+          formsg.mrfSubmission = mrfSubmission
+          return mrfSubmission
+        })
+        .map((mrfSubmission) => {
+          // Step 4: Retrieve latest form definition
+          return FormService.retrieveFullFormById(formId)
             .mapErr((error) => {
-              logger.error({
-                message:
-                  'Trying to submit non-multirespondent submission on multirespondent submission endpoint',
+              logger.warn({
+                message: 'Failed to retrieve form from database',
                 meta: logMeta,
+                error,
               })
-              const { statusCode, errorMessage } = mapRouteError(error)
-              return res.status(statusCode).json({
-                message: errorMessage,
-              })
+              const { errorMessage, statusCode } = mapRouteError(error)
+              return res.status(statusCode).json({ message: errorMessage })
             })
-            .map((multirespondentFormDef) => {
-              // Step 4b: Set formsg.formDef
-              formsg.formDef = multirespondentFormDef
+            .andThen((latestFormDef) => {
+              // Step 4a: Check form is multirespondent form
+              return checkFormIsMultirespondent(latestFormDef).mapErr(
+                (error) => {
+                  logger.error({
+                    message:
+                      'Trying to submit non-multirespondent submission on multirespondent submission endpoint',
+                    meta: logMeta,
+                    error,
+                  })
+                  const { statusCode, errorMessage } = mapRouteError(error)
+                  return res.status(statusCode).json({
+                    message: errorMessage,
+                  })
+                },
+              )
+            })
+            .map((latestMrfFormDef) => {
+              // Step 4b: Set formsg.latestFormDef
+              formsg.formDef = latestMrfFormDef
 
-              // Step 5: Check if form has public key
-              if (!multirespondentFormDef.publicKey) {
+              if (mrfSubmission) {
+                const snapshottedMrfFormDefinition: SnapshottedFormDef = {
+                  _id: mrfSubmission.form.toString(),
+                  title: latestMrfFormDef.title,
+                  form_fields: mrfSubmission.form_fields,
+                  form_logics: mrfSubmission.form_logics,
+                  workflow: mrfSubmission.workflow,
+                  hasRespondentCopy: latestMrfFormDef.hasRespondentCopy,
+                  emails: latestMrfFormDef.emails,
+                  stepOneEmailNotificationFieldId:
+                    latestMrfFormDef.stepOneEmailNotificationFieldId,
+                  stepsToNotify: latestMrfFormDef.stepsToNotify,
+                }
+                formsg.snapshottedFormDef = snapshottedMrfFormDefinition
+              }
+            })
+            .map(() => {
+              const formDef = formsg.formDef
+              // Step 5: Check that the form def has a public key
+              if (!formDef.publicKey) {
                 const message = 'Form does not have a public key'
                 logger.warn({ message, meta: logMeta })
                 return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
@@ -173,8 +226,8 @@ export const createFormsgAndRetrieveForm = async (
               req.formsg = formsg
 
               return next()
-            }),
-        )
+            })
+        })
     })
 }
 
@@ -388,6 +441,7 @@ export const validateMultirespondentSubmission = async (
   next: NextFunction,
 ) => {
   const { formId, submissionId } = req.params
+  const { mrfSubmission } = req.formsg
 
   const logMeta = {
     action: 'validateMultirespondentSubmission',
@@ -398,27 +452,27 @@ export const validateMultirespondentSubmission = async (
 
   return (
     // Step 0: Prepare by retrieving relevant reference data
-    okAsync(submissionId)
-      .andThen((submissionId) =>
+    ok(mrfSubmission)
+      .andThen((mrfSubmission) =>
         // Step 0a: If its an existing submission, use the reference data from
         // the submission rather than the form
-        submissionId
-          ? getMultirespondentSubmission(submissionId).map((submission) => ({
+        mrfSubmission
+          ? ok({
               previousSubmission: {
-                encryptedContent: submission.encryptedContent,
-                version: submission.version,
+                encryptedContent: mrfSubmission.encryptedContent,
+                version: mrfSubmission.version,
               },
-              workflowStep: submission.workflowStep + 1,
-              workflow: submission.workflow,
-              form_fields: submission.form_fields,
-              form_logics: submission.form_logics,
-            }))
-          : okAsync({
+              workflowStep: mrfSubmission.workflowStep + 1,
+              workflow: mrfSubmission.workflow,
+              form_fields: mrfSubmission.form_fields,
+              form_logics: mrfSubmission.form_logics,
+            })
+          : ok({
               previousSubmission: undefined,
               workflowStep: 0,
               workflow: req.formsg.formDef.workflow,
               form_fields: req.formsg.formDef.form_fields.map(
-                (ff) => ff.toObject() as FormFieldDto,
+                (ff_schema) => ff_schema.toObject() as FormFieldDto,
               ),
               form_logics: req.formsg.formDef.form_logics,
             }),

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -4,7 +4,11 @@ import { NextFunction } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
-import { IAttachmentInfo, IMultirespondentSubmissionSchema } from 'src/types'
+import {
+  IAttachmentInfo,
+  IMultirespondentSubmissionSchema,
+  IPopulatedMultirespondentForm,
+} from 'src/types'
 
 import { featureFlags } from '../../../../../shared/constants'
 import {
@@ -112,10 +116,26 @@ const retrieveMultirespondentSubmissionIfExists = (
   return okAsync(undefined)
 }
 
+const getSnapshottedFormDef = (
+  mrfSubmission: IMultirespondentSubmissionSchema,
+  currentFormDef: IPopulatedMultirespondentForm,
+): SnapshottedFormDef => ({
+  _id: mrfSubmission.form.toString(),
+  title: currentFormDef.title,
+  form_fields: mrfSubmission.form_fields,
+  form_logics: mrfSubmission.form_logics,
+  workflow: mrfSubmission.workflow,
+  hasRespondentCopy: currentFormDef.hasRespondentCopy,
+  emails: currentFormDef.emails,
+  stepOneEmailNotificationFieldId:
+    currentFormDef.stepOneEmailNotificationFieldId,
+  stepsToNotify: currentFormDef.stepsToNotify,
+})
+
 /**
  * Creates formsg namespace in req.body and populates it with featureFlags, formDef and encryptedFormDef.
  */
-export const createFormsgAndRetrieveForm = async (
+export const createFormsgAndRetrieveForm = (
   req: CreateFormsgAndRetrieveFormMiddlewareHandlerRequest,
   res: Parameters<CreateFormsgAndRetrieveFormMiddlewareHandlerType>[1],
   next: NextFunction,
@@ -144,7 +164,7 @@ export const createFormsgAndRetrieveForm = async (
         error,
       })
     })
-    .map((featureFlags) => {
+    .andThen((featureFlags) => {
       // Step 2b: Set formsg.featureFlags
       formsg.featureFlags = featureFlags
       // Step 3: Retrieve mrf submission if exists
@@ -162,7 +182,7 @@ export const createFormsgAndRetrieveForm = async (
           formsg.mrfSubmission = mrfSubmission
           return mrfSubmission
         })
-        .map((mrfSubmission) => {
+        .andThen((mrfSubmission) => {
           // Step 4: Retrieve latest form definition
           return FormService.retrieveFullFormById(formId)
             .mapErr((error) => {
@@ -194,21 +214,12 @@ export const createFormsgAndRetrieveForm = async (
             .map((latestMrfFormDef) => {
               // Step 4b: Set formsg.latestFormDef
               formsg.formDef = latestMrfFormDef
-
+              // Step 4c: Set formsg.snapshottedFormDef if mrfSubmission exists
               if (mrfSubmission) {
-                const snapshottedMrfFormDefinition: SnapshottedFormDef = {
-                  _id: mrfSubmission.form.toString(),
-                  title: latestMrfFormDef.title,
-                  form_fields: mrfSubmission.form_fields,
-                  form_logics: mrfSubmission.form_logics,
-                  workflow: mrfSubmission.workflow,
-                  hasRespondentCopy: latestMrfFormDef.hasRespondentCopy,
-                  emails: latestMrfFormDef.emails,
-                  stepOneEmailNotificationFieldId:
-                    latestMrfFormDef.stepOneEmailNotificationFieldId,
-                  stepsToNotify: latestMrfFormDef.stepsToNotify,
-                }
-                formsg.snapshottedFormDef = snapshottedMrfFormDefinition
+                formsg.snapshottedFormDef = getSnapshottedFormDef(
+                  mrfSubmission,
+                  latestMrfFormDef,
+                )
               }
             })
             .map(() => {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -6,6 +6,7 @@ import Mail from 'nodemailer/lib/mailer'
 import {
   BasicField,
   FieldResponsesV3,
+  FormFieldDto,
   FormResponseMode,
   FormWorkflowStepDto,
   SubmittedApprovalStep,
@@ -17,12 +18,16 @@ import { getSignatureFileName } from '../../../../../shared/utils/signature'
 import { getMultirespondentSubmissionEditPath } from '../../../../../shared/utils/urls'
 import {
   Environment,
+  FormFieldSchema,
   IAttachmentInfo,
   IMultirespondentSubmissionSchema,
   IPopulatedForm,
   IPopulatedMultirespondentForm,
 } from '../../../../types'
-import { MultirespondentSubmissionDto } from '../../../../types/api'
+import {
+  MultirespondentSubmissionDto,
+  SnapshottedFormDef,
+} from '../../../../types/api'
 import config from '../../../config/config'
 import {
   createLoggerWithLabel,
@@ -78,7 +83,9 @@ export const checkFormIsMultirespondent = (
       )
 }
 
-const checkIsFormApproval = (form: IPopulatedMultirespondentForm): boolean => {
+const checkIsFormApproval = (
+  form: Pick<IPopulatedMultirespondentForm, 'workflow'>,
+): boolean => {
   return (
     form.workflow &&
     form.workflow.map((step) => step.approval_field).filter(Boolean).length > 0
@@ -91,7 +98,7 @@ const checkIsStepRejected = ({
   responses,
 }: {
   zeroIndexedStepNumber: number
-  form: IPopulatedMultirespondentForm
+  form: Pick<IPopulatedMultirespondentForm, 'workflow'>
   responses: FieldResponsesV3
 }): Result<
   boolean,
@@ -121,7 +128,9 @@ const checkIsStepRejected = ({
 
 interface sendNextStepEmailProps {
   nextStepNumber: number
-  form: IPopulatedMultirespondentForm
+  form: Pick<IPopulatedMultirespondentForm, 'workflow'> & {
+    form_fields: FormFieldSchema[] | FormFieldDto[]
+  }
   formTitle: string
   responseUrl: string
   formId: string
@@ -307,7 +316,17 @@ const sendMrfOutcomeEmails = ({
   attachments,
 }: {
   currentStepNumber: number
-  form: IPopulatedMultirespondentForm
+  form: Pick<
+    IPopulatedMultirespondentForm,
+    | '_id'
+    | 'title'
+    | 'emails'
+    | 'stepOneEmailNotificationFieldId'
+    | 'stepsToNotify'
+    | 'workflow'
+  > & {
+    form_fields: FormFieldSchema[] | FormFieldDto[]
+  }
   responses: FieldResponsesV3
   submissionId: string
   isApproval?: boolean
@@ -463,7 +482,12 @@ const sendMrfRespondentCopyEmails = ({
   attachments,
   respondentEmails,
 }: {
-  form: IPopulatedMultirespondentForm
+  form: Pick<
+    IPopulatedMultirespondentForm,
+    '_id' | 'title' | 'hasRespondentCopy'
+  > & {
+    form_fields: FormFieldSchema[] | FormFieldDto[]
+  }
   responses: FieldResponsesV3
   submissionId: string
   attachments?: IAttachmentInfo[]
@@ -712,12 +736,12 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
 
 export const updateMultiRespondentFormSubmission = ({
   submissionId,
-  form,
+  snapshottedFormDef,
   encryptedPayload,
   logMeta,
 }: {
   submissionId: string
-  form: IPopulatedMultirespondentForm
+  snapshottedFormDef: SnapshottedFormDef
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
 }): ResultAsync<
@@ -730,7 +754,7 @@ export const updateMultiRespondentFormSubmission = ({
   }
 
   return saveAttachmentsToDbIfExists({
-    formId: form._id,
+    formId: snapshottedFormDef._id,
     attachments: encryptedPayload.attachments,
   })
     .map(async (attachmentMetadata) => {
@@ -760,12 +784,12 @@ export const updateMultiRespondentFormSubmission = ({
 
       const nextStepNumber = workflowStep + 1
       const nextStep =
-        form.workflow.length > nextStepNumber
-          ? form.workflow[nextStepNumber]
+        snapshottedFormDef.workflow.length > nextStepNumber
+          ? snapshottedFormDef.workflow[nextStepNumber]
           : null
       const nextStepRecipientEmailsResult = nextStep
         ? retrieveWorkflowStepEmailAddresses(
-            form,
+            snapshottedFormDef,
             nextStep,
             encryptedPayload.responses,
           )
@@ -785,10 +809,10 @@ export const updateMultiRespondentFormSubmission = ({
         ? nextStepRecipientEmailsResult.unwrapOr(undefined)
         : undefined
 
-      const isApprovalForm = checkIsFormApproval(form)
+      const isApprovalForm = checkIsFormApproval(snapshottedFormDef)
       const isStepRejectedResult = checkIsStepRejected({
         zeroIndexedStepNumber: workflowStep,
-        form,
+        form: snapshottedFormDef,
         responses: encryptedPayload.responses,
       })
       if (isStepRejectedResult.isErr()) {
@@ -857,7 +881,7 @@ export const updateMultiRespondentFormSubmission = ({
 
 export const performMultiRespondentPostSubmissionUpdateActions = ({
   submissionId,
-  form,
+  snapshottedFormDef,
   currentStepNumber,
   encryptedPayload,
   logMeta,
@@ -865,7 +889,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   respondentEmails,
 }: {
   submissionId: string
-  form: IPopulatedMultirespondentForm
+  snapshottedFormDef: SnapshottedFormDef
   currentStepNumber: number
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
@@ -884,13 +908,13 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     ...logMeta,
     action: 'performMultiRespondentPostSubmissionUpdateActions',
     currentWorkflowStep: currentStepNumber,
-    formId: form._id,
+    formId: snapshottedFormDef._id,
     submissionId,
   }
 
   if (respondentEmails && respondentEmails.length > 0) {
     sendMrfRespondentCopyEmails({
-      form,
+      form: snapshottedFormDef,
       responses,
       submissionId,
       attachments,
@@ -906,7 +930,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
 
   const isStepRejectedResult = checkIsStepRejected({
     zeroIndexedStepNumber: currentStepNumber,
-    form,
+    form: snapshottedFormDef,
     responses,
   }).mapErr((error) => {
     logger.error({
@@ -931,7 +955,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   if (isStepRejected) {
     return sendMrfOutcomeEmails({
       currentStepNumber,
-      form,
+      form: snapshottedFormDef,
       responses,
       submissionId,
       isApproval: true,
@@ -948,10 +972,10 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   }
   return sendMrfOutcomeEmails({
     currentStepNumber,
-    form,
+    form: snapshottedFormDef,
     responses,
     submissionId,
-    isApproval: checkIsFormApproval(form),
+    isApproval: checkIsFormApproval(snapshottedFormDef),
     attachments: attachments,
   })
     .mapErr((error) => {
@@ -965,14 +989,14 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     .andThen(() =>
       sendNextStepEmail({
         nextStepNumber: currentStepNumber + 1,
-        form,
-        formTitle: form.title,
+        form: snapshottedFormDef,
+        formTitle: snapshottedFormDef.title,
         responseUrl: `${appUrl}/${getMultirespondentSubmissionEditPath(
-          form._id,
+          snapshottedFormDef._id,
           submissionId,
           { key: submissionSecretKey },
         )}`,
-        formId: form._id,
+        formId: snapshottedFormDef._id,
         submissionId,
         responses,
       }).mapErr((error) => {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.types.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.types.ts
@@ -17,7 +17,7 @@ import { ControllerHandler } from '../../core/core.types'
 
 export type CreateFormsgAndRetrieveFormMiddlewareHandlerType =
   ControllerHandler<
-    { formId: string },
+    { formId: string; submissionId?: string },
     SubmissionResponseDto | SubmissionErrorDto,
     ParsedMultirespondentSubmissionBody,
     { captchaResponse?: unknown; captchaType?: unknown }

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -15,7 +15,6 @@ import { handleAddressResponseDisplay } from '../../../../../shared/utils/addres
 import { getSignatureFileName } from '../../../../../shared/utils/signature'
 import {
   FormFieldSchema,
-  IPopulatedForm,
   MultirespondentSubmissionData,
 } from '../../../../types'
 import { ParsedClearFormFieldResponsesV3 } from '../../../../types/api'
@@ -73,11 +72,11 @@ export const getEmailFromResponses = (
 }
 
 const getConditionalFieldEmailRecipient = (
-  form: IPopulatedForm,
+  form_fields: FormFieldSchema[] | FormFieldDto[],
   fieldId: string,
   responses: FieldResponsesV3,
 ): string[] => {
-  const conditionalField = form.form_fields.find(
+  const conditionalField = form_fields.find(
     (field) => field._id.toString() === fieldId.toString(),
   )
   const conditionalFieldResponse = responses[fieldId]
@@ -104,7 +103,7 @@ const getConditionalFieldEmailRecipient = (
 }
 
 export const retrieveWorkflowStepEmailAddresses = (
-  form: IPopulatedForm,
+  form: { form_fields: FormFieldSchema[] | FormFieldDto[] },
   step: FormWorkflowStepDto,
   responses: FieldResponsesV3,
 ): Result<string[], InvalidWorkflowTypeError> => {
@@ -121,7 +120,7 @@ export const retrieveWorkflowStepEmailAddresses = (
     case WorkflowType.Conditional: {
       return ok(
         getConditionalFieldEmailRecipient(
-          form,
+          form.form_fields,
           step.conditional_field,
           responses,
         ),
@@ -205,7 +204,7 @@ export const getQuestionTitleAnswerString = ({
   formFields,
   responses,
 }: {
-  formFields: FormFieldSchema[]
+  formFields: FormFieldSchema[] | FormFieldDto[]
   responses: FieldResponsesV3
 }): QuestionAnswer[] => {
   const questionAnswerPair = []

--- a/src/types/api/multirespondent_submission.ts
+++ b/src/types/api/multirespondent_submission.ts
@@ -1,10 +1,13 @@
 import {
   FieldResponsesV3,
+  FormFieldDto,
+  FormLogic,
   FormResponseMode,
   ResponseMetadata,
   SubmissionAttachmentsMap,
 } from '../../../shared/types'
 import { IPopulatedMultirespondentForm } from '../form'
+import { IMultirespondentSubmissionSchema } from '../submission'
 
 export type ParsedMultirespondentSubmissionBody = {
   responses: FieldResponsesV3
@@ -14,9 +17,25 @@ export type ParsedMultirespondentSubmissionBody = {
   respondentEmails?: string[]
 }
 
+export type SnapshottedFormDef = Pick<
+  IPopulatedMultirespondentForm,
+  | 'emails'
+  | 'stepOneEmailNotificationFieldId'
+  | 'stepsToNotify'
+  | 'hasRespondentCopy'
+  | 'title'
+  | 'workflow'
+> & {
+  _id: string
+  form_fields: FormFieldDto[]
+  form_logics: FormLogic[]
+}
+
 export type MultirespondentFormLoadedDto = {
   responseMode: FormResponseMode.Multirespondent
   formDef: IPopulatedMultirespondentForm
+  snapshottedFormDef?: SnapshottedFormDef
+  mrfSubmission?: IMultirespondentSubmissionSchema
   featureFlags: string[]
   respondentEmails?: string[]
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
MRF forms that are in progress (step >=2 onwards) are using the latest form definitions instead of the intended snapshotted form definitions. This causes corruption to the ongoing MRF submission steps if the admin changes the form in the meantime. 

## Solution
<!-- How did you solve the problem? -->
Use the snapshotted values for mrf updates. 

In the get formsg method for MRF: 
- add snapshottedFormDef to be used by the submit update mrf functions  
- update the types for functions to be minimal and only contain necessary fields so that it is compatible with various form types. 
- add TC for middleware to ensure that the formsg fields eg, snapshottedFormDef and mrfSubmission is set correctly  

**Breaking Changes** 
No - this PR is backwards compatible  

## Tests