### PR TITLE
feat: setup stg on iac

### DIFF
--- a/.github/workflows/aws-deploy-scanner.yml
+++ b/.github/workflows/aws-deploy-scanner.yml
@@ -1,3 +1,4 @@
+# TODO: Remove once stg-alt2 is migrated to IAC. Since aws-deploy-scanner-legacy.yml replaces this file's function. 
 name: AWS Deploy Scanner
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches-ignore:
-      - staging
-      - staging-alt
+      - stg
       - staging-alt2
       - stg-alt
       - stg-alt3
@@ -12,8 +11,7 @@ on:
   pull_request:
     types: [opened, reopened]
     branches-ignore:
-      - staging
-      - staging-alt
+      - stg
       - staging-alt2
       - stg-alt
       - stg-alt3

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -1,3 +1,4 @@
+# TODO: Remove this once stg-alt2 is migrated to IAC. Since elastic beanstalk is no longer used in favour of ECS. 
 name: Deploy to AWS Elastic Beanstalk
 on:
   push:

--- a/.github/workflows/deploy-eb.yml
+++ b/.github/workflows/deploy-eb.yml
@@ -5,8 +5,6 @@ on:
     # release-al2, staging, staging-alt2.
     # This is different from the DEPLOY_ENV secret which corresponds to elastic beanstalk environment name.
     branches:
-      - release-al2
-      - staging
       - staging-alt2
 
 permissions:

--- a/.github/workflows/deploy-ecs-stg.yml
+++ b/.github/workflows/deploy-ecs-stg.yml
@@ -1,0 +1,51 @@
+name: Deploy FormSG app to stg (main staging environment)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - stg
+
+jobs:
+  deploy:
+    name: Deploy
+    uses: ./.github/workflows/deploy-ecs.yml
+    with:
+      gha-environment: 'stg'
+      # Environment configuration
+      environment: 'stg'
+      environment-site-name: 'stg'
+      app-version: ${{ github.sha }}
+      app-url: 'https://stg.form.gov.sg'
+      react-app-form-sg-sdk-mode: 'staging'
+      # AWS configuration
+      aws-region: 'ap-southeast-1'
+      ecr-repository: 'formsg'
+      # ECS configuration
+      ecs-cpu: 1024
+      ecs-memory: 2048
+      ecs-cluster-name: 'formsg-stg-ecs'
+      ecs-service-name: 'formsg-stg-ecs-service'
+      ecs-task-definition: 'formsg-stg-ecs'
+      ecs-task-definition-path: 'deploy/ecs-task-definition.json'
+      ecs-container-name: 'formsg-app'
+      # CodeDeploy configuration
+      codedeploy-application: 'formsg-stg-ecs-app'
+      codedeploy-appspec-path: deploy/appspec.yml
+      codedeploy-deployment-group: 'formsg-stg-ecs-dg'
+      # Datadog config
+      dd-env: 'stg'
+    secrets:
+      # AWS credentials and configuration
+      aws-account-id: ${{ secrets.AWS_ACCOUNT_ID }}
+      cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}
+      # Monitoring and analytics configuration
+      ga-tracking-id: ${{ secrets.GA_TRACKING_ID }}
+      dd-rum-app-id: ${{ secrets.DD_RUM_APP_ID }}
+      dd-rum-client-token: ${{ secrets.DD_RUM_CLIENT_TOKEN }}
+      dd-sample-rate: ${{ secrets.DD_SAMPLE_RATE }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      S3_STATIC_ASSETS_BUCKET_NAME: ${{ secrets.S3_STATIC_ASSETS_BUCKET_NAME }}

--- a/.github/workflows/deploy-ecs-stg.yml
+++ b/.github/workflows/deploy-ecs-stg.yml
@@ -1,4 +1,4 @@
-name: Deploy FormSG app to stg (main staging environment)
+name: Deploy FormSG app to stg
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -13,7 +13,7 @@ on:
       environment-site-name:
         description: 'Deployment environment site name'
         required: true
-        type: string # staging, staging-alt, staging-alt2, stg-alt, stg-alt3, prod, uat
+        type: string # stg, stg-alt, stg-alt2, stg-alt3, prod, uat
       ecs-cpu:
         description: 'ECS CPU units to use'
         required: true

--- a/.github/workflows/deploy-pdf-gen-stg.yml
+++ b/.github/workflows/deploy-pdf-gen-stg.yml
@@ -1,4 +1,4 @@
-name: Deploy PDF Generator Lambda to staging
+name: Deploy PDF Generator Lambda to stg (main staging environment)
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,15 +11,15 @@ permissions:
 on:
   push:
     branches:
-      - staging
+      - stg
 
 jobs:
   deploy-pdf-gen-lambda: 
     name: Deploy PDF Generator Lambda
     uses: ./.github/workflows/deploy-pdf-gen-lambda.yml
     with:
-      gha-environment: 'staging'
-      checkoutBranch: 'staging'
-      environment: 'staging'
+      gha-environment: 'stg'
+      checkoutBranch: 'stg'
+      environment: 'stg'
     secrets:
       cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}

