### PR TITLE
fix: optional signature field

### DIFF
--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -2,6 +2,7 @@ import JoiDate from '@joi/date'
 import { celebrate, Joi as BaseJoi, Segments } from 'celebrate'
 import { AuthedSessionData } from 'express-session'
 import { StatusCodes } from 'http-status-codes'
+import { isEmpty } from 'lodash'
 import mongoose from 'mongoose'
 import Mail from 'nodemailer/lib/mailer'
 import Stripe from 'stripe'
@@ -811,6 +812,9 @@ const _createSubmission = async ({
   const signatureAttachments: Mail.Attachment[] = []
   emailFields.forEach((field) => {
     if (field.fieldType === BasicField.Signature) {
+      // no signature
+      if (isEmpty(field.answerArray)) return
+
       const vectorArray = convertToSignatureVectorArray(field.answerArray[1])
       const signatureData = convertToSignaturePngBuffer(vectorArray)
       signatureAttachments.push({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Image generation fails when an optional Signature field that's left empty is submitted

## Solution
<!-- How did you solve the problem? -->

- Ensure signature field is not empty before attempting to generate image

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
### Regression
**Submission should work on Empty Optional Signature Fields** 
- [x] Create a Signature Field with required toggled off
- [x] Make a submission without drawing on the signature field
- [x] Ensure that submission is successful
- [x] Ensure that the signature is not attached in the response email

**Submission should work on filled in Optional Signature Fields** 
- [x] Create a Signature Field with required toggled **on**
- [x] Draw on the Signature Field
- [x] Make a submission
- [x] Ensure that submission is successful
- [x] Ensure that the signature is as attached in the response email

**Submission should work on required Signature Fields** 
- [x] Create a Signature Field with required toggled **on**
- [x] Draw on the Signature Field
- [x] Make a submission
- [x] Ensure that submission is successful
- [x] Ensure that the signature is as attached in the response email