### PR TITLE
feat: update save draft toast and admin toggle copy

### DIFF
--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -966,7 +966,7 @@ WithSaveDraftEnabledAndClickFloatingSaveDraftButton.play = async ({
       await waitFor(
         async () => {
           await expect(document.body).toHaveTextContent(
-            'Your draft has been saved.',
+            'Draft saved. Reopen this link in this browser to resume filling it.',
           )
         },
         { timeout: 3000 },
@@ -1078,7 +1078,7 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     async () => {
       await waitFor(
         () => {
-          expect(document.body).toHaveTextContent('Your draft has been saved.')
+          expect(document.body).toHaveTextContent('Draft saved. Reopen this link in this browser to resume filling it.')
         },
         { timeout: 3000 },
       )
@@ -1181,7 +1181,7 @@ WithSaveDraftExcludingSavingMyInfoFields.play = async ({
     async () => {
       await waitFor(
         () => {
-          expect(document.body).toHaveTextContent('Your draft has been saved.')
+          expect(document.body).toHaveTextContent('Draft saved. Reopen this link in this browser to resume filling it.')
         },
         { timeout: 3000 },
       )

--- a/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1078,7 +1078,9 @@ WithSaveDraftEnabledAndClickSaveDraftButton.play = async ({
     async () => {
       await waitFor(
         () => {
-          expect(document.body).toHaveTextContent('Draft saved. Reopen this link in this browser to resume filling it.')
+          expect(document.body).toHaveTextContent(
+            'Draft saved. Reopen this link in this browser to resume filling it.',
+          )
         },
         { timeout: 3000 },
       )
@@ -1181,7 +1183,9 @@ WithSaveDraftExcludingSavingMyInfoFields.play = async ({
     async () => {
       await waitFor(
         () => {
-          expect(document.body).toHaveTextContent('Draft saved. Reopen this link in this browser to resume filling it.')
+          expect(document.body).toHaveTextContent(
+            'Draft saved. Reopen this link in this browser to resume filling it.',
+          )
         },
         { timeout: 3000 },
       )

--- a/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -30,7 +30,7 @@ export const enSG = {
   saveDraft: {
     label: 'Enable saving of draft responses',
     description:
-      'Respondents will be able to save a draft of their responses on their browser.',
+      "Respondents can save what they've filled in and continue later on the same browser.",
   },
   captcha: {
     label: 'Enable reCAPTCHA',

--- a/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -38,7 +38,7 @@ export const enSG: PublicForm = {
     },
     saveDraft: {
       toast: {
-        success: 'Your draft has been saved.',
+        success: 'Draft saved. Reopen this link in this browser to resume filling it.',
         restoredAllFields: 'Your draft has been successfully restored.',
         restoredOnlyUnchangedFields:
           'Some fields were not restored as the form has been updated.',

--- a/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -38,7 +38,8 @@ export const enSG: PublicForm = {
     },
     saveDraft: {
       toast: {
-        success: 'Draft saved. Reopen this link in this browser to resume filling it.',
+        success:
+          'Draft saved. Reopen this link in this browser to resume filling it.',
         restoredAllFields: 'Your draft has been successfully restored.',
         restoredOnlyUnchangedFields:
           'Some fields were not restored as the form has been updated.',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

After respondents use save draft, they may be uncertain on how to restore and continue filling the form as no instructions are provided. 

## Solution
<!-- How did you solve the problem? -->
Provide explicit instructions in the save draft toast so respondents know how to return to their drafts. Also, update the admin settings page save draft toggle copy. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  