### PR TITLE
feat: PhoneNumberInput improvements

### DIFF
--- a/frontend/src/components/PhoneNumberInput/PhoneNumberInput.tsx
+++ b/frontend/src/components/PhoneNumberInput/PhoneNumberInput.tsx
@@ -89,7 +89,7 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputProps, 'input'>(
       allowInternational,
       onChange,
       onBlur,
-      defaultValue: value,
+      defaultValue: value ?? '',
       examples,
       examplePlaceholder,
       placeholder: props.placeholder,

--- a/frontend/src/components/PhoneNumberInput/PhoneNumberInputContext.tsx
+++ b/frontend/src/components/PhoneNumberInput/PhoneNumberInputContext.tsx
@@ -18,7 +18,7 @@ import {
 import defaultExamples from 'libphonenumber-js/examples.mobile.json'
 
 type PhoneNumberInputContextProps = {
-  defaultValue?: string
+  defaultValue: string
   defaultCountry: CountryCode
   /**
    * Set the input's placeholder to an example number for the selected country,
@@ -117,7 +117,7 @@ const useProvidePhoneNumberInput = ({
   ...props
 }: PhoneNumberInputContextProps): PhoneNumberInputContextReturn => {
   // Internal states of the component.
-  const [inputValue, setInputValue] = useState(defaultValue ?? '')
+  const [inputValue, setInputValue] = useState(defaultValue)
   const [country, setCountry] = useState(defaultCountry)
 
   // Refs of the phone number input so focus can be passed to the input when
@@ -169,9 +169,7 @@ const useProvidePhoneNumberInput = ({
         setInputValue(newValue)
       }
 
-      const number = formatter.getNumber()
-
-      const e164 = number?.number as string | undefined
+      const e164 = formatter.getNumber()?.number ?? ''
       onChange(e164)
 
       // On a similar vein, do not set country even if the country has changed
@@ -206,13 +204,14 @@ const useProvidePhoneNumberInput = ({
 
   const handleFormatInput = useCallback(() => {
     const number = formatter.getNumber()
+    const e164 = number?.number ?? ''
 
     // Trigger on change again in case formatted number changes.
     // This can happen in the following scenario:
     // 1. `onInputChange` gets called when user types for example "65aabvcd123"
     // 2. `formatter.getNumber().number` will transform that into "65" and cut out the remaining characters since the remaining string is not a valid number
     // 3. Will need to call onChange on this new number.
-    onChange(number?.number as string | undefined)
+    onChange(e164)
     // Check and update possibility
     const possible = number?.isPossible()
 
@@ -245,9 +244,9 @@ const useProvidePhoneNumberInput = ({
   // This allows the cursor position to be updated after formatting the input
   // without "jumping" to the end of the input string and disrupting the user.
   useLayoutEffect(() => {
-    const number = formatter.getNumber()?.number
+    const e164 = formatter.getNumber()?.number ?? ''
 
-    if (number !== defaultValue) {
+    if (e164 !== defaultValue) {
       // Override the phone number if the field has a number and its e164
       // representation does not match the prop value.
       formatter.reset()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The PhoneNumberInput component's defaultValue behaviour causes issues with saving / restoring the field from a draft submission.

Closes [insert issue #]

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Make the defaultValue prop of the PhoneNumberInput field a required field.
- Change the default value of the PhoneNumberInput from `undefined` to `''`
- Required by the Save Draft feature.

Thanks @kevin9foong for working on this as part of #8744 

## Tests
<!-- What tests should be run to confirm functionality? -->

- [x] no UI diffs are expected or observed from this change

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
