### PR TITLE
chore(deps): remove unused frontend deps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -96,7 +96,6 @@
         "use-draggable-scroll": "^0.1.0",
         "validator": "^13.7.0",
         "vite-plugin-node-stdlib-browser": "^0.2.1",
-        "web-vitals": "^2.1.2",
         "zustand": "^4.1.1"
       },
       "devDependencies": {
@@ -108,8 +107,6 @@
         "@storybook/addon-links": "8.3.1",
         "@storybook/addon-themes": "8.3.1",
         "@storybook/blocks": "8.3.1",
-        "@storybook/node-logger": "8.3.1",
-        "@storybook/preset-create-react-app": "8.3.1",
         "@storybook/preview-api": "8.3.1",
         "@storybook/react": "8.3.1",
         "@storybook/react-vite": "8.3.1",
@@ -149,11 +146,9 @@
         "msw": "^2.10.5",
         "msw-storybook-addon": "^2.0.5",
         "prettier": "^3.2.5",
-        "react-refresh": "^0.14.0",
         "resize-observer-polyfill": "^1.5.1",
         "rimraf": "^3.0.2",
         "storybook": "8.3.1",
-        "storybook-react-i18next": "^3.0.1",
         "vite": "^5.4.19",
         "vite-plugin-svgr": "^4.2.0",
         "vite-tsconfig-paths": "^4.3.2",
@@ -3365,144 +3360,6 @@
         "url": "https://opencollective.com/unts"
       }
     },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.8.tgz",
-      "integrity": "sha512-wxXRwf+IQ6zvHSJZ+5T2RQNEsq+kx4jKRXfFvdt3nBIUzJUAvXEFsUeoaohDe/Kr84MTjGwcuIUPNcstNJORsA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
-        "core-js-pure": "^3.23.3",
-        "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
-        "html-entities": "^2.1.0",
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 10.13"
-      },
-      "peerDependencies": {
-        "@types/webpack": "4.x || 5.x",
-        "react-refresh": ">=0.10.0 <1.0.0",
-        "sockjs-client": "^1.4.0",
-        "type-fest": ">=0.17.0 <4.0.0",
-        "webpack": ">=4.43.0 <6.0.0",
-        "webpack-dev-server": "3.x || 4.x",
-        "webpack-hot-middleware": "2.x",
-        "webpack-plugin-serve": "0.x || 1.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/webpack": {
-          "optional": true
-        },
-        "sockjs-client": {
-          "optional": true
-        },
-        "type-fest": {
-          "optional": true
-        },
-        "webpack-dev-server": {
-          "optional": true
-        },
-        "webpack-hot-middleware": {
-          "optional": true
-        },
-        "webpack-plugin-serve": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.8",
-        "ajv": "^6.12.5",
-        "ajv-keywords": "^3.5.2"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/@pmmmwh/react-refresh-webpack-plugin/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@popperjs/core": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
@@ -4406,52 +4263,6 @@
         "storybook": "^8.3.1"
       }
     },