--- a/.github/workflows/deploy-pdf-gen-stg.yml
+++ b/.github/workflows/deploy-pdf-gen-stg.yml
@@ -1,4 +1,4 @@
-name: Deploy PDF Generator Lambda to stg (main staging environment)
+name: Deploy PDF Generator Lambda to stg
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy-virus-scanner-guardduty-prod.yml
+++ b/.github/workflows/deploy-virus-scanner-guardduty-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy Virus Scanner GuardDuty to IaC OGP AWS environment
+name: Deploy Virus Scanner GuardDuty to production
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy-virus-scanner-guardduty-stg-alt3.yml
+++ b/.github/workflows/deploy-virus-scanner-guardduty-stg-alt3.yml
@@ -1,4 +1,4 @@
-name: Deploy Virus Scanner GuardDuty to IaC OGP AWS environment
+name: Deploy Virus Scanner GuardDuty to stg-alt3
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy-virus-scanner-guardduty-stg.yml
+++ b/.github/workflows/deploy-virus-scanner-guardduty-stg.yml
@@ -1,4 +1,4 @@
-name: Deploy Virus Scanner GuardDuty to stg-alt
+name: Deploy Virus Scanner GuardDuty to stg
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,16 +11,16 @@ permissions:
 on:
   push:
     branches:
-      - stg-alt
+      - stg
 
 jobs:
   deploy-scanner-guardduty:
     name: Deploy Scanner GuardDuty
     uses: ./.github/workflows/aws-deploy-scanner-guardduty-iac.yml
     with:
-      checkoutBranch: 'stg-alt'
-      gha-environment: 'stg-alt'
-      environment: 'stg-alt'
+      checkoutBranch: 'stg'
+      gha-environment: 'stg'
+      environment: 'stg'
       provisionedConcurrency: 1
     secrets:
       cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}

--- a/.github/workflows/deploy-virus-scanner-guardduty-uat.yml
+++ b/.github/workflows/deploy-virus-scanner-guardduty-uat.yml
@@ -1,4 +1,4 @@
-name: Deploy Virus Scanner GuardDuty to new OGP AWS production account
+name: Deploy Virus Scanner GuardDuty to uat
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy-virus-scanner-legacy-stg-alt.yml
+++ b/.github/workflows/deploy-virus-scanner-legacy-stg-alt.yml
@@ -1,4 +1,4 @@
-name: Deploy Virus Scanner GuardDuty to stg-alt
+name: Deploy Legacy Virus Scanner to stg-alt
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,11 +12,14 @@ on:
   push:
     branches:
       - stg-alt
+  # For legacy virus scanner: schedule builds for 12:00AM GMT+8 everyday to get latest ClamAV virus definitions
+  schedule:
+    - cron: '0 16 * * *'
 
 jobs:
-  deploy-scanner-guardduty:
-    name: Deploy Scanner GuardDuty
-    uses: ./.github/workflows/aws-deploy-scanner-guardduty-iac.yml
+  deploy-scanner:
+    name: Deploy Scanner
+    uses: ./.github/workflows/aws-deploy-scanner-legacy.yml
     with:
       checkoutBranch: 'stg-alt'
       gha-environment: 'stg-alt'

