### PR TITLE
feat: pinning pdf to generate from lambda

### DIFF
--- a/src/app/utils/__tests__/convert-html-to-pdf.spec.ts
+++ b/src/app/utils/__tests__/convert-html-to-pdf.spec.ts
@@ -155,29 +155,6 @@ describe('convert-html-to-pdf', () => {
     beforeEach(() => {
       AwsConfig.pdfGeneratorLambda.invoke = jest.fn()
     })
-    it('should not invoke lambda and just return local output when AwsConfig.pdfGeneratorLambdaFunctionName is empty', async () => {
-      // Arrange
-      const mockLocalBuffer = Buffer.from('local pdf content')
-      AwsConfig.pdfGeneratorLambdaFunctionName = ''
-
-      // Mock local response
-      const mockPage = {
-        setContent: jest.fn(),
-        pdf: jest.fn().mockResolvedValue(mockLocalBuffer),
-      }
-      const mockBrowser = {
-        newPage: jest.fn().mockResolvedValue(mockPage),
-        close: jest.fn(),
-      }
-      ;(puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser)
-
-      // Act
-      const result = await generatePdfFromHtml(MOCK_HTML, true)
-
-      // Assert
-      expect(result).toEqual(mockLocalBuffer)
-      expect(AwsConfig.pdfGeneratorLambda.invoke).not.toHaveBeenCalled()
-    })
 
     it('should use lambda output when isUseLambdaOutput is true and not use local output and AwsConfig.pdfGeneratorLambdaFunctionName is defined', async () => {
       // Arrange
@@ -225,46 +202,6 @@ describe('convert-html-to-pdf', () => {
       })
     })
 
-    it('should use local output when isUseLambdaOutput is false and not use lambda output and AwsConfig.pdfGeneratorLambdaFunctionName is defined', async () => {
-      // Arrange
-      const mockLambdaBuffer = Buffer.from('lambda pdf content')
-      const mockLocalBuffer = Buffer.from('local pdf content')
-
-      const DUMMY_PDF_GENERATOR_FUNCTION_NAME =
-        'dummy-pdf-generator-function-name'
-      AwsConfig.pdfGeneratorLambdaFunctionName =
-        DUMMY_PDF_GENERATOR_FUNCTION_NAME
-
-      // Mock lambda response
-      const mockLambdaResponse = {
-        Payload: JSON.stringify({
-          statusCode: 200,
-          body: mockLambdaBuffer.toString('base64'),
-        }),
-      }
-      ;(AwsConfig.pdfGeneratorLambda.invoke as jest.Mock).mockResolvedValueOnce(
-        mockLambdaResponse,
-      )
-
-      // Mock local response
-      const mockPage = {
-        setContent: jest.fn(),
-        pdf: jest.fn().mockResolvedValue(mockLocalBuffer),
-      }
-      const mockBrowser = {
-        newPage: jest.fn().mockResolvedValue(mockPage),
-        close: jest.fn(),
-      }
-      ;(puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser)
-
-      // Act
-      const result = await generatePdfFromHtml(MOCK_HTML, false)
-
-      // Assert
-      expect(result).toEqual(mockLocalBuffer)
-      expect(result).not.toEqual(mockLambdaBuffer)
-    })
-
     it('should generate PDFs using both methods in parallel regardless of isUseLambdaOutput setting if AwsConfig.pdfGeneratorLambdaFunctionName is defined', async () => {
       // Arrange
       const mockLambdaBuffer = Buffer.from('lambda pdf content')
@@ -307,8 +244,8 @@ describe('convert-html-to-pdf', () => {
       // Assert
       // Both lambda and local generation should be called for each invocation
       expect(AwsConfig.pdfGeneratorLambda.invoke).toHaveBeenCalledTimes(2)
-      expect(puppeteer.launch).toHaveBeenCalledTimes(2)
-      expect(mockPage.pdf).toHaveBeenCalledTimes(2)
+      expect(puppeteer.launch).toHaveBeenCalledTimes(0)
+      expect(mockPage.pdf).toHaveBeenCalledTimes(0)
 
       // Verify the lambda invocation parameters
       expect(AwsConfig.pdfGeneratorLambda.invoke).toHaveBeenCalledWith({

--- a/src/app/utils/convert-html-to-pdf.ts
+++ b/src/app/utils/convert-html-to-pdf.ts
@@ -146,31 +146,6 @@ export const generatePdfFromHtml = async (
     meta: logMeta,
   })
 
-  const localStopwatch = startStopwatch()
-  const localResult = generatePdfFromHtmlLocally(summaryHtml).then((result) => {
-    const latencyMs = localStopwatch.stop()
-    logger.info({
-      message: 'Successfully generated pdf from html using local',
-      meta: { ...logMeta, latencyMs },
-    })
-    submitPdfGenerationLatencyMetric({
-      latencyMs,
-      isLocal: true,
-    })
-    return result
-  })
-
-  const isPdfGenerationLambdaConfigured =
-    !!AwsConfig.pdfGeneratorLambdaFunctionName
-  if (!isPdfGenerationLambdaConfigured) {
-    logger.info({
-      message:
-        'Pdf generation lambda is not configured - using result from local pdf generation',
-      meta: logMeta,
-    })
-    return localResult
-  }
-
   const lambdaStopwatch = startStopwatch()
   const lambdaResultAsync = generatePdfFromHtmlLambda(summaryHtml).map(
     (result) => {
@@ -187,31 +162,22 @@ export const generatePdfFromHtml = async (
     },
   )
 
-  if (isUseLambdaOutput) {
-    const lambdaResult = await lambdaResultAsync
-    if (lambdaResult.isErr()) {
-      logger.error({
-        message: 'Error generating pdf from html using lambda',
-        meta: logMeta,
-        error: lambdaResult.error,
-      })
-      throw lambdaResult.error
-    }
-
-    logger.info({
-      message:
-        'Successfully generated pdf from html - using result from lambda pdf generation',
+  const lambdaResult = await lambdaResultAsync
+  if (lambdaResult.isErr()) {
+    logger.error({
+      message: 'Error generating pdf from html using lambda',
       meta: logMeta,
+      error: lambdaResult.error,
     })
-    return lambdaResult.value
+    throw lambdaResult.error
   }
 
   logger.info({
     message:
-      'Successfully generated pdf from html - using result from local pdf generation',
+      'Successfully generated pdf from html - using result from lambda pdf generation',
     meta: logMeta,
   })
-  return await localResult
+  return lambdaResult.value
 }
 
 export const _generatePdfFromHtmlLocallyForTest = generatePdfFromHtmlLocally


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

We want to stop local PDF generation.

## Solution
<!-- How did you solve the problem? -->

Fixing `generatePdfFromHtml` to always generating from lambda.

Note: Explicit ring fencing changes small and purposefully located to be in one file instead of removing the whole lambda generation.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
