### PR TITLE
chore(test): page level delays, inherit msw handlers

### DIFF
--- a/frontend/src/features/admin-form/AdminFormResultsFeedbackPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsFeedbackPage.stories.tsx
@@ -39,7 +39,7 @@ export default {
   component: FeedbackPage,
   parameters: {
     // Required so skeleton "animation" does not hide content.
-    chromatic: { pauseAnimationAtEnd: true, delay: 200 },
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
     layout: 'fullscreen',
     msw: { handlers: { default: DEFAULT_MSW_ROUTES } },
   },

--- a/frontend/src/features/admin-form/AdminFormResultsFeedbackPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsFeedbackPage.stories.tsx
@@ -7,6 +7,7 @@ import {
   getAdminFormCollaborators,
   getAdminFormFeedback,
   getAdminFormIssue,
+  getAdminFormSubmissions,
   getEmptyAdminFormFeedback,
   getEmptyAdminFormIssue,
   getStorageSubmissionMetadataResponse,
@@ -30,6 +31,7 @@ const DEFAULT_MSW_ROUTES = [
   getAdminFormIssue(),
   getUser(),
   getAdminFormCollaborators(),
+  getAdminFormSubmissions(),
 ]
 
 export default {
@@ -37,9 +39,9 @@ export default {
   component: FeedbackPage,
   parameters: {
     // Required so skeleton "animation" does not hide content.
-    chromatic: { pauseAnimationAtEnd: true },
+    chromatic: { pauseAnimationAtEnd: true, delay: 200 },
     layout: 'fullscreen',
-    msw: DEFAULT_MSW_ROUTES,
+    msw: { handlers: { default: DEFAULT_MSW_ROUTES } },
   },
 } as Meta
 
@@ -74,20 +76,32 @@ export const Default = Template.bind({})
 
 export const EmptyReviewAndIssue = Template.bind({})
 EmptyReviewAndIssue.parameters = {
-  msw: [
-    getEmptyAdminFormIssue(),
-    getEmptyAdminFormFeedback(),
-    ...DEFAULT_MSW_ROUTES,
-  ],
+  msw: {
+    handlers: {
+      default: [
+        getEmptyAdminFormIssue(),
+        getEmptyAdminFormFeedback(),
+        ...DEFAULT_MSW_ROUTES,
+      ],
+    },
+  },
 }
 
 export const EmptyReview = Template.bind({})
 EmptyReview.parameters = {
-  msw: [getEmptyAdminFormFeedback(), ...DEFAULT_MSW_ROUTES],
+  msw: {
+    handlers: {
+      default: [getEmptyAdminFormFeedback(), ...DEFAULT_MSW_ROUTES],
+    },
+  },
 }
 export const EmptyIssue = Template.bind({})
 EmptyIssue.parameters = {
-  msw: [getEmptyAdminFormIssue(), ...DEFAULT_MSW_ROUTES],
+  msw: {
+    handlers: {
+      default: [getEmptyAdminFormIssue(), ...DEFAULT_MSW_ROUTES],
+    },
+  },
 }
 
 export const Tablet = Template.bind({})
@@ -104,7 +118,14 @@ Mobile.parameters = getMobileViewParameters()
 export const LoadingDesktop = Template.bind({})
 LoadingDesktop.storyName = 'Loading/Desktop'
 LoadingDesktop.parameters = {
-  msw: [getAdminFormIssue({ delay: 'infinite' }), ...DEFAULT_MSW_ROUTES],
+  msw: {
+    handlers: {
+      default: [
+        getAdminFormIssue({ delay: 'infinite' }),
+        ...DEFAULT_MSW_ROUTES,
+      ],
+    },
+  },
 }
 export const LoadingMobile = Template.bind({})
 LoadingMobile.storyName = 'Loading/Mobile'

--- a/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
@@ -35,12 +35,16 @@ export default {
     // Required so skeleton "animation" does not hide content.
     chromatic: { pauseAnimationAtEnd: true },
     layout: 'fullscreen',
-    msw: [
-      ...createFormBuilderMocks({}, 0),
-      getAdminFormSubmissions(),
-      getUser(),
-      getAdminFormCollaborators(),
-    ],
+    msw: {
+      handlers: {
+        default: [
+          ...createFormBuilderMocks({}, 0),
+          getAdminFormSubmissions(),
+          getUser(),
+          getAdminFormCollaborators(),
+        ],
+      },
+    },
   },
 } as Meta
 
@@ -83,24 +87,32 @@ export const EmailForm = Template.bind({})
 
 export const EmailFormLoading = Template.bind({})
 EmailFormLoading.parameters = {
-  msw: [
-    ...createFormBuilderMocks({}, 0),
-    getAdminFormSubmissions({ delay: 'infinite' }),
-    getUser(),
-    getAdminFormCollaborators(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks({}, 0),
+        getAdminFormSubmissions({ delay: 'infinite' }),
+        getUser(),
+        getAdminFormCollaborators(),
+      ],
+    },
+  },
 }
 
 export const EmptyEmailForm = Template.bind({})
 EmptyEmailForm.parameters = {
-  msw: [
-    ...createFormBuilderMocks({}, 0),
-    getAdminFormSubmissions({
-      override: 0,
-    }),
-    getUser(),
-    getAdminFormCollaborators(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks({}, 0),
+        getAdminFormSubmissions({
+          override: 0,
+        }),
+        getUser(),
+        getAdminFormCollaborators(),
+      ],
+    },
+  },
 }
 
 export const EmailFormTablet = Template.bind({})
@@ -116,19 +128,23 @@ EmailFormMobile.parameters = getMobileViewParameters()
 
 export const StorageForm = Template.bind({})
 StorageForm.parameters = {
-  msw: [
-    ...createFormBuilderMocks(
-      {
-        responseMode: FormResponseMode.Encrypt,
-        publicKey: MOCK_KEYPAIR.publicKey,
-      },
-      0,
-    ),
-    getAdminFormSubmissions(),
-    getStorageSubmissionMetadataResponse(),
-    getUser(),
-    getAdminFormCollaborators(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks(
+          {
+            responseMode: FormResponseMode.Encrypt,
+            publicKey: MOCK_KEYPAIR.publicKey,
+          },
+          0,
+        ),
+        getAdminFormSubmissions(),
+        getStorageSubmissionMetadataResponse(),
+        getUser(),
+        getAdminFormCollaborators(),
+      ],
+    },
+  },
 }
 
 export const StorageFormUnlocked = Template.bind({})
