### PR TITLE
feat: signature v1.2

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
@@ -148,32 +148,34 @@ const DecryptedSignatureRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
     const canvas = canvasRef.current
     if (!canvas || vectorArray.length === 0) return
 
-    // Step 1: Compute bounding box of all x and y points
     const { minX, minY, maxX, maxY } = getBoundingBox(vectorArray)
 
-    const padding = SIGNATURE_OUTPUT_PADDING_DEFAULT
-    const width = maxX - minX
-    const height = maxY - minY
-    const canvasWidth = width + padding * 2
-    const canvasHeight = height + padding * 2
+    // apply devicePixelRatio to maintain sharpness
+    const dpr = window.devicePixelRatio || 1
+    canvas.width = maxX * dpr
+    canvas.height = maxY * dpr
 
-    // Step 2: Resize canvas
-    canvas.width = canvasWidth
-    canvas.height = canvasHeight
-    setCanvasSize({ width: canvasWidth, height: canvasHeight })
+    // keep the CSS size same as logical size
+    canvas.style.width = `${maxX}px`
+    canvas.style.height = `${maxY}px`
+
+    const padding = SIGNATURE_OUTPUT_PADDING_DEFAULT
+    setCanvasSize({ width: maxX, height: maxY })
 
     const ctx = canvas.getContext('2d')
     if (!ctx) return
-    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    // Scale the context to account for dpr
+    ctx.scale(dpr, dpr)
+    ctx.clearRect(0, 0, maxX - minX + padding * 2, maxY - minY + padding * 2)
 
