### PR TITLE
feat(singpass): hiding unselected collapsed options

### DIFF
--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -329,7 +329,7 @@ const addAuthSettings = async (
 
   // Don't need to click if SGID is desired auth type
   // since SGID is the default once Singpass is enabled
-  if (formSettings.authType !== FormAuthType.SGID) {
+  if (formSettings.authType !== FormAuthType.MyInfo) {
     await page
       .locator('label', {
         has: page.locator(

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -343,9 +343,7 @@ const addAuthSettings = async (
   }
 
   switch (formSettings.authType) {
-    case FormAuthType.SP:
     case FormAuthType.CP:
-    case FormAuthType.MyInfo:
       if (!formSettings.esrvcId) throw new Error('No esrvcid provided!')
       await page.locator(`id=esrvcId`).fill(formSettings.esrvcId)
       await page.keyboard.press('Enter')

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingpassAuthToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormSingpassAuthToggle.tsx
@@ -11,7 +11,7 @@ interface FormSingpassAuthToggleProps {
   isDisabled: boolean
 }
 
-const DEFAULT_FORM_AUTH_TYPE = FormAuthType.SGID
+const DEFAULT_FORM_AUTH_TYPE = FormAuthType.MyInfo
 
 export const FormSingpassAuthToggle = ({
   settings,

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
@@ -117,7 +117,6 @@ export const SingpassAuthOptionsRadio = ({
                 {[
                   FormAuthType.SGID,
                   FormAuthType.SGID_MyInfo,
-                  FormAuthType.SP,
                   FormAuthType.MyInfo,
                 ].includes(authType) ? (
                   <>

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
@@ -3,6 +3,7 @@ import {
   KeyboardEventHandler,
   MouseEventHandler,
   useCallback,
+  useMemo,
   useState,
 } from 'react'
 import { Box, Flex, Spacer } from '@chakra-ui/react'
@@ -16,12 +17,21 @@ import { useMutateFormSettings } from '../../mutations'
 
 import { FORM_SINGPASS_AUTHTYPES } from './constants'
 import { EsrvcIdBox } from './EsrvcIdBox'
+import { pickBy } from 'lodash'
 
 export interface SingpassAuthOptionsRadioProps {
   settings: FormSettings
   isDisabled: boolean
 }
 
+type RadioOptionsType = [FormAuthType, string][]
+
+/**
+ * Only CorpPass requires esrvcid as other options will use FormSG's
+ * supplied value to increase Singpass Myinfo adoption
+ * @param authType
+ * @returns
+ */
 const isEsrvcidRequired = (authType: FormAuthType) => {
   switch (authType) {
     case FormAuthType.CP:
@@ -31,8 +41,14 @@ const isEsrvcidRequired = (authType: FormAuthType) => {
   }
 }
 
-const radioOptions: [FormAuthType, string][] = Object.entries(
+const COLLAPSED_FORM_SINGPASS_AUTHTYPES = pickBy(
   FORM_SINGPASS_AUTHTYPES,
+  (_, key) =>
+    [FormAuthType.MyInfo, FormAuthType.CP].includes(key as FormAuthType),
+)
+
+const baseRadioOptions: RadioOptionsType = Object.entries(
+  COLLAPSED_FORM_SINGPASS_AUTHTYPES,
 ) as [FormAuthType, string][]
 
 export const SingpassAuthOptionsRadio = ({
@@ -49,6 +65,21 @@ export const SingpassAuthOptionsRadio = ({
   const checkIsDisabled = useCallback(() => {
     return isDisabled || mutateFormAuthType.isLoading
   }, [isDisabled, mutateFormAuthType.isLoading])
+
+  const radioOptionsWithInitialChoice: RadioOptionsType = useMemo(() => {
+    if (baseRadioOptions.some(([key, _]) => key === settings.authType)) {
+      return baseRadioOptions
+    }
+    if (settings.authType === FormAuthType.NIL) {
+      return baseRadioOptions
+    }
+
+    // reinsert the initial choice so that admins can see it in the list
+    return [
+      [settings.authType, FORM_SINGPASS_AUTHTYPES[settings.authType]],
+      ...baseRadioOptions,
+    ]
+  }, [settings.authType])
 
   const handleEnterKeyDown: KeyboardEventHandler = useCallback(
     (e) => {
@@ -91,14 +122,18 @@ export const SingpassAuthOptionsRadio = ({
       onKeyDown={handleEnterKeyDown}
       onChange={(e: FormAuthType) => setFocusedValue(e)}
     >
-      {radioOptions.map(([authType, text]) => (
+      {radioOptionsWithInitialChoice.map(([authType, text]) => (
         <Fragment key={authType}>
           <Box onClick={handleOptionClick(authType)}>
             <Radio value={authType} isDisabled={checkIsDisabled()}>
               <Flex>
                 {text}
-                {authType === FormAuthType.SGID ||
-                authType === FormAuthType.SGID_MyInfo ? (
+                {[
+                  FormAuthType.SGID,
+                  FormAuthType.SGID_MyInfo,
+                  FormAuthType.SP,
+                  FormAuthType.MyInfo,
+                ].includes(authType) ? (
                   <>
                     <Spacer w="16px" />
                     <Tag size="sm" variant="subtle">

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from 'react'
 import { Box, Flex, Spacer } from '@chakra-ui/react'
+import { pickBy } from 'lodash'
 
 import { FormAuthType, FormSettings, FormStatus } from '~shared/types'
 
@@ -14,11 +15,10 @@ import Radio from '~components/Radio'
 import { Tag } from '~components/Tag'
 
 import { useMutateFormSettings } from '../../mutations'
+import { isEsrvcidRequired } from '../utils'
 
 import { FORM_SINGPASS_AUTHTYPES } from './constants'
 import { EsrvcIdBox } from './EsrvcIdBox'
-import { pickBy } from 'lodash'
-import { isEsrvcidRequired } from '../utils'
 
 export interface SingpassAuthOptionsRadioProps {
   settings: FormSettings

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
@@ -18,6 +18,7 @@ import { useMutateFormSettings } from '../../mutations'
 import { FORM_SINGPASS_AUTHTYPES } from './constants'
 import { EsrvcIdBox } from './EsrvcIdBox'
 import { pickBy } from 'lodash'
+import { isEsrvcidRequired } from '../utils'
 
 export interface SingpassAuthOptionsRadioProps {
   settings: FormSettings
@@ -25,21 +26,6 @@ export interface SingpassAuthOptionsRadioProps {
 }
 
 type RadioOptionsType = [FormAuthType, string][]
-
-/**
- * Only CorpPass requires esrvcid as other options will use FormSG's
- * supplied value to increase Singpass Myinfo adoption
- * @param authType
- * @returns
- */
-const isEsrvcidRequired = (authType: FormAuthType) => {
-  switch (authType) {
-    case FormAuthType.CP:
-      return true
-    default:
-      return false
-  }
-}
 
 const COLLAPSED_FORM_SINGPASS_AUTHTYPES = pickBy(
   FORM_SINGPASS_AUTHTYPES,

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
@@ -24,8 +24,6 @@ export interface SingpassAuthOptionsRadioProps {
 
 const isEsrvcidRequired = (authType: FormAuthType) => {
   switch (authType) {
-    case FormAuthType.SP:
-    case FormAuthType.MyInfo:
     case FormAuthType.CP:
       return true
     default:

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
@@ -6,6 +6,6 @@ export const FORM_SINGPASS_AUTHTYPES: Record<FormSingpassAuthType, string> = {
   [FormAuthType.SGID]: 'Singpass App-only Login',
   [FormAuthType.SGID_MyInfo]: 'Singpass App-only with Myinfo',
   [FormAuthType.SP]: 'Singpass',
-  [FormAuthType.MyInfo]: 'Singpass (to be updated by 5 September)',
-  [FormAuthType.CP]: 'Singpass (Corporate)',
+  [FormAuthType.MyInfo]: 'Singpass',
+  [FormAuthType.CP]: 'Corpass',
 }

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
@@ -7,5 +7,5 @@ export const FORM_SINGPASS_AUTHTYPES: Record<FormSingpassAuthType, string> = {
   [FormAuthType.SGID_MyInfo]: 'Singpass App-only with Myinfo',
   [FormAuthType.SP]: 'Singpass',
   [FormAuthType.MyInfo]: 'Singpass',
-  [FormAuthType.CP]: 'Corpass',
+  [FormAuthType.CP]: 'Corppass',
 }

--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
@@ -6,6 +6,6 @@ export const FORM_SINGPASS_AUTHTYPES: Record<FormSingpassAuthType, string> = {
   [FormAuthType.SGID]: 'Singpass App-only Login',
   [FormAuthType.SGID_MyInfo]: 'Singpass App-only with Myinfo',
   [FormAuthType.SP]: 'Singpass',
-  [FormAuthType.MyInfo]: 'Singpass with Myinfo',
+  [FormAuthType.MyInfo]: 'Singpass (to be updated by 5 September)',
   [FormAuthType.CP]: 'Singpass (Corporate)',
 }

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -20,6 +20,7 @@ import { useAdminFormSettings } from '../queries'
 
 import { EmailModeConvertModal } from './EmailModeConvertModal'
 import { SecretKeyActivationModal } from './SecretKeyActivationModal'
+import { isEsrvcidRequired } from './utils'
 
 export const FormStatusToggle = (): JSX.Element => {
   const { t } = useTranslation()
@@ -41,7 +42,7 @@ export const FormStatusToggle = (): JSX.Element => {
     if (status === FormStatus.Public) return
 
     // Prevent form activation if form has authType but no esrvcId.
-    if (authType && [FormAuthType.CP].includes(authType) && !esrvcId) {
+    if (authType && isEsrvcidRequired(authType) && !esrvcId) {
       return t(
         'features.adminForm.settings.general.status.supplySingpassEServiceId',
       )

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -41,13 +41,7 @@ export const FormStatusToggle = (): JSX.Element => {
     if (status === FormStatus.Public) return
 
     // Prevent form activation if form has authType but no esrvcId.
-    if (
-      authType &&
-      [FormAuthType.CP, FormAuthType.SP, FormAuthType.MyInfo].includes(
-        authType,
-      ) &&
-      !esrvcId
-    ) {
+    if (authType && [FormAuthType.CP].includes(authType) && !esrvcId) {
       return t(
         'features.adminForm.settings.general.status.supplySingpassEServiceId',
       )

--- a/frontend/src/features/admin-form/settings/components/utils.ts
+++ b/frontend/src/features/admin-form/settings/components/utils.ts
@@ -9,6 +9,7 @@ import { FormAuthType } from '~shared/types'
 
 export const isEsrvcidRequired = (authType: FormAuthType) => {
   switch (authType) {
+    case FormAuthType.SP:
     case FormAuthType.CP:
       return true
     default:

--- a/frontend/src/features/admin-form/settings/components/utils.ts
+++ b/frontend/src/features/admin-form/settings/components/utils.ts
@@ -1,0 +1,17 @@
+import { FormAuthType } from '~shared/types'
+
+/**
+ * Only CorpPass requires esrvcid as other options will use FormSG's
+ * supplied value to increase Singpass Myinfo adoption
+ * @param authType
+ * @returns
+ */
+
+export const isEsrvcidRequired = (authType: FormAuthType) => {
+  switch (authType) {
+    case FormAuthType.CP:
+      return true
+    default:
+      return false
+  }
+}

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -22,4 +22,5 @@ export const featureFlags = {
   ogpSuiteSso: 'ogp-suite-sso' as const,
   enableIntranetSgidLogin: 'enable-intranet-sgid-login' as const,
   enableMrfWebhooks: 'enable-mrf-webhooks' as const,
+  useFormsgEsrvcId: 'use-formsg-esrvcid' as const,
 }

--- a/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -4,6 +4,7 @@ import { ObjectId } from 'bson'
 import { Request } from 'express'
 import { err, errAsync, ok, okAsync } from 'neverthrow'
 
+import { spcpMyInfoConfig } from 'src/app/config/features/spcp-myinfo.config'
 import { DatabaseError } from 'src/app/modules/core/core.errors'
 import {
   MOCK_ACCESS_TOKEN,
@@ -67,7 +68,9 @@ jest.mock('../../../spcp/spcp.oidc.service/spcp.oidc.service.sp')
 jest.mock('../../../spcp/spcp.oidc.service/spcp.oidc.service.cp')
 jest.mock('../../../myinfo/myinfo.service')
 jest.mock('../../../billing/billing.service')
+jest.mock('src/app/config/features/spcp-myinfo.config')
 
+const MockSpCpMyInfoConfig = jest.mocked(spcpMyInfoConfig)
 const MockFormService = jest.mocked(FormService)
 const MockPublicFormService = jest.mocked(PublicFormService)
 const MockAuthService = jest.mocked(AuthService)
@@ -1252,11 +1255,19 @@ describe('public-form.controller', () => {
 
     it('should return 200 with the redirect url when the request is valid and the form has authType MyInfo', async () => {
       // Arrange
+      const FORM_ESRVC_ID = 'MOCKED_FORM_ESRVC_ID'
       const MOCK_FORM = {
         authType: FormAuthType.MyInfo,
-        esrvcId: '12345',
+        esrvcId: FORM_ESRVC_ID,
         getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
       } as unknown as MyInfoForm<IFormDocument>
+
+      const MOCKED_DEFAULT_ESRVC_ID = 'MOCKED_DEFAULT_ESRVC_ID'
+      MockSpCpMyInfoConfig.spEsrvcId = MOCKED_DEFAULT_ESRVC_ID
+      const createRedirectURLSpy = jest.spyOn(
+        MockMyInfoService,
+        'createRedirectURL',
+      )
 
       const mockRes = expressHandler.mockResponse()
       MockFormService.retrieveFullFormById.mockReturnValueOnce(
@@ -1274,6 +1285,51 @@ describe('public-form.controller', () => {
       )
 
       // Assert
+      expect(createRedirectURLSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formEsrvcId: FORM_ESRVC_ID,
+        }),
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(200)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        redirectURL: MOCK_REDIRECT_URL,
+      })
+    })
+
+    it('should return 200 with the redirect url when the request is valid and the form has authType MyInfo and no esrvcId', async () => {
+      // Arrange
+      const MOCK_FORM = {
+        authType: FormAuthType.MyInfo,
+        esrvcId: undefined,
+        getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+      } as unknown as MyInfoForm<IFormDocument>
+
+      const DEFAULT_ESRVC_ID = 'MOCKED_DEFAULT_ESRVC_ID'
+      MockSpCpMyInfoConfig.spEsrvcId = DEFAULT_ESRVC_ID
+      const createRedirectURLSpy = jest.spyOn(
+        MockMyInfoService,
+        'createRedirectURL',
+      )
+
+      const mockRes = expressHandler.mockResponse()
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
+
+      createRedirectURLSpy.mockReturnValueOnce(ok(MOCK_REDIRECT_URL))
+      // Act
+      await PublicFormController._handleFormAuthRedirect(
+        MOCK_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(createRedirectURLSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formEsrvcId: DEFAULT_ESRVC_ID,
+        }),
+      )
       expect(mockRes.status).toHaveBeenCalledWith(200)
       expect(mockRes.json).toHaveBeenCalledWith({
         redirectURL: MOCK_REDIRECT_URL,
@@ -1304,58 +1360,6 @@ describe('public-form.controller', () => {
       expect(mockRes.json).toHaveBeenCalledWith({
         message:
           'Please ensure that the form has authentication enabled. Please refresh and try again.',
-      })
-    })
-
-    it('should return 400 when the form has authType MyInfo and is missing esrvcId', async () => {
-      // Arrange
-      const MOCK_FORM = {
-        authType: FormAuthType.MyInfo,
-      } as unknown as MyInfoForm<IFormDocument>
-
-      const mockRes = expressHandler.mockResponse()
-      MockFormService.retrieveFullFormById.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-
-      // Act
-      await PublicFormController._handleFormAuthRedirect(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
-
-      // Assert
-      expect(mockRes.status).toHaveBeenCalledWith(400)
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message:
-          'This form does not have a valid eServiceId. Please refresh and try again.',
-      })
-    })
-
-    it('should return 400 when the form has authType SP and is missing esrvcId', async () => {
-      // Arrange
-      const MOCK_FORM = {
-        authType: FormAuthType.SP,
-      } as unknown as SpcpForm<IFormDocument>
-
-      const mockRes = expressHandler.mockResponse()
-      MockFormService.retrieveFullFormById.mockReturnValueOnce(
-        okAsync(MOCK_FORM),
-      )
-
-      // Act
-      await PublicFormController._handleFormAuthRedirect(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
-
-      // Assert
-      expect(mockRes.status).toHaveBeenCalledWith(400)
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message:
-          'This form does not have a valid eServiceId. Please refresh and try again.',
       })
     })
 

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -35,7 +35,7 @@ import { MyInfoService } from '../../myinfo/myinfo.service'
 import {
   createMyInfoLoginCookie,
   extractAuthCode,
-  validateMyInfoForm,
+  getMyInfoEserviceIdInForm,
 } from '../../myinfo/myinfo.util'
 import { SGIDMyInfoData } from '../../sgid/sgid.adapter'
 import {
@@ -663,9 +663,9 @@ export const _handleFormAuthRedirect: ControllerHandler<
       formAuthType = form.authType
       switch (form.authType) {
         case FormAuthType.MyInfo:
-          return validateMyInfoForm(form).andThen((form) =>
+          return getMyInfoEserviceIdInForm(form).andThen(([form, eserviceId]) =>
             MyInfoService.createRedirectURL({
-              formEsrvcId: form.esrvcId,
+              formEsrvcId: eserviceId,
               formId,
               requestedAttributes: form.getUniqueMyInfoAttrs(),
               encodedQuery,

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -2,8 +2,8 @@ import { HttpStatusCode } from 'axios'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 import { err, ok, Result } from 'neverthrow'
-import { featureFlags } from 'shared/constants'
 
+import { featureFlags } from '../../../../../shared/constants'
 import {
   ErrorCode,
   ErrorDto,

--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -2,6 +2,7 @@ import { HttpStatusCode } from 'axios'
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
 import { err, ok, Result } from 'neverthrow'
+import { featureFlags } from 'shared/constants'
 
 import {
   ErrorCode,
@@ -661,15 +662,19 @@ export const _handleFormAuthRedirect: ControllerHandler<
   return FormService.retrieveFullFormById(formId)
     .andThen((form) => {
       formAuthType = form.authType
+      const useFormsgEsrvcId = req.growthbook?.isOn(
+        featureFlags.useFormsgEsrvcId,
+      )
       switch (form.authType) {
         case FormAuthType.MyInfo:
-          return getMyInfoEserviceIdInForm(form).andThen(([form, eserviceId]) =>
-            MyInfoService.createRedirectURL({
-              formEsrvcId: eserviceId,
-              formId,
-              requestedAttributes: form.getUniqueMyInfoAttrs(),
-              encodedQuery,
-            }),
+          return getMyInfoEserviceIdInForm(form, useFormsgEsrvcId).andThen(
+            ([form, eserviceId]) =>
+              MyInfoService.createRedirectURL({
+                formEsrvcId: eserviceId,
+                formId,
+                requestedAttributes: form.getUniqueMyInfoAttrs(),
+                encodedQuery,
+              }),
           )
         case FormAuthType.SP: {
           return validateSpcpForm(form).asyncAndThen((form) => {

--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -1,5 +1,6 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
+import { featureFlags } from 'shared/constants'
 
 import { Environment } from '../../../types'
 import config from '../../config/config'
@@ -47,8 +48,9 @@ export const respondWithRedirectURL: ControllerHandler<
   { formId: string; encodedQuery?: string }
 > = async (req, res) => {
   const { formId, encodedQuery } = req.query
+  const useFormsgEsrvcId = req.growthbook?.isOn(featureFlags.useFormsgEsrvcId)
   return FormService.retrieveFormById(formId)
-    .andThen((form) => getMyInfoEserviceIdInForm(form))
+    .andThen((form) => getMyInfoEserviceIdInForm(form, useFormsgEsrvcId))
     .andThen(([form, eserviceId]) =>
       MyInfoService.createRedirectURL({
         formEsrvcId: eserviceId,

--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -1,7 +1,7 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { StatusCodes } from 'http-status-codes'
-import { featureFlags } from 'shared/constants'
 
+import { featureFlags } from '../../../../shared/constants'
 import { Environment } from '../../../types'
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'

--- a/src/app/modules/myinfo/myinfo.controller.ts
+++ b/src/app/modules/myinfo/myinfo.controller.ts
@@ -18,7 +18,7 @@ import {
   MyInfoAuthCodeCookieState,
   MyInfoAuthCodeSuccessPayload,
 } from './myinfo.types'
-import { mapRedirectURLError, validateMyInfoForm } from './myinfo.util'
+import { getMyInfoEserviceIdInForm, mapRedirectURLError } from './myinfo.util'
 
 const logger = createLoggerWithLabel(module)
 
@@ -48,10 +48,10 @@ export const respondWithRedirectURL: ControllerHandler<
 > = async (req, res) => {
   const { formId, encodedQuery } = req.query
   return FormService.retrieveFormById(formId)
-    .andThen((form) => validateMyInfoForm(form))
-    .andThen((form) =>
+    .andThen((form) => getMyInfoEserviceIdInForm(form))
+    .andThen(([form, eserviceId]) =>
       MyInfoService.createRedirectURL({
-        formEsrvcId: form.esrvcId,
+        formEsrvcId: eserviceId,
         formId,
         requestedAttributes: form.getUniqueMyInfoAttrs(),
         encodedQuery,

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -61,12 +61,12 @@ import {
   createRelayState,
   getMyInfoAttr,
   getMyInfoAttributeConstantsList,
+  getMyInfoEserviceIdInForm,
   hashFieldValues,
   isMyInfoChildrenBirthRecords,
   isMyInfoLoginCookie,
   isMyInfoRelayState,
   logIfFieldValueNotInMyinfoList,
-  validateMyInfoForm,
 } from './myinfo.util'
 import getMyInfoHashModel from './myinfo_hash.model'
 
@@ -500,13 +500,13 @@ export class MyInfoServiceClass {
     | MyInfoFetchError
   > {
     const requestedAttributes = form.getUniqueMyInfoAttrs()
-    return validateMyInfoForm(form).asyncAndThen((form) =>
+    return getMyInfoEserviceIdInForm(form).asyncAndThen(([, eserviceId]) =>
       ResultAsync.fromPromise(
         this.#myInfoPersonBreaker
           .fire(
             accessToken,
             internalAttrListToScopes(requestedAttributes),
-            form.esrvcId,
+            eserviceId,
           )
           .then((response) => new MyInfoData(response)),
         (error) => {

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -314,26 +314,27 @@ export const createRelayState = (
   })
 
 /**
- * Validates that a form is a MyInfo form with an e-service ID
+ * returns form with an e-service ID if form is a MyInfo form
  * @param form Form to validate
  */
-export const validateMyInfoForm = <T extends IFormSchema>(
+export const getMyInfoEserviceIdInForm = <T extends IFormSchema>(
   form: T,
-): Result<MyInfoForm<T>, FormAuthNoEsrvcIdError | AuthTypeMismatchError> => {
-  if (!form.esrvcId) {
-    return err(new FormAuthNoEsrvcIdError(form._id))
-  }
-  if (isMyInfoFormWithEsrvcId(form)) {
-    return ok(form)
+): Result<
+  [MyInfoForm<T>, string],
+  FormAuthNoEsrvcIdError | AuthTypeMismatchError
+> => {
+  if (isMyInfoForm(form)) {
+    const esrvcId = form.esrvcId || spcpMyInfoConfig.spEsrvcId
+    return ok([form, esrvcId])
   }
   return err(new AuthTypeMismatchError(FormAuthType.MyInfo, form.authType))
 }
 
-// Typeguard to ensure that form has eserviceId and MyInfo authType
-const isMyInfoFormWithEsrvcId = <F extends IFormSchema>(
+// Typeguard to ensure that form is MyInfo authType
+const isMyInfoForm = <F extends IFormSchema>(
   form: F,
 ): form is MyInfoForm<F> => {
-  return form.authType === FormAuthType.MyInfo && !!form.esrvcId
+  return form.authType === FormAuthType.MyInfo
 }
 
 /**

--- a/src/app/modules/myinfo/myinfo.util.ts
+++ b/src/app/modules/myinfo/myinfo.util.ts
@@ -319,12 +319,15 @@ export const createRelayState = (
  */
 export const getMyInfoEserviceIdInForm = <T extends IFormSchema>(
   form: T,
+  useFormsgEsrvcId?: boolean,
 ): Result<
   [MyInfoForm<T>, string],
   FormAuthNoEsrvcIdError | AuthTypeMismatchError
 > => {
   if (isMyInfoForm(form)) {
-    const esrvcId = form.esrvcId || spcpMyInfoConfig.spEsrvcId
+    const esrvcId = useFormsgEsrvcId
+      ? spcpMyInfoConfig.spEsrvcId
+      : form.esrvcId || spcpMyInfoConfig.spEsrvcId
     return ok([form, esrvcId])
   }
   return err(new AuthTypeMismatchError(FormAuthType.MyInfo, form.authType))

--- a/src/app/routes/api/v3/forms/__tests__/public-forms.auth.routes.spec.ts
+++ b/src/app/routes/api/v3/forms/__tests__/public-forms.auth.routes.spec.ts
@@ -180,17 +180,15 @@ describe('public-form.auth.routes', () => {
       expect(response.body).toEqual(expectedResponse)
     })
 
-    it('should return 400 with the redirect URL when the form has no esrvcId', async () => {
+    it('should return 200 with the redirect URL when the form has no esrvcId', async () => {
       // Arrange
-      const { form } = await dbHandler.insertEmailForm({
+      const FORM_ESRVC_ID = 'MOCKED_FORM_ESRVC_ID'
+      const { form } = await dbHandler.insertEncryptForm({
         formOptions: {
           authType: FormAuthType.MyInfo,
           status: FormStatus.Public,
+          esrvcId: FORM_ESRVC_ID,
         },
-      })
-      const expectedResponse = jsonParseStringify({
-        message:
-          'This form does not have a valid eServiceId. Please refresh and try again.',
       })
 
       // Act
@@ -199,8 +197,13 @@ describe('public-form.auth.routes', () => {
         .query({ isPersistentLogin: false })
 
       // Assert
-      expect(response.status).toEqual(StatusCodes.BAD_REQUEST)
-      expect(response.body).toEqual(expectedResponse)
+      expect(response.status).toEqual(StatusCodes.OK)
+      expect(response.body).toMatchObject({
+        redirectURL: expect.toIncludeMultiple([
+          String(form._id),
+          form.esrvcId!,
+        ]),
+      })
     })
 
     it('should return 404 when the form is not in the database', async () => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- Admins can create Singpass forms and set to options that will be collapsed
- We want to mitigate migration risks that will happen on Sept 5 by allowing admins to switch their forms earlier

Closes FRM-2139

## Solution
<!-- How did you solve the problem? -->

- Hide collapsed options to prevent admins selected collapsed options
- Only show options that were hidden so that admins can only switch to offered options

```
Singpass App-only Login           | NA // Removed
Singpass App-only with Myinfo     | NA // Removed
Singpass                          | NA // Removed
Singpass with Myinfo              | Singpass  // renamed
Singpass (Corporate)              | Corppass
```


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->
