### PR TITLE
fix: add env variable for prod samconfig

### DIFF
--- a/serverless/pdf-gen-sparticuz/samconfig.yaml
+++ b/serverless/pdf-gen-sparticuz/samconfig.yaml
@@ -63,3 +63,4 @@ production:
       image_repositories: [] 
       disable_rollback: false # Rolls back to previous version if the deployment fails 
       confirm_changeset: true
+      parameter_overrides: Environment=production


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Previously missed out setting the env, causing the lambda to use the fallback `dev` env. 

## Solution
<!-- How did you solve the problem? -->
Set the env as `production`. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  