### PR TITLE
fix: indexdb infinite renders causing poor performance

### DIFF
--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1051,7 +1051,7 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     'Hover over the save draft button to see the save draft tooltip',
     async () => {
       await userEvent.hover(mainSaveDraftButton)
-    }
+    },
   )
 
   await step(

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1051,7 +1051,7 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     'Hover over the save draft button to see the save draft tooltip',
     async () => {
       await userEvent.hover(mainSaveDraftButton)
-    },
+    }
   )
 
   await step(

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -780,14 +780,19 @@ export const PublicFormProvider = ({
     isMrf: form?.responseMode === FormResponseMode.Multirespondent,
     currentMrfWorkflowStepNumber: currentWorkflowStepNumber,
   })
+
+  const memoizedInitialValue = useMemo(
+    () => ({
+      lastUpdated: null,
+      draftResponses: null,
+      fieldDefinitionsChecksum: null,
+    }),
+    [],
+  )
   const [draftSubmission, setDraftSubmission, clearDraftSubmission] =
     useIndexedDb<DraftSubmission>({
       key: formDraftSubmissionKey,
-      initialValue: {
-        lastUpdated: null,
-        draftResponses: null,
-        fieldDefinitionsChecksum: null,
-      },
+      initialValue: memoizedInitialValue,
       storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
     })
 

--- a/frontend/src/hooks/useIndexedDb.ts
+++ b/frontend/src/hooks/useIndexedDb.ts
@@ -104,6 +104,9 @@ export const useIndexedDb = <T>({
   storeName,
 }: {
   key: string | null
+  /**
+   * @note Warning: If the initial value is a object reference, it will cause re-renders.
+   */
   initialValue?: T
   storeName: string
 }): readonly [


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Solves #inc-697-09_16_2025-mobile-respondents-cannot-click-on-buttons

## Solution
<!-- How did you solve the problem? -->
Prevent infinite re-rendering due to the object reference changing on each render. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  