@@ -177,39 +193,54 @@ StorageFormMobile.parameters = {
 
 export const StorageFormLoading = Template.bind({})
 StorageFormLoading.parameters = {
-  msw: [
-    ...createFormBuilderMocks({ responseMode: FormResponseMode.Encrypt }, 0),
-    getAdminFormSubmissions({ delay: 'infinite' }),
-    getStorageSubmissionMetadataResponse({}, 'infinite'),
-    getUser(),
-    getAdminFormCollaborators(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks(
+          { responseMode: FormResponseMode.Encrypt },
+          0,
+        ),
+        getAdminFormSubmissions({ delay: 'infinite' }),
+        getStorageSubmissionMetadataResponse({}, 'infinite'),
+        getUser(),
+        getAdminFormCollaborators(),
+      ],
+    },
+  },
 }
 
 export const MultiRespondentFormUnlocked = Template.bind({})
 MultiRespondentFormUnlocked.parameters = {
-  msw: [
-    ...createFormBuilderMocks(
-      {
-        responseMode: FormResponseMode.Multirespondent,
-        publicKey: MOCK_KEYPAIR.publicKey,
-      },
-      0,
-    ),
-    getAdminFormSubmissions({ override: 5 }),
-    getMultiRespondentSubmissionMetadataResponse(),
-    getUser(),
-    getAdminFormCollaborators(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks(
+          {
+            responseMode: FormResponseMode.Multirespondent,
+            publicKey: MOCK_KEYPAIR.publicKey,
+          },
+          0,
+        ),
+        getAdminFormSubmissions({ override: 5 }),
+        getMultiRespondentSubmissionMetadataResponse(),
+        getUser(),
+        getAdminFormCollaborators(),
+      ],
+    },
+  },
 }
 MultiRespondentFormUnlocked.play = StorageFormUnlocked.play
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: [
-    ...createFormBuilderMocks({ responseMode: undefined }, 'infinite'),
-    getAdminFormSubmissions({ delay: 'infinite' }),
-    getUser(),
-    getAdminFormCollaborators(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks({ responseMode: undefined }, 'infinite'),
+        getAdminFormSubmissions({ delay: 'infinite' }),
+        getUser(),
+        getAdminFormCollaborators(),
+      ],
+    },
+  },
 }

--- a/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
@@ -51,7 +51,7 @@ export default {
   ],
   parameters: {
     // Required so skeleton "animation" does not hide content.
-    chromatic: { pauseAnimationAtEnd: true, delay: 200 },
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
     layout: 'fullscreen',
     msw: {
       handlers: {

--- a/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
@@ -51,16 +51,20 @@ export default {
   ],
   parameters: {
     // Required so skeleton "animation" does not hide content.
-    chromatic: { pauseAnimationAtEnd: true },
+    chromatic: { pauseAnimationAtEnd: true, delay: 200 },
     layout: 'fullscreen',
-    msw: [
-      ...createFormBuilderMocks(),
-      getAdminFormSettings(),
-      getAdminFormSubmissions(),
-      patchAdminFormSettings(),
-      getUser(),
-      getAdminFormCollaborators(),
-    ],
+    msw: {
+      handlers: {
+        default: [
+          ...createFormBuilderMocks(),
+          getAdminFormSettings(),
+          getAdminFormSubmissions(),
+          patchAdminFormSettings(),
+          getUser(),
+          getAdminFormCollaborators(),
+        ],
+      },
+    },
   },
 } as Meta
 
@@ -69,20 +73,24 @@ export const Desktop = Template.bind({})
 
 export const PreventActivation = Template.bind({})
 PreventActivation.parameters = {
-  msw: [
-    ...createFormBuilderMocks(),
-    getAdminFormSubmissions(),
-    patchAdminFormSettings(),
-    getAdminFormSettings({
-      overrides: {
-        status: FormStatus.Private,
-        authType: FormAuthType.SP,
-        esrvcId: '',
-      },
-    }),
-    getUser(),
-    getAdminFormCollaborators(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks(),
+        getAdminFormSubmissions(),
+        patchAdminFormSettings(),
+        getAdminFormSettings({
+          overrides: {
+            status: FormStatus.Private,
+            authType: FormAuthType.SP,
+            esrvcId: '',
+          },
+        }),
+        getUser(),
+        getAdminFormCollaborators(),
+      ],
+    },
+  },
 }
 
 export const Tablet = Template.bind({})
@@ -108,21 +116,25 @@ StorageModeSettings.parameters = {
   docs: {
     storyDescription: `The passing secret key is ${storageModeKeypair.secretKey}`,
   },
-  msw: [
-    ...createFormBuilderMocks({ responseMode: FormResponseMode.Encrypt }),
-    getAdminFormSettings({
-      mode: FormResponseMode.Encrypt,
-      overrides: {
-        status: FormStatus.Private,
-        publicKey: storageModeKeypair.publicKey,
-      },
-    }),
-    getAdminFormSubmissions(),
-    patchAdminFormSettings({
-      mode: FormResponseMode.Encrypt,
-      overrides: { publicKey: storageModeKeypair.publicKey },
-    }),
-    getUser(),
-    getAdminFormCollaborators(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks({ responseMode: FormResponseMode.Encrypt }),
+        getAdminFormSettings({
+          mode: FormResponseMode.Encrypt,
+          overrides: {
+            status: FormStatus.Private,
+            publicKey: storageModeKeypair.publicKey,
+          },
+        }),
+        getAdminFormSubmissions(),
+        patchAdminFormSettings({
+          mode: FormResponseMode.Encrypt,
+          overrides: { publicKey: storageModeKeypair.publicKey },
+        }),
+        getUser(),
+        getAdminFormCollaborators(),
+      ],
+    },
+  },
 }

--- a/frontend/src/features/admin-form/create/logic/CreatePageLogicTab.stories.tsx
+++ b/frontend/src/features/admin-form/create/logic/CreatePageLogicTab.stories.tsx
@@ -37,8 +37,8 @@ export default {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
     // the story has loaded
-    chromatic: { pauseAnimationAtEnd: true, delay: 50 },
-    msw: buildMswRoutes(),
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+    msw: { handlers: { default: buildMswRoutes() } },
   },
 } as Meta
 
@@ -132,12 +132,12 @@ const FORM_WITH_LOGIC: Partial<AdminFormDto> = {
 const Template: StoryFn = () => <CreatePageLogicTab />
 export const NoLogic = Template.bind({})
 NoLogic.parameters = {
-  msw: buildMswRoutes({ form_logics: [] }),
+  msw: { handlers: { default: buildMswRoutes({ form_logics: [] }) } },
 }
 
 export const MobileNoLogic = Template.bind({})
 MobileNoLogic.parameters = {
-  msw: buildMswRoutes({ form_logics: [] }),
+  msw: { handlers: { default: buildMswRoutes({ form_logics: [] }) } },
   viewport: {
     defaultViewport: 'mobile1',
   },
@@ -146,12 +146,12 @@ MobileNoLogic.parameters = {
 
 export const WithLogic = Template.bind({})
 WithLogic.parameters = {
-  msw: buildMswRoutes(FORM_WITH_LOGIC),
+  msw: { handlers: { default: buildMswRoutes(FORM_WITH_LOGIC) } },
 }
 
 export const MobileWithLogic = Template.bind({})
 MobileWithLogic.parameters = {
-  msw: buildMswRoutes(FORM_WITH_LOGIC),
+  msw: { handlers: { default: buildMswRoutes(FORM_WITH_LOGIC) } },
   viewport: {
     defaultViewport: 'mobile1',
   },
@@ -168,26 +168,40 @@ ErrorIfDeleted.parameters = {
 
 export const ErrorShowSomeDeleted = Template.bind({})
 ErrorShowSomeDeleted.parameters = {
-  msw: buildMswRoutes({
-    form_fields: [form_field_1, form_field_2, form_field_4],
-    form_logics: [if_12_show_34, if_12_preventsubmit],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        form_fields: [form_field_1, form_field_2, form_field_4],
+        form_logics: [if_12_show_34, if_12_preventsubmit],
+      }),
+    },
+  },
 }
 
 export const ErrorShowAllDeleted = Template.bind({})
 ErrorShowAllDeleted.parameters = {
-  msw: buildMswRoutes({
-    form_fields: [form_field_1, form_field_2],
-    form_logics: [if_12_show_34, if_12_preventsubmit],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        form_fields: [form_field_1, form_field_2],
+        form_logics: [if_12_show_34, if_12_preventsubmit],
+      }),
+    },
+  },
 }
 
 export const ErrorAllDeleted = Template.bind({})
 ErrorAllDeleted.parameters = {
-  msw: buildMswRoutes({ form_logics: [if_12_show_34, if_12_preventsubmit] }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        form_logics: [if_12_show_34, if_12_preventsubmit],
+      }),
+    },
+  },
 }
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: buildMswRoutes({}, 'infinite'),
+  msw: { handlers: { default: buildMswRoutes({}, 'infinite') } },
 }