-    // Step 3: Draw centered strokes inside trimmed canvas
+    // Draw strokes using original coordinates but shift by minX and minY to remove whitespace
     vectorArray.forEach((stroke) => {
-      const normalizedStroke = stroke.map(([x, y, pressure]) => [
+      const shiftedStroke = stroke.map(([x, y, pressure]) => [
         x - minX + padding,
         y - minY + padding,
         pressure,
       ])
-      const pathData = getStroke(normalizedStroke, {
+      const pathData = getStroke(shiftedStroke, {
         size: SIGNATURE_STROKE_SIZE,
         thinning: SIGNATURE_STROKE_THINNING,
         smoothing: SIGNATURE_STROKE_SMOOTHING,
@@ -190,7 +192,6 @@ const DecryptedSignatureRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
         background="white"
         width={`${canvasSize.width}px`}
         height={`${canvasSize.height}px`}
-        border="1px solid"
         borderColor="neutral.400"
         borderRadius="0.25rem"
       >

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
@@ -11,11 +11,11 @@ import { handleAddressResponseDisplay } from '~shared/utils/address'
 import {
   convertToSignatureVectorArray,
   getBoundingBox,
-  signatureOutputPaddingDefault,
-  signatureStrokeSize,
-  signatureStrokeSmoothing,
-  signatureStrokeStreamline,
-  signatureStrokeThinning,
+  SIGNATURE_OUTPUT_PADDING_DEFAULT,
+  SIGNATURE_STROKE_SIZE,
+  SIGNATURE_STROKE_SMOOTHING,
+  SIGNATURE_STROKE_STREAMLINE,
+  SIGNATURE_STROKE_THINNING,
 } from '~shared/utils/signature'
 
 import { drawStroke } from '~utils/convertSignatureOutput'
@@ -151,7 +151,7 @@ const DecryptedSignatureRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
     // Step 1: Compute bounding box of all x and y points
     const { minX, minY, maxX, maxY } = getBoundingBox(vectorArray)
 
-    const padding = signatureOutputPaddingDefault
+    const padding = SIGNATURE_OUTPUT_PADDING_DEFAULT
     const width = maxX - minX
     const height = maxY - minY
     const canvasWidth = width + padding * 2
@@ -174,10 +174,10 @@ const DecryptedSignatureRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
         pressure,
       ])
       const pathData = getStroke(normalizedStroke, {
-        size: signatureStrokeSize,
-        thinning: signatureStrokeThinning,
-        smoothing: signatureStrokeSmoothing,
-        streamline: signatureStrokeStreamline,
+        size: SIGNATURE_STROKE_SIZE,
+        thinning: SIGNATURE_STROKE_THINNING,
+        smoothing: SIGNATURE_STROKE_SMOOTHING,
+        streamline: SIGNATURE_STROKE_STREAMLINE,
       })
       drawStroke(ctx, pathData)
     })

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BiChevronLeft, BiChevronRight, BiLeftArrowAlt } from 'react-icons/bi'
 import { FaRegFilePdf } from 'react-icons/fa6'
@@ -19,7 +19,7 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
+import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants'
 
@@ -111,7 +111,19 @@ export const IndividualResponseNavbar = (): JSX.Element => {
   const { t } = useTranslation()
 
   const { user } = useUser()
-  const isSignatureFieldEnabled = useFeatureIsOn(featureFlags.signatureField)
+  const gb = useGrowthBook()
+
+  useEffect(() => {
+    if (user) {
+      gb?.setAttributes({
+        id: user._id,
+        email: user.email,
+        agency: user.agency,
+      })
+    }
+  }, [gb, user])
+
+  const isAdminPrintPdfEnabled = useFeatureIsOn(featureFlags.adminPrintPdf)
 
   return (
     <Grid
@@ -146,16 +158,25 @@ export const IndividualResponseNavbar = (): JSX.Element => {
               {t('features.common.response')}
               {currentResponseNumber ? ` #${currentResponseNumber}` : ''}
             </Text>
-            {user?.betaFlags?.signatureField && isSignatureFieldEnabled ? (
+            {isAdminPrintPdfEnabled && (
               <Box>
                 <IconButton
                   aria-label="Print"
                   icon={<FaRegFilePdf />}
-                  onClick={() => window.print()}
+                  onClick={() => {
+                    console.log({
+                      meta: {
+                        action: featureFlags.adminPrintPdf,
+                        userId: user?._id,
+                        submissionId: submissionId,
+                      },
+                    })
+                    window.print()
+                  }}
                   variant="clear"
                 />
               </Box>
-            ) : null}
+            )}
           </Stack>
         </Skeleton>
       </Flex>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -19,11 +19,11 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react'
+import { datadogLogs } from '@datadog/browser-logs'
 import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants'
 
-import { datadogRum } from '~utils/datadog'
 import { noPrintCss } from '~utils/noPrintCss'
 import IconButton from '~components/IconButton'
 
@@ -165,11 +165,11 @@ export const IndividualResponseNavbar = (): JSX.Element => {
                   aria-label="Print"
                   icon={<FaRegFilePdf />}
                   onClick={() => {
-                    datadogRum.addAction(
-                      'individualresponsepage.navbar.print',
+                    datadogLogs.logger.info(
+                      `IndividualResponseNavbar: admin printing pdf`,
                       {
                         meta: {
-                          action: featureFlags.adminPrintPdf,
+                          action: 'adminPrintPdf',
                           userId: user?._id,
                           submissionId: submissionId,
                         },

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -165,7 +165,7 @@ export const IndividualResponseNavbar = (): JSX.Element => {
                   aria-label="Print"
                   icon={<FaRegFilePdf />}
                   onClick={() => {
-                    datadogRum.addAction(featureFlags.adminPrintPdf, {
+                    datadogRum.addAction('individualresponsepage.navbar.print', {
                       meta: {
                         action: featureFlags.adminPrintPdf,
                         userId: user?._id,

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -19,16 +19,18 @@ import {
   Stack,
   Text,
 } from '@chakra-ui/react'
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
+
+import { featureFlags } from '~shared/constants'
 
 import { noPrintCss } from '~utils/noPrintCss'
 import IconButton from '~components/IconButton'
 
+import { useUser } from '~features/user/queries'
+
 import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
 
 import { useIndividualSubmission } from './queries'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
-import { featureFlags } from '~shared/constants'
-import { useUser } from '~features/user/queries'
 
 export const IndividualResponseNavbar = (): JSX.Element => {
   const { state } = useLocation()
@@ -145,7 +147,7 @@ export const IndividualResponseNavbar = (): JSX.Element => {
               {currentResponseNumber ? ` #${currentResponseNumber}` : ''}
             </Text>
             {user?.betaFlags?.signatureField && isSignatureFieldEnabled ? (
-              <Box onClick={() => window.print()}>
+              <Box>
                 <IconButton
                   aria-label="Print"
                   icon={<FaRegFilePdf />}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BiChevronLeft, BiChevronRight, BiLeftArrowAlt } from 'react-icons/bi'
+import { FaRegFilePdf } from 'react-icons/fa6'
 import {
   Link as ReactLink,
   useLocation,
@@ -8,12 +9,14 @@ import {
   useParams,
 } from 'react-router-dom'
 import {
+  Box,
   ButtonGroup,
   Flex,
   Grid,
   Icon,
   Link,
   Skeleton,
+  Stack,
   Text,
 } from '@chakra-ui/react'
 
@@ -23,6 +26,9 @@ import IconButton from '~components/IconButton'
 import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
 
 import { useIndividualSubmission } from './queries'
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
+import { featureFlags } from '~shared/constants'
+import { useUser } from '~features/user/queries'
 
 export const IndividualResponseNavbar = (): JSX.Element => {
   const { state } = useLocation()
@@ -102,6 +108,9 @@ export const IndividualResponseNavbar = (): JSX.Element => {
 
   const { t } = useTranslation()
 
+  const { user } = useUser()
+  const isSignatureFieldEnabled = useFeatureIsOn(featureFlags.signatureField)
+
   return (
     <Grid
       sx={noPrintCss}
@@ -130,10 +139,22 @@ export const IndividualResponseNavbar = (): JSX.Element => {
       </Flex>
       <Flex gridArea="respondent" justify="center" align="center">
         <Skeleton isLoaded={!isLoading}>
-          <Text textStyle="h2" as="h2">
-            {t('features.common.response')}
-            {currentResponseNumber ? ` #${currentResponseNumber}` : ''}
-          </Text>
+          <Stack direction="row" justify="center" align="center">
+            <Text textStyle="h2" as="h2">
+              {t('features.common.response')}
+              {currentResponseNumber ? ` #${currentResponseNumber}` : ''}
+            </Text>
+            {user?.betaFlags?.signatureField && isSignatureFieldEnabled ? (
+              <Box onClick={() => window.print()}>
+                <IconButton
+                  aria-label="Print"
+                  icon={<FaRegFilePdf />}
+                  onClick={() => window.print()}
+                  variant="clear"
+                />
+              </Box>
+            ) : null}
+          </Stack>
         </Skeleton>
       </Flex>
       <ButtonGroup gridArea="navigate">

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -165,13 +165,16 @@ export const IndividualResponseNavbar = (): JSX.Element => {
                   aria-label="Print"
                   icon={<FaRegFilePdf />}
                   onClick={() => {
-                    datadogRum.addAction('individualresponsepage.navbar.print', {
-                      meta: {
-                        action: featureFlags.adminPrintPdf,
-                        userId: user?._id,
-                        submissionId: submissionId,
+                    datadogRum.addAction(
+                      'individualresponsepage.navbar.print',
+                      {
+                        meta: {
+                          action: featureFlags.adminPrintPdf,
+                          userId: user?._id,
+                          submissionId: submissionId,
+                        },
                       },
-                    })
+                    )
                     window.print()
                   }}
                   variant="clear"

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -23,6 +23,7 @@ import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants'
 
+import { datadogRum } from '~utils/datadog'
 import { noPrintCss } from '~utils/noPrintCss'
 import IconButton from '~components/IconButton'
 
@@ -164,7 +165,7 @@ export const IndividualResponseNavbar = (): JSX.Element => {
                   aria-label="Print"
                   icon={<FaRegFilePdf />}
                   onClick={() => {
-                    console.log({
+                    datadogRum.addAction(featureFlags.adminPrintPdf, {
                       meta: {
                         action: featureFlags.adminPrintPdf,
                         userId: user?._id,

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -282,7 +282,14 @@ export const SignatureField = ({
               </Box>
             </Stack>
           </Flex>
-          <Box alignSelf="end" marginTop="0.5rem">
+          <Flex justify="space-between" mt="0.5rem" align="flex-start">
+            {signatureErrors?.message ? (
+              <FormErrorMessage mt="0">
+                {signatureErrors.message}
+              </FormErrorMessage>
+            ) : (
+              <Box /> // placeholder to consistently flush button to the right
+            )}
             <Button
               onClick={() => {
                 handleClearPerfectFreehandSignature()
@@ -292,8 +299,7 @@ export const SignatureField = ({
             >
               Clear
             </Button>
-          </Box>
-          <FormErrorMessage>{signatureErrors?.message}</FormErrorMessage>
+          </Flex>
         </Stack>
       </FormControl>
     </Box>

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -169,11 +169,13 @@ export const SignatureField = ({
     canvas.addEventListener('pointerdown', handlePointerDown)
     canvas.addEventListener('pointermove', handlePointerMove)
     canvas.addEventListener('pointerup', handlePointerUp)
+    canvas.addEventListener('pointerleave', handlePointerUp)
 
     return () => {
       canvas.removeEventListener('pointerdown', handlePointerDown)
       canvas.removeEventListener('pointermove', handlePointerMove)
       canvas.removeEventListener('pointerup', handlePointerUp)
+      canvas.addEventListener('pointerleave', handlePointerUp)
     }
   }, [
     drawAllStrokes,

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -5,10 +5,10 @@ import getStroke from 'perfect-freehand'
 
 import { SignatureVectorArray } from '~shared/types'
 import {
-  signatureStrokeSize,
-  signatureStrokeSmoothing,
-  signatureStrokeStreamline,
-  signatureStrokeThinning,
+  SIGNATURE_STROKE_SIZE,
+  SIGNATURE_STROKE_SMOOTHING,
+  SIGNATURE_STROKE_STREAMLINE,
+  SIGNATURE_STROKE_THINNING,
 } from '~shared/utils/signature'
 
 import { createSignatureValidationRules } from '~utils/fieldValidation'
@@ -73,10 +73,10 @@ export const SignatureField = ({
 
     for (const strokePoints of pfStrokes) {
       const stroke = getStroke(strokePoints, {
-        size: signatureStrokeSize,
-        thinning: signatureStrokeThinning,
-        smoothing: signatureStrokeSmoothing,
-        streamline: signatureStrokeStreamline,
+        size: SIGNATURE_STROKE_SIZE,
+        thinning: SIGNATURE_STROKE_THINNING,
+        smoothing: SIGNATURE_STROKE_SMOOTHING,
+        streamline: SIGNATURE_STROKE_STREAMLINE,
       })
 
       ctx.beginPath()

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -158,6 +158,7 @@ export const SignatureField = ({
     }
 
     const handlePointerUp = () => {
+      if (!isDrawing) return
       setIsDrawing(false)
       setValue(
         `${schema._id}`,

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -227,13 +227,7 @@ export const SignatureField = ({
                 width="100%"
                 maxWidth="100%"
                 height="11.125rem"
-                border={
-                  signatureErrors
-                    ? '1px solid'
-                    : isDrawing
-                      ? '2px solid'
-                      : '1px solid'
-                }
+                border="1px solid"
                 borderRadius="0.25rem"
                 cursor={schema.disabled ? 'not-allowed' : 'auto'}
                 borderColor={
@@ -247,6 +241,7 @@ export const SignatureField = ({
                 overflow="hidden"
                 _hover={{
                   background: schema.disabled ? 'neutral.200' : 'primary.100',
+                  outline: isDrawing ? '2px solid #445fcd' : 'none',
                 }}
               >
                 {showSignaturePlaceholder && (
@@ -297,6 +292,7 @@ export const SignatureField = ({
               }}
               isLoading={isSubmitting}
               isDisabled={schema.disabled}
+              variant={'outline'}
             >
               Clear
             </Button>

--- a/frontend/src/utils/convertSignatureOutput.ts
+++ b/frontend/src/utils/convertSignatureOutput.ts
@@ -31,6 +31,7 @@ export const drawStroke = (
 export const convertToSignatureSvgString = (
   vectorArray: SignatureVectorArray,
   padding = SIGNATURE_OUTPUT_PADDING_DEFAULT,
+  dpr = 3,
 ): string => {
   if (vectorArray.length === 0) return ''
 
@@ -45,13 +46,13 @@ export const convertToSignatureSvgString = (
     if (stroke.length === 0) return ''
 
     const normalizedStroke = stroke.map(([x, y, pressure]) => [
-      x - minX + padding,
-      y - minY + padding,
+      (x - minX + padding) * dpr,
+      (y - minY + padding) * dpr,
       pressure,
     ])
 
     const strokePoints = getStroke(normalizedStroke, {
-      size: SIGNATURE_STROKE_SIZE,
+      size: SIGNATURE_STROKE_SIZE * dpr,
       thinning: SIGNATURE_STROKE_THINNING,
       smoothing: SIGNATURE_STROKE_SMOOTHING,
       streamline: SIGNATURE_STROKE_STREAMLINE,
@@ -73,7 +74,7 @@ export const convertToSignatureSvgString = (
   const svg = `
     <svg xmlns="http://www.w3.org/2000/svg"
          width="${canvasWidth}" height="${canvasHeight}"
-         viewBox="0 0 ${canvasWidth} ${canvasHeight}">
+         viewBox="0 0 ${canvasWidth * dpr} ${canvasHeight * dpr}">
       <rect width="100%" height="100%" fill="white" />
       ${paths.join('\n')}
     </svg>

--- a/frontend/src/utils/convertSignatureOutput.ts
+++ b/frontend/src/utils/convertSignatureOutput.ts
@@ -2,14 +2,14 @@ import getStroke from 'perfect-freehand'
 
 import { SignatureVectorArray } from '~shared/types'
 import {
-  boxHeightDefault,
-  boxWidthDefault,
+  BOX_HEIGHT_DEFAULT,
+  BOX_WIDTH_DEFAULT,
   getBoundingBox,
-  signatureOutputPaddingDefault,
-  signatureStrokeSize,
-  signatureStrokeSmoothing,
-  signatureStrokeStreamline,
-  signatureStrokeThinning,
+  SIGNATURE_OUTPUT_PADDING_DEFAULT,
+  SIGNATURE_STROKE_SIZE,
+  SIGNATURE_STROKE_SMOOTHING,
+  SIGNATURE_STROKE_STREAMLINE,
+  SIGNATURE_STROKE_THINNING,
 } from '~shared/utils/signature'
 
 export const drawStroke = (
@@ -30,13 +30,13 @@ export const drawStroke = (
 
 export const convertToSignatureSvgString = (
   vectorArray: SignatureVectorArray,
-  padding = signatureOutputPaddingDefault,
+  padding = SIGNATURE_OUTPUT_PADDING_DEFAULT,
 ): string => {
   if (vectorArray.length === 0) return ''
 
   const { minX, minY, maxX, maxY } = getBoundingBox(vectorArray)
-  const boxWidth = maxX - minX || boxWidthDefault
-  const boxHeight = maxY - minY || boxHeightDefault
+  const boxWidth = maxX - minX || BOX_WIDTH_DEFAULT
+  const boxHeight = maxY - minY || BOX_HEIGHT_DEFAULT
 
   const canvasWidth = boxWidth + 2 * padding
   const canvasHeight = boxHeight + 2 * padding
@@ -51,10 +51,10 @@ export const convertToSignatureSvgString = (
     ])
 
     const strokePoints = getStroke(normalizedStroke, {
-      size: signatureStrokeSize,
-      thinning: signatureStrokeThinning,
-      smoothing: signatureStrokeSmoothing,
-      streamline: signatureStrokeStreamline,
+      size: SIGNATURE_STROKE_SIZE,
+      thinning: SIGNATURE_STROKE_THINNING,
+      smoothing: SIGNATURE_STROKE_SMOOTHING,
+      streamline: SIGNATURE_STROKE_STREAMLINE,
     })
 
     if (strokePoints.length === 0) return ''

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -18,6 +18,7 @@ export const featureFlags = {
   statusTracker: 'status-tracker' as const,
   designDrawerFormTitle: 'design-drawer-form-title' as const,
   signatureField: 'signature-field' as const,
+  adminPrintPdf: 'admin-print-pdf' as const,
   ogpSuiteSso: 'ogp-suite-sso' as const,
   enableIntranetSgidLogin: 'enable-intranet-sgid-login' as const,
 }

--- a/shared/utils/signature.ts
+++ b/shared/utils/signature.ts
@@ -1,15 +1,15 @@
 import { SignatureVectorArray } from '../types'
 
-export const signatureStrokeSize = 8
-export const signatureStrokeThinning = 0.5
-export const signatureStrokeSmoothing = 0.5
-export const signatureStrokeStreamline = 0.5
+export const SIGNATURE_STROKE_SIZE = 8
+export const SIGNATURE_STROKE_THINNING = 0.5
+export const SIGNATURE_STROKE_SMOOTHING = 0.5
+export const SIGNATURE_STROKE_STREAMLINE = 0.5
 
-export const signatureOutputPaddingDefault = 10
-export const signatureOutputStrokeFillStyle = 'black'
+export const SIGNATURE_OUTPUT_PADDING_DEFAULT = 10
+export const SIGNATURE_OUTPUT_STROKE_FILL_STYLE = 'black'
 
-export const boxHeightDefault = 1
-export const boxWidthDefault = 1
+export const BOX_HEIGHT_DEFAULT = 1
+export const BOX_WIDTH_DEFAULT = 1
 
 /**
  *  converts a vectorArray to a string output

--- a/src/app/utils/convert-vector-array-to-png.ts
+++ b/src/app/utils/convert-vector-array-to-png.ts
@@ -3,27 +3,27 @@ import getStroke from 'perfect-freehand'
 import { SignatureVectorArray } from 'shared/types'
 
 import {
-  boxHeightDefault,
-  boxWidthDefault,
+  BOX_HEIGHT_DEFAULT,
+  BOX_WIDTH_DEFAULT,
   getBoundingBox,
-  signatureOutputPaddingDefault,
-  signatureOutputStrokeFillStyle,
-  signatureStrokeSize,
-  signatureStrokeSmoothing,
-  signatureStrokeStreamline,
-  signatureStrokeThinning,
+  SIGNATURE_OUTPUT_PADDING_DEFAULT,
+  SIGNATURE_OUTPUT_STROKE_FILL_STYLE,
+  SIGNATURE_STROKE_SIZE,
+  SIGNATURE_STROKE_SMOOTHING,
+  SIGNATURE_STROKE_STREAMLINE,
+  SIGNATURE_STROKE_THINNING,
 } from '../../../shared/utils/signature'
 
 export const convertToSignaturePngBuffer = (
   vectorArray: SignatureVectorArray,
-  padding = signatureOutputPaddingDefault,
+  padding = SIGNATURE_OUTPUT_PADDING_DEFAULT,
 ): Buffer => {
   if (vectorArray.length === 0) return Buffer.alloc(0)
 
   // Calculate bounding box
   const { minX, minY, maxX, maxY } = getBoundingBox(vectorArray)
-  const boxWidth = maxX - minX || boxWidthDefault
-  const boxHeight = maxY - minY || boxHeightDefault
+  const boxWidth = maxX - minX || BOX_WIDTH_DEFAULT
+  const boxHeight = maxY - minY || BOX_HEIGHT_DEFAULT
 
   // Canvas size includes padding on all sides
   const canvasWidth = boxWidth + 2 * padding
@@ -44,13 +44,13 @@ export const convertToSignaturePngBuffer = (
       pressure,
     ])
     const pathData = getStroke(normalizedStroke, {
-      size: signatureStrokeSize,
-      thinning: signatureStrokeThinning,
-      smoothing: signatureStrokeSmoothing,
-      streamline: signatureStrokeStreamline,
+      size: SIGNATURE_STROKE_SIZE,
+      thinning: SIGNATURE_STROKE_THINNING,
+      smoothing: SIGNATURE_STROKE_SMOOTHING,
+      streamline: SIGNATURE_STROKE_STREAMLINE,
     })
 
-    ctx.fillStyle = signatureOutputStrokeFillStyle
+    ctx.fillStyle = SIGNATURE_OUTPUT_STROKE_FILL_STYLE
     drawStroke(ctx, pathData)
   }
 

--- a/src/app/utils/convert-vector-array-to-png.ts
+++ b/src/app/utils/convert-vector-array-to-png.ts
@@ -25,13 +25,17 @@ export const convertToSignaturePngBuffer = (
   const boxWidth = maxX - minX || BOX_WIDTH_DEFAULT
   const boxHeight = maxY - minY || BOX_HEIGHT_DEFAULT
 
+  // default dpr to 3 for overall sharpness
+  const dpr = 3
   // Canvas size includes padding on all sides
-  const canvasWidth = boxWidth + 2 * padding
-  const canvasHeight = boxHeight + 2 * padding
+  const canvasWidth = (boxWidth + 2 * padding) * dpr
+  const canvasHeight = (boxHeight + 2 * padding) * dpr
 
   const canvas = createCanvas(canvasWidth, canvasHeight)
   const ctx = canvas.getContext('2d')
 
+  // Scale the context to account for dpr
+  ctx.scale(dpr, dpr)
   ctx.fillStyle = 'white'
   ctx.fillRect(0, 0, canvasWidth, canvasHeight)
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Signature field beta has a few FE issues that affect the hygiene of the feature. These include:

1. Auto-pointer up (unfocus) when click anywhere outside of canvas
2. 'Draw your signature' helper text appears again if there is a stroke
3. Signature field box shrinks when focused and unfocused
4. Ensure pixel consistency with Signature field input & outputs (email png, svg, pdf & individual response page)
5. Remove box border from signature display in individual response page

Closes FRM-2093

## Solution
<!-- How did you solve the problem? -->

1. Utilize 'pointerleave' end stroke when user's pointer leaves the canvas frame, automatically unfocusing
2. Same as ^
3. Change **outline** on drawing instead of **border** (outline doesn't affect the layout, keeping canvas the same size
4. Take consideration of dpr (device-pixel ratio) when rasterizing signature image

_Experiment for Signatures v1.3_
UTs have revealed that admins would like the ability to download a PDF copy of form responses. As an experimental prototype, we are including a PDF print screen button on the individual response page, to give admins this ability. Note that PDF consistency with respondent copy PDF is not yet worked on.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Description | **BEFORE** | **AFTER** |
| --- | --- | --- |
| Auto-pointer up unfocus | ![1](https://github.com/user-attachments/assets/58c30305-7678-47e6-b7d1-dadb04bbbba1) | ![1-1](https://github.com/user-attachments/assets/44dc3313-5b19-4cfc-8e04-aee0d28d69f0) |
| 'Draw your signature' | ![2](https://github.com/user-attachments/assets/30ff3a4a-3a25-4f60-ac00-aec382a86da4) | ![2-1](https://github.com/user-attachments/assets/438144db-efe4-451c-9e7d-da50fd16224f) |
| Signature field box shrinking | ![3](https://github.com/user-attachments/assets/139a2c49-bfec-41a6-aeb2-acb2d7262cd8) | ![3-1](https://github.com/user-attachments/assets/771f6485-9e27-48f0-a697-c460ed5ed347) |
| Ensure pixel consistency, remove box border | <img width="347" height="178" alt="image" src="https://github.com/user-attachments/assets/94d5b08d-cede-4ca2-b38f-af42157335bc" /> | <img width="351" height="226" alt="image" src="https://github.com/user-attachments/assets/dc2cb2e9-965d-4cc1-8a41-eefca1bc82e2" /> |
| PDF download of Individual response page | | ![pdf](https://github.com/user-attachments/assets/833e4c96-cce0-4e80-854a-7153aa6771de) |


## Tests
<!-- What tests should be run to confirm functionality? -->
** Make a submission on encrypt mode form**
- [x] Ensure you have betaFlag: `signatureField` enabled on testing env
- [x] Add an email field and enable respondent copy + PDF
- [x] Create a storage mode form and add a signature field
- [x] Attempt to make a submission successfully
- [x] Observe on the IndividualResponsePage, the signature response shows a **sharp** image
- [x] Observe in the respondent copy email, .png and pdf shows a **sharp** image

**Make a submission on MRF form with signatures**
- [x] Ensure you have betaFlag: `signatureField` enabled on testing env
- [x] Create a MRF mode form and add a signature field
- [x] Add your email to receive a workflow completion email (email settings)
- [x] Add another basic field, and set the workflow to signature field - step 1, other field - step 2
- [x] Attempt to make a submission successfully for step 1
- [x] Attempt to make submission for step 2, observe that signature field is present, shown and disabled
- [x] After submission is complete, observe on the IndividualResponsePage that the signature response shows a **sharp** image
