### PR TITLE
fix: radio others bug v2

### DIFF
--- a/frontend/src/features/form/utils/__tests__/extractMrfPreviousStepResponseValue.spec.ts
+++ b/frontend/src/features/form/utils/__tests__/extractMrfPreviousStepResponseValue.spec.ts
@@ -1,0 +1,95 @@
+import { CLIENT_RADIO_OTHERS_INPUT_VALUE } from '~shared/constants'
+import { CountryRegion } from '~shared/constants/countryRegion'
+import {
+  AttachmentFieldResponseV3,
+  BasicField,
+  FieldResponseV3,
+  FormFieldDto,
+} from '~shared/types'
+
+import { RadioFieldValues } from '~templates/Field'
+
+import { extractMrfPreviousStepResponseValue } from '../extractMrfPreviousStepResponseValue'
+
+jest.mock('~utils/bufferToFile', () => ({
+  bufferToFile: jest.fn((buffer, name) => ({ buffer, name })),
+}))
+
+describe('extractMrfPreviousStepResponseValue', () => {
+  it('should return the correct CountryRegion enum value if matches', () => {
+    const field: FormFieldDto = { fieldType: BasicField.CountryRegion } as any
+    const previousResponse: FieldResponseV3 = { answer: 'Singapore' } as any
+
+    const result = extractMrfPreviousStepResponseValue(field, previousResponse)
+
+    expect(result).toBe(CountryRegion.Singapore)
+  })
+
+  it('should return undefined if CountryRegion does not match', () => {
+    const field: FormFieldDto = { fieldType: BasicField.CountryRegion } as any
+    const previousResponse: FieldResponseV3 = { answer: 'Bad Country' } as any
+
+    const result = extractMrfPreviousStepResponseValue(field, previousResponse)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return a file object for Attachment if buffer is provided', () => {
+    const field: FormFieldDto = { fieldType: BasicField.Attachment } as any
+    const previousResponse: FieldResponseV3 = {
+      answer: { answer: 'file.txt' } as AttachmentFieldResponseV3,
+    } as any
+    const buffer = new ArrayBuffer(8)
+
+    const result = extractMrfPreviousStepResponseValue(
+      field,
+      previousResponse,
+      buffer,
+    )
+
+    expect(result).toEqual({ buffer, name: 'file.txt' })
+  })
+
+  it('should return undefined for Attachment if buffer is not provided', () => {
+    const field: FormFieldDto = { fieldType: BasicField.Attachment } as any
+    const previousResponse: FieldResponseV3 = {
+      answer: { answer: 'file.txt' } as AttachmentFieldResponseV3,
+    } as any
+
+    const result = extractMrfPreviousStepResponseValue(field, previousResponse)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should set value to CLIENT_RADIO_OTHERS_INPUT_VALUE if othersInput exists but value is empty', () => {
+    const field: FormFieldDto = { fieldType: BasicField.Radio } as any
+    const previousResponse: FieldResponseV3 = {
+      answer: { othersInput: 'some input', value: '' } as RadioFieldValues,
+    } as any
+
+    const result = extractMrfPreviousStepResponseValue(
+      field,
+      previousResponse,
+    ) as RadioFieldValues
+
+    expect(result.value).toBe(CLIENT_RADIO_OTHERS_INPUT_VALUE)
+    expect(result.othersInput).toBe('some input')
+  })
+
+  it('should return undefined if previousFieldResponse is undefined', () => {
+    const field: FormFieldDto = { fieldType: BasicField.Radio } as any
+
+    const result = extractMrfPreviousStepResponseValue(field)
+
+    expect(result).toBeUndefined()
+  })
+
+  it('should return the answer as-is for other field types', () => {
+    const field: FormFieldDto = { fieldType: 'Text' } as any
+    const previousResponse: FieldResponseV3 = { answer: 'Hello' } as any
+
+    const result = extractMrfPreviousStepResponseValue(field, previousResponse)
+
+    expect(result).toBe('Hello')
+  })
+})

--- a/frontend/src/features/form/utils/__tests__/extractMrfPreviousStepResponseValue.test.ts
+++ b/frontend/src/features/form/utils/__tests__/extractMrfPreviousStepResponseValue.test.ts
@@ -7,18 +7,21 @@ import {
   FormFieldDto,
 } from '~shared/types'
 
