### PR TITLE
fix(copy): update MyInfo fields banner text

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -288,7 +288,7 @@ const MyInfoText = ({
   if (isMyInfoDisabled) {
     return (
       <Text>
-        Enable MyInfo in the{' '}
+        Enable Singpass in the{' '}
         <Link as={ReactLink} to={ADMINFORM_SETTINGS_SINGPASS_SUBROUTE}>
           Settings
         </Link>{' '}


### PR DESCRIPTION
## Problem
MyInfo banner copy was not updated with the latest collapse of Singpass options

## Solution
Replace `MyInfo` with `Singpass` in banner
