### PR TITLE
fix: save draft interaction test to never flake again

### DIFF
--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react'
-import { expect, userEvent, waitFor, within } from '@storybook/test'
+import { expect, screen, userEvent, waitFor, within } from '@storybook/test'
 import dedent from 'dedent'
 
 import { ErrorCode } from '~shared/types'
@@ -921,28 +921,27 @@ WithSaveDraftEnabledAndClickFloatingSaveDraftButton.play = async ({
   step,
 }) => {
   const canvas = within(canvasElement)
-
-  // Wait for the floating save draft button to be available (using aria-label for specificity
+  const screen = within(document.body)
 
   let floatingSaveDraftButton: HTMLElement
 
   await step('Find the floating save draft button', async () => {
-    await waitFor(async () => {
-      const foundFloatingSaveDraftButton =
-        await canvas.getByLabelText('Save a draft')
-      await expect(foundFloatingSaveDraftButton).toBeInTheDocument()
-      if (!foundFloatingSaveDraftButton) {
-        throw new Error('Floating save draft button not found')
-      }
-      floatingSaveDraftButton = foundFloatingSaveDraftButton
-    })
+    await waitFor(
+      async () => {
+        const foundFloatingSaveDraftButton =
+          canvas.getByLabelText('Save a draft')
+        floatingSaveDraftButton = foundFloatingSaveDraftButton
+        expect(floatingSaveDraftButton).toBeInTheDocument()
+      },
+      { timeout: 3000 },
+    )
   })
 
-  step('Click the floating save draft button', async () => {
+  await step('Click the floating save draft button', async () => {
     await userEvent.click(floatingSaveDraftButton)
   })
 
-  step(
+  await step(
     'Assert that the saved draft success toast message appears',
     async () => {
       await waitFor(
@@ -956,33 +955,20 @@ WithSaveDraftEnabledAndClickFloatingSaveDraftButton.play = async ({
     },
   )
 
-  step(
+  await step(
     'Hover over the save draft button to see the save draft tooltip',
     async () => {
       await userEvent.hover(floatingSaveDraftButton)
     },
   )
 
-  step(
+  await step(
     'Assert that a tooltip appears reflecting that draft has been saved',
     async () => {
+      let tooltip: HTMLElement | null = null
       await waitFor(
         () => {
-          const tooltipSelectors = [
-            '[role="tooltip"]',
-            '[data-testid*="tooltip"]',
-            '.chakra-tooltip',
-            '[aria-describedby]',
-            '.tooltip',
-          ]
-
-          const tooltip = tooltipSelectors
-            .map((selector) => document.querySelector(selector))
-            .find(
-              (element) =>
-                element && element.textContent?.includes('Last saved'),
-            )
-
+          tooltip = screen.getByRole('tooltip', { name: /Last saved/i })
           expect(tooltip).toBeInTheDocument()
         },
         { timeout: 5000 },
@@ -1011,22 +997,26 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
   step,
 }) => {
   const canvas = within(canvasElement)
+  const screen = within(document.body)
 
   let mainSaveDraftButton: HTMLElement
 
   await step('Find the main save draft button', async () => {
-    await waitFor(async () => {
-      const foundMainSaveDraftButton = await canvas
-        .getAllByRole('button', {
-          name: 'Save a draft',
-        })
-        .find((button) => button.textContent?.includes('Save a draft'))
-      await expect(foundMainSaveDraftButton).toBeInTheDocument()
-      if (!foundMainSaveDraftButton) {
-        throw new Error('Main save draft button not found')
-      }
-      mainSaveDraftButton = foundMainSaveDraftButton
-    })
+    await waitFor(
+      () => {
+        const foundMainSaveDraftButton = canvas
+          .getAllByRole('button', {
+            name: 'Save a draft',
+          })
+          .find((button) => button.textContent?.includes('Save a draft'))
+        if (!foundMainSaveDraftButton) {
+          throw new Error('Main save draft button not found')
+        }
+        mainSaveDraftButton = foundMainSaveDraftButton
+        expect(foundMainSaveDraftButton).toBeInTheDocument()
+      },
+      { timeout: 3000 },
+    )
   })
 
   await step('Click the main save draft button', async () => {
@@ -1037,10 +1027,8 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     'Assert that the saved draft success toast message appears',
     async () => {
       await waitFor(
-        async () => {
-          await expect(document.body).toHaveTextContent(
-            'Your draft has been saved.',
-          )
+        () => {
+          expect(document.body).toHaveTextContent('Your draft has been saved.')
         },
         { timeout: 3000 },
       )
@@ -1058,22 +1046,10 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     'Assert that a tooltip appears reflecting that draft has been saved',
     async () => {
       await waitFor(
-        () => {
-          const tooltipSelectors = [
-            '[role="tooltip"]',
-            '[data-testid*="tooltip"]',
-            '.chakra-tooltip',
-            '[aria-describedby]',
-            '.tooltip',
-          ]
-
-          const tooltip = tooltipSelectors
-            .map((selector) => document.querySelector(selector))
-            .find(
-              (element) =>
-                element && element.textContent?.includes('Last saved'),
-            )
-
+        async () => {
+          const tooltip = await screen.getByRole('tooltip', {
+            name: /Last saved/i,
+          })
           expect(tooltip).toBeInTheDocument()
         },
         { timeout: 5000 },

--- a/frontend/src/features/public-form/components/FloatingToolBar/FloatingSaveDraftButton.tsx
+++ b/frontend/src/features/public-form/components/FloatingToolBar/FloatingSaveDraftButton.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { BiSave } from 'react-icons/bi'
+import { Text } from '@chakra-ui/react'
 
 import { useIsMobile } from '~hooks/useIsMobile'
 import IconButton from '~components/IconButton'
@@ -22,7 +23,10 @@ export const FloatingSaveDraftButton = ({
     : t('features.publicForm.components.saveDraft.tooltip.default')
 
   return (
-    <Tooltip placement={isMobile ? 'top' : 'left'} label={tooltipLabel}>
+    <Tooltip
+      placement={isMobile ? 'top' : 'left'}
+      label={<Text data-chromatic="ignore">{tooltipLabel}</Text>}
+    >
       <IconButton
         variant="outline"
         cursor="pointer"

--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -1,7 +1,13 @@
 import { MouseEventHandler, useMemo, useState } from 'react'
 import { useFormState, UseFormTrigger, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Flex, Stack, useDisclosure, VisuallyHidden } from '@chakra-ui/react'
+import {
+  Flex,
+  Stack,
+  Text,
+  useDisclosure,
+  VisuallyHidden,
+} from '@chakra-ui/react'
 
 import { PAYMENT_CONTACT_FIELD_ID } from '~shared/constants'
 import { FormField, Language, LogicDto, MyInfoFormField } from '~shared/types'
@@ -33,7 +39,10 @@ const PublicFormSaveDraftButton = (props: ButtonProps) => {
     : ''
 
   return (
-    <Tooltip placement="top" label={tooltipLabel}>
+    <Tooltip
+      placement="top"
+      label={<Text data-chromatic="ignore">{tooltipLabel}</Text>}
+    >
       <Button variant="outline" onClick={onSaveDraft} {...props}>
         {t('features.publicForm.components.saveDraft.button.label')}
       </Button>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Fix flaky tests related to save draft interaction stories. 
This is mainly caused by missing out the `await` before  each `step`. This means the tooltip check can occur before the hover occurs.  

Fixes FRM-2150.

## Solution
<!-- How did you solve the problem? -->
Add the required await statements before each step. 

This fix has been verified by running the tc locally and checking for the sequencing and that it awaits properly. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  