### PR TITLE
feat: remove betaFlag from signature field in basic field list drawer

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -20,7 +20,6 @@ import {
   CREATE_FIELD_PERSONAL_DROP_ID,
 } from '~features/admin-form/create/builder-and-design/constants'
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
-import { useUser } from '~features/user/queries'
 
 import { useCreateTabForm } from '../../../../builder-and-design/useCreateTabForm'
 import { DraggableBasicFieldListOption } from '../FieldListOption'
@@ -29,7 +28,6 @@ import { FieldSection } from './FieldSection'
 import { filterFieldsBySearchValue } from './utils'
 
 export const BasicFieldPanel = ({ searchValue }: { searchValue: string }) => {
-  const { user } = useUser()
   const { isLoading } = useCreateTabForm()
 
   const isSignatureFieldEnabled = useFeatureIsOn(featureFlags.signatureField)

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -180,7 +180,7 @@ export const BasicFieldPanel = ({ searchValue }: { searchValue: string }) => {
                     const shouldDisableField = isLoading
 
                     if (
-                      fieldType == BasicField.Signature &&
+                      fieldType === BasicField.Signature &&
                       !isSignatureFieldEnabled
                     )
                       return null

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -183,8 +183,7 @@ export const BasicFieldPanel = ({ searchValue }: { searchValue: string }) => {
 
                     if (
                       fieldType == BasicField.Signature &&
-                      (!isSignatureFieldEnabled ||
-                        !user?.betaFlags?.signatureField)
+                      !isSignatureFieldEnabled
                     )
                       return null
                     return (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Signature field is still under beta flag which requires form team to whitelist specific users in order to allow them usage of feature. As part of moving feature to an open beta, we are removing the need for manual whitelisting.

## Solution
<!-- How did you solve the problem? -->

Remove beta flag for signature field display in the field list drawer of the form builder.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

**Able to create a field with signature field without beta access**
- [ ] Ensure that you do not have user-level `signatureField` beta flag present, or set to true
- [ ] Create a form and successfully add a signature field to the form
- [ ] Successfully attempt a submission for the form

**Regression test for feature flag**
- [ ] Turn off `signature-field` feature flag on growthbook for the testing env (staging)
- [ ] Observe that you are longer able to see the signature field under the basic field field list drawer
- [ ] Turn on `signature-field` feature flag, observe that the signature field is displayed again in the drawer 
