### PR TITLE
fix: myinfo mobile rerender

### DIFF
--- a/src/app/modules/myinfo/__tests__/myinfo.adapter.spec.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.adapter.spec.ts
@@ -74,7 +74,7 @@ describe('myinfo.adapter', () => {
           // code: '65',
           // prefix: '+',
           // nbr: '97324992',
-          const expected = '+65 97324992'
+          const expected = '+6597324992'
           const response: IPersonResponse = {
             uinFin: MOCK_UINFIN,
             data: MYINFO_MOBILENO_AVAILABLE,

--- a/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
+++ b/src/app/modules/myinfo/__tests__/myinfo.test.constants.ts
@@ -91,7 +91,7 @@ export const MOCK_HASHED_FIELD_IDS = new Set(
 
 const populatedValues = [
   { fieldValue: 'TAN XIAO HUI', disabled: true },
-  { fieldValue: '+65 97324992', disabled: false },
+  { fieldValue: '+6597324992', disabled: false },
   {
     fieldValue: '548 BEDOK NORTH AVENUE 1, #09-128, SINGAPORE 460548',
     disabled: false,

--- a/src/app/modules/myinfo/myinfo.format.ts
+++ b/src/app/modules/myinfo/myinfo.format.ts
@@ -17,7 +17,7 @@ const logger = createLoggerWithLabel(module)
 /**
  * Formats MyInfo attribute as phone number
  * @param phone
- * @example +65 98654321
+ * @example +6598654321
  * @returns Phone number if phone.nbr exists. Else return empty string.
  */
 export const formatPhoneNumber = (
@@ -26,7 +26,7 @@ export const formatPhoneNumber = (
   if (!phone || phone.unavailable || !phone.nbr.value) return ''
 
   return phone.prefix.value && phone.areacode.value
-    ? `${phone.prefix.value}${phone.areacode.value} ${phone.nbr.value}`
+    ? `${phone.prefix.value}${phone.areacode.value}${phone.nbr.value}`
     : phone.nbr.value
 }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Under very specific circumstances, when a form has:
- a Singpass MyInfo Mobile Number field
- Prefilled fields
- and a markdown-formatted description / paragraph field

iOS users are not able to interact with or submit the form.

Closes FRM-2155

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Phone numbers should not have a space in the e164 format
- Prevented the e164 reformatting from causing a re-render in FormFields

## Before & After Screenshots

**Diagram**:
<!-- [insert screenshot here] -->

<img width="2956" height="1131" alt="image" src="https://github.com/user-attachments/assets/8dc53602-d4b8-4f83-bea8-05763285f003" />


![telegram-cloud-photo-size-5-6244773708858249812-y](https://github.com/user-attachments/assets/3a69792a-8834-4ab7-8520-f9b618bae42f)

**BEFORE**:
<!-- [insert screenshot here] -->

![formsg-myinfo-mobile-rerender](https://github.com/user-attachments/assets/edafde45-c910-4657-891c-e01526435da3)

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