--- a/.github/workflows/deploy-virus-scanner-legacy-stg-alt3.yml
+++ b/.github/workflows/deploy-virus-scanner-legacy-stg-alt3.yml
@@ -1,4 +1,4 @@
-name: Deploy Legacy Virus Scanner to new OGP AWS environment
+name: Deploy Legacy Virus Scanner to stg-alt3
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/deploy-virus-scanner-legacy-stg.yml
+++ b/.github/workflows/deploy-virus-scanner-legacy-stg.yml
@@ -1,4 +1,4 @@
-name: Deploy Legacy Virus Scanner to production
+name: Deploy Legacy Virus Scanner to stg
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,7 +11,7 @@ permissions:
 on:
   push:
     branches:
-      - release-al2
+      - stg
   # For legacy virus scanner: schedule builds for 12:00AM GMT+8 everyday to get latest ClamAV virus definitions
   schedule:
     - cron: '0 16 * * *'
@@ -21,9 +21,9 @@ jobs:
     name: Deploy Scanner
     uses: ./.github/workflows/aws-deploy-scanner-legacy.yml
     with:
-      checkoutBranch: 'release-al2'
-      gha-environment: 'release-al2'
-      environment: 'production'
-      provisionedConcurrency: 10
+      checkoutBranch: 'stg'
+      gha-environment: 'stg'
+      environment: 'stg'
+      provisionedConcurrency: 1
     secrets:
       cicd-role: ${{ secrets.IAC_AWS_CI_ROLE_TO_ASSUME }}

--- a/.github/workflows/deploy-virus-scanner-legacy-uat.yml
+++ b/.github/workflows/deploy-virus-scanner-legacy-uat.yml
@@ -1,4 +1,4 @@
-name: Deploy Legacy Virus Scanner to new OGP AWS production account
+name: Deploy Legacy Virus Scanner to uat
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,7 +3,7 @@ name: Playwright Tests
 on:
   push:
     branches-ignore:
-      - staging
+      - stg
       - staging-alt2
       - stg-alt
       - stg-alt3
@@ -11,7 +11,7 @@ on:
   pull_request:
     types: [opened, reopened]
     branches-ignore:
-      - staging
+      - stg
       - staging-alt2
       - stg-alt
       - stg-alt3

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -57,7 +57,7 @@ git checkout -b ${release_branch}
 git branch -D ${temp_release_branch}
 
 git push origin ${may_force_push} HEAD:${release_branch}
-git push -f origin HEAD:staging
+git push -f origin HEAD:stg
 git push origin ${release_version}
 
 # extract changelog to inject into the PR

--- a/serverless/pdf-gen-sparticuz/samconfig.yaml
+++ b/serverless/pdf-gen-sparticuz/samconfig.yaml
@@ -3,15 +3,15 @@ version: 0.1
 staging: 
   deploy: 
     parameters:
-      stack_name: pdf-gen-sparticuz-staging
+      stack_name: pdf-gen-sparticuz-stg
       s3_bucket: pdf-gen-lambda-code-zip-uat-4882a20 # Reuse uat bucket as this env is not IACed. 
       region: ap-southeast-1
       capabilities: CAPABILITY_IAM # Allows the deployment to create IAM resources 
-      s3_prefix: staging
+      s3_prefix: stg
       image_repositories: [] 
       disable_rollback: false # Rolls back to previous version if the deployment fails 
       confirm_changeset: true
-      parameter_overrides: Environment=staging
+      parameter_overrides: Environment=stg
 
 stg-alt:
   deploy:

--- a/serverless/pdf-gen-sparticuz/samconfig.yaml
+++ b/serverless/pdf-gen-sparticuz/samconfig.yaml
@@ -4,7 +4,7 @@ stg:
   deploy: 
     parameters:
       stack_name: pdf-gen-sparticuz-stg
-      s3_bucket: pdf-gen-lambda-code-zip-uat-4882a20 # Reuse uat bucket as this env is not IACed. 
+      s3_bucket: pdf-gen-lambda-code-zip-stg-2d429c2 # Created by pulumi in formsg-infra to store AWS SAM builds. 
       region: ap-southeast-1
       capabilities: CAPABILITY_IAM # Allows the deployment to create IAM resources 
       s3_prefix: stg

--- a/serverless/pdf-gen-sparticuz/samconfig.yaml
+++ b/serverless/pdf-gen-sparticuz/samconfig.yaml
@@ -1,6 +1,6 @@
 version: 0.1
 