-    "node_modules/@storybook/node-logger": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.3.1.tgz",
-      "integrity": "sha512-+Xf2fyS9gJUk8kU9Z1fj4xKyH/X9ewIZR5ZmFj6qvvSH9PUsnozZo5A5xh4hm0k86ebiajVi+yEVAtjZr2qG2g==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^8.3.1"
-      }
-    },
-    "node_modules/@storybook/preset-create-react-app": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-create-react-app/-/preset-create-react-app-8.3.1.tgz",
-      "integrity": "sha512-BE/od7Xi4hsGA3t5QSf8OAbrXNKhLSf2um6MocoUF5Ld8F2uieNWdsP04Wl/0NmZsCp+E0VoRVioIkVvy4S46w==",
-      "dev": true,
-      "dependencies": {
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
-        "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
-        "@types/semver": "^7.5.6",
-        "pnp-webpack-plugin": "^1.7.0",
-        "semver": "^7.5.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react-scripts": ">=5.0.0",
-        "storybook": "^8.3.1"
-      }
-    },
-    "node_modules/@storybook/preset-create-react-app/node_modules/pnp-webpack-plugin": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.7.0.tgz",
-      "integrity": "sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==",
-      "dev": true,
-      "dependencies": {
-        "ts-pnp": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@storybook/preview-api": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.3.1.tgz",
@@ -4513,25 +4324,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storybook/react-docgen-typescript-plugin": {
-      "version": "1.0.6--canary.9.0c3f3b7.0",
-      "resolved": "https://registry.npmjs.org/@storybook/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.6--canary.9.0c3f3b7.0.tgz",
-      "integrity": "sha512-KUqXC3oa9JuQ0kZJLBhVdS4lOneKTOopnNBK4tUAgoxWQ3u/IjzdueZjFr7gyBrXMoU6duutk3RQR9u8ZpYJ4Q==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "endent": "^2.0.1",
-        "find-cache-dir": "^3.3.1",
-        "flat-cache": "^3.0.4",
-        "micromatch": "^4.0.2",
-        "react-docgen-typescript": "^2.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">= 4.x",
-        "webpack": ">= 4"
       }
     },
     "node_modules/@storybook/react-dom-shim": {
@@ -6330,6 +6122,16 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@vitejs/plugin-react/node_modules/react-refresh": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
@@ -6715,18 +6517,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ansi-html-community": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
-      "dev": true,
-      "engines": [
-        "node >= 0.8.0"
-      ],
-      "bin": {
-        "ansi-html": "bin/ansi-html"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -7019,6 +6809,19 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
@@ -7099,15 +6902,6 @@
       "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -8193,12 +7987,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
-      "dev": true
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -8297,17 +8085,6 @@
       "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
       "dependencies": {
         "toggle-selection": "^1.0.6"
-      }
-    },
-    "node_modules/core-js-pure": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.0.tgz",
-      "integrity": "sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -9090,15 +8867,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "node_modules/emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -9116,17 +8884,6 @@
       "optional": true,
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/endent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/endent/-/endent-2.1.0.tgz",
-      "integrity": "sha512-r8VyPX7XL8U01Xgnb1CjZ3XV+z90cXIJ9JPE/R9SEC9vpw2P6CfsRPJmp20DppC5N7ZAMCmjYkJIa744Iyg96w==",
-      "dev": true,
-      "dependencies": {
-        "dedent": "^0.7.0",
-        "fast-json-parse": "^1.0.3",
-        "objectorarray": "^1.0.5"
       }
     },
     "node_modules/enquirer": {
@@ -9270,14 +9027,14 @@
       }
     },
     "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
       "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
+        "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10210,12 +9967,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-json-parse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
-      "dev": true
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -10559,21 +10310,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -11209,12 +10945,6 @@
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
       }
-    },
-    "node_modules/html-entities": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
-      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
-      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -12341,20 +12071,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
-      },
-      "engines": {
-        "node": ">=8.9.0"
       }
     },
     "node_modules/locate-path": {
@@ -14028,12 +13744,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/objectorarray": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
-      "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
-      "dev": true
-    },
     "node_modules/oblivious-set": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
@@ -15567,15 +15277,6 @@
         "detect-node": "^2.0.4"
       }
     },
