### PR TITLE
feat(i18n): extract text from settings page (except singpass tab)

### DIFF
--- a/frontend/src/features/admin-form/settings/components/DataClassificationInfoBox.tsx
+++ b/frontend/src/features/admin-form/settings/components/DataClassificationInfoBox.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { BiSolidInfoCircle } from 'react-icons/bi'
 import { Flex, Icon } from '@chakra-ui/react'
 
@@ -5,6 +6,9 @@ import { useMdComponents } from '~hooks/useMdComponents'
 import { MarkdownText } from '~components/MarkdownText'
 
 export default function DataClassificationInfoBox() {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.general',
+  })
   const mdComponents = useMdComponents({})
 
   return (
@@ -15,9 +19,9 @@ export default function DataClassificationInfoBox() {
         fontSize="1.5rem"
         mr="0.5rem"
       />
-      <MarkdownText
-        components={mdComponents}
-      >{`All forms support up to Confidential (Cloud-Eligible) and Sensitive (High) data.`}</MarkdownText>
+      <MarkdownText components={mdComponents}>
+        {t('dataClassificationInfo')}
+      </MarkdownText>
     </Flex>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/EmailNotificationsHeader.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailNotificationsHeader.tsx
@@ -8,14 +8,17 @@ import InlineMessage from '~components/InlineMessage'
 import { MarkdownText } from '~components/MarkdownText'
 
 const MRFAdvertisingInfobox = () => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.emailNotifications',
+  })
   const mdComponents = useMdComponents()
 
   return (
     <Flex bg="primary.100" p="1rem" marginBottom="40px">
       <Icon as={BiBulb} color="primary.500" fontSize="1.5rem" mr="0.5rem" />
-      <MarkdownText
-        components={mdComponents}
-      >{`Require routing and approval? [Check out our new feature: Multi-respondent forms!](${GUIDE_FORM_MRF})`}</MarkdownText>
+      <MarkdownText components={mdComponents}>
+        {t('mrfAdvertising', { url: GUIDE_FORM_MRF })}
+      </MarkdownText>
     </Flex>
   )
 }

--- a/frontend/src/features/admin-form/settings/components/EmailNotificationsSection/StatusTrackerToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/EmailNotificationsSection/StatusTrackerToggle.tsx
@@ -12,7 +12,9 @@ import { useMutateFormSettings } from '../../mutations'
 import { useAdminFormSettings } from '../../queries'
 
 export const StatusTrackerToggle = (): JSX.Element => {
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.emailNotifications',
+  })
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings<MultirespondentFormSettings>()
 
