### PR TITLE
fix: ignore url line in printable response

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react'
-import { Box, Center, Text } from '@chakra-ui/react'
+import { Box, Text } from '@chakra-ui/react'
 import { FieldType } from '@opengovsg/formsg-sdk/dist/types'
 
 import { BasicField } from '~shared/types/field'
@@ -166,9 +166,9 @@ export const PrintableResponse = ({
           color="white"
           textDecor="underline"
           textDecorationColor="white"
+          data-chromatic="ignore"
         >
-          <span data-chromatic="ignore">{window.location.origin}</span>
-          <span>{`/${formId}`}</span>
+          {window.location.origin}/{formId}
         </Text>
       </Box>
       <Box mx="5%" my="30px">


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

On each build, chromatic has an expected different url causing noise due to diffs in the PrintableResponse.tsx component stories. 

## Solution
<!-- How did you solve the problem? -->

Ignore the line where the expected url diffs. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  