-    "node_modules/react-refresh": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-remove-scroll": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
@@ -16787,27 +16488,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/storybook-i18n": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/storybook-i18n/-/storybook-i18n-3.0.1.tgz",
-      "integrity": "sha512-euCfw6ABqq8jSZ4fCaAIsNwk1FBIrSIr4kMP900bjUgO/mGgzZzXmrYmZaXs51mx9A2p87xo0OktPPZUuKYCTQ==",
-      "dev": true
-    },
-    "node_modules/storybook-react-i18next": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/storybook-react-i18next/-/storybook-react-i18next-3.0.1.tgz",
-      "integrity": "sha512-zv8RkhNJdY51cXOuc3v0bCcQn0Gh8i8S9yunMXEloqaeF5rbHpPJz1jgFDvNhbUhQPWKm0qbcn8ir0/tKYvfXg==",
-      "dev": true,
-      "dependencies": {
-        "storybook-i18n": "^3.0.1"
-      },
-      "peerDependencies": {
-        "i18next": "^22.0.0 || ^23.0.0 || ^24.0.0",
-        "i18next-browser-languagedetector": "^7.0.0",
-        "i18next-http-backend": "^2.0.0",
-        "react-i18next": "^12.0.0 || ^13.0.0 || ^14.0.0"
-      }
-    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -17418,20 +17098,6 @@
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
       "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
-    },
-    "node_modules/ts-pnp": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
-      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
     },
     "node_modules/tsconfck": {
       "version": "3.0.3",
@@ -18782,11 +18448,6 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.2.tgz",
-      "integrity": "sha512-nZnEH8dj+vJFqCRYdvYv0a59iLXsb8jJkt+xvXfwgnkyPdsSLtKNlYmtTDiHmTNGXeSXtpjTTUcNvFtrAk6VMQ=="
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",
@@ -21204,79 +20865,6 @@
       "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
       "dev": true
     },
-    "@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.8.tgz",
-      "integrity": "sha512-wxXRwf+IQ6zvHSJZ+5T2RQNEsq+kx4jKRXfFvdt3nBIUzJUAvXEFsUeoaohDe/Kr84MTjGwcuIUPNcstNJORsA==",
-      "dev": true,
-      "requires": {
-        "ansi-html-community": "^0.0.8",
-        "common-path-prefix": "^3.0.0",
-        "core-js-pure": "^3.23.3",
-        "error-stack-parser": "^2.0.6",
-        "find-up": "^5.0.0",
-        "html-entities": "^2.1.0",
-        "loader-utils": "^2.0.0",
-        "schema-utils": "^3.0.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^6.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^5.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^0.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^3.0.2"
-          }
-        },
-        "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
-        "source-map": {
-          "version": "0.7.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-          "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-          "dev": true
-        }
-      }
-    },
     "@popperjs/core": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
@@ -21843,36 +21431,6 @@
       "integrity": "sha512-GHJr1/nNAfkzNs4P8z31zBN8ZBucMfl+aSH6ciCy12jN3dOmEfb67mx3aes2PmBJjY3K8HG2lgsO9tNKIyDJXQ==",
       "dev": true
     },
-    "@storybook/node-logger": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.3.1.tgz",
-      "integrity": "sha512-+Xf2fyS9gJUk8kU9Z1fj4xKyH/X9ewIZR5ZmFj6qvvSH9PUsnozZo5A5xh4hm0k86ebiajVi+yEVAtjZr2qG2g==",
-      "dev": true
-    },
-    "@storybook/preset-create-react-app": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@storybook/preset-create-react-app/-/preset-create-react-app-8.3.1.tgz",
-      "integrity": "sha512-BE/od7Xi4hsGA3t5QSf8OAbrXNKhLSf2um6MocoUF5Ld8F2uieNWdsP04Wl/0NmZsCp+E0VoRVioIkVvy4S46w==",
-      "dev": true,
-      "requires": {
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.1",
-        "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.0c3f3b7.0",
-        "@types/semver": "^7.5.6",
-        "pnp-webpack-plugin": "^1.7.0",
-        "semver": "^7.5.4"
-      },
-      "dependencies": {
-        "pnp-webpack-plugin": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/pnp-webpack-plugin/-/pnp-webpack-plugin-1.7.0.tgz",
-          "integrity": "sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==",
-          "dev": true,
-          "requires": {
-            "ts-pnp": "^1.1.6"
-          }
-        }
-      }
-    },
     "@storybook/preview-api": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.3.1.tgz",
