### PR TITLE
fix: add missing response id and time submitted in local generated pdf

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.stories.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.stories.tsx
@@ -145,10 +145,13 @@ Default.args = {
   formTitle: 'Default Form Submission',
   formId: '61540ece3d4a6e50ac0cc6ff',
   decryptedResponses: mockResponses,
+  responseId: '68e4a1b6aa7e70297d82e8e2',
+  submissionTime: 'Mon, 6 Oct 2025, 02:00:31 PM',
 }
 
 export const MinimalForm = Template.bind({})
 MinimalForm.args = {
+  ...Default.args,
   formTitle: 'Minimal Form Submission',
   formId: '61540ece3d4a6e50ac0cc6ff',
   decryptedResponses: [
@@ -169,6 +172,7 @@ MinimalForm.args = {
 
 export const LongFormTitle = Template.bind({})
 LongFormTitle.args = {
+  ...Default.args,
   formTitle:
     'Comprehensive Employee Onboarding and Information Collection Form for New Hires',
   formId: '61540ece3d4a6e50ac0cc6ff',
@@ -177,6 +181,7 @@ LongFormTitle.args = {
 
 export const EmptyResponses = Template.bind({})
 EmptyResponses.args = {
+  ...Default.args,
   formTitle: 'Empty Form',
   formId: '61540ece3d4a6e50ac0cc6ff',
   decryptedResponses: [],
@@ -184,6 +189,7 @@ EmptyResponses.args = {
 
 export const OnlySections = Template.bind({})
 OnlySections.args = {
+  ...Default.args,
   formTitle: 'Form with Headings Only',
   formId: '61540ece3d4a6e50ac0cc6ff',
   decryptedResponses: [
@@ -204,6 +210,7 @@ OnlySections.args = {
 
 export const TableHeavyForm = Template.bind({})
 TableHeavyForm.args = {
+  ...Default.args,
   formTitle: 'Table Heavy Form',
   formId: '61540ece3d4a6e50ac0cc6ff',
   decryptedResponses: [
@@ -234,6 +241,7 @@ TableHeavyForm.args = {
 
 export const LongTextForm = Template.bind({})
 LongTextForm.args = {
+  ...Default.args,
   formTitle: 'Feedback Form',
   formId: '61540ece3d4a6e50ac0cc6ff',
   decryptedResponses: [
@@ -256,6 +264,7 @@ LongTextForm.args = {
 
 export const OptionalSignature = Template.bind({})
 OptionalSignature.args = {
+  ...Default.args,
   formTitle: 'Optional signature with and without answer',
   formId: '61540ece3d4a6e50ac0cc6ff',
   decryptedResponses: [

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -60,6 +60,21 @@ const TableSingleColItem = ({ children }: { children: React.ReactNode }) => (
   </td>
 )
 
+const StandardPrintableRow = ({
+  question,
+  answer,
+}: {
+  question: string
+  answer: string
+}) => {
+  return (
+    <TableRow>
+      <TableSingleColItem>{question}</TableSingleColItem>
+      <TableSingleColItem>{answer}</TableSingleColItem>
+    </TableRow>
+  )
+}
+
 const PrintableDecryptedRow = ({
   row,
 }: {
@@ -81,22 +96,21 @@ const PrintableDecryptedRow = ({
         row.answerArray as string[],
       ).join(', ')
       return (
-        <TableRow>
-          <TableSingleColItem>{row.question}</TableSingleColItem>
-          <TableSingleColItem>{transformedAddress}</TableSingleColItem>
-        </TableRow>
+        <StandardPrintableRow
+          question={row.question}
+          answer={transformedAddress}
+        />
       )
     }
     case BasicField.Table:
       return (
         <>
           {row.answerArray?.map((ans, idx) => (
-            <TableRow key={idx}>
-              <TableSingleColItem>{row.question}</TableSingleColItem>
-              <TableSingleColItem>
-                {Array.isArray(ans) ? ans.join(', ') : ans}
-              </TableSingleColItem>
-            </TableRow>
+            <StandardPrintableRow
+              question={row.question}
+              answer={Array.isArray(ans) ? ans.join(', ') : ans}
+              key={idx}
+            />
           ))}
         </>
       )
@@ -111,20 +125,39 @@ const PrintableDecryptedRow = ({
       )
     default:
       return (
-        <TableRow>
-          <TableSingleColItem>{row.question}</TableSingleColItem>
-          <TableSingleColItem>
-            {row.answer || row.answerArray?.join(', ') || ''}
-          </TableSingleColItem>
-        </TableRow>
+        <StandardPrintableRow
+          question={row.question}
+          answer={row.answer || row.answerArray?.join(', ') || ''}
+        />
       )
   }
 }
 
+const getDefaultRows = ({
+  responseId,
+  submissionTime,
+}: {
+  responseId: string
+  submissionTime: string
+}) => [
+  {
+    question: 'Response ID',
+    answer: responseId,
+  },
+  {
+    question: 'Time Submitted',
+    answer: submissionTime,
+  },
+]
+
 const PrintableResponseRows = ({
   decryptedResponses,
+  responseId,
+  submissionTime,
 }: {
   decryptedResponses: AugmentedDecryptedResponse[]
+  responseId: string
+  submissionTime: string
 }) => {
   return (
     <table
@@ -133,6 +166,13 @@ const PrintableResponseRows = ({
       }}
     >
       <tbody>
+        {getDefaultRows({ responseId, submissionTime }).map((r, idx) => (
+          <StandardPrintableRow
+            question={r.question}
+            answer={r.answer}
+            key={idx}
+          />
+        ))}
         {decryptedResponses.map((r, idx) => (
           <PrintableDecryptedRow row={r} key={idx} />
         ))}
@@ -145,10 +185,14 @@ export const PrintableResponse = ({
   formTitle,
   formId,
   decryptedResponses,
+  responseId,
+  submissionTime,
 }: {
   formTitle: string
   formId: string
   decryptedResponses: AugmentedDecryptedResponse[]
+  responseId: string
+  submissionTime: string
 }) => {
   return (
     <Box py="16px" fontFamily="sans-serif">
@@ -172,7 +216,11 @@ export const PrintableResponse = ({
         </Text>
       </Box>
       <Box mx="5%" my="30px">
-        <PrintableResponseRows decryptedResponses={decryptedResponses} />
+        <PrintableResponseRows
+          decryptedResponses={decryptedResponses}
+          responseId={responseId}
+          submissionTime={submissionTime}
+        />
       </Box>
     </Box>
   )
@@ -189,6 +237,8 @@ const PrintableResponseContainer = forwardRef<HTMLDivElement>((_, ref) => {
         formTitle={form.title}
         formId={form._id}
         decryptedResponses={data?.responses}
+        responseId={data.refNo}
+        submissionTime={data.submissionTime}
       />
     </Box>
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

In the local pdf print button - the response ID and timestamp are not included in the generated PDF, differing from the emailed PDF. 

Expected: 
<img width="1994" height="1338" alt="image" src="https://github.com/user-attachments/assets/46900e29-e77f-49c7-a3a5-46cbfd161c90" />

Actual: 
<img width="1994" height="1338" alt="image" src="https://github.com/user-attachments/assets/2cc8a503-1862-47bd-93a2-070b7e8b2c4b" />

## Solution
<!-- How did you solve the problem? -->
Include these values 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
MRF: 
- [x] Click on local print for an mrf response. 
- [x] Assert the response id and submitted time is included. 
- [x] This time and resp id should match the time in the response in the web app.  

Storage mode: 
- [ ] Click on local print for a storage mode response. 
- [ ] Assert the response id and submitted time is included. 
- [ ] This time and resp id should match the time in the response in the web app.  