--- a/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
+++ b/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
@@ -28,11 +28,15 @@ export default {
     // Required so skeleton "animation" does not hide content.
     // Pass a very short delay to avoid bug where Chromatic takes a snapshot before
     // the story has loaded
-    chromatic: { pauseAnimationAtEnd: true, delay: 50 },
-    msw: buildMswRoutes({
-      responseMode: FormResponseMode.Multirespondent,
-      workflow: [],
-    }),
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+    msw: {
+      handlers: {
+        default: buildMswRoutes({
+          responseMode: FormResponseMode.Multirespondent,
+          workflow: [],
+        }),
+      },
+    },
   },
 } as Meta
 
@@ -243,12 +247,12 @@ MobileNoWorkflow.parameters = {
 
 export const WithWorkflow = Template.bind({})
 WithWorkflow.parameters = {
-  msw: buildMswRoutes(FORM_WITH_WORKFLOW),
+  msw: { handlers: { default: buildMswRoutes(FORM_WITH_WORKFLOW) } },
 }
 
 export const MobileWithWorkflow = Template.bind({})
 MobileWithWorkflow.parameters = {
-  msw: buildMswRoutes(FORM_WITH_WORKFLOW),
+  msw: { handlers: { default: buildMswRoutes(FORM_WITH_WORKFLOW) } },
   viewport: {
     defaultViewport: 'mobile1',
   },
@@ -257,10 +261,14 @@ MobileWithWorkflow.parameters = {
 
 export const Step1 = Template.bind({})
 Step1.parameters = {
-  msw: buildMswRoutes({
-    ...FORM_WITH_WORKFLOW,
-    workflow: [workflow_step_1],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [workflow_step_1],
+      }),
+    },
+  },
   documentation: {
     storyDescription:
       'Step 1 of a workflow should not show any respondent selected',
@@ -269,63 +277,91 @@ Step1.parameters = {
 
 export const Step3Approval = Template.bind({})
 Step3Approval.parameters = {
-  msw: buildMswRoutes({
-    ...FORM_WITH_WORKFLOW,
-    workflow: [workflow_step_1, workflow_step_2, workflow_step_3_with_approval],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [
+          workflow_step_1,
+          workflow_step_2,
+          workflow_step_3_with_approval,
+        ],
+      }),
+    },
+  },
 }
 
 export const Step3ApprovalFieldDeleted = Template.bind({})
 Step3ApprovalFieldDeleted.parameters = {
-  msw: buildMswRoutes({
-    ...FORM_WITH_WORKFLOW,
-    workflow: [
-      workflow_step_1,
-      workflow_step_2,
-      workflow_step_3_with_deleted_approval,
-    ],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [
+          workflow_step_1,
+          workflow_step_2,
+          workflow_step_3_with_deleted_approval,
+        ],
+      }),
+    },
+  },
 }
 
 export const Step2FieldDeleted = Template.bind({})
 Step2FieldDeleted.parameters = {
-  msw: buildMswRoutes({
-    ...FORM_WITH_WORKFLOW,
-    workflow: [workflow_step_1, workflow_step_2_with_deleted_field],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [workflow_step_1, workflow_step_2_with_deleted_field],
+      }),
+    },
+  },
 }
 
 export const Step2AllFieldsDeleted = Template.bind({})
 Step2AllFieldsDeleted.parameters = {
-  msw: buildMswRoutes({
-    ...FORM_WITH_WORKFLOW,
-    workflow: [workflow_step_1, workflow_step_2_with_all_fields_deleted],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [workflow_step_1, workflow_step_2_with_all_fields_deleted],
+      }),
+    },
+  },
 }
 
 export const Step2ValidConditionalRecipientSelected = Template.bind({})
 Step2ValidConditionalRecipientSelected.parameters = {
-  msw: buildMswRoutes({
-    ...FORM_WITH_WORKFLOW,
-    workflow: [
-      workflow_step_1,
-      workflow_step_2_with_valid_conditional_recipient,
-    ],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [
+          workflow_step_1,
+          workflow_step_2_with_valid_conditional_recipient,
+        ],
+      }),
+    },
+  },
 }
 
 export const Step2InvalidConditionalRecipientSelected = Template.bind({})
 Step2InvalidConditionalRecipientSelected.parameters = {
-  msw: buildMswRoutes({
-    ...FORM_WITH_WORKFLOW,
-    workflow: [
-      workflow_step_1,
-      workflow_step_2_with_invalid_conditional_recipient,
-    ],
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [
+          workflow_step_1,
+          workflow_step_2_with_invalid_conditional_recipient,
+        ],
+      }),
+    },
+  },
 }
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: buildMswRoutes({}, 'infinite'),
+  msw: { handlers: { default: buildMswRoutes({}, 'infinite') } },
 }

--- a/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
@@ -45,7 +45,6 @@ export default {
   parameters: {
     // Required so skeleton "animation" does not hide content.
     chromatic: { pauseAnimationAtEnd: true, delay: 300 },
-    msw: { handlers: { default: buildEmailModeMswRoutes() } },
   },
 } as Meta
 
@@ -374,7 +373,9 @@ Tablet.parameters = {
   chromatic: { viewports: [viewports.md] },
   msw: {
     handlers: {
-      default: PrivateStorageSingpassFormAllTogglesEnabled.parameters.msw,
+      default:
+        PrivateStorageSingpassFormAllTogglesEnabled.parameters.msw.handlers
+          .default,
     },
   },
 }
@@ -387,7 +388,9 @@ Mobile.parameters = {
   chromatic: { viewports: [viewports.xs] },
   msw: {
     handlers: {
-      default: PrivateStorageSingpassFormAllTogglesEnabled.parameters.msw,
+      default:
+        PrivateStorageSingpassFormAllTogglesEnabled.parameters.msw.handlers
+          .default,
     },
   },
 }

--- a/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
@@ -27,11 +27,13 @@ const DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE = {
 }
 
 const buildEmailModeMswRoutes = (overrides?: Partial<FormSettings>) => [
+  ...createFormBuilderMocks(),
   getAdminFormSettings({ overrides }),
   patchAdminFormSettings({ overrides }),
 ]
 
 const buildEncryptModeMswRoutes = (overrides: Partial<FormSettings>) => [
+  ...createFormBuilderMocks(),
   getAdminFormSettings({ overrides, mode: FormResponseMode.Encrypt }),
   patchAdminFormSettings({ overrides, mode: FormResponseMode.Encrypt }),
 ]
