### PR TITLE
feat: signatures v1.4 (webhooks)

### DIFF
--- a/shared/types/response-v3.ts
+++ b/shared/types/response-v3.ts
@@ -144,3 +144,7 @@ export type SignatureFieldResponseV3 = {
   type: 'draw'
   value: SignatureVectorArray
 }
+
+export type SignatureFieldWebhookResponseV3 = {
+  value: string[]
+}

--- a/shared/types/response-v3.ts
+++ b/shared/types/response-v3.ts
@@ -146,6 +146,6 @@ export type SignatureFieldResponseV3 = {
 }
 
 export type SignatureFieldWebhookResponseV3 = {
-  fieldType: BasicField
+  fieldType: BasicField.Signature
   answer: string[]
 }

--- a/shared/types/response-v3.ts
+++ b/shared/types/response-v3.ts
@@ -146,5 +146,6 @@ export type SignatureFieldResponseV3 = {
 }
 
 export type SignatureFieldWebhookResponseV3 = {
-  value: string[]
+  fieldType: BasicField
+  answer: string[]
 }

--- a/src/app/models/submission.server.model.ts
+++ b/src/app/models/submission.server.model.ts
@@ -592,6 +592,7 @@ MultirespondentSubmissionSchema.methods.getWebhookView = async function (
     formId,
     submissionId: String(this._id),
     encryptedContent: this.encryptedContent,
+    encryptedSubmissionSecretKey: this.encryptedSubmissionSecretKey,
     verifiedContent: '',
     version: this.version,
     created: this.created,

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.middleware.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.middleware.spec.ts
@@ -1,0 +1,159 @@
+import { ObjectId } from 'bson'
+
+import { BasicField } from '../../../../../../shared/types'
+import formsgSdk from '../../../../config/formsg-sdk'
+import { getEncryptedAttachmentsMapFromAttachmentsMap } from '../../submission.utils'
+import { encryptSubmission } from '../encrypt-submission.middleware'
+import { prepareWebhookResponseContent } from '../encrypt-submission.utils'
+
+jest.mock('../encrypt-submission.utils', () => ({
+  ...jest.requireActual('../encrypt-submission.utils'),
+  prepareWebhookResponseContent: jest.fn(),
+}))
+jest.mock('../../../../config/formsg-sdk')
+jest.mock('../../submission.utils')
+
+describe('encryptSubmission', () => {
+  const MOCK_FORM_ID = new ObjectId().toHexString()
+  const MOCK_PUBLIC_KEY = 'mock-public-key'
+  const MOCK_ENCRYPTED_WEBHOOK_CONTENT = 'mock-encrypted-webhook-content'
+  const MOCK_WEBHOOK_RESPONSES: ReturnType<
+    typeof prepareWebhookResponseContent
+  > = [
+    {
+      fieldType: BasicField.ShortText,
+      answer: 'test answer',
+      _id: 'field1',
+      question: 'Test Question 1',
+    },
+    {
+      fieldType: BasicField.Email,
+      answer: 'test@example.com',
+      _id: 'field2',
+      question: 'Test Question 2',
+    },
+  ]
+
+  const MOCK_ENCRYPTED_FORM_DEF = {
+    _id: MOCK_FORM_ID,
+    publicKey: MOCK_PUBLIC_KEY,
+    title: 'Test Form',
+  }
+
+  const MOCK_RESPONSES = [
+    {
+      fieldType: BasicField.ShortText,
+      answer: 'test answer',
+      _id: 'field1',
+      question: 'Test Question 1',
+      isVisible: true,
+    },
+    {
+      fieldType: BasicField.Email,
+      answer: 'test@example.com',
+      _id: 'field2',
+      question: 'Test Question 2',
+      isVisible: true,
+    },
+  ]
+
+  const MOCK_STRIPPED_BODY_RESPONSES = [
+    {
+      fieldType: BasicField.ShortText,
+      answer: 'test answer',
+      _id: 'field1',
+      question: 'Test Question 1',
+      // isVisible property should be removed by omitResponseKeys
+    },
+    {
+      fieldType: BasicField.Email,
+      answer: 'test@example.com',
+      _id: 'field2',
+      question: 'Test Question 2',
+      // isVisible property should be removed by omitResponseKeys
+    },
+  ]
+
+  const createMockReq = (params: { formId: string }) =>
+    ({
+      params,
+      body: {
+        responses: MOCK_RESPONSES,
+        version: 1,
+      },
+      formsg: {
+        encryptedFormDef: MOCK_ENCRYPTED_FORM_DEF,
+      },
+      get: jest.fn((name: string) => {
+        if (name === 'cf-connecting-ip') return '127.0.0.1'
+        if (name === 'cf-ray') return 'mock-cf-ray'
+        return undefined
+      }),
+      ip: '127.0.0.1',
+      id: 'mock-request-id',
+      headers: {
+        'cf-connecting-ip': '127.0.0.1',
+        'cf-ray': 'mock-cf-ray',
+        'x-request-id': 'mock-request-id',
+      },
+      baseUrl: '/api/v3',
+      path: '/forms/mock-form-id/submissions',
+      originalUrl: '/api/v3/forms/mock-form-id/submissions?param=value',
+    }) as any
+
+  const createMockRes = () => ({
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  })
+
+  const mockNext = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetAllMocks()
+
+    // Mock formsgSdk.crypto.encrypt
+    jest
+      .mocked(formsgSdk.crypto.encrypt)
+      .mockReturnValue(MOCK_ENCRYPTED_WEBHOOK_CONTENT)
+
+    // Mock prepareWebhookResponseContent
+    jest
+      .mocked(prepareWebhookResponseContent)
+      .mockReturnValue(MOCK_WEBHOOK_RESPONSES)
+
+    // Mock getEncryptedAttachmentsMapFromAttachmentsMap
+    jest
+      .mocked(getEncryptedAttachmentsMapFromAttachmentsMap)
+      .mockResolvedValue({})
+  })
+
+  it('should include encryptedWebhookContent in req.formsg', async () => {
+    const mockReq = createMockReq({
+      formId: MOCK_FORM_ID,
+    })
+    const mockRes = createMockRes()
+
+    // Act
+    await encryptSubmission(mockReq, mockRes as any, mockNext)
+
+    // Assert
+    expect(mockNext).toHaveBeenCalled()
+    expect(mockReq.formsg).toHaveProperty('encryptedWebhookContent')
+    expect(mockReq.formsg.encryptedWebhookContent).toBe(
+      MOCK_ENCRYPTED_WEBHOOK_CONTENT,
+    )
+
+    // Verify that prepareWebhookResponseContent was called with correct parameters
+    expect(prepareWebhookResponseContent).toHaveBeenCalledWith(
+      MOCK_STRIPPED_BODY_RESPONSES,
+    )
+
+    // Verify that formsgSdk.crypto.encrypt was called with correct parameters
+    expect(formsgSdk.crypto.encrypt).toHaveBeenCalledWith(
+      MOCK_WEBHOOK_RESPONSES,
+      MOCK_PUBLIC_KEY,
+    )
+  })
+})

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -65,16 +65,18 @@ describe('encrypt-submission.service', () => {
       .spyOn(WebhookFactory, 'sendInitialWebhook')
       .mockReturnValue(okAsync(true))
 
+    const MOCK_ENCRYPTED_CONTENT = 'mockEncryptedContent'
+    const MOCK_VERIFIED_CONTENT = 'mockVerifiedContent'
+    const MOCK_WEBHOOK_URL = 'https://example.com/webhook'
+
     const MOCK_FORM = {
       admin: new ObjectId(),
       _id: new ObjectId(),
       title: 'mock title',
       getUniqueMyInfoAttrs: () => [],
       authType: 'NIL',
-      webhook: { url: 'https://example.com/webhook', isRetryEnabled: true },
+      webhook: { url: MOCK_WEBHOOK_URL, isRetryEnabled: true },
     } as unknown as IPopulatedEncryptedForm
-    const MOCK_ENCRYPTED_CONTENT = 'mockEncryptedContent'
-    const MOCK_VERIFIED_CONTENT = 'mockVerifiedContent'
 
     const MOCK_SUBMISSION = {
       _id: 'submission123',
@@ -89,7 +91,7 @@ describe('encrypt-submission.service', () => {
       jest
         .spyOn(FormService, 'retrieveFullFormById')
         .mockReturnValue(okAsync(MOCK_FORM))
-      const result = await performEncryptPostSubmissionActions({
+      await performEncryptPostSubmissionActions({
         submission: { ...MOCK_SUBMISSION } as IEncryptedSubmissionSchema,
         responses: [],
         encryptedWebhookContent,
@@ -100,7 +102,7 @@ describe('encrypt-submission.service', () => {
             encryptedContent: encryptedWebhookContent,
             verifiedContent: MOCK_VERIFIED_CONTENT,
           }),
-          'https://example.com/webhook',
+          MOCK_WEBHOOK_URL,
           true,
         )
       })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -107,5 +107,20 @@ describe('encrypt-submission.service', () => {
         )
       })
     })
+
+    it('should not call WebhookFactory.sendInitialWebhook if encryptedWebhookContent is undefined', async () => {
+      const encryptedWebhookContent = undefined
+
+      jest
+        .spyOn(FormService, 'retrieveFullFormById')
+        .mockReturnValue(okAsync(MOCK_FORM))
+      await performEncryptPostSubmissionActions({
+        submission: { ...MOCK_SUBMISSION } as IEncryptedSubmissionSchema,
+        responses: [],
+        encryptedWebhookContent,
+      }).map(() => {
+        expect(webhookSpy).not.toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -2,11 +2,17 @@
 import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
 import mongoose from 'mongoose'
+import { okAsync } from 'neverthrow'
 
 import { getEncryptSubmissionModel } from 'src/app/models/submission.server.model'
-import { IPopulatedEncryptedForm } from 'src/types'
+import { WebhookFactory } from 'src/app/modules/webhook/webhook.factory'
+import { IEncryptedSubmissionSchema, IPopulatedEncryptedForm } from 'src/types'
 
-import { createEncryptSubmissionWithoutSave } from '../encrypt-submission.service'
+import * as FormService from '../../../form/form.service'
+import {
+  createEncryptSubmissionWithoutSave,
+  performEncryptPostSubmissionActions,
+} from '../encrypt-submission.service'
 
 const EncryptSubmission = getEncryptSubmissionModel(mongoose)
 
@@ -51,6 +57,53 @@ describe('encrypt-submission.service', () => {
       )
       expect(result.version).toEqual(MOCK_VERSION)
       expect(foundInDatabase).toBeNull()
+    })
+  })
+
+  describe('performEncryptPostSubmissionActions', () => {
+    const webhookSpy = jest
+      .spyOn(WebhookFactory, 'sendInitialWebhook')
+      .mockReturnValue(okAsync(true))
+
+    const MOCK_FORM = {
+      admin: new ObjectId(),
+      _id: new ObjectId(),
+      title: 'mock title',
+      getUniqueMyInfoAttrs: () => [],
+      authType: 'NIL',
+      webhook: { url: 'https://example.com/webhook', isRetryEnabled: true },
+    } as unknown as IPopulatedEncryptedForm
+    const MOCK_ENCRYPTED_CONTENT = 'mockEncryptedContent'
+    const MOCK_VERIFIED_CONTENT = 'mockVerifiedContent'
+
+    const MOCK_SUBMISSION = {
+      _id: 'submission123',
+      form: MOCK_FORM._id,
+      encryptedContent: MOCK_ENCRYPTED_CONTENT,
+      verifiedContent: MOCK_VERIFIED_CONTENT,
+    } as unknown as IEncryptedSubmissionSchema
+
+    it('should call WebhookFactory.sendInitialWebhook with the correct arguments', async () => {
+      const encryptedWebhookContent = 'mockEncryptedWebhookContent'
+
+      jest
+        .spyOn(FormService, 'retrieveFullFormById')
+        .mockReturnValue(okAsync(MOCK_FORM))
+      const result = await performEncryptPostSubmissionActions({
+        submission: { ...MOCK_SUBMISSION } as IEncryptedSubmissionSchema,
+        responses: [],
+        encryptedWebhookContent,
+      }).map(() => {
+        expect(webhookSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: 'submission123',
+            encryptedContent: encryptedWebhookContent,
+            verifiedContent: MOCK_VERIFIED_CONTENT,
+          }),
+          'https://example.com/webhook',
+          true,
+        )
+      })
     })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
@@ -1,13 +1,29 @@
 import { ObjectId } from 'bson'
 import moment from 'moment-timezone'
-import { FormPaymentsField, PaymentType, SubmissionType } from 'shared/types'
+import {
+  BasicField,
+  FormPaymentsField,
+  PaymentType,
+  SubmissionType,
+} from 'shared/types'
+import { SIGNATURE_CAPTURED_STRING } from 'shared/utils/signature'
 
 import { IPopulatedEncryptedForm, StorageModeSubmissionData } from 'src/types'
+import {
+  EncryptFormFieldResponse,
+  ParsedClearAttachmentWebhookResponse,
+  ParsedClearFormFieldResponse,
+} from 'src/types/api'
 
+import {
+  ProcessedFieldResponse,
+  ProcessedSignatureResponse,
+} from '../../submission.types'
 import {
   createStorageModeSubmissionDto,
   getPaymentAmount,
   getPaymentIntentDescription,
+  prepareWebhookResponseContent,
 } from '../encrypt-submission.utils'
 
 describe('encrypt-submission.utils', () => {
@@ -148,6 +164,69 @@ describe('encrypt-submission.utils', () => {
       const result = getPaymentIntentDescription(formData, products)
 
       expect(result).toContain(expectedValue)
+    })
+  })
+
+  describe('prepareWebhookResponseContent', () => {
+    const input: Array<
+      | ProcessedFieldResponse
+      | ParsedClearFormFieldResponse
+      | EncryptFormFieldResponse
+      | ParsedClearAttachmentWebhookResponse
+    > = [
+      {
+        _id: 'field1',
+        fieldType: BasicField.Dropdown,
+        answer: 'Option A',
+      } as ParsedClearFormFieldResponse,
+      {
+        _id: 'field2',
+        fieldType: BasicField.Signature,
+        answerArray: ['draw', '[[[0,0,0],[0,0,1]]]'],
+      } as ProcessedSignatureResponse,
+      {
+        _id: 'field3',
+        fieldType: BasicField.Attachment,
+        filename: undefined,
+        content: undefined,
+      } as ParsedClearAttachmentWebhookResponse,
+    ]
+
+    it('should replace signature answerArray with SIGNATURE_CAPTURED_STRING', () => {
+      const output = prepareWebhookResponseContent(input)
+
+      // Non-signature fields remain unchanged
+      expect(output[0]).toEqual(input[0])
+      expect(output[2]).toEqual(input[2])
+
+      // Signature field answerArray is replaced
+      const sigResponse = output.find(
+        (r): r is ProcessedSignatureResponse =>
+          r.fieldType === BasicField.Signature,
+      )
+      expect(sigResponse).toBeDefined()
+      expect(sigResponse!.answerArray).toEqual([SIGNATURE_CAPTURED_STRING])
+    })
+
+    it('should leave signature fields with empty answerArray unchanged', () => {
+      const updatedInput = input.map((field) => {
+        if (
+          field._id === 'field2' &&
+          field.fieldType === BasicField.Signature
+        ) {
+          return { ...field, answerArray: [] } // replace with empty array
+        }
+        return field
+      })
+
+      const output = prepareWebhookResponseContent(updatedInput)
+
+      // Non-signature fields remain unchanged
+      expect(output[0]).toEqual(input[0])
+      expect(output[2]).toEqual(input[2])
+
+      //Empty signature field to also remain unchanged
+      expect(output[1]).toEqual(input[1])
     })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
@@ -222,11 +222,11 @@ describe('encrypt-submission.utils', () => {
       const output = prepareWebhookResponseContent(updatedInput)
 
       // Non-signature fields remain unchanged
-      expect(output[0]).toEqual(input[0])
-      expect(output[2]).toEqual(input[2])
+      expect(output[0]).toEqual(updatedInput[0])
+      expect(output[2]).toEqual(updatedInput[2])
 
       //Empty signature field to also remain unchanged
-      expect(output[1]).toEqual(input[1])
+      expect(output[1]).toEqual(updatedInput[1])
     })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -850,6 +850,7 @@ const _createSubmission = async ({
     emailData,
     attachments: emailAttachments,
     respondentEmails,
+    encryptedWebhookContent: req.formsg?.encryptedWebhookContent,
   })
 }
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -11,7 +11,6 @@ import {
   FormResponseMode,
   isPaymentsProducts,
 } from '../../../../../shared/types'
-import { SIGNATURE_CAPTURED_STRING } from '../../../../../shared/utils/signature'
 import { IPopulatedForm } from '../../../../types'
 import {
   EncryptAttachmentResponse,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -533,7 +533,7 @@ export const encryptSubmission = async (
   )
 
   // Modify response data for webhook responses and encrypt separately
-  const strippedBodyResponsesWebhook = strippedBodyResponses.map((response) => {
+  const strippedResponsesWebhook = strippedBodyResponses.map((response) => {
     if (
       response.fieldType === BasicField.Signature &&
       response.answerArray.length > 0
@@ -546,7 +546,7 @@ export const encryptSubmission = async (
   })
 
   const encryptedWebhookContent = formsgSdk.crypto.encrypt(
-    strippedBodyResponsesWebhook,
+    strippedResponsesWebhook,
     publicKey,
   )
   req.formsg.encryptedWebhookContent = encryptedWebhookContent

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -11,6 +11,7 @@ import {
   FormResponseMode,
   isPaymentsProducts,
 } from '../../../../../shared/types'
+import { SIGNATURE_CAPTURED_STRING } from '../../../../../shared/utils/signature'
 import { IPopulatedForm } from '../../../../types'
 import {
   EncryptAttachmentResponse,
@@ -530,6 +531,25 @@ export const encryptSubmission = async (
     strippedBodyResponses,
     publicKey,
   )
+
+  // Modify response data for webhook responses and encrypt separately
+  const strippedBodyResponsesWebhook = strippedBodyResponses.map((response) => {
+    if (
+      response.fieldType === BasicField.Signature &&
+      response.answerArray.length > 0
+    )
+      return {
+        ...response,
+        answerArray: [SIGNATURE_CAPTURED_STRING],
+      }
+    return response
+  })
+
+  const encryptedWebhookContent = formsgSdk.crypto.encrypt(
+    strippedBodyResponsesWebhook,
+    publicKey,
+  )
+  req.formsg.encryptedWebhookContent = encryptedWebhookContent
 
   req.formsg.encryptedPayload = {
     attachments: encryptedAttachments,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -58,6 +58,7 @@ import {
 import {
   formatMyInfoStorageResponseData,
   omitResponseKeys,
+  prepareWebhookResponseContent,
 } from './encrypt-submission.utils'
 import IncomingEncryptSubmission from './IncomingEncryptSubmission.class'
 
@@ -533,17 +534,9 @@ export const encryptSubmission = async (
   )
 
   // Modify response data for webhook responses and encrypt separately
-  const strippedResponsesWebhook = strippedBodyResponses.map((response) => {
-    if (
-      response.fieldType === BasicField.Signature &&
-      response.answerArray.length > 0
-    )
-      return {
-        ...response,
-        answerArray: [SIGNATURE_CAPTURED_STRING],
-      }
-    return response
-  })
+  const strippedResponsesWebhook = prepareWebhookResponseContent(
+    strippedBodyResponses,
+  )
 
   const encryptedWebhookContent = formsgSdk.crypto.encrypt(
     strippedResponsesWebhook,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -152,6 +152,7 @@ export const performEncryptPostSubmissionActions = ({
   emailData,
   attachments,
   respondentEmails,
+  encryptedWebhookContent,
 }: {
   submission: IEncryptedSubmissionSchema
   responses: FieldResponse[]
@@ -159,6 +160,7 @@ export const performEncryptPostSubmissionActions = ({
   emailData?: SubmissionEmailObj
   attachments?: Mail.Attachment[]
   respondentEmails?: string[]
+  encryptedWebhookContent?: string
 }): ResultAsync<
   true,
   | FormNotFoundError
@@ -183,6 +185,19 @@ export const performEncryptPostSubmissionActions = ({
         // do not await on webhook
         const webhookUrl = form.webhook?.url
         if (!webhookUrl) return okAsync(form)
+
+        // replace encryptedContent with encryptedWebhookContent before firing
+        if (encryptedWebhookContent)
+          submission.encryptedContent = encryptedWebhookContent
+        else {
+          logger.error({
+            message:
+              'Error while sending webhook, no encryptedWebhookContent found',
+            meta: {
+              action: 'useEncryptedWebhookContent',
+            },
+          })
+        }
 
         return WebhookFactory.sendInitialWebhook(
           submission,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -187,9 +187,14 @@ export const performEncryptPostSubmissionActions = ({
         if (!webhookUrl) return okAsync(form)
 
         // replace encryptedContent with encryptedWebhookContent before firing
-        if (encryptedWebhookContent)
+        if (encryptedWebhookContent) {
           submission.encryptedContent = encryptedWebhookContent
-        else {
+          return WebhookFactory.sendInitialWebhook(
+            submission,
+            webhookUrl,
+            !!form.webhook?.isRetryEnabled,
+          ).andThen(() => okAsync(form))
+        } else {
           logger.error({
             message:
               'Error while sending webhook, no encryptedWebhookContent found',
@@ -198,13 +203,8 @@ export const performEncryptPostSubmissionActions = ({
               action: 'useEncryptedWebhookContent',
             },
           })
+          return okAsync(form)
         }
-
-        return WebhookFactory.sendInitialWebhook(
-          submission,
-          webhookUrl,
-          !!form.webhook?.isRetryEnabled,
-        ).andThen(() => okAsync(form))
       })
       // TODO [PDF-LAMBDA-GENERATION]: Remove setting of Growthbook targetting once pdf generation rollout is complete
       .map(async (form) => {

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -194,6 +194,7 @@ export const performEncryptPostSubmissionActions = ({
             message:
               'Error while sending webhook, no encryptedWebhookContent found',
             meta: {
+              ...logMeta,
               action: 'useEncryptedWebhookContent',
             },
           })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -24,7 +24,6 @@ import {
 } from '../../../../types'
 import {
   EncryptFormFieldResponse,
-  ParsedClearAttachmentResponse,
   ParsedClearAttachmentWebhookResponse,
   ParsedClearFormFieldResponse,
 } from '../../../../types/api'

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -2,6 +2,7 @@ import moment from 'moment-timezone'
 import Stripe from 'stripe'
 
 import {
+  BasicField,
   FormPaymentsField,
   PaymentChannel,
   PaymentFieldsDto,
@@ -13,6 +14,7 @@ import {
   SubmissionType,
 } from '../../../../../shared/types'
 import { calculatePrice } from '../../../../../shared/utils/paymentProductPrice'
+import { SIGNATURE_CAPTURED_STRING } from '../../../../../shared/utils/signature'
 import { isProcessedChildResponse } from '../../../../app/utils/field-validation/field-validation.guards'
 import {
   IEncryptedSubmissionSchema,
@@ -22,6 +24,8 @@ import {
 } from '../../../../types'
 import {
   EncryptFormFieldResponse,
+  ParsedClearAttachmentResponse,
+  ParsedClearAttachmentWebhookResponse,
   ParsedClearFormFieldResponse,
 } from '../../../../types/api'
 import { MyInfoKey } from '../../myinfo/myinfo.types'
@@ -183,4 +187,30 @@ export const getStripePaymentMethod = (
       enabled: true,
     },
   }
+}
+
+export const prepareWebhookResponseContent = (
+  input: Array<
+    | ProcessedFieldResponse
+    | ParsedClearFormFieldResponse
+    | EncryptFormFieldResponse
+    | ParsedClearAttachmentWebhookResponse
+  >,
+): Array<
+  | ProcessedFieldResponse
+  | ParsedClearFormFieldResponse
+  | EncryptFormFieldResponse
+  | ParsedClearAttachmentWebhookResponse
+> => {
+  return input.map((response) => {
+    if (
+      response.fieldType === BasicField.Signature &&
+      response.answerArray.length > 0
+    )
+      return {
+        ...response,
+        answerArray: [SIGNATURE_CAPTURED_STRING],
+      }
+    return response
+  })
 }

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -1,19 +1,26 @@
 import { ObjectId } from 'bson'
 import { errAsync, ok, okAsync } from 'neverthrow'
 
-import { FormResponseMode } from '../../../../../../shared/types'
+import { BasicField, FormResponseMode } from '../../../../../../shared/types'
+import formsgSdk from '../../../../config/formsg-sdk'
 import * as FeatureFlagService from '../../../feature-flags/feature-flags.service'
 import * as FormService from '../../../form/form.service'
 import { SubmissionNotFoundError } from '../../submission.errors'
-import { createFormsgAndRetrieveForm } from '../multirespondent-submission.middleware'
+import {
+  createFormsgAndRetrieveForm,
+  encryptSubmission,
+} from '../multirespondent-submission.middleware'
 import {
   checkFormIsMultirespondent,
   getMultirespondentSubmission,
 } from '../multirespondent-submission.service'
+import { prepareWebhookResponseContentV3 } from '../multirespondent-submission.utils'
 
 jest.mock('../../../feature-flags/feature-flags.service')
 jest.mock('../../../form/form.service')
 jest.mock('../multirespondent-submission.service')
+jest.mock('../multirespondent-submission.utils')
+jest.mock('../../../../config/formsg-sdk')
 
 describe('createFormsgAndRetrieveForm', () => {
   const MOCK_FORM_ID = new ObjectId().toHexString()
@@ -264,5 +271,152 @@ describe('createFormsgAndRetrieveForm', () => {
 
     // Verify that getMultirespondentSubmission was NOT called
     expect(getMultirespondentSubmission).not.toHaveBeenCalled()
+  })
+})
+
+describe('encryptSubmission', () => {
+  const MOCK_FORM_ID = new ObjectId().toHexString()
+  const MOCK_SUBMISSION_ID = new ObjectId().toHexString()
+  const MOCK_PUBLIC_KEY = 'mock-public-key'
+  const MOCK_SUBMISSION_PUBLIC_KEY = 'mock-submission-public-key'
+  const MOCK_ENCRYPTED_WEBHOOK_CONTENT = 'mock-encrypted-webhook-content'
+  const MOCK_WEBHOOK_RESPONSES: ReturnType<
+    typeof prepareWebhookResponseContentV3
+  > = {
+    field1: {
+      fieldType: BasicField.ShortText,
+      answer: 'test answer',
+    },
+    field2: {
+      fieldType: BasicField.Email,
+      answer: {
+        value: 'test@example.com',
+      },
+    },
+  }
+
+  const MOCK_FORM_DEF = {
+    _id: MOCK_FORM_ID,
+    publicKey: MOCK_PUBLIC_KEY,
+    title: 'Test Form',
+  }
+
+  const MOCK_RESPONSES = {
+    field1: {
+      fieldType: BasicField.ShortText,
+      answer: 'test answer',
+    },
+    field2: {
+      fieldType: BasicField.Email,
+      answer: 'test@example.com',
+    },
+  }
+
+  const MOCK_STRIPPED_ATTACHMENT_RESPONSES = {
+    field1: {
+      fieldType: BasicField.ShortText,
+      answer: 'test answer',
+    },
+    field2: {
+      fieldType: BasicField.Email,
+      answer: 'test@example.com',
+    },
+  }
+
+  const createMockReq = (params: { formId: string; submissionId?: string }) =>
+    ({
+      params,
+      body: {
+        responses: MOCK_RESPONSES,
+        version: 1,
+        workflowStep: 1,
+        responseMetadata: {},
+      },
+      formsg: {
+        formDef: MOCK_FORM_DEF,
+      },
+      get: jest.fn((name: string) => {
+        if (name === 'cf-connecting-ip') return '127.0.0.1'
+        if (name === 'cf-ray') return 'mock-cf-ray'
+        return undefined
+      }),
+      ip: '127.0.0.1',
+      id: 'mock-request-id',
+      headers: {
+        'cf-connecting-ip': '127.0.0.1',
+        'cf-ray': 'mock-cf-ray',
+        'x-request-id': 'mock-request-id',
+      },
+      baseUrl: '/api/v3',
+      path: '/forms/mock-form-id/submissions',
+      originalUrl: '/api/v3/forms/mock-form-id/submissions?param=value',
+    }) as any
+
+  const createMockRes = () => ({
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+  })
+
+  const mockNext = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetAllMocks()
+
+    // Mock formsgSdk.cryptoV3.encrypt
+    jest.mocked(formsgSdk.cryptoV3.encrypt).mockReturnValue({
+      encryptedContent: 'mock-encrypted-content',
+      encryptedSubmissionSecretKey: 'mock-encrypted-secret-key',
+      submissionSecretKey: 'mock-secret-key',
+      submissionPublicKey: MOCK_SUBMISSION_PUBLIC_KEY,
+    })
+
+    // Mock formsgSdk.crypto.encrypt
+    jest
+      .mocked(formsgSdk.crypto.encrypt)
+      .mockReturnValue(MOCK_ENCRYPTED_WEBHOOK_CONTENT)
+
+    // Mock prepareWebhookResponseContentV3
+    jest
+      .mocked(prepareWebhookResponseContentV3)
+      .mockReturnValue(MOCK_WEBHOOK_RESPONSES)
+
+    // Mock getEncryptedAttachmentsMapFromAttachmentsMap
+    jest.doMock('../multirespondent-submission.utils', () => ({
+      ...jest.requireActual('../multirespondent-submission.utils'),
+      getEncryptedAttachmentsMapFromAttachmentsMap: jest
+        .fn()
+        .mockResolvedValue({}),
+    }))
+  })
+
+  it('should include encryptedWebhookContent in req.formsg', async () => {
+    const mockReq = createMockReq({
+      formId: MOCK_FORM_ID,
+      submissionId: MOCK_SUBMISSION_ID,
+    })
+    const mockRes = createMockRes()
+
+    // Act
+    await encryptSubmission(mockReq, mockRes as any, mockNext)
+
+    // Assert
+    expect(mockNext).toHaveBeenCalled()
+    expect(mockReq.formsg).toHaveProperty('encryptedWebhookContent')
+    expect(mockReq.formsg.encryptedWebhookContent).toBe(
+      MOCK_ENCRYPTED_WEBHOOK_CONTENT,
+    )
+
+    // Verify that prepareWebhookResponseContentV3 was called with correct parameters
+    expect(prepareWebhookResponseContentV3).toHaveBeenCalledWith(
+      MOCK_STRIPPED_ATTACHMENT_RESPONSES,
+    )
+
+    // Verify that formsgSdk.crypto.encrypt was called with correct parameters
+    expect(formsgSdk.crypto.encrypt).toHaveBeenCalledWith(
+      MOCK_WEBHOOK_RESPONSES,
+      MOCK_SUBMISSION_PUBLIC_KEY,
+    )
   })
 })

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -9,6 +9,7 @@ import {
   WorkflowType,
 } from 'shared/types'
 
+import { WebhookFactory } from 'src/app/modules/webhook/webhook.factory'
 import MailService from 'src/app/services/mail/mail.service'
 import {
   IMultirespondentSubmissionSchema,
@@ -27,7 +28,6 @@ import {
   sendNextStepReminderEmail,
 } from '../multirespondent-submission.service'
 import * as MultirespondentSubmissionService from '../multirespondent-submission.service'
-import { WebhookFactory } from 'src/app/modules/webhook/webhook.factory'
 
 jest.mock('src/app/modules/datadog/datadog.utils')
 
@@ -1645,7 +1645,7 @@ describe('multirespondent-submission.service', () => {
       )
     })
 
-    it('should call fire webhook with the correct arguments', async () => {
+    it('should fire webhook with the correct arguments for first submission', async () => {
       const encryptedWebhookContent = 'mockEncryptedWebhookContent'
       // Act
       await performMultiRespondentPostSubmissionCreateActions({
@@ -1664,6 +1664,76 @@ describe('multirespondent-submission.service', () => {
           version: 1,
           submissionPublicKey: 'submissionPublicKey',
           encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+        encryptedWebhookContent,
+      })
+
+      expect(webhookSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: mockSubmissionId,
+          encryptedContent: encryptedWebhookContent,
+        }),
+        MOCK_WEBHOOK_URL,
+        true,
+      )
+    })
+
+    it('should fire webhook with the correct arguments for subsequent submission', async () => {
+      const encryptedWebhookContent = 'mockEncryptedWebhookContent'
+      const mockFormId = new ObjectId().toHexString()
+      const mockSubmissionId = new ObjectId().toHexString()
+
+      const stepOneEmailNotificationFieldId = new ObjectId().toHexString()
+      const stepOneEditEmailFieldId = new ObjectId().toHexString()
+      const staticEmail = 'expected_static_email@example.com'
+      const expectedStepTwoEmail = 'expected_step_two_static_email@example.com'
+
+      const stepOneId = new ObjectId().toHexString()
+      const stepTwoId = new ObjectId().toHexString()
+
+      const workflow: FormWorkflowStepDto[] = [
+        {
+          _id: stepOneId,
+          workflow_type: WorkflowType.Dynamic,
+          field: stepOneEditEmailFieldId,
+          edit: [stepOneEditEmailFieldId],
+        },
+        {
+          _id: stepTwoId,
+          workflow_type: WorkflowType.Static,
+          emails: [expectedStepTwoEmail],
+          edit: [],
+        },
+      ]
+      const snapshottedFormDef = {
+        _id: mockFormId,
+        workflow,
+        emails: [staticEmail],
+        stepsToNotify: [stepTwoId],
+        stepOneEmailNotificationFieldId,
+        webhook: { url: MOCK_WEBHOOK_URL, isRetryEnabled: true },
+      } as SnapshottedFormDef
+
+      const submissionResponses: FieldResponsesV3 = {
+        // stepOneEmailNotificationFieldId is not present in responses
+      }
+
+      // Act
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
+        submissionId: mockSubmissionId,
+        snapshottedFormDef,
+        currentStepNumber: workflow.length - 1,
+        encryptedPayload: {
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+          responses: submissionResponses,
+          workflowStep: workflow.length - 1,
         } as MultirespondentSubmissionDto,
         logMeta: {} as any,
         encryptedWebhookContent,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1647,6 +1647,7 @@ describe('multirespondent-submission.service', () => {
 
     it('should fire webhook with the correct arguments for first submission', async () => {
       const encryptedWebhookContent = 'mockEncryptedWebhookContent'
+      const encryptedSubmissionSecretKey = 'encryptedSubmissionSecretKey'
       // Act
       await performMultiRespondentPostSubmissionCreateActions({
         submission: {
@@ -1663,7 +1664,7 @@ describe('multirespondent-submission.service', () => {
           encryptedContent: 'encryptedContent',
           version: 1,
           submissionPublicKey: 'submissionPublicKey',
-          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+          encryptedSubmissionSecretKey: encryptedSubmissionSecretKey,
         } as MultirespondentSubmissionDto,
         logMeta: {} as any,
         encryptedWebhookContent,
@@ -1673,6 +1674,7 @@ describe('multirespondent-submission.service', () => {
         expect.objectContaining({
           _id: mockSubmissionId,
           encryptedContent: encryptedWebhookContent,
+          encryptedSubmissionSecretKey: encryptedSubmissionSecretKey,
         }),
         MOCK_WEBHOOK_URL,
         true,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -125,6 +125,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -234,6 +237,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -349,6 +355,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -460,6 +469,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -566,6 +578,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -690,6 +705,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -801,6 +819,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -854,6 +875,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionCreateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         form: {
           _id: mockFormId,
@@ -947,6 +971,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -1046,6 +1073,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -1138,6 +1168,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
@@ -1204,6 +1237,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
@@ -1270,6 +1306,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
@@ -1357,6 +1396,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
@@ -1408,6 +1450,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionCreateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         form: {
           _id: mockFormId,
@@ -1448,6 +1493,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
           _id: mockFormId,
@@ -1489,6 +1537,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionCreateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         form: {
           _id: mockFormId,
@@ -1577,6 +1628,9 @@ describe('multirespondent-submission.service', () => {
 
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
         currentStepNumber: workflow.length - 1,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1648,6 +1648,33 @@ describe('multirespondent-submission.service', () => {
       )
     })
 
+    it('should not fire webhook if the encryptedWebhookContent is undefined', async () => {
+      // Act
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission: {
+          _id: mockSubmissionId,
+          encryptedSubmissionSecretKey: encryptedSubmissionSecretKey,
+        } as unknown as IMultirespondentSubmissionSchema,
+        submissionId: mockSubmissionId,
+        form: {
+          _id: mockFormId,
+          workflow: singleStepWorkflow,
+          emails: ['email1@example.com'],
+          webhook: { url: MOCK_WEBHOOK_URL, isRetryEnabled: true },
+        } as IPopulatedMultirespondentForm,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: encryptedSubmissionSecretKey,
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+        encryptedWebhookContent: undefined,
+      })
+
+      expect(webhookSpy).not.toHaveBeenCalled()
+    })
+
     it('should fire webhook with the correct arguments for first submission', async () => {
       // Act
       await performMultiRespondentPostSubmissionCreateActions({

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -27,6 +27,7 @@ import {
   sendNextStepReminderEmail,
 } from '../multirespondent-submission.service'
 import * as MultirespondentSubmissionService from '../multirespondent-submission.service'
+import { WebhookFactory } from 'src/app/modules/webhook/webhook.factory'
 
 jest.mock('src/app/modules/datadog/datadog.utils')
 
@@ -1429,22 +1430,28 @@ describe('multirespondent-submission.service', () => {
     })
   })
 
-  describe('sendRespondentCopyEmail', () => {
+  describe('postSubmissionActions', () => {
+    const singleStepWorkflow: FormWorkflowStepDto[] = [
+      {
+        _id: new ObjectId().toHexString(),
+        workflow_type: WorkflowType.Static,
+        emails: [],
+        edit: [],
+      },
+    ]
+    const webhookSpy = jest
+      .spyOn(WebhookFactory, 'sendInitialWebhook')
+      .mockReturnValue(okAsync(true))
+
+    const MOCK_ENCRYPTED_CONTENT = 'mockEncryptedContent'
+    const MOCK_WEBHOOK_URL = 'https://example.com/webhook'
+
     it('should not send respondent copy if respondent emails are not present on performMultiRespondentPostSubmissionCreateActions', async () => {
       // Arrange
       const sendMrfRespondentCopyEmailSpy = jest.spyOn(
         MailService,
         'sendMrfRespondentCopyEmail',
       )
-
-      const singleStepWorkflow: FormWorkflowStepDto[] = [
-        {
-          _id: new ObjectId().toHexString(),
-          workflow_type: WorkflowType.Static,
-          emails: [],
-          edit: [],
-        },
-      ]
 
       const emptyRespondentEmails: string[] = []
 
@@ -1460,7 +1467,7 @@ describe('multirespondent-submission.service', () => {
           emails: ['email1@example.com'],
         } as IPopulatedMultirespondentForm,
         encryptedPayload: {
-          encryptedContent: 'encryptedContent',
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
           submissionPublicKey: 'submissionPublicKey',
           encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
@@ -1480,15 +1487,6 @@ describe('multirespondent-submission.service', () => {
         'sendMrfRespondentCopyEmail',
       )
 
-      const singleStepWorkflow: FormWorkflowStepDto[] = [
-        {
-          _id: new ObjectId().toHexString(),
-          workflow_type: WorkflowType.Static,
-          emails: [],
-          edit: [],
-        },
-      ]
-
       const emptyRespondentEmails: string[] = []
 
       // Act
@@ -1504,7 +1502,7 @@ describe('multirespondent-submission.service', () => {
         } as SnapshottedFormDef,
         currentStepNumber: 1,
         encryptedPayload: {
-          encryptedContent: 'encryptedContent',
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
           submissionPublicKey: 'submissionPublicKey',
           encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
@@ -1524,15 +1522,6 @@ describe('multirespondent-submission.service', () => {
         'sendMrfRespondentCopyEmail',
       )
 
-      const singleStepWorkflow: FormWorkflowStepDto[] = [
-        {
-          _id: new ObjectId().toHexString(),
-          workflow_type: WorkflowType.Static,
-          emails: [],
-          edit: [],
-        },
-      ]
-
       const respondentEmails = ['test@example.com', 'test1@example.com']
 
       // Act
@@ -1547,7 +1536,7 @@ describe('multirespondent-submission.service', () => {
           emails: ['email1@example.com'],
         } as IPopulatedMultirespondentForm,
         encryptedPayload: {
-          encryptedContent: 'encryptedContent',
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
           submissionPublicKey: 'submissionPublicKey',
           encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
@@ -1635,7 +1624,7 @@ describe('multirespondent-submission.service', () => {
         snapshottedFormDef,
         currentStepNumber: workflow.length - 1,
         encryptedPayload: {
-          encryptedContent: 'encryptedContent',
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
           submissionPublicKey: 'submissionPublicKey',
           encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
@@ -1653,6 +1642,40 @@ describe('multirespondent-submission.service', () => {
       ).toContainValues(respondentEmails)
       expect(sendMrfRespondentCopyEmailSpy.mock.calls[0][0].emails.length).toBe(
         2,
+      )
+    })
+
+    it('should call fire webhook with the correct arguments', async () => {
+      const encryptedWebhookContent = 'mockEncryptedWebhookContent'
+      // Act
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
+        submissionId: mockSubmissionId,
+        form: {
+          _id: mockFormId,
+          workflow: singleStepWorkflow,
+          emails: ['email1@example.com'],
+          webhook: { url: MOCK_WEBHOOK_URL, isRetryEnabled: true },
+        } as IPopulatedMultirespondentForm,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+        } as MultirespondentSubmissionDto,
+        logMeta: {} as any,
+        encryptedWebhookContent,
+      })
+
+      expect(webhookSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: mockSubmissionId,
+          encryptedContent: encryptedWebhookContent,
+        }),
+        MOCK_WEBHOOK_URL,
+        true,
       )
     })
   })

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1443,6 +1443,9 @@ describe('multirespondent-submission.service', () => {
       .spyOn(WebhookFactory, 'sendInitialWebhook')
       .mockReturnValue(okAsync(true))
 
+    const encryptedWebhookContent = 'mockEncryptedWebhookContent'
+    const encryptedSubmissionSecretKey = 'encryptedSubmissionSecretKey'
+
     const MOCK_ENCRYPTED_CONTENT = 'mockEncryptedContent'
     const MOCK_WEBHOOK_URL = 'https://example.com/webhook'
 
@@ -1646,12 +1649,11 @@ describe('multirespondent-submission.service', () => {
     })
 
     it('should fire webhook with the correct arguments for first submission', async () => {
-      const encryptedWebhookContent = 'mockEncryptedWebhookContent'
-      const encryptedSubmissionSecretKey = 'encryptedSubmissionSecretKey'
       // Act
       await performMultiRespondentPostSubmissionCreateActions({
         submission: {
           _id: mockSubmissionId,
+          encryptedSubmissionSecretKey: encryptedSubmissionSecretKey,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         form: {
@@ -1725,6 +1727,7 @@ describe('multirespondent-submission.service', () => {
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
           _id: mockSubmissionId,
+          encryptedSubmissionSecretKey: encryptedSubmissionSecretKey,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
@@ -1733,7 +1736,7 @@ describe('multirespondent-submission.service', () => {
           encryptedContent: MOCK_ENCRYPTED_CONTENT,
           version: 1,
           submissionPublicKey: 'submissionPublicKey',
-          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+          encryptedSubmissionSecretKey: encryptedSubmissionSecretKey,
           responses: submissionResponses,
           workflowStep: workflow.length - 1,
         } as MultirespondentSubmissionDto,
@@ -1745,6 +1748,7 @@ describe('multirespondent-submission.service', () => {
         expect.objectContaining({
           _id: mockSubmissionId,
           encryptedContent: encryptedWebhookContent,
+          encryptedSubmissionSecretKey: encryptedSubmissionSecretKey,
         }),
         MOCK_WEBHOOK_URL,
         true,

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -45,7 +45,7 @@ import { ValidateFieldErrorV3 } from '../../submission.errors'
 import {
   createMultirespondentSubmissionDto,
   getQuestionTitleAnswerString,
-  prepareWebhookResponseContent,
+  prepareWebhookResponseContentV3,
   retrieveWorkflowStepEmailAddresses,
   validateMrfFieldResponses,
 } from '../multirespondent-submission.utils'
@@ -711,7 +711,7 @@ describe('multirespondent-submission.utils', () => {
     const mockResponses: Record<string, ParsedClearFormFieldResponseV3> = {
       ['mockId1']: {
         fieldType: BasicField.Dropdown,
-        answer: 'Option C', // Option not in mapping
+        answer: 'Option C',
       },
       ['mockId2']: {
         fieldType: BasicField.Signature,
@@ -722,10 +722,34 @@ describe('multirespondent-submission.utils', () => {
       },
     }
 
-    const webhookResponses = prepareWebhookResponseContent(mockResponses)
+    const webhookResponses = prepareWebhookResponseContentV3(mockResponses)
 
+    expect(webhookResponses['mockId1']).toEqual(mockResponses['mockId1'])
     expect(webhookResponses['mockId2'].answer).toEqual(
       expect.arrayContaining([SIGNATURE_CAPTURED_STRING]),
+    )
+
+    const mockResponsesEmptySignature: Record<
+      string,
+      ParsedClearFormFieldResponseV3
+    > = {
+      ['mockId1']: {
+        fieldType: BasicField.Dropdown,
+        answer: 'Option C',
+      },
+      ['mockId2']: {
+        fieldType: BasicField.Signature,
+        answer: {
+          type: 'draw',
+          value: [],
+        },
+      },
+    }
+    expect(mockResponsesEmptySignature['mockId1']).toEqual(
+      mockResponsesEmptySignature['mockId1'],
+    )
+    expect(mockResponsesEmptySignature['mockId2'].answer).toEqual(
+      expect.arrayContaining([]),
     )
   })
 })

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -23,6 +23,7 @@ import {
   WorkflowStatus,
   WorkflowType,
 } from 'shared/types'
+import { SIGNATURE_CAPTURED_STRING } from 'shared/utils/signature'
 
 import {
   FormFieldSchema,
@@ -38,11 +39,13 @@ import {
   MultirespondentSubmissionData,
 } from 'src/types'
 
+import { ParsedClearFormFieldResponseV3 } from '../../../../../types/api'
 import * as fieldValidation from '../../../../utils/field-validation'
 import { ValidateFieldErrorV3 } from '../../submission.errors'
 import {
   createMultirespondentSubmissionDto,
   getQuestionTitleAnswerString,
+  prepareWebhookResponseContent,
   retrieveWorkflowStepEmailAddresses,
   validateMrfFieldResponses,
 } from '../multirespondent-submission.utils'
@@ -702,5 +705,27 @@ describe('multirespondent-submission.utils', () => {
       responses: null as unknown as FieldResponsesV3,
     })
     expect(nullResult).toEqual([])
+  })
+
+  it('should return desired webhook response value changes', () => {
+    const mockResponses: Record<string, ParsedClearFormFieldResponseV3> = {
+      ['mockId1']: {
+        fieldType: BasicField.Dropdown,
+        answer: 'Option C', // Option not in mapping
+      },
+      ['mockId2']: {
+        fieldType: BasicField.Signature,
+        answer: {
+          type: 'draw',
+          value: [[[10, 20, 0.5]], [[40, 40, 0.5]]],
+        },
+      },
+    }
+
+    const webhookResponses = prepareWebhookResponseContent(mockResponses)
+
+    expect(webhookResponses['mockId2'].answer).toEqual(
+      expect.arrayContaining([SIGNATURE_CAPTURED_STRING]),
+    )
   })
 })

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -156,6 +156,7 @@ const submitMultirespondentForm = async (
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
     respondentEmails: req.formsg.respondentEmails,
+    encryptedWebhookContent: req.formsg.encryptedWebhookContent,
   })
 }
 
@@ -252,6 +253,7 @@ const updateMultirespondentSubmission = async (
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
     respondentEmails: req.formsg.respondentEmails,
+    encryptedWebhookContent: req.formsg.encryptedWebhookContent,
   })
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto'
 import { NextFunction } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
+import { SIGNATURE_CAPTURED_STRING } from 'shared/utils/signature'
 
 import {
   IAttachmentInfo,
@@ -16,6 +17,7 @@ import {
   FormDto,
   FormFieldDto,
   FormResponseMode,
+  SignatureFieldWebhookResponseV3,
   SubmissionType,
 } from '../../../../../shared/types'
 import { isDev } from '../../../../app/config/config'
@@ -795,6 +797,30 @@ export const encryptSubmission = async (
       submissionPublicKey,
       req.body.version,
     )
+
+  // Modify response data for webhook responses and encrypt separately
+  const strippedResponsesWebhook = Object.entries(
+    strippedAttachmentResponses,
+  ).map(([key, value]) => {
+    if (
+      value.fieldType === BasicField.Signature &&
+      value.answer.value.length > 0
+    ) {
+      const webhookValue: SignatureFieldWebhookResponseV3 = {
+        value: [SIGNATURE_CAPTURED_STRING],
+      }
+
+      return [key, webhookValue]
+    }
+    return [key, value]
+  })
+
+  const encryptedWebhookContent = formsgSdk.crypto.encrypt(
+    strippedResponsesWebhook,
+    submissionPublicKey,
+  )
+
+  req.formsg.encryptedWebhookContent = encryptedWebhookContent
 
   req.formsg.encryptedPayload = {
     attachments: encryptedAttachments,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -68,7 +68,7 @@ import {
   StrippedAttachmentResponseV3,
 } from './multirespondent-submission.types'
 import {
-  prepareWebhookResponseContent,
+  prepareWebhookResponseContentV3,
   validateMrfFieldResponses,
 } from './multirespondent-submission.utils'
 
@@ -800,7 +800,7 @@ export const encryptSubmission = async (
     )
 
   // Modify response data for webhook responses and encrypt separately
-  const strippedResponsesWebhook = prepareWebhookResponseContent(
+  const strippedResponsesWebhook = prepareWebhookResponseContentV3(
     strippedAttachmentResponses,
   )
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -3,7 +3,6 @@ import crypto from 'crypto'
 import { NextFunction } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
-import { SIGNATURE_CAPTURED_STRING } from 'shared/utils/signature'
 
 import {
   IAttachmentInfo,
@@ -17,7 +16,6 @@ import {
   FormDto,
   FormFieldDto,
   FormResponseMode,
-  SignatureFieldWebhookResponseV3,
   SubmissionType,
 } from '../../../../../shared/types'
 import { isDev } from '../../../../app/config/config'
@@ -69,7 +67,10 @@ import {
   ProcessedMultirespondentSubmissionHandlerType,
   StrippedAttachmentResponseV3,
 } from './multirespondent-submission.types'
-import { validateMrfFieldResponses } from './multirespondent-submission.utils'
+import {
+  prepareWebhookResponseContent,
+  validateMrfFieldResponses,
+} from './multirespondent-submission.utils'
 
 const logger = createLoggerWithLabel(module)
 
@@ -799,21 +800,9 @@ export const encryptSubmission = async (
     )
 
   // Modify response data for webhook responses and encrypt separately
-  const strippedResponsesWebhook = Object.entries(
+  const strippedResponsesWebhook = prepareWebhookResponseContent(
     strippedAttachmentResponses,
-  ).map(([key, value]) => {
-    if (
-      value.fieldType === BasicField.Signature &&
-      value.answer.value.length > 0
-    ) {
-      const webhookValue: SignatureFieldWebhookResponseV3 = {
-        value: [SIGNATURE_CAPTURED_STRING],
-      }
-
-      return [key, webhookValue]
-    }
-    return [key, value]
-  })
+  )
 
   const encryptedWebhookContent = formsgSdk.crypto.encrypt(
     strippedResponsesWebhook,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -636,6 +636,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   logMeta,
   attachments,
   respondentEmails,
+  encryptedWebhookContent,
 }: {
   submission: IMultirespondentSubmissionSchema
   submissionId: string
@@ -644,6 +645,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   logMeta: CustomLoggerParams['meta']
   attachments?: IAttachmentInfo[]
   respondentEmails?: string[]
+  encryptedWebhookContent?: string
 }): ResultAsync<boolean, InvalidWorkflowTypeError | MailSendError> => {
   const { submissionSecretKey, responses } = encryptedPayload
   const currentStepNumber = 0
@@ -674,25 +676,36 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   }
 
   const webhookUrl = form.webhook?.url
+
   if (webhookUrl) {
     logger.info({
-      message: 'Sending initial webhook for multirespondent submission',
+      message: 'Sending update webhook for multirespondent submission',
       meta: logMeta,
     })
 
-    WebhookFactory.sendInitialWebhook(
-      submission,
-      webhookUrl,
-      !!form.webhook?.isRetryEnabled,
-    )
-      .andThen(() => okAsync(form))
-      .mapErr((error) => {
-        logger.error({
-          message: 'Multirespondent submission webhook error',
-          meta: logMeta,
-          error,
-        })
+    if (!encryptedWebhookContent) {
+      logger.error({
+        message:
+          'Error while sending webhook, no encryptedWebhookContent found',
+        meta: { action: 'useEncryptedWebhookContentMrf' },
       })
+    } else {
+      submission.encryptedContent = encryptedWebhookContent
+
+      WebhookFactory.sendInitialWebhook(
+        submission,
+        webhookUrl,
+        !!form.webhook?.isRetryEnabled,
+      )
+        .andThen(() => okAsync(form))
+        .mapErr((error) => {
+          logger.error({
+            message: 'Multirespondent submission webhook error',
+            meta: logMeta,
+            error,
+          })
+        })
+    }
   }
 
   return sendNextStepEmail({
@@ -889,6 +902,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   logMeta,
   attachments,
   respondentEmails,
+  encryptedWebhookContent,
 }: {
   submission: IMultirespondentSubmissionSchema
   submissionId: string
@@ -898,6 +912,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   logMeta: CustomLoggerParams['meta']
   attachments?: IAttachmentInfo[]
   respondentEmails?: string[]
+  encryptedWebhookContent?: string
 }): ResultAsync<
   boolean,
   | InvalidWorkflowTypeError
@@ -956,25 +971,36 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   const isStepRejected = isStepRejectedResult.value
 
   const webhookUrl = snapshottedFormDef.webhook?.url
+
   if (webhookUrl) {
     logger.info({
       message: 'Sending update webhook for multirespondent submission',
       meta: logMeta,
     })
 
-    WebhookFactory.sendInitialWebhook(
-      submission,
-      webhookUrl,
-      !!snapshottedFormDef.webhook?.isRetryEnabled,
-    )
-      .andThen(() => okAsync(undefined))
-      .mapErr((error) => {
-        logger.error({
-          message: 'Multirespondent submission webhook error',
-          meta: logMeta,
-          error,
-        })
+    if (!encryptedWebhookContent) {
+      logger.error({
+        message:
+          'Error while sending webhook, no encryptedWebhookContent found',
+        meta: { action: 'useEncryptedWebhookContentMrf' },
       })
+    } else {
+      submission.encryptedContent = encryptedWebhookContent
+
+      WebhookFactory.sendInitialWebhook(
+        submission,
+        webhookUrl,
+        !!snapshottedFormDef.webhook?.isRetryEnabled,
+      )
+        .andThen(() => okAsync(snapshottedFormDef))
+        .mapErr((error) => {
+          logger.error({
+            message: 'Multirespondent submission webhook error',
+            meta: logMeta,
+            error,
+          })
+        })
+    }
   }
 
   if (isStepRejected) {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -679,7 +679,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
 
   if (webhookUrl) {
     logger.info({
-      message: 'Sending update webhook for multirespondent submission',
+      message: 'Sending webhook for multirespondent submission',
       meta: logMeta,
     })
 
@@ -687,7 +687,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
       logger.error({
         message:
           'Error while sending webhook, no encryptedWebhookContent found',
-        meta: { action: 'useEncryptedWebhookContentMrf' },
+        meta: logMeta,
       })
     } else {
       submission.encryptedContent = encryptedWebhookContent
@@ -974,7 +974,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
 
   if (webhookUrl) {
     logger.info({
-      message: 'Sending update webhook for multirespondent submission',
+      message: 'Sending webhook for multirespondent submission',
       meta: logMeta,
     })
 
@@ -982,7 +982,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
       logger.error({
         message:
           'Error while sending webhook, no encryptedWebhookContent found',
-        meta: { action: 'useEncryptedWebhookContentMrf' },
+        meta: logMeta,
       })
     } else {
       submission.encryptedContent = encryptedWebhookContent

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -8,6 +8,7 @@ import {
   FormFieldDto,
   FormWorkflowStepDto,
   MultirespondentSubmissionDto,
+  SignatureFieldWebhookResponseV3,
   SubmissionType,
   WorkflowType,
 } from '../../../../../shared/types'
@@ -17,7 +18,10 @@ import {
   FormFieldSchema,
   MultirespondentSubmissionData,
 } from '../../../../types'
-import { ParsedClearFormFieldResponsesV3 } from '../../../../types/api'
+import {
+  ParsedClearFormFieldResponsesV3,
+  ParsedClearFormFieldResponseV3,
+} from '../../../../types/api'
 import { validateFieldV3 } from '../../../utils/field-validation'
 import { FieldIdSet } from '../../../utils/logic-adaptor'
 import { QuestionAnswer } from '../../../views/templates/MrfWorkflowCompletionEmail'
@@ -27,6 +31,8 @@ import {
   ValidateFieldErrorV3,
 } from '../submission.errors'
 import { buildMrfMetadata } from '../submission.utils'
+
+import { StrippedAttachmentResponseV3 } from './multirespondent-submission.types'
 
 /**
  * Creates and returns a MultirespondentSubmissionDto object from submissionData and
@@ -340,4 +346,42 @@ export const getQuestionTitleAnswerString = ({
     })
   }
   return questionAnswerPair
+}
+
+/**
+ * Converts responses to webhook desired outputs before encryption (again)
+ */
+export const prepareWebhookResponseContent = (
+  input: Record<
+    string,
+    ParsedClearFormFieldResponseV3 | StrippedAttachmentResponseV3
+  >,
+): Record<
+  string,
+  | ParsedClearFormFieldResponseV3
+  | StrippedAttachmentResponseV3
+  | SignatureFieldWebhookResponseV3
+> => {
+  const result: Record<
+    string,
+    | ParsedClearFormFieldResponseV3
+    | StrippedAttachmentResponseV3
+    | SignatureFieldWebhookResponseV3
+  > = {}
+
+  for (const [key, value] of Object.entries(input)) {
+    if (
+      value.fieldType === BasicField.Signature &&
+      value.answer.value.length > 0
+    ) {
+      result[key] = {
+        ...value,
+        answer: [SIGNATURE_CAPTURED_STRING],
+      }
+    } else {
+      result[key] = value
+    }
+  }
+
+  return result
 }

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -351,7 +351,7 @@ export const getQuestionTitleAnswerString = ({
 /**
  * Converts responses to webhook desired outputs before encryption (again)
  */
-export const prepareWebhookResponseContent = (
+export const prepareWebhookResponseContentV3 = (
   input: Record<
     string,
     ParsedClearFormFieldResponseV3 | StrippedAttachmentResponseV3

--- a/src/types/api/submission.ts
+++ b/src/types/api/submission.ts
@@ -15,6 +15,14 @@ export type ParsedClearAttachmentResponse = AttachmentResponse & {
   content: Buffer
 }
 
+export type ParsedClearAttachmentWebhookResponse = Omit<
+  ParsedClearAttachmentResponse,
+  'filename' | 'content'
+> & {
+  filename?: string
+  content?: Buffer
+}
+
 export type ParsedClearFormFieldResponse =
   | Exclude<FieldResponse, AttachmentResponse>
   | ParsedClearAttachmentResponse

--- a/src/types/submission.ts
+++ b/src/types/submission.ts
@@ -30,6 +30,7 @@ export interface WebhookData {
   attachmentDownloadUrls: Record<string, string>
   paymentContent?: PaymentWebhookEventObject | object
   workflowContent?: WorkflowWebhookEventObject | object
+  encryptedSubmissionSecretKey?: string
 }
 
 export interface WebhookView {

--- a/src/types/vendor/express.d.ts
+++ b/src/types/vendor/express.d.ts
@@ -40,6 +40,7 @@ declare global {
             encryptedPayload?: EncryptSubmissionDto
             encryptedFormDef?: IPopulatedEncryptedForm
             unencryptedAttachments?: IAttachmentInfo[]
+            encryptedWebhookContent?: string
           }
         | {
             responseMode: FormResponseMode.Multirespondent
@@ -47,6 +48,7 @@ declare global {
             featureFlags?: string[]
             encryptedPayload?: MultirespondentSubmissionDto
             unencryptedAttachments?: IAttachmentInfo[]
+            encryptedWebhookContent?: string
           }
     }
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Incremental development of signatures field. For v1.4, webhooks are settled - converting the `vectorArray` to a `Signature captured` string to prevent leaking of sensitive signature information

Closes FRM-2161

## Solution
<!-- How did you solve the problem? -->

Handling webhooks in the BE has changed in order to support this update of signature field value. Originally, encryption happens once, and `encryptedContent` is saved in DB and sent in the webhook. To support a different field value in webhooks, responses need to be manipulated before encryption, and then encrypted independently from db `encryptedContent`. The diagram below depicts these decoupling changes

<img width="578" height="683" alt="image" src="https://github.com/user-attachments/assets/17d6f7a4-b8bc-44d8-8c2f-2f44f0ff9a69" />

Key changes:
1. Responses are updated to desired webhook values and encrypted as `encryptedWebhookContent`
2. `encryptedWebhookContent` is saved in req (`req.formsg.encryptedWebhookContent`)
3. `encryptedWebhookContent` replaced `encryptedContent into `submission` object just before firing webhook
*For MRF, webhook responses are encrypted using `submissionPublicKey` taken from the encryption of db responses which is done first. 

4. Change to include `encryptionSubmisisonSecretKey` in MRF webhook payload.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible

## Before and after screenshots

## Tests
<!-- What tests should be run to confirm functionality? -->

**Regression storage mode form webhook**
- [x] Create a storage mode form with 1-2 basic fields
- [x] Enable webhooks on the form (can generate a URL on webhook.site)
- [x] Successfully make a submission
- [x] Decrypt the webhook response and observe that encryptedResponse can be successfully decrypted

**Storage mode form + signature webhook**
- [x] Add the signature field to the recently created storage mode form
- [x] Successfully make a submission
- [x] Decrypt the webhook response and observe that encryptedResponse can be successfully decrypted
- [x] Observe that under signature response, `['Signature captured']` is shown instead of the signature vector array

**Storage mode form + signature optional webhook**
- [x] Update the signature field to be optional in the recently created storage mode form
- [x] Successfully make a submission
- [x] Decrypt the webhook response and observe that encryptedResponse can be successfully decrypted
- [x] Observe that under signature response, `[]` is shown

**MRF mode form + signature webhook**
- [x] Create a MRF mode form with 1-2 basic fields and a signature field
- [x] (optional) create 2 workflow steps and assign signature field to step 1, other fields to any
- [x] Successfully complete step 1 & subsequent step submissions
- [x] At each step, decrypt the webhook response (rmb to use cryptoV3.decrypt) and observe that encryptedResponse can be successfully decrypted
- [x] Observe that under signature response, `['Signature captured']` is shown instead of the signature vector array
