### PR TITLE
fix: announcement and contact modals

### DIFF
--- a/__tests__/e2e/helpers/closeModals.ts
+++ b/__tests__/e2e/helpers/closeModals.ts
@@ -1,0 +1,20 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Closes any modals that may obstruct test flow,
+ * such as the Rollout Announcement and Emergency Contact modals.
+ * @param {Page} page Playwright page
+ */
+export const closeModals = async (
+  page: Page,
+) => {
+  // Close the Rollout Announcement modal if it is visible.
+  if (await page.getByText('New feature').isVisible()) {
+    await page.getByRole('button', { name: 'Cancel' }).click()
+  }
+
+  // Close the Emergency Contact modal if it is visible.
+  if (await page.getByRole('heading', { name: 'Emergency Contact' }).isVisible()) {
+    await page.locator('button[aria-label="Close"]').click()
+  }
+}

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -49,6 +49,7 @@ import {
   getMyInfoAttribute,
   getTitleWithQuestionNumber,
 } from '../utils'
+import { closeModals } from './closeModals';
 
 type CreateFormReturn = {
   form: IFormSchema
@@ -116,11 +117,17 @@ const addForm = async (
 
     await page.goto(`${ADMIN_FORM_PAGE_PREFIX}/${formId}`)
 
+    // Close any modals that may obstruct test flow
+    await closeModals(page)
+
     await page.getByRole('button', { name: 'Next' }).press('Escape')
 
     return { formId, formResponseMode }
   }
   await page.goto(DASHBOARD_PAGE)
+
+  // Close any modals that may obstruct test flow
+  await closeModals(page)
 
   // Press escape 5 times to get rid of any banners
   await page.keyboard.press('Escape')

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -143,10 +143,6 @@ const addForm = async (
   await page.getByText('Storage mode form').click()
   await page.getByRole('button', { name: 'Create form' }).click()
 
-  await page.getByRole('button', { name: 'Cancel' }).click()
-
-  await page.getByRole('button', { name: 'Close' }).click()
-
   const downloadButton = page.getByRole('button', { name: 'Download key' })
   await expect(downloadButton).toBeEnabled({ timeout: 15000 })
   const downloadPromise = page.waitForEvent('download')

--- a/__tests__/e2e/login.spec.ts
+++ b/__tests__/e2e/login.spec.ts
@@ -57,6 +57,14 @@ test.describe('login', () => {
 
     await page.getByRole('button', { name: 'Sign in' }).click()
     await expect(page).toHaveURL(DASHBOARD_PAGE)
+
+    if (await page.getByText('New feature').isVisible()) {
+      await page.getByRole('button', { name: 'Cancel' }).click()
+    }
+
+    if (await page.getByRole('heading', { name: 'Emergency Contact' }).isVisible()) {
+      await page.locator('button[aria-label="Close"]').click()
+    }
   })
 
   test('Prevent login if OTP is incorrect', async ({ page }) => {

--- a/__tests__/e2e/login.spec.ts
+++ b/__tests__/e2e/login.spec.ts
@@ -57,14 +57,6 @@ test.describe('login', () => {
 
     await page.getByRole('button', { name: 'Sign in' }).click()
     await expect(page).toHaveURL(DASHBOARD_PAGE)
-
-    if (await page.getByText('New feature').isVisible()) {
-      await page.getByRole('button', { name: 'Cancel' }).click()
-    }
-
-    if (await page.getByRole('heading', { name: 'Emergency Contact' }).isVisible()) {
-      await page.locator('button[aria-label="Close"]').click()
-    }
   })
 
   test('Prevent login if OTP is incorrect', async ({ page }) => {

--- a/frontend/src/features/workspace/WorkspaceContent.tsx
+++ b/frontend/src/features/workspace/WorkspaceContent.tsx
@@ -49,6 +49,10 @@ export const WorkspaceContent = (): JSX.Element => {
         isOpen={createFormModalDisclosure.isOpen}
         onClose={createFormModalDisclosure.onClose}
       />
+      <RolloutAnnouncementModal
+        onClose={() => setHasSeenAnnouncement(true)}
+        isOpen={isAnnouncementModalOpen}
+      />
       {totalFormsCount === 0 && isDefaultWorkspace ? (
         <EmptyDefaultWorkspace
           handleOpenCreateFormModal={createFormModalDisclosure.onOpen}
@@ -88,10 +92,6 @@ export const WorkspaceContent = (): JSX.Element => {
             <EmptyNewWorkspace isLoading={isLoading} />
           ) : (
             <Box gridArea="main">
-              <RolloutAnnouncementModal
-                onClose={() => setHasSeenAnnouncement(true)}
-                isOpen={isAnnouncementModalOpen}
-              />
               <WorkspaceFormRows />
             </Box>
           )}

--- a/frontend/src/features/workspace/WorkspacePage.stories.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.stories.tsx
@@ -134,6 +134,34 @@ LoadingMobile.parameters = {
 export const Empty = Template.bind({})
 Empty.parameters = {
   msw: [
+    ...envHandlers,
+    http.get<never, never, AdminDashboardFormMetaDto[]>(
+      '/api/v3/admin/forms',
+      () => {
+        return HttpResponse.json()
+      },
+    ),
+    getWorkspaces(),
+    getUser({
+      delay: 0,
+      mockUser: {
+        ...MOCK_USER,
+        _id: 'undefined' as UserId,
+        email: 'meh@example.com',
+      },
+    }),
+  ],
+}
+
+export const EmptyMobile = Template.bind({})
+EmptyMobile.parameters = {
+  ...Empty.parameters,
+  ...Mobile.parameters,
+}
+
+export const EmptyWithAnnouncementModal = Template.bind({})
+EmptyWithAnnouncementModal.parameters = {
+  msw: [
     http.get<never, never, AdminDashboardFormMetaDto[]>(
       '/api/v3/admin/forms',
       () => {
@@ -144,9 +172,9 @@ Empty.parameters = {
   ],
 }
 
-export const EmptyMobile = Template.bind({})
-EmptyMobile.parameters = {
-  ...Empty.parameters,
+export const EmptyMobileWithAnnouncementModal = Template.bind({})
+EmptyMobileWithAnnouncementModal.parameters = {
+  ...EmptyWithAnnouncementModal.parameters,
   ...Mobile.parameters,
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The announcements modal would only appear on the Admin Workspace for new users while trying to save their first secret key.

This modal was conditionally hidden until `totalFormsCount > 0`, which was triggered at a disruptive step (in the form creation workflow).

Closes FRM-2077

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Hoist the RolloutAnnouncement modal on the Admin Workspace
- Unblock the Emergency Contact modal 

## Before & After Screenshots

| Description | **BEFORE** | **AFTER** |
| --- | --- | --- |
| Displaying the Announcements and Emergency Contact Modals | ![formsg-modals-before](https://github.com/user-attachments/assets/5687c5b1-89ee-4d96-a5d6-414706e11607) | ![formsg-modals-after](https://github.com/user-attachments/assets/a90c6e87-1614-40cd-9c8f-dbe30c02ac18) |

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Log in as a user with ZERO forms**
- [x] Use an email / user with no assigned forms (either delete or transfer them)
- [x] Clear the `has-seen-rollout-announcement` and `has-seen-emergency-contact` local storage keys
- [x] Log in as this "brand-new" user account normally
- [x] Observe that the Rollout Announcements modal appears
- [x] Observe that the Emergency Contact modal appears

**TC2: Create any Storage / MRF form**
- [x] Using the same user in TC1, click "Create Form"
- [x] Enter a name for the form, then click "Create Form"
- [x] Observe that no modal appears over the Secret Key download page.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
