### PR TITLE
fix: remove optionsToRecipientsMap when duplicating form

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -3412,7 +3412,6 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        undefined,
       )
     })
 
@@ -3464,7 +3463,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        mockWorkspaceId,
+        { workspaceId: mockWorkspaceId },
       )
     })
 
@@ -3534,7 +3533,6 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        undefined,
       )
     })
 
@@ -3670,7 +3668,6 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        undefined,
       )
     })
   })
@@ -3900,8 +3897,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        undefined,
-        true,
+        { duplicateStripped: true },
       )
     })
 
@@ -3973,8 +3969,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        undefined,
-        true,
+        { duplicateStripped: true },
       )
     })
 
@@ -4124,8 +4119,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        undefined,
-        true,
+        { duplicateStripped: true },
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -3900,6 +3900,8 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        undefined,
+        true,
       )
     })
 
@@ -3971,6 +3973,8 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        undefined,
+        true,
       )
     })
 
@@ -4120,6 +4124,8 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        undefined,
+        true,
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -3412,6 +3412,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        { workspaceId: undefined },
       )
     })
 
@@ -3533,6 +3534,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        { workspaceId: undefined },
       )
     })
 
@@ -3668,6 +3670,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        { workspaceId: undefined },
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -514,7 +514,7 @@ describe('admin-form.service', () => {
         mockForm,
         mockNewAdminId,
         MOCK_EMAIL_OVERRIDE_PARAMS,
-        mockWorkspaceId,
+        { workspaceId: mockWorkspaceId },
       )
 
       // Assert

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1057,7 +1057,7 @@ export const handleCopyTemplateForm: ControllerHandler<
             userId,
             overrideParams,
             undefined,
-            true
+            true,
           )
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -935,7 +935,7 @@ export const duplicateAdminForm: ControllerHandler<
               originalForm,
               userId,
               overrideParams,
-              workspaceId,
+              { workspaceId: workspaceId },
             ),
           )
           // Step 4: Retrieve dashboard view of duplicated form.
@@ -1056,8 +1056,7 @@ export const handleCopyTemplateForm: ControllerHandler<
             originalForm,
             userId,
             overrideParams,
