### PR TITLE
fix(ui): disabled others field

### DIFF
--- a/frontend/src/components/Checkbox/Checkbox.tsx
+++ b/frontend/src/components/Checkbox/Checkbox.tsx
@@ -70,6 +70,7 @@ export interface CheckboxOthersWrapperProps {
   colorScheme?: FieldColorScheme
   size?: string
   children: ReactNode
+  disabled?: boolean
 }
 
 /**
@@ -86,7 +87,9 @@ const OthersWrapper = ({
 
   return (
     <CheckboxOthersContext.Provider value={{ checkboxRef, inputRef }}>
-      <Box __css={styles.othersContainer}>{children}</Box>
+      <Box __css={styles.othersContainer} aria-disabled={props.disabled}>
+        {children}
+      </Box>
     </CheckboxOthersContext.Provider>
   )
 }

--- a/frontend/src/components/Radio/Radio.tsx
+++ b/frontend/src/components/Radio/Radio.tsx
@@ -331,6 +331,7 @@ export const OthersInput = forwardRef<InputProps, 'input'>(
 
 export interface OthersProps extends RadioProps {
   children: React.ReactNode
+  disabled?: boolean
 }
 
 const OthersWrapper = forwardRef<OthersProps, 'input'>(
@@ -341,7 +342,7 @@ const OthersWrapper = forwardRef<OthersProps, 'input'>(
     })
 
     return (
-      <Box __css={styles.othersContainer}>
+      <Box __css={styles.othersContainer} aria-disabled={props.disabled}>
         <OthersRadio {...props} ref={ref} />
         {children}
       </Box>

--- a/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -132,7 +132,10 @@ export const CheckboxField = ({
                 <input type="checkbox" hidden value="" />
               ) : null}
               {schema.othersRadioButton ? (
-                <Checkbox.OthersWrapper colorScheme={fieldColorScheme}>
+                <Checkbox.OthersWrapper
+                  colorScheme={fieldColorScheme}
+                  disabled={schema.disabled}
+                >
                   <FormControl
                     isRequired={schema.required}
                     isDisabled={schema.disabled}

--- a/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -131,6 +131,7 @@ export const RadioField = ({
                 colorScheme={fieldColorScheme}
                 value={RADIO_OTHERS_INPUT_VALUE}
                 isHighContrast={isHighContrast}
+                disabled={schema.disabled}
               >
                 <FormControl
                   isRequired={schema.required}

--- a/frontend/src/theme/components/Checkbox.ts
+++ b/frontend/src/theme/components/Checkbox.ts
@@ -39,6 +39,7 @@ const baseStyle: PartsStyleFunction<typeof parts> = ({
     _disabled: {
       borderColor: getColor(theme, `neutral.500`),
       bg: 'white',
+      cursor: 'not-allowed',
       _checked: {
         borderColor: getColor(theme, `neutral.500`),
         bg: getColor(theme, `neutral.500`),
@@ -124,6 +125,9 @@ const variantFullWidth: PartsStyleFunction<typeof parts> = (props) => {
       borderRadius: '4px',
       _hover: {
         bg: `${getColor(props.theme, `${props.colorScheme}.100`)}`,
+        _disabled: {
+          bg: 'none',
+        },
       },
       _active: {
         bg: `${getColor(props.theme, `${props.colorScheme}.200`)}`,

--- a/frontend/src/theme/components/Radio.ts
+++ b/frontend/src/theme/components/Radio.ts
@@ -105,11 +105,11 @@ export const Radio: ComponentMultiStyleConfig<typeof parts> = {
         boxShadow: `inset 0 0 0 0.125rem ${getColor(theme, `${c}.500`)}`,
       },
       _disabled: {
-        bg: 'white',
+        bg: 'none',
         color: 'neutral.500',
         cursor: 'not-allowed',
         _hover: {
-          bg: 'white',
+          bg: 'none',
         },
       },
     },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Form respondents could be confused by conflicting cues when disabled and hover states are not correctly applied to inputs.
When filling in a multi-respondent form, disabled fields belonging to another respondent still respond to the user's hover state.

Closes FRM-2130

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- propagate the `disabled` prop to the `aria-disabled` attribute on the `Box` container
- fix hover + disabled styles:
  - `not-allowed` cursor state
  - `bg` should be none

## Before & After Screenshots

> [!NOTE]
> The screen capture doesn't correctly record the `not-allowed` cursor, which behaves correctly under normal circumstances.

**BEFORE**:
<!-- [insert screenshot here] -->

![others-hover-disabled-before](https://github.com/user-attachments/assets/f9e29e00-dee7-4ca3-8b03-c5d4935f19a9)

**AFTER**:
<!-- [insert screenshot here] -->

![others-hover-disabled-after](https://github.com/user-attachments/assets/715ecff4-af14-4774-8947-b37a8c807005)

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC: Verify that disabled Radio / Checkbox fields have the correct hover interaction**
- [x] Create a Multi-Respondent Form with three fields: one text field, one checkbox, and one radio field
- [x] Enable 'Others' for both checkbox and radio fields
- [x] Create a workflow and assign the text field to the first respondent, and the checkbox / radio fields to the second respondent.
- [x] Set the Form to OPEN and visit the Form
- [x] Observe that the Checkbox's Other field should have no hover background and a `not-allowed` cursor.
- [x] Observe that the Radio's Other field should have no hover background and a `not-allowed` cursor.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
