### PR TITLE
fix(ui): respondent copy padding

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -259,7 +259,7 @@ export const FormFields = ({
         <PublicFormPaymentResumeModal />
         {/* TODO: (respondent copy): Remove when respondent copy is out of beta */}
         {form?.hasRespondentCopy && isRespondentCopyEnabled ? (
-          <Box mt="2.5rem">
+          <Box mt="2.5rem" px={{ base: '1rem', md: 0 }}>
             <PublicRespondentEmailField />
           </Box>
         ) : null}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Respondent copy fields on Mobile and Responsive layouts incorrectly follow the top-level section margins visually.

Closes FRM-2144

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Use the padding values common to the submit button and the section above

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

![respondent-copy-padding-before](https://github.com/user-attachments/assets/36ae119f-0409-4625-9a8d-06eeb813395f)

**AFTER**:
<!-- [insert screenshot here] -->

![respondent-copy-padding-after](https://github.com/user-attachments/assets/1862a636-43d3-4049-bb6e-e6d1b53f3528)

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Check alignment on desktop view**
- [x] Using an account with the respondentCopy beta flag, create a form
- [x] Enable respondent copy in the email notification settings
- [x] Visit the form on a desktop browser
- [x] Check that the respondent copy field aligns with the submit button

**TC2: Check alignment on mobile / responsive layouts**
- [x] Visit the same form using a mobile device
- [x] Check that the respondent copy field aligns with the submit button

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