-            undefined,
-            true,
+            {duplicateStripped: true},
           )
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1052,12 +1052,9 @@ export const handleCopyTemplateForm: ControllerHandler<
         // Step 2: Check if form is currently public.
         AuthService.getFormIfPublic(formId).andThen((originalForm) =>
           // Step 3: Duplicate form.
-          AdminFormService.duplicateForm(
-            originalForm,
-            userId,
-            overrideParams,
-            {duplicateStripped: true},
-          )
+          AdminFormService.duplicateForm(originalForm, userId, overrideParams, {
+            duplicateStripped: true,
+          })
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),
         ),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1052,7 +1052,13 @@ export const handleCopyTemplateForm: ControllerHandler<
         // Step 2: Check if form is currently public.
         AuthService.getFormIfPublic(formId).andThen((originalForm) =>
           // Step 3: Duplicate form.
-          AdminFormService.duplicateForm(originalForm, userId, overrideParams, undefined, true)
+          AdminFormService.duplicateForm(
+            originalForm,
+            userId,
+            overrideParams,
+            undefined,
+            true
+          )
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),
         ),

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1052,7 +1052,7 @@ export const handleCopyTemplateForm: ControllerHandler<
         // Step 2: Check if form is currently public.
         AuthService.getFormIfPublic(formId).andThen((originalForm) =>
           // Step 3: Duplicate form.
-          AdminFormService.duplicateForm(originalForm, userId, overrideParams)
+          AdminFormService.duplicateForm(originalForm, userId, overrideParams, undefined, true)
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),
         ),

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -670,6 +670,7 @@ export const duplicateForm = (
   newAdminId: string,
   overrideParams: DuplicateFormOverwriteDto,
   workspaceId?: string,
+  duplicateStripped?: boolean,
 ): ResultAsync<IFormDocument, FormNotFoundError | DatabaseError> => {
   const overrideProps = processDuplicateOverrideProps(
     overrideParams,
@@ -690,7 +691,7 @@ export const duplicateForm = (
   const duplicateParams = originalForm.getDuplicateParams(overrideProps)
 
   // remove conditional routing mapping from dropdown fields
-  if (duplicateParams?.form_fields) {
+  if (duplicateParams?.form_fields && duplicateStripped) {
     duplicateParams.form_fields.forEach((field) => {
       if (field.fieldType === BasicField.Dropdown) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -689,9 +689,11 @@ export const duplicateForm = (
 
   const duplicateParams = originalForm.getDuplicateParams(overrideProps)
 
+  // remove conditional routing mapping from dropdown fields
   if (duplicateParams?.form_fields) {
     duplicateParams.form_fields.forEach((field) => {
       if (field.fieldType === BasicField.Dropdown) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ;(field as any).optionsToRecipientsMap = undefined
       }
     })

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -693,8 +693,7 @@ export const duplicateForm = (
     duplicateParams.form_fields.forEach((field) => {
       if (field.fieldType === BasicField.Dropdown) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (field as any).optionsToRecipientsMap = undefined
-        console.log(field)
+        ; (field as any).optionsToRecipientsMap = undefined
       }
     })
   }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -689,6 +689,16 @@ export const duplicateForm = (
 
   const duplicateParams = originalForm.getDuplicateParams(overrideProps)
 
+  if (duplicateParams?.form_fields) {
+    duplicateParams.form_fields.forEach((field) => {
+      if (field.fieldType === BasicField.Dropdown) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (field as any).optionsToRecipientsMap = undefined
+        console.log(field)
+      }
+    })
+  }
+
   if (workspaceId)
     return ResultAsync.fromPromise(
       createFormInWorkspaceTransaction(duplicateParams, workspaceId),

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -671,7 +671,10 @@ export const duplicateForm = (
   originalForm: IFormDocument,
   newAdminId: string,
   overrideParams: DuplicateFormOverwriteDto,
-  { workspaceId, duplicateStripped }: { workspaceId?: string; duplicateStripped?: boolean } = {},
+  {
+    workspaceId,
+    duplicateStripped,
+  }: { workspaceId?: string; duplicateStripped?: boolean } = {},
 ): ResultAsync<IFormDocument, FormNotFoundError | DatabaseError> => {
   const overrideProps = processDuplicateOverrideProps(
     overrideParams,

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -692,8 +692,7 @@ export const duplicateForm = (
   if (duplicateParams?.form_fields) {
     duplicateParams.form_fields.forEach((field) => {
       if (field.fieldType === BasicField.Dropdown) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ; (field as any).optionsToRecipientsMap = undefined
+        ;(field as any).optionsToRecipientsMap = undefined
       }
     })
   }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -662,15 +662,16 @@ export const processCreateFormInWorkspace = async (
  * @param originalForm the form to be duplicated
  * @param newAdminId the id of the admin of the duplicated form
  * @param overrideParams params to override in the duplicated form; e.g. the new emails or public key of the form.
- * @param workspaceId the id of the workspace to duplicate the form into
+ * @param options - Optional configuration for duplication.
+ * @param options.workspaceId - The ID of the workspace to duplicate the form into.
+ * @param options.duplicateStripped - If true, duplicates only a stripped version of the form (without certain metadata or fields).
  * @returns the newly created duplicated form
  */
 export const duplicateForm = (
   originalForm: IFormDocument,
   newAdminId: string,
   overrideParams: DuplicateFormOverwriteDto,
-  workspaceId?: string,
-  duplicateStripped?: boolean,
+  { workspaceId, duplicateStripped }: { workspaceId?: string; duplicateStripped?: boolean } = {},
 ): ResultAsync<IFormDocument, FormNotFoundError | DatabaseError> => {
   const overrideProps = processDuplicateOverrideProps(
     overrideParams,
@@ -694,8 +695,7 @@ export const duplicateForm = (
   if (duplicateParams?.form_fields && duplicateStripped) {
     duplicateParams.form_fields.forEach((field) => {
       if (field.fieldType === BasicField.Dropdown) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ;(field as any).optionsToRecipientsMap = undefined
+        field.optionsToRecipientsMap = undefined
       }
     })
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When form is duplicated using use-template, the conditional routing dropdown email mappings also get duplicated. This is due to the mapping of the options to emails being saved in the field itself, under `optionsToRecipientsMapping` variable

## Solution
<!-- How did you solve the problem? -->

Remove `optionsToRecipientsMapping` when duplicating a form

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  