@@ -42,234 +44,324 @@ export default {
   decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
   parameters: {
     // Required so skeleton "animation" does not hide content.
-    chromatic: { pauseAnimationAtEnd: true },
-    msw: buildEmailModeMswRoutes(),
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+    msw: { handlers: { default: buildEmailModeMswRoutes() } },
   },
 } as Meta
 
 const Template: StoryFn = () => <SettingsAuthPage />
 export const PrivateEmailNilAuthForm = Template.bind({})
 PrivateEmailNilAuthForm.parameters = {
-  msw: buildEmailModeMswRoutes({ status: FormStatus.Private }),
+  msw: {
+    handlers: {
+      default: buildEmailModeMswRoutes({ status: FormStatus.Private }),
+    },
+  },
 }
 
 export const PrivateStorageNilAuthForm = Template.bind({})
 PrivateStorageNilAuthForm.parameters = {
-  msw: buildEncryptModeMswRoutes({
-    responseMode: FormResponseMode.Encrypt,
-    status: FormStatus.Private,
-  }),
+  msw: {
+    handlers: {
+      default: buildEncryptModeMswRoutes({
+        responseMode: FormResponseMode.Encrypt,
+        status: FormStatus.Private,
+      }),
+    },
+  },
 }
 
 export const PublicEmailNilAuthForm = Template.bind({})
 PublicEmailNilAuthForm.parameters = {
-  msw: buildEmailModeMswRoutes({
-    responseMode: FormResponseMode.Email,
-    status: FormStatus.Public,
-  }),
+  msw: {
+    handlers: {
+      default: buildEmailModeMswRoutes({
+        responseMode: FormResponseMode.Email,
+        status: FormStatus.Public,
+      }),
+    },
+  },
 }
 
 export const PublicStorageNilAuthForm = Template.bind({})
 PublicStorageNilAuthForm.parameters = {
-  msw: buildEncryptModeMswRoutes({
-    responseMode: FormResponseMode.Encrypt,
-    status: FormStatus.Public,
-  }),
+  msw: {
+    handlers: {
+      default: buildEncryptModeMswRoutes({
+        responseMode: FormResponseMode.Encrypt,
+        status: FormStatus.Public,
+      }),
+    },
+  },
 }
 
 export const PublicStorageNilAuthFormSubmitterIdCollectionEnabled =
   Template.bind({})
 PublicStorageNilAuthFormSubmitterIdCollectionEnabled.parameters = {
-  msw: buildEncryptModeMswRoutes({
-    responseMode: FormResponseMode.Encrypt,
-    status: FormStatus.Public,
-    isSubmitterIdCollectionEnabled: true,
-  }),
+  msw: {
+    handlers: {
+      default: buildEncryptModeMswRoutes({
+        responseMode: FormResponseMode.Encrypt,
+        status: FormStatus.Public,
+        isSubmitterIdCollectionEnabled: true,
+      }),
+    },
+  },
 }
 
 export const PrivateStorageCorppassForm = Template.bind({})
 PrivateStorageCorppassForm.parameters = {
-  msw: buildEncryptModeMswRoutes({
-    status: FormStatus.Private,
-    authType: FormAuthType.CP,
-    esrvcId: 'STORYBOOK-TEST',
-    responseMode: FormResponseMode.Encrypt,
-  }),
+  msw: {
+    handlers: {
+      default: buildEncryptModeMswRoutes({
+        status: FormStatus.Private,
+        authType: FormAuthType.CP,
+        esrvcId: 'STORYBOOK-TEST',
+        responseMode: FormResponseMode.Encrypt,
+      }),
+    },
+  },
 }
 
 export const PublicEmailSingpassForm = Template.bind({})
 PublicEmailSingpassForm.parameters = {
-  msw: buildEmailModeMswRoutes({
-    status: FormStatus.Public,
-    authType: FormAuthType.SP,
-    esrvcId: 'STORYBOOK-TEST',
-    responseMode: FormResponseMode.Email,
-  }),
+  msw: {
+    handlers: {
+      default: buildEmailModeMswRoutes({
+        status: FormStatus.Public,
+        authType: FormAuthType.SP,
+        esrvcId: 'STORYBOOK-TEST',
+        responseMode: FormResponseMode.Email,
+      }),
+    },
+  },
 }
 
 export const PrivateEmailMyInfoWithoutMyInfoFieldsForm = Template.bind({})
 PrivateEmailMyInfoWithoutMyInfoFieldsForm.parameters = {
-  msw: [
-    ...buildEmailModeMswRoutes({
-      status: FormStatus.Private,
-      authType: FormAuthType.MyInfo,
-      esrvcId: 'STORYBOOK-TEST',
-    }),
-    ...createFormBuilderMocks({ form_fields: [] }),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...buildEmailModeMswRoutes({
+          status: FormStatus.Private,
+          authType: FormAuthType.MyInfo,
+          esrvcId: 'STORYBOOK-TEST',
+        }),
+        ...createFormBuilderMocks({ form_fields: [] }),
+      ],
+    },
+  },
 }
 
 export const PrivateEmailMyinfoForm = Template.bind({})
 PrivateEmailMyinfoForm.parameters = {
-  msw: [
-    ...buildEmailModeMswRoutes({
-      status: FormStatus.Private,
-      authType: FormAuthType.MyInfo,
-      esrvcId: 'STORYBOOK-TEST',
-    }),
-    ...createFormBuilderMocks({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...buildEmailModeMswRoutes({
+          status: FormStatus.Private,
+          authType: FormAuthType.MyInfo,
+          esrvcId: 'STORYBOOK-TEST',
+        }),
+        ...createFormBuilderMocks({
+          form_fields: MOCK_FORM_FIELDS_WITH_MYINFO,
+        }),
+      ],
+    },
+  },
 }
 
 export const PublicEmailMyInfoForm = Template.bind({})
 PublicEmailMyInfoForm.parameters = {
-  msw: [
-    ...buildEmailModeMswRoutes({
-      status: FormStatus.Public,
-      authType: FormAuthType.MyInfo,
-      esrvcId: 'STORYBOOK-TEST',
-    }),
-    ...createFormBuilderMocks({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...buildEmailModeMswRoutes({
+          status: FormStatus.Public,
+          authType: FormAuthType.MyInfo,
+          esrvcId: 'STORYBOOK-TEST',
+        }),
+        ...createFormBuilderMocks({
+          form_fields: MOCK_FORM_FIELDS_WITH_MYINFO,
+        }),
+      ],
+    },
+  },
 }
 
 export const PrivateEmailSingpassFormSubmitterIdCollectionEnabled =
   Template.bind({})
 PrivateEmailSingpassFormSubmitterIdCollectionEnabled.parameters = {
-  msw: buildEmailModeMswRoutes({
-    status: FormStatus.Private,
-    authType: FormAuthType.SGID,
-    isSubmitterIdCollectionEnabled: true,
-  }),
+  msw: {
+    handlers: {
+      default: buildEmailModeMswRoutes({
+        status: FormStatus.Private,
+        authType: FormAuthType.SGID,
+        isSubmitterIdCollectionEnabled: true,
+      }),
+    },
+  },
 }
 export const PrivateEmailMyInfoFormSubmitterIdCollectionEnabled = Template.bind(
   {},
 )
 PrivateEmailMyInfoFormSubmitterIdCollectionEnabled.parameters = {
-  msw: [
-    ...buildEmailModeMswRoutes({
-      status: FormStatus.Private,
-      authType: FormAuthType.MyInfo,
-      esrvcId: 'STORYBOOK-TEST',
-      isSubmitterIdCollectionEnabled: true,
-    }),
-    ...createFormBuilderMocks({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...buildEmailModeMswRoutes({
+          status: FormStatus.Private,
+          authType: FormAuthType.MyInfo,
+          esrvcId: 'STORYBOOK-TEST',
+          isSubmitterIdCollectionEnabled: true,
+        }),
+        ...createFormBuilderMocks({
+          form_fields: MOCK_FORM_FIELDS_WITH_MYINFO,
+        }),
+      ],
+    },
+  },
 }
 
 export const PrivateEmailSingpassFormSingleSubmissionEnabled = Template.bind({})
 PrivateEmailSingpassFormSingleSubmissionEnabled.parameters = {
-  msw: buildEmailModeMswRoutes({
-    status: FormStatus.Private,
-    authType: FormAuthType.SGID,
-    isSingleSubmission: true,
-  }),
+  msw: {
+    handlers: {
+      default: buildEmailModeMswRoutes({
+        status: FormStatus.Private,
+        authType: FormAuthType.SGID,
+        isSingleSubmission: true,
+      }),
+    },
+  },
 }
 
 // purpose: displays all available singpass settings in an enabled state
 export const PrivateStorageSingpassFormAllTogglesEnabled = Template.bind({})
 PrivateStorageSingpassFormAllTogglesEnabled.parameters = {
-  msw: buildEncryptModeMswRoutes({
-    status: FormStatus.Private,
-    authType: FormAuthType.SGID,
-    isSingleSubmission: true,
-    isSubmitterIdCollectionEnabled: true,
-  }),
+  msw: {
+    handlers: {
+      default: buildEncryptModeMswRoutes({
+        status: FormStatus.Private,
+        authType: FormAuthType.SGID,
+        isSingleSubmission: true,
+        isSubmitterIdCollectionEnabled: true,
+      }),
+    },
+  },
 }
 
 export const PublicEmailCorppassAllTogglesEnabledForm = Template.bind({})
 PublicEmailCorppassAllTogglesEnabledForm.parameters = {
-  msw: buildEmailModeMswRoutes({
-    status: FormStatus.Public,
-    authType: FormAuthType.CP,
-    isSingleSubmission: true,
-    isSubmitterIdCollectionEnabled: true,
-  }),
+  msw: {
+    handlers: {
+      default: buildEmailModeMswRoutes({
+        status: FormStatus.Public,
+        authType: FormAuthType.CP,
+        isSingleSubmission: true,
+        isSubmitterIdCollectionEnabled: true,
+      }),
+    },
+  },
 }
 
 export const PrivateStorageMyInfoPaymentEnabledForm = Template.bind({})
 PrivateStorageMyInfoPaymentEnabledForm.parameters = {
-  msw: [
-    ...buildEncryptModeMswRoutes({
-      status: FormStatus.Private,
-      authType: FormAuthType.MyInfo,
-      esrvcId: 'STORYBOOK-TEST',
-      responseMode: FormResponseMode.Encrypt,
-      payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
-    }),
-    ...createFormBuilderMocks({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...buildEncryptModeMswRoutes({
+          status: FormStatus.Private,
+          authType: FormAuthType.MyInfo,
+          esrvcId: 'STORYBOOK-TEST',
+          responseMode: FormResponseMode.Encrypt,
+          payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
+        }),
+        ...createFormBuilderMocks({
+          form_fields: MOCK_FORM_FIELDS_WITH_MYINFO,
+        }),
+      ],
+    },
+  },
 }
 
 export const PublicStorageMyInfoPaymentEnabledForm = Template.bind({})
 PublicStorageMyInfoPaymentEnabledForm.parameters = {
-  msw: [
-    ...buildEncryptModeMswRoutes({
-      status: FormStatus.Public,
-      authType: FormAuthType.MyInfo,
-      esrvcId: 'STORYBOOK-TEST',
-      responseMode: FormResponseMode.Encrypt,
-      payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
-    }),
-    ...createFormBuilderMocks({ form_fields: MOCK_FORM_FIELDS_WITH_MYINFO }),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...buildEncryptModeMswRoutes({
+          status: FormStatus.Public,
+          authType: FormAuthType.MyInfo,
+          esrvcId: 'STORYBOOK-TEST',
+          responseMode: FormResponseMode.Encrypt,
+          payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
+        }),
+        ...createFormBuilderMocks({
+          form_fields: MOCK_FORM_FIELDS_WITH_MYINFO,
+        }),
+      ],
+    },
+  },
 }
 
 export const PrivateStorageSgidPaymentEnabledForm = Template.bind({})
 PrivateStorageSgidPaymentEnabledForm.parameters = {
-  msw: [
-    ...buildEncryptModeMswRoutes({
-      status: FormStatus.Private,
-      authType: FormAuthType.SGID,
-      responseMode: FormResponseMode.Encrypt,
-      payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
-    }),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...buildEncryptModeMswRoutes({
+          status: FormStatus.Private,
+          authType: FormAuthType.SGID,
+          responseMode: FormResponseMode.Encrypt,
+          payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
+        }),
+      ],
+    },
+  },
 }
 
 // stories for whitelist setting
 export const PrivateStorageSgidWhitelistEnabledForm = Template.bind({})
 PrivateStorageSgidWhitelistEnabledForm.parameters = {
-  msw: [
-    ...buildEncryptModeMswRoutes({
-      status: FormStatus.Private,
-      authType: FormAuthType.SGID,
-      responseMode: FormResponseMode.Encrypt,
-      whitelistedSubmitterIds: {
-        isWhitelistEnabled: true,
-      },
-    }),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...buildEncryptModeMswRoutes({
+          status: FormStatus.Private,
+          authType: FormAuthType.SGID,
+          responseMode: FormResponseMode.Encrypt,
+          whitelistedSubmitterIds: {
+            isWhitelistEnabled: true,
+          },
+        }),
+      ],
+    },
+  },
 }
 
 export const PrivateStorageMyInfoUpdateWhitelistValidationErrorForm =
   Template.bind({})
 PrivateStorageMyInfoUpdateWhitelistValidationErrorForm.parameters = {
-  msw: [
-    ...buildEncryptModeMswRoutes({
-      status: FormStatus.Private,
-      authType: FormAuthType.MyInfo,
-      responseMode: FormResponseMode.Encrypt,
-      whitelistedSubmitterIds: {
-        isWhitelistEnabled: false,
+  msw: {
+    handlers: {
+      default: [
+        ...buildEncryptModeMswRoutes({
+          status: FormStatus.Private,
+          authType: FormAuthType.MyInfo,
+          responseMode: FormResponseMode.Encrypt,
+          whitelistedSubmitterIds: {
+            isWhitelistEnabled: false,
+          },
+        }),
+        putFormWhitelistSettingSimulateCsvStringValidationError('12345'),
+      ],
+      docs: {
+        description: {
+          story:
+            'Uploading a valid CSV file should display a mock validation error. This story is used to simulate validation errors are displayed correctly in the UI.',
+        },
       },
-    }),
-    putFormWhitelistSettingSimulateCsvStringValidationError('12345'),
-  ],
-  docs: {
-    description: {
-      story:
-        'Uploading a valid CSV file should display a mock validation error. This story is used to simulate validation errors are displayed correctly in the UI.',
     },
   },
 }
@@ -280,7 +372,11 @@ Tablet.parameters = {
     defaultViewport: 'tablet',
   },
   chromatic: { viewports: [viewports.md] },
-  msw: PrivateStorageSingpassFormAllTogglesEnabled.parameters.msw,
+  msw: {
+    handlers: {
+      default: PrivateStorageSingpassFormAllTogglesEnabled.parameters.msw,
+    },
+  },
 }
 
 export const Mobile = Template.bind({})
@@ -289,10 +385,14 @@ Mobile.parameters = {
     defaultViewport: 'mobile1',
   },
   chromatic: { viewports: [viewports.xs] },
-  msw: PrivateStorageSingpassFormAllTogglesEnabled.parameters.msw,
+  msw: {
+    handlers: {
+      default: PrivateStorageSingpassFormAllTogglesEnabled.parameters.msw,
+    },
+  },
 }
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: [getAdminFormSettings({ delay: 'infinite' })],
+  msw: { handlers: { default: [getAdminFormSettings({ delay: 'infinite' })] } },
 }