+import bufferToFile from '~utils/bufferToFile'
 import { RadioFieldValues } from '~templates/Field'
 
 import { extractMrfPreviousStepResponseValue } from '../extractMrfPreviousStepResponseValue'
 
-jest.mock('~utils/bufferToFile', () => ({
-  bufferToFile: jest.fn((buffer, name) => ({ buffer, name })),
-}))
+vi.mock('~utils/bufferToFile')
 
 describe('extractMrfPreviousStepResponseValue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('should return the correct CountryRegion enum value if matches', () => {
     const field: FormFieldDto = { fieldType: BasicField.CountryRegion } as any
-    const previousResponse: FieldResponseV3 = { answer: 'Singapore' } as any
+    const previousResponse: FieldResponseV3 = { answer: 'SINGAPORE' } as any
 
     const result = extractMrfPreviousStepResponseValue(field, previousResponse)
 
@@ -35,6 +38,9 @@ describe('extractMrfPreviousStepResponseValue', () => {
   })
 
   it('should return a file object for Attachment if buffer is provided', () => {
+    const mockFile = new File([''], 'file.txt')
+    vi.mocked(bufferToFile).mockReturnValue(mockFile)
+
     const field: FormFieldDto = { fieldType: BasicField.Attachment } as any
     const previousResponse: FieldResponseV3 = {
       answer: { answer: 'file.txt' } as AttachmentFieldResponseV3,
@@ -47,7 +53,7 @@ describe('extractMrfPreviousStepResponseValue', () => {
       buffer,
     )
 
-    expect(result).toEqual({ buffer, name: 'file.txt' })
+    expect(result).toEqual(mockFile)
   })
 
   it('should return undefined for Attachment if buffer is not provided', () => {

--- a/frontend/src/features/form/utils/extractMrfPreviousStepResponseValue.ts
+++ b/frontend/src/features/form/utils/extractMrfPreviousStepResponseValue.ts
@@ -1,3 +1,4 @@
+import { CLIENT_RADIO_OTHERS_INPUT_VALUE } from '~shared/constants'
 import { CountryRegion } from '~shared/constants/countryRegion'
 import {
   AttachmentFieldResponseV3,
@@ -7,7 +8,7 @@ import {
 } from '~shared/types'
 
 import bufferToFile from '~utils/bufferToFile'
-import { FormFieldValue } from '~templates/Field'
+import { FormFieldValue, RadioFieldValues } from '~templates/Field'
 
 /**
  * Retrieves the filled value for a field from the previous step response for MRF.
@@ -42,6 +43,13 @@ export const extractMrfPreviousStepResponseValue = (
             return bufferToFile(fileData, fileName)
           }
           return
+        }
+        case BasicField.Radio: {
+          const radioAnswer = previousFieldResponse.answer as RadioFieldValues
+          if (radioAnswer.othersInput && !radioAnswer.value) {
+            radioAnswer.value = CLIENT_RADIO_OTHERS_INPUT_VALUE
+          }
+          return radioAnswer
         }
         default:
           return previousFieldResponse.answer as FormFieldValue


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

**Context**
MRF submissions with preceding submitted data containing a radio "others" field is causing subsequent steps to fail because of BE validation error. This is because during rehydration of radio input data, value is not being rehydrated correctly
Correct value:  {value: 'OTHERS', othersInput: 'custom text'}
Current value: {value: '', othersInput: 'custom text'}  :arrow_left: This fails BE validation due to ''
This was fixed before [here](https://github.com/opengovsg/FormSG/pull/8699), but is back since we made some changes regarding handling defaultValues and this might be been missed out during that implementation.

## Solution
<!-- How did you solve the problem? -->

1. Re-implementation of https://github.com/opengovsg/FormSG/pull/8699
2. Regression unit tests have also been included

## Tests
**Field shown on logic based on radio field 'others' option**
<!-- What tests should be run to confirm functionality? -->
- [ ] Create an MRF form, Include a radio field with 'others' enabled, and a short text field
- [ ] Add logic that IF 'others' is selected, SHOW short text field
- [ ] Add a 2 step workflow assigning radio field to step 1, short text field to step 2
- [ ] Make the form public and make a step 1 submission with 'others' selected
- [ ] Attempt to make a step 2 submission, observe that the short text field is visible consistently when being interacted on (doesn't hide away)
- [ ] Successfully submit step 2

