### PR TITLE
chore: use bitnamilegacy/mongodb image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,7 +157,7 @@ services:
     network_mode: 'service:backend' # reuse backend service's network stack so that it can resolve localhost:5156 to mockpass:5156
 
   database:
-    image: 'bitnami/mongodb:4.4'
+    image: 'bitnamilegacy/mongodb:4.4'
     environment:
       - MONGODB_DATABASE=formsg
       - MONGODB_ADVERTISED_HOSTNAME=database


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Bitnami has deprecated their image repositories.

Closes FRM-2159

## Solution
<!-- How did you solve the problem? -->

Switch to the [bitnamilegacy repository for development purposes](https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon#:~:text=Switching%20to%20Bitnami%20Legacy%20Registry).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  