--- a/frontend/src/features/admin-form/settings/SettingsEmailsPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsEmailsPage.stories.tsx
@@ -96,8 +96,8 @@ export default {
   decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
   parameters: {
     // Required so skeleton "animation" does not hide content.
-    chromatic: { pauseAnimationAtEnd: true },
-    msw: buildMswRoutes(),
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+    msw: { handlers: { default: buildMswRoutes() } },
   },
 } as Meta
 
@@ -105,175 +105,220 @@ const Template: StoryFn = () => <SettingsEmailsPage />
 
 export const PrivateStorageForm = Template.bind({})
 PrivateStorageForm.parameters = {
-  msw: buildMswRoutes({
-    mode: FormResponseMode.Encrypt,
-    overrides: {
-      status: FormStatus.Private,
-      emails: [], // has one email by default
-      ...PAYMENTS_DISABLED,
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Encrypt,
+        overrides: {
+          status: FormStatus.Private,
+          emails: [], // has one email by default
+          ...PAYMENTS_DISABLED,
+        },
+      }),
     },
-  }),
+  },
 }
 
 export const PrivateEmailForm = Template.bind({})
 PrivateEmailForm.parameters = {
-  msw: buildMswRoutes({
-    mode: FormResponseMode.Email,
-    overrides: {
-      status: FormStatus.Private,
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Email,
+        overrides: {
+          status: FormStatus.Private,
+        },
+      }),
     },
-  }),
+  },
 }
 
 export const PrivateMultiRespondentForm = Template.bind({})
 PrivateMultiRespondentForm.parameters = {
-  msw: buildMswRoutes({
-    mode: FormResponseMode.Multirespondent,
-    overrides: {
-      form_fields: [
-        {
-          _id: 'email_field_id',
-          fieldType: BasicField.Email,
-          title: 'Respondent 1 Email',
-        } as FormFieldDto,
-      ],
-      status: FormStatus.Private,
-      stepOneEmailNotificationFieldId: 'email_field_id',
-      emails: ['selected_email@example.com', 'selected_email_2@example.com'],
-      stepsToNotify: ['field_id_2'],
-      workflow: [
-        {
-          _id: 'field_id_1',
-          workflow_type: WorkflowType.Dynamic,
-          field: 'email_field_id',
-          edit: [],
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Multirespondent,
+        overrides: {
+          form_fields: [
+            {
+              _id: 'email_field_id',
+              fieldType: BasicField.Email,
+              title: 'Respondent 1 Email',
+            } as FormFieldDto,
+          ],
+          status: FormStatus.Private,
+          stepOneEmailNotificationFieldId: 'email_field_id',
+          emails: [
+            'selected_email@example.com',
+            'selected_email_2@example.com',
+          ],
+          stepsToNotify: ['field_id_2'],
+          workflow: [
+            {
+              _id: 'field_id_1',
+              workflow_type: WorkflowType.Dynamic,
+              field: 'email_field_id',
+              edit: [],
+            },
+            {
+              _id: 'field_id_2',
+              workflow_type: WorkflowType.Static,
+              emails: [],
+              edit: [],
+            },
+          ],
         },
-        {
-          _id: 'field_id_2',
-          workflow_type: WorkflowType.Static,
-          emails: [],
-          edit: [],
-        },
-      ],
+      }),
     },
-  }),
+  },
 }
 
 export const PrivateMultiRespondentFormWithInvalidStepOneEmailNotificationFieldId =
   Template.bind({})
 PrivateMultiRespondentFormWithInvalidStepOneEmailNotificationFieldId.parameters =
   {
-    msw: buildMswRoutes({
-      mode: FormResponseMode.Multirespondent,
-      overrides: {
-        status: FormStatus.Private,
-        stepOneEmailNotificationFieldId: 'invalid_field_id',
-        emails: ['selected_email@example.com', 'selected_email_2@example.com'],
-        stepsToNotify: ['field_id_2'],
-        workflow: [
-          {
-            _id: 'field_id_1',
-            workflow_type: WorkflowType.Dynamic,
-            field: 'email_field_id',
-            edit: [],
+    msw: {
+      handlers: {
+        default: buildMswRoutes({
+          mode: FormResponseMode.Multirespondent,
+          overrides: {
+            status: FormStatus.Private,
+            stepOneEmailNotificationFieldId: 'invalid_field_id',
+            emails: [
+              'selected_email@example.com',
+              'selected_email_2@example.com',
+            ],
+            stepsToNotify: ['field_id_2'],
+            workflow: [
+              {
+                _id: 'field_id_1',
+                workflow_type: WorkflowType.Dynamic,
+                field: 'email_field_id',
+                edit: [],
+              },
+              {
+                _id: 'field_id_2',
+                workflow_type: WorkflowType.Static,
+                emails: [],
+                edit: [],
+              },
+            ],
           },
-          {
-            _id: 'field_id_2',
-            workflow_type: WorkflowType.Static,
-            emails: [],
-            edit: [],
-          },
-        ],
+        }),
       },
-    }),
+    },
   }
 
 export const PrivateMultiRespondentFormNothingSelected = Template.bind({})
 PrivateMultiRespondentFormNothingSelected.parameters = {
-  msw: buildMswRoutes({
-    mode: FormResponseMode.Multirespondent,
-    overrides: {
-      status: FormStatus.Private,
-      emails: [],
-      stepsToNotify: [],
-      stepOneEmailNotificationFieldId: undefined,
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Multirespondent,
+        overrides: {
+          status: FormStatus.Private,
+          emails: [],
+          stepsToNotify: [],
+          stepOneEmailNotificationFieldId: undefined,
+        },
+      }),
     },
-  }),
+  },
 }
 
 export const PublicForm = Template.bind({})
 PublicForm.parameters = {
-  msw: buildMswRoutes({
-    mode: FormResponseMode.Encrypt,
-    overrides: {
-      status: FormStatus.Public,
-      emails: [],
-      ...PAYMENTS_DISABLED,
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Encrypt,
+        overrides: {
+          status: FormStatus.Public,
+          emails: [],
+          ...PAYMENTS_DISABLED,
+        },
+      }),
     },
-  }),
+  },
 }
 
 export const PublicMultiRespondentForm = Template.bind({})
 PublicMultiRespondentForm.parameters = {
-  msw: buildMswRoutes({
-    mode: FormResponseMode.Multirespondent,
-    overrides: {
-      form_fields: [
-        {
-          _id: 'email_field_id',
-          fieldType: BasicField.Email,
-          title: 'Respondent 1 Email',
-        } as FormFieldDto,
-      ],
-      status: FormStatus.Public,
-      stepOneEmailNotificationFieldId: 'email_field_id',
-      emails: ['selected_email@example.com', 'selected_email_2@example.com'],
-      stepsToNotify: ['field_id_2'],
-      workflow: [
-        {
-          _id: 'field_id_1',
-          workflow_type: WorkflowType.Dynamic,
-          field: 'email_field_id',
-          edit: [],
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Multirespondent,
+        overrides: {
+          form_fields: [
+            {
+              _id: 'email_field_id',
+              fieldType: BasicField.Email,
+              title: 'Respondent 1 Email',
+            } as FormFieldDto,
+          ],
+          status: FormStatus.Public,
+          stepOneEmailNotificationFieldId: 'email_field_id',
+          emails: [
+            'selected_email@example.com',
+            'selected_email_2@example.com',
+          ],
+          stepsToNotify: ['field_id_2'],
+          workflow: [
+            {
+              _id: 'field_id_1',
+              workflow_type: WorkflowType.Dynamic,
+              field: 'email_field_id',
+              edit: [],
+            },
+            {
+              _id: 'field_id_2',
+              workflow_type: WorkflowType.Static,
+              emails: [],
+              edit: [],
+            },
+          ],
         },
-        {
-          _id: 'field_id_2',
-          workflow_type: WorkflowType.Static,
-          emails: [],
-          edit: [],
-        },
-      ],
+      }),
     },
-  }),
+  },
 }
 
 export const PaymentForm = Template.bind({})
 PaymentForm.parameters = {
-  msw: buildMswRoutes({
-    mode: FormResponseMode.Encrypt,
-    overrides: {
-      status: FormStatus.Private,
-      emails: [],
-      ...PAYMENTS_ENABLED,
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Encrypt,
+        overrides: {
+          status: FormStatus.Private,
+          emails: [],
+          ...PAYMENTS_ENABLED,
+        },
+      }),
     },
-  }),
+  },
 }
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: buildMswRoutes({ delay: 'infinite' }),
+  msw: { handlers: { default: buildMswRoutes({ delay: 'infinite' }) } },
 }
 
 export const NoEmailsAddedForm = Template.bind({})
 NoEmailsAddedForm.parameters = {
-  msw: buildMswRoutes({
-    mode: FormResponseMode.Encrypt,
-    overrides: {
-      status: FormStatus.Private,
-      emails: [],
-      ...PAYMENTS_DISABLED,
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Encrypt,
+        overrides: {
+          status: FormStatus.Private,
+          emails: [],
+          ...PAYMENTS_DISABLED,
+        },
+      }),
     },
-  }),
+  },
 }
 
 export const Mobile = Template.bind({})

