### PR TITLE
fix: updated payment pdf to include gst

### DIFF
--- a/src/app/modules/payments/stripe.utils.ts
+++ b/src/app/modules/payments/stripe.utils.ts
@@ -508,8 +508,8 @@ export const convertToProofOfPaymentFormat = (
           `<strong>Amount charged</strong> <i>(includes GST)</i>`,
         )
         .replace(
-          '<strong>Amount paid</strong>',
-          `<strong>Amount paid</strong> <i>(includes GST)</i>`,
+          /(<strong>Amount paid<\/strong>|Amount paid)/g,
+          '$1 <i>(includes GST)</i>',
         )
     : paymentByProductsEdits
         .replace(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

**7 months back**
- stripe updated their receipt from Amount charged (bold) to Amount paid  (bold)
- [fix](https://github.com/opengovsg/FormSG/pull/8109) was made to look for this string, and attach (includes GST) behind

**recently**
- stripe updated their Amount paid (bold) to Amount paid (no bold)
- original fix that looks for Amount paid (bold) doesn't find it in the receipt, so we don't attach (includes GST)

Closes [insert issue #]

## Solution
<!-- How did you solve the problem? -->

Update regex to search for "Amount paid" regardless of form text style, causing (include GST) to always be included

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| **BEFORE**| **AFTER**: |
| --- | --- |
| <img width="816" height="817" alt="Screenshot 2025-09-04 at 10 26 24 AM" src="https://github.com/user-attachments/assets/9742afff-9135-43fe-9c3d-a49a47a05c91" /> | <img width="825" height="776" alt="Screenshot 2025-09-04 at 10 23 04 AM" src="https://github.com/user-attachments/assets/7a5d4b3a-213f-48f4-8cad-062de6dd48c6" /> |


## Tests
<!-- What tests should be run to confirm functionality? -->

**Verify (includes GST) is present**
-  [x] Find an existing payments form/ creating a payment form
-  [x] Make a submission with payment
-  [x] Go to the received 'payment successful' email and view proof
-  [x] Verify that "Amount Paid" has "(includes GST)" in the string
