### PR TITLE
fix: signatures v1.3 bugs

### DIFF
--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -214,7 +214,7 @@ const transformToSignatureOutput = (
   input?: SignatureFieldValues | SignatureFieldResponseV3,
 ): SignatureResponse => {
   let answerArray: string[] = []
-  if (input && input.value !== undefined && input.value !== null) {
+  if (input && input.value !== null) {
     answerArray = [input.type, convertToSignatureStringOutput(input.value)]
   }
   return {

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -214,7 +214,7 @@ const transformToSignatureOutput = (
   input?: SignatureFieldValues | SignatureFieldResponseV3,
 ): SignatureResponse => {
   let answerArray: string[] = []
-  if (input !== undefined && input !== null) {
+  if (input && input.value !== undefined && input.value !== null) {
     answerArray = [input.type, convertToSignatureStringOutput(input.value)]
   }
   return {

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -58,8 +58,10 @@ export const SignatureField = ({
   // perfect freehand variables
   const pfCanvasRef = useRef<HTMLCanvasElement>(null)
   const boxRef = useRef<HTMLDivElement>(null)
-  
-  const watchedSignature = useWatch({ name: schema._id }) as { value: SignatureVectorArray }
+
+  const watchedSignature = useWatch({ name: schema._id }) as {
+    value: SignatureVectorArray
+  }
   const [pfStrokes, setPfStrokes] = useState<SignatureVectorArray>([])
 
   // Sync when form value changes
@@ -68,7 +70,6 @@ export const SignatureField = ({
       setPfStrokes(watchedSignature.value)
     }
   }, [watchedSignature])
-
 
   const [currentStroke, setCurrentStroke] = useState<
     [number, number, number][]

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useFormContext, useFormState } from 'react-hook-form'
+import { useFormContext, useFormState, useWatch } from 'react-hook-form'
 import { Box, Flex, FormControl, Stack, Text } from '@chakra-ui/react'
 import getStroke from 'perfect-freehand'
 
@@ -58,11 +58,17 @@ export const SignatureField = ({
   // perfect freehand variables
   const pfCanvasRef = useRef<HTMLCanvasElement>(null)
   const boxRef = useRef<HTMLDivElement>(null)
+  
+  const watchedSignature = useWatch({ name: schema._id }) as { value: SignatureVectorArray }
+  const [pfStrokes, setPfStrokes] = useState<SignatureVectorArray>([])
 
-  const [pfStrokes, setPfStrokes] = useState<SignatureVectorArray>(() => {
-    const preExistingSignature = getValues(`${schema._id}`)
-    return preExistingSignature?.value ?? []
-  })
+  // Sync when form value changes
+  useEffect(() => {
+    if (watchedSignature?.value) {
+      setPfStrokes(watchedSignature.value)
+    }
+  }, [watchedSignature])
+
 
   const [currentStroke, setCurrentStroke] = useState<
     [number, number, number][]

--- a/frontend/src/templates/Field/types.ts
+++ b/frontend/src/templates/Field/types.ts
@@ -161,7 +161,7 @@ export type AddressCompoundFieldValues = {
 
 export type SignatureFieldValues = {
   type: 'draw'
-  value: SignatureVectorArray
+  value: SignatureVectorArray | null
 }
 
 // Various schemas used by different fields

--- a/shared/types/response-v3.ts
+++ b/shared/types/response-v3.ts
@@ -142,5 +142,5 @@ export type AddressCompoundFieldResponseV3 = {
 
 export type SignatureFieldResponseV3 = {
   type: 'draw'
-  value: SignatureVectorArray
+  value: SignatureVectorArray | null
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

1. In MRF, submission blocked (Zod validation error) at current step if signature is assigned to succeeding step
2. MRF image does not get rehydrated

## Solution
<!-- How did you solve the problem? -->

1. Update validateResponses to check for input.value instead of input. Default Signature is now changed to 'input' is ['draw', undefined], or ['draw', null]
2. Utilize useWatch to rehydrate/redraw signature if value comes async after form loads

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Description | **BEFORE** | **AFTER** |
| --- | --- | --- |
| MRF succeeding assigned field error | ![old](https://github.com/user-attachments/assets/47debfdf-3b8a-4f0b-a568-b69ce75c10f4) | ![new](https://github.com/user-attachments/assets/b3f1d94c-79e8-49de-b7c3-24544ca5242d) |
| rehydration delay | ![ol1](https://github.com/user-attachments/assets/42f344d9-a97e-4178-bd5f-9e266d60802a) | ![ne1](https://github.com/user-attachments/assets/35442efd-efdb-426b-84b3-445becaa2cf5) |


## Tests
<!-- What tests should be run to confirm functionality? -->

**Rehydration for MRF signature value**
- [x] Create a 2 step workflow MRF form with signature (step 1) and short answer (step 2)
- [x] Attempt to make a step 1 submission
- [x] During attemp to make step 2 submission, observe that previous step signature is present

**Submission successful at current step with signature field in suceeding step**
- [x] Create a 2 step workflow MRF form with signature (step 2) and short answer (step 1)
- [x] Attempt to make a step 1 submission successfully
- [x] Attempt to make a step 2 submission sucecssfully