--- a/frontend/src/features/admin-form/settings/SettingsMultiLangPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsMultiLangPage.stories.tsx
@@ -45,8 +45,8 @@ export default {
   ],
   parameters: {
     // Required so skeleton "animation" does not hide content.
-    chromatic: { pauseAnimationAtEnd: true },
-    msw: buildMswRoutes(),
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+    msw: { handlers: { default: buildMswRoutes() } },
   },
 } as Meta
 
@@ -56,26 +56,42 @@ const Template: StoryFn = () => <SettingsMultiLangPage />
 // and choosing which language to enable translations for
 export const MultiLangNotSelected = Template.bind({})
 MultiLangNotSelected.parameters = {
-  msw: buildMswRoutes({
-    overrides: { hasMultiLang: false },
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: { hasMultiLang: false },
+      }),
+    },
+  },
 }
 
 export const MultiLangAllLanguagesSelected = Template.bind({})
 MultiLangAllLanguagesSelected.parameters = {
-  msw: buildMswRoutes({
-    overrides: { hasMultiLang: true },
-  }),
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: { hasMultiLang: true },
+      }),
+    },
+  },
 }
 
 export const MultiLangEnglishChineseMalaySelected = Template.bind({})
 MultiLangEnglishChineseMalaySelected.parameters = {
-  msw: buildMswRoutes({
-    overrides: {
-      hasMultiLang: true,
-      supportedLanguages: [Language.ENGLISH, Language.CHINESE, Language.MALAY],
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          hasMultiLang: true,
+          supportedLanguages: [
+            Language.ENGLISH,
+            Language.CHINESE,
+            Language.MALAY,
+          ],
+        },
+      }),
     },