@@ -26,11 +28,9 @@ export const StatusTrackerToggle = (): JSX.Element => {
   const ToggleDescription = () => {
     return (
       <Text textStyle="body-2" color="secondary.400">
-        {t(
-          'features.adminForm.settings.emailNotifications.section.regular.statusTrackerDescription',
-        )}{' '}
+        {t('section.regular.statusTrackerDescription')}{' '}
         <Link target="_blank" href={STATUS_TRACKER_PREVIEW_LINK}>
-          here
+          {t('section.regular.statusTrackerLink')}
         </Link>{' '}
         <Link target="_blank" href={STATUS_TRACKER_PREVIEW_LINK}>
           <Icon as={BiLinkExternal} verticalAlign="middle" />
@@ -51,9 +51,7 @@ export const StatusTrackerToggle = (): JSX.Element => {
       <Toggle
         isLoading={mutateMrfStatusTracker.isLoading}
         isChecked={hasStatusTracker}
-        label={t(
-          'features.adminForm.settings.emailNotifications.section.regular.statusTrackerInfo',
-        )}
+        label={t('section.regular.statusTrackerInfo')}
         onChange={() => handleToggleStatusTracker()}
       />
       <ToggleDescription />

--- a/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormDetailsSection.tsx
@@ -1,5 +1,6 @@
 import { KeyboardEventHandler, useCallback } from 'react'
 import { Controller, RegisterOptions, useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { FormControl, Skeleton, Stack } from '@chakra-ui/react'
 import { isEmpty } from 'lodash'
 
@@ -30,6 +31,9 @@ interface FormTitleInputProps {
 export const FormTitleInput = ({
   initialTitle,
 }: FormTitleInputProps): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.general',
+  })
   const {
     control,
     handleSubmit,
@@ -71,7 +75,7 @@ export const FormTitleInput = ({
 
   return (
     <FormControl isInvalid={!isEmpty(errors)}>
-      <FormLabel isRequired>Form name</FormLabel>
+      <FormLabel isRequired>{t('formName')}</FormLabel>
 
       <Controller<{ title: string }>
         control={control}

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -107,7 +107,9 @@ export const FormEmailSection = ({
   const { user } = useUser()
   const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
 
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.emailNotifications',
+  })
   const initialEmailSet = useMemo(
     () => new Set(settings.emails),
     [settings.emails],
@@ -136,8 +138,6 @@ export const FormEmailSection = ({
 
   const isEmailMode = settings.responseMode === FormResponseMode.Email
 
-  const DESCRIPTION_TEXT = `All email addresses below will be notified. Ensure that inboxes can support the classification and sensitivity.`
-
   return (
     <>
       <FormProvider {...formMethods}>
@@ -145,12 +145,10 @@ export const FormEmailSection = ({
           <FormLabel
             isRequired={isEmailMode}
             useMarkdownForDescription
-            description={DESCRIPTION_TEXT}
+            description={t('section.regular.labelDescription')}
             isHighContrast={isHighContrast}
           >
-            {t(
-              'features.adminForm.settings.emailNotifications.section.regular.label',
-            )}
+            {t('section.regular.label')}
           </FormLabel>
           <AdminEmailRecipientsInput
             onSubmit={handleSubmitEmails}
@@ -163,9 +161,7 @@ export const FormEmailSection = ({
               mt="0.5rem"
               opacity="1"
             >
-              {t(
-                'features.adminForm.settings.emailNotifications.section.regular.description',
-              )}
+              {t('section.regular.description')}
             </FormLabel.Description>
           ) : null}
         </FormControl>

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormLogicTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormLogicTranslationContainer.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Divider, Flex, FormControl, Text } from '@chakra-ui/react'
 
 import { Language, PreventSubmitLogicDto } from '~shared/types'
@@ -18,6 +19,9 @@ export const FormLogicTranslationContainer = ({
   unicodeLocale,
   formLogics,
 }: TableTranslationContainerProps) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.multiLanguage',
+  })
   const { register } = useFormContext<TranslationInput>()
 
   return (
@@ -44,7 +48,7 @@ export const FormLogicTranslationContainer = ({
               fontWeight="600"
               mb="1rem"
             >
-              Disable Submission
+              {t('formLogic.disableSubmission')}
             </Text>
             <Flex direction="column" width="100%">
               <Flex alignItems="flex-start" mb="2rem">

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormMultiLanguageToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormMultiLanguageToggle.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiEditAlt } from 'react-icons/bi'
 import { GoEye, GoEyeClosed } from 'react-icons/go'
 import { useParams, useSearchParams } from 'react-router-dom'
@@ -41,6 +42,9 @@ const LanguageTranslationRow = ({
   isDefaultLanguage,
   isLast,
 }: LanguageTranslationRowProps): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.multiLanguage',
+  })
   const { formId } = useParams()
   const { data: settings } = useAdminFormSettings()
   const [, setSearchParams] = useSearchParams()
@@ -99,7 +103,7 @@ const LanguageTranslationRow = ({
         </Flex>
         {!isDefaultLanguage && (
           <HStack spacing="0.75rem">
-            <Tooltip label="Hide/show language on form">
+            <Tooltip label={t('languageRow.hideShowTooltip')}>
               <IconButton
                 variant="clear"
                 icon={
@@ -114,7 +118,7 @@ const LanguageTranslationRow = ({
                 onClick={() => handleToggleSupportedLanguage(unicodeLocale)}
               />
             </Tooltip>
-            <Tooltip label="Edit translation">
+            <Tooltip label={t('languageRow.editTooltip')}>
               <IconButton
                 variant="clear"
                 icon={<BiEditAlt width="44px" />}
@@ -160,6 +164,9 @@ const LanguageTranslationSection = ({
 }
 
 export const FormMultiLanguageToggle = (): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.multiLanguage',
+  })
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -196,8 +203,8 @@ export const FormMultiLanguageToggle = (): JSX.Element => {
       <Toggle
         onChange={handleToggleMultiLang}
         isChecked={hasMultiLang}
-        label="Enable multi-language"
-        description="This will allow respondents to select a language they prefer to view your form in. Translations are not automated."
+        label={t('toggle.label')}
+        description={t('toggle.description')}
       />
       {settings && hasMultiLang ? (
         <Skeleton isLoaded={true}>

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
@@ -1,4 +1,5 @@
 import { FieldError, useFormContext } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Divider, Flex, FormControl, Text } from '@chakra-ui/react'
 
 import { Language } from '~shared/types'
@@ -30,6 +31,9 @@ export const TableTranslationContainer = ({
   unicodeLocale,
   errors,
 }: TableTranslationContainerProps) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.multiLanguage',
+  })
   const { register } = useFormContext<TranslationInput>()
 
   return (
@@ -65,7 +69,7 @@ export const TableTranslationContainer = ({
               fontWeight="600"
               mb="1rem"
             >
-              Column
+              {t('table.column')}
             </Text>
             <Flex direction="column" width="100%">
               <Flex alignItems="flex-start" mb="2rem">

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationListSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationListSection.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiArrowBack, BiCheck, BiError, BiGitMerge } from 'react-icons/bi'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import {
@@ -62,6 +63,9 @@ export const QuestionRow = ({
   isEndPage = false,
   isFormLogic = false,
 }: QuestionRowProps): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.multiLanguage',
+  })
   const [, setSearchParams] = useSearchParams()
 
   const isTranslationRowDisabled = isMyInfoField
@@ -81,7 +85,7 @@ export const QuestionRow = ({
   return (
     <Flex direction="row">
       <Tooltip
-        label={isMyInfoField ? 'Myinfo fields cannot be translated' : ''}
+        label={isMyInfoField ? t('myinfoTooltip') : ''}
         hasArrow
         placement="top"
       >
@@ -176,6 +180,9 @@ export const TranslationListSection = ({
 }: {
   language: string
 }): JSX.Element | null => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.multiLanguage',
+  })
   const { formId } = useParams()
   const { data: form, isLoading } = useAdminForm()
   const navigate = useNavigate()
@@ -342,7 +349,7 @@ export const TranslationListSection = ({
             <>
               <QuestionRow
                 key="Instructions"
-                questionTitle="Instructions"
+                questionTitle={t('instructions')}
                 icon={BxsDockTop}
                 isMyInfoField={false}
                 hasTranslations={hasStartPageTranslations}
@@ -380,7 +387,7 @@ export const TranslationListSection = ({
             <>
               <QuestionRow
                 key="Form Logic"
-                questionTitle="Logic"
+                questionTitle={t('logic')}
                 icon={BiGitMerge}
                 isMyInfoField={false}
                 hasTranslations={hasFormLogicTranslations}

--- a/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationSection.tsx
@@ -1,4 +1,5 @@
 import { FormProvider, useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { BiChevronLeft } from 'react-icons/bi'
 import { Button, Flex, Skeleton } from '@chakra-ui/react'
 
@@ -40,13 +41,15 @@ export const TranslationSection = ({
   isEndPageTranslations = false,
   isFormLogicTranslations = false,
 }: TranslationSectionProps) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.multiLanguage',
+  })
   const { data: form, isLoading } = useAdminForm()
   const toast = useToast({ status: 'danger' })
 
   if (!isLoading && !form) {
     toast({
-      description:
-        'There was an error retrieving your form. Please try again later.',
+      description: t('retrievalError'),
     })
   }
 
@@ -86,7 +89,7 @@ export const TranslationSection = ({
           onClick={handleOnBackClick}
           marginRight="2.25rem"
         >
-          Back to all questions
+          {t('backToQuestions')}
         </Button>
       </Flex>
       <FormProvider {...methods}>
@@ -121,7 +124,7 @@ export const TranslationSection = ({
             />
           )}
           <Button variant="solid" width="30%" onClick={handleOnSaveClick}>
-            Save Translation
+            {t('saveTranslation')}
           </Button>
         </Flex>
       </FormProvider>

--- a/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyActivationModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { UseDisclosureReturn } from '@chakra-ui/react'
 
 import { FormStatus } from '~shared/types/form/form'
@@ -16,6 +17,9 @@ export const SecretKeyActivationModal = ({
   isOpen,
   publicKey,
 }: SecretKeyActivationModalProps): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.general.secretKeyModal',
+  })
   const { mutateFormStatus } = useMutateFormSettings()
 
   const onSubmit = () => {
@@ -29,8 +33,8 @@ export const SecretKeyActivationModal = ({
       onClose={onClose}
       isOpen={isOpen}
       publicKey={publicKey}
-      modalActionText="Activate your form"
-      submitButtonText="Activate form"
+      modalActionText={t('activationTitle')}
+      submitButtonText={t('activateButton')}
       onSubmit={onSubmit}
       hasAck
     />

--- a/frontend/src/features/admin-form/settings/components/SecretKeyFormModal.tsx
+++ b/frontend/src/features/admin-form/settings/components/SecretKeyFormModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { BiRightArrowAlt, BiUpload } from 'react-icons/bi'
 import {
   Container,
@@ -49,6 +50,9 @@ export const SecretKeyFormModal = ({
   onSubmit,
   hasAck = false,
 }: SecretKeyFormModalProps): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.general.secretKeyModal',
+  })
   const {
     dragging,
     errors,
@@ -102,22 +106,20 @@ export const SecretKeyFormModal = ({
                 mb="1rem"
                 isDisabled={isLoading}
               >
-                <FormLabel>Enter or upload Secret Key</FormLabel>
+                <FormLabel>{t('secretKeyLabel')}</FormLabel>
                 <Stack direction="row" spacing="0.5rem">
                   <Input
                     type="password"
                     {...register(SECRET_KEY_NAME, {
-                      required: "Please enter the form's secret key",
+                      required: t('secretKeyRequired'),
                       pattern: {
                         value: SECRET_KEY_REGEX,
-                        message: 'The secret key provided is invalid',
+                        message: t('secretKeyInvalid'),
                       },
                       setValueAs: (v) => v.trim(),
                     })}
                     placeholder={
-                      dragging
-                        ? 'Drop your Secret Key here'
-                        : 'Enter or drop your Secret Key to continue'
+                      dragging ? t('dropSecretKey') : t('enterOrDropSecretKey')
                     }
                     onDragEnter={handleDragEnter}
                     onDragLeave={handleDragLeave}
@@ -143,8 +145,7 @@ export const SecretKeyFormModal = ({
                       required: true,
                     })}
                   >
-                    If I lose my key, I will not be able to activate my form and
-                    all my responses will be lost permanently
+                    {t('acknowledgement')}
                   </Checkbox>
                 </FormControl>
               ) : null}

--- a/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookUrlInput.tsx
+++ b/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookUrlInput.tsx
@@ -19,7 +19,9 @@ import { useMutateFormSettings } from '../../mutations'
 import { useAdminFormSettings } from '../../queries'
 
 export const WebhookUrlInput = (): JSX.Element => {
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.webhooks',
+  })
   const { data: settings, isLoading } = useAdminFormSettings()
   const { mutateFormWebhookUrl } = useMutateFormSettings()
   const {
@@ -62,7 +64,7 @@ export const WebhookUrlInput = (): JSX.Element => {
           protocols: ['https'],
           require_protocol: true,
         }) ||
-        'Please enter a valid URL (starting with https://)'
+        t('input.validationError')
       )
     },
   })
@@ -88,12 +90,8 @@ export const WebhookUrlInput = (): JSX.Element => {
       isReadOnly={mutateFormWebhookUrl.isLoading}
       isInvalid={!!errors.url}
     >
-      <FormLabel
-        description={t(
-          'features.adminForm.settings.webhooks.input.description',
-        )}
-      >
-        {t('features.adminForm.settings.webhooks.input.label')}
+      <FormLabel description={t('input.description')}>
+        {t('input.label')}
       </FormLabel>
       <Skeleton isLoaded={!isLoading}>
         <InputGroup>
@@ -103,7 +101,7 @@ export const WebhookUrlInput = (): JSX.Element => {
             </InputRightElement>
           ) : null}
           <Input
-            placeholder="https://your-webhook.com/url"
+            placeholder={t('input.placeholder')}
             onKeyDown={handleWebhookUrlEnterKeyDown}
             {...urlRegister}
             ref={mergedRefs}

--- a/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksUnsupportedMsg.tsx
+++ b/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksUnsupportedMsg.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Flex, Text } from '@chakra-ui/react'
 
 import { GUIDE_WEBHOOKS } from '~constants/links'
@@ -6,17 +7,19 @@ import Link from '~components/Link'
 import { SettingsUnsupportedSvgr } from '~features/admin-form/settings/svgrs/SettingsUnsupportedSvgr'
 
 export const WebhooksUnsupportedMsg = (): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.settings.webhooks',
+  })
+
   return (
     <Flex justify="center" flexDir="column" textAlign="center">
       <Text textStyle="h2" as="h2" color="primary.500" mb="1rem">
-        Webhooks are only available in storage mode
+        {t('unsupportedMessage.title')}
       </Text>
       <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
-        Webhooks are useful for agencies who wish to have form response data
-        sent directly to existing IT systems. This feature is only available in
-        storage mode.{' '}
+        {t('unsupportedMessage.description')}{' '}
         <Link isExternal href={GUIDE_WEBHOOKS}>
-          Read more about webhooks
+          {t('unsupportedMessage.learnMore')}
         </Link>
       </Text>
       <SettingsUnsupportedSvgr />

--- a/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
@@ -1,5 +1,7 @@
 export const enSG = {
   title: 'Email notifications',
+  mrfAdvertising:
+    'Require routing and approval? [Check out our new feature: Multi-respondent forms!]({url})',
   header: {
     closeFormFirst:
       'To change email recipients, close your form to new responses.',
@@ -31,10 +33,13 @@ export const enSG = {
     },
     regular: {
       label: 'Notifications for new responses',
+      labelDescription:
+        'All email addresses below will be notified. Ensure that inboxes can support the classification and sensitivity.',
       info: 'Allow respondents to receive a copy of their submission',
       description: 'Separate multiple email addresses with a comma',
       statusTrackerInfo: 'Allow respondents to track their submission status',
       statusTrackerDescription: 'View a sample status tracking link',
+      statusTrackerLink: 'here',
     },
   },
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
@@ -3,6 +3,7 @@ import { type HasTitle } from '..'
 export * from './en-sg'
 
 export interface EmailNotifications extends HasTitle {
+  mrfAdvertising: string
   header: {
     closeFormFirst: string
     noEmailsForPaymentForms: string
@@ -31,10 +32,12 @@ export interface EmailNotifications extends HasTitle {
     }
     regular: {
       label: string
+      labelDescription: string
       info: string
       description: string
       statusTrackerInfo: string
       statusTrackerDescription: string
+      statusTrackerLink: string
     }
   }
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
@@ -1,5 +1,6 @@
 import { enSG as emailNotifications } from './email-notifications'
 import { enSG as general } from './general'
+import { enSG as multiLanguage } from './multi-language'
 import { enSG as payments } from './payments'
 import { enSG as webhooks } from './webhooks'
 
@@ -11,4 +12,5 @@ export const enSG = {
   emailNotifications,
   webhooks,
   payments,
+  multiLanguage,
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -42,4 +42,18 @@ export const enSG = {
     description:
       'You will receive a maximum of one email per form, per day if there are any issues reported.',
   },
+  formName: 'Form name',
+  dataClassificationInfo:
+    'All forms support up to Confidential (Cloud-Eligible) and Sensitive (High) data.',
+  secretKeyModal: {
+    activationTitle: 'Activate your form',
+    activateButton: 'Activate form',
+    secretKeyLabel: 'Enter or upload Secret Key',
+    secretKeyRequired: "Please enter the form's secret key",
+    secretKeyInvalid: 'The secret key provided is invalid',
+    dropSecretKey: 'Drop your Secret Key here',
+    enterOrDropSecretKey: 'Enter or drop your Secret Key to continue',
+    acknowledgement:
+      'If I lose my key, I will not be able to activate my form and all my responses will be lost permanently',
+  },
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
@@ -38,4 +38,16 @@ export interface General extends HasTitle {
     label: string
     description: string
   }
+  formName: string
+  dataClassificationInfo: string
+  secretKeyModal: {
+    activationTitle: string
+    activateButton: string
+    secretKeyLabel: string
+    secretKeyRequired: string
+    secretKeyInvalid: string
+    dropSecretKey: string
+    enterOrDropSecretKey: string
+    acknowledgement: string
+  }
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/index.ts
@@ -1,5 +1,6 @@
 import { EmailNotifications } from './email-notifications'
 import { General } from './general'
+import { MultiLanguage } from './multi-language'
 import { Payments } from './payments'
 import { Webhooks } from './webhooks'
 
@@ -15,4 +16,5 @@ export interface Settings {
   emailNotifications: EmailNotifications
   webhooks: Webhooks
   payments: Payments
+  multiLanguage: MultiLanguage
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/multi-language/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/multi-language/en-sg.ts
@@ -1,0 +1,27 @@
+import { MultiLanguage } from './index'
+
+export const enSG: MultiLanguage = {
+  title: 'Multi-language',
+  toggle: {
+    label: 'Enable multi-language',
+    description:
+      'This will allow respondents to select a language they prefer to view your form in. Translations are not automated.',
+  },
+  languageRow: {
+    hideShowTooltip: 'Hide/show language on form',
+    editTooltip: 'Edit translation',
+  },
+  instructions: 'Instructions',
+  logic: 'Logic',
+  myinfoTooltip: 'Myinfo fields cannot be translated',
+  backToQuestions: 'Back to all questions',
+  saveTranslation: 'Save Translation',
+  retrievalError:
+    'There was an error retrieving your form. Please try again later.',
+  formLogic: {
+    disableSubmission: 'Disable Submission',
+  },
+  table: {
+    column: 'Column',
+  },
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/multi-language/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/multi-language/index.ts
@@ -1,0 +1,25 @@
+export * from './en-sg'
+
+export interface MultiLanguage {
+  title: string
+  toggle: {
+    label: string
+    description: string
+  }
+  languageRow: {
+    hideShowTooltip: string
+    editTooltip: string
+  }
+  instructions: string
+  logic: string
+  myinfoTooltip: string
+  backToQuestions: string
+  saveTranslation: string
+  retrievalError: string
+  formLogic: {
+    disableSubmission: string
+  }
+  table: {
+    column: string
+  }
+}

--- a/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
@@ -4,9 +4,17 @@ export const enSG = {
     label: 'Endpoint URL',
     description:
       'FormSG will POST encrypted form responses in real-time to the HTTPS endpoint specified here. Ensure that your external system can support the classification and sensitivity.',
+    placeholder: 'https://your-webhook.com/url',
+    validationError: 'Please enter a valid URL (starting with https://)',
   },
   retry: {
     label: 'Enable retries',
     description: `Your system must meet certain requirements before retries can be safely enabled. [Learn more]({url})`,
+  },
+  unsupportedMessage: {
+    title: 'Webhooks are only available in storage mode',
+    description:
+      'Webhooks are useful for agencies who wish to have form response data sent directly to existing IT systems. This feature is only available in storage mode.',
+    learnMore: 'Read more about webhooks',
   },
 }

--- a/frontend/src/i18n/locales/features/admin-form/settings/webhooks/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/webhooks/index.ts
@@ -6,9 +6,16 @@ export interface Webhooks extends HasTitle {
   input: {
     label: string
     description: string
+    placeholder: string
+    validationError: string
   }
   retry: {
     label: string
     description: string
+  }
+  unsupportedMessage: {
+    title: string
+    description: string
+    learnMore: string
   }
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Extracted text for more i18n coverage in settings and secret key page
- Closes #8453 
- Closes #8452 
- Closes #8410
- Closes #8448
- Closes #8449
- Closes #8445

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
