### PR TITLE
fix: added encryptedWebhookContent to payments

### DIFF
--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -210,6 +210,7 @@ export const confirmPaymentPendingSubmission = (
 export const performPaymentPostSubmissionActions = (
   paymentId: IPaymentSchema['_id'],
   growthbook: GrowthBook | undefined,
+  encryptedWebhookContent?: string,
 ): ResultAsync<
   void,
   | PaymentNotFoundError
@@ -245,6 +246,7 @@ export const performPaymentPostSubmissionActions = (
                   submission,
                   responses: payment.responses,
                   growthbook,
+                  encryptedWebhookContent,
                 })
                   .andThen(() =>
                     // If successfully sent email confirmations, delete response data from payment document.

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -307,6 +307,7 @@ export const reconcileAccount: ControllerHandler<
       await StripeService.handleStripeEvent(
         event as Stripe.DiscriminatedEvent,
         req.growthbook,
+        req.formsg?.encryptedWebhookContent
       )
         .andThen(() => {
           logger.warn({

--- a/src/app/modules/payments/stripe.controller.ts
+++ b/src/app/modules/payments/stripe.controller.ts
@@ -307,7 +307,7 @@ export const reconcileAccount: ControllerHandler<
       await StripeService.handleStripeEvent(
         event as Stripe.DiscriminatedEvent,
         req.growthbook,
-        req.formsg?.encryptedWebhookContent
+        req.formsg?.encryptedWebhookContent,
       )
         .andThen(() => {
           logger.warn({

--- a/src/app/modules/payments/stripe.events.controller.ts
+++ b/src/app/modules/payments/stripe.events.controller.ts
@@ -89,7 +89,11 @@ const _handleStripeEventUpdates: ControllerHandler<
 
   // Step 3: Process the event
   return (
-    StripeService.handleStripeEvent(event, req.growthbook)
+    StripeService.handleStripeEvent(
+      event,
+      req.growthbook,
+      req.formsg?.encryptedWebhookContent,
+    )
       // Step 4: Return response to Stripe based on result
       .match(
         () => res.sendStatus(StatusCodes.OK),

--- a/src/app/modules/payments/stripe.service.ts
+++ b/src/app/modules/payments/stripe.service.ts
@@ -452,6 +452,7 @@ type HandleStripeEventResultError =
 export const handleStripeEvent = (
   event: Stripe.DiscriminatedEvent,
   growthbook: GrowthBook | undefined,
+  encryptedWebhookContent?: string,
 ): ResultAsync<void, HandleStripeEventResultError> => {
   const logMeta = {
     action: 'handleStripeEvent',
@@ -499,6 +500,7 @@ export const handleStripeEvent = (
             return PaymentsService.performPaymentPostSubmissionActions(
               paymentId,
               growthbook,
+              encryptedWebhookContent,
             )
               .andThen(() => okAsync(undefined))
               .orElse((e) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Encrypted webhook content isn't handled in payments.service in post submission actions, leading to no webhooks being fire for payment forms

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- No - this PR is backwards compatible  


