### PR TITLE
fix: use esrvcid myinfo retrieval

### DIFF
--- a/src/app/modules/form/public-form/public-form.controller.ts
+++ b/src/app/modules/form/public-form/public-form.controller.ts
@@ -207,10 +207,11 @@ export const handleGetPublicForm: ControllerHandler<
         MYINFO_AUTH_CODE_COOKIE_NAME,
         MYINFO_AUTH_CODE_COOKIE_OPTIONS,
       )
+      const useEsrvcId = req.growthbook?.isOn(featureFlags.useFormsgEsrvcId)
       const myInfoFieldsResult = await extractAuthCode(authCodeCookie)
         .asyncAndThen((authCode) => MyInfoService.retrieveAccessToken(authCode))
         .andThen((accessToken) =>
-          MyInfoService.getMyInfoDataForForm(form, accessToken),
+          MyInfoService.getMyInfoDataForForm(form, accessToken, useEsrvcId),
         )
 
       if (myInfoFieldsResult.isErr()) {

--- a/src/app/modules/myinfo/myinfo.service.ts
+++ b/src/app/modules/myinfo/myinfo.service.ts
@@ -492,6 +492,7 @@ export class MyInfoServiceClass {
   getMyInfoDataForForm(
     form: IPopulatedForm,
     accessToken: string,
+    useEsrvcID?: boolean,
   ): ResultAsync<
     MyInfoData,
     | FormAuthNoEsrvcIdError
@@ -500,37 +501,38 @@ export class MyInfoServiceClass {
     | MyInfoFetchError
   > {
     const requestedAttributes = form.getUniqueMyInfoAttrs()
-    return getMyInfoEserviceIdInForm(form).asyncAndThen(([, eserviceId]) =>
-      ResultAsync.fromPromise(
-        this.#myInfoPersonBreaker
-          .fire(
-            accessToken,
-            internalAttrListToScopes(requestedAttributes),
-            eserviceId,
-          )
-          .then((response) => new MyInfoData(response)),
-        (error) => {
-          const logMeta = {
-            action: 'getMyInfoDataForForm',
-            requestedAttributes,
-          }
-          if (CircuitBreaker.isOurError(error)) {
-            logger.error({
-              message: 'Circuit breaker tripped',
-              meta: logMeta,
-              error,
-            })
-            return new MyInfoCircuitBreakerError()
-          } else {
-            logger.error({
-              message: 'Error retrieving data from MyInfo',
-              meta: logMeta,
-              error,
-            })
-            return new MyInfoFetchError()
-          }
-        },
-      ),
+    return getMyInfoEserviceIdInForm(form, useEsrvcID).asyncAndThen(
+      ([, eserviceId]) =>
+        ResultAsync.fromPromise(
+          this.#myInfoPersonBreaker
+            .fire(
+              accessToken,
+              internalAttrListToScopes(requestedAttributes),
+              eserviceId,
+            )
+            .then((response) => new MyInfoData(response)),
+          (error) => {
+            const logMeta = {
+              action: 'getMyInfoDataForForm',
+              requestedAttributes,
+            }
+            if (CircuitBreaker.isOurError(error)) {
+              logger.error({
+                message: 'Circuit breaker tripped',
+                meta: logMeta,
+                error,
+              })
+              return new MyInfoCircuitBreakerError()
+            } else {
+              logger.error({
+                message: 'Error retrieving data from MyInfo',
+                meta: logMeta,
+                error,
+              })
+              return new MyInfoFetchError()
+            }
+          },
+        ),
     )
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

MyInfo Person API retrieval requests were using the wrong E-Service ID

Closes [insert issue #]

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Propagate and use the feature flag correctly to toggle the E-Service ID

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

