### PR TITLE
feat: email redact

### DIFF
--- a/frontend/src/features/form/utils/augmentFieldWithMrfWorkflowDisabling.ts
+++ b/frontend/src/features/form/utils/augmentFieldWithMrfWorkflowDisabling.ts
@@ -1,9 +1,9 @@
-import { FormFieldDto, FormWorkflowStep } from '~shared/types'
+import { FormFieldDto, StrippedFormWorkflowStepDto } from '~shared/types'
 
 import { NON_RESPONSE_FIELD_SET } from '../constants'
 
 export const isFieldEnabledByMrfWorkflow = (
-  workflowStep: FormWorkflowStep | undefined,
+  workflowStep: StrippedFormWorkflowStepDto | undefined,
   field: FormFieldDto,
 ) => {
   // If no workflow, default to enabled
@@ -24,7 +24,7 @@ export const isFieldEnabledByMrfWorkflow = (
  * @returns The field with the disabled property set based on the workflow step and its previous disabled state
  */
 export const augmentFieldWithMrfWorkflowDisabling = (
-  workflowStep: FormWorkflowStep | undefined,
+  workflowStep: StrippedFormWorkflowStepDto | undefined,
   field: FormFieldDto,
 ) => ({
   ...field,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -30,10 +30,10 @@ import { ErrorCode } from '~shared/types/errorCodes'
 import {
   FormAuthType,
   FormResponseMode,
-  FormWorkflowStepDto,
   Language,
   ProductItem,
   PublicFormDto,
+  StrippedFormWorkflowStepDto,
 } from '~shared/types/form'
 import { centsToDollars, dollarsToCents } from '~shared/utils/payments'
 
@@ -210,7 +210,7 @@ const transformFormInputTrimTextInputs =
 
 export const augmentFormFields = (
   formFields: FormFieldDto[],
-  currentStepNumberWorkflowStep?: FormWorkflowStepDto,
+  currentStepNumberWorkflowStep?: StrippedFormWorkflowStepDto,
 ) => {
   return formFields
     .map(augmentWithMyInfo)
@@ -256,7 +256,7 @@ export const getInitialFormValues = ({
   formResponseMode: FormResponseMode
   previousSubmission?: ReturnType<typeof decryptSubmission>
   previousAttachments?: Record<string, ArrayBuffer>
-  currentStepNumberWorkflowStep?: FormWorkflowStepDto
+  currentStepNumberWorkflowStep?: StrippedFormWorkflowStepDto
   augmentedFormFields: FormFieldDto[]
   fieldPrefillMap: PrefillMap
   draftResponsesToRestore: FormFieldValues

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -321,7 +321,10 @@ export type StrippedPublicMultirespondentFormDto =
     workflow: StrippedFormWorkflowDto
   }
 
-// Conditional type that omits optionsToRecipientsMap only for Dropdown field types
+/**
+ * Used for public form view to redact sensitive information.
+ * Specifically, it omits optionsToRecipientsMap for Dropdown field types.
+ */
 export type StrippedFormFieldDto<T extends FormFieldDto = FormFieldDto> =
   T extends {
     fieldType: BasicField.Dropdown

--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -1,5 +1,6 @@
 import { PublicUserDto, UserDto } from '../user'
 import {
+  BasicField,
   FormField,
   FormFieldDto,
   MyInfoChildData,
@@ -7,7 +8,7 @@ import {
 } from '../field'
 
 import { FormLogo } from './form_logo'
-import type { Merge, Tagged, PartialDeep } from 'type-fest'
+import type { Except, Merge, Tagged, PartialDeep } from 'type-fest'
 import {
   ADMIN_FORM_META_FIELDS,
   EMAIL_FORM_SETTINGS_FIELDS,
@@ -21,7 +22,12 @@ import { DateString } from '../generic'
 import { FormLogic, LogicDto } from './form_logic'
 import { PaymentChannel, PaymentMethodType, PaymentType } from '../payment'
 import { Product } from './product'
-import { FormWorkflow, FormWorkflowDto, FormWorkflowStepDto } from './workflow'
+import {
+  FormWorkflow,
+  FormWorkflowDto,
+  FormWorkflowStepDto,
+  StrippedFormWorkflowDto,
+} from './workflow'
 import { ErrorCode } from '../errorCodes'
 
 export type FormId = Tagged<string, 'FormId'>
@@ -310,10 +316,25 @@ export type PublicMultirespondentFormDto = Merge<
   PublicFormBase
 >
 
-export type PublicFormDto =
+export type StrippedPublicMultirespondentFormDto =
+  PublicMultirespondentFormDto & {
+    workflow: StrippedFormWorkflowDto
+  }
+
+// Conditional type that omits optionsToRecipientsMap only for Dropdown field types
+export type StrippedFormFieldDto<T extends FormFieldDto = FormFieldDto> =
+  T extends {
+    fieldType: BasicField.Dropdown
+  }
+    ? Except<T, 'optionsToRecipientsMap'>
+    : T
+
+export type PublicFormDto = Merge<
   | PublicStorageFormDto
   | PublicEmailFormDto
-  | PublicMultirespondentFormDto
+  | StrippedPublicMultirespondentFormDto,
+  { form_fields: StrippedFormFieldDto[] }
+>
 
 export type EmailFormSettings = Pick<
   EmailFormDto,

--- a/shared/utils/strip-dropdown-field-optionsToRecipientsMap.ts
+++ b/shared/utils/strip-dropdown-field-optionsToRecipientsMap.ts
@@ -1,0 +1,14 @@
+import { BasicField, FormFieldDto } from '../types'
+
+export function stripDropdownFieldOptionsToRecipientsMap(
+  formFields: FormFieldDto[],
+): FormFieldDto[] {
+  return formFields.map((formField) => {
+    if (formField.fieldType === BasicField.Dropdown) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { optionsToRecipientsMap, ...rest } = formField
+      return rest
+    }
+    return formField
+  })
+}

--- a/shared/utils/strip-dropdown-field-optionsToRecipientsMap.ts
+++ b/shared/utils/strip-dropdown-field-optionsToRecipientsMap.ts
@@ -1,3 +1,4 @@
+import { omit } from 'lodash'
 import { BasicField, FormFieldDto } from '../types'
 
 export function stripDropdownFieldOptionsToRecipientsMap(
@@ -5,9 +6,7 @@ export function stripDropdownFieldOptionsToRecipientsMap(
 ): FormFieldDto[] {
   return formFields.map((formField) => {
     if (formField.fieldType === BasicField.Dropdown) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { optionsToRecipientsMap, ...rest } = formField
-      return rest
+      return omit(formField, 'optionsToRecipientsMap')
     }
     return formField
   })

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -6,6 +6,7 @@ import { cloneDeep, map, merge, omit, orderBy, pick } from 'lodash'
 import mongoose, { Types } from 'mongoose'
 import {
   EMAIL_PUBLIC_FORM_FIELDS,
+  MULTIRESPONDENT_PUBLIC_FORM_FIELDS,
   STORAGE_PUBLIC_FORM_FIELDS,
 } from 'shared/constants/form'
 import {
@@ -20,6 +21,8 @@ import {
   FormResponseMode,
   FormStartPage,
   FormStatus,
+  FormWorkflowStepConditional,
+  FormWorkflowStepDto,
   LogicDto,
   LogicType,
   PaymentChannel,
@@ -28,6 +31,7 @@ import {
   WhitelistedSubmitterIdsWithReferenceOid,
   WorkflowType,
 } from 'shared/types'
+import { aws } from 'src/app/config/config'
 
 import getFormModel, {
   getEmailFormModel,
@@ -2557,6 +2561,49 @@ describe('Form Model', () => {
     })
 
     describe('getPublicView', () => {
+      const getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap = () => {
+        return Object.values(BasicField).map((fieldType) => {
+          if (fieldType === BasicField.Dropdown) {
+            return generateDefaultField(BasicField.Dropdown, {
+              optionsToRecipientsMap: {
+                'Option 1': ['recipient1@example.com', 'recipient2@example.com'],
+                'Option 2': ['recipient3@example.com'],
+              }
+            })
+          }
+          if (fieldType === BasicField.Image) {
+            return generateDefaultField(fieldType, {
+              url: `${aws.imageBucketUrl}/test-image.jpg`,
+            })
+          }
+          return generateDefaultField(fieldType)
+        })
+      }
+
+      it('should correctly strip optionsToRecipientMap for dropdown field for email mode form', async () => {
+        // Arrange
+        const emailFormWithAllFieldTypes = await Form.create({
+          admin: populatedAdmin._id,
+          responseMode: FormResponseMode.Email,
+          title: 'mock email form',
+          emails: [populatedAdmin.email],
+          form_fields: getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap(),
+        })
+
+        // Act
+        const actual = emailFormWithAllFieldTypes?.getPublicView()
+
+        // Assert
+        const expected = { ...pick(emailFormWithAllFieldTypes.toObject(), EMAIL_PUBLIC_FORM_FIELDS) }
+        expected.form_fields = expected.form_fields?.map((field) => {
+          if (field.fieldType === BasicField.Dropdown) {
+            return omit(field, 'optionsToRecipientsMap')
+          }
+          return field
+        })
+        expect(actual).toEqual(expected)
+      })
+
       it('should correctly return public view of unpopulated email mode form', async () => {
         // Arrange
         const emailForm = await Form.create({
@@ -2570,7 +2617,7 @@ describe('Form Model', () => {
         const actual = emailForm.getPublicView()
 
         // Assert
-        expect(actual).toEqual(pick(emailForm, EMAIL_PUBLIC_FORM_FIELDS))
+        expect(actual).toEqual(pick(emailForm.toObject(), EMAIL_PUBLIC_FORM_FIELDS))
         // Admin should be plain admin id since form is not populated.
         expect(actual.admin).toBeInstanceOf(ObjectId)
       })
@@ -2603,6 +2650,30 @@ describe('Form Model', () => {
         )
       })
 
+      it('should correctly strip optionsToRecipientMap for dropdown field for encrypt mode form', async () => {
+        // Arrange
+        const encryptedFormWithAllFieldTypes = await Form.create({
+          admin: populatedAdmin._id,
+          responseMode: FormResponseMode.Encrypt,
+          title: 'mock encrypt form',
+          publicKey: 'mock public key',
+          form_fields: getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap(),
+        })
+
+        // Act
+        const actual = encryptedFormWithAllFieldTypes?.getPublicView()
+
+        // Assert
+        const expected = { ...pick(encryptedFormWithAllFieldTypes.toObject(), STORAGE_PUBLIC_FORM_FIELDS) }
+        expected.form_fields = expected.form_fields?.map((field) => {
+          if (field.fieldType === BasicField.Dropdown) {
+            return omit(field, 'optionsToRecipientsMap')
+          }
+          return field
+        })
+        expect(actual).toEqual(expected)
+      })
+
       it('should correctly return public view of unpopulated encrypt mode form', async () => {
         // Arrange
         const encryptForm = await Form.create({
@@ -2616,7 +2687,7 @@ describe('Form Model', () => {
         const actual = encryptForm.getPublicView()
 
         // Assert
-        expect(actual).toEqual(pick(encryptForm, STORAGE_PUBLIC_FORM_FIELDS))
+        expect(actual).toEqual(pick(encryptForm.toObject(), STORAGE_PUBLIC_FORM_FIELDS))
         // Admin should be plain admin id since form is not populated.
         expect(actual.admin).toBeInstanceOf(ObjectId)
       })
@@ -2641,6 +2712,116 @@ describe('Form Model', () => {
         expect(JSON.stringify(actual)).toEqual(
           JSON.stringify({
             ...pick(populatedEncryptForm, STORAGE_PUBLIC_FORM_FIELDS),
+            // Admin should only contain public view of agency since agency is populated.
+            admin: {
+              agency: expectedPublicAgencyView,
+            },
+          }),
+        )
+      })
+
+      it('should correctly strip emails in static workflow step and strip optionsToRecipientMap for dropdown field for multirespondent mode form', async () => {
+        // Arrange
+        const formFields = getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap()
+        const dropdownField = formFields.find((field) => field.fieldType === BasicField.Dropdown)
+        const emailField = formFields.find((field) => field.fieldType === BasicField.Email)
+        const yesNoField = formFields.find((field) => field.fieldType === BasicField.YesNo)
+        const shortTextField = formFields.find((field) => field.fieldType === BasicField.ShortText)
+
+        const multirespondentFormWithAllFieldTypes = await Form.create({
+          admin: populatedAdmin._id,
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mock multirespondent form',
+          publicKey: 'mock public key',
+          form_fields: formFields,
+          workflow: [
+            {
+              _id: new ObjectId(),
+              workflow_type: WorkflowType.Static,
+              emails: [], // Step 1 does not have emails, since anyone with form link is the step 
+              edit: [],
+            },
+            {
+              _id: new ObjectId(),
+              workflow_type: WorkflowType.Static,
+              emails: ['test@open.gov.sg', 'test2@open.gov.sg'],
+              edit: [emailField?.id],
+              step_name: 'Static step where emails should be stripped',
+            },
+            {
+              _id: new ObjectId(),
+              workflow_type: WorkflowType.Dynamic,
+              field: emailField?._id,
+              edit: [dropdownField?._id],
+            },
+            {
+              _id: new ObjectId(),
+              workflow_type: WorkflowType.Conditional,
+              conditional_field: dropdownField?._id,
+              edit: [yesNoField?._id, shortTextField?._id],
+              approval_field: yesNoField?._id,
+            } as FormWorkflowStepConditional
+          ]
+        })
+
+        // Act
+        const actual = multirespondentFormWithAllFieldTypes?.getPublicView()
+
+        // Assert
+        const expected: any = pick(multirespondentFormWithAllFieldTypes.toObject(), MULTIRESPONDENT_PUBLIC_FORM_FIELDS)
+        expected.workflow = expected.workflow?.map((step: FormWorkflowStepDto) => {
+          if (step.workflow_type === WorkflowType.Static) {
+            return omit(step, 'emails')
+          }
+          return step
+        })
+        expected.form_fields = expected.form_fields?.map((field: FormFieldDto) => {
+          if (field.fieldType === BasicField.Dropdown) {
+            return omit(field, 'optionsToRecipientsMap')
+          }
+          return field
+        })
+        expect(actual).toEqual(expected)
+      })
+
+      it('should correctly return public view of unpopulated multirespondent mode form', async () => {
+        // Arrange
+        const multirespondentForm = await Form.create({
+          admin: populatedAdmin._id,
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mock multirespondent form',
+          publicKey: 'mock public key',
+        })
+
+        // Act
+        const actual = multirespondentForm.getPublicView()
+
+        // Assert
+        expect(actual).toEqual(pick(multirespondentForm.toObject(), MULTIRESPONDENT_PUBLIC_FORM_FIELDS))
+        // Admin should be plain admin id since form is not populated.
+        expect(actual.admin).toBeInstanceOf(ObjectId)
+      })
+
+      it('should correctly return public view of populated multirespondent mode form', async () => {
+        // Arrange
+        const multirespondentForm = await Form.create({
+          admin: populatedAdmin._id,
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mock multirespondent form electric boogaloo',
+          publicKey: 'some public key again',
+        })
+        const populatedMultirespondentForm = await Form.getFullFormById(multirespondentForm._id)
+        expect(populatedMultirespondentForm).not.toBeNull()
+
+        // Act
+        const actual = populatedMultirespondentForm?.getPublicView()
+
+        // Assert
+        const expectedPublicAgencyView = populatedAdmin.agency.getPublicView()
+
+        expect(JSON.stringify(actual)).toEqual(
+          JSON.stringify({
+            ...pick(populatedMultirespondentForm, MULTIRESPONDENT_PUBLIC_FORM_FIELDS),
             // Admin should only contain public view of agency since agency is populated.
             admin: {
               agency: expectedPublicAgencyView,
@@ -2811,10 +2992,10 @@ describe('Form Model', () => {
 
       it('should not duplicate unwanted fields', () => {
         const whitelistedSubmitterIdsParam: WhitelistedSubmitterIdsWithReferenceOid =
-          {
-            isWhitelistEnabled: true,
-            encryptedWhitelistedSubmitterIds: 'some object id',
-          }
+        {
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: 'some object id',
+        }
         const MOCK_ALL_FORM_PARAMS = {
           whitelistedSubmitterIds: whitelistedSubmitterIdsParam,
         }

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -31,8 +31,8 @@ import {
   WhitelistedSubmitterIdsWithReferenceOid,
   WorkflowType,
 } from 'shared/types'
-import { aws } from 'src/app/config/config'
 
+import { aws } from 'src/app/config/config'
 import getFormModel, {
   getEmailFormModel,
   getEncryptedFormModel,
@@ -2566,9 +2566,12 @@ describe('Form Model', () => {
           if (fieldType === BasicField.Dropdown) {
             return generateDefaultField(BasicField.Dropdown, {
               optionsToRecipientsMap: {
-                'Option 1': ['recipient1@example.com', 'recipient2@example.com'],
+                'Option 1': [
+                  'recipient1@example.com',
+                  'recipient2@example.com',
+                ],
                 'Option 2': ['recipient3@example.com'],
-              }
+              },
             })
           }
           if (fieldType === BasicField.Image) {
@@ -2587,14 +2590,18 @@ describe('Form Model', () => {
           responseMode: FormResponseMode.Email,
           title: 'mock email form',
           emails: [populatedAdmin.email],
-          form_fields: getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap(),
+          form_fields:
+            getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap(),
         })
 
         // Act
         const actual = emailFormWithAllFieldTypes?.getPublicView()
 
         // Assert
-        const expected = pick(emailFormWithAllFieldTypes.toObject(), EMAIL_PUBLIC_FORM_FIELDS)
+        const expected = pick(
+          emailFormWithAllFieldTypes.toObject(),
+          EMAIL_PUBLIC_FORM_FIELDS,
+        )
         expected.form_fields = expected.form_fields?.map((field) => {
           if (field.fieldType === BasicField.Dropdown) {
             return omit(field, 'optionsToRecipientsMap')
@@ -2617,7 +2624,9 @@ describe('Form Model', () => {
         const actual = emailForm.getPublicView()
 
         // Assert
-        expect(actual).toEqual(pick(emailForm.toObject(), EMAIL_PUBLIC_FORM_FIELDS))
+        expect(actual).toEqual(
+          pick(emailForm.toObject(), EMAIL_PUBLIC_FORM_FIELDS),
+        )
         // Admin should be plain admin id since form is not populated.
         expect(actual.admin).toBeInstanceOf(ObjectId)
       })
@@ -2657,14 +2666,18 @@ describe('Form Model', () => {
           responseMode: FormResponseMode.Encrypt,
           title: 'mock encrypt form',
           publicKey: 'mock public key',
-          form_fields: getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap(),
+          form_fields:
+            getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap(),
         })
 
         // Act
         const actual = encryptedFormWithAllFieldTypes?.getPublicView()
 
         // Assert
-        const expected = pick(encryptedFormWithAllFieldTypes.toObject(), STORAGE_PUBLIC_FORM_FIELDS)
+        const expected = pick(
+          encryptedFormWithAllFieldTypes.toObject(),
+          STORAGE_PUBLIC_FORM_FIELDS,
+        )
         expected.form_fields = expected.form_fields?.map((field) => {
           if (field.fieldType === BasicField.Dropdown) {
             return omit(field, 'optionsToRecipientsMap')
@@ -2687,7 +2700,9 @@ describe('Form Model', () => {
         const actual = encryptForm.getPublicView()
 
         // Assert
-        expect(actual).toEqual(pick(encryptForm.toObject(), STORAGE_PUBLIC_FORM_FIELDS))
+        expect(actual).toEqual(
+          pick(encryptForm.toObject(), STORAGE_PUBLIC_FORM_FIELDS),
+        )
         // Admin should be plain admin id since form is not populated.
         expect(actual.admin).toBeInstanceOf(ObjectId)
       })
@@ -2722,11 +2737,20 @@ describe('Form Model', () => {
 
       it('should correctly strip emails in static workflow step and strip optionsToRecipientMap for dropdown field for multirespondent mode form', async () => {
         // Arrange
-        const formFields = getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap()
-        const dropdownField = formFields.find((field) => field.fieldType === BasicField.Dropdown)
-        const emailField = formFields.find((field) => field.fieldType === BasicField.Email)
-        const yesNoField = formFields.find((field) => field.fieldType === BasicField.YesNo)
-        const shortTextField = formFields.find((field) => field.fieldType === BasicField.ShortText)
+        const formFields =
+          getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap()
+        const dropdownField = formFields.find(
+          (field) => field.fieldType === BasicField.Dropdown,
+        )
+        const emailField = formFields.find(
+          (field) => field.fieldType === BasicField.Email,
+        )
+        const yesNoField = formFields.find(
+          (field) => field.fieldType === BasicField.YesNo,
+        )
+        const shortTextField = formFields.find(
+          (field) => field.fieldType === BasicField.ShortText,
+        )
 
         const multirespondentFormWithAllFieldTypes = await Form.create({
           admin: populatedAdmin._id,
@@ -2738,7 +2762,7 @@ describe('Form Model', () => {
             {
               _id: new ObjectId(),
               workflow_type: WorkflowType.Static,
-              emails: [], // Step 1 does not have emails, since anyone with form link is the step 
+              emails: [], // Step 1 does not have emails, since anyone with form link is the step
               edit: [],
             },
             {
@@ -2760,27 +2784,34 @@ describe('Form Model', () => {
               conditional_field: dropdownField?._id,
               edit: [yesNoField?._id, shortTextField?._id],
               approval_field: yesNoField?._id,
-            } as FormWorkflowStepConditional
-          ]
+            } as FormWorkflowStepConditional,
+          ],
         })
 
         // Act
         const actual = multirespondentFormWithAllFieldTypes?.getPublicView()
 
         // Assert
-        const expected: any = pick(multirespondentFormWithAllFieldTypes.toObject(), MULTIRESPONDENT_PUBLIC_FORM_FIELDS)
-        expected.workflow = expected.workflow?.map((step: FormWorkflowStepDto) => {
-          if (step.workflow_type === WorkflowType.Static) {
-            return omit(step, 'emails')
-          }
-          return step
-        })
-        expected.form_fields = expected.form_fields?.map((field: FormFieldDto) => {
-          if (field.fieldType === BasicField.Dropdown) {
-            return omit(field, 'optionsToRecipientsMap')
-          }
-          return field
-        })
+        const expected: any = pick(
+          multirespondentFormWithAllFieldTypes.toObject(),
+          MULTIRESPONDENT_PUBLIC_FORM_FIELDS,
+        )
+        expected.workflow = expected.workflow?.map(
+          (step: FormWorkflowStepDto) => {
+            if (step.workflow_type === WorkflowType.Static) {
+              return omit(step, 'emails')
+            }
+            return step
+          },
+        )
+        expected.form_fields = expected.form_fields?.map(
+          (field: FormFieldDto) => {
+            if (field.fieldType === BasicField.Dropdown) {
+              return omit(field, 'optionsToRecipientsMap')
+            }
+            return field
+          },
+        )
         expect(actual).toEqual(expected)
       })
 
@@ -2797,7 +2828,12 @@ describe('Form Model', () => {
         const actual = multirespondentForm.getPublicView()
 
         // Assert
-        expect(actual).toEqual(pick(multirespondentForm.toObject(), MULTIRESPONDENT_PUBLIC_FORM_FIELDS))
+        expect(actual).toEqual(
+          pick(
+            multirespondentForm.toObject(),
+            MULTIRESPONDENT_PUBLIC_FORM_FIELDS,
+          ),
+        )
         // Admin should be plain admin id since form is not populated.
         expect(actual.admin).toBeInstanceOf(ObjectId)
       })
@@ -2810,7 +2846,9 @@ describe('Form Model', () => {
           title: 'mock multirespondent form electric boogaloo',
           publicKey: 'some public key again',
         })
-        const populatedMultirespondentForm = await Form.getFullFormById(multirespondentForm._id)
+        const populatedMultirespondentForm = await Form.getFullFormById(
+          multirespondentForm._id,
+        )
         expect(populatedMultirespondentForm).not.toBeNull()
 
         // Act
@@ -2821,7 +2859,10 @@ describe('Form Model', () => {
 
         expect(JSON.stringify(actual)).toEqual(
           JSON.stringify({
-            ...pick(populatedMultirespondentForm, MULTIRESPONDENT_PUBLIC_FORM_FIELDS),
+            ...pick(
+              populatedMultirespondentForm,
+              MULTIRESPONDENT_PUBLIC_FORM_FIELDS,
+            ),
             // Admin should only contain public view of agency since agency is populated.
             admin: {
               agency: expectedPublicAgencyView,
@@ -2992,10 +3033,10 @@ describe('Form Model', () => {
 
       it('should not duplicate unwanted fields', () => {
         const whitelistedSubmitterIdsParam: WhitelistedSubmitterIdsWithReferenceOid =
-        {
-          isWhitelistEnabled: true,
-          encryptedWhitelistedSubmitterIds: 'some object id',
-        }
+          {
+            isWhitelistEnabled: true,
+            encryptedWhitelistedSubmitterIds: 'some object id',
+          }
         const MOCK_ALL_FORM_PARAMS = {
           whitelistedSubmitterIds: whitelistedSubmitterIdsParam,
         }

--- a/src/app/models/__tests__/form.server.model.spec.ts
+++ b/src/app/models/__tests__/form.server.model.spec.ts
@@ -2594,7 +2594,7 @@ describe('Form Model', () => {
         const actual = emailFormWithAllFieldTypes?.getPublicView()
 
         // Assert
-        const expected = { ...pick(emailFormWithAllFieldTypes.toObject(), EMAIL_PUBLIC_FORM_FIELDS) }
+        const expected = pick(emailFormWithAllFieldTypes.toObject(), EMAIL_PUBLIC_FORM_FIELDS)
         expected.form_fields = expected.form_fields?.map((field) => {
           if (field.fieldType === BasicField.Dropdown) {
             return omit(field, 'optionsToRecipientsMap')
@@ -2664,7 +2664,7 @@ describe('Form Model', () => {
         const actual = encryptedFormWithAllFieldTypes?.getPublicView()
 
         // Assert
-        const expected = { ...pick(encryptedFormWithAllFieldTypes.toObject(), STORAGE_PUBLIC_FORM_FIELDS) }
+        const expected = pick(encryptedFormWithAllFieldTypes.toObject(), STORAGE_PUBLIC_FORM_FIELDS)
         expected.form_fields = expected.form_fields?.map((field) => {
           if (field.fieldType === BasicField.Dropdown) {
             return omit(field, 'optionsToRecipientsMap')

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1011,6 +1011,61 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       return formSettings
     }
 
+  EmailFormSchema.method<IFormDocument>(
+    'getPublicView',
+    function (): PublicForm {
+      const emailFormPublicViewFields = pick(
+        this,
+        EMAIL_PUBLIC_FORM_FIELDS,
+      ) as PublicForm
+
+      // NOTE: While email mode forms do not allow adding optionsToRecipient mapping for dropdown fields,
+      // it is still possible for optionsToRecipientsMap to be defined if the form was duplicated from a multirespondent form.
+      const strippedFormFields = stripDropdownFieldOptionsToRecipientsMap(
+        emailFormPublicViewFields.form_fields,
+      )
+      const emailFormPublicView = {
+        ...emailFormPublicViewFields,
+        form_fields: strippedFormFields,
+      } as PublicForm
+
+      const isAdminPopulated = this.populated('admin')
+      if (isAdminPopulated) {
+        // Override admin id with public view of admin
+        emailFormPublicView.admin = this.admin.getPublicView()
+      }
+
+      return emailFormPublicView
+    },
+  )
+
+  EncryptedFormSchema.method<IEncryptedFormDocument>(
+    'getPublicView',
+    function (): PublicForm {
+      const encryptFormPublicViewFields = pick(
+        this,
+        STORAGE_PUBLIC_FORM_FIELDS,
+      ) as PublicStorageFormDto
+      // NOTE: While encrypt mode forms do not allow adding optionsToRecipient mapping for dropdown fields,
+      // it is still possible for optionsToRecipientsMap to be defined if the form was duplicated from a multirespondent form.
+      const strippedFormFields = stripDropdownFieldOptionsToRecipientsMap(
+        encryptFormPublicViewFields.form_fields,
+      )
+      const encryptedFormPublicView = {
+        ...encryptFormPublicViewFields,
+        form_fields: strippedFormFields,
+      } as PublicForm
+
+      const isAdminPopulated = this.populated('admin')
+      if (isAdminPopulated) {
+        // Override admin id with public view of admin
+        encryptedFormPublicView.admin = this.admin.getPublicView()
+      }
+
+      return encryptedFormPublicView
+    },
+  )
+
   MultirespondentFormSchema.method<IMultirespondentFormDocument>(
     'getPublicView',
     function (): PublicForm {
@@ -1023,60 +1078,19 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         mrfPublicViewFields.form_fields,
       )
       const strippedWorkflow = stripWorkflowEmails(mrfPublicViewFields.workflow)
-      const isAdminPopulated = this.populated('admin')
       const mrfPublicView = {
         ...mrfPublicViewFields,
         workflow: strippedWorkflow,
         form_fields: strippedFormFields,
-        admin: isAdminPopulated ? this.admin.getPublicView() : undefined,
       } as PublicForm
+
+      const isAdminPopulated = this.populated('admin')
+      if (isAdminPopulated) {
+        // Override admin id with public view of admin
+        mrfPublicView.admin = this.admin.getPublicView()
+      }
 
       return mrfPublicView
-    },
-  )
-
-  EncryptedFormSchema.method<IEncryptedFormDocument>(
-    'getPublicView',
-    function (): PublicForm {
-      const encryptFormPublicViewFields = pick(
-        this,
-        STORAGE_PUBLIC_FORM_FIELDS,
-      ) as PublicStorageFormDto
-      const strippedFormFields = stripDropdownFieldOptionsToRecipientsMap(
-        encryptFormPublicViewFields.form_fields,
-      )
-      const isAdminPopulated = this.populated('admin')
-
-      const encryptedFormPublicView = {
-        ...encryptFormPublicViewFields,
-        form_fields: strippedFormFields,
-        admin: isAdminPopulated ? this.admin.getPublicView() : undefined,
-      } as PublicForm
-
-      return encryptedFormPublicView
-    },
-  )
-
-  EmailFormSchema.method<IFormDocument>(
-    'getPublicView',
-    function (): PublicForm {
-      const emailFormPublicViewFields = pick(
-        this,
-        EMAIL_PUBLIC_FORM_FIELDS,
-      ) as PublicForm
-
-      const strippedFormFields = stripDropdownFieldOptionsToRecipientsMap(
-        emailFormPublicViewFields.form_fields,
-      )
-      const isAdminPopulated = this.populated('admin')
-
-      const emailFormPublicView = {
-        ...emailFormPublicViewFields,
-        form_fields: strippedFormFields,
-        admin: isAdminPopulated ? this.admin.getPublicView() : undefined,
-      } as PublicForm
-
-      return emailFormPublicView
     },
   )
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -48,11 +48,15 @@ import {
   MultirespondentFormSettings,
   PaymentChannel,
   PaymentType,
+  PublicMultirespondentFormDto,
+  PublicStorageFormDto,
   StorageFormSettings,
   WorkflowType,
 } from '../../../shared/types'
 import { reorder } from '../../../shared/utils/immutable-array-fns'
 import { getApplicableIfStates } from '../../../shared/utils/logic'
+import { stripDropdownFieldOptionsToRecipientsMap } from '../../../shared/utils/strip-dropdown-field-optionsToRecipientsMap'
+import { stripWorkflowEmails } from '../../../shared/utils/strip-workflow-emails'
 import {
   FormFieldSchema,
   FormLogicSchema,
@@ -67,6 +71,7 @@ import {
   IFormModel,
   IFormSchema,
   ILogicSchema,
+  IMultirespondentFormDocument,
   IMultirespondentFormModel,
   IMultirespondentFormSchema,
   IPopulatedForm,
@@ -1006,35 +1011,72 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       return formSettings
     }
 
-  FormDocumentSchema.method<IFormDocument>(
+  MultirespondentFormSchema.method<IMultirespondentFormDocument>(
     'getPublicView',
     function (): PublicForm {
-      let basePublicView
-      switch (this.responseMode) {
-        case FormResponseMode.Encrypt:
-          basePublicView = pick(this, STORAGE_PUBLIC_FORM_FIELDS) as PublicForm
-          break
-        case FormResponseMode.Email:
-          basePublicView = pick(this, EMAIL_PUBLIC_FORM_FIELDS) as PublicForm
-          break
-        case FormResponseMode.Multirespondent:
-          basePublicView = pick(
-            this,
-            MULTIRESPONDENT_PUBLIC_FORM_FIELDS,
-          ) as PublicForm
-          break
-      }
+      const mrfPublicViewFields = pick(
+        this.toObject(),
+        MULTIRESPONDENT_PUBLIC_FORM_FIELDS,
+      ) as PublicMultirespondentFormDto
 
-      // Return non-populated public fields of form if not populated.
-      if (!this.populated('admin')) {
-        return basePublicView
-      }
+      const strippedFormFields = stripDropdownFieldOptionsToRecipientsMap(
+        mrfPublicViewFields.form_fields,
+      )
+      const strippedWorkflow = stripWorkflowEmails(mrfPublicViewFields.workflow)
+      const isAdminPopulated = this.populated('admin')
+      const mrfPublicView = {
+        ...mrfPublicViewFields,
+        workflow: strippedWorkflow,
+        form_fields: strippedFormFields,
+        admin: isAdminPopulated ? this.admin.getPublicView() : undefined,
+      } as PublicForm
 
-      // Populated, return public view with user's public view.
-      return {
-        ...basePublicView,
-        admin: (this.admin as IUserSchema).getPublicView(),
-      }
+      return mrfPublicView
+    },
+  )
+
+  EncryptedFormSchema.method<IEncryptedFormDocument>(
+    'getPublicView',
+    function (): PublicForm {
+      const encryptFormPublicViewFields = pick(
+        this,
+        STORAGE_PUBLIC_FORM_FIELDS,
+      ) as PublicStorageFormDto
+      const strippedFormFields = stripDropdownFieldOptionsToRecipientsMap(
+        encryptFormPublicViewFields.form_fields,
+      )
+      const isAdminPopulated = this.populated('admin')
+
+      const encryptedFormPublicView = {
+        ...encryptFormPublicViewFields,
+        form_fields: strippedFormFields,
+        admin: isAdminPopulated ? this.admin.getPublicView() : undefined,
+      } as PublicForm
+
+      return encryptedFormPublicView
+    },
+  )
+
+  EmailFormSchema.method<IFormDocument>(
+    'getPublicView',
+    function (): PublicForm {
+      const emailFormPublicViewFields = pick(
+        this,
+        EMAIL_PUBLIC_FORM_FIELDS,
+      ) as PublicForm
+
+      const strippedFormFields = stripDropdownFieldOptionsToRecipientsMap(
+        emailFormPublicViewFields.form_fields,
+      )
+      const isAdminPopulated = this.populated('admin')
+
+      const emailFormPublicView = {
+        ...emailFormPublicViewFields,
+        form_fields: strippedFormFields,
+        admin: isAdminPopulated ? this.admin.getPublicView() : undefined,
+      } as PublicForm
+
+      return emailFormPublicView
     },
   )
 

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1015,7 +1015,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     'getPublicView',
     function (): PublicForm {
       const emailFormPublicViewFields = pick(
-        this,
+        this.toObject(),
         EMAIL_PUBLIC_FORM_FIELDS,
       ) as PublicForm
 
@@ -1043,7 +1043,7 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     'getPublicView',
     function (): PublicForm {
       const encryptFormPublicViewFields = pick(
-        this,
+        this.toObject(),
         STORAGE_PUBLIC_FORM_FIELDS,
       ) as PublicStorageFormDto
       // NOTE: While encrypt mode forms do not allow adding optionsToRecipient mapping for dropdown fields,
@@ -1254,12 +1254,12 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       })
       return data
         ? ({
-            form: data._id,
-            formAdmin: {
-              email: data.admin.email,
-              userId: data.admin._id,
-            },
-          } as FormOtpData)
+          form: data._id,
+          formAdmin: {
+            email: data.admin.email,
+            userId: data.admin._id,
+          },
+        } as FormOtpData)
         : null
     } catch {
       return null

--- a/src/app/models/form.server.model.ts
+++ b/src/app/models/form.server.model.ts
@@ -1254,12 +1254,12 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       })
       return data
         ? ({
-          form: data._id,
-          formAdmin: {
-            email: data.admin.email,
-            userId: data.admin._id,
-          },
-        } as FormOtpData)
+            form: data._id,
+            formAdmin: {
+              email: data.admin.email,
+              userId: data.admin._id,
+            },
+          } as FormOtpData)
         : null
     } catch {
       return null

--- a/src/types/form.ts
+++ b/src/types/form.ts
@@ -329,6 +329,8 @@ interface IFormBaseDocument<T extends IFormSchema> {
 }
 
 export type IFormDocument = IFormBaseDocument<IFormSchema> & IFormSchema
+export type IMultirespondentFormDocument =
+  IFormBaseDocument<IMultirespondentFormSchema> & IMultirespondentFormSchema
 
 export interface IPopulatedForm extends Omit<IFormDocument, 'toJSON'> {
   admin: IPopulatedUser


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->


## Solution
<!-- How did you solve the problem? -->
Split the `getPublicView` to each response mode type to simplify the typing and for simpler customization. 

Utilise TS to safeguard against misuse in the FE and enforce redaction. 

<img width="433" height="120" alt="image" src="https://github.com/user-attachments/assets/607c373c-9f2c-4c16-bd3b-8f35abd649db" />

For example, the TS prevents `optionsToRecipientsMap` from being used in the FE public form provider. This prevents undesired bugs as the `optionsToRecipientsMap` will not be present. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
 No - this PR is backwards compatible  