### PR TITLE
feat: duplicate form workflow and override emails

### DIFF
--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -395,6 +395,7 @@ export type DuplicateFormOverwriteDto = {
   | {
       responseMode: FormResponseMode.Multirespondent
       publicKey: string
+      workflow?: FormWorkflowDto
     }
 )
 

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -2830,6 +2830,118 @@ describe('Form Model', () => {
         )
 
         expect(duplicatedForm).not.toHaveProperty('whitelistedSubmitterIds')
+        expect(duplicatedForm.workflow).toBeUndefined()
+      })
+
+      describe('for multirespondent form', () => {
+        const MOCK_EMAIL_FIELD = {
+          _id: new ObjectId().toString(),
+          fieldType: BasicField.Email,
+        }
+        const MOCK_DROPDOWN_FIELD = {
+          _id: new ObjectId().toString(),
+          fieldType: BasicField.Dropdown,
+          optionsToRecipientsMap: {
+            'Option 1': ['initial_option1@example.com'],
+          },
+        }
+        const MOCK_YES_NO_FIELD = {
+          _id: new ObjectId().toString(),
+          fieldType: BasicField.YesNo,
+        }
+        const MOCK_FORM_FIELDS = [
+          MOCK_EMAIL_FIELD,
+          MOCK_DROPDOWN_FIELD,
+          MOCK_YES_NO_FIELD,
+        ]
+        const MOCK_WORKFLOW = [
+          {
+            _id: new ObjectId().toString(),
+            workflow_type: WorkflowType.Static,
+            emails: ['step1email@gmail.com'],
+            edit: [MOCK_EMAIL_FIELD._id],
+          },
+          {
+            _id: new ObjectId().toString(),
+            workflow_type: WorkflowType.Dynamic,
+            field: new ObjectId().toString(),
+            edit: [MOCK_DROPDOWN_FIELD._id],
+          },
+          {
+            _id: new ObjectId().toString(),
+            workflow_type: WorkflowType.Conditional,
+            conditional_field: new ObjectId().toString(),
+            edit: [MOCK_YES_NO_FIELD._id],
+          },
+        ]
+
+        it('should duplicate all required fields, including workflow', () => {
+          const MOCK_ALL_OVERRIDE_PARAMS = {
+            admin: 'duplicated admin',
+            title: 'duplicated mrf form title',
+            responseMode: FormResponseMode.Multirespondent,
+            publicKey: 'duplicated public key',
+          }
+          const MOCK_ALL_FORM_PARAMS = {
+            title: 'Test Form',
+            admin: MOCK_ADMIN_OBJ_ID,
+            isSubmitterIdCollectionEnabled: true,
+            isSingleSubmission: true,
+            isSaveDraftEnabled: true,
+            inactiveMessage: 'inactive_test',
+            responseMode: FormResponseMode.Multirespondent,
+            submissionLimit: 1000,
+            publicKey: 'initial public key',
+            workflow: MOCK_WORKFLOW,
+            form_fields: MOCK_FORM_FIELDS,
+          }
+
+          const sourceForm = new MultirespondentForm(MOCK_ALL_FORM_PARAMS)
+          const duplicatedForm = sourceForm.getDuplicateParams(
+            MOCK_ALL_OVERRIDE_PARAMS,
+          )
+
+          // Assert overriden fields
+          expect(duplicatedForm.title).toEqual(MOCK_ALL_OVERRIDE_PARAMS.title)
+          expect(duplicatedForm.admin).toEqual(MOCK_ALL_OVERRIDE_PARAMS.admin)
+          expect(duplicatedForm.responseMode).toEqual(
+            MOCK_ALL_OVERRIDE_PARAMS.responseMode,
+          )
+          expect(duplicatedForm.publicKey).toEqual(
+            MOCK_ALL_OVERRIDE_PARAMS.publicKey,
+          )
+
+          // Assert unoverriden fields
+          // Assert workflow is duplicated
+          const duplicatedWorkflow = JSON.parse(
+            JSON.stringify(duplicatedForm.workflow),
+          )
+          expect(duplicatedWorkflow).toEqual(MOCK_ALL_FORM_PARAMS.workflow)
+
+          const duplicatedFormFieldIds = JSON.parse(
+            JSON.stringify(duplicatedForm.form_fields),
+          ).map((field: FormFieldDto) => field._id)
+          const expectedFormFieldIds = MOCK_ALL_FORM_PARAMS.form_fields.map(
+            (field) => field._id,
+          )
+          expect(duplicatedFormFieldIds).toEqual(expectedFormFieldIds)
+
+          expect(duplicatedForm.submissionLimit).toEqual(
+            MOCK_ALL_FORM_PARAMS.submissionLimit,
+          )
+          expect(duplicatedForm.isSubmitterIdCollectionEnabled).toEqual(
+            MOCK_ALL_FORM_PARAMS.isSubmitterIdCollectionEnabled,
+          )
+          expect(duplicatedForm.isSingleSubmission).toEqual(
+            MOCK_ALL_FORM_PARAMS.isSingleSubmission,
+          )
+          expect(duplicatedForm.isSaveDraftEnabled).toEqual(
+            MOCK_ALL_FORM_PARAMS.isSaveDraftEnabled,
+          )
+          expect(duplicatedForm.inactiveMessage).toEqual(
+            MOCK_ALL_FORM_PARAMS.inactiveMessage,
+          )
+        })
       })
     })
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -122,6 +122,20 @@ import { isPositiveInteger } from './utils'
 
 export const FORM_SCHEMA_ID = 'Form'
 