-  }),
+  },
 }
 
 // Stories related to displaying list of form fields for translations
@@ -85,20 +101,28 @@ MultiLangListOfFormFieldsWithNoTranslations.parameters = {
     initialEntries: ['/61540ece3d4a6e50ac0cc6ff/settings/language'],
     path: '/:formId/settings/language',
   },
-  msw: [
-    ...createFormBuilderMocks({
-      form_fields: MOCK_FORM_FIELDS_WITH_NO_TRANSLATIONS,
-      startPage: {
-        colorTheme: FormColorTheme.Blue,
-        logo: { state: FormLogoState.Default },
-        paragraph: 'Test start page',
-      },
-      hasMultiLang: true,
-      supportedLanguages: [Language.ENGLISH, Language.CHINESE, Language.MALAY],
-    }),
-    getAdminFormSettings(),
-    patchAdminFormSettings(),
-  ],
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks({
+          form_fields: MOCK_FORM_FIELDS_WITH_NO_TRANSLATIONS,
+          startPage: {
+            colorTheme: FormColorTheme.Blue,
+            logo: { state: FormLogoState.Default },
+            paragraph: 'Test start page',
+          },
+          hasMultiLang: true,
+          supportedLanguages: [
+            Language.ENGLISH,
+            Language.CHINESE,
+            Language.MALAY,
+          ],
+        }),
+        getAdminFormSettings(),
+        patchAdminFormSettings(),
+      ],
+    },
+  },
 }
 
 export const MultiLangListOfFormFieldsWithCompletedTranslations = Template.bind(
@@ -109,46 +133,57 @@ MultiLangListOfFormFieldsWithCompletedTranslations.parameters = {
     initialEntries: ['/61540ece3d4a6e50ac0cc6ff/settings/language'],
     path: '/:formId/settings/language',
   },
-  msw: [
-    ...createFormBuilderMocks({
-      form_fields: MOCK_FORM_FIELDS_WITH_TRANSLATIONS,
-      // Completed translations for start page
-      startPage: {
-        colorTheme: FormColorTheme.Blue,
-        logo: { state: FormLogoState.Default },
-        paragraph: 'Test start page',
-        paragraphTranslations: [
-          { language: Language.CHINESE, translation: 'Fake Translations' },
-        ],
-      },
-      // Completed translations for end page
-      endPage: {
-        title: 'Thank you for filling out the form.',
-        titleTranslations: [
-          { language: Language.CHINESE, translation: 'Fake Title Translation' },
-        ],
-        paragraph: 'Test end page paragraph',
-        paragraphTranslations: [
-          {
-            language: Language.CHINESE,
-            translation: 'Fake Paragraph Translation',
+  msw: {
+    handlers: {
+      default: [
+        ...createFormBuilderMocks({
+          form_fields: MOCK_FORM_FIELDS_WITH_TRANSLATIONS,
+          // Completed translations for start page
+          startPage: {
+            colorTheme: FormColorTheme.Blue,
+            logo: { state: FormLogoState.Default },
+            paragraph: 'Test start page',
+            paragraphTranslations: [
+              { language: Language.CHINESE, translation: 'Fake Translations' },
+            ],
           },
-        ],
-        buttonText: 'Submit another form',
-        paymentTitle: 'payment title',
-        paymentParagraph: 'payment paragraph',
-      },
-      hasMultiLang: true,
-      supportedLanguages: [Language.ENGLISH, Language.CHINESE, Language.MALAY],
-    }),
-    getAdminFormSettings(),
-    patchAdminFormSettings(),
-  ],
+          // Completed translations for end page
+          endPage: {
+            title: 'Thank you for filling out the form.',
+            titleTranslations: [
+              {
+                language: Language.CHINESE,
+                translation: 'Fake Title Translation',
+              },
+            ],
+            paragraph: 'Test end page paragraph',
+            paragraphTranslations: [
+              {
+                language: Language.CHINESE,
+                translation: 'Fake Paragraph Translation',
+              },
+            ],
+            buttonText: 'Submit another form',
+            paymentTitle: 'payment title',
+            paymentParagraph: 'payment paragraph',
+          },
+          hasMultiLang: true,
+          supportedLanguages: [
+            Language.ENGLISH,
+            Language.CHINESE,
+            Language.MALAY,
+          ],
+        }),
+        getAdminFormSettings(),
+        patchAdminFormSettings(),
+      ],
+    },
+  },
 }
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: buildMswRoutes({ delay: 'infinite' }),
+  msw: { handlers: { default: buildMswRoutes({ delay: 'infinite' }) } },
 }
 
 export const Mobile = Template.bind({})