@@ -21919,21 +21477,6 @@
           "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
           "dev": true
         }
-      }
-    },
-    "@storybook/react-docgen-typescript-plugin": {
-      "version": "1.0.6--canary.9.0c3f3b7.0",
-      "resolved": "https://registry.npmjs.org/@storybook/react-docgen-typescript-plugin/-/react-docgen-typescript-plugin-1.0.6--canary.9.0c3f3b7.0.tgz",
-      "integrity": "sha512-KUqXC3oa9JuQ0kZJLBhVdS4lOneKTOopnNBK4tUAgoxWQ3u/IjzdueZjFr7gyBrXMoU6duutk3RQR9u8ZpYJ4Q==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "endent": "^2.0.1",
-        "find-cache-dir": "^3.3.1",
-        "flat-cache": "^3.0.4",
-        "micromatch": "^4.0.2",
-        "react-docgen-typescript": "^2.2.2",
-        "tslib": "^2.0.0"
       }
     },
     "@storybook/react-dom-shim": {
@@ -23198,6 +22741,14 @@
         "@babel/plugin-transform-react-jsx-source": "^7.24.1",
         "@types/babel__core": "^7.20.5",
         "react-refresh": "^0.14.2"
+      },
+      "dependencies": {
+        "react-refresh": {
+          "version": "0.14.2",
+          "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
+          "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+          "dev": true
+        }
       }
     },
     "@vitest/expect": {
@@ -23482,12 +23033,6 @@
         }
       }
     },
-    "ansi-html-community": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
-      "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
-      "dev": true
-    },
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -23700,6 +23245,18 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "babel-plugin-macros": {
@@ -23754,12 +23311,6 @@
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
       "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
-    },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -24549,12 +24100,6 @@
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
     },
-    "common-path-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
-      "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
-      "dev": true
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -24633,12 +24178,6 @@
       "requires": {
         "toggle-selection": "^1.0.6"
       }
-    },
-    "core-js-pure": {
-      "version": "3.26.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.0.tgz",
-      "integrity": "sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -25285,12 +24824,6 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
-    },
     "encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -25304,17 +24837,6 @@
       "optional": true,
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "endent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/endent/-/endent-2.1.0.tgz",
-      "integrity": "sha512-r8VyPX7XL8U01Xgnb1CjZ3XV+z90cXIJ9JPE/R9SEC9vpw2P6CfsRPJmp20DppC5N7ZAMCmjYkJIa744Iyg96w==",
-      "dev": true,
-      "requires": {
-        "dedent": "^0.7.0",
-        "fast-json-parse": "^1.0.3",
-        "objectorarray": "^1.0.5"
       }
     },
     "enquirer": {
@@ -25431,14 +24953,14 @@
       }
     },
     "es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+      "integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+      "dev": true,
       "requires": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
+        "get-intrinsic": "^1.2.4",
         "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.1"
       }
     },
     "es-shim-unscopables": {
@@ -26106,12 +25628,6 @@
         "micromatch": "^4.0.4"
       }
     },
-    "fast-json-parse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==",
-      "dev": true
-    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -26350,18 +25866,6 @@
             "has-flag": "^4.0.0"
           }
         }
-      }
-    },
-    "form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -26800,12 +26304,6 @@
       "version": "3.13.7",
       "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.13.7.tgz",
       "integrity": "sha512-ygFIdTqqwG4fFP7kkiYlvayZppeIQX2aPpirsngkv1xM1lP0piDY5QEh68nQnIKvz64hfocxhBaD/uK3sSK1yQ=="
-    },
-    "html-entities": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
-      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
-      "dev": true
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -27592,17 +27090,6 @@
             "strip-ansi": "^6.0.0"
           }
         }
-      }
-    },
-    "loader-utils": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
-      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
-      "dev": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
       }
     },
     "locate-path": {
@@ -28744,12 +28231,6 @@
         "es-object-atoms": "^1.0.0"
       }
     },
