### PR TITLE
feat: respondent copy v3 (phase 1)

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -187,7 +187,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
           )}
         />
       </FormControl>
-            <Box>
+      <Box>
         <FormControl
           isReadOnly={isLoading}
           isDisabled={isToggleEmailConfirmationDisabled}

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -145,7 +145,9 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     form?.responseMode === FormResponseMode.Email || isPaymentDisabledForm
 
   const pdfResponseToggleDescription = isPdfResponseEnabled
-    ? undefined
+    ? t(
+        'features.adminForm.sidebar.fields.email.emailConfirmation.includeResponseDescription',
+      )
     : t(
         'features.adminForm.sidebar.fields.email.emailConfirmation.includePdfResponseWarning',
       )
@@ -185,6 +187,72 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
           )}
         />
       </FormControl>
+            <Box>
+        <FormControl
+          isReadOnly={isLoading}
+          isDisabled={isToggleEmailConfirmationDisabled}
+        >
+          <Toggle
+            {...register('autoReplyOptions.hasAutoReply')}
+            description={t(
+              'features.adminForm.sidebar.fields.email.emailConfirmation.description',
+            )}
+            label={t(
+              'features.adminForm.sidebar.fields.email.emailConfirmation.title',
+            )}
+          />
+        </FormControl>
+        {watchedHasAutoReply && (
+          <>
+            <FormControl isReadOnly={isLoading} mt="1.5rem">
+              <Toggle
+                {...register('autoReplyOptions.includeFormSummary')}
+                label={t(
+                  'features.adminForm.sidebar.fields.email.emailConfirmation.includeResponse',
+                )}
+                description={pdfResponseToggleDescription}
+                isDisabled={!isPdfResponseEnabled}
+              />
+            </FormControl>
+            <FormControl isRequired isReadOnly={isLoading} mt="1.5rem">
+              <FormLabel>Subject</FormLabel>
+              <Input
+                autoFocus
+                placeholder={t(
+                  'features.adminForm.sidebar.fields.email.emailConfirmation.subject.placeholder',
+                )}
+                {...register('autoReplyOptions.autoReplySubject')}
+              />
+            </FormControl>
+            <FormControl isRequired isReadOnly={isLoading} mt="1.5rem">
+              <FormLabel>
+                {t(
+                  'features.adminForm.sidebar.fields.email.emailConfirmation.senderName.title',
+                )}
+              </FormLabel>
+              <Input
+                placeholder={t(
+                  'features.adminForm.sidebar.fields.email.emailConfirmation.senderName.placeholder',
+                )}
+                {...register('autoReplyOptions.autoReplySender')}
+              />
+            </FormControl>
+            <FormControl isReadOnly={isLoading} isRequired mt="1.5rem">
+              <FormLabel>
+                {t(
+                  'features.adminForm.sidebar.fields.email.emailConfirmation.content.title',
+                )}
+              </FormLabel>
+              <Textarea
+                placeholder={t(
+                  'features.adminForm.sidebar.fields.email.emailConfirmation.content.placeholder',
+                )}
+                {...register('autoReplyOptions.autoReplyMessage')}
+              />
+            </FormControl>
+          </>
+        )}
+      </Box>
       <FormControl isReadOnly={isLoading}>
         <Toggle
           {...register('isVerifiable')}
@@ -229,72 +297,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
               {errors?.allowedEmailDomains?.message}
             </FormErrorMessage>
           </FormControl>
