### PR TITLE
fix: ignore secret key content

### DIFF
--- a/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
+++ b/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
@@ -140,6 +140,7 @@ export const SaveSecretKeyContent = ({
                   bg="neutral.200"
                   color="secondary.500"
                   borderRadius="4px"
+                  data-chromatic="ignore" // secret key always changes in Chromatic so this should be ignored
                 >
                   {secretKey}
                 </Code>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There are false positives from Chromatic on Secret Key modal.


## Solution
<!-- How did you solve the problem? -->

- Add `data-chromatic="ignore"` to ignore textual diff

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

