### PR TITLE
fix: singpass myinfo box texts

### DIFF
--- a/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
+++ b/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsDisabledExplanationText.tsx
@@ -11,8 +11,6 @@ interface AuthSettingsDisabledExplanationTextProps {
   formResponseMode?: string
 }
 
-const CONTAINS_MYINFO_FIELDS_DISABLED_EXPLANATION_TEXT =
-  'To change any Singpass setting, close your form to new responses. For changes to your Singpass authentication mode, remove all existing Myinfo fields.'
 const FORM_IS_PUBLIC_DISABLED_EXPLANATION_TEXT =
   'To change Singpass settings, close your form to new responses.'
 const FORM_HAS_MYINFO_FIELDS =
@@ -34,9 +32,10 @@ export const AuthSettingsDisabledExplanationText = ({
 
   if (isFormPublic) {
     infoboxTextArray.push(FORM_IS_PUBLIC_DISABLED_EXPLANATION_TEXT)
-    if (containsMyInfoFields) {
-      infoboxTextArray.push(FORM_HAS_MYINFO_FIELDS)
-    }
+  }
+
+  if (containsMyInfoFields) {
+    infoboxTextArray.push(FORM_HAS_MYINFO_FIELDS)
   }
 
   const infoboxTextComponent = infoboxTextArray.length ? (


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Singpass Myinfo box recent changes had removed the display of 'hasMyInfo' text when there is myInfo fields. Admins may get confused when they find themselves unable to switch authentication modes

<img width="1230" height="541" alt="image" src="https://github.com/user-attachments/assets/16045fc2-f7b9-4e52-9799-3265b42a458e" />


## Solution
<!-- How did you solve the problem? -->

Decouple displaying of 'hasMyInfo' text in infobox from 'isFormPublic' text. They should be independent.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
