### PR TITLE
fix: home number fields are added to the draft despite not being modified 

### DIFF
--- a/frontend/src/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/frontend/src/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -89,7 +89,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, 'input'>(
       allowInternational,
       onChange,
       onBlur,
-      defaultValue: value,
+      defaultValue: value ?? '',
       examples,
       examplePlaceholder,
       placeholder: props.placeholder,

--- a/frontend/src/components/PhoneNumberInput/PhoneNumberInputContext.tsx
+++ b/frontend/src/components/PhoneNumberInput/PhoneNumberInputContext.tsx
@@ -18,7 +18,7 @@ import {
 import defaultExamples from 'libphonenumber-js/examples.mobile.json'
 
 type PhoneNumberInputContextProps = {
-  defaultValue?: string
+  defaultValue: string
   defaultCountry: CountryCode
   /**
    * Set the input's placeholder to an example number for the selected country,
@@ -117,7 +117,7 @@ const useProvidePhoneNumberInput = ({
   ...props
 }: PhoneNumberInputContextProps): PhoneNumberInputContextReturn => {
   // Internal states of the component.
-  const [inputValue, setInputValue] = useState(defaultValue ?? '')
+  const [inputValue, setInputValue] = useState(defaultValue)
   const [country, setCountry] = useState(defaultCountry)
 
   // Refs of the phone number input so focus can be passed to the input when
@@ -169,9 +169,7 @@ const useProvidePhoneNumberInput = ({
         setInputValue(newValue)
       }
 
-      const number = formatter.getNumber()
-
-      const e164 = number?.number as string | undefined
+      const e164 = formatter.getNumber()?.number ?? ''
       onChange(e164)
 
       // On a similar vein, do not set country even if the country has changed
@@ -206,13 +204,14 @@ const useProvidePhoneNumberInput = ({
 
   const handleFormatInput = useCallback(() => {
     const number = formatter.getNumber()
+    const e164 = number?.number ?? ''
 
     // Trigger on change again in case formatted number changes.
     // This can happen in the following scenario:
     // 1. `onInputChange` gets called when user types for example "65aabvcd123"
     // 2. `formatter.getNumber().number` will transform that into "65" and cut out the remaining characters since the remaining string is not a valid number
     // 3. Will need to call onChange on this new number.
-    onChange(number?.number as string | undefined)
+    onChange(e164)
     // Check and update possibility
     const possible = number?.isPossible()
 
@@ -245,9 +244,9 @@ const useProvidePhoneNumberInput = ({
   // This allows the cursor position to be updated after formatting the input
   // without "jumping" to the end of the input string and disrupting the user.
   useLayoutEffect(() => {
-    const number = formatter.getNumber()?.number
+    const e164 = formatter.getNumber()?.number ?? ''
 
-    if (number !== defaultValue) {
+    if (e164 !== defaultValue) {
       // Override the phone number if the field has a number and its e164
       // representation does not match the prop value.
       formatter.reset()

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -973,16 +973,19 @@ WithSaveDraftEnabledAndClickFloatingSaveDraftButton.play = async ({
             '[data-testid*="tooltip"]',
             '.chakra-tooltip',
             '[aria-describedby]',
-            '.tooltip'
+            '.tooltip',
           ]
-          
+
           const tooltip = tooltipSelectors
-            .map(selector => document.querySelector(selector))
-            .find(element => element && element.textContent?.includes('Last saved'))
-          
+            .map((selector) => document.querySelector(selector))
+            .find(
+              (element) =>
+                element && element.textContent?.includes('Last saved'),
+            )
+
           expect(tooltip).toBeInTheDocument()
         },
-        { timeout: 5000 }
+        { timeout: 5000 },
       )
     },
   )
@@ -1048,7 +1051,7 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     'Hover over the save draft button to see the save draft tooltip',
     async () => {
       await userEvent.hover(mainSaveDraftButton)
-    }
+    },
   )
 
   await step(
@@ -1061,16 +1064,19 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
             '[data-testid*="tooltip"]',
             '.chakra-tooltip',
             '[aria-describedby]',
-            '.tooltip'
+            '.tooltip',
           ]
-          
+
           const tooltip = tooltipSelectors
-            .map(selector => document.querySelector(selector))
-            .find(element => element && element.textContent?.includes('Last saved'))
-          
+            .map((selector) => document.querySelector(selector))
+            .find(
+              (element) =>
+                element && element.textContent?.includes('Last saved'),
+            )
+
           expect(tooltip).toBeInTheDocument()
         },
-        { timeout: 5000 }
+        { timeout: 5000 },
       )
     },
   )

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -964,13 +964,25 @@ WithSaveDraftEnabledAndClickFloatingSaveDraftButton.play = async ({
   )
 
   step(
-    'Assert that the tooltip reflects that draft has been saved',
+    'Assert that a tooltip appears reflecting that draft has been saved',
     async () => {
       await waitFor(
-        async () => {
-          await expect(document.body).toHaveTextContent('Last saved')
+        () => {
+          const tooltipSelectors = [
+            '[role="tooltip"]',
+            '[data-testid*="tooltip"]',
+            '.chakra-tooltip',
+            '[aria-describedby]',
+            '.tooltip'
+          ]
+          
+          const tooltip = tooltipSelectors
+            .map(selector => document.querySelector(selector))
+            .find(element => element && element.textContent?.includes('Last saved'))
+          
+          expect(tooltip).toBeInTheDocument()
         },
-        { timeout: 3000 },
+        { timeout: 5000 }
       )
     },
   )
@@ -1036,17 +1048,29 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     'Hover over the save draft button to see the save draft tooltip',
     async () => {
       await userEvent.hover(mainSaveDraftButton)
-    },
+    }
   )
 
   await step(
-    'Assert that the tooltip reflects that draft has been saved',
+    'Assert that a tooltip appears reflecting that draft has been saved',
     async () => {
       await waitFor(
-        async () => {
-          await expect(document.body).toHaveTextContent('Last saved')
+        () => {
+          const tooltipSelectors = [
+            '[role="tooltip"]',
+            '[data-testid*="tooltip"]',
+            '.chakra-tooltip',
+            '[aria-describedby]',
+            '.tooltip'
+          ]
+          
+          const tooltip = tooltipSelectors
+            .map(selector => document.querySelector(selector))
+            .find(element => element && element.textContent?.includes('Last saved'))
+          
+          expect(tooltip).toBeInTheDocument()
         },
-        { timeout: 3000 },
+        { timeout: 5000 }
       )
     },
   )

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -800,13 +800,12 @@ export const PublicFormProvider = ({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   // RATIONALE: draftSubmission.lastUpdated is used as a source of truth to see if the draftSubmission has changed.
-  const { draftResponsesToRestore, changedFieldIds } =
-    useMemo(() => {
-      return getRestoreDraftFormValues({
-        currentFormFields: formFields,
-        savedDraftSubmission: draftSubmission,
-      })
-    }, [draftSubmission?.lastUpdated, formFields])
+  const { draftResponsesToRestore, changedFieldIds } = useMemo(() => {
+    return getRestoreDraftFormValues({
+      currentFormFields: formFields,
+      savedDraftSubmission: draftSubmission,
+    })
+  }, [draftSubmission?.lastUpdated, formFields])
 
   const hasDraft = Boolean(draftSubmission?.lastUpdated)
   const hasShownRestoredDraftToast = useRef<boolean>(false)

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -800,7 +800,7 @@ export const PublicFormProvider = ({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   // RATIONALE: draftSubmission.lastUpdated is used as a source of truth to see if the draftSubmission has changed.
-  const { draftResponsesToRestore, unchangedFieldIds, changedFieldIds } =
+  const { draftResponsesToRestore, changedFieldIds } =
     useMemo(() => {
       return getRestoreDraftFormValues({
         currentFormFields: formFields,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Home number fields are added to the draft despite not being modified. This causes issues with displaying the correct restored draft toast message which relies on knowing which fields have been changed. 

For example, user did not edit home number field, but its value is added to the draft. Admin removes home number field. user restores draft and sees incorrect toast message telling him/her the draft is not fully restored. 

## Solution
<!-- How did you solve the problem? -->
Set the empty value from `undefined` to '""' for home number, to match the other field types. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Home number field not added to draft if not edited 
- [x] Create form with home number field 
- [x] Save draft without editing. 
- [x] Assert draft does not include home number field. 
- [x] Edit the home number field. 
- [x] Assert draft included edited home number field and can be restored. 
- [x] Assert can submit the restored draft value. 