-        )}
-      </Box>
-      <Box>
-        <FormControl
-          isReadOnly={isLoading}
-          isDisabled={isToggleEmailConfirmationDisabled}
-        >
-          <Toggle
-            {...register('autoReplyOptions.hasAutoReply')}
-            description={t(
-              'features.adminForm.sidebar.fields.email.emailConfirmation.description',
-            )}
-            label={t(
-              'features.adminForm.sidebar.fields.email.emailConfirmation.title',
-            )}
-          />
-        </FormControl>
-        {watchedHasAutoReply && (
-          <>
-            <FormControl isRequired isReadOnly={isLoading} mt="1.5rem">
-              <FormLabel>Subject</FormLabel>
-              <Input
-                autoFocus
-                placeholder={t(
-                  'features.adminForm.sidebar.fields.email.emailConfirmation.subject.placeholder',
-                )}
-                {...register('autoReplyOptions.autoReplySubject')}
-              />
-            </FormControl>
-            <FormControl isRequired isReadOnly={isLoading} mt="1.5rem">
-              <FormLabel>
-                {t(
-                  'features.adminForm.sidebar.fields.email.emailConfirmation.senderName.title',
-                )}
-              </FormLabel>
-              <Input
-                placeholder={t(
-                  'features.adminForm.sidebar.fields.email.emailConfirmation.senderName.placeholder',
-                )}
-                {...register('autoReplyOptions.autoReplySender')}
-              />
-            </FormControl>
-            <FormControl isReadOnly={isLoading} isRequired mt="1.5rem">
-              <FormLabel>
-                {t(
-                  'features.adminForm.sidebar.fields.email.emailConfirmation.content.title',
-                )}
-              </FormLabel>
-              <Textarea
-                placeholder={t(
-                  'features.adminForm.sidebar.fields.email.emailConfirmation.content.placeholder',
-                )}
-                {...register('autoReplyOptions.autoReplyMessage')}
-              />
-            </FormControl>
-            <FormControl isReadOnly={isLoading} mt="1.5rem">
-              <Toggle
-                {...register('autoReplyOptions.includeFormSummary')}
-                label={t(
-                  'features.adminForm.sidebar.fields.email.emailConfirmation.includePdfResponse',
-                )}
-                description={pdfResponseToggleDescription}
-                isDisabled={!isPdfResponseEnabled}
-              />
-            </FormControl>
-          </>
         )}
       </Box>
       <FormFieldDrawerActions

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -220,7 +220,9 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
                 autoFocus
                 placeholder={t(
                   'features.adminForm.sidebar.fields.email.emailConfirmation.subject.placeholder',
+                  { formTitle: form?.title },
                 )}
+                _placeholder={{ color: 'secondary.700' }}
                 {...register('autoReplyOptions.autoReplySubject')}
               />
             </FormControl>
@@ -231,9 +233,8 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
                 )}
               </FormLabel>
               <Input
-                placeholder={t(
-                  'features.adminForm.sidebar.fields.email.emailConfirmation.senderName.placeholder',
-                )}
+                placeholder={form?.admin.agency.fullName}
+                _placeholder={{ color: 'secondary.700' }}
                 {...register('autoReplyOptions.autoReplySender')}
               />
             </FormControl>
@@ -246,7 +247,14 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
               <Textarea
                 placeholder={t(
                   'features.adminForm.sidebar.fields.email.emailConfirmation.content.placeholder',
+                  { agencyName: form?.admin.agency.fullName },
                 )}
+                sx={{
+                  '::placeholder': {
+                    color: 'secondary.700',
+                    opacity: 1,
+                  },
+                }}
                 {...register('autoReplyOptions.autoReplyMessage')}
               />
             </FormControl>

--- a/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
@@ -88,9 +88,11 @@ export const enSG: Fields = {
         title: 'Content',
         placeholder: 'Default email body',
       },
-      includePdfResponse: 'Include PDF response',
+      includeResponse: 'Include a copy of their responses',
       includePdfResponseWarning:
         'PDF responses are not available for payment forms.',
+      includeResponseDescription:
+        'Responses are included in the email and as a PDF attachment',
     },
   },
   mobileNo: {

--- a/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
@@ -78,7 +78,7 @@ export const enSG: Fields = {
       description: 'Customise an email acknowledgement to respondents',
       subject: {
         title: 'Subject',
-        placeholder: 'Default email subject',
+        placeholder: 'Thank you for submitting {formTitle}',
       },
       senderName: {
         title: 'Sender name',
@@ -86,7 +86,8 @@ export const enSG: Fields = {
       },
       content: {
         title: 'Content',
-        placeholder: 'Default email body',
+        placeholder:
+          'To whom it may concern,\n\nThank you for submitting this form.\n\nRegards,\n{agencyName}',
       },
       includeResponse: 'Include a copy of their responses',
       includePdfResponseWarning:

--- a/frontend/src/i18n/locales/features/admin-form/sidebar/fields/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/sidebar/fields/index.ts
@@ -87,8 +87,9 @@ export interface Fields {
         title: string
         placeholder: string
       }
-      includePdfResponse: string
+      includeResponse: string
       includePdfResponseWarning: string
+      includeResponseDescription: string
     }
   }
   mobileNo: {

--- a/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
+++ b/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
@@ -39,6 +39,8 @@ export const enSG: Fields = {
       domainDisallowed:
         'The entered email does not belong to an allowed email domain',
     },
+    respondentCopyHelperText:
+      'A copy of your responses will be sent to this email address',
   },
   verification: {
     button: {

--- a/frontend/src/i18n/locales/features/public-form/fields/index.ts
+++ b/frontend/src/i18n/locales/features/public-form/fields/index.ts
@@ -14,6 +14,7 @@ export interface Fields {
     validation: {
       domainDisallowed: string
     }
+    respondentCopyHelperText: string
   }
   attachment: {
     disabled: string

--- a/frontend/src/templates/Field/Email/EmailFieldInput.tsx
+++ b/frontend/src/templates/Field/Email/EmailFieldInput.tsx
@@ -6,7 +6,7 @@ import {
   useFormState,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Text } from '@chakra-ui/react'
+import { Flex, Text } from '@chakra-ui/react'
 
 import { Language } from '~shared/types'
 
@@ -64,7 +64,7 @@ export const EmailFieldInput = ({
       name={schema._id}
       defaultValue={{ value: '' }}
       render={({ field: { onChange, value, ...field } }) => (
-        <>
+        <Flex direction="column" flex="1">
           <Input
             autoComplete="email"
             value={value?.value ?? ''}
@@ -93,7 +93,7 @@ export const EmailFieldInput = ({
               )}
             </Text>
           ) : null}
-        </>
+        </Flex>
       )}
     />
   )

--- a/frontend/src/templates/Field/Email/EmailFieldInput.tsx
+++ b/frontend/src/templates/Field/Email/EmailFieldInput.tsx
@@ -12,6 +12,7 @@ import Input, { InputProps } from '~components/Input'
 
 import { EmailFieldSchema, VerifiableFieldInput } from '../types'
 
+import { Text } from '@chakra-ui/react'
 export interface EmailFieldInputProps {
   schema: EmailFieldSchema
   disableRequiredValidation?: boolean
@@ -59,20 +60,34 @@ export const EmailFieldInput = ({
       name={schema._id}
       defaultValue={{ value: '' }}
       render={({ field: { onChange, value, ...field } }) => (
-        <Input
-          autoComplete="email"
-          value={value?.value ?? ''}
-          onChange={(event) => {
-            const value = event.target.value.trim().toLowerCase()
-            return handleInputChange
-              ? handleInputChange(onChange)(value)
-              : onChange({ value })
-          }}
-          isHighContrast={isHighContrast}
-          preventDefaultOnEnter
-          {...field}
-          {...inputProps}
-        />
+        <>
+          <Input
+            autoComplete="email"
+            value={value?.value ?? ''}
+            onChange={(event) => {
+              const value = event.target.value.trim().toLowerCase()
+              return handleInputChange
+                ? handleInputChange(onChange)(value)
+                : onChange({ value })
+            }}
+            isHighContrast={isHighContrast}
+            preventDefaultOnEnter
+            {...field}
+            {...inputProps}
+          />
+          {schema.autoReplyOptions?.includeFormSummary ? 
+          <Text
+            color="secondary.400"
+            textStyle="body-2"
+            aria-hidden
+            my="0.5rem"
+          >
+            {t(
+              'features.publicForm.components.fields.email.respondentCopyHelperText',
+            )}
+            </Text>
+            : null}
+        </>
       )}
     />
   )

--- a/frontend/src/templates/Field/Email/EmailFieldInput.tsx
+++ b/frontend/src/templates/Field/Email/EmailFieldInput.tsx
@@ -79,7 +79,8 @@ export const EmailFieldInput = ({
             {...field}
             {...inputProps}
           />
-          {schema.autoReplyOptions?.includeFormSummary &&
+          {schema.autoReplyOptions?.hasAutoReply &&
+          schema.autoReplyOptions?.includeFormSummary &&
           !schema.disabled &&
           !error ? (
             <Text

--- a/frontend/src/templates/Field/Email/EmailFieldInput.tsx
+++ b/frontend/src/templates/Field/Email/EmailFieldInput.tsx
@@ -79,7 +79,7 @@ export const EmailFieldInput = ({
             {...field}
             {...inputProps}
           />
-          {schema.autoReplyOptions?.includeFormSummary && !error ? (
+          {schema.autoReplyOptions?.includeFormSummary && !schema.disabled && !error ? (
             <Text
               color="secondary.400"
               textStyle="body-2"

--- a/frontend/src/templates/Field/Email/EmailFieldInput.tsx
+++ b/frontend/src/templates/Field/Email/EmailFieldInput.tsx
@@ -79,7 +79,9 @@ export const EmailFieldInput = ({
             {...field}
             {...inputProps}
           />
-          {schema.autoReplyOptions?.includeFormSummary && !schema.disabled && !error ? (
+          {schema.autoReplyOptions?.includeFormSummary &&
+          !schema.disabled &&
+          !error ? (
             <Text
               color="secondary.400"
               textStyle="body-2"

--- a/frontend/src/templates/Field/Email/EmailFieldInput.tsx
+++ b/frontend/src/templates/Field/Email/EmailFieldInput.tsx
@@ -1,9 +1,12 @@
 import {
   Controller,
   ControllerRenderProps,
+  get,
   useFormContext,
+  useFormState,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { Text } from '@chakra-ui/react'
 
 import { Language } from '~shared/types'
 
@@ -12,7 +15,6 @@ import Input, { InputProps } from '~components/Input'
 
 import { EmailFieldSchema, VerifiableFieldInput } from '../types'
 
-import { Text } from '@chakra-ui/react'
 export interface EmailFieldInputProps {
   schema: EmailFieldSchema
   disableRequiredValidation?: boolean
@@ -39,6 +41,7 @@ export const EmailFieldInput = ({
   isHighContrast,
 }: EmailFieldInputProps): JSX.Element => {
   const { t } = useTranslation()
+  const { errors } = useFormState({ name: schema._id })
   // TODO: decide how to combine with field-validations en-sg.ts
   const validationErrorMessages = t(
     'features.publicForm.components.fields.email.validation',
@@ -52,6 +55,7 @@ export const EmailFieldInput = ({
   )
 
   const { control } = useFormContext<VerifiableFieldInput>()
+  const error = !!get(errors, schema._id)
 
   return (
     <Controller
@@ -75,18 +79,18 @@ export const EmailFieldInput = ({
             {...field}
             {...inputProps}
           />
-          {schema.autoReplyOptions?.includeFormSummary ? 
-          <Text
-            color="secondary.400"
-            textStyle="body-2"
-            aria-hidden
-            my="0.5rem"
-          >
-            {t(
-              'features.publicForm.components.fields.email.respondentCopyHelperText',
-            )}
+          {schema.autoReplyOptions?.includeFormSummary && !error ? (
+            <Text
+              color="secondary.400"
+              textStyle="body-2"
+              aria-hidden
+              my="0.5rem"
+            >
+              {t(
+                'features.publicForm.components.fields.email.respondentCopyHelperText',
+              )}
             </Text>
-            : null}
+          ) : null}
         </>
       )}
     />

--- a/shared/constants/mail.ts
+++ b/shared/constants/mail.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_RESPONDENT_COPY_EMAIL = {
+  subject: 'Thank you for submitting {formTitle}',
+  content:
+    'To whom it may concern,\n\nThank you for submitting this form.\n\nRegards,\n{agencyName}',
+}

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -724,9 +724,10 @@ describe('mail.service', () => {
           email: MOCK_VALID_EMAIL_2,
         },
       ],
+      isUseLambdaOutput: false,
     }
     const DEFAULT_AUTO_REPLY_BODY =
-      `Dear Sir or Madam,\n\nThank you for submitting this form.\n\nRegards,\n${MOCK_AUTOREPLY_PARAMS.form.admin.agency.fullName}`.split(
+      `To whom it may concern,\n\nThank you for submitting this form.\n\nRegards,\n${MOCK_AUTOREPLY_PARAMS.form.admin.agency.fullName}`.split(
         '\n',
       )
 

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -303,7 +303,10 @@ export class MailService {
 
     const autoReplyBody = (
       autoReplyMailData.body ||
-      DEFAULT_RESPONDENT_COPY_EMAIL.content.replace('{agencyName}', emailSender)
+      DEFAULT_RESPONDENT_COPY_EMAIL.content.replace(
+        '{agencyName}',
+        form.admin.agency.fullName,
+      )
     ).split('\n')
 
     const templateData = {

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -7,6 +7,7 @@ import Mail from 'nodemailer/lib/mailer'
 import promiseRetry from 'promise-retry'
 import validator from 'validator'
 
+import { DEFAULT_RESPONDENT_COPY_EMAIL } from '../../../../shared/constants/mail'
 import { FormResponseMode, PaymentChannel } from '../../../../shared/types'
 import { centsToDollars } from '../../../../shared/utils/payments'
 import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
@@ -291,15 +292,19 @@ export class MailService {
     MailSendError | MailGenerationError
   > => {
     const emailSubject =
-      autoReplyMailData.subject || `Thank you for submitting ${form.title}`
+      autoReplyMailData.subject ||
+      DEFAULT_RESPONDENT_COPY_EMAIL.subject.replace('{formTitle}', form.title)
+
     // Sender's name appearing after "("" symbol gets truncated. Escaping it
     // solves the problem.
     const emailSender = (
       autoReplyMailData.sender || form.admin.agency.fullName
     ).replace('(', '\\(')
 
-    const defaultBody = `Dear Sir or Madam,\n\nThank you for submitting this form.\n\nRegards,\n${form.admin.agency.fullName}`
-    const autoReplyBody = (autoReplyMailData.body || defaultBody).split('\n')
+    const autoReplyBody = (
+      autoReplyMailData.body ||
+      DEFAULT_RESPONDENT_COPY_EMAIL.content.replace('{agencyName}', emailSender)
+    ).split('\n')
 
     const templateData = {
       submissionId: submission.id,


### PR DESCRIPTION
## Problem 
<!-- What problem are you trying to solve? What issue does this close? -->

- Enhancements to allow respondents to get a copy of their responses after submitting the form.
- Support signature workflows where a copy of the responses is essential
- Iterate from respondent copy v2 pilot

Note: Respondent copy v3 is split into 2 phases for incremental releases. Please refer to PRD to understand scopes of phase 1/2 delivery

Closes FRM-2171

## Solution
<!-- How did you solve the problem? -->

- [x]  Include helper text for respondent
    - [x]  Assigned state should include helper text
    - [x]  Unassigned state should not have helper text
- [x]  Default sender, subject and message displayed for user
- [x]  Move “Include a PDF response” above Subject
    - [x]  Replace “Include PDF response” with a different copy
- [x]  Move “Enable email confirmation” above OTP verification

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** | 
| --- | --- | --- |
| Helper text & replace behaviour | <img width="806" height="129" alt="image" src="https://github.com/user-attachments/assets/c9726931-5b1c-4f2c-b3ea-925981ceec32" /> | ![error_replace](https://github.com/user-attachments/assets/494e6dfd-ebd1-4f2c-b726-82e1c06ac228) |
| Moving toggle up in email field builder + copy changes to default placeholders | <img width="460" height="662" alt="image" src="https://github.com/user-attachments/assets/1f4bae48-ffdf-407c-94ea-f1c15331b10f" /> | <img width="468" height="609" alt="image" src="https://github.com/user-attachments/assets/6a050a14-2e1a-437f-ad62-248cce81e695" /> |

## Tests
<!-- What tests should be run to confirm functionality? -->

**Helper text shows/hides as expected**
- [x] Create a storage mode form and add an email field to the form
- [x] In the email field settings, toggle on **email confirmation** and **Include a copy of their responses**
- [x] Observe that a helper text shows up in the form builder
- [x] In the form builder, attempt to enter an invalid email, observe that the error message replaces the helper text
