### PR TITLE
feat(i18n): extract text from admin results page

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -113,7 +113,9 @@ export const IndividualResponseNavbar = (): JSX.Element => {
     return `..?${searchParams}`
   }, [lastNavPage, lastNavSubmissionId])
 
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.individualResponse',
+  })
 
   const { user } = useUser()
   const gb = useGrowthBook()
@@ -159,20 +161,20 @@ export const IndividualResponseNavbar = (): JSX.Element => {
           to={backLink}
         >
           <Icon as={BiLeftArrowAlt} fontSize="1.5rem" mr="0.5rem" />
-          {t('features.adminForm.responses.individualResponse.backToList')}
+          {t('backToList')}
         </Link>
       </Flex>
       <Flex gridArea="respondent" justify="center" align="center">
         <Skeleton isLoaded={!isLoading}>
           <Stack direction="row" justify="center" align="center">
             <Text textStyle="h2" as="h2">
-              {t('features.common.response')}
+              {t('features.common.response', { ns: 'translation', keyPrefix: '' })}
               {currentResponseNumber ? ` #${currentResponseNumber}` : ''}
             </Text>
             {isAdminPrintPdfEnabled && (
               <Box>
                 <IconButton
-                  aria-label="Print"
+                  aria-label={t('individualResponseNavbar.printAriaLabel')}
                   icon={<FaRegFilePdf />}
                   isLoading={isLoading || isFormLoading}
                   onClick={() => {
@@ -201,17 +203,13 @@ export const IndividualResponseNavbar = (): JSX.Element => {
           isDisabled={!prevSubmissionId || isAnyFetching}
           onClick={handleNavigatePrev}
           icon={<BiChevronLeft />}
-          aria-label={t(
-            'features.adminForm.responses.individualResponse.previousSubmission',
-          )}
+          aria-label={t('previousSubmission')}
         />
         <IconButton
           isDisabled={!nextSubmissionId || isAnyFetching}
           onClick={handleNavigateNext}
           icon={<BiChevronRight />}
-          aria-label={t(
-            'features.adminForm.responses.individualResponse.nextSubmission',
-          )}
+          aria-label={t('nextSubmission')}
         />
       </ButtonGroup>
     </Grid>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -113,7 +113,9 @@ const StackRow = ({
 }
 
 export const IndividualResponsePage = (): JSX.Element => {
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.individualResponse',
+  })
   const { submissionId, formId } = useParams()
   if (!submissionId) throw new Error('Missing submissionId')
   if (!formId) throw new Error('Missing formId')
@@ -168,12 +170,8 @@ export const IndividualResponsePage = (): JSX.Element => {
     return (
       <SecretKeyVerification
         heroSvg={<FormActivationSvg />}
-        ctaText={t(
-          'features.adminForm.responses.individualResponse.secretKeyVerification.ctaText',
-        )}
-        label={t(
-          'features.adminForm.responses.individualResponse.secretKeyVerification.label',
-        )}
+        ctaText={t('secretKeyVerification.ctaText')}
+        label={t('secretKeyVerification.label')}
       />
     )
 
@@ -210,15 +208,15 @@ export const IndividualResponsePage = (): JSX.Element => {
       >
         <Stack bg="primary.100" p="1.5rem" textStyle="monospace">
           <StackRow
-            label="Response ID"
+            label={t('labels.responseId')}
             value={submissionId}
             isLoading={isLoading}
             isError={isError}
           />
           <StackRow
-            label={isMrf ? MRF_RESPONSE_TIMESTAMP_LABEL : 'Timestamp'}
+            label={isMrf ? MRF_RESPONSE_TIMESTAMP_LABEL : t('labels.timestamp')}
             value={
-              data?.submissionTime ?? t('features.common.loadingWithEllipsis')
+              data?.submissionTime ?? t('features.common.loadingWithEllipsis', { ns: 'translation', keyPrefix: '' })
             }
             isLoading={isLoading}
             isError={isError}
@@ -238,11 +236,14 @@ export const IndividualResponsePage = (): JSX.Element => {
                   workflowCurrentStepNumber === undefined ||
                   workflowNumTotalSteps === undefined
                     ? '-'
-                    : getPendingResponseAtString({
-                        workflowStatus,
-                        workflowCurrentStepNumber,
-                        workflowNumTotalSteps,
-                      })
+                    : getPendingResponseAtString(
+                        {
+                          workflowStatus,
+                          workflowCurrentStepNumber,
+                          workflowNumTotalSteps,
+                        },
+                        t,
+                      )
                 }
                 isLoading={isLoading}
                 isError={isError}
@@ -266,7 +267,7 @@ export const IndividualResponsePage = (): JSX.Element => {
                 textStyle="subhead-1"
                 py={{ base: '0', md: '0.25rem' }}
               >
-                {t('features.common.attachments')}:
+                {t('features.common.attachments', { ns: 'translation', keyPrefix: '' })}:
               </Text>
               <Skeleton isLoaded={!isLoading && !isError}>
                 <Button
@@ -281,10 +282,9 @@ export const IndividualResponsePage = (): JSX.Element => {
                     )
                   }
                 >
-                  {t(
-                    'features.adminForm.responses.individualResponse.downloadAttachmentsAsZip',
-                    { attachmentSize: attachmentDownloadUrls.size },
-                  )}
+                  {t('downloadAttachmentsAsZip', {
+                    attachmentSize: attachmentDownloadUrls.size,
+                  })}
                 </Button>
               </Skeleton>
             </Stack>
@@ -292,9 +292,7 @@ export const IndividualResponsePage = (): JSX.Element => {
           {form?.responseMode === FormResponseMode.Multirespondent &&
             user?.betaFlags?.mrfAdminSubmissionKey && (
               <StackRow
-                label={t(
-                  'features.adminForm.responses.individualResponse.responseLinkLabel',
-                )}
+                label={t('responseLinkLabel')}
                 value={responseLinkWithKey}
                 isLoading={isLoading}
                 isError={isError}

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PaymentSection.tsx
@@ -20,41 +20,37 @@ export const PaymentSection = ({
   payment,
   formId,
 }: PaymentSectionProps): JSX.Element | null => {
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.individualResponse',
+  })
 
   if (!payment) return null
 
   const paymentDataMap = keyBy(
-    getPaymentDataView(window.location.origin, payment, formId),
+    getPaymentDataView(window.location.origin, payment, formId, t),
     'key',
   )
 
   const paymentTagProps =
     payment.status === PaymentStatus.Succeeded
       ? {
-          label: t('features.common.success'),
+          label: t('features.common.success', { ns: 'translation', keyPrefix: '' }),
           colorScheme: 'success',
           rightIcon: BiCheck,
         }
       : payment.status === PaymentStatus.PartiallyRefunded
         ? {
-            label: t(
-              'features.adminForm.responses.individualResponse.paymentSection.paymentStatusLabel.partiallyRefunded',
-            ),
+            label: t('paymentSection.paymentStatusLabel.partiallyRefunded'),
             colorScheme: 'secondary',
           }
         : payment.status === PaymentStatus.FullyRefunded
           ? {
-              label: t(
-                'features.adminForm.responses.individualResponse.paymentSection.paymentStatusLabel.fullyRefunded',
-              ),
+              label: t('paymentSection.paymentStatusLabel.fullyRefunded'),
               colorScheme: 'secondary',
             }
           : payment.status === PaymentStatus.Disputed
             ? {
-                label: t(
-                  'features.adminForm.responses.individualResponse.paymentSection.paymentStatusLabel.disputed',
-                ),
+                label: t('paymentSection.paymentStatusLabel.disputed'),
                 colorScheme: 'warning',
               }
             : undefined // The remaining options should never appear.
@@ -62,12 +58,12 @@ export const PaymentSection = ({
   const payoutTagProps =
     payment.payoutId || payment.payoutDate
       ? {
-          label: t('features.common.success'),
+          label: t('features.common.success', { ns: 'translation', keyPrefix: '' }),
           colorScheme: 'success',
           rightIcon: BiCheck,
         }
       : {
-          label: t('features.common.pending'),
+          label: t('features.common.pending', { ns: 'translation', keyPrefix: '' }),
           colorScheme: 'secondary',
         }
 
@@ -77,7 +73,10 @@ export const PaymentSection = ({
   return (
     <Flex flexDir="column" gap="4rem">
       <Flex flexDir="column" gap="1.25rem">
-        <PaymentDataHeader name="Payment" {...paymentTagProps} />
+        <PaymentDataHeader
+          name={t('paymentSection.headers.payment')}
+          {...paymentTagProps}
+        />
         <Flex flexDir="column" gap="0.75rem">
           <PaymentDataItem {...paymentDataMap['email']} />
           <PaymentDataItem {...paymentDataMap['receiptUrl']} isUrl />
@@ -95,7 +94,10 @@ export const PaymentSection = ({
         </Flex>
       </Flex>
       <Flex flexDir="column" gap="1.25rem">
-        <PayoutDataHeader name="Payout to bank account" {...payoutTagProps} />
+        <PayoutDataHeader
+          name={t('paymentSection.headers.payout')}
+          {...payoutTagProps}
+        />
         <Flex flexDir="column" gap="0.75rem">
           <PaymentDataItem {...paymentDataMap['payoutId']} isMonospace />
           <PaymentDataItem {...paymentDataMap['payoutDate']} />
@@ -118,7 +120,9 @@ function PayoutDataHeader({
   colorScheme,
   rightIcon,
 }: PaymentDataHeaderProps) {
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.individualResponse',
+  })
 
   return (
     <Flex gap="1rem" align="center">
@@ -127,12 +131,7 @@ function PayoutDataHeader({
           {name}
         </Text>
 
-        <Tooltip
-          placement="top"
-          label={t(
-            'features.adminForm.responses.individualResponse.paymentSection.tooltipLabel',
-          )}
-        >
+        <Tooltip placement="top" label={t('paymentSection.tooltipLabel')}>
           <Flex justify="center" align="center">
             <Icon as={BiInfoCircle} fontSize="1.25rem" ml="0.5rem" />
           </Flex>
@@ -186,16 +185,16 @@ function PaymentDataItem({
   isMonospace,
   isUrl,
 }: PaymentDataItemProps): JSX.Element {
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.individualResponse',
+  })
   return (
     <Flex flexDir={{ base: 'column', md: 'row' }} gap="0.25rem">
       <Text textStyle="subhead-1">{name}:</Text>
       <Text textStyle={isMonospace ? 'monospace' : undefined}>
         {isUrl ? (
           <Link href={value} target="_blank">
-            {t(
-              'features.adminForm.responses.individualResponse.paymentSection.paymentDataItemPdfDownloadLabel',
-            )}
+            {t('paymentSection.paymentDataItemPdfDownloadLabel')}
           </Link>
         ) : (
           value

--- a/frontend/src/features/admin-form/responses/ResponsesPage/ResponsesPage.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/ResponsesPage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { FormResponseMode } from '~shared/types/form'
 
 import { useToast } from '~hooks/useToast'
@@ -9,6 +10,9 @@ import { ResponsesPageSkeleton } from './ResponsesPageSkeleton'
 import { StorageResponsesTab } from './storage'
 
 export const ResponsesPage = (): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.responsesPage',
+  })
   const { data: form, isLoading } = useAdminForm()
 
   const toast = useToast({ status: 'danger' })
@@ -17,8 +21,7 @@ export const ResponsesPage = (): JSX.Element => {
 
   if (!form) {
     toast({
-      description:
-        'There was an error retrieving your form. Please try again later.',
+      description: t('errors.formRetrievalError'),
     })
     return <ResponsesPageSkeleton />
   }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useThrottle } from 'react-use'
 import { Box, MenuButton, Text, useDisclosure } from '@chakra-ui/react'
-import simplur from 'simplur'
 
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
 import { BxsChevronUp } from '~assets/icons/BxsChevronUp'
@@ -71,29 +70,34 @@ export const DownloadButton = (): JSX.Element => {
       onSuccess: ({ successCount, expectedCount, errorCount }) => {
         if (downloadParams?.responsesCount === 0) {
           toast({
-            description: 'No responses to download',
+            description: t('storage.unlockedResponses.downloadButton.toasts.noResponses'),
           })
           return
         }
         if (errorCount > 0) {
           toast({
             status: 'warning',
-            description: simplur`Partial success. ${successCount}/${expectedCount} ${[
+            description: t('storage.unlockedResponses.downloadButton.toasts.partialSuccess', {
               successCount,
-            ]}response[|s] [was|were] decrypted. ${errorCount} failed.`,
+              expectedCount,
+              count: successCount,
+              errorCount,
+            }),
           })
           return
         }
         toast({
-          description: simplur`Success. ${successCount}/${expectedCount} ${[
+          description: t('storage.unlockedResponses.downloadButton.toasts.success', {
             successCount,
-          ]}response[|s] [was|were] decrypted.`,
+            expectedCount,
+            count: successCount,
+          }),
         })
       },
       onError: () => {
         toast({
           status: 'danger',
-          description: 'Failed to start download. Please try again later.',
+          description: t('storage.unlockedResponses.downloadButton.toasts.failedToStart'),
         })
       },
       onSettled: (decryptResult) => {
@@ -138,17 +142,19 @@ export const DownloadButton = (): JSX.Element => {
     handleModalClose()
     toast({
       status: 'warning',
-      description: 'Responses download has been canceled.',
+      description: t('storage.unlockedResponses.downloadButton.toasts.downloadCanceled'),
     })
     setDownloadMetadata({ isCanceled: true })
-  }, [handleModalClose, toast])
+  }, [handleModalClose, t, toast])
 
   const handleAttachmentsDownloadCancel = useCallback(() => {
     resetDownload()
     setDownloadMetadata({ isCanceled: true })
   }, [resetDownload])
 
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.responsesPage',
+  })
 
   return (
     <>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { BiCheck } from 'react-icons/bi'
 import {
   Badge,
@@ -46,7 +46,9 @@ export const ConfirmationScreen = ({
   responsesCount,
 }: ConfirmationScreenProps): JSX.Element => {
   const isMobile = useIsMobile()
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.responsesPage',
+  })
 
   return (
     <>
@@ -54,9 +56,7 @@ export const ConfirmationScreen = ({
       <ModalHeader color="secondary.700" pr="4.5rem">
         <Wrap shouldWrapChildren direction="row" align="center">
           <Text>
-            {t(
-              'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.title',
-            )}
+            {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.title')}
           </Text>
           <Badge w="fit-content" colorScheme="success">
             {t('features.common.betaBadgeLabel')}
@@ -66,59 +66,46 @@ export const ConfirmationScreen = ({
       <ModalBody whiteSpace="pre-wrap" color="secondary.500">
         <Stack spacing="1rem">
           <Text>
-            Separate zip files will be downloaded, <b>one for each response</b>.
-            You can adjust the date range before proceeding.
+            <Trans
+              i18nKey="storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.description"
+              t={t}
+              components={{ b: <b /> }}
+            />
             <br />
             <br />
             <b>
-              {t(
-                'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.numberOfResponsesAndAttachments',
-              )}
+              {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.numberOfResponsesAndAttachments')}
               :
             </b>{' '}
             {responsesCount.toLocaleString()}
             <br />
             <b>
-              {t(
-                'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.estimatedTime',
-              )}
+              {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.estimatedTime')}
               :
             </b>{' '}
-            {t(
-              'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.estimatedTimeReference',
-            )}
+            {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.estimatedTimeReference')}
           </Text>
           <InlineMessage>
             <Stack>
               <Text textStyle="subhead-1">
-                {t(
-                  'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.title',
-                )}
+                {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.title')}
               </Text>
               <List>
                 <InlineTextListItem>
-                  {t(
-                    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.doNotUseIE',
-                  )}
+                  {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.doNotUseIE')}
                 </InlineTextListItem>
                 <InlineTextListItem>
-                  {t(
-                    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.ensureStrongNetworkConnectivity',
-                  )}
+                  {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.ensureStrongNetworkConnectivity')}
                 </InlineTextListItem>
                 <InlineTextListItem>
-                  {t(
-                    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.ensureEnoughDiskSpace',
-                  )}
+                  {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.ensureEnoughDiskSpace')}
                 </InlineTextListItem>
               </List>
             </Stack>
           </InlineMessage>
           {responsesCount === 0 && (
             <InlineMessage variant="warning">
-              {t(
-                'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.noResponsesInSelectedDateRange',
-              )}
+              {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.noResponsesInSelectedDateRange')}
             </InlineMessage>
           )}
         </Stack>
@@ -135,9 +122,7 @@ export const ConfirmationScreen = ({
             isLoading={isDownloading}
             isDisabled={responsesCount === 0}
           >
-            {t(
-              'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.startDownload',
-            )}
+            {t('storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.startDownload')}
           </Button>
           <Button
             isFullWidth={isMobile}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/CompleteScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ProgressModal/CompleteScreen.tsx
@@ -10,7 +10,6 @@ import {
   Text,
   Wrap,
 } from '@chakra-ui/react'
-import simplur from 'simplur'
 
 import { BxsCheckCircle, BxsXCircle } from '~assets/icons'
 import { useIsMobile } from '~hooks/useIsMobile'
@@ -32,7 +31,9 @@ export const CompleteScreen = ({
   onClose,
   downloadMetadata,
 }: CompleteScreenProps): JSX.Element => {
-  const { t } = useTranslation()
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.responsesPage',
+  })
   const isMobile = useIsMobile()
   const mdComponents = useMdComponents()
 
@@ -40,34 +41,40 @@ export const CompleteScreen = ({
     if (!downloadMetadata) return ''
     const { successCount, expectedCount } = downloadMetadata
     if (successCount >= expectedCount) {
-      return `All responses${
-        isWithAttachments ? ' and attachments' : ''
-      } have been downloaded successfully.`
+      return isWithAttachments
+        ? t('storage.unlockedResponses.progressModal.completeScreen.successMessages.allResponsesWithAttachments')
+        : t('storage.unlockedResponses.progressModal.completeScreen.successMessages.allResponses')
     }
     // Success count is less than expected count.
     // This means some responses were not downloaded successfully.
     // Show the user the number of responses that were not downloaded.
-    // Not inlining conditional since simplur seems to not work with inlined conditionals.
     if (isWithAttachments) {
-      return simplur`**${successCount.toLocaleString()}** ${[
-        successCount,
-      ]}response[|s] and attachment[|s] ha[s|ve] been downloaded successfully, refer to the downloaded CSV file for more details`
+      return t('storage.unlockedResponses.progressModal.completeScreen.successMessages.partialSuccessWithAttachments', {
+        successCount: successCount.toLocaleString(),
+        count: successCount,
+      })
     }
-    return simplur`**${successCount.toLocaleString()}** ${[
-      successCount,
-    ]}response[|s] ha[s|ve] been downloaded successfully, refer to the downloaded CSV file for more details`
-  }, [downloadMetadata, isWithAttachments])
+    return t('storage.unlockedResponses.progressModal.completeScreen.successMessages.partialSuccess', {
+      successCount: successCount.toLocaleString(),
+      count: successCount,
+    })
+  }, [downloadMetadata, isWithAttachments, t])
 
   const attachmentErrorMessage = useMemo(() => {
     if (!downloadMetadata?.errorCount) return ''
 
-    // Not inlining conditional since simplur seems to not work with inlined conditionals.
     if (isWithAttachments) {
-      return simplur`**${downloadMetadata.errorCount}** response[|s] and attachment[|s] could not be downloaded.`
+      return t('storage.unlockedResponses.progressModal.completeScreen.errorMessages.withAttachments', {
+        errorCount: downloadMetadata.errorCount,
+        count: downloadMetadata.errorCount,
+      })
     }
 
-    return simplur`**${downloadMetadata.errorCount}** response[|s] could not be downloaded.`
-  }, [downloadMetadata?.errorCount, isWithAttachments])
+    return t('storage.unlockedResponses.progressModal.completeScreen.errorMessages.withoutAttachments', {
+      errorCount: downloadMetadata.errorCount,
+      count: downloadMetadata.errorCount,
+    })
+  }, [downloadMetadata?.errorCount, isWithAttachments, t])
 
   return (
     <>
@@ -75,9 +82,7 @@ export const CompleteScreen = ({
       <ModalHeader color="secondary.700" pr="4.5rem">
         <Wrap shouldWrapChildren direction="row" align="center">
           <Text>
-            {t(
-              'features.adminForm.responses.responsesPage.storage.unlockedResponses.progressModal.completeScreen.downloadComplete',
-            )}
+            {t('storage.unlockedResponses.progressModal.completeScreen.downloadComplete')}
           </Text>
           <Badge w="fit-content" colorScheme="success">
             {t('features.common.betaBadgeLabel')}
@@ -116,9 +121,7 @@ export const CompleteScreen = ({
       </ModalBody>
       <ModalFooter>
         <Button isFullWidth={isMobile} onClick={onClose}>
-          {t(
-            'features.adminForm.responses.responsesPage.storage.unlockedResponses.progressModal.completeScreen.backToResponses',
-          )}
+          {t('storage.unlockedResponses.progressModal.completeScreen.backToResponses')}
         </Button>
       </ModalFooter>
     </>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTable.tsx
@@ -30,12 +30,6 @@ import Badge from '~components/Badge'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 import { getPendingResponseAtString } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
-import {
-  MRF_PENDING_RESPONSE_AT_LABEL,
-  MRF_REMINDERS_LABEL,
-  MRF_RESPONSE_TIMESTAMP_LABEL,
-  MRF_WORKFLOW_STATUS_LABEL,
-} from '~features/admin-form/responses/constants'
 
 import { useUnlockedResponses } from '../UnlockedResponsesProvider'
 
@@ -75,6 +69,13 @@ function PendingBadge() {
   )
 }
 
+function PayoutPendingText() {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.responsesPage',
+  })
+  return t('storage.unlockedResponses.responsesTable.status.payoutPending')
+}
+
 function CompletedBadge() {
   const { t } = useTranslation()
   return (
@@ -108,23 +109,24 @@ function NotApprovedBadge() {
   )
 }
 
-const BASE_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
+// Helper function to create base columns with translations
+const createBaseColumns = (t: (key: string) => string): Column<ResponseColumnData>[] => [
   {
-    Header: '#',
+    Header: t('storage.unlockedResponses.responsesTable.headers.number'),
     accessor: 'number',
-    width: 80, // width is used for both the flex-basis and flex-grow
-    minWidth: 80, // minWidth is only used as a limit for resizing
-    maxWidth: 100, // maxWidth is only used as a limit for resizing
+    width: 80,
+    minWidth: 80,
+    maxWidth: 100,
   },
   {
-    Header: 'Response ID',
+    Header: t('storage.unlockedResponses.responsesTable.headers.responseId'),
     accessor: 'refNo',
     width: 300,
     minWidth: 300,
     maxWidth: 300,
   },
   {
-    Header: 'Timestamp',
+    Header: t('storage.unlockedResponses.responsesTable.headers.timestamp'),
     accessor: 'submissionTime',
     width: 250,
     minWidth: 250,
@@ -132,9 +134,10 @@ const BASE_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   },
 ]
 
-const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
+// Helper function to create payment columns with translations
+const createPaymentColumns = (t: (key: string) => string): Column<ResponseColumnData>[] => [
   {
-    Header: 'Email',
+    Header: t('storage.unlockedResponses.responsesTable.headers.email'),
     accessor: ({ payments }) => {
       if (!payments?.email) {
         return ''
@@ -144,9 +147,8 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
     minWidth: 250,
     width: 250,
   },
-
   {
-    Header: 'Paid Amount (S$)', //  (amt responder paid)
+    Header: t('storage.unlockedResponses.responsesTable.headers.paidAmount'),
     accessor: ({ payments }) => {
       if (!payments) {
         return ''
@@ -156,9 +158,8 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
     minWidth: 150,
     width: 150,
   },
-
   {
-    Header: 'Fees (S$)', //  (paid - net)
+    Header: t('storage.unlockedResponses.responsesTable.headers.fees'),
     accessor: ({ payments }) => {
       if (!payments?.transactionFee) {
         return ''
@@ -166,25 +167,22 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
       if (payments.transactionFee < 0) {
         return ''
       }
-
       return `${centsToDollars(payments.transactionFee)}`
     },
     minWidth: 150,
     width: 150,
   },
-
   {
-    Header: 'Net Amount (S$)', //  (amt they receive in bank)
+    Header: t('storage.unlockedResponses.responsesTable.headers.netAmount'),
     accessor: ({ payments }) => getNetAmount(payments),
     minWidth: 150,
     width: 150,
   },
-
   {
-    Header: 'Payout Date',
+    Header: t('storage.unlockedResponses.responsesTable.headers.payoutDate'),
     accessor: ({ payments }) => {
       if (!payments) {
-        return 'Pending'
+        return <PayoutPendingText />
       }
       return payments.payoutDate
     },
@@ -194,23 +192,24 @@ const PAYMENT_COLUMNS: Column<ResponseColumnData>[] = [
   },
 ]
 
-const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
+// Helper function to create MRF columns with translations
+const createMrfColumns = (t: (key: string) => string): Column<ResponseColumnData>[] => [
   {
-    Header: '#',
+    Header: t('storage.unlockedResponses.responsesTable.headers.number'),
     accessor: 'number',
     width: 80,
     minWidth: 80,
     maxWidth: 100,
   },
   {
-    Header: 'Response ID',
+    Header: t('storage.unlockedResponses.responsesTable.headers.responseId'),
     accessor: 'refNo',
     width: 240,
     minWidth: 240,
     maxWidth: 240,
   },
   {
-    Header: MRF_WORKFLOW_STATUS_LABEL,
+    Header: t('storage.unlockedResponses.responsesTable.mrf.workflowStatus'),
     accessor: ({ mrf }) => {
       if (!mrf?.workflowStatus) {
         return ''
@@ -233,7 +232,7 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     maxWidth: 160,
   },
   {
-    Header: MRF_PENDING_RESPONSE_AT_LABEL,
+    Header: t('storage.unlockedResponses.responsesTable.mrf.pendingResponseAt'),
     accessor: ({ mrf }) => {
       const workflowStatus = mrf?.workflowStatus
       const workflowCurrentStepNumber = mrf?.workflowCurrentStepNumber
@@ -256,23 +255,14 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
     maxWidth: 180,
   },
   {
-    Header: MRF_RESPONSE_TIMESTAMP_LABEL,
+    Header: t('storage.unlockedResponses.responsesTable.mrf.responseTimestamp'),
     accessor: 'submissionTime',
-    // TODO(FRM-1933): using submissionTime as we are undecided on showing first submission vs lastSubmittedAt
-    // accessor: ({ mrf }) =>
-    //   mrf?.lastSubmittedAt
-    //     ? formatInTimeZone(
-    //         mrf.lastSubmittedAt,
-    //         'Asia/Singapore',
-    //         'do MMM yyyy, hh:mm:ss a',
-    //       )
-    //     : '',
     width: 240,
     minWidth: 240,
     maxWidth: 240,
   },
   {
-    Header: MRF_REMINDERS_LABEL,
+    Header: t('storage.unlockedResponses.responsesTable.mrf.reminders'),
     Cell: ({ row }) => {
       const isPending =
         row.original.mrf?.workflowStatus === WorkflowStatus.PENDING
@@ -288,10 +278,10 @@ const MRF_RESPONSE_TABLE_COLUMNS: Column<ResponseColumnData>[] = [
   },
 ]
 
-const PAYMENT_RESPONSE_TABLE_COLUMNS =
-  BASE_RESPONSE_TABLE_COLUMNS.concat(PAYMENT_COLUMNS)
-
 export const ResponsesTable = () => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.responses.responsesPage',
+  })
   const { data: form } = useAdminForm()
   const isPaymentsForm =
     form?.responseMode === FormResponseMode.Encrypt
@@ -325,13 +315,13 @@ export const ResponsesTable = () => {
 
   const columns = useMemo(() => {
     if (isMultiRespondentForm) {
-      return MRF_RESPONSE_TABLE_COLUMNS
+      return createMrfColumns(t)
     }
     if (isPaymentsForm) {
-      return PAYMENT_RESPONSE_TABLE_COLUMNS
+      return createBaseColumns(t).concat(createPaymentColumns(t))
     }
-    return BASE_RESPONSE_TABLE_COLUMNS
-  }, [isMultiRespondentForm, isPaymentsForm])
+    return createBaseColumns(t)
+  }, [isMultiRespondentForm, isPaymentsForm, t])
 
   const {
     prepareRow,

--- a/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/getPaymentDataView.ts
@@ -1,3 +1,5 @@
+import { TFunction } from 'i18next'
+
 import { SubmissionPaymentDto } from '~shared/types'
 
 import { getPaymentInvoiceDownloadUrl } from '~features/public-form/utils/urls'
@@ -36,42 +38,52 @@ const getFullInvoiceDownloadUrl = (
 /**
  * Helper function to obtain the payment field data that we want to display to
  * admins, used both in the individual response page and the exported CSV.
+ * @param hostOrigin the origin of the host
  * @param payment the payment data object returned within the submission object
+ * @param formId the form ID
+ * @param t optional translation function. If not provided, uses English defaults
  * @returns payment data view with an array of names and values, ordered in CSV column order.
  */
 export const getPaymentDataView = (
   hostOrigin: string,
   payment: SubmissionPaymentDto,
   formId: string,
+  t?: TFunction,
 ): PaymentDataViewItem[] =>
   // Payment data association of keys to values, in CSV column order
   [
     {
       key: 'status',
-      name: 'Payment status',
+      name: t ? t('paymentDataView.fields.paymentStatus') : 'Payment status',
       value: toSentenceCase(payment.status),
     },
 
-    { key: 'email', name: 'Payer', value: payment.email },
+    {
+      key: 'email',
+      name: t ? t('paymentDataView.fields.payer') : 'Payer',
+      value: payment.email,
+    },
     {
       key: 'receiptUrl',
-      name: 'Proof of Payment',
+      name: t ? t('paymentDataView.fields.proofOfPayment') : 'Proof of Payment',
       value: getFullInvoiceDownloadUrl(hostOrigin, formId, payment.id),
     },
 
     {
       key: 'paymentIntentId',
-      name: 'Payment intent ID',
+      name: t
+        ? t('paymentDataView.fields.paymentIntentId')
+        : 'Payment intent ID',
       value: payment.paymentIntentId,
     },
     {
       key: 'amount',
-      name: 'Payment amount',
+      name: t ? t('paymentDataView.fields.paymentAmount') : 'Payment amount',
       value: centsToDollarString(payment.amount),
     },
     {
       key: 'products',
-      name: 'Product/service',
+      name: t ? t('paymentDataView.fields.productService') : 'Product/service',
       value:
         payment.products
           ?.map(({ name, quantity }) => `${name} x ${quantity}`)
@@ -79,24 +91,28 @@ export const getPaymentDataView = (
     },
     {
       key: 'paymentDate',
-      name: 'Payment date and time',
+      name: t
+        ? t('paymentDataView.fields.paymentDateTime')
+        : 'Payment date and time',
       value: payment.paymentDate,
     },
 
     {
       key: 'transactionFee',
-      name: 'Transaction fee',
+      name: t ? t('paymentDataView.fields.transactionFee') : 'Transaction fee',
       value: centsToDollarString(payment.transactionFee),
     },
 
     {
       key: 'payoutId',
-      name: 'Payout ID',
+      name: t ? t('paymentDataView.fields.payoutId') : 'Payout ID',
       value: payment.payoutId ?? '-',
     },
     {
       key: 'payoutDate',
-      name: 'Payout date and time',
+      name: t
+        ? t('paymentDataView.fields.payoutDateTime')
+        : 'Payout date and time',
       value: payment.payoutDate ?? '-',
     },
   ]

--- a/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
+++ b/frontend/src/features/admin-form/responses/common/utils/mrfSubmissionView.ts
@@ -1,3 +1,5 @@
+import { TFunction } from 'i18next'
+
 import {
   StrippedFormWorkflowDto,
   SubmittedStep,
@@ -18,11 +20,14 @@ interface CurrentWorkflowInfo {
 }
 
 /** Gets the business friendly message for the current pending step of the workflow.  */
-export const getPendingResponseAtString = ({
-  workflowStatus,
-  workflowCurrentStepNumber,
-  workflowNumTotalSteps,
-}: CurrentWorkflowInfo) => {
+export const getPendingResponseAtString = (
+  {
+    workflowStatus,
+    workflowCurrentStepNumber,
+    workflowNumTotalSteps,
+  }: CurrentWorkflowInfo,
+  t?: TFunction,
+) => {
   const isPending =
     workflowStatus === WorkflowStatus.PENDING &&
     workflowCurrentStepNumber < workflowNumTotalSteps
@@ -34,23 +39,36 @@ export const getPendingResponseAtString = ({
   // Thus, it should mean that it is pending the response of N+1
   const pendingStep = workflowCurrentStepNumber + 1
 
-  return getCurrentStepString({
-    workflowCurrentStepNumber: pendingStep,
-    workflowNumTotalSteps,
-  })
+  return getCurrentStepString(
+    {
+      workflowCurrentStepNumber: pendingStep,
+      workflowNumTotalSteps,
+    },
+    t,
+  )
 }
 
 /** Gets the business friendly string for current step of workflow. */
-const getCurrentStepString = ({
-  workflowCurrentStepNumber,
-  workflowNumTotalSteps,
-}: Pick<
-  CurrentWorkflowInfo,
-  'workflowNumTotalSteps' | 'workflowCurrentStepNumber'
->) => {
-  return workflowCurrentStepNumber && workflowNumTotalSteps
-    ? `Step ${workflowCurrentStepNumber} of ${workflowNumTotalSteps}`
-    : ''
+const getCurrentStepString = (
+  {
+    workflowCurrentStepNumber,
+    workflowNumTotalSteps,
+  }: Pick<
+    CurrentWorkflowInfo,
+    'workflowNumTotalSteps' | 'workflowCurrentStepNumber'
+  >,
+  t?: TFunction,
+) => {
+  if (!workflowCurrentStepNumber || !workflowNumTotalSteps) {
+    return ''
+  }
+
+  return t
+    ? t('mrf.workflowStep', {
+        currentStep: workflowCurrentStepNumber,
+        totalSteps: workflowNumTotalSteps,
+      })
+    : `Step ${workflowCurrentStepNumber} of ${workflowNumTotalSteps}`
 }
 
 /** Gets the business friendly string for MRF submission status. */

--- a/frontend/src/i18n/locales/features/admin-form/responses/individual-response/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/individual-response/en-sg.ts
@@ -11,7 +11,15 @@ export const enSG: ResponsesIndividualResponse = {
   downloadAttachmentsAsZip:
     'Download {attachmentSize, plural, =1 {# attachment} other {# attachments}} as .zip',
   responseLinkLabel: 'Response link',
+  labels: {
+    responseId: 'Response ID',
+    timestamp: 'Timestamp',
+  },
   paymentSection: {
+    headers: {
+      payment: 'Payment',
+      payout: 'Payout to bank account',
+    },
     paymentStatusLabel: {
       partiallyRefunded: 'Partially refunded',
       fullyRefunded: 'Fully refunded',
@@ -20,6 +28,26 @@ export const enSG: ResponsesIndividualResponse = {
     tooltipLabel: `This is when money collected gets deposited into your bank account.
         Depending on payment method, payouts happen 1 - 3 working days after a respondent makes payment.`,
     paymentDataItemPdfDownloadLabel: 'Download as PDF',
+  },
+  paymentDataView: {
+    fields: {
+      paymentStatus: 'Payment status',
+      payer: 'Payer',
+      proofOfPayment: 'Proof of Payment',
+      paymentIntentId: 'Payment intent ID',
+      paymentAmount: 'Payment amount',
+      productService: 'Product/service',
+      paymentDateTime: 'Payment date and time',
+      transactionFee: 'Transaction fee',
+      payoutId: 'Payout ID',
+      payoutDateTime: 'Payout date and time',
+    },
+  },
+  mrf: {
+    workflowStep: 'Step {currentStep} of {totalSteps}',
+  },
+  individualResponseNavbar: {
+    printAriaLabel: 'Print',
   },
   decryptedAttachment: {
     aria: 'Download file',

--- a/frontend/src/i18n/locales/features/admin-form/responses/individual-response/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/individual-response/index.ts
@@ -10,7 +10,15 @@ export interface ResponsesIndividualResponse {
   }
   downloadAttachmentsAsZip: string
   responseLinkLabel: string
+  labels: {
+    responseId: string
+    timestamp: string
+  }
   paymentSection: {
+    headers: {
+      payment: string
+      payout: string
+    }
     paymentStatusLabel: {
       partiallyRefunded: string
       fullyRefunded: string
@@ -18,6 +26,26 @@ export interface ResponsesIndividualResponse {
     }
     tooltipLabel: string
     paymentDataItemPdfDownloadLabel: string
+  }
+  paymentDataView: {
+    fields: {
+      paymentStatus: string
+      payer: string
+      proofOfPayment: string
+      paymentIntentId: string
+      paymentAmount: string
+      productService: string
+      paymentDateTime: string
+      transactionFee: string
+      payoutId: string
+      payoutDateTime: string
+    }
+  }
+  mrf: {
+    workflowStep: string
+  }
+  individualResponseNavbar: {
+    printAriaLabel: string
   }
   decryptedAttachment: {
     aria: string

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
@@ -1,6 +1,10 @@
 import { ResponsesResponsesPage } from '.'
 
 export const enSG: ResponsesResponsesPage = {
+  errors: {
+    formRetrievalError:
+      'There was an error retrieving your form. Please try again later.',
+  },
   emptyResponses: {
     title: "You don't have any responses yet.",
     subtitle: 'Try using {link} to send out your form links!',
@@ -22,6 +26,8 @@ export const enSG: ResponsesResponsesPage = {
         },
         confirmationScreen: {
           title: 'Download responses and attachments',
+          description:
+            'Separate zip files will be downloaded, <b>one for each response</b>. You can adjust the date range before proceeding.',
           numberOfResponsesAndAttachments:
             'Number of responses and attachments',
           estimatedTime: 'Estimated time',
@@ -48,6 +54,21 @@ export const enSG: ResponsesResponsesPage = {
         completeScreen: {
           downloadComplete: 'Download complete',
           backToResponses: 'Back to responses',
+          successMessages: {
+            allResponses: 'All responses have been downloaded successfully.',
+            allResponsesWithAttachments:
+              'All responses and attachments have been downloaded successfully.',
+            partialSuccessWithAttachments:
+              '**{successCount}** {count, plural, =1 {response and attachment has} other {responses and attachments have}} been downloaded successfully, refer to the downloaded CSV file for more details',
+            partialSuccess:
+              '**{successCount}** {count, plural, =1 {response has} other {responses have}} been downloaded successfully, refer to the downloaded CSV file for more details',
+          },
+          errorMessages: {
+            withAttachments:
+              '**{errorCount}** {count, plural, =1 {response and attachment} other {responses and attachments}} could not be downloaded.',
+            withoutAttachments:
+              '**{errorCount}** {count, plural, =1 {response} other {responses}} could not be downloaded.',
+          },
         },
         content: {
           title: 'Downloading...',
@@ -56,6 +77,26 @@ export const enSG: ResponsesResponsesPage = {
         },
       },
       responsesTable: {
+        headers: {
+          number: '#',
+          responseId: 'Response ID',
+          timestamp: 'Timestamp',
+          email: 'Email',
+          paidAmount: 'Paid Amount (S$)',
+          fees: 'Fees (S$)',
+          netAmount: 'Net Amount (S$)',
+          payoutDate: 'Payout Date',
+        },
+        status: {
+          payoutPending: 'Pending',
+        },
+        mrf: {
+          responseTimestamp: 'Response timestamp',
+          pendingResponseAt: 'Pending response at',
+          workflowStatus: 'Workflow status',
+          reminders: 'Reminders',
+          statusTrackingLink: 'Status tracking link',
+        },
         sendReminderButton: {
           sendReminder: 'Send reminder',
           reminderSent: 'Reminder sent',
@@ -75,6 +116,15 @@ export const enSG: ResponsesResponsesPage = {
         menuItem: {
           csvOnly: 'CSV only',
           csvWithAttachments: 'CSV with attachments',
+        },
+        toasts: {
+          noResponses: 'No responses to download',
+          partialSuccess:
+            'Partial success. {successCount}/{expectedCount} {count, plural, =1 {response was} other {responses were}} decrypted. {errorCount} failed.',
+          success:
+            'Success. {successCount}/{expectedCount} {count, plural, =1 {response was} other {responses were}} decrypted.',
+          failedToStart: 'Failed to start download. Please try again later.',
+          downloadCanceled: 'Responses download has been canceled.',
         },
       },
       unlockedResponses: {

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
@@ -1,6 +1,9 @@
 export * from './en-sg'
 
 export interface ResponsesResponsesPage {
+  errors: {
+    formRetrievalError: string
+  }
   emptyResponses: {
     title: string
     subtitle: string
@@ -19,6 +22,7 @@ export interface ResponsesResponsesPage {
         }
         confirmationScreen: {
           title: string
+          description: string
           numberOfResponsesAndAttachments: string
           estimatedTime: string
           estimatedTimeReference: string
@@ -39,6 +43,16 @@ export interface ResponsesResponsesPage {
         completeScreen: {
           downloadComplete: string
           backToResponses: string
+          successMessages: {
+            allResponses: string
+            allResponsesWithAttachments: string
+            partialSuccessWithAttachments: string
+            partialSuccess: string
+          }
+          errorMessages: {
+            withAttachments: string
+            withoutAttachments: string
+          }
         }
         content: {
           title: string
@@ -47,6 +61,26 @@ export interface ResponsesResponsesPage {
         }
       }
       responsesTable: {
+        headers: {
+          number: string
+          responseId: string
+          timestamp: string
+          email: string
+          paidAmount: string
+          fees: string
+          netAmount: string
+          payoutDate: string
+        }
+        status: {
+          payoutPending: string
+        }
+        mrf: {
+          responseTimestamp: string
+          pendingResponseAt: string
+          workflowStatus: string
+          reminders: string
+          statusTrackingLink: string
+        }
         sendReminderButton: {
           sendReminder: string
           reminderSent: string
@@ -64,6 +98,13 @@ export interface ResponsesResponsesPage {
         menuItem: {
           csvOnly: string
           csvWithAttachments: string
+        }
+        toasts: {
+          noResponses: string
+          partialSuccess: string
+          success: string
+          failedToStart: string
+          downloadCanceled: string
         }
       }
       unlockedResponses: {


### PR DESCRIPTION
## Problem
Extract remaining text for i18n on results page
- Closes #8313
- Partially closes #8448

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
