### PR TITLE
fix: hide empty tooltip for main save draft button

### DIFF
--- a/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -41,6 +41,7 @@ const PublicFormSaveDraftButton = (props: ButtonProps) => {
   return (
     <Tooltip
       placement="top"
+      isDisabled={!tooltipLabel}
       label={<Text data-chromatic="ignore">{tooltipLabel}</Text>}
     >
       <Button variant="outline" onClick={onSaveDraft} {...props}>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Save draft button shows an empty tooltip when no draft is saved. There should ideally be no popup. 

<img width="473" height="118" alt="image" src="https://github.com/user-attachments/assets/ee0fd582-902f-4c3a-80dd-02c97b0c49dd" />

## Solution
<!-- How did you solve the problem? -->
Disable (hide) the tooltip if no label exists.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  