### PR TITLE
chore(compose): use composev2 logging attributes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,8 +180,7 @@ services:
       - ./.localstack/volume:/var/lib/localstack
       - /var/run/docker.sock:/var/run/docker.sock
     network_mode: 'service:backend' # reuse backend service's network stack so that it can resolve localhost:4566 to localstack:4566
-    logging:
-      driver: none
+    attach: false
 
   maildev:
     image: maildev/maildev


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`podman` doesn't properly support v1 params for `docker-compose`


## Solution
<!-- How did you solve the problem? -->

Update from `driver: logger: none` to `attach: false`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible 