### PR TITLE
fix: update signature defaultValue to standardized format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,30 +1,21 @@
 {
-  "eslint.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
-  "eslint.run": "onType",
+  "eslint.validate": ["javascript", "typescript"],
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  // "[javascript]": {
-  //   "editor.formatOnSave": false
-  // },
-  // "[typescript]": {
-  //   "editor.formatOnSave": false
-  // },
-  // "[html]": {
-  //   "editor.codeActionsOnSave": {
-  //     "source.fixAll.eslint": "never"
-  //   },
-  //   "editor.defaultFormatter": "esbenp.prettier-vscode"
-  // },
+  "[javascript]": {
+    "editor.formatOnSave": false
+  },
+  "[typescript]": {
+    "editor.formatOnSave": false
+  },
+  "[html]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "never"
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "typescript.tsdk": "node_modules/typescript/lib",
   "markdown.extension.toc.omittedFromToc": {
     "README.md": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,21 +1,30 @@
 {
+  "eslint.enable": true,
   "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.validate": ["javascript", "typescript"],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "eslint.run": "onType",
   "editor.formatOnSave": true,
-  "[javascript]": {
-    "editor.formatOnSave": false
-  },
-  "[typescript]": {
-    "editor.formatOnSave": false
-  },
-  "[html]": {
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "never"
-    },
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  // "[javascript]": {
+  //   "editor.formatOnSave": false
+  // },
+  // "[typescript]": {
+  //   "editor.formatOnSave": false
+  // },
+  // "[html]": {
+  //   "editor.codeActionsOnSave": {
+  //     "source.fixAll.eslint": "never"
+  //   },
+  //   "editor.defaultFormatter": "esbenp.prettier-vscode"
+  // },
   "typescript.tsdk": "node_modules/typescript/lib",
   "markdown.extension.toc.omittedFromToc": {
     "README.md": [

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -170,7 +170,7 @@ const FieldRowContainer = ({
     if (field.fieldType === BasicField.Signature) {
       const defaultType = 'draw'
       return {
-        [field._id]: {type: defaultType, value: []}
+        [field._id]: { type: defaultType, value: [] },
       }
     }
 

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -167,6 +167,13 @@ const FieldRowContainer = ({
       }
     }
 
+    if (field.fieldType === BasicField.Signature) {
+      const defaultType = 'draw'
+      return {
+        [field._id]: {type: defaultType, value: []}
+      }
+    }
+
     const augmentedField = augmentWithMyInfoDisplayValue(field)
 
     if (hasExistingFieldValue(augmentedField)) {

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -315,6 +315,8 @@ const getInitialFormValues = ({
           acc[field._id] = times(field.minimumRows || 0, () =>
             createTableRow(field),
           )
+        } else if (field.fieldType === BasicField.Signature) {
+          acc[field._id] = {type: 'draw', value: []}
         } else {
           // Set a default value for React Hook form to use as initial SSOT for comparing if field is dirty. This is used for Save Draft.
           acc[field._id] = ''

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -316,7 +316,7 @@ const getInitialFormValues = ({
             createTableRow(field),
           )
         } else if (field.fieldType === BasicField.Signature) {
-          acc[field._id] = {type: 'draw', value: []}
+          acc[field._id] = { type: 'draw', value: [] }
         } else {
           // Set a default value for React Hook form to use as initial SSOT for comparing if field is dirty. This is used for Save Draft.
           acc[field._id] = ''

--- a/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/frontend/src/features/public-form/utils/createSubmission.ts
@@ -271,7 +271,6 @@ const createResponsesV3 = (
       case BasicField.Uen:
       case BasicField.Date:
       case BasicField.CountryRegion:
-      case BasicField.Signature:
       case BasicField.YesNo: {
         const input = formInputs[ff._id] as
           | FormFieldValue<typeof ff.fieldType>
@@ -399,6 +398,19 @@ const createResponsesV3 = (
       case BasicField.Section:
       case BasicField.Image:
       case BasicField.Statement: {
+        break
+      }
+      case BasicField.Signature: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        // since default value is {type: '', value: []}, empty array = no input
+        if (input && input?.value.length > 0) {
+          returnedInputs[ff._id] = {
+            fieldType: ff.fieldType,
+            answer: input,
+          } as FieldResponseV3
+        }
         break
       }
       default: {

--- a/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -214,7 +214,7 @@ const transformToSignatureOutput = (
   input?: SignatureFieldValues | SignatureFieldResponseV3,
 ): SignatureResponse => {
   let answerArray: string[] = []
-  if (input && input.value !== null) {
+  if (input && input.value.length > 0) {
     answerArray = [input.type, convertToSignatureStringOutput(input.value)]
   }
   return {

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -55,7 +55,6 @@ export const SignatureField = ({
   )
 
   useEffect(() => {
-    
     formContext.register(schema._id, signatureValidationRules)
   }, [formContext, schema._id, signatureValidationRules])
 
@@ -201,7 +200,11 @@ export const SignatureField = ({
   const handleClearPerfectFreehandSignature = async () => {
     setShowSignaturePlaceholder(true)
     setPfStrokes([])
-    setValue(`${schema._id}`, {type: defaultType, value: []}, { shouldValidate: true })
+    setValue(
+      `${schema._id}`,
+      { type: defaultType, value: [] },
+      { shouldValidate: true },
+    )
     const canvas = pfCanvasRef.current
     const ctx = canvas?.getContext('2d')
     if (ctx && canvas) {

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -46,6 +46,9 @@ export const SignatureField = ({
 
   const signatureErrors = errors?.[schema._id]
 
+  // Future implementations will expand on signature types (text, cryptographic)
+  const defaultType = 'draw'
+
   const signatureValidationRules = useMemo(
     () => createSignatureValidationRules(schema, disableRequiredValidation),
     [schema, disableRequiredValidation],
@@ -132,7 +135,7 @@ export const SignatureField = ({
     window.addEventListener('resize', resizeCanvas)
     return () => window.removeEventListener('resize', resizeCanvas)
   }, [drawAllStrokes])
-
+  console.log(`signature value`, `${JSON.stringify(getValues(schema._id))}`)
   // draw signature
   useEffect(() => {
     const canvas = pfCanvasRef.current
@@ -176,7 +179,7 @@ export const SignatureField = ({
       setIsDrawing(false)
       setValue(
         `${schema._id}`,
-        { type: 'draw', value: pfStrokes },
+        { type: defaultType, value: pfStrokes },
         { shouldValidate: true },
       )
     }
@@ -197,7 +200,7 @@ export const SignatureField = ({
   const handleClearPerfectFreehandSignature = async () => {
     setShowSignaturePlaceholder(true)
     setPfStrokes([])
-    setValue(`${schema._id}`, null, { shouldValidate: true })
+    setValue(`${schema._id}`, {type: defaultType, value: []}, { shouldValidate: true })
     const canvas = pfCanvasRef.current
     const ctx = canvas?.getContext('2d')
     if (ctx && canvas) {

--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -55,6 +55,7 @@ export const SignatureField = ({
   )
 
   useEffect(() => {
+    
     formContext.register(schema._id, signatureValidationRules)
   }, [formContext, schema._id, signatureValidationRules])
 

--- a/frontend/src/templates/Field/types.ts
+++ b/frontend/src/templates/Field/types.ts
@@ -161,7 +161,7 @@ export type AddressCompoundFieldValues = {
 
 export type SignatureFieldValues = {
   type: 'draw'
-  value: SignatureVectorArray | null
+  value: SignatureVectorArray
 }
 
 // Various schemas used by different fields

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -76,6 +76,7 @@ import {
   loadDateFromNormalizedDate,
 } from './date'
 import { formatNumberToLocaleString } from './stringFormat'
+import { CorppassUnauthorizedSubmitterIdCollectionEnabled } from '~features/public-form/PublicFormPage.stories'
 
 type EmailValidationErrorMessages = Fields['email']['validation']
 
@@ -948,7 +949,6 @@ export const createSignatureValidationRules: ValidationRuleFn<
     validate: {
       required: (val?: SignatureFieldValues) => {
         if (disableRequiredValidation || !schema.required) return true
-
         const strokes = val?.value
         const hasValidStroke = Array.isArray(strokes) && strokes.length > 0
         return hasValidStroke ? true : REQUIRED_ERROR

--- a/frontend/src/utils/fieldValidation.ts
+++ b/frontend/src/utils/fieldValidation.ts
@@ -67,6 +67,7 @@ import {
   VerifiableFieldValues,
 } from '~templates/Field/types'
 
+import { CorppassUnauthorizedSubmitterIdCollectionEnabled } from '~features/public-form/PublicFormPage.stories'
 import { VerifiableFieldBase } from '~features/verifiable-fields/types'
 
 import {
@@ -76,7 +77,6 @@ import {
   loadDateFromNormalizedDate,
 } from './date'
 import { formatNumberToLocaleString } from './stringFormat'
-import { CorppassUnauthorizedSubmitterIdCollectionEnabled } from '~features/public-form/PublicFormPage.stories'
 
 type EmailValidationErrorMessages = Fields['email']['validation']
 

--- a/shared/types/response-v3.ts
+++ b/shared/types/response-v3.ts
@@ -142,5 +142,5 @@ export type AddressCompoundFieldResponseV3 = {
 
 export type SignatureFieldResponseV3 = {
   type: 'draw'
-  value: SignatureVectorArray | null
+  value: SignatureVectorArray
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Signatures field values differ based on various interactions in the FE. This is complex due to signature field being an uncontrolled component.

If field is untouched, value = `undefined`
If field is registered, default values to = `""` (e.g. when field is hidden at first, and then shown)
If field is interacted with, value = `{type:'draw', value: [[1,1,1],...]}`
If field is cleared, value = `null`

This is creating a lot of inconsistencies when we deal with validations during submissions.

## Solution
<!-- How did you solve the problem? -->

1. By default, value will be `{type: 'draw', value; []}` whenever component is mounted. The only instance that its value remains `undefined` is if the field is hidden from form.
2. Clearing signature input defaults value back to `[]`, `{type: 'draw', value; []}` this will be the default state of a non-inputted signature field