+const FORM_SCHEMA_COMMON_DUPLICATE_PARAMS = [
+  'form_fields',
+  'form_logics',
+  'startPage',
+  'endPage',
+  'authType',
+  'isSaveDraftEnabled',
+  'isSubmitterIdCollectionEnabled',
+  'isSingleSubmission',
+  'inactiveMessage',
+  'responseMode',
+  'submissionLimit',
+] as const
+
 const formSchemaOptions: SchemaOptions<IFormSchema> = {
   id: false,
   toJSON: {
@@ -443,6 +457,16 @@ const MultirespondentFormSchema = new Schema<IMultirespondentFormSchema>({
     default: false,
   },
 })
+
+MultirespondentFormSchema.methods.getDuplicateParams = function (
+  overrideProps: OverrideProps,
+) {
+  const newForm = pick(this, [
+    ...FORM_SCHEMA_COMMON_DUPLICATE_PARAMS,
+    'workflow',
+  ]) as PickDuplicateForm
+  return { ...newForm, ...overrideProps }
+}
 
 const MultirespondentFormWorkflowPath = MultirespondentFormSchema.path(
   'workflow',
@@ -923,19 +947,10 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   FormSchema.methods.getDuplicateParams = function (
     overrideProps: OverrideProps,
   ) {
-    const newForm = pick(this, [
-      'form_fields',
-      'form_logics',
-      'startPage',
-      'endPage',
-      'authType',
-      'isSaveDraftEnabled',
-      'isSubmitterIdCollectionEnabled',
-      'isSingleSubmission',
-      'inactiveMessage',
-      'responseMode',
-      'submissionLimit',
-    ]) as PickDuplicateForm
+    const newForm = pick(
+      this,
+      FORM_SCHEMA_COMMON_DUPLICATE_PARAMS,
+    ) as PickDuplicateForm
     return { ...newForm, ...overrideProps }
   }
 

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -3412,7 +3412,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { workspaceId: undefined },
+        { workspaceId: undefined, overrideEmails: undefined },
       )
     })
 
@@ -3464,7 +3464,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { workspaceId: mockWorkspaceId },
+        { workspaceId: mockWorkspaceId, overrideEmails: undefined },
       )
     })
 
@@ -3534,7 +3534,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { workspaceId: undefined },
+        { workspaceId: undefined, overrideEmails: undefined },
       )
     })
 
@@ -3670,7 +3670,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { workspaceId: undefined },
+        { workspaceId: undefined, overrideEmails: undefined },
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -3900,7 +3900,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { duplicateStripped: true },
+        { overrideEmails: ['andanother@example.com'] },
       )
     })
 
@@ -3972,7 +3972,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { duplicateStripped: true },
+        { overrideEmails: ['andanother@example.com'] },
       )
     })
 
@@ -4122,7 +4122,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { duplicateStripped: true },
+        { overrideEmails: ['andanother@example.com'] },
       )
     })
   })

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -5,6 +5,11 @@ import { ObjectId } from 'bson'
 import { assignIn, cloneDeep, merge, omit, pick } from 'lodash'
 import mongoose, { ClientSession } from 'mongoose'
 import { err, errAsync, ok, okAsync } from 'neverthrow'
+import {
+  FormWorkflowStepConditional,
+  FormWorkflowStepDynamic,
+  FormWorkflowStepStatic,
+} from 'shared/types/form/workflow'
 import { Workspace } from 'shared/types/workspace'
 import {
   EncryptedStringsMessageContent,
@@ -46,6 +51,7 @@ import {
   PickDuplicateForm,
 } from 'src/types'
 import { EditFormFieldParams } from 'src/types/api'
+import { IMultirespondentFormSchema } from 'src/types/form'
 
 import {
   CONDITIONAL_ROUTING_EMAILS_OPTIONS_MISSING_ERROR_MESSAGE,
@@ -59,6 +65,7 @@ import {
   AdminDashboardFormMetaDto,
   BasicField,
   CustomFormLogo,
+  DropdownFieldBase,
   DuplicateFormBodyDto,
   FieldCreateDto,
   FieldUpdateDto,
@@ -75,6 +82,7 @@ import {
   PaymentChannel,
   PaymentType,
   SettingsUpdateDto,
+  WorkflowType,
 } from '../../../../../../shared/types'
 import {
   FormNotFoundError,
@@ -447,6 +455,349 @@ describe('admin-form.service', () => {
       merge({}, MOCK_VALID_FORM, {
         getDuplicateParams: jest.fn().mockReturnValue(expectedParams),
       }) as IFormDocument
+
+    describe('mrf workflow duplication', () => {
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
+
+      const EMAIL_FIELD_ID = 'emailFieldId'
+      const DROPDOWN_FIELD_ID = 'dropdownFieldId'
+      const DROPDOWN_FIELD_OPTIONS_TO_RECIPIENTS_MAP = {
+        'Option 1': ['option1@example.com'],
+        'Option 2': ['option2@example.com'],
+      }
+      const MOCK_MRF_FORM_FIELDS = [
+        {
+          _id: 'shortTextFieldId',
+          fieldType: BasicField.ShortText,
+          title: 'Text Field',
+        },
+        {
+          _id: 'yesNoFieldId',
+          fieldType: BasicField.YesNo,
+          title: 'YesNo Field',
+        },
+        {
+          _id: EMAIL_FIELD_ID,
+          fieldType: BasicField.Email,
+          title: 'Email Field',
+        },
+        {
+          _id: DROPDOWN_FIELD_ID,
+          fieldType: BasicField.Dropdown,
+          title: 'Dropdown Field',
+          optionsToRecipientsMap: DROPDOWN_FIELD_OPTIONS_TO_RECIPIENTS_MAP,
+        },
+      ]
+      const ORIGINAL_STATIC_STEP_EMAILS = [
+        'original@example.com',
+        'original2@example.com',
+      ]
+      const MOCK_MRF_WORKFLOW = [
+        {
+          _id: 'step1',
+          workflow_type: WorkflowType.Static,
+          emails: ORIGINAL_STATIC_STEP_EMAILS,
+          edit: ['shortTextFieldId', 'emailFieldId'],
+          step_name: 'Static Step',
+        },
+        {
+          _id: 'step2',
+          workflow_type: WorkflowType.Dynamic,
+          field: 'emailFieldId',
+          edit: ['dropdownFieldId'],
+          step_name: 'Dynamic Step',
+        },
+        {
+          _id: 'step3',
+          workflow_type: WorkflowType.Conditional,
+          conditional_field: 'dropdownFieldId',
+          edit: ['yesNoFieldId'],
+          step_name: 'Conditional Step',
+        },
+      ]
+      const MOCK_MRF_FORM = {
+        ...MOCK_VALID_FORM,
+        responseMode: FormResponseMode.Multirespondent,
+        workflow: MOCK_MRF_WORKFLOW,
+        form_fields: MOCK_MRF_FORM_FIELDS,
+      } as unknown as IPopulatedMultirespondentForm
+
+      const MOCK_OVERRIDE_EMAILS = [
+        'replaced1@example.com',
+        'replaced2@example.com',
+      ]
+
+      const NO_OVERRIDE_EMAILS_OPTS = {}
+      const OVERRIDE_EMAILS_OPTS = {
+        overrideEmails: MOCK_OVERRIDE_EMAILS,
+      }
+
+      const OVERRIDE_PARAMS: DuplicateFormBodyDto = {
+        responseMode: FormResponseMode.Multirespondent,
+        title: 'Duplicated MRF Form',
+        publicKey: 'duplicated public key',
+      }
+
+      it('for static workflow step, should not replace destination email if override emails is not provided', async () => {
+        // Arrange
+        const mockNewAdminId = new ObjectId().toHexString()
+        const isolatedFormFields = cloneDeep(MOCK_MRF_FORM_FIELDS)
+        const isolatedWorkflow = cloneDeep(MOCK_MRF_WORKFLOW)
+        const mockForm = {
+          ...MOCK_MRF_FORM,
+          getDuplicateParams: jest.fn().mockReturnValue({
+            admin: mockNewAdminId,
+            responseMode: FormResponseMode.Multirespondent,
+            title: 'Duplicated MRF Form',
+            publicKey: 'duplicated public key',
+            form_fields: isolatedFormFields,
+            workflow: isolatedWorkflow,
+          }),
+        } as unknown as IFormDocument
+
+        const createSpy = jest
+          .spyOn(FormModel, 'create')
+          .mockResolvedValueOnce(mockForm as never)
+
+        // Act
+        const result = await AdminFormService.duplicateForm(
+          mockForm,
+          mockNewAdminId,
+          OVERRIDE_PARAMS,
+          NO_OVERRIDE_EMAILS_OPTS,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+
+        const duplicatedForm = createSpy.mock.calls[0][0] as PickDuplicateForm
+        const staticStep = (duplicatedForm as IMultirespondentFormSchema)
+          .workflow[0] as FormWorkflowStepStatic
+        expect(staticStep.emails).toEqual(ORIGINAL_STATIC_STEP_EMAILS)
+      })
+
+      it('for static workflow step, should replace step email with override emails if override emails is provided', async () => {
+        // Arrange
+        const mockNewAdminId = new ObjectId().toHexString()
+        const isolatedFormFields = cloneDeep(MOCK_MRF_FORM_FIELDS)
+        const isolatedWorkflow = cloneDeep(MOCK_MRF_WORKFLOW)
+        const mockForm = {
+          ...MOCK_MRF_FORM,
+          getDuplicateParams: jest.fn().mockReturnValue({
+            admin: mockNewAdminId,
+            responseMode: FormResponseMode.Multirespondent,
+            title: 'Duplicated MRF Form',
+            publicKey: 'duplicated public key',
+            form_fields: isolatedFormFields,
+            workflow: isolatedWorkflow,
+          }),
+        } as unknown as IFormDocument
+
+        const createSpy = jest
+          .spyOn(FormModel, 'create')
+          .mockResolvedValueOnce(mockForm as never)
+
+        // Act
+        const result = await AdminFormService.duplicateForm(
+          mockForm,
+          mockNewAdminId,
+          OVERRIDE_PARAMS,
+          OVERRIDE_EMAILS_OPTS,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+
+        const duplicatedForm = createSpy.mock.calls[0][0] as PickDuplicateForm
+        const staticStep = (duplicatedForm as IMultirespondentFormSchema)
+          .workflow[0] as FormWorkflowStepStatic
+
+        expect(staticStep.emails).toEqual(MOCK_OVERRIDE_EMAILS)
+      })
+
+      it('for dynamic workflow step, should not replace email field id when override emails is provided', async () => {
+        // Arrange
+        const mockNewAdminId = new ObjectId().toHexString()
+        const isolatedFormFields = cloneDeep(MOCK_MRF_FORM_FIELDS)
+        const isolatedWorkflow = cloneDeep(MOCK_MRF_WORKFLOW)
+        const mockForm = {
+          ...MOCK_MRF_FORM,
+          getDuplicateParams: jest.fn().mockReturnValue({
+            admin: mockNewAdminId,
+            responseMode: FormResponseMode.Multirespondent,
+            title: 'Duplicated MRF Form',
+            publicKey: 'duplicated public key',
+            form_fields: isolatedFormFields,
+            workflow: isolatedWorkflow,
+          }),
+        } as unknown as IFormDocument
+
+        const createSpy = jest
+          .spyOn(FormModel, 'create')
+          .mockResolvedValueOnce(mockForm as never)
+
+        // Act
+        const result = await AdminFormService.duplicateForm(
+          mockForm,
+          mockNewAdminId,
+          OVERRIDE_PARAMS,
+          OVERRIDE_EMAILS_OPTS,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+
+        const duplicatedForm = createSpy.mock.calls[0][0] as PickDuplicateForm
+        const dynamicStep = (duplicatedForm as IMultirespondentFormSchema)
+          .workflow[1] as FormWorkflowStepDynamic
+
+        expect(dynamicStep.field).toEqual(EMAIL_FIELD_ID)
+      })
+
+      it('for dynamic workflow step, should not replace email field id when override emails is not provided', async () => {
+        // Arrange
+        const mockNewAdminId = new ObjectId().toHexString()
+        const isolatedFormFields = cloneDeep(MOCK_MRF_FORM_FIELDS)
+        const isolatedWorkflow = cloneDeep(MOCK_MRF_WORKFLOW)
+        const mockForm = {
+          ...MOCK_MRF_FORM,
+          getDuplicateParams: jest.fn().mockReturnValue({
+            admin: mockNewAdminId,
+            responseMode: FormResponseMode.Multirespondent,
+            title: 'Duplicated MRF Form',
+            publicKey: 'duplicated public key',
+            form_fields: isolatedFormFields,
+            workflow: isolatedWorkflow,
+          }),
+        } as unknown as IFormDocument
+
+        const createSpy = jest
+          .spyOn(FormModel, 'create')
+          .mockResolvedValueOnce(mockForm as never)
+
+        // Act
+        const result = await AdminFormService.duplicateForm(
+          mockForm,
+          mockNewAdminId,
+          OVERRIDE_PARAMS,
+          NO_OVERRIDE_EMAILS_OPTS,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+
+        const duplicatedForm = createSpy.mock.calls[0][0] as PickDuplicateForm
+        const dynamicStep = (duplicatedForm as IMultirespondentFormSchema)
+          .workflow[1] as FormWorkflowStepDynamic
+        expect(dynamicStep.field).toEqual(EMAIL_FIELD_ID)
+      })
+
+      it('for conditional workflow step, should not replace dropdown field id and optionsToRecipientsMap is changed when override emails is provided', async () => {
+        // Arrange
+        const mockNewAdminId = new ObjectId().toHexString()
+        const isolatedFormFields = cloneDeep(MOCK_MRF_FORM_FIELDS)
+        const isolatedWorkflow = cloneDeep(MOCK_MRF_WORKFLOW)
+        const mockForm = {
+          ...MOCK_MRF_FORM,
+          getDuplicateParams: jest.fn().mockReturnValue({
+            admin: mockNewAdminId,
+            responseMode: FormResponseMode.Multirespondent,
+            title: 'Duplicated MRF Form',
+            publicKey: 'duplicated public key',
+            form_fields: isolatedFormFields,
+            workflow: isolatedWorkflow,
+          }),
+        } as unknown as IFormDocument
+
+        const createSpy = jest
+          .spyOn(FormModel, 'create')
+          .mockResolvedValueOnce(mockForm as never)
+
+        // Act
+        const result = await AdminFormService.duplicateForm(
+          mockForm,
+          mockNewAdminId,
+          OVERRIDE_PARAMS,
+          OVERRIDE_EMAILS_OPTS,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+
+        const duplicatedForm = createSpy.mock.calls[0][0] as PickDuplicateForm
+        const conditionalStep = (duplicatedForm as IMultirespondentFormSchema)
+          .workflow[2] as FormWorkflowStepConditional
+        expect(conditionalStep.conditional_field).toEqual(DROPDOWN_FIELD_ID)
+
+        const duplicatedDropdownField = (
+          duplicatedForm as IMultirespondentFormSchema
+        ).form_fields?.find(
+          (field) => field._id.toString() === DROPDOWN_FIELD_ID,
+        ) as DropdownFieldBase
+        const duplicatedDropdownFieldOptionsToRecipientsMap =
+          duplicatedDropdownField?.optionsToRecipientsMap
+        expect(duplicatedDropdownFieldOptionsToRecipientsMap).not.toEqual(
+          DROPDOWN_FIELD_OPTIONS_TO_RECIPIENTS_MAP,
+        )
+        const expectedMap = {
+          'Option 1': OVERRIDE_EMAILS_OPTS.overrideEmails,
+          'Option 2': OVERRIDE_EMAILS_OPTS.overrideEmails,
+        }
+        expect(duplicatedDropdownFieldOptionsToRecipientsMap).toEqual(
+          expectedMap,
+        )
+      })
+
+      it('for conditional workflow step, should not replace dropdown field id and optionsToRecipientsMap is not changed when override emails is not provided', async () => {
+        // Arrange
+        const isolatedFormFields = cloneDeep(MOCK_MRF_FORM_FIELDS)
+        const isolatedWorkflow = cloneDeep(MOCK_MRF_WORKFLOW)
+        const mockNewAdminId = new ObjectId().toHexString()
+        const mockForm = {
+          ...MOCK_MRF_FORM,
+          getDuplicateParams: jest.fn().mockReturnValue({
+            admin: mockNewAdminId,
+            responseMode: FormResponseMode.Multirespondent,
+            title: 'Duplicated MRF Form',
+            publicKey: 'duplicated public key',
+            form_fields: isolatedFormFields,
+            workflow: isolatedWorkflow,
+          }),
+        } as unknown as IFormDocument
+
+        const createSpy = jest
+          .spyOn(FormModel, 'create')
+          .mockResolvedValueOnce(mockForm as never)
+
+        // Act
+        const result = await AdminFormService.duplicateForm(
+          mockForm,
+          mockNewAdminId,
+          OVERRIDE_PARAMS,
+          NO_OVERRIDE_EMAILS_OPTS,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+        const duplicatedForm = createSpy.mock.calls[0][0] as PickDuplicateForm
+        const conditionalStep = (duplicatedForm as IMultirespondentFormSchema)
+          .workflow[2] as FormWorkflowStepConditional
+        expect(conditionalStep.conditional_field).toEqual(DROPDOWN_FIELD_ID)
+        const duplicatedDropdownField = (
+          duplicatedForm as IMultirespondentFormSchema
+        ).form_fields?.find(
+          (field) => field._id.toString() === DROPDOWN_FIELD_ID,
+        ) as DropdownFieldBase
+
+        const duplicatedDropdownFieldOptionsToRecipientsMap =
+          duplicatedDropdownField?.optionsToRecipientsMap
+        expect(duplicatedDropdownFieldOptionsToRecipientsMap).toEqual(
+          DROPDOWN_FIELD_OPTIONS_TO_RECIPIENTS_MAP,
+        )
+      })
+    })
 
     it('should successfully duplicate form', async () => {
       // Arrange

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1053,7 +1053,7 @@ export const handleCopyTemplateForm: ControllerHandler<
         AuthService.getFormIfPublic(formId).andThen((originalForm) =>
           // Step 3: Duplicate form.
           AdminFormService.duplicateForm(originalForm, userId, overrideParams, {
-            duplicateStripped: true,
+            overrideEmails: [user.email],
           })
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -657,29 +657,32 @@ export const processCreateFormInWorkspace = async (
   return form
 }
 
+type DuplicateFormOpts = {
+  // The ID of the workspace to duplicate the form into.
+  workspaceId?: string
+  // If true, overrides the emails of MRF workflows and dropdown fields with the given overrideEmails
+  overrideEmails?: string[]
+}
+
 /**
  * Duplicates given formId and replace owner with newAdminId.
  * @param originalForm the form to be duplicated
  * @param newAdminId the id of the admin of the duplicated form
  * @param overrideParams params to override in the duplicated form; e.g. the new emails or public key of the form.
- * @param options - Optional configuration for duplication.
- * @param options.workspaceId - The ID of the workspace to duplicate the form into.
- * @param options.duplicateStripped - If true, duplicates only a stripped version of the form (without certain metadata or fields).
+ * @param opts - Optional configuration for duplication.
  * @returns the newly created duplicated form
  */
 export const duplicateForm = (
   originalForm: IFormDocument,
   newAdminId: string,
   overrideParams: DuplicateFormOverwriteDto,
-  {
-    workspaceId,
-    duplicateStripped,
-  }: { workspaceId?: string; duplicateStripped?: boolean } = {},
+  opts?: DuplicateFormOpts,
 ): ResultAsync<IFormDocument, FormNotFoundError | DatabaseError> => {
   const overrideProps = processDuplicateOverrideProps(
     overrideParams,
     newAdminId,
   )
+  const { workspaceId, overrideEmails } = opts ?? {}
 
   // Set startPage.logo to default irregardless.
   overrideProps.startPage = {
@@ -692,13 +695,45 @@ export const duplicateForm = (
     overrideProps.endPage = omit(originalForm.endPage, 'buttonLink')
   }
 
+  // If the form is an MRF, copy the workflow as well
+  if (
+    originalForm.responseMode === FormResponseMode.Multirespondent &&
+    overrideProps.responseMode === FormResponseMode.Multirespondent
+  ) {
+    overrideProps.workflow = (
+      originalForm as IPopulatedMultirespondentForm
+    ).workflow.map((step) => {
+      switch (step.workflow_type) {
+        case WorkflowType.Static: {
+          return {
+            ...step,
+            // Override the emails if the option is specified
+            emails: overrideEmails ?? step.emails,
+          }
+        }
+        case WorkflowType.Conditional:
+        case WorkflowType.Dynamic:
+          // Duplication preserves dropdown and Email Field IDs
+          return step
+      }
+    })
+  }
+
   const duplicateParams = originalForm.getDuplicateParams(overrideProps)
 
   // remove conditional routing mapping from dropdown fields
-  if (duplicateParams?.form_fields && duplicateStripped) {
+  if (duplicateParams?.form_fields && overrideEmails) {
     duplicateParams.form_fields.forEach((field) => {
       if (field.fieldType === BasicField.Dropdown) {
-        field.optionsToRecipientsMap = undefined
+        field.optionsToRecipientsMap = Object.keys(
+          field.optionsToRecipientsMap ?? {},
+        ).reduce(
+          (acc, curr) => {
+            acc[curr] = overrideEmails
+            return acc
+          },
+          {} as Record<string, string[]>,
+        )
       }
     })
   }

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -695,35 +695,18 @@ export const duplicateForm = (
     overrideProps.endPage = omit(originalForm.endPage, 'buttonLink')
   }
 
-  // If the form is an MRF, copy the workflow as well
-  if (
-    originalForm.responseMode === FormResponseMode.Multirespondent &&
-    overrideProps.responseMode === FormResponseMode.Multirespondent
-  ) {
-    overrideProps.workflow = (
-      originalForm as IPopulatedMultirespondentForm
-    ).workflow.map((step) => {
-      switch (step.workflow_type) {
-        case WorkflowType.Static: {
-          return {
-            ...step,
-            // Override the emails if the option is specified
-            emails: overrideEmails ?? step.emails,
-          }
-        }
-        case WorkflowType.Conditional:
-        case WorkflowType.Dynamic:
-          // Duplication preserves dropdown and Email Field IDs
-          return step
-      }
-    })
-  }
-
   const duplicateParams = originalForm.getDuplicateParams(overrideProps)
 
-  // remove conditional routing mapping from dropdown fields
-  if (duplicateParams?.form_fields && overrideEmails) {
-    duplicateParams.form_fields.forEach((field) => {
+  if (overrideEmails) {
+    // override emails for static workflow steps
+    duplicateParams.workflow?.forEach((step) => {
+      if (step.workflow_type === WorkflowType.Static) {
+        step.emails = overrideEmails
+      }
+    })
+
+    // remove conditional routing mapping from dropdown fields
+    duplicateParams.form_fields?.forEach((field) => {
       if (field.fieldType === BasicField.Dropdown) {
         field.optionsToRecipientsMap = Object.keys(
           field.optionsToRecipientsMap ?? {},

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -660,7 +660,7 @@ export const processCreateFormInWorkspace = async (
 type DuplicateFormOpts = {
   // The ID of the workspace to duplicate the form into.
   workspaceId?: string
-  // If true, overrides the emails of MRF workflows and dropdown fields with the given overrideEmails
+  // If defined, overrides the emails of MRF workflows and dropdown fields with the given overrideEmails
   overrideEmails?: string[]
 }
 

--- a/src/app/modules/form/admin-form/admin-form.types.ts
+++ b/src/app/modules/form/admin-form/admin-form.types.ts
@@ -4,6 +4,7 @@ import { FormResponseMode } from '../../../../../shared/types'
 import {
   FormFieldSchema,
   IForm,
+  IMultirespondentForm,
   IPopulatedForm,
   IUserSchema,
 } from '../../../../types'
@@ -31,6 +32,7 @@ export type OverrideProps = {
   emails?: string | string[]
   publicKey?: string
   submissionLimit?: number | null
+  workflow?: IMultirespondentForm['workflow']
 }
 
 export type EditFormFieldResult = Result<FormFieldSchema[], EditFieldError>

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -97,20 +97,36 @@ export type IForm = Merge<
 /**
  * Typing for duplicate form with specific keys.
  */
-export type PickDuplicateForm = Pick<
-  IFormSchema,
-  | 'form_fields'
-  | 'form_logics'
-  | 'startPage'
-  | 'endPage'
-  | 'authType'
-  | 'isSubmitterIdCollectionEnabled'
-  | 'isSingleSubmission'
-  | 'isSaveDraftEnabled'
-  | 'inactiveMessage'
-  | 'submissionLimit'
-  | 'responseMode'
->
+export type PickDuplicateForm =
+  | Pick<
+      IFormSchema,
+      | 'form_fields'
+      | 'form_logics'
+      | 'startPage'
+      | 'endPage'
+      | 'authType'
+      | 'isSubmitterIdCollectionEnabled'
+      | 'isSingleSubmission'
+      | 'isSaveDraftEnabled'
+      | 'inactiveMessage'
+      | 'submissionLimit'
+      | 'responseMode'
+    >
+  | Pick<
+      IMultirespondentFormSchema,
+      | 'form_fields'
+      | 'form_logics'
+      | 'startPage'
+      | 'endPage'
+      | 'authType'
+      | 'isSubmitterIdCollectionEnabled'
+      | 'isSingleSubmission'
+      | 'isSaveDraftEnabled'
+      | 'inactiveMessage'
+      | 'submissionLimit'
+      | 'responseMode'
+      | 'workflow'
+    >
 
 export interface IFormSchema extends IForm, Document, PublicView<PublicForm> {
   form_fields?: FormFieldSchema[]


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Multi-respondent Forms (MRFs) can't be duplicated along with their workflows.
Workflow creation is tedious, time-consuming, and error-prone -- which prevents users from benefiting from this feature.

Builds upon #8764
Closes FRM-2164

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Duplicate the entire MRF including its Workflow
  - If the duplication is triggered from the dashboard by the Form Owner / Editor, the workflow's emails will be preserved.
  - If the form is duplicated as a shared template, the workflow's emails will be reset to the new owner's email.

## Screenshots

<img width="1512" height="869" alt="image" src="https://github.com/user-attachments/assets/1a3cfab9-80a7-4270-a3f9-3ab6776e0be4" />

## Tests
<!-- What tests should be run to confirm functionality? -->

**Setup: Create an MRF and a workflow**
- [ ] Create a new MRF in the Form Admin Workspace
- [ ] Add a workflow that contains three steps, and a dropdown field
- [ ] The second step should request approval from 'Specific email(s)': use a distinct email (e.g. `test@example.com`)
- [ ] The third step should request approval from 'Emails assigned to options in a dropdown field': (e.g. `test+option1@example.com`)

**TC1: Duplicate an MRF as a Form Owner / Editor from the Admin Workspace**
- [ ] Return to the Admin Workspace, click the dropdown menu on the right of the newly-created Form, and click Duplicate
- [ ] Set up the duplicate as an MRF
- [ ] Visit the 'Workflow' tab in the left sidebar, and inspect the copied workflow
- [ ] The 'Specific email(s)' field should contain the original emails
- [ ] The CSV attached under 'Emails assigned to options in a dropdown field' should contain the original emails

**TC2: Create a new MRF from a template using a shared `/use-template` link.
- [ ] Click on Share > Template > Copy the shareable link to `/use-template`
- [ ] Set up the new form created from the template as an MRF
- [ ] Visit the 'Workflow' tab in the left sidebar, and inspect the copied workflow
- [ ] The 'Specific email(s)' field should contain your email
- [ ] The CSV attached under 'Emails assigned to options in a dropdown field' should only contain your email

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
