### PR TITLE
fix: high contrast UI fixes part 2

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
@@ -32,7 +32,7 @@ const FormEmailSectionContainer = ({
   settings,
 }: FormEmailSectionContainerProps): JSX.Element => {
   if (settings.responseMode === FormResponseMode.Multirespondent) {
-    return <MrfFormEmailSection isDisabled={isDisabled} settings={settings} />
+    return <MrfFormEmailSection isDisabled={isDisabled} settings={settings}/>
   }
   return <FormEmailSection isDisabled={isDisabled} settings={settings} />
 }

--- a/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsEmailsPage.tsx
@@ -32,7 +32,7 @@ const FormEmailSectionContainer = ({
   settings,
 }: FormEmailSectionContainerProps): JSX.Element => {
   if (settings.responseMode === FormResponseMode.Multirespondent) {
-    return <MrfFormEmailSection isDisabled={isDisabled} settings={settings}/>
+    return <MrfFormEmailSection isDisabled={isDisabled} settings={settings} />
   }
   return <FormEmailSection isDisabled={isDisabled} settings={settings} />
 }

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -153,7 +153,10 @@ export const FormEmailSection = ({
               'features.adminForm.settings.emailNotifications.section.regular.label',
             )}
           </FormLabel>
-          <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} isDisabled={isDisabled} />
+          <AdminEmailRecipientsInput
+            onSubmit={handleSubmitEmails}
+            isDisabled={isDisabled}
+          />
           <FormErrorMessage>{get(errors, 'emails.message')}</FormErrorMessage>
           {isEmpty(errors) ? (
             <FormLabel.Description

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -162,7 +162,7 @@ export const FormEmailSection = ({
             <FormLabel.Description
               color="secondary.400"
               mt="0.5rem"
-              opacity={'1'}
+              opacity='1'
             >
               {t(
                 'features.adminForm.settings.emailNotifications.section.regular.description',

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -162,7 +162,7 @@ export const FormEmailSection = ({
             <FormLabel.Description
               color="secondary.400"
               mt="0.5rem"
-              opacity='1'
+              opacity="1"
             >
               {t(
                 'features.adminForm.settings.emailNotifications.section.regular.description',

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -36,16 +36,19 @@ import { RespondentCopyToggle } from './EmailNotificationsSection/RespondentCopy
 interface EmailFormSectionProps {
   isDisabled: boolean
   settings: EmailFormSettings | StorageFormSettings
+  isHighContrast?: boolean
 }
 
 interface AdminEmailRecipientsInputProps {
   onSubmit: (params: { emails: string[] }) => void
+  isDisabled: boolean
 }
 
 const EMAILS_FIELD_NAME = 'emails'
 
 const AdminEmailRecipientsInput = ({
   onSubmit,
+  isDisabled,
 }: AdminEmailRecipientsInputProps): JSX.Element => {
   const { getValues, setValue, control, handleSubmit } = useFormContext<{
     emails: string[]
@@ -85,7 +88,7 @@ const AdminEmailRecipientsInput = ({
       }
       render={({ field }) => (
         <TagInput
-          placeholder={emailsFieldPlaceholder}
+          placeholder={isDisabled ? undefined : emailsFieldPlaceholder}
           {...field}
           value={field.value as string[]}
           tagValidation={isEmail}
@@ -99,6 +102,7 @@ const AdminEmailRecipientsInput = ({
 export const FormEmailSection = ({
   isDisabled,
   settings,
+  isHighContrast = true,
 }: EmailFormSectionProps): JSX.Element => {
   //TODO: (Respondent Copy): Remove isTest and user when respondent copy is out of beta
   const { user } = useUser()
@@ -143,18 +147,19 @@ export const FormEmailSection = ({
             isRequired={isEmailMode}
             useMarkdownForDescription
             description={DESCRIPTION_TEXT}
+            isHighContrast={isHighContrast}
           >
             {t(
               'features.adminForm.settings.emailNotifications.section.regular.label',
             )}
           </FormLabel>
-          <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} />
+          <AdminEmailRecipientsInput onSubmit={handleSubmitEmails} isDisabled={isDisabled} />
           <FormErrorMessage>{get(errors, 'emails.message')}</FormErrorMessage>
           {isEmpty(errors) ? (
             <FormLabel.Description
               color="secondary.400"
               mt="0.5rem"
-              opacity={isDisabled ? '0.3' : '1'}
+              opacity={'1'}
             >
               {t(
                 'features.adminForm.settings.emailNotifications.section.regular.description',

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -29,6 +29,7 @@ import { RespondentCopyToggle } from './EmailNotificationsSection/RespondentCopy
 interface MrfEmailNotificationsFormProps {
   settings: MultirespondentFormSettings
   isDisabled: boolean
+  isHighContrast: boolean
 }
 
 const WORKFLOW_EMAIL_MULTISELECT_NAME = 'email-multi-select'
@@ -45,6 +46,7 @@ interface FormData {
 const MrfEmailNotificationsForm = ({
   settings,
   isDisabled,
+  isHighContrast,
 }: MrfEmailNotificationsFormProps) => {
   const { t } = useTranslation()
   const {
@@ -217,7 +219,7 @@ const MrfEmailNotificationsForm = ({
                   values={values}
                   onChange={onChange}
                   onBlur={handleSubmit(onSubmit)}
-                  placeholder={t(
+                  placeholder={isDisabled ? null : t(
                     'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.placeholder',
                   )}
                   isSelectedItemFullWidth
@@ -242,6 +244,7 @@ const MrfEmailNotificationsForm = ({
             tooltipText={t(
               'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
             )}
+            isHighContrast={isHighContrast}
           >
             {t(
               'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
@@ -255,7 +258,7 @@ const MrfEmailNotificationsForm = ({
             }
             render={({ field }) => (
               <TagInput
-                placeholder={otherPartiesEmailInputPlaceholder}
+                placeholder={isDisabled ? undefined : otherPartiesEmailInputPlaceholder}
                 {...field}
                 value={field.value as string[]}
                 isDisabled={isDisabled}
@@ -291,15 +294,17 @@ const MrfEmailNotificationsForm = ({
 interface MrfFormEmailSectionProps {
   settings: MultirespondentFormSettings
   isDisabled: boolean
+  isHighContrast: boolean
 }
 
 export const MrfFormEmailSection = ({
   settings,
   isDisabled,
+  isHighContrast = true,
 }: MrfFormEmailSectionProps): JSX.Element => {
   return (
-    <Box opacity={isDisabled ? 0.3 : 1}>
-      <MrfEmailNotificationsForm settings={settings} isDisabled={isDisabled} />
+    <Box opacity={1}>
+      <MrfEmailNotificationsForm settings={settings} isDisabled={isDisabled} isHighContrast={isHighContrast} />
     </Box>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -294,7 +294,7 @@ const MrfEmailNotificationsForm = ({
 interface MrfFormEmailSectionProps {
   settings: MultirespondentFormSettings
   isDisabled: boolean
-  isHighContrast: boolean
+  isHighContrast?: boolean
 }
 
 export const MrfFormEmailSection = ({

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -219,9 +219,13 @@ const MrfEmailNotificationsForm = ({
                   values={values}
                   onChange={onChange}
                   onBlur={handleSubmit(onSubmit)}
-                  placeholder={isDisabled ? null : t(
-                    'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.placeholder',
-                  )}
+                  placeholder={
+                    isDisabled
+                      ? null
+                      : t(
+                          'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.placeholder',
+                        )
+                  }
                   isSelectedItemFullWidth
                   isDisabled={isLoading || isDisabled}
                   {...rest}
@@ -258,7 +262,9 @@ const MrfEmailNotificationsForm = ({
             }
             render={({ field }) => (
               <TagInput
-                placeholder={isDisabled ? undefined : otherPartiesEmailInputPlaceholder}
+                placeholder={
+                  isDisabled ? undefined : otherPartiesEmailInputPlaceholder
+                }
                 {...field}
                 value={field.value as string[]}
                 isDisabled={isDisabled}
@@ -304,7 +310,11 @@ export const MrfFormEmailSection = ({
 }: MrfFormEmailSectionProps): JSX.Element => {
   return (
     <Box opacity={1}>
-      <MrfEmailNotificationsForm settings={settings} isDisabled={isDisabled} isHighContrast={isHighContrast} />
+      <MrfEmailNotificationsForm
+        settings={settings}
+        isDisabled={isDisabled}
+        isHighContrast={isHighContrast}
+      />
     </Box>
   )
 }

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -18,6 +18,7 @@ import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 import { FieldFactory } from './FieldFactory'
 import { PrefillMap } from './FormFields'
 import { useFormSections } from './FormSectionsContext'
+import { isMyInfo } from '~features/myinfo/utils'
 
 interface VisibleFormFieldsProps {
   control: Control<FormFieldValues>
@@ -78,7 +79,7 @@ export const VisibleFormFields = ({
           disableRequiredValidation={
             !isFieldEnabledByWorkflow(workflowStep, field)
           }
-          isHighContrast={!isFieldEnabledByWorkflow(workflowStep, field)}
+          isHighContrast={!isFieldEnabledByWorkflow(workflowStep, field) || isMyInfo(field)}
           key={field._id}
           prefill={fieldPrefillMap[field._id]}
         />

--- a/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/VisibleFormFields.tsx
@@ -13,12 +13,12 @@ import { FormFieldWithQuestionNo } from '~features/form/types'
 import { augmentWithQuestionNo } from '~features/form/utils'
 import { isFieldEnabledByWorkflow } from '~features/form/utils/augmentWithWorkflowDisabling'
 import { getVisibleFieldIds } from '~features/logic/utils'
+import { isMyInfo } from '~features/myinfo/utils'
 import { usePublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { FieldFactory } from './FieldFactory'
 import { PrefillMap } from './FormFields'
 import { useFormSections } from './FormSectionsContext'
-import { isMyInfo } from '~features/myinfo/utils'
 
 interface VisibleFormFieldsProps {
   control: Control<FormFieldValues>
@@ -79,7 +79,9 @@ export const VisibleFormFields = ({
           disableRequiredValidation={
             !isFieldEnabledByWorkflow(workflowStep, field)
           }
-          isHighContrast={!isFieldEnabledByWorkflow(workflowStep, field) || isMyInfo(field)}
+          isHighContrast={
+            !isFieldEnabledByWorkflow(workflowStep, field) || isMyInfo(field)
+          }
           key={field._id}
           prefill={fieldPrefillMap[field._id]}
         />

--- a/frontend/src/theme/components/SingleSelect.ts
+++ b/frontend/src/theme/components/SingleSelect.ts
@@ -71,6 +71,9 @@ const baseStyle: PartsStyleFunction<typeof parts> = (props) => {
       color: 'secondary.500',
       borderRightRadius: '4px',
       borderLeftRadius: 0,
+      _hover: {
+        bg: 'white',
+      },
     },
     icon: {
       transitionProperty: 'common',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There are inconsistencies with disabled states across multiple fields.

## Solution
<!-- How did you solve the problem? -->

- Removed opacity differentiation when component is disabled
- Introduced `isHighContrast` boolean to make disabled color and bg color consistent
- Remove placeholder text by conditionally showing based on `isDisabled` 

Changes are related to the outstanding items in the PRD not worked on in [part 1](https://github.com/opengovsg/FormSG/pull/8665). These include:
1. MyInfo fields
2. Storage & MRF mode email settings page
3. Dropdown field cancel button disabled bg change on hover

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | --- | --- |
| MyInfo highContrast | <img width="991" height="756" alt="image" src="https://github.com/user-attachments/assets/b17917ce-f3f5-4584-9b52-ac1c235054a1" /> | <img width="1069" height="667" alt="image" src="https://github.com/user-attachments/assets/cbbceddb-bba5-400a-8e0e-08e9d1df9aad" /> |
| Storage mode disabled settings page | <img width="779" height="405" alt="image" src="https://github.com/user-attachments/assets/01185292-5497-44a8-a03a-74811beebaf0" /> | <img width="776" height="431" alt="image" src="https://github.com/user-attachments/assets/23342f38-c3a9-4c4b-915e-b8f3d53e7e3a" /> |
| MRF mode disabled settings page | <img width="790" height="632" alt="image" src="https://github.com/user-attachments/assets/91979111-9848-42e4-9e4b-507f57108f6e" /> | <img width="808" height="630" alt="image" src="https://github.com/user-attachments/assets/9eeb6a92-d107-4eec-be30-37a4553d1625" /> | 