-    "objectorarray": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
-      "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
-      "dev": true
-    },
     "oblivious-set": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
@@ -29855,12 +29336,6 @@
         }
       }
     },
-    "react-refresh": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
-      "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-      "dev": true
-    },
     "react-remove-scroll": {
       "version": "2.5.10",
       "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.10.tgz",
@@ -30727,21 +30202,6 @@
         "@storybook/core": "8.3.1"
       }
     },
-    "storybook-i18n": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/storybook-i18n/-/storybook-i18n-3.0.1.tgz",
-      "integrity": "sha512-euCfw6ABqq8jSZ4fCaAIsNwk1FBIrSIr4kMP900bjUgO/mGgzZzXmrYmZaXs51mx9A2p87xo0OktPPZUuKYCTQ==",
-      "dev": true
-    },
-    "storybook-react-i18next": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/storybook-react-i18next/-/storybook-react-i18next-3.0.1.tgz",
-      "integrity": "sha512-zv8RkhNJdY51cXOuc3v0bCcQn0Gh8i8S9yunMXEloqaeF5rbHpPJz1jgFDvNhbUhQPWKm0qbcn8ir0/tKYvfXg==",
-      "dev": true,
-      "requires": {
-        "storybook-i18n": "^3.0.1"
-      }
-    },
     "stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -31186,12 +30646,6 @@
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
       "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
-    },
-    "ts-pnp": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
-      "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
-      "dev": true
     },
     "tsconfck": {
       "version": "3.0.3",
@@ -31973,11 +31427,6 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "web-vitals": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.2.tgz",
-      "integrity": "sha512-nZnEH8dj+vJFqCRYdvYv0a59iLXsb8jJkt+xvXfwgnkyPdsSLtKNlYmtTDiHmTNGXeSXtpjTTUcNvFtrAk6VMQ=="
     },
     "webpack-virtual-modules": {
       "version": "0.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,7 +92,6 @@
     "use-draggable-scroll": "^0.1.0",
     "validator": "^13.7.0",
     "vite-plugin-node-stdlib-browser": "^0.2.1",
-    "web-vitals": "^2.1.2",
     "zustand": "^4.1.1"
   },
   "scripts": {
@@ -131,8 +130,6 @@
     "@storybook/addon-links": "8.3.1",
     "@storybook/addon-themes": "8.3.1",
     "@storybook/blocks": "8.3.1",
-    "@storybook/node-logger": "8.3.1",
-    "@storybook/preset-create-react-app": "8.3.1",
     "@storybook/preview-api": "8.3.1",
     "@storybook/react": "8.3.1",
     "@storybook/react-vite": "8.3.1",
@@ -172,11 +169,9 @@
     "msw": "^2.10.5",
     "msw-storybook-addon": "^2.0.5",
     "prettier": "^3.2.5",
-    "react-refresh": "^0.14.0",
     "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^3.0.2",
     "storybook": "8.3.1",
-    "storybook-react-i18next": "^3.0.1",
     "vite": "^5.4.19",
     "vite-plugin-svgr": "^4.2.0",
     "vite-tsconfig-paths": "^4.3.2",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Unused dependencies can cause dependabot to update them, requiring engs to spend time reviewing unnecessary PRs.
Also slows down installs during CI.

## Solution
<!-- How did you solve the problem? -->

Removing unused or unnecessary packages from both the main and development dependencies. Focusing on `frontend/`.

Dependency removals:

* Removed `web-vitals` as we're not using this.
* Removed `react-refresh`, as `vite/plugin-react` supports this natively.

Storybook-related cleanup:

* Removed `@storybook/node-logger` and `@storybook/preset-create-react-app` from the development dependencies, which are not needed for the current Storybook setup.
* Removed `storybook-react-i18next`, as we're not using i18next in storybook.


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