-staging: 
+stg: 
   deploy: 
     parameters:
       stack_name: pdf-gen-sparticuz-stg

--- a/serverless/virus-scanner-guardduty/serverless.yml
+++ b/serverless/virus-scanner-guardduty/serverless.yml
@@ -75,7 +75,7 @@ functions:
     memorySize: 128 # Usage of the smallest memory size is possible since the lambda function does not load the file content into memory and simply makes API calls to S3.
     # Provision concurrency so at least one instance always hot
     # https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml/#provisioned-concurrency
-    # 1 for staging, 5 for prod
+    # 1 for staging environments, 5 for prod
     provisionedConcurrency: ${param:provisionedConcurrency}
 
 plugins:

--- a/serverless/virus-scanner-guardduty/src/config.ts
+++ b/serverless/virus-scanner-guardduty/src/config.ts
@@ -7,7 +7,7 @@ const isTest = process.env.NODE_ENV === 'test'
 export const config = convict({
   environment: {
     env: 'NODE_ENV',
-    format: ['development', 'staging', 'stg-alt', 'stg-alt3', 'uat', 'production', 'test'],
+    format: ['development', 'stg', 'stg-alt', 'stg-alt3', 'uat', 'production', 'test'],
     default: 'development',
   },
   isTestOrDev: {

--- a/serverless/virus-scanner/scripts/envLoader.mjs
+++ b/serverless/virus-scanner/scripts/envLoader.mjs
@@ -22,12 +22,13 @@ const SHORT_ENV_MAP = {
   vapt: 'vapt',
 }
 
+const IAC_MIGRATED_SHORT_ENVS = ['uat', 'prod', 'stg', 'stg-alt', 'stg-alt3']
 /**
  * Returns true if the environment is an IaC migrated environment.
  * IaC migrated environments use new SSM keys and format that are different from the legacy ones.
  */
-const isIacMigratedSsmKeys = (env) => {
-  return env === SHORT_ENV_MAP['stg-alt3']
+const isIacMigratedSsmKeys = (shortEnv) => {
+  return IAC_MIGRATED_SHORT_ENVS.includes(shortEnv)
 }
 
 const PARAM_KEYS = [
@@ -44,7 +45,7 @@ const getParamString = async (env) => {
   if (isIacMigratedSsmKeys(env)) {
     console.log('Running on IaC migrated environment...')
     const PARAM_KEY_PREFIX = `/virus-scanner/${SHORT_ENV_MAP[env]}/`
-    
+
     const keyValuePromises = PARAM_KEYS.map(async key => {
       console.log(`Fetching ${PARAM_KEY_PREFIX}${key} from SSM...`)
       const res = await client.send(

--- a/serverless/virus-scanner/serverless.yml
+++ b/serverless/virus-scanner/serverless.yml
@@ -42,7 +42,7 @@ functions:
     memorySize: 2048
     # Provision concurrency so at least one instance always hot
     # https://www.serverless.com/framework/docs/providers/aws/guide/serverless.yml/#provisioned-concurrency
-    # 1 for staging, 5 for prod
+    # 1 for staging environments, 5 for prod
     provisionedConcurrency: ${param:provisionedConcurrency}
 
 plugins:

--- a/serverless/virus-scanner/src/config.ts
+++ b/serverless/virus-scanner/src/config.ts
@@ -7,7 +7,7 @@ const isTest = process.env.NODE_ENV === 'test'
 export const config = convict({
   environment: {
     env: 'NODE_ENV',
-    format: ['development', 'staging', 'stg-alt3', 'uat', 'production', 'test'],
+    format: ['development', 'stg', 'stg-alt', 'stg-alt3', 'uat', 'production', 'test'],
     default: 'development',
   },
   isTestOrDev: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Staging environment is still not on iac, causing drift and not being to benefit from benefits of new iac-ed environment (eg, faster deployment times) 

## Solution
<!-- How did you solve the problem? -->
Mark scripts that may be deleted after stg-alt2 migration with TODO comment. 
Remove deployment of release-al2 and staging to EBS, since it is now deprecated. 
Create GH action CD scripts for new iac stg environment.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  