### PR TITLE
fix: save draft public form table field unwanted update

### DIFF
--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -324,7 +324,6 @@ AdminFormBuilderWithAdditionalRowsTableField.play = async ({
   await step('Update the minimum rows to 4', async () => {
     await waitFor(async () => {
       const minimumRowsInput = screen.getByText('Minimum rows')
-      console.log('minimumRowsInput', minimumRowsInput.outerHTML)
       if (!minimumRowsInput) throw new Error('Minimum rows input not found')
       await userEvent.click(minimumRowsInput)
       await userEvent.keyboard('{arrowright}{backspace}4')
@@ -344,7 +343,6 @@ AdminFormBuilderWithAdditionalRowsTableField.play = async ({
   await step('Update the minimum rows to 1', async () => {
     await waitFor(async () => {
       const minimumRowsInput = screen.getByText('Minimum rows')
-      console.log('minimumRowsInput', minimumRowsInput.outerHTML)
       if (!minimumRowsInput) throw new Error('Minimum rows input not found')
       await userEvent.click(minimumRowsInput)
       await userEvent.keyboard('{arrowright}{backspace}1')

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -245,8 +245,11 @@ AdminFormBuilderWithAdditionalRowsTableField.parameters = {
     form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
   }),
   viewport: {
-    defaultViewport: 'lg',
+    value: 'lg', // Forces to desktop view so that the edit drawer opens when the table field is clicked
   },
+  docs: {
+    storyDescription: `Verifies that the table field rows are updated when the minimum rows is updated. Needs to be in lg viewport to work.`,
+  }
 }
 
 AdminFormBuilderWithAdditionalRowsTableField.play = async ({

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react'
+import { expect, screen, userEvent, waitFor, within } from '@storybook/test'
 
 import { PaymentChannel, PaymentType, UserId } from '~shared/types'
 import {
@@ -34,7 +35,6 @@ import {
 import { CreatePage } from '~features/admin-form/create/CreatePage'
 
 import { useMagicFormBuilderStore } from './create/builder-and-design/MagicFormBuilder/useMagicFormBuilderStore'
-import { expect, userEvent, waitFor, within, screen } from '@storybook/test'
 
 const buildMswRoutes = (
   overrides?: Partial<AdminFormDto>,
@@ -249,7 +249,7 @@ AdminFormBuilderWithAdditionalRowsTableField.parameters = {
   },
   docs: {
     storyDescription: `Verifies that the table field rows are updated when the minimum rows is updated. Needs to be in lg viewport to work.`,
-  }
+  },
 }
 
 AdminFormBuilderWithAdditionalRowsTableField.play = async ({

--- a/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormCreatePage.stories.tsx
@@ -17,6 +17,7 @@ import {
   MOCK_FORM_FIELDS,
   MOCK_FORM_FIELDS_WITH_MYINFO,
   MOCK_FORM_LOGICS,
+  TABLE_FIELD_ADDITIONAL_ROWS_FIELD,
 } from '~/mocks/msw/handlers/admin-form'
 import { getUser, MOCK_USER } from '~/mocks/msw/handlers/user'
 
@@ -33,6 +34,7 @@ import {
 import { CreatePage } from '~features/admin-form/create/CreatePage'
 
 import { useMagicFormBuilderStore } from './create/builder-and-design/MagicFormBuilder/useMagicFormBuilderStore'
+import { expect, userEvent, waitFor, within, screen } from '@storybook/test'
 
 const buildMswRoutes = (
   overrides?: Partial<AdminFormDto>,
@@ -235,4 +237,124 @@ export const FormWithPaymentMobile = Template.bind({})
 FormWithPaymentMobile.parameters = {
   ...FormWithPayment.parameters,
   ...getMobileViewParameters(),
+}
+
+export const AdminFormBuilderWithAdditionalRowsTableField = Template.bind({})
+AdminFormBuilderWithAdditionalRowsTableField.parameters = {
+  msw: buildMswRoutes({
+    form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+  }),
+  viewport: {
+    defaultViewport: 'lg',
+  },
+}
+
+AdminFormBuilderWithAdditionalRowsTableField.play = async ({
+  canvasElement,
+  step,
+}) => {
+  const canvas = within(canvasElement)
+
+  let tableFieldTable: HTMLElement
+
+  await step(
+    'Find the table field table and add another row button',
+    async () => {
+      await waitFor(async () => {
+        const foundTableFieldGroup = canvas.getByRole('group', {
+          name: (_, element) => {
+            const label = element.querySelector(
+              '#table-field-for-test-id-label',
+            )
+            return !!label
+          },
+        })
+        if (!foundTableFieldGroup)
+          throw new Error('Table field group not found')
+        const foundTableFieldTable =
+          within(foundTableFieldGroup).getByRole('table')
+        if (!foundTableFieldTable)
+          throw new Error('Table field table not found')
+        tableFieldTable = foundTableFieldTable
+      })
+    },
+  )
+
+  await step(
+    `Assert that the table is initiated with ${TABLE_FIELD_ADDITIONAL_ROWS_FIELD.minimumRows} rows which is the minimum rows`,
+    async () => {
+      await waitFor(async () => {
+        const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+        const tbody = rowGroups.find((group) => group.localName === 'tbody')
+        if (!tbody) throw new Error('Table field table body not found')
+        const rows = within(tbody).getAllByRole('row')
+        expect(rows).toHaveLength(
+          Number(TABLE_FIELD_ADDITIONAL_ROWS_FIELD.minimumRows),
+        )
+      })
+    },
+  )
+
+  await step(
+    'Find and click on the HighlightableFlex component surrounding the table field',
+    async () => {
+      await waitFor(async () => {
+        // Find the HighlightableFlex by looking for the field container that contains the table field
+        // The HighlightableFlex is the clickable wrapper around the field with role="button"
+        const highlightableFlex = canvas.getByRole('button', {
+          name: (content, element) => {
+            // Look for a button that contains the table field title
+            // The HighlightableFlex wraps the entire field including its title
+            return content.includes('Table field for test')
+          },
+        })
+
+        if (!highlightableFlex) {
+          throw new Error('HighlightableFlex component not found')
+        }
+
+        await userEvent.click(highlightableFlex)
+      })
+    },
+  )
+
+  await step('Update the minimum rows to 4', async () => {
+    await waitFor(async () => {
+      const minimumRowsInput = screen.getByText('Minimum rows')
+      console.log('minimumRowsInput', minimumRowsInput.outerHTML)
+      if (!minimumRowsInput) throw new Error('Minimum rows input not found')
+      await userEvent.click(minimumRowsInput)
+      await userEvent.keyboard('{arrowright}{backspace}4')
+    })
+  })
+
+  await step(`Assert that the table is updated to have 4 rows`, async () => {
+    await waitFor(async () => {
+      const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+      const tbody = rowGroups.find((group) => group.localName === 'tbody')
+      if (!tbody) throw new Error('Table field table body not found')
+      const rows = within(tbody).getAllByRole('row')
+      expect(rows).toHaveLength(4)
+    })
+  })
+
+  await step('Update the minimum rows to 1', async () => {
+    await waitFor(async () => {
+      const minimumRowsInput = screen.getByText('Minimum rows')
+      console.log('minimumRowsInput', minimumRowsInput.outerHTML)
+      if (!minimumRowsInput) throw new Error('Minimum rows input not found')
+      await userEvent.click(minimumRowsInput)
+      await userEvent.keyboard('{arrowright}{backspace}1')
+    })
+  })
+
+  await step(`Assert that the table is updated to have 1 rows`, async () => {
+    await waitFor(async () => {
+      const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+      const tbody = rowGroups.find((group) => group.localName === 'tbody')
+      if (!tbody) throw new Error('Table field table body not found')
+      const rows = within(tbody).getAllByRole('row')
+      expect(rows).toHaveLength(1)
+    })
+  })
 }

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
@@ -26,6 +26,7 @@ import { ADMINFORM_PREVIEW_ROUTE } from '~constants/routes'
 import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
 
 import PreviewFormPage from './PreviewFormPage'
+import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,
@@ -397,5 +398,23 @@ WithPayment.parameters = {
       },
     }),
     ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+
+export const MultirespondentFormWithAdditionalRowsTableField = Template.bind({})
+MultirespondentFormWithAdditionalRowsTableField.parameters = {
+  docs: {
+    storyDescription: `There should be ${TABLE_FIELD_ADDITIONAL_ROWS_FIELD.minimumRows} rows since the minimum rows is ${TABLE_FIELD_ADDITIONAL_ROWS_FIELD.minimumRows}`,
+  },
+  msw: [
+    getPreviewFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          workflow: [],
+          form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+        },
+      },
+    }),
   ],
 }

--- a/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormPage.stories.tsx
@@ -9,6 +9,7 @@ import {
   FormResponseMode,
 } from '~shared/types/form'
 
+import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
 import {
   getPreviewFormErrorResponse,
   getPreviewFormResponse,
@@ -26,7 +27,6 @@ import { ADMINFORM_PREVIEW_ROUTE } from '~constants/routes'
 import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
 
 import PreviewFormPage from './PreviewFormPage'
-import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,

--- a/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -18,6 +18,7 @@ import {
 import {
   augmentFormFields,
   getFieldPrefillMap,
+  getInitialFormValues,
   useCommonFormProvider,
 } from '~/features/public-form/PublicFormProvider'
 
@@ -359,13 +360,31 @@ export const PreviewFormProvider = ({
     [formFields, currentStepNumberWorkflowStep],
   )
 
-  const defaultFormValues = useMemo(() => ({}), [])
+  const isSaveDraftEnabled = Boolean(form?.isSaveDraftEnabled)
+
+  const defaultFormValues = useMemo(() => {
+    if (!form?.responseMode) return {}
+    return getInitialFormValues({
+      formResponseMode: form?.responseMode,
+      currentStepNumberWorkflowStep,
+      augmentedFormFields,
+      fieldPrefillMap,
+      draftResponsesToRestore: {},
+      searchParams,
+      isSaveDraftEnabled,
+    })
+  }, [
+    form?.responseMode,
+    currentStepNumberWorkflowStep,
+    augmentedFormFields,
+    fieldPrefillMap,
+    isSaveDraftEnabled,
+    searchParams,
+  ])
 
   const formMethods = useForm<FormFieldValues>({
     defaultValues: defaultFormValues,
   })
-
-  const isSaveDraftEnabled = Boolean(form?.isSaveDraftEnabled)
 
   if (isNotFormId) {
     return <NotFoundErrorPage />

--- a/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
@@ -15,6 +15,8 @@ import { ADMINFORM_USETEMPLATE_ROUTE } from '~constants/routes'
 import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
 
 import TemplateFormPage from './TemplateFormPage'
+import { FormResponseMode } from '~shared/types'
+import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,
@@ -56,4 +58,22 @@ export const FormNotFoundMobile = Template.bind({})
 FormNotFoundMobile.parameters = {
   ...FormNotFound.parameters,
   ...getMobileViewParameters(),
+}
+
+export const MultirespondentFormWithAdditionalRowsTableField = Template.bind({})
+MultirespondentFormWithAdditionalRowsTableField.parameters = {
+  docs: {
+    storyDescription: `There should be ${TABLE_FIELD_ADDITIONAL_ROWS_FIELD.minimumRows} rows since the minimum rows is ${TABLE_FIELD_ADDITIONAL_ROWS_FIELD.minimumRows}`,
+  },
+  msw: [
+    getTemplateFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          workflow: [],
+          form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+        },
+      },
+    }),
+  ],
 }

--- a/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormPage.stories.tsx
@@ -1,5 +1,8 @@
 import { Meta, StoryFn } from '@storybook/react'
 
+import { FormResponseMode } from '~shared/types'
+
+import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
 import {
   getTemplateFormErrorResponse,
   getTemplateFormResponse,
@@ -15,8 +18,6 @@ import { ADMINFORM_USETEMPLATE_ROUTE } from '~constants/routes'
 import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
 
 import TemplateFormPage from './TemplateFormPage'
-import { FormResponseMode } from '~shared/types'
-import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,

--- a/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
+++ b/frontend/src/features/admin-form/template/TemplateFormProvider.tsx
@@ -14,6 +14,7 @@ import { PublicFormContext } from '~/features/public-form/PublicFormContext'
 import {
   augmentFormFields,
   getFieldPrefillMap,
+  getInitialFormValues,
   useCommonFormProvider,
 } from '~/features/public-form/PublicFormProvider'
 
@@ -120,13 +121,31 @@ export const TemplateFormProvider = ({
     [formFields, currentStepNumberWorkflowStep],
   )
 
-  const defaultFormValues = useMemo(() => ({}), [])
+  const isSaveDraftEnabled = Boolean(form?.isSaveDraftEnabled)
+
+  const defaultFormValues = useMemo(() => {
+    if (!form?.responseMode) return {}
+    return getInitialFormValues({
+      formResponseMode: form?.responseMode,
+      currentStepNumberWorkflowStep,
+      augmentedFormFields,
+      fieldPrefillMap,
+      draftResponsesToRestore: {},
+      searchParams,
+      isSaveDraftEnabled,
+    })
+  }, [
+    form?.responseMode,
+    currentStepNumberWorkflowStep,
+    augmentedFormFields,
+    fieldPrefillMap,
+    isSaveDraftEnabled,
+    searchParams,
+  ])
 
   const formMethods = useForm<FormFieldValues>({
     defaultValues: defaultFormValues,
   })
-
-  const isSaveDraftEnabled = Boolean(form?.isSaveDraftEnabled)
 
   if (isNotFormId) {
     return <NotFoundErrorPage />

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect } from 'react'
 import { Meta, StoryFn } from '@storybook/react'
 import { expect, userEvent, waitFor, within } from '@storybook/test'
 import dedent from 'dedent'
@@ -28,6 +29,7 @@ import {
   SHOW_FIELDS_ON_YES_LOGIC,
 } from '~/mocks/msw/handlers/public-form'
 
+import { useIndexedDb } from '~hooks/useIndexedDb'
 import {
   getMobileViewParameters,
   getTabletViewParameters,
@@ -35,6 +37,9 @@ import {
 } from '~utils/storybook'
 import { ShortTextFieldSchema } from '~templates/Field'
 
+import { SAVE_DRAFT_INDEXEDDB_STORE_NAME } from '~features/form/constants'
+
+import { DraftSubmission } from './PublicFormContext'
 import PublicFormPage from './PublicFormPage'
 
 const DEFAULT_MSW_HANDLERS = [
@@ -96,6 +101,35 @@ const generateMswHandlersForColorTheme = (colorTheme: FormColorTheme) => {
     postGenerateVfnOtpResponse(),
     postVerifyVfnOtpResponse(),
   ]
+}
+
+// Component that sets up draft data using hooks
+export const DraftSetupWrapper = ({
+  children,
+  draftKey,
+  draftValue,
+}: {
+  children: React.ReactNode
+  draftKey: string
+  draftValue: DraftSubmission
+}) => {
+  // Use the useIndexedDb hook to set draft value
+  const [, setDraftSubmission] = useIndexedDb<DraftSubmission>({
+    key: draftKey,
+    initialValue: {
+      lastUpdated: null,
+      draftResponses: null,
+      fieldDefinitionsChecksum: null,
+    },
+    storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+  })
+
+  // Set the draft value when component mounts
+  useLayoutEffect(() => {
+    setDraftSubmission(draftValue)
+  }, [setDraftSubmission, draftValue])
+
+  return <>{children}</>
 }
 
 export default {
@@ -1065,6 +1099,117 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     },
   )
 }
+
+const DRAFT_TO_RESTORE = {
+  lastUpdated: 1759305125679,
+  draftResponses: {
+    '5da04eb5e397fc0013f63c7e': 'Yes',
+    '5da0290b4073c800128388b4': {
+      value: 'kevin.foong@washere.com',
+    },
+    '5da0290b4073c800128388z4': {
+      value: 'open@open.gov.sg',
+    },
+    '5da04ea3e397fc0013f63c78': {
+      value: '+6590008000',
+    },
+    '5da04ea3e397fc0013f63c11': {
+      value: '+6562223535',
+    },
+    '5da04ea9e397fc0013f63c7b': '321',
+    '5da04eab3738d10012607734': '3.21',
+    '5da04eafe397fc0013f63c7c': '<Start>This is a short text.</End>',
+    '5da04eb1e397fc0013f63c7d': '<Start>This is a long text.</End>',
+    '5da04eb23738d10012607737': 'Option 2',
+    '5da04eb7e397fc0013f63c80': {
+      value: ['Option 1', 'Option 3', 'Option 2'],
+    },
+    '5da04eb93738d10012607738': {
+      value: 'Option 3',
+    },
+    '5da04ebfe397fc0013f63c83': '01/10/2025',
+    '5da04ec13738d1001260773a': '3',
+    '5da04ec43738d1001260773b': 'T2546896H',
+    '5da04f833738d1001260777f': [
+      {
+        '5da04f833738d10012607781': 'Row 1/2',
+        '5dadaeb719eccb0012364550': 'Option 1',
+      },
+      {
+        '5da04f833738d10012607781': 'Row 2/2',
+        '5dadaeb719eccb0012364550': 'Option 2',
+      },
+    ],
+  },
+  fieldDefinitionsChecksum: {
+    '5da04eb5e397fc0013f63c7e':
+      '{"title":"Yes/No","description":"This is a\\n\\nmultiline description\\r\\nanother line","required":true,"disabled":false,"fieldType":"yes_no","_id":"5da04eb5e397fc0013f63c7e","globalId":"CnGRpTpnqSrISnk28yLDvKt8MI2HCFJuYbk72ie0l56"}',
+    '5da0290b4073c800128388b4':
+      '{"autoReplyOptions":{"hasAutoReply":true,"autoReplySubject":"my subject","autoReplySender":"my name","autoReplyMessage":"my email","includeFormSummary":true},"isVerifiable":false,"hasAllowedEmailDomains":false,"allowedEmailDomains":[],"title":"Email","description":"","required":true,"disabled":false,"fieldType":"email","_id":"5da0290b4073c800128388b4","globalId":"nhTtR59j90TGAxKCIdSQ7FFFjF5z0d6ifKDIxr2IfgO"}',
+    '5da0290b4073c800128388z4':
+      '{"autoReplyOptions":{"hasAutoReply":true,"autoReplySubject":"my subject","autoReplySender":"my name","autoReplyMessage":"my email","includeFormSummary":true},"isVerifiable":true,"hasAllowedEmailDomains":true,"allowedEmailDomains":["@open.gov.sg"],"title":"Verifiable Email","description":"Only allows @open.gov.sg email domains","required":true,"disabled":false,"fieldType":"email","_id":"5da0290b4073c800128388z4","globalId":"nhTtR59j90TGAxKCIdSQ7FFFjF5z0d6ifKDIxr2Ifg1"}',
+    '5da04ea3e397fc0013f63c78':
+      '{"allowIntlNumbers":false,"isVerifiable":false,"title":"Mobile Number","description":"","required":true,"disabled":false,"fieldType":"mobile","_id":"5da04ea3e397fc0013f63c78","globalId":"IsZAjzS1J2AJqsUnAnCSQStxoknyIdUEXam6cPlNYuJ"}',
+    '5da04ea3e397fc0013f63c11':
+      '{"allowIntlNumbers":true,"isVerifiable":true,"title":"Verifiable Mobile Number","description":"","required":true,"disabled":false,"fieldType":"mobile","_id":"5da04ea3e397fc0013f63c11","globalId":"IsZAjzS1J2AJqsUnAnCSQStxoknyIdUEXam6cPlNYuY"}',
+    '5da04ea9e397fc0013f63c7b':
+      '{"ValidationOptions":{"_id":"6148614ee2fb650012928dd9","selectedValidation":null,"LengthValidationOptions":{"selectedLengthValidation":null,"customVal":null},"RangeValidationOptions":{"customMin":null,"customMax":null},"id":"6148614ee2fb650012928dd9"},"title":"Number","description":"","required":true,"disabled":false,"fieldType":"number","_id":"5da04ea9e397fc0013f63c7b","globalId":"TUAlegPQaX1L5kzEBtNWNlohV0eUoFsZ7WL2m3IMbFv"}',
+    '5da04eab3738d10012607734':
+      '{"ValidationOptions":{"customMax":null,"customMin":null},"validateByValue":false,"title":"Decimal","description":"","required":true,"disabled":false,"fieldType":"decimal","_id":"5da04eab3738d10012607734","globalId":"bRvL9Y3syNYSZDUI09lbMM0ET1nAaDoJNXxGEYH5P4S"}',
+    '5da04eafe397fc0013f63c7c':
+      '{"ValidationOptions":{"_id":"6148614ee2fb650012928ddb","customVal":null,"selectedValidation":null,"customMin":null,"customMax":null,"id":"6148614ee2fb650012928ddb"},"allowPrefill":false,"title":"Short Text","description":"","required":true,"disabled":false,"fieldType":"textfield","_id":"5da04eafe397fc0013f63c7c","globalId":"gi588V2s1fBk7BcWOHoqnFy1by7KIxjw8njXV5NeC3g"}',
+    '5da04eb1e397fc0013f63c7d':
+      '{"ValidationOptions":{"_id":"6148614ee2fb650012928ddd","customVal":null,"selectedValidation":null,"customMin":null,"customMax":null,"id":"6148614ee2fb650012928ddd"},"title":"Long Text","description":"","required":true,"disabled":false,"fieldType":"textarea","_id":"5da04eb1e397fc0013f63c7d","globalId":"iJpZkr9GasJrAvQHOYAyRiGRGNhDJAzRw6FwTLaQImS"}',
+    '5da04eb23738d10012607737':
+      '{"fieldOptions":["Option 1","Option 2","Option 3"],"title":"Dropdown","description":"","required":true,"disabled":false,"fieldType":"dropdown","_id":"5da04eb23738d10012607737","globalId":"wzV4A56NIxpfdjdB0WJO0vcovDOiY7wjuE8ZH4Pr9at"}',
+    '5da04eb7e397fc0013f63c80':
+      '{"ValidationOptions":{"customMax":null,"customMin":null},"fieldOptions":["Option 1","Option 2","Option 3"],"othersRadioButton":false,"validateByValue":false,"title":"Checkbox","description":"","required":true,"disabled":false,"fieldType":"checkbox","_id":"5da04eb7e397fc0013f63c80","globalId":"l4gMDfFhA1ITmhUPQCjA05aUAOROUOwlNAjMJMkwmJ7"}',
+    '5da04eb93738d10012607738':
+      '{"fieldOptions":["Option 1","Option 2","Option 3"],"othersRadioButton":false,"title":"Radio","description":"","required":true,"disabled":false,"fieldType":"radiobutton","_id":"5da04eb93738d10012607738","globalId":"pJc2jhdmSk0auIes9O4Y1Wwq3xLVab1e3D3VrMWuJVt"}',
+    '5da04ebfe397fc0013f63c83':
+      '{"dateValidation":{"customMinDate":null,"customMaxDate":null,"selectedDateValidation":null},"title":"Date","description":"","required":true,"disabled":false,"fieldType":"date","_id":"5da04ebfe397fc0013f63c83","globalId":"pq8tWED4Jf6FkuWr9VKUqz5Ea6rCASbx73aO6T2LhAN"}',
+    '5da04ec13738d1001260773a':
+      '{"ratingOptions":{"steps":5,"shape":"Heart"},"title":"Rating","description":"","required":true,"disabled":false,"fieldType":"rating","_id":"5da04ec13738d1001260773a","globalId":"1KjTqMp582fiF9oChFxmw6De7B2U1zQGvJ0TLm5rcZu"}',
+    '5da04ec43738d1001260773b':
+      '{"title":"NRIC","description":"","required":true,"disabled":false,"fieldType":"nric","_id":"5da04ec43738d1001260773b","globalId":"0KHU4aNnFVS5y8CLqkXWf9A0RknGIqzNoVfOUlqNRDl"}',
+    '5da04f833738d1001260777f':
+      '{"addMoreRows":false,"title":"Table","description":"","required":true,"disabled":false,"fieldType":"table","_id":"5da04f833738d1001260777f","columns":[{"ValidationOptions":{"_id":"6148614ee2fb650012928ddf","customMax":null,"customMin":null,"customVal":null,"selectedValidation":null,"id":"6148614ee2fb650012928ddf"},"allowPrefill":false,"columnType":"textfield","_id":"5da04f833738d10012607781","title":"Text Field","required":true},{"fieldOptions":["Option 1","Option 2"],"columnType":"dropdown","_id":"5dadaeb719eccb0012364550","title":"Db","required":true}],"minimumRows":2,"globalId":"E7udA19YGZOZuiFhlDSm5FwmogBiz9DaUulRFe9ygGD"}',
+    '5da04f873738d10012607783':
+      '{"title":"Attachment","description":"","required":false,"disabled":false,"fieldType":"attachment","_id":"5da04f873738d10012607783","attachmentSize":"1","globalId":"gE8XOqZA6MA3Rl7bQbrSOKpxjfeVSeYSfMZhRSitEn1"}',
+  },
+}
+
+export const WithSaveDraftRestored = Template.bind({})
+WithSaveDraftRestored.parameters = {
+  docs: {
+    storyDescription:
+      'This story asserts that the saved draft is restored when the page is loaded.' +
+      'Note that the attachment field is not stored and will not be restored.',
+  },
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Encrypt,
+          isSaveDraftEnabled: true,
+        },
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+WithSaveDraftRestored.decorators = [
+  (Story) => {
+    return (
+      <DraftSetupWrapper
+        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
+        draftValue={DRAFT_TO_RESTORE}
+      >
+        <Story />
+      </DraftSetupWrapper>
+    )
+  },
+]
 
 export const WithStorageModeTableFieldAdditionalRows = Template.bind({})
 WithStorageModeTableFieldAdditionalRows.parameters = {

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -29,12 +29,19 @@ import {
 } from '~/mocks/msw/handlers/public-form'
 
 import {
+  _getFromIndexedDBForTest,
+  _removeFromIndexedDBForTest,
+} from '~hooks/useIndexedDb'
+import {
   getMobileViewParameters,
   getTabletViewParameters,
   StoryRouter,
 } from '~utils/storybook'
 import { ShortTextFieldSchema } from '~templates/Field'
 
+import { SAVE_DRAFT_INDEXEDDB_STORE_NAME } from '~features/form/constants'
+
+import { DraftSubmission } from './PublicFormContext'
 import PublicFormPage from './PublicFormPage'
 import SaveDraftSetupWrapper from './SaveDraftSetupWrapper'
 
@@ -909,6 +916,9 @@ WithSaveDraftEnabledMobile.parameters = {
   ...getMobileViewParameters(),
 }
 
+const STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY =
+  'formsg-save-draft-61540ece3d4a6e50ac0cc6ff'
+
 export const WithSaveDraftEnabledAndClickFloatingSaveDraftButton =
   Template.bind({})
 WithSaveDraftEnabledAndClickFloatingSaveDraftButton.parameters = {
@@ -984,6 +994,24 @@ WithSaveDraftEnabledAndClickFloatingSaveDraftButton.play = async ({
       )
     },
   )
+
+  await step(
+    'Assert that the saved draft is created in IndexedDB',
+    async () => {
+      const savedDraft = (await _getFromIndexedDBForTest({
+        key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+        storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+      })) as DraftSubmission | undefined
+      expect(savedDraft).toBeDefined()
+    },
+  )
+
+  await step('Cleanup saved draft', async () => {
+    await _removeFromIndexedDBForTest({
+      key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+      storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+    })
+  })
 }
 
 export const WithSaveDraftEnabledAndClickSaveDraftButton = Template.bind({})
@@ -1009,6 +1037,19 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
   const screen = within(document.body)
 
   let mainSaveDraftButton: HTMLElement
+
+  await step('Find the first short text field and fill it in', async () => {
+    await waitFor(
+      async () => {
+        const shortTextField = within(document.body).getByText('Short Text')
+        await userEvent.type(
+          shortTextField,
+          'Save draft test input for short text field',
+        )
+      },
+      { timeout: 3000 },
+    )
+  })
 
   await step('Find the main save draft button', async () => {
     await waitFor(
@@ -1065,6 +1106,116 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
       )
     },
   )
+
+  await step(
+    'Assert that the saved draft is created in IndexedDB',
+    async () => {
+      const savedDraft = (await _getFromIndexedDBForTest({
+        key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+        storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+      })) as DraftSubmission | undefined
+      expect(savedDraft?.draftResponses).toBeTruthy()
+      expect(savedDraft?.draftResponses?.['5da04eafe397fc0013f63c7c']).toEqual(
+        'Save draft test input for short text field',
+      )
+    },
+  )
+
+  await step('Cleanup saved draft', async () => {
+    await _removeFromIndexedDBForTest({
+      key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+      storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+    })
+  })
+}
+
+export const WithSaveDraftExcludingSavingMyInfoFields = Template.bind({})
+
+WithSaveDraftExcludingSavingMyInfoFields.parameters = {
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Encrypt,
+          form_fields: MOCK_PREFILLED_MYINFO_FIELDS,
+          isSaveDraftEnabled: true,
+        },
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+
+WithSaveDraftExcludingSavingMyInfoFields.play = async ({
+  canvasElement,
+  step,
+}) => {
+  const canvas = within(canvasElement)
+
+  let mainSaveDraftButton: HTMLElement
+
+  await step('Find the main save draft button', async () => {
+    await waitFor(
+      () => {
+        const foundMainSaveDraftButton = canvas
+          .getAllByRole('button', {
+            name: 'Save a draft',
+          })
+          .find((button) => button.textContent?.includes('Save a draft'))
+        if (!foundMainSaveDraftButton) {
+          throw new Error('Main save draft button not found')
+        }
+        mainSaveDraftButton = foundMainSaveDraftButton
+        expect(foundMainSaveDraftButton).toBeInTheDocument()
+      },
+      { timeout: 3000 },
+    )
+  })
+
+  await step('Click the main save draft button', async () => {
+    await userEvent.click(mainSaveDraftButton)
+  })
+
+  await step(
+    'Assert that the saved draft success toast message appears',
+    async () => {
+      await waitFor(
+        () => {
+          expect(document.body).toHaveTextContent('Your draft has been saved.')
+        },
+        { timeout: 3000 },
+      )
+    },
+  )
+
+  await step('Assert that the MyInfo fields are not saved', async () => {
+    const savedDraft = (await _getFromIndexedDBForTest({
+      key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+      storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+    })) as DraftSubmission | undefined
+    expect(savedDraft?.draftResponses).toBeNull()
+    expect(savedDraft?.fieldDefinitionsChecksum).toBeNull()
+    const draftResponses = savedDraft?.draftResponses
+      ? Object.keys(savedDraft.draftResponses)
+      : []
+    const savedDraftChecksum = savedDraft?.fieldDefinitionsChecksum
+      ? Object.keys(savedDraft.fieldDefinitionsChecksum)
+      : []
+
+    const myInfoFieldIds = MOCK_PREFILLED_MYINFO_FIELDS.map(
+      (field) => field._id,
+    )
+
+    expect(draftResponses).not.toContain(myInfoFieldIds)
+    expect(savedDraftChecksum).not.toContain(myInfoFieldIds)
+  })
+
+  await step('Cleanup saved draft', async () => {
+    await _removeFromIndexedDBForTest({
+      key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+      storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+    })
+  })
 }
 
 const DRAFT_TO_RESTORE = {
@@ -1169,7 +1320,7 @@ WithSaveDraftRestored.decorators = [
   (Story) => {
     return (
       <SaveDraftSetupWrapper
-        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
+        draftKey={STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY}
         draftValue={DRAFT_TO_RESTORE}
       >
         <Story />
@@ -1177,6 +1328,25 @@ WithSaveDraftRestored.decorators = [
     )
   },
 ]
+WithSaveDraftRestored.play = async ({ step }) => {
+  await step(
+    'Assert that the saved draft is created in IndexedDB',
+    async () => {
+      const savedDraft = (await _getFromIndexedDBForTest({
+        key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+        storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+      })) as DraftSubmission | undefined
+      expect(savedDraft?.draftResponses).toBeTruthy()
+    },
+  )
+
+  await step('Cleanup saved draft', async () => {
+    await _removeFromIndexedDBForTest({
+      key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+      storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+    })
+  })
+}
 
 export const WithSaveDraftRestoredYesNoFieldSchemaChanged = Template.bind({})
 WithSaveDraftRestoredYesNoFieldSchemaChanged.parameters = {
@@ -1200,7 +1370,7 @@ WithSaveDraftRestoredYesNoFieldSchemaChanged.decorators = [
   (Story) => {
     return (
       <SaveDraftSetupWrapper
-        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
+        draftKey={STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY}
         draftValue={{
           lastUpdated: new Date().getTime() - 10,
           draftResponses: {
@@ -1217,6 +1387,30 @@ WithSaveDraftRestoredYesNoFieldSchemaChanged.decorators = [
     )
   },
 ]
+
+WithSaveDraftRestoredYesNoFieldSchemaChanged.play = async ({ step }) => {
+  await step(
+    'Assert that the saved draft is created in IndexedDB',
+    async () => {
+      const savedDraft = (await _getFromIndexedDBForTest({
+        key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+        storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+      })) as DraftSubmission | undefined
+      expect(savedDraft?.draftResponses).toBeTruthy()
+      expect(savedDraft?.draftResponses).toBeDefined()
+      expect(savedDraft?.draftResponses!['5da04eb5e397fc0013f63c7e']).toEqual(
+        DRAFT_TO_RESTORE.draftResponses!['5da04eb5e397fc0013f63c7e'],
+      )
+    },
+  )
+
+  await step('Cleanup saved draft', async () => {
+    await _removeFromIndexedDBForTest({
+      key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+      storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+    })
+  })
+}
 
 export const WithPrefilledNormalFieldsWithSaveDraftRestored = Template.bind({})
 WithPrefilledNormalFieldsWithSaveDraftRestored.parameters = {
@@ -1237,7 +1431,7 @@ WithPrefilledNormalFieldsWithSaveDraftRestored.decorators = [
   (Story) => {
     return (
       <SaveDraftSetupWrapper
-        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
+        draftKey={STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY}
         draftValue={{
           lastUpdated: new Date().getTime() - 10,
           draftResponses: {
@@ -1252,6 +1446,37 @@ WithPrefilledNormalFieldsWithSaveDraftRestored.decorators = [
             ...DRAFT_TO_RESTORE.fieldDefinitionsChecksum,
           },
         }}
+      >
+        <Story />
+      </SaveDraftSetupWrapper>
+    )
+  },
+]
+WithPrefilledNormalFieldsWithSaveDraftRestored.play = async ({ step }) => {
+  await step(
+    'Assert that the saved draft is created in IndexedDB',
+    async () => {
+      const savedDraft = (await _getFromIndexedDBForTest({
+        key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+        storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+      })) as DraftSubmission | undefined
+      expect(savedDraft?.draftResponses).toBeTruthy()
+    },
+  )
+
+  await step('Cleanup saved draft', async () => {
+    await _removeFromIndexedDBForTest({
+      key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+      storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+    })
+  })
+}
+WithPrefilledNormalFieldsWithSaveDraftRestored.decorators = [
+  (Story) => {
+    return (
+      <SaveDraftSetupWrapper
+        draftKey={STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY}
+        draftValue={DRAFT_TO_RESTORE}
       >
         <Story />
       </SaveDraftSetupWrapper>

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react'
-import { expect, screen, userEvent, waitFor, within } from '@storybook/test'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
 import dedent from 'dedent'
 
 import { ErrorCode } from '~shared/types'
@@ -8,9 +8,13 @@ import {
   FormAuthType,
   FormColorTheme,
   FormResponseMode,
+  WorkflowType,
 } from '~shared/types/form'
 
-import { MOCK_PREFILLED_MYINFO_FIELDS } from '~/mocks/msw/handlers/admin-form'
+import {
+  MOCK_PREFILLED_MYINFO_FIELDS,
+  TABLE_FIELD_ADDITIONAL_ROWS_FIELD,
+} from '~/mocks/msw/handlers/admin-form'
 import { envHandlers } from '~/mocks/msw/handlers/env'
 import {
   getPublicFormErrorResponse,
@@ -1058,6 +1062,235 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
         },
         { timeout: 5000 },
       )
+    },
+  )
+}
+
+export const WithStorageModeTableFieldAdditionalRows = Template.bind({})
+WithStorageModeTableFieldAdditionalRows.parameters = {
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Encrypt,
+          form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+        },
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+
+// Assert that the table field additional rows limits and add another row buttons are working as expected
+WithStorageModeTableFieldAdditionalRows.play = async ({
+  canvasElement,
+  step,
+}) => {
+  const canvas = within(canvasElement)
+
+  let tableFieldTable: HTMLElement
+  let tableFieldAddAnotherRowButton: HTMLElement
+
+  await step(
+    'Find the table field table and add another row button',
+    async () => {
+      await waitFor(async () => {
+        const foundTableFieldGroup = canvas.getByRole('group', {
+          name: (_, element) => {
+            const label = element.querySelector(
+              '#table-field-for-test-id-label',
+            )
+            return !!label
+          },
+        })
+        if (!foundTableFieldGroup)
+          throw new Error('Table field group not found')
+
+        const foundTableFieldTable =
+          within(foundTableFieldGroup).getByRole('table')
+        if (!foundTableFieldTable)
+          throw new Error('Table field table not found')
+        tableFieldTable = foundTableFieldTable
+
+        const foundTableFieldAddAnotherRowButton = within(
+          foundTableFieldGroup,
+        ).getByRole('button', { name: /Add another row/i })
+        if (!foundTableFieldAddAnotherRowButton)
+          throw new Error('Table field add another row button not found')
+        tableFieldAddAnotherRowButton = foundTableFieldAddAnotherRowButton
+      })
+    },
+  )
+
+  await step(
+    'Assert that the table is initiated with 2 rows which is the minimum rows',
+    async () => {
+      await waitFor(async () => {
+        const rows = within(tableFieldTable).getAllByRole('row')
+        expect(rows).toHaveLength(2)
+      })
+    },
+  )
+
+  await step(
+    'Click the add another row button for the table field so there is 3 rows',
+    async () => {
+      await userEvent.click(tableFieldAddAnotherRowButton)
+    },
+  )
+
+  await step(
+    'Assert that the table is initiated with 3 rows which is the minimum rows',
+    async () => {
+      await waitFor(async () => {
+        const rows = within(tableFieldTable).getAllByRole('row')
+        expect(rows).toHaveLength(3)
+      })
+    },
+  )
+
+  await step(
+    'Click the add another row button for the table field so there is 4 rows',
+    async () => {
+      await userEvent.click(tableFieldAddAnotherRowButton)
+    },
+  )
+
+  await step(
+    'Assert that the table is initiated with 4 rows which is the minimum rows',
+    async () => {
+      await waitFor(async () => {
+        const rows = within(tableFieldTable).getAllByRole('row')
+        expect(rows).toHaveLength(4)
+      })
+    },
+  )
+
+  await step(
+    'Assert the add another row button is disabled since number of rows is maximum ',
+    async () => {
+      await waitFor(async () => {
+        expect(tableFieldAddAnotherRowButton).toBeDisabled()
+      })
+    },
+  )
+}
+
+export const WithMultiRespondentFormStep1TableFieldAdditionalRows =
+  Template.bind({})
+WithMultiRespondentFormStep1TableFieldAdditionalRows.parameters = {
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          workflow: [
+            {
+              _id: 'step-1',
+              edit: ['table-field-for-test-id'],
+              workflow_type: WorkflowType.Static,
+              emails: [],
+            },
+          ],
+          form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+        },
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+
+// Assert that the table field additional rows limits and add another row buttons are working as expected
+WithMultiRespondentFormStep1TableFieldAdditionalRows.play = async ({
+  canvasElement,
+  step,
+}) => {
+  const canvas = within(canvasElement)
+
+  let tableFieldTable: HTMLElement
+  let tableFieldAddAnotherRowButton: HTMLElement
+
+  await step(
+    'Find the table field table and add another row button',
+    async () => {
+      await waitFor(async () => {
+        const foundTableFieldGroup = canvas.getByRole('group', {
+          name: (_, element) => {
+            const label = element.querySelector(
+              '#table-field-for-test-id-label',
+            )
+            return !!label
+          },
+        })
+        if (!foundTableFieldGroup)
+          throw new Error('Table field group not found')
+
+        const foundTableFieldTable =
+          within(foundTableFieldGroup).getByRole('table')
+        if (!foundTableFieldTable)
+          throw new Error('Table field table not found')
+        tableFieldTable = foundTableFieldTable
+
+        const foundTableFieldAddAnotherRowButton = within(
+          foundTableFieldGroup,
+        ).getByRole('button', { name: /Add another row/i })
+        if (!foundTableFieldAddAnotherRowButton)
+          throw new Error('Table field add another row button not found')
+        tableFieldAddAnotherRowButton = foundTableFieldAddAnotherRowButton
+      })
+    },
+  )
+
+  await step(
+    'Assert that the table is initiated with 2 rows which is the minimum rows',
+    async () => {
+      await waitFor(async () => {
+        const rows = within(tableFieldTable).getAllByRole('row')
+        expect(rows).toHaveLength(2)
+      })
+    },
+  )
+
+  await step(
+    'Click the add another row button for the table field so there is 3 rows',
+    async () => {
+      await userEvent.click(tableFieldAddAnotherRowButton)
+    },
+  )
+
+  await step(
+    'Assert that the table is initiated with 3 rows which is the minimum rows',
+    async () => {
+      await waitFor(async () => {
+        const rows = within(tableFieldTable).getAllByRole('row')
+        expect(rows).toHaveLength(3)
+      })
+    },
+  )
+
+  await step(
+    'Click the add another row button for the table field so there is 4 rows',
+    async () => {
+      await userEvent.click(tableFieldAddAnotherRowButton)
+    },
+  )
+
+  await step(
+    'Assert that the table is initiated with 4 rows which is the minimum rows',
+    async () => {
+      await waitFor(async () => {
+        const rows = within(tableFieldTable).getAllByRole('row')
+        expect(rows).toHaveLength(4)
+      })
+    },
+  )
+
+  await step(
+    'Assert the add another row button is disabled since number of rows is maximum ',
+    async () => {
+      await waitFor(async () => {
+        expect(tableFieldAddAnotherRowButton).toBeDisabled()
+      })
     },
   )
 }

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1186,7 +1186,7 @@ WithMultiRespondentFormStep1TableFieldAdditionalRows.parameters = {
           responseMode: FormResponseMode.Multirespondent,
           workflow: [
             {
-              _id: 'step-1',
+              _id: 'step-0',
               edit: ['table-field-for-test-id'],
               workflow_type: WorkflowType.Static,
               emails: [],

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1,4 +1,3 @@
-import { useLayoutEffect } from 'react'
 import { Meta, StoryFn } from '@storybook/react'
 import { expect, userEvent, waitFor, within } from '@storybook/test'
 import dedent from 'dedent'
@@ -29,7 +28,6 @@ import {
   SHOW_FIELDS_ON_YES_LOGIC,
 } from '~/mocks/msw/handlers/public-form'
 
-import { useIndexedDb } from '~hooks/useIndexedDb'
 import {
   getMobileViewParameters,
   getTabletViewParameters,
@@ -37,10 +35,8 @@ import {
 } from '~utils/storybook'
 import { ShortTextFieldSchema } from '~templates/Field'
 
-import { SAVE_DRAFT_INDEXEDDB_STORE_NAME } from '~features/form/constants'
-
-import { DraftSubmission } from './PublicFormContext'
 import PublicFormPage from './PublicFormPage'
+import SaveDraftSetupWrapper from './SaveDraftSetupWrapper'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,
@@ -101,35 +97,6 @@ const generateMswHandlersForColorTheme = (colorTheme: FormColorTheme) => {
     postGenerateVfnOtpResponse(),
     postVerifyVfnOtpResponse(),
   ]
-}
-
-// Component that sets up draft data using hooks
-export const DraftSetupWrapper = ({
-  children,
-  draftKey,
-  draftValue,
-}: {
-  children: React.ReactNode
-  draftKey: string
-  draftValue: DraftSubmission
-}) => {
-  // Use the useIndexedDb hook to set draft value
-  const [, setDraftSubmission] = useIndexedDb<DraftSubmission>({
-    key: draftKey,
-    initialValue: {
-      lastUpdated: null,
-      draftResponses: null,
-      fieldDefinitionsChecksum: null,
-    },
-    storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
-  })
-
-  // Set the draft value when component mounts
-  useLayoutEffect(() => {
-    setDraftSubmission(draftValue)
-  }, [setDraftSubmission, draftValue])
-
-  return <>{children}</>
 }
 
 export default {
@@ -1201,12 +1168,12 @@ WithSaveDraftRestored.parameters = {
 WithSaveDraftRestored.decorators = [
   (Story) => {
     return (
-      <DraftSetupWrapper
+      <SaveDraftSetupWrapper
         draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
         draftValue={DRAFT_TO_RESTORE}
       >
         <Story />
-      </DraftSetupWrapper>
+      </SaveDraftSetupWrapper>
     )
   },
 ]
@@ -1232,7 +1199,7 @@ WithSaveDraftRestoredYesNoFieldSchemaChanged.parameters = {
 WithSaveDraftRestoredYesNoFieldSchemaChanged.decorators = [
   (Story) => {
     return (
-      <DraftSetupWrapper
+      <SaveDraftSetupWrapper
         draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
         draftValue={{
           lastUpdated: new Date().getTime() - 10,
@@ -1246,7 +1213,7 @@ WithSaveDraftRestoredYesNoFieldSchemaChanged.decorators = [
         }}
       >
         <Story />
-      </DraftSetupWrapper>
+      </SaveDraftSetupWrapper>
     )
   },
 ]
@@ -1269,7 +1236,7 @@ WithPrefilledNormalFieldsWithSaveDraftRestored.parameters = {
 WithPrefilledNormalFieldsWithSaveDraftRestored.decorators = [
   (Story) => {
     return (
-      <DraftSetupWrapper
+      <SaveDraftSetupWrapper
         draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
         draftValue={{
           lastUpdated: new Date().getTime() - 10,
@@ -1287,7 +1254,7 @@ WithPrefilledNormalFieldsWithSaveDraftRestored.decorators = [
         }}
       >
         <Story />
-      </DraftSetupWrapper>
+      </SaveDraftSetupWrapper>
     )
   },
 ]

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1211,6 +1211,87 @@ WithSaveDraftRestored.decorators = [
   },
 ]
 
+export const WithSaveDraftRestoredYesNoFieldSchemaChanged = Template.bind({})
+WithSaveDraftRestoredYesNoFieldSchemaChanged.parameters = {
+  docs: {
+    storyDescription:
+      'This story asserts that the saved draft does not restore fields where the schema has changed. In particular, the Yes no field definition has changed and hence is not restored.',
+  },
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Encrypt,
+          isSaveDraftEnabled: true,
+        },
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+WithSaveDraftRestoredYesNoFieldSchemaChanged.decorators = [
+  (Story) => {
+    return (
+      <DraftSetupWrapper
+        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
+        draftValue={{
+          lastUpdated: new Date().getTime() - 10,
+          draftResponses: {
+            ...DRAFT_TO_RESTORE.draftResponses,
+          },
+          fieldDefinitionsChecksum: {
+            ...DRAFT_TO_RESTORE.fieldDefinitionsChecksum,
+            '5da04eb5e397fc0013f63c7e': '{}', // Emulates Yes no field definition change
+          },
+        }}
+      >
+        <Story />
+      </DraftSetupWrapper>
+    )
+  },
+]
+
+export const WithPrefilledNormalFieldsWithSaveDraftRestored = Template.bind({})
+WithPrefilledNormalFieldsWithSaveDraftRestored.parameters = {
+  msw: [
+    getPublicFormResponse({
+      delay: 0,
+      overrides: {
+        form: {
+          isSaveDraftEnabled: true,
+          responseMode: FormResponseMode.Encrypt,
+          form_fields: [PREFILLABLE_NORMAL_SHORTTEXT_FIELD],
+        },
+      },
+    }),
+  ],
+}
+WithPrefilledNormalFieldsWithSaveDraftRestored.decorators = [
+  (Story) => {
+    return (
+      <DraftSetupWrapper
+        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff"
+        draftValue={{
+          lastUpdated: new Date().getTime() - 10,
+          draftResponses: {
+            '5da04eafe397fc0013f63b22':
+              'This draft value should not be restored since prefills have higher precedence.',
+            ...DRAFT_TO_RESTORE.draftResponses,
+          },
+          fieldDefinitionsChecksum: {
+            '5da04eafe397fc0013f63b22': JSON.stringify(
+              PREFILLABLE_NORMAL_SHORTTEXT_FIELD,
+            ),
+            ...DRAFT_TO_RESTORE.fieldDefinitionsChecksum,
+          },
+        }}
+      >
+        <Story />
+      </DraftSetupWrapper>
+    )
+  },
+]
+
 export const WithStorageModeTableFieldAdditionalRows = Template.bind({})
 WithStorageModeTableFieldAdditionalRows.parameters = {
   msw: [

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1126,7 +1126,10 @@ WithStorageModeTableFieldAdditionalRows.play = async ({
     'Assert that the table is initiated with 2 rows which is the minimum rows',
     async () => {
       await waitFor(async () => {
-        const rows = within(tableFieldTable).getAllByRole('row')
+        const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+        const tbody = rowGroups.find((group) => group.localName === 'tbody')
+        if (!tbody) throw new Error('Table field table body not found')
+        const rows = within(tbody).getAllByRole('row')
         expect(rows).toHaveLength(2)
       })
     },
@@ -1143,7 +1146,10 @@ WithStorageModeTableFieldAdditionalRows.play = async ({
     'Assert that the table is initiated with 3 rows which is the minimum rows',
     async () => {
       await waitFor(async () => {
-        const rows = within(tableFieldTable).getAllByRole('row')
+        const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+        const tbody = rowGroups.find((group) => group.localName === 'tbody')
+        if (!tbody) throw new Error('Table field table body not found')
+        const rows = within(tbody).getAllByRole('row')
         expect(rows).toHaveLength(3)
       })
     },
@@ -1160,7 +1166,10 @@ WithStorageModeTableFieldAdditionalRows.play = async ({
     'Assert that the table is initiated with 4 rows which is the minimum rows',
     async () => {
       await waitFor(async () => {
-        const rows = within(tableFieldTable).getAllByRole('row')
+        const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+        const tbody = rowGroups.find((group) => group.localName === 'tbody')
+        if (!tbody) throw new Error('Table field table body not found')
+        const rows = within(tbody).getAllByRole('row')
         expect(rows).toHaveLength(4)
       })
     },
@@ -1245,7 +1254,10 @@ WithMultiRespondentFormStep1TableFieldAdditionalRows.play = async ({
     'Assert that the table is initiated with 2 rows which is the minimum rows',
     async () => {
       await waitFor(async () => {
-        const rows = within(tableFieldTable).getAllByRole('row')
+        const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+        const tbody = rowGroups.find((group) => group.localName === 'tbody')
+        if (!tbody) throw new Error('Table field table body not found')
+        const rows = within(tbody).getAllByRole('row')
         expect(rows).toHaveLength(2)
       })
     },
@@ -1262,7 +1274,10 @@ WithMultiRespondentFormStep1TableFieldAdditionalRows.play = async ({
     'Assert that the table is initiated with 3 rows which is the minimum rows',
     async () => {
       await waitFor(async () => {
-        const rows = within(tableFieldTable).getAllByRole('row')
+        const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+        const tbody = rowGroups.find((group) => group.localName === 'tbody')
+        if (!tbody) throw new Error('Table field table body not found')
+        const rows = within(tbody).getAllByRole('row')
         expect(rows).toHaveLength(3)
       })
     },
@@ -1279,7 +1294,10 @@ WithMultiRespondentFormStep1TableFieldAdditionalRows.play = async ({
     'Assert that the table is initiated with 4 rows which is the minimum rows',
     async () => {
       await waitFor(async () => {
-        const rows = within(tableFieldTable).getAllByRole('row')
+        const rowGroups = within(tableFieldTable).getAllByRole('rowgroup')
+        const tbody = rowGroups.find((group) => group.localName === 'tbody')
+        if (!tbody) throw new Error('Table field table body not found')
+        const rows = within(tbody).getAllByRole('row')
         expect(rows).toHaveLength(4)
       })
     },

--- a/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
@@ -11,6 +11,10 @@ import {
 import { envHandlers } from '~/mocks/msw/handlers/env'
 import { FormResponseMode, WorkflowType } from '~shared/types'
 import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
+import { useIndexedDb } from '~hooks/useIndexedDb'
+import { SAVE_DRAFT_INDEXEDDB_STORE_NAME } from '~features/form/constants'
+import { DraftSubmission } from './PublicFormContext'
+import { useLayoutEffect } from 'react'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,
@@ -40,12 +44,47 @@ export default {
   },
 } as Meta
 
+// Component that sets up draft data using hooks
+const DraftSetupWrapper = ({
+  children,
+  draftKey,
+  draftValue,
+}: {
+  children: React.ReactNode
+  draftKey: string
+  draftValue: DraftSubmission
+}) => {
+  // Use the useIndexedDb hook to set draft value
+  const [, setDraftSubmission] = useIndexedDb<DraftSubmission>({
+    key: draftKey,
+    initialValue: {
+      lastUpdated: null,
+      draftResponses: null,
+      fieldDefinitionsChecksum: null,
+    },
+    storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+  })
+
+  // Set the draft value when component mounts
+  useLayoutEffect(() => {
+    setDraftSubmission(draftValue)
+  }, [setDraftSubmission, draftValue])
+
+  return <>{children}</>
+}
+
 const Template: StoryFn = () => <PublicFormPage />
 
-export const WithMultiRespondentFormStep2TableFieldAdditionalRows =
-  Template.bind({})
+const PREVIOUS_SUBMISSION_TABLE_FIELD_WITH_ADDITIONAL_ROWS =
+  '{"table-field-for-test-id":{"fieldType":"table","answer":[{"table-field-for-test-id-col-1":"start 1/3","table-field-for-test-id-col-2":"cool beans"},{"table-field-for-test-id-col-1":"mid 2/3","table-field-for-test-id-col-2":"see ya later alligator"},{"table-field-for-test-id-col-1":"end 3/3","table-field-for-test-id-col-2":"far out man"}]}}'
 
-WithMultiRespondentFormStep2TableFieldAdditionalRows.parameters = {
+// Only contains 1 row, while the minimum is 2.
+const PREVIOUS_SUBMISSION_TABLE_FIELD_WITH_ONE_ROW =
+  '{"table-field-for-test-id":{"fieldType":"table","answer":[{"table-field-for-test-id-col-1":"start and end 1/1","table-field-for-test-id-col-2":"cool beans"}]}}'
+
+export const WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRows =
+  Template.bind({})
+WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRows.parameters = {
   msw: [
     getPublicFormResponse({
       overrides: {
@@ -59,23 +98,206 @@ WithMultiRespondentFormStep2TableFieldAdditionalRows.parameters = {
       overrides: {
         workflow: [
           {
-            _id: 'step-1',
+            _id: 'step-0',
             edit: ['table-field-for-test-id'],
             workflow_type: WorkflowType.Static,
             emails: [],
           },
           {
-            _id: 'step-2',
+            _id: 'step-1',
             edit: [],
             workflow_type: WorkflowType.Static,
             emails: [],
           },
         ],
         form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
-        encryptedContent:
-          '{"table-field-for-test-id":{"fieldType":"table","answer":[{"table-field-for-test-id-col-1":"start 1/3","table-field-for-test-id-col-2":"cool beans"},{"table-field-for-test-id-col-1":"mid 2/3","table-field-for-test-id-col-2":"see ya later alligator"},{"table-field-for-test-id-col-1":"end 3/3","table-field-for-test-id-col-2":"far out man"}]}}',
+        encryptedContent: PREVIOUS_SUBMISSION_TABLE_FIELD_WITH_ADDITIONAL_ROWS,
       },
     }),
     ...DEFAULT_MSW_HANDLERS,
   ],
 }
+
+export const WithMultiRespondentFormStep2EditableTableFieldLessThanMinimumRows =
+  Template.bind({})
+
+WithMultiRespondentFormStep2EditableTableFieldLessThanMinimumRows.parameters = {
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          workflow: [],
+        },
+      },
+    }),
+    getEncryptedSubmissionResponse({
+      overrides: {
+        workflow: [
+          {
+            _id: 'step-0',
+            edit: ['table-field-for-test-id'],
+            workflow_type: WorkflowType.Static,
+            emails: [],
+          },
+          {
+            _id: 'step-1',
+            edit: ['table-field-for-test-id'],
+            workflow_type: WorkflowType.Static,
+            emails: [],
+          },
+        ],
+        form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+        workflowStep: 0,
+        encryptedContent: PREVIOUS_SUBMISSION_TABLE_FIELD_WITH_ONE_ROW,
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+
+const STEP_2_SAVED_DRAFT_RESPONSES = {
+  'table-field-for-test-id': [
+    {
+      'table-field-for-test-id-col-1': 'this is saved draft 1/4',
+      'table-field-for-test-id-col-2': 'cool beans',
+    },
+    {
+      'table-field-for-test-id-col-1': 'this is saved draft 2/4',
+      'table-field-for-test-id-col-2': 'cool beans',
+    },
+    {
+      'table-field-for-test-id-col-1': 'this is saved draft 3/4',
+      'table-field-for-test-id-col-2': 'cool beans',
+    },
+    {
+      'table-field-for-test-id-col-1': 'this is saved draft 4/4',
+      'table-field-for-test-id-col-2': 'cool beans',
+    },
+  ],
+}
+
+const STEP_2_TABLE_FIELD_ONLY_CHECKSUM = {
+  'table-field-for-test-id':
+    '{"title":"Table field for test","description":"No more table field regressions please","required":true,"disabled":false,"fieldType":"table","_id":"table-field-for-test-id","globalId":"not-used","minimumRows":2,"columns":[{"title":"Short text column","required":true,"columnType":"textfield","ValidationOptions":{"customVal":null,"selectedValidation":null},"_id":"table-field-for-test-id-col-1"},{"title":"Dropdown column","required":true,"columnType":"dropdown","fieldOptions":["cool beans","see ya later alligator","far out man"],"_id":"table-field-for-test-id-col-2"}],"addMoreRows":true,"maximumRows":4}',
+}
+
+export const WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft =
+  Template.bind({})
+
+WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft.parameters =
+  {
+    docs: {
+      storyDescription:
+        'This story asserts that the saved draft does not override the previous submission when the table field is non-editabl in the current mrf workflow step',
+    },
+    msw: [
+      getPublicFormResponse({
+        overrides: {
+          form: {
+            responseMode: FormResponseMode.Multirespondent,
+            workflow: [],
+            isSaveDraftEnabled: true,
+          },
+        },
+      }),
+      getEncryptedSubmissionResponse({
+        overrides: {
+          workflow: [
+            {
+              _id: 'step-0',
+              edit: ['table-field-for-test-id'],
+              workflow_type: WorkflowType.Static,
+              emails: [],
+            },
+            {
+              _id: 'step-1',
+              edit: [],
+              workflow_type: WorkflowType.Static,
+              emails: [],
+            },
+          ],
+          form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+          encryptedContent:
+            PREVIOUS_SUBMISSION_TABLE_FIELD_WITH_ADDITIONAL_ROWS,
+        },
+      }),
+      ...DEFAULT_MSW_HANDLERS,
+    ],
+  }
+
+WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft.decorators =
+  [
+    (Story) => (
+      <DraftSetupWrapper
+        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff-68d4b9900415e65225fd3e4e-step1"
+        draftValue={{
+          lastUpdated: new Date().getTime() - 10,
+          draftResponses: STEP_2_SAVED_DRAFT_RESPONSES,
+          fieldDefinitionsChecksum: STEP_2_TABLE_FIELD_ONLY_CHECKSUM,
+        }}
+      >
+        <Story />
+      </DraftSetupWrapper>
+    ),
+  ]
+
+export const WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft =
+  Template.bind({})
+
+WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft.parameters =
+  {
+    docs: {
+      storyDescription:
+        'This story asserts that the saved draft overrides the previous submission when the table field is editable in the current mrf workflow step',
+    },
+    msw: [
+      getPublicFormResponse({
+        overrides: {
+          form: {
+            responseMode: FormResponseMode.Multirespondent,
+            workflow: [],
+            isSaveDraftEnabled: true,
+          },
+        },
+      }),
+      getEncryptedSubmissionResponse({
+        overrides: {
+          workflow: [
+            {
+              _id: 'step-0',
+              edit: ['table-field-for-test-id'],
+              workflow_type: WorkflowType.Static,
+              emails: [],
+            },
+            {
+              _id: 'step-1',
+              edit: ['table-field-for-test-id'],
+              workflow_type: WorkflowType.Static,
+              emails: [],
+            },
+          ],
+          form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+          encryptedContent:
+            PREVIOUS_SUBMISSION_TABLE_FIELD_WITH_ADDITIONAL_ROWS,
+        },
+      }),
+      ...DEFAULT_MSW_HANDLERS,
+    ],
+  }
+
+WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft.decorators =
+  [
+    (Story) => (
+      <DraftSetupWrapper
+        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff-68d4b9900415e65225fd3e4e-step1"
+        draftValue={{
+          lastUpdated: new Date().getTime() - 10,
+          draftResponses: STEP_2_SAVED_DRAFT_RESPONSES,
+          fieldDefinitionsChecksum: STEP_2_TABLE_FIELD_ONLY_CHECKSUM,
+        }}
+      >
+        <Story />
+      </DraftSetupWrapper>
+    ),
+  ]

--- a/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react/*'
+import { expect, waitFor } from '@storybook/test'
 
 import { FormResponseMode, WorkflowType } from '~shared/types'
 
@@ -12,8 +13,15 @@ import {
   postVfnTransactionResponse,
 } from '~/mocks/msw/handlers/public-form'
 
+import {
+  _getFromIndexedDBForTest,
+  _removeFromIndexedDBForTest,
+} from '~hooks/useIndexedDb'
 import { StoryRouter } from '~utils/storybook'
 
+import { SAVE_DRAFT_INDEXEDDB_STORE_NAME } from '~features/form/constants'
+
+import { DraftSubmission } from './PublicFormContext'
 import PublicFormPage from './PublicFormPage'
 import SaveDraftSetupWrapper from './SaveDraftSetupWrapper'
 
@@ -154,6 +162,9 @@ const STEP_2_TABLE_FIELD_ONLY_CHECKSUM = {
     '{"title":"Table field for test","description":"No more table field regressions please","required":true,"disabled":false,"fieldType":"table","_id":"table-field-for-test-id","globalId":"not-used","minimumRows":2,"columns":[{"title":"Short text column","required":true,"columnType":"textfield","ValidationOptions":{"customVal":null,"selectedValidation":null},"_id":"table-field-for-test-id-col-1"},{"title":"Dropdown column","required":true,"columnType":"dropdown","fieldOptions":["cool beans","see ya later alligator","far out man"],"_id":"table-field-for-test-id-col-2"}],"addMoreRows":true,"maximumRows":4}',
 }
 
+const MULTIRESPONDENT_MODE_PUBLIC_FORM_STEP_1_SAVE_DRAFT_KEY =
+  'formsg-save-draft-61540ece3d4a6e50ac0cc6ff-68d4b9900415e65225fd3e4e-step1'
+
 export const WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft =
   Template.bind({})
 
@@ -202,7 +213,7 @@ WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft.dec
   [
     (Story) => (
       <SaveDraftSetupWrapper
-        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff-68d4b9900415e65225fd3e4e-step1"
+        draftKey={MULTIRESPONDENT_MODE_PUBLIC_FORM_STEP_1_SAVE_DRAFT_KEY}
         draftValue={{
           lastUpdated: new Date().getTime() - 10,
           draftResponses: STEP_2_SAVED_DRAFT_RESPONSES,
@@ -213,6 +224,41 @@ WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft.dec
       </SaveDraftSetupWrapper>
     ),
   ]
+
+WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft.play =
+  async ({ step }) => {
+    await step(
+      'Assert that the saved draft is created in IndexedDB',
+      async () => {
+        const savedDraft = (await _getFromIndexedDBForTest({
+          key: MULTIRESPONDENT_MODE_PUBLIC_FORM_STEP_1_SAVE_DRAFT_KEY,
+          storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+        })) as DraftSubmission | undefined
+        expect(savedDraft?.draftResponses).toBeTruthy()
+      },
+    )
+
+    await step(
+      'Assert that the save draft restored toast message appears',
+      async () => {
+        await waitFor(
+          () => {
+            expect(document.body).toHaveTextContent(
+              'Your draft has been successfully restored.',
+            )
+          },
+          { timeout: 3000 },
+        )
+      },
+    )
+
+    await step('Cleanup saved draft', async () => {
+      await _removeFromIndexedDBForTest({
+        key: MULTIRESPONDENT_MODE_PUBLIC_FORM_STEP_1_SAVE_DRAFT_KEY,
+        storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+      })
+    })
+  }
 
 export const WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft =
   Template.bind({})
@@ -262,7 +308,7 @@ WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft.decora
   [
     (Story) => (
       <SaveDraftSetupWrapper
-        draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff-68d4b9900415e65225fd3e4e-step1"
+        draftKey={MULTIRESPONDENT_MODE_PUBLIC_FORM_STEP_1_SAVE_DRAFT_KEY}
         draftValue={{
           lastUpdated: new Date().getTime() - 10,
           draftResponses: STEP_2_SAVED_DRAFT_RESPONSES,
@@ -273,3 +319,38 @@ WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft.decora
       </SaveDraftSetupWrapper>
     ),
   ]
+
+WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft.play =
+  async ({ step }) => {
+    await step(
+      'Assert that the saved draft is created in IndexedDB',
+      async () => {
+        const savedDraft = (await _getFromIndexedDBForTest({
+          key: MULTIRESPONDENT_MODE_PUBLIC_FORM_STEP_1_SAVE_DRAFT_KEY,
+          storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+        })) as DraftSubmission | undefined
+        expect(savedDraft?.draftResponses).toBeTruthy()
+      },
+    )
+
+    await step(
+      'Assert that the save draft restored toast message appears',
+      async () => {
+        await waitFor(
+          () => {
+            expect(document.body).toHaveTextContent(
+              'Your draft has been successfully restored.',
+            )
+          },
+          { timeout: 3000 },
+        )
+      },
+    )
+
+    await step('Cleanup saved draft', async () => {
+      await _removeFromIndexedDBForTest({
+        key: MULTIRESPONDENT_MODE_PUBLIC_FORM_STEP_1_SAVE_DRAFT_KEY,
+        storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+      })
+    })
+  }

--- a/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
@@ -1,20 +1,21 @@
-import { StoryRouter } from '~utils/storybook'
-import PublicFormPage from './PublicFormPage'
 import { Meta, StoryFn } from '@storybook/react/*'
+
+import { FormResponseMode, WorkflowType } from '~shared/types'
+
+import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
+import { envHandlers } from '~/mocks/msw/handlers/env'
 import {
   getEncryptedSubmissionResponse,
   getPublicFormResponse,
-  postVfnTransactionResponse,
   postGenerateVfnOtpResponse,
   postVerifyVfnOtpResponse,
+  postVfnTransactionResponse,
 } from '~/mocks/msw/handlers/public-form'
-import { envHandlers } from '~/mocks/msw/handlers/env'
-import { FormResponseMode, WorkflowType } from '~shared/types'
-import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
-import { useIndexedDb } from '~hooks/useIndexedDb'
-import { SAVE_DRAFT_INDEXEDDB_STORE_NAME } from '~features/form/constants'
-import { DraftSubmission } from './PublicFormContext'
-import { useLayoutEffect } from 'react'
+
+import { StoryRouter } from '~utils/storybook'
+
+import PublicFormPage from './PublicFormPage'
+import { DraftSetupWrapper } from './PublicFormPage.stories'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,
@@ -43,35 +44,6 @@ export default {
     msw: DEFAULT_MSW_HANDLERS,
   },
 } as Meta
-
-// Component that sets up draft data using hooks
-const DraftSetupWrapper = ({
-  children,
-  draftKey,
-  draftValue,
-}: {
-  children: React.ReactNode
-  draftKey: string
-  draftValue: DraftSubmission
-}) => {
-  // Use the useIndexedDb hook to set draft value
-  const [, setDraftSubmission] = useIndexedDb<DraftSubmission>({
-    key: draftKey,
-    initialValue: {
-      lastUpdated: null,
-      draftResponses: null,
-      fieldDefinitionsChecksum: null,
-    },
-    storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
-  })
-
-  // Set the draft value when component mounts
-  useLayoutEffect(() => {
-    setDraftSubmission(draftValue)
-  }, [setDraftSubmission, draftValue])
-
-  return <>{children}</>
-}
 
 const Template: StoryFn = () => <PublicFormPage />
 

--- a/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
@@ -1,0 +1,81 @@
+import { StoryRouter } from '~utils/storybook'
+import PublicFormPage from './PublicFormPage'
+import { Meta, StoryFn } from '@storybook/react/*'
+import {
+  getEncryptedSubmissionResponse,
+  getPublicFormResponse,
+  postVfnTransactionResponse,
+  postGenerateVfnOtpResponse,
+  postVerifyVfnOtpResponse,
+} from '~/mocks/msw/handlers/public-form'
+import { envHandlers } from '~/mocks/msw/handlers/env'
+import { FormResponseMode, WorkflowType } from '~shared/types'
+import { TABLE_FIELD_ADDITIONAL_ROWS_FIELD } from '~/mocks/msw/handlers/admin-form'
+
+const DEFAULT_MSW_HANDLERS = [
+  ...envHandlers,
+  getPublicFormResponse(),
+  postVfnTransactionResponse(),
+  postGenerateVfnOtpResponse(),
+  postVerifyVfnOtpResponse(),
+  getEncryptedSubmissionResponse(),
+]
+
+export default {
+  title: 'Pages/PublicFormPageMrfSubsequentSteps',
+  component: PublicFormPage,
+  decorators: [
+    StoryRouter({
+      initialEntries: [
+        `/61540ece3d4a6e50ac0cc6ff/edit/68d4b9900415e65225fd3e4e?key=mock-key`,
+      ],
+      path: '/:formId/edit/:submissionId',
+    }),
+  ],
+  parameters: {
+    // Required so skeleton "animation" does not hide content.
+    chromatic: { pauseAnimationAtEnd: true },
+    layout: 'fullscreen',
+    msw: DEFAULT_MSW_HANDLERS,
+  },
+} as Meta
+
+const Template: StoryFn = () => <PublicFormPage />
+
+export const WithMultiRespondentFormStep2TableFieldAdditionalRows =
+  Template.bind({})
+
+WithMultiRespondentFormStep2TableFieldAdditionalRows.parameters = {
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          workflow: [],
+        },
+      },
+    }),
+    getEncryptedSubmissionResponse({
+      overrides: {
+        workflow: [
+          {
+            _id: 'step-1',
+            edit: ['table-field-for-test-id'],
+            workflow_type: WorkflowType.Static,
+            emails: [],
+          },
+          {
+            _id: 'step-2',
+            edit: [],
+            workflow_type: WorkflowType.Static,
+            emails: [],
+          },
+        ],
+        form_fields: [TABLE_FIELD_ADDITIONAL_ROWS_FIELD],
+        encryptedContent:
+          '{"table-field-for-test-id":{"fieldType":"table","answer":[{"table-field-for-test-id-col-1":"start 1/3","table-field-for-test-id-col-2":"cool beans"},{"table-field-for-test-id-col-1":"mid 2/3","table-field-for-test-id-col-2":"see ya later alligator"},{"table-field-for-test-id-col-1":"end 3/3","table-field-for-test-id-col-2":"far out man"}]}}',
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}

--- a/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
@@ -76,11 +76,11 @@ const DraftSetupWrapper = ({
 const Template: StoryFn = () => <PublicFormPage />
 
 const PREVIOUS_SUBMISSION_TABLE_FIELD_WITH_ADDITIONAL_ROWS =
-  '{"table-field-for-test-id":{"fieldType":"table","answer":[{"table-field-for-test-id-col-1":"start 1/3","table-field-for-test-id-col-2":"cool beans"},{"table-field-for-test-id-col-1":"mid 2/3","table-field-for-test-id-col-2":"see ya later alligator"},{"table-field-for-test-id-col-1":"end 3/3","table-field-for-test-id-col-2":"far out man"}]}}'
+  '{"table-field-for-test-id":{"fieldType":"table","answer":[{"table-field-for-test-id-col-1":"prev submission start 1/3","table-field-for-test-id-col-2":"cool beans"},{"table-field-for-test-id-col-1":"prev submission mid 2/3","table-field-for-test-id-col-2":"see ya later alligator"},{"table-field-for-test-id-col-1":"prev submission end 3/3","table-field-for-test-id-col-2":"far out man"}]}}'
 
 // Only contains 1 row, while the minimum is 2.
 const PREVIOUS_SUBMISSION_TABLE_FIELD_WITH_ONE_ROW =
-  '{"table-field-for-test-id":{"fieldType":"table","answer":[{"table-field-for-test-id-col-1":"start and end 1/1","table-field-for-test-id-col-2":"cool beans"}]}}'
+  '{"table-field-for-test-id":{"fieldType":"table","answer":[{"table-field-for-test-id-col-1":"prev submission start and end 1/1","table-field-for-test-id-col-2":"cool beans"}]}}'
 
 export const WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRows =
   Template.bind({})

--- a/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPageMrfSubsequentSteps.stories.tsx
@@ -15,7 +15,7 @@ import {
 import { StoryRouter } from '~utils/storybook'
 
 import PublicFormPage from './PublicFormPage'
-import { DraftSetupWrapper } from './PublicFormPage.stories'
+import SaveDraftSetupWrapper from './SaveDraftSetupWrapper'
 
 const DEFAULT_MSW_HANDLERS = [
   ...envHandlers,
@@ -201,7 +201,7 @@ WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft.par
 WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft.decorators =
   [
     (Story) => (
-      <DraftSetupWrapper
+      <SaveDraftSetupWrapper
         draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff-68d4b9900415e65225fd3e4e-step1"
         draftValue={{
           lastUpdated: new Date().getTime() - 10,
@@ -210,7 +210,7 @@ WithMultiRespondentFormStep2NonEditableTableFieldAdditionalRowsWithSaveDraft.dec
         }}
       >
         <Story />
-      </DraftSetupWrapper>
+      </SaveDraftSetupWrapper>
     ),
   ]
 
@@ -261,7 +261,7 @@ WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft.parame
 WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft.decorators =
   [
     (Story) => (
-      <DraftSetupWrapper
+      <SaveDraftSetupWrapper
         draftKey="formsg-save-draft-61540ece3d4a6e50ac0cc6ff-68d4b9900415e65225fd3e4e-step1"
         draftValue={{
           lastUpdated: new Date().getTime() - 10,
@@ -270,6 +270,6 @@ WithMultiRespondentFormStep2EditableTableFieldAdditionalRowsWithSaveDraft.decora
         }}
       >
         <Story />
-      </DraftSetupWrapper>
+      </SaveDraftSetupWrapper>
     ),
   ]

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -313,15 +313,14 @@ export const getInitialFormValues = ({
         }
       }
 
-      // Append extra empty rows to existing value until the minimum is met. 
+      // Append extra empty rows to existing value until the minimum is met.
       if (field.fieldType === BasicField.Table && acc[field._id]) {
-        const currentValue = acc[field._id] as TableFieldValues 
+        const currentValue = acc[field._id] as TableFieldValues
         if (currentValue.length < (field.minimumRows || 0)) {
           acc[field._id] = [
             ...currentValue,
-            ...times(
-              (field.minimumRows || 0) - currentValue.length,
-              () => createTableRow(field),
+            ...times((field.minimumRows || 0) - currentValue.length, () =>
+              createTableRow(field),
             ),
           ]
         }
@@ -373,7 +372,7 @@ const getSaveDraftKey = ({
   isMrf: boolean
   /**
    * @note currentMrfWorkflowStepNumber is 0-indexed.
-   */ 
+   */
   currentMrfWorkflowStepNumber: number
 }) => {
   const FORMSG_SAVE_DRAFT_PREFIX = 'formsg-save-draft'

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -887,11 +887,13 @@ export const PublicFormProvider = ({
     mode: 'onTouched',
   })
 
-  // Reset default values when they change
   const {
     formState: { isDirty },
     reset,
   } = formMethods
+
+  // Reset cached default values when they change if
+  // the user has not yet changed the form values.
   useEffect(() => {
     if (!isDirty) {
       reset(defaultFormValues)

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -242,7 +242,7 @@ export const getFieldPrefillMap = (
   }, {} as PrefillMap)
 }
 
-const getInitialFormValues = ({
+export const getInitialFormValues = ({
   formResponseMode,
   previousSubmission,
   previousAttachments,
@@ -886,19 +886,6 @@ export const PublicFormProvider = ({
     defaultValues: defaultFormValues,
     mode: 'onTouched',
   })
-
-  const {
-    formState: { isDirty },
-    reset,
-  } = formMethods
-
-  // Reset cached default values when they change if
-  // the user has not yet changed the form values.
-  useEffect(() => {
-    if (!isDirty) {
-      reset(defaultFormValues)
-    }
-  }, [defaultFormValues, isDirty, reset])
 
   const onSaveDraft = () => {
     // Used to track save draft usage

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -47,7 +47,7 @@ import {
   HttpError,
   SingleSubmissionValidationError,
 } from '~services/ApiService'
-import { FormFieldValues } from '~templates/Field'
+import { FormFieldValues, TableFieldValues } from '~templates/Field'
 import { createTableRow } from '~templates/Field/Table/utils/createRow'
 
 import NotFoundErrorPage from '~pages/NotFoundError'
@@ -313,6 +313,20 @@ export const getInitialFormValues = ({
         }
       }
 
+      // Append extra empty rows to existing value until the minimum is met. 
+      if (field.fieldType === BasicField.Table && acc[field._id]) {
+        const currentValue = acc[field._id] as TableFieldValues 
+        if (currentValue.length < (field.minimumRows || 0)) {
+          acc[field._id] = [
+            ...currentValue,
+            ...times(
+              (field.minimumRows || 0) - currentValue.length,
+              () => createTableRow(field),
+            ),
+          ]
+        }
+      }
+
       if (!acc[field._id]) {
         // Required so table column fields will render due to useFieldArray usage.
         // See https://react-hook-form.com/api/usefieldarray
@@ -357,6 +371,9 @@ const getSaveDraftKey = ({
   formId: string
   formSubmissionId?: string
   isMrf: boolean
+  /**
+   * @note currentMrfWorkflowStepNumber is 0-indexed.
+   */ 
   currentMrfWorkflowStepNumber: number
 }) => {
   const FORMSG_SAVE_DRAFT_PREFIX = 'formsg-save-draft'

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -380,6 +380,8 @@ export const PublicFormProvider = ({
   const { t, i18n } = useTranslation()
   const selectedLanguage = i18n.language as Language
 
+  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
+
   // Once form has been submitted, submission data will be set here.
   const [submissionData, setSubmissionData] = useState<SubmissionData>()
 
@@ -563,10 +565,12 @@ export const PublicFormProvider = ({
     !previousSubmission &&
     !isSubmissionSecretKeyInvalid
   ) {
-    const isValid = isKeypairValid(
-      encryptedPreviousSubmission.submissionPublicKey,
-      submissionSecretKey,
-    )
+    // During test, we want to bypass the secret key validation
+    const isValid =
+      isKeypairValid(
+        encryptedPreviousSubmission.submissionPublicKey,
+        submissionSecretKey,
+      ) || isTest
 
     if (isValid) {
       setPreviousSubmission(
@@ -803,7 +807,6 @@ export const PublicFormProvider = ({
     })
 
   // TODO [Save Draft v1.0]: Remove feature flag once save draft is out of beta
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
   const isSaveDraftFeatureEnabled =
     useFeatureIsOn(featureFlags.saveDraft) || isTest
   const isSaveDraftEnabled =

--- a/frontend/src/features/public-form/SaveDraftSetupWrapper.tsx
+++ b/frontend/src/features/public-form/SaveDraftSetupWrapper.tsx
@@ -1,0 +1,40 @@
+import { useLayoutEffect } from 'react'
+
+import { useIndexedDb } from '~hooks/useIndexedDb'
+
+import { SAVE_DRAFT_INDEXEDDB_STORE_NAME } from '~features/form/constants'
+
+import { DraftSubmission } from './PublicFormContext'
+
+/**
+ * Used in Storybook to set up draft data using hooks.
+ */
+const SaveDraftSetupWrapper = ({
+  children,
+  draftKey,
+  draftValue,
+}: {
+  children: React.ReactNode
+  draftKey: string
+  draftValue: DraftSubmission
+}) => {
+  // Use the useIndexedDb hook to set draft value
+  const [, setDraftSubmission] = useIndexedDb<DraftSubmission>({
+    key: draftKey,
+    initialValue: {
+      lastUpdated: null,
+      draftResponses: null,
+      fieldDefinitionsChecksum: null,
+    },
+    storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+  })
+
+  // Set the draft value when component mounts
+  useLayoutEffect(() => {
+    setDraftSubmission(draftValue)
+  }, [setDraftSubmission, draftValue])
+
+  return <>{children}</>
+}
+
+export default SaveDraftSetupWrapper

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -56,9 +56,23 @@ export const FormFields = ({
 
   useFetchPrefillQuery()
 
-  const { fieldPrefillMap, form, augmentedFormFields } = usePublicFormContext()
+  const { defaultFormValues, fieldPrefillMap, form, augmentedFormFields } =
+    usePublicFormContext()
 
-  const { trigger, handleSubmit, control } = useFormContext<FormFieldValues>()
+  const {
+    reset,
+    formState: { isDirty },
+    trigger,
+    handleSubmit,
+    control,
+  } = useFormContext<FormFieldValues>()
+
+  // Reset cached default values when they change
+  useEffect(() => {
+    if (!isDirty) {
+      reset(defaultFormValues)
+    }
+  }, [defaultFormValues, isDirty, reset])
 
   const hasLockedPrefills = Object.values(fieldPrefillMap).some(
     (field) => field.lockPrefill && field.prefillValue,

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -56,23 +56,9 @@ export const FormFields = ({
 
   useFetchPrefillQuery()
 
-  const { defaultFormValues, fieldPrefillMap, form, augmentedFormFields } =
-    usePublicFormContext()
+  const { fieldPrefillMap, form, augmentedFormFields } = usePublicFormContext()
 
-  const {
-    reset,
-    formState: { isDirty },
-    trigger,
-    handleSubmit,
-    control,
-  } = useFormContext<FormFieldValues>()
-
-  // Reset default values when they change
-  useEffect(() => {
-    if (!isDirty) {
-      reset(defaultFormValues)
-    }
-  }, [defaultFormValues, isDirty, reset])
+  const { trigger, handleSubmit, control } = useFormContext<FormFieldValues>()
 
   const hasLockedPrefills = Object.values(fieldPrefillMap).some(
     (field) => field.lockPrefill && field.prefillValue,

--- a/frontend/src/features/public-form/utils/decryptSubmission.ts
+++ b/frontend/src/features/public-form/utils/decryptSubmission.ts
@@ -51,8 +51,6 @@ export const decryptSubmission = ({
   )
   if (!decryptedContent) throw new Error('Could not decrypt the response')
 
-  console.log('decryptedContent:', JSON.stringify(decryptedContent.responses))
-
   // Add metadata for display.
   return {
     ...rest,

--- a/frontend/src/features/public-form/utils/decryptSubmission.ts
+++ b/frontend/src/features/public-form/utils/decryptSubmission.ts
@@ -30,6 +30,19 @@ export const decryptSubmission = ({
   if (!submission) throw Error('Encrypted submission undefined')
   if (!secretKey) throw Error('Secret key undefined')
 
+  // For testing, do not perform decryption and return the encrypted content directly
+  // (which will be a un-encrypted FieldResponsesV3 object)
+  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
+  if (isTest) {
+    return {
+      ...submission,
+      responses: JSON.parse(
+        submission.encryptedContent,
+      ) as unknown as FieldResponsesV3,
+      submissionSecretKey: secretKey,
+    }
+  }
+
   const { encryptedContent, version, ...rest } = submission
 
   const decryptedContent = formsgSdk.cryptoV3.decryptFromSubmissionKey(
@@ -37,6 +50,8 @@ export const decryptSubmission = ({
     { encryptedContent, version },
   )
   if (!decryptedContent) throw new Error('Could not decrypt the response')
+
+  console.log('decryptedContent:', JSON.stringify(decryptedContent.responses))
 
   // Add metadata for display.
   return {

--- a/frontend/src/hooks/useIndexedDb.ts
+++ b/frontend/src/hooks/useIndexedDb.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 // For testing, use a different database name to avoid conflicts with the main database.
 const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-const DB_NAME = isTest ? 'TestFormSG' : 'FormSG'
+export const DB_NAME = isTest ? 'TestFormSG' : 'FormSG'
 const DB_VERSION = 1 // Update this version when you make changes to the database schema
 
 const initDB = ({ storeName }: { storeName: string }): Promise<IDBDatabase> => {
@@ -52,6 +52,8 @@ const getFromIndexedDB = async ({
   }
 }
 
+export const _getFromIndexedDBForTest = getFromIndexedDB
+
 const setInIndexedDB = async ({
   key,
   value,
@@ -99,6 +101,8 @@ const removeFromIndexedDB = async ({
     throw error
   }
 }
+
+export const _removeFromIndexedDBForTest = removeFromIndexedDB
 
 export const useIndexedDb = <T>({
   key,

--- a/frontend/src/hooks/useIndexedDb.ts
+++ b/frontend/src/hooks/useIndexedDb.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 
-const DB_NAME = 'FormSG'
+// For testing, use a different database name to avoid conflicts with the main database.
+const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
+const DB_NAME = isTest ? 'TestFormSG' : 'FormSG'
 const DB_VERSION = 1 // Update this version when you make changes to the database schema
 
 const initDB = ({ storeName }: { storeName: string }): Promise<IDBDatabase> => {

--- a/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -10,6 +10,7 @@ import {
   FieldCreateDto,
   FormFieldDto,
   RatingShape,
+  TableFieldBase,
   TableFieldDto,
 } from '~shared/types/field'
 import {
@@ -961,6 +962,38 @@ export const createMockForm = (
       },
     ) as AdminFormDto,
   }
+}
+
+export const TABLE_FIELD_ADDITIONAL_ROWS_FIELD: FormFieldDto<TableFieldBase> = {
+  title: 'Table field for test',
+  description: 'No more table field regressions please',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.Table,
+  _id: 'table-field-for-test-id',
+  globalId: 'not-used',
+  minimumRows: 2,
+  columns: [
+    {
+      title: 'Short text column',
+      required: true,
+      columnType: BasicField.ShortText,
+      ValidationOptions: {
+        customVal: null,
+        selectedValidation: null,
+      },
+      _id: 'table-field-for-test-id-col-1',
+    },
+    {
+      title: 'Dropdown column',
+      required: true,
+      columnType: BasicField.Dropdown,
+      fieldOptions: ['cool beans', 'see ya later alligator', 'far out man'],
+      _id: 'table-field-for-test-id-col-2',
+    },
+  ],
+  addMoreRows: true,
+  maximumRows: 4,
 }
 
 export const createFormBuilderMocks = (

--- a/frontend/src/mocks/msw/handlers/public-form.ts
+++ b/frontend/src/mocks/msw/handlers/public-form.ts
@@ -7,6 +7,7 @@ import {
   LogicConditionState,
   LogicIfValue,
   LogicType,
+  MultirespondentSubmissionDto,
   PaymentChannel,
   PreventSubmitLogicDto,
   ShowFieldLogicDto,
@@ -578,6 +579,51 @@ export const postVerifyVfnOtpResponse = ({
   )
 }
 
+export const getEncryptedSubmissionResponse = ({
+  delay = 0,
+  overrides,
+}: {
+  delay?: number | 'infinite'
+  overrides?: PartialDeep<MultirespondentSubmissionDto>
+} = {}) => {
+  return http.get<
+    { formId: string; submissionId: string },
+    never,
+    MultirespondentSubmissionDto
+  >('/api/v3/forms/:formId/submissions/:submissionId', async ({ params }) => {
+    const {
+      formId = '61540ece3d4a6e50ac0cc6ff',
+      submissionId = '68d4b9900415e65225fd3e4e',
+    } = params
+
+    const response = mergeWith(
+      {},
+      {
+        _id: submissionId,
+        form: formId,
+        workflowStep: 0,
+        submissionPublicKey: 'mock-public-key',
+        encryptedContent: '{}', // Store the decrypted responses as a JSON string
+        version: 1,
+        mrfVersion: 1,
+        attachmentMetadata: {},
+        form_fields: [],
+        form_logics: [],
+        workflow: [],
+      },
+      overrides,
+      (objValue, srcValue) => {
+        if (Array.isArray(objValue)) {
+          return [...srcValue, ...objValue]
+        }
+      },
+    ) as MultirespondentSubmissionDto
+
+    await MswDelay(delay)
+    return HttpResponse.json(response)
+  })
+}
+
 export const publicFormHandlers = [
   getPublicFormResponse(),
   getPublicFormWithoutSectionsResponse(),
@@ -585,4 +631,5 @@ export const publicFormHandlers = [
   postVfnTransactionResponse(),
   postGenerateVfnOtpResponse(),
   postVerifyVfnOtpResponse(),
+  getEncryptedSubmissionResponse(),
 ]

--- a/frontend/src/templates/Field/Table/TableField.tsx
+++ b/frontend/src/templates/Field/Table/TableField.tsx
@@ -50,7 +50,11 @@ export const TableField = ({
   isHighContrast,
 }: TableFieldProps): JSX.Element => {
   const { i18n } = useTranslation()
-  const hasMinRowsChanged = useHasChanged(schema.minimumRows)
+  // RATIONALE for setting isIgnoreUndefined to true:
+  // Since schema.minimumRows is always defined, we should ignore undefined values.
+  // This prevents unwanted update of rows for public form page while
+  // still detecting minimum row schema changes for the admin form builder page.
+  const hasMinRowsChanged = useHasChanged(schema.minimumRows, true)
   const isMobile = useIsMobile()
 
   const selectedLanguage = i18n.language as Language


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
- Hoisting react hook form state led to table fields not reinstating the correct number of rows, causing failures in MRF ≥2nd step submission.
- 248 fix was incorrect fix, it did not address the problem as the root cause analysis was incorrect.

To understand why this is happening, we compare the previous (pre-hoisting) with the new hoisted behavior: 

**Prev:**

In `FormFieldsContainer.tsx`, there is a guard clause

```jsx
**const** renderFields = useMemo(() **=>** {
*// Render skeleton when no data*     
*if (isLoading) {*       
	*return <FormFieldsSkeleton />*    
*}*
```

This prevents rendering of the FormFields component if the previousSubmission is not yet defined.
This is important since when `FormFields.tsx` is rendered, it will compute the `defaultFormValues`, then set it in the `useForm` hook.

```tsx
// In FormFields.tsx  
const formMethods = useForm<FormFieldValues>({
  defaultValues: defaultFormValues,
  mode: 'onTouched',
})
```

The guard clause asserts that `previousSubmission` used for computing the `defaultFormValues` exists and will always be the latest value before the `defaultFormValues` are computed. 
(Without it, `previousSubmission` may be `undefined` as it is received async via network response). 
Hence, `defaultValue` is always set to the correct values since the very first render and when the `useForm` hook is run. 

**The default value being the correct value in the very first render `useForm`  is the required condition for correctness in this case.**

### Key codes of interest that explain the rendered outcome:

This is important as in TableField there are 4 important pieces of code:

- A useEffect in `FormFields.tsx` which resets the default values cache of React hook form (A)

```tsx
  useEffect(() => {
    if (!isDirty) {
      reset(defaultFormValues)
  }, [defaultFormValues, isDirty, reset])
```

- A tracker for when the schema for min rows has changed (B)

```
  const hasMinRowsChanged = useHasChanged(schema.minimumRows)
```

- A use effect which add / deletes rows when the min rows schema change is detected (C)

```
  useEffect(() => {
    // Update field array when min rows changes.
    if (hasMinRowsChanged) {
      const minRows = schema.minimumRows || 0
      const prevRowLength = fields.length
      if (minRows > prevRowLength) {
        for (let i = prevRowLength; i < minRows; i++) {
          appendTableRow()
        }
      } else {
        // Remove rows from field array
        **for (let i = prevRowLength; i > minRows; i--) {
          remove(i - 1)
        }**
      }
    }
  }, [appendTableRow, fields.length, hasMinRowsChanged, remove, schema])

```

- The `remove` function provided by React hook form  (D)

```
  const { **fields**, append, remove } = useFieldArray<TableFieldInputs>({
    control: formMethods.control,
    name: schema._id,
  })
```

The key thing about this function is that **field** is retrieved, it is equivalent to the value stored in React hook form’s cached “default values”. 

```jsx
useForm(
	{
		defaultValues: <this is retreived by 'field' and stores the cached values>
  }
)
```

### Prerequisites: Understanding React useEffect() theory

To understand what happens, we need to understand the order by which React uses `useEffect`

```jsx
// Given the following where A and B call useEffect() 
<A>
	<B /> 
</A> 

// From top to bottom ordering: 
// A mounts and begins painting
// Child component B mounts and begins painting  
// B finishes painting
// A finishes painting
// commits 
// useEffect of child B is invoked
// useEffect of parent A is invoked 
```

Let’s now study what happens when the `FormFields.tsx` and `TableField.tsx` is rendered: 

1. The `useForm` hook is defined with the correct complete `defaultFormValues` 
2. `hasMinRowsChanged` in (B) evaluates to true since the previous value is `undefined` 
3. The table field is rendered completely with the `defaultValues`.
4. After table field renders, this causes the useEffect in (C) (which is in the child `TableField.tsx` to execute and remove the fields). 
5. Then, the useEffect in (A) runs and resets the fields and reinstates the correct number of rows (A). 
Since `defaultFormValues` is correct from the first initialization, it never changes. Hence, useEffect (A) is only run once.  
6. After the reset, React hook form’s cached defaultFormValues is updated to the same complete `defaultFormValues`. 
7. Since the prevVal used in (B) was set in step 2 to the schema’s minRows, which is unchanged, `hasMinRowsChanged` is false, so no rows are removed. 
8. Hence, the final result renders the correct number of rows in the correct `defaultFormValues`.

---

**248:**

For 248, the `useForm` initialization of the `defaultValue` is hoisted to the provider.

This means that there is no guard clause to check if the form and previous submission is loaded before setting the `defaultValue` in the `useForm` hook. (Doing this check is also complicated since `useForm` is a hook and cannot be run conditionally) 

For example - the following is not possible now after it is hoisted: 

```jsx
let formMethods
if (isFormLoaded && isSubmissionLoaded) {
	formMethods = useForm({defaultValues: computeDefaultValues(prevSubmission)})
}
```

Hence, `defaultValue` first returns an invalid (does not contain the latest values) in the first render before then returning the latest values after the form and submission is loaded. 

For example, when the form response mode is not yet loaded, it returns `{}`

```jsx
const defaultFormValues = useMemo(() => {
    // return {"65c753727177d728a526be25":"","65d70123e28bc57002a961aa":{"value":"Operating Theatre(s)"},"65d7113c1a59cf739deaf270":"","660a6bb003552e0dc0531968":"","65c74f097a6e43e3d46b71f9":"kevin.foong@open.gov.sg","65c753e047e450bd2968bc97":"kevin.foong@open.gov.sg","65c74f1d97b72744d22b2f60":{"value":"kevin.foong@open.gov.sg"},"65c74fc3fbdefe5b36db7f02":"+6562223535","65c7538cd602a5e429e5ffc4":"kevin.foong@open.gov.sg","65dc1f544e0ee4bae76f35f8":"No","65c7506b7a6e43e3d46b7a3b":"30/09/2025","65c7506e8af607588945eec7":"01/10/2025","65dc21841a59cf739d60f4d4":"","65d7060d38c912c32104c65c":"","65d70624f55d126c0d36b7ab":"","65c7545cd8b3cc71bfbf00e3":"","65c750ab4f8c96bc7dae795e":"kevin.foong@open.gov.sg","65c751a1fbdefe5b36db8b92":{"value":"kevin.foong@open.gov.sg"},"65c752351b19a8e90ad2aa63":[{"65c752351b19a8e90ad2aa64":"k"},{"65c752351b19a8e90ad2aa64":"f"},{"65c752351b19a8e90ad2aa64":"w"},{"65c752351b19a8e90ad2aa64":"t"}],"662f0fc14927b8088b7f7dd8":[{"65c752351b19a8e90ad2aa65":"Halifax","65c7524216a0c0b769294179":"Halifax","662f1001ddc25f32de2cfd5e":"13"},{"65c752351b19a8e90ad2aa65":"Annex Building","65c7524216a0c0b769294179":"Annex Building","662f1001ddc25f32de2cfd5e":"23"},{"65c752351b19a8e90ad2aa65":"B2","65c7524216a0c0b769294179":"B2","662f1001ddc25f32de2cfd5e":"33"}],"6603a5c7dc6b1959b18a20f0":"","65c753107177d728a526bc69":"Yes","67a9728a43736111900a7a2d":"","respondent_email_field":[]}
    if (!form?.responseMode)
      return {}
    return getInitialFormValues({
      formResponseMode: form?.responseMode,
      previousSubmission,
      previousAttachments,
      augmentedFormFields,
      currentStepNumberWorkflowStep,
      fieldPrefillMap,
      draftResponsesToRestore,
      searchParams,
      isSaveDraftEnabled,
    })
  }, [
    form?.responseMode,
    previousSubmission,
    previousAttachments,
    augmentedFormFields,
    currentStepNumberWorkflowStep,
    fieldPrefillMap,
    draftResponsesToRestore,
    searchParams,
    isSaveDraftEnabled,
  ])
```

As a result, this in particular causes multiple (2 in particular) invocations of (A).

**Let’s study what happens when the `FormFields.tsx` and `TableField.tsx` is rendered for 248:** 

1. The computed `defaultFormValue` is set to `{}` (since form response mode is not yet loaded). 

```jsx
// In PublicFormProvider.tsx (hoisted)  
const formMethods = useForm<FormFieldValues>({
  defaultValues: computeDefaultFormValues() // = {},
  mode: 'onTouched',
})
```

Hence, `FormFields.tsx` sets React hook form’s `defaultValues` as `{}` which is not the final desired value. 

1. In `TableField.tsx`, `hasMinRowsChanged` in (B) evaluates to true since the previous value is `undefined` . This also sets the previousVal of the `hasChanged` hook to `schema.minRows`
2. The table field is rendered completely with the `defaultValues` with empty table field values, since the `defaultValues` is `{}`
3. After table field renders, this causes the useEffect in (C) (which is in the child `TableField.tsx` to execute). No fields are removed since minRows ≥ currentRows
4. Then, the useEffect in (A) runs and resets the fields and reinstates the correct number of rows (A). This time it has the correct values loaded. 
5. Resetting with a different updated `defaultValue` causes a re-render of the child component `TableField.tsx` but **where the `hasMinRowsChanged` previous value is reset to `undefined`**
    1. Hence, when `TableField.tsx` is re-rendered,  `hasMinRowsChanged` is evaluated as true. 
6. After table field renders again, this causes the useEffect in (C) (which is in the child `TableField.tsx` to execute). Fields are now removed since minRows < currentRows which use the updated `defaultValue` value. 
7. This removal of rows causes the `TableField.tsx` to re-render. 
    1. However, this re-render does not reset the previous value for `hasMinRowsChanged` and it evaluates to false. 
8. Finally, the useEffect in (A) is executed in the parent `FormField.tsx` component. But since step 8 removes the additional rows, **the `isDirty` is true and the default value `reset` is not invoked.** 
    1. This causes the final number of rows to not be updated and remain as `schema.minRows` value.   

## Solution
<!-- How did you solve the problem? -->

The main cause seems to be due to `isDirty` being detected as true, causing the reset to not run and set the form values to the latest retrieved `defaultFormValues` . However, upon further analysis, this should indeed be true, since the `remove` was invoked to remove the rows, causing the value to differ from the `defaultValues` provided. 

This means that the `defaultValues` and the `values` are actually reflecting the correct latest values. Hence, there is no data incorrectness here. 

Hence, making a “fix” such that `isDirty` does not evaluate to false seems strange. (And it is strange that for the prev version, the `isDirty` is true). Since, `isDirty` is expected to be `true` given the current values defer from the set `defaultValue`. 

Hence, instead, the error seems that the `isMinRowsChanged` is set to true, which causes a removal of the table rows when useEffect (C) is run - which should not occur in the first place for public forms (since the form schema should always be unchanged during the public form submission page, we do not need to remove/add rows based on schema min row changes). 

So, what is useEffect (C) used for then? 

This useEffect is mainly used for the admin form builder, when the schema for the Table field is updated. This is documented by this PR https://github.com/opengovsg/FormSG/issues/3922 where this `useEffect` was [added to the existing `TableField.tsx` just to support the admin form builder](https://github.com/opengovsg/FormSG/pull/3922/files#diff-387e2b9cc993f540acd069e14b6b54c58ee94b13f0cdbb46a141ae44ca1c5720) and hence it does not need to run for public form submission/preview/use-template page! 

Hence, the proposed fix is to ignore `undefined` during `isMinRowsChanged`. 

**Why is ignoring `undefined` safe?** 

Case I: For public form submission page / preview page / use template page 

Quoting…

> This useEffect is mainly used for the admin form builder, when the schema for the Table field is updated. This is documented by this PR https://github.com/opengovsg/FormSG/issues/3922 where this `useEffect` was [added to the existing `TableField.tsx` just to support the admin form builder](https://github.com/opengovsg/FormSG/pull/3922/files#diff-387e2b9cc993f540acd069e14b6b54c58ee94b13f0cdbb46a141ae44ca1c5720) and hence it does not need to run for public form submission/preview/use-template page!
> 

The useEffect (C) is mainly intended to reflect updates in schema changes in the form builder page and not for the form submission page where the schema.minimumRows should never change. Thus, it should ideally be not be invoked for these pages. 

Ignoring the initial `undefined` in `hasMinRowsChanged` causes the useEffect(C) removal to not execute on the first render, which is intended. 

Furthermore, 

Schema.minimumRows is always asserted to be defined by TS. Hence, it should never be `undefined`. Hence, comparing with `undefined` is not required and causes an unnecessary useEffect (C) execution - which is causing the bug.  

Case II: For admin form template form builder page: 

Schema.minimumRows is always asserted to be defined by TS. Hence, the useEffect (C) will still invoke when changes to the form schema are made in the builder, achieving its intended effect.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## To prevent regressions: 
To prevent regressions, the following chromatic stories are added: (link: https://www.chromatic.com/build?appId=60911f69d4403b0039b266a2&number=9334)

**Admin form page:**
- When the admin updates the min rows, the rows are updated accordingly.

**Public form page**
- storage mode:
- edited fields are saved in the saved draft
- floating button appears when save draft is enabled
- restores save draft (covers rating, email, nric fields)
- prefills higher precedence than save draft
- myinfo fields are not saved in the draft
- save draft not restored for schema changed fields
- when add more rows are added, the number of rows increase in the table field. disabled when max rows are met.

1st step mrf:
- restores save draft
- when add more rows are added, the number of rows increase in the table field. disabled when max rows are met.

2nd step mrf:
- prev submission restored with correct row count
- if non editable, prev submission not overriden by saved draft
- if editable, prev submission overriden by saved draft
- if restored default value < min rows, more rows are appended in default values to meet the min rows

**Template page and preview page:**
- table field is initialised with correct number of min rows

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Table field MRF works 
- [ ] Create an mrf form with table field with additional rows, make min rows = 3, max = 5
- [ ] Make it 4 steps, where table field is editable only on first step and third step 
- [ ] First step fill in the field and set it to 5 rows 
- [ ] Submit past step 2 
- [ ] For step 3, edit to 4 rows 
- [ ] Submit past step 4
- [ ] Assert the full workflow can go through and the correct results are displayed in the form results page after each step.  