### PR TITLE
feat: override workflow duplication with admin email if viewer

### DIFF
--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -55,6 +55,7 @@ import {
   IPopulatedEmailForm,
   IPopulatedEncryptedForm,
   IPopulatedForm,
+  IPopulatedMultirespondentForm,
   IPopulatedUser,
   IUserSchema,
   PublicForm,
@@ -75,6 +76,7 @@ import {
   FormStatus,
   LogicDto,
   SubmissionType,
+  WorkflowType,
 } from '../../../../../../shared/types'
 import * as CryptoUtil from '../../../../../../shared/utils/crypto'
 import ParsedResponsesObject from '../../../submission/ParsedResponsesObject.class'
@@ -3365,6 +3367,146 @@ describe('admin-form.controller', () => {
       body: {} as CreateFormBodyDto,
     })
 
+    describe('multirespondent form', () => {
+      it('should override emails in workflow when admin is viewer collaborator', async () => {
+        // Arrange
+        const expectedParams: DuplicateFormBodyDto = {
+          responseMode: FormResponseMode.Multirespondent,
+          publicKey: 'some public key',
+          title: 'mock title',
+        }
+        const mockDupedFormView = {
+          title: 'mock view',
+        } as AdminDashboardFormMetaDto
+        const mockDupedForm = merge({}, MOCK_FORM, {
+          title: 'duped form with new title',
+          _id: new ObjectId(),
+          getDashboardView: jest.fn().mockReturnValue(mockDupedFormView),
+        })
+        const mockRes = expressHandler.mockResponse()
+        const mockReqWithParams = merge({}, MOCK_REQ, {
+          body: expectedParams,
+        })
+        MockUserService.getPopulatedUserById.mockReturnValueOnce(
+          okAsync(MOCK_USER),
+        )
+        MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+          okAsync(MOCK_FORM),
+        )
+        MockAdminFormService.duplicateForm.mockReturnValueOnce(
+          okAsync(mockDupedForm),
+        )
+
+        // Mock admin that is duplicating form not having WRITE permissions to form.
+        const mockCheckFormForPermissions = jest
+          .fn()
+          .mockReturnValue(
+            err(new ForbiddenFormError('User does not have write access')),
+          )
+        MockAuthService.checkFormForPermissions.mockReturnValueOnce(
+          mockCheckFormForPermissions,
+        )
+
+        // Act
+        await AdminFormController.duplicateAdminForm(
+          mockReqWithParams,
+          mockRes,
+          jest.fn(),
+        )
+
+        // Assert
+        // Form is still duplicated
+        expect(mockRes.status).not.toHaveBeenCalled()
+        expect(mockRes.json).toHaveBeenCalledWith(mockDupedFormView)
+        expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+          MOCK_USER_ID,
+        )
+        // The user's permissions are being checked for given form.
+        expect(MockAuthService.checkFormForPermissions).toHaveBeenCalledWith(
+          PermissionLevel.Write,
+        )
+        expect(mockCheckFormForPermissions).toHaveBeenCalledWith({
+          user: MOCK_USER,
+          form: MOCK_FORM,
+        })
+        // The form is duplicated with the admin's email being used in the workflow routing.
+        expect(MockAdminFormService.duplicateForm).toHaveBeenCalledWith(
+          MOCK_FORM,
+          MOCK_USER_ID,
+          expectedParams,
+          { workspaceId: undefined, overrideEmails: [MOCK_USER.email] },
+        )
+      })
+
+      it('should not override emails in workflow when admin is editor collaborator or form owner', async () => {
+        // Arrange
+        const expectedParams: DuplicateFormBodyDto = {
+          responseMode: FormResponseMode.Multirespondent,
+          publicKey: 'some public key',
+          title: 'mock title',
+        }
+        const mockDupedFormView = {
+          title: 'mock view',
+        } as AdminDashboardFormMetaDto
+        const mockDupedForm = merge({}, MOCK_FORM, {
+          title: 'duped form with new title',
+          _id: new ObjectId(),
+          getDashboardView: jest.fn().mockReturnValue(mockDupedFormView),
+        })
+        const mockRes = expressHandler.mockResponse()
+        const mockReqWithParams = merge({}, MOCK_REQ, {
+          body: expectedParams,
+        })
+        MockUserService.getPopulatedUserById.mockReturnValueOnce(
+          okAsync(MOCK_USER),
+        )
+        MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+          okAsync(MOCK_FORM),
+        )
+        MockAdminFormService.duplicateForm.mockReturnValueOnce(
+          okAsync(mockDupedForm),
+        )
+
+        // Mock admin that is duplicating form has WRITE permissions to form.
+        const mockCheckFormForPermissions = jest
+          .fn()
+          .mockReturnValue(ok(MOCK_FORM))
+        MockAuthService.checkFormForPermissions.mockReturnValueOnce(
+          mockCheckFormForPermissions,
+        )
+
+        // Act
+        await AdminFormController.duplicateAdminForm(
+          mockReqWithParams,
+          mockRes,
+          jest.fn(),
+        )
+
+        // Assert
+        // Form is still duplicated
+        expect(mockRes.status).not.toHaveBeenCalled()
+        expect(mockRes.json).toHaveBeenCalledWith(mockDupedFormView)
+        expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+          MOCK_USER_ID,
+        )
+        // The user's permissions are being checked for given form.
+        expect(MockAuthService.checkFormForPermissions).toHaveBeenCalledWith(
+          PermissionLevel.Write,
+        )
+        expect(mockCheckFormForPermissions).toHaveBeenCalledWith({
+          user: MOCK_USER,
+          form: MOCK_FORM,
+        })
+        // The form is duplicated and the admin's email is not being used in the workflow routing.
+        expect(MockAdminFormService.duplicateForm).toHaveBeenCalledWith(
+          MOCK_FORM,
+          MOCK_USER_ID,
+          expectedParams,
+          { workspaceId: undefined, overrideEmails: undefined },
+        )
+      })
+    })
+
     it('should return duplicated form view on duplicate success', async () => {
       // Arrange
       const expectedParams: DuplicateFormBodyDto = {
@@ -3390,6 +3532,12 @@ describe('admin-form.controller', () => {
       )
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         okAsync(MOCK_FORM),
+      )
+      const mockCheckFormForPermissions = jest
+        .fn()
+        .mockReturnValue(ok(MOCK_FORM))
+      MockAuthService.checkFormForPermissions.mockReturnValueOnce(
+        mockCheckFormForPermissions,
       )
       MockAdminFormService.duplicateForm.mockReturnValueOnce(
         okAsync(mockDupedForm),
@@ -3442,6 +3590,12 @@ describe('admin-form.controller', () => {
       )
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         okAsync(MOCK_FORM),
+      )
+      const mockCheckFormForPermissions = jest
+        .fn()
+        .mockReturnValue(ok(MOCK_FORM))
+      MockAuthService.checkFormForPermissions.mockReturnValueOnce(
+        mockCheckFormForPermissions,
       )
       MockAdminFormService.duplicateForm.mockReturnValueOnce(
         okAsync(mockDupedForm),
@@ -3510,6 +3664,12 @@ describe('admin-form.controller', () => {
       )
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         okAsync(MOCK_FORM),
+      )
+      const mockCheckFormForPermissions = jest
+        .fn()
+        .mockReturnValue(ok(MOCK_FORM))
+      MockAuthService.checkFormForPermissions.mockReturnValueOnce(
+        mockCheckFormForPermissions,
       )
       MockAdminFormService.duplicateForm.mockReturnValueOnce(
         errAsync(new FormNotFoundError(mockErrorString)),
@@ -3646,6 +3806,12 @@ describe('admin-form.controller', () => {
       )
       MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
         okAsync(MOCK_FORM),
+      )
+      const mockCheckFormForPermissions = jest
+        .fn()
+        .mockReturnValue(ok(MOCK_FORM))
+      MockAuthService.checkFormForPermissions.mockReturnValueOnce(
+        mockCheckFormForPermissions,
       )
       MockAdminFormService.duplicateForm.mockReturnValueOnce(
         errAsync(new DatabaseError(mockErrorString)),

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -55,7 +55,6 @@ import {
   IPopulatedEmailForm,
   IPopulatedEncryptedForm,
   IPopulatedForm,
-  IPopulatedMultirespondentForm,
   IPopulatedUser,
   IUserSchema,
   PublicForm,
@@ -76,7 +75,6 @@ import {
   FormStatus,
   LogicDto,
   SubmissionType,
-  WorkflowType,
 } from '../../../../../../shared/types'
 import * as CryptoUtil from '../../../../../../shared/utils/crypto'
 import ParsedResponsesObject from '../../../submission/ParsedResponsesObject.class'

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -930,17 +930,22 @@ export const duplicateAdminForm: ControllerHandler<
           level: PermissionLevel.Read,
         })
           .map((originalForm) => {
-            // Step 2b: Check if admin is allowed to view workflow details - which is only if admin has write permissions.
-            const isAdminAllowedToViewWorkflow =
-              AuthService.checkFormForPermissions(PermissionLevel.Write)({
-                user,
-                form: originalForm,
-              }).isOk()
+            // Step 2b: Override emails in workflow if admin is allowed to view workflow details - which is only if admin has write permissions.
+            const hasWritePermissions = AuthService.checkFormForPermissions(
+              PermissionLevel.Write,
+            )({
+              user,
+              form: originalForm,
+            })
+            const isAdminAllowedToViewWorkflowDetails =
+              hasWritePermissions.isOk()
 
-            const overrideEmails = isAdminAllowedToViewWorkflow
-              ? undefined
-              : [user.email] // If admin is not allowed to view workflow details, override emails with admin email.
-            return { originalForm, overrideEmails }
+            const overrideWithDuplicatingAdminEmail =
+              !isAdminAllowedToViewWorkflowDetails ? [user.email] : undefined
+            return {
+              originalForm,
+              overrideEmails: overrideWithDuplicatingAdminEmail,
+            }
           })
           .andThen(({ originalForm, overrideEmails }) =>
             // Step 3: Duplicate form.

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -929,13 +929,26 @@ export const duplicateAdminForm: ControllerHandler<
           formId,
           level: PermissionLevel.Read,
         })
-          .andThen((originalForm) =>
+          .map((originalForm) => {
+            // Step 2b: Check if admin is allowed to view workflow details - which is only if admin has write permissions.
+            const isAdminAllowedToViewWorkflow =
+              AuthService.checkFormForPermissions(PermissionLevel.Write)({
+                user,
+                form: originalForm,
+              }).isOk()
+
+            const overrideEmails = isAdminAllowedToViewWorkflow
+              ? undefined
+              : [user.email] // If admin is not allowed to view workflow details, override emails with admin email.
+            return { originalForm, overrideEmails }
+          })
+          .andThen(({ originalForm, overrideEmails }) =>
             // Step 3: Duplicate form.
             AdminFormService.duplicateForm(
               originalForm,
               userId,
               overrideParams,
-              { workspaceId: workspaceId },
+              { workspaceId: workspaceId, overrideEmails },
             ),
           )
           // Step 4: Retrieve dashboard view of duplicated form.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

For admins with collaborator access, they should not see the workflow email details when the form is duplicated in the admin panel. 

## Solution
<!-- How did you solve the problem? -->
Check if the duplicating admin has permissions to view the workflow details (ie, form write access). 
If admin has permissions, no not pass `overrideEmails`, otherwise, pass in `overrideEmails`. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Viewer admin duplication. 
- [ ] Create a MRF form with static, dynamic and conditional routing workflow steps. 
- [ ] Share this MRF form to another admin with viewer access. 
- [ ] Duplicate the form. 
- [ ] Assert the workflow emails (conditional routing map, static emails) are replaced with the duplicating admin's email only. 

TC2: Editor admin duplication. 
- [ ] Create a MRF form with static, dynamic and conditional routing workflow steps. 
- [ ] Share this MRF form to another admin with editor access. 
- [ ] Duplicate the form. 
- [ ] Assert the workflow emails (conditional routing map, static emails) are original and NOT replaced. 

TC3: Form owner admin duplication 
- [ ] Repeat TC2 as form owner

## Deploy Notes
The following cases have been covered via BE unit tests - assuming that WRITE and above = Editor / Owner. Non-WRITE + READ = Viewer 
