### PR TITLE
fix: improve flaky tooltip test

### DIFF
--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -976,12 +976,13 @@ WithSaveDraftEnabledAndClickFloatingSaveDraftButton.play = async ({
             '.tooltip',
           ]
 
-          const tooltip = tooltipSelectors
-            .map((selector) => document.querySelector(selector))
-            .find(
-              (element) =>
-                element && element.textContent?.includes('Last saved'),
-            )
+          const tooltip =
+            tooltipSelectors
+              .map((selector) => document.querySelector(selector))
+              .find(
+                (element) =>
+                  element && element.textContent?.includes('Last saved'),
+              ) ?? new Element()
 
           expect(tooltip).toBeInTheDocument()
         },
@@ -1067,12 +1068,13 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
             '.tooltip',
           ]
 
-          const tooltip = tooltipSelectors
-            .map((selector) => document.querySelector(selector))
-            .find(
-              (element) =>
-                element && element.textContent?.includes('Last saved'),
-            )
+          const tooltip =
+            tooltipSelectors
+              .map((selector) => document.querySelector(selector))
+              .find(
+                (element) =>
+                  element && element.textContent?.includes('Last saved'),
+              ) ?? new Element()
 
           expect(tooltip).toBeInTheDocument()
         },

--- a/frontend/src/features/public-form/components/FloatingToolBar/FloatingSaveDraftButton.tsx
+++ b/frontend/src/features/public-form/components/FloatingToolBar/FloatingSaveDraftButton.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { BiSave } from 'react-icons/bi'
+import { Text } from '@chakra-ui/react'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import IconButton from '~components/IconButton'
@@ -22,7 +23,10 @@ export const FloatingSaveDraftButton = ({
     : t('features.publicForm.components.saveDraft.tooltip.default')
 
   return (
-    <Tooltip placement={isMobile ? 'top' : 'left'} label={tooltipLabel}>
+    <Tooltip
+      placement={isMobile ? 'top' : 'left'}
+      label={<Text data-chromatic="ignore">{tooltipLabel}</Text>}
+    >
       <IconButton
         variant="outline"
         cursor="pointer"

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,7 +1,13 @@
 import { MouseEventHandler, useMemo, useState } from 'react'
 import { useFormState, UseFormTrigger, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Flex, Stack, useDisclosure, VisuallyHidden } from '@chakra-ui/react'
+import {
+  Flex,
+  Stack,
+  Text,
+  useDisclosure,
+  VisuallyHidden,
+} from '@chakra-ui/react'
 
 import { PAYMENT_CONTACT_FIELD_ID } from '~shared/constants'
 import { FormField, Language, LogicDto, MyInfoFormField } from '~shared/types'
@@ -33,7 +39,10 @@ const PublicFormSaveDraftButton = (props: ButtonProps) => {
     : ''
 
   return (
-    <Tooltip placement="top" label={tooltipLabel}>
+    <Tooltip
+      placement="top"
+      label={<Text data-chromatic="ignore">{tooltipLabel}</Text>}
+    >
       <Button variant="outline" onClick={onSaveDraft} {...props}>
         {t('features.publicForm.components.saveDraft.button.label')}
       </Button>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The test which detects the last saved draft tooltip in #8091 and #8705 may be somewhat flaky

Closes FRM-2150

## Solution
<!-- How did you solve the problem? -->

Prevent the test from failing prematurely before the tooltip has been inserted into the Document Object Model (DOM).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [x] No - this PR is backwards compatible  

**Improvements**:

- Try introducing a dummy element not in the document to prevent the test from crashing

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

<img width="5344" height="3054" alt="image" src="https://github.com/user-attachments/assets/fa0cc775-9e9a-4b3d-963c-ffceb69451f0" />

**AFTER**:
<!-- [insert screenshot here] -->

<img width="5344" height="3054" alt="image" src="https://github.com/user-attachments/assets/c73ab7b4-47f7-4e0d-820f-dc4a15fd3037" />

## Tests
<!-- What tests should be run to confirm functionality? -->

The UI tests should pass.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