--- a/frontend/src/features/admin-form/settings/SettingsPaymentsPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsPaymentsPage.stories.tsx
@@ -21,7 +21,7 @@ export default {
   component: SettingsPaymentsPage,
   decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
   parameters: {
-    msw: buildEncryptModeMswRoutes(),
+    msw: { handlers: { default: buildEncryptModeMswRoutes() } },
   },
 } as Meta
 
@@ -30,19 +30,37 @@ export const IsSingleSubmissionEnabledWithoutEmailNotifications = Template.bind(
   {},
 )
 IsSingleSubmissionEnabledWithoutEmailNotifications.parameters = {
-  msw: buildEncryptModeMswRoutes({ isSingleSubmission: true, emails: [] }),
+  msw: {
+    handlers: {
+      default: buildEncryptModeMswRoutes({
+        isSingleSubmission: true,
+        emails: [],
+      }),
+    },
+  },
 }
 
 export const IsSingleSubmissionEnabledWithEmailNotifications = Template.bind({})
 IsSingleSubmissionEnabledWithEmailNotifications.parameters = {
-  msw: buildEncryptModeMswRoutes({
-    isSingleSubmission: true,
-    emails: ['dummy@dummy.com'],
-  }),
+  msw: {
+    handlers: {
+      default: buildEncryptModeMswRoutes({
+        isSingleSubmission: true,
+        emails: ['dummy@dummy.com'],
+      }),
+    },
+  },
 }
 
 export const IsSingleSubmissionDisabledWithoutEmailNotifications =
   Template.bind({})
 IsSingleSubmissionDisabledWithoutEmailNotifications.parameters = {
-  msw: buildEncryptModeMswRoutes({ isSingleSubmission: false, emails: [] }),
+  msw: {
+    handlers: {
+      default: buildEncryptModeMswRoutes({
+        isSingleSubmission: false,
+        emails: [],
+      }),
+    },
+  },
 }

--- a/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
@@ -32,39 +32,47 @@ export default {
   decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
   parameters: {
     // Required so skeleton "animation" does not hide content.
-    chromatic: { pauseAnimationAtEnd: true },
-    msw: buildMswRoutes(),
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+    msw: { handlers: { default: buildMswRoutes() } },
   },
 } as Meta
 
 const Template: StoryFn = () => <SettingsWebhooksPage />
 export const StorageModeEmpty = Template.bind({})
 StorageModeEmpty.parameters = {
-  msw: buildMswRoutes({
-    overrides: {
-      responseMode: FormResponseMode.Encrypt,
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Encrypt,
+        },
+      }),
     },
-  }),
+  },
 }
 
 export const StorageModeRetryEnabled = Template.bind({})
 StorageModeRetryEnabled.parameters = {
-  msw: buildMswRoutes({
-    overrides: {
-      responseMode: FormResponseMode.Encrypt,
-      webhook: {
-        url: 'https://example.com/webhook',
-        isRetryEnabled: true,
-      },
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Encrypt,
+          webhook: {
+            url: 'https://example.com/webhook',
+            isRetryEnabled: true,
+          },
+        },
+      }),
     },
-  }),
+  },
 }
 
 export const UnsupportedEmailMode = Template.bind({})
 
 export const Loading = Template.bind({})
 Loading.parameters = {
-  msw: buildMswRoutes({ delay: 'infinite' }),
+  msw: { handlers: { default: buildMswRoutes({ delay: 'infinite' }) } },
 }
 
 export const Mobile = Template.bind({})

--- a/frontend/src/features/admin-form/share/ShareFormModal.stories.tsx
+++ b/frontend/src/features/admin-form/share/ShareFormModal.stories.tsx
@@ -16,7 +16,7 @@ export default {
   parameters: {
     layout: 'fullscreen',
     // Prevent flaky tests due to modal animating in.
-    chromatic: { pauseAnimationAtEnd: true },
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
   },
 } as Meta
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We have a lot of flakey chromatic tests, which makes UI review difficult, due to the false positives, for our designers, especially when we're trying to introduce an array of UI fixes.

1. Various apis that the Page-level stories calls are not handled under `msw`, i.e. `/client/env`, `/feature-flag`. 
2. Delays not present for several Page-level stories which results in UI diff being highlighted by chromatic. This introduces a lot of noise for the reviewer.


## Solution
<!-- How did you solve the problem? -->

1. In order for us to import globally injected msw values, we have to migrate to `Object{}` syntax instead of `Array[]` during the parameters declaration. This is only supported in `>= msw@1.6` which is already addressed in #8648.
2. Add and standardise delays (`delay: 300`)to avoid chromatic capturing the snapshot as the Shimmering Loading animation is still animating.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
