### PR TITLE
feat: respondent copy v3 (phase2)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,25 @@
 {
-  "eslint.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
-  "eslint.run": "onType",
+  "eslint.validate": ["javascript", "typescript"],
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.formatOnSave": false
+  },
+  "[typescript]": {
+    "editor.formatOnSave": false
+  },
+  "[html]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "never"
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "typescript.tsdk": "node_modules/typescript/lib",
+  "markdown.extension.toc.omittedFromToc": {
+    "README.md": [
+      "## Table of Contents"
+  ]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,25 +1,17 @@
 {
+  "eslint.enable": true,
   "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit",
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.validate": ["javascript", "typescript"],
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "eslint.run": "onType",
   "editor.formatOnSave": true,
-  "[javascript]": {
-    "editor.formatOnSave": false
-  },
-  "[typescript]": {
-    "editor.formatOnSave": false
-  },
-  "[html]": {
-    "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": "never"
-    },
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "typescript.tsdk": "node_modules/typescript/lib",
-  "markdown.extension.toc.omittedFromToc": {
-    "README.md": [
-      "## Table of Contents"
-  ]
-  }
 }

--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -49,6 +49,7 @@ import {
   getMyInfoAttribute,
   getTitleWithQuestionNumber,
 } from '../utils'
+
 import { closeModals } from './closeModals';
 
 type CreateFormReturn = {

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -222,7 +222,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
                   'features.adminForm.sidebar.fields.email.emailConfirmation.subject.placeholder',
                   { formTitle: form?.title },
                 )}
-                _placeholder={{ color: 'secondary.700' }}
                 {...register('autoReplyOptions.autoReplySubject')}
               />
             </FormControl>
@@ -234,7 +233,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
               </FormLabel>
               <Input
                 placeholder={form?.admin.agency.fullName}
-                _placeholder={{ color: 'secondary.700' }}
                 {...register('autoReplyOptions.autoReplySender')}
               />
             </FormControl>
@@ -249,12 +247,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
                   'features.adminForm.sidebar.fields.email.emailConfirmation.content.placeholder',
                   { agencyName: form?.admin.agency.fullName },
                 )}
-                sx={{
-                  '::placeholder': {
-                    color: 'secondary.700',
-                    opacity: 1,
-                  },
-                }}
                 {...register('autoReplyOptions.autoReplyMessage')}
               />
             </FormControl>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -145,6 +145,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     isEncryptMode &&
     form.payments_channel.channel !== PaymentChannel.Unconnected
 
+  // payment forms disallows for sends as it has a separate payment confirmation email
   const pdfResponseToggleDescription = isPaymentDisabledForm
     ? t(
         'features.adminForm.sidebar.fields.email.emailConfirmation.includePdfResponseWarning',

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -155,8 +155,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
       )
 
   // TODO: FRM-2172 Remove when respondent copy is out of beta
-  const isToggleEmailConfirmationDisabled =
-    !user?.betaFlags?.respondentCopy && !field.autoReplyOptions.hasAutoReply
+  const isToggleEmailConfirmationDisabled = !user?.betaFlags?.respondentCopy
 
   return (
     <CreatePageDrawerContentContainer>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -145,15 +145,12 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     isEncryptMode &&
     form.payments_channel.channel !== PaymentChannel.Unconnected
 
-  const isPdfResponseEnabled =
-    form?.responseMode === FormResponseMode.Email || isPaymentDisabledForm
-
-  const pdfResponseToggleDescription = isPdfResponseEnabled
+  const pdfResponseToggleDescription = isPaymentDisabledForm
     ? t(
-        'features.adminForm.sidebar.fields.email.emailConfirmation.includeResponseDescription',
+        'features.adminForm.sidebar.fields.email.emailConfirmation.includePdfResponseWarning',
       )
     : t(
-        'features.adminForm.sidebar.fields.email.emailConfirmation.includePdfResponseWarning',
+        'features.adminForm.sidebar.fields.email.emailConfirmation.includeResponseDescription',
       )
 
   // TODO: FRM-2172 Remove when respondent copy is out of beta
@@ -214,7 +211,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
                   'features.adminForm.sidebar.fields.email.emailConfirmation.includeResponse',
                 )}
                 description={pdfResponseToggleDescription}
-                isDisabled={!isPdfResponseEnabled}
+                isDisabled={isPaymentDisabledForm}
               />
             </FormControl>
             <FormControl isRequired isReadOnly={isLoading} mt="1.5rem">

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -16,6 +16,8 @@ import Input from '~components/Input'
 import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 
+import { useUser } from '~features/user/queries'
+
 import { CreatePageDrawerContentContainer } from '../../../../../common'
 import { useCreateTabForm } from '../../../../useCreateTabForm'
 import { SPLIT_TEXTAREA_TRANSFORM } from '../common/constants'
@@ -87,6 +89,8 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
   const watchedHasAllowedEmailDomains = watch('hasAllowedEmailDomains')
   const watchedHasAutoReply = watch('autoReplyOptions.hasAutoReply')
 
+  const { user } = useUser()
+
   const requiredValidationRule = useMemo(
     () =>
       createBaseValidationRules<EditEmailInputs, 'title'>({
@@ -152,10 +156,9 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         'features.adminForm.sidebar.fields.email.emailConfirmation.includePdfResponseWarning',
       )
 
-  // email confirmation is not supported on MRF
+  // TODO: FRM-2172 Remove when respondent copy is out of beta
   const isToggleEmailConfirmationDisabled =
-    form?.responseMode === FormResponseMode.Multirespondent &&
-    !field.autoReplyOptions.hasAutoReply
+    !user?.betaFlags?.respondentCopy && !field.autoReplyOptions.hasAutoReply
 
   return (
     <CreatePageDrawerContentContainer>

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -143,7 +143,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
   const isEncryptMode = form?.responseMode === FormResponseMode.Encrypt
   const isPaymentDisabledForm =
     isEncryptMode &&
-    form.payments_channel.channel === PaymentChannel.Unconnected
+    form.payments_channel.channel !== PaymentChannel.Unconnected
 
   const isPdfResponseEnabled =
     form?.responseMode === FormResponseMode.Email || isPaymentDisabledForm

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -145,7 +145,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
     isEncryptMode &&
     form.payments_channel.channel !== PaymentChannel.Unconnected
 
-  // payment forms disallows for sends as it has a separate payment confirmation email
+  // For payment forms inclusion of PDF responses are disallowed
   const pdfResponseToggleDescription = isPaymentDisabledForm
     ? t(
         'features.adminForm.sidebar.fields.email.emailConfirmation.includePdfResponseWarning',
@@ -155,7 +155,9 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
       )
 
   // TODO: FRM-2172 Remove when respondent copy is out of beta
-  const isToggleEmailConfirmationDisabled = !user?.betaFlags?.respondentCopy
+  const isToggleEmailConfirmationDisabled =
+    form?.responseMode === FormResponseMode.Multirespondent &&
+    !user?.betaFlags?.respondentCopy
 
   return (
     <CreatePageDrawerContentContainer>

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel.ts
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel.ts
@@ -13,6 +13,12 @@ export const getLogicFieldLabel = (field: FormFieldWithQuestionNo) => {
     case BasicField.Image:
       title = field.name
       break
+    case BasicField.Email:
+      // Inform admins if email confirmation will be sent
+      if (field.autoReplyOptions.hasAutoReply) {
+        title = title + " (confirmation will be sent)"
+      }
+      break
     default:
       break
   }

--- a/frontend/src/features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel.ts
+++ b/frontend/src/features/admin-form/create/logic/components/LogicContent/utils/getLogicFieldLabel.ts
@@ -16,7 +16,7 @@ export const getLogicFieldLabel = (field: FormFieldWithQuestionNo) => {
     case BasicField.Email:
       // Inform admins if email confirmation will be sent
       if (field.autoReplyOptions.hasAutoReply) {
-        title = title + " (confirmation will be sent)"
+        title = title + ' (confirmation will be sent)'
       }
       break
     default:

--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/StepNameBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/StepNameBlock.tsx
@@ -81,7 +81,6 @@ export const StepNameBlock = ({
                 <Input
                   {...field}
                   placeholder={displayStepName}
-                  _placeholder={{ color: 'secondary.700' }}
                   _focus={{
                     _placeholder: { color: 'transparent' },
                   }}

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -169,13 +169,6 @@ export const FormEmailSection = ({
             </FormLabel.Description>
           ) : null}
         </FormControl>
-        {isTest || user?.betaFlags?.respondentCopy ? (
-          <FormControl isDisabled={isDisabled}>
-            <Box mt={'1.5rem'}>
-              <RespondentCopyToggle />
-            </Box>
-          </FormControl>
-        ) : null}
       </FormProvider>
     </>
   )

--- a/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -103,10 +103,6 @@ export const FormEmailSection = ({
   settings,
   isHighContrast = true,
 }: EmailFormSectionProps): JSX.Element => {
-  //TODO: (Respondent Copy): Remove isTest and user when respondent copy is out of beta
-  const { user } = useUser()
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-
   const { t } = useTranslation()
   const initialEmailSet = useMemo(
     () => new Set(settings.emails),

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -5,7 +5,6 @@ import { Flex, Skeleton, Stack, Text, useDisclosure } from '@chakra-ui/react'
 import { BasicField } from '~shared/types'
 import {
   EmailFormDto,
-  FormAuthType,
   FormResponseMode,
   FormStatus,
 } from '~shared/types/form/form'
@@ -14,6 +13,7 @@ import InlineMessage from '~components/InlineMessage'
 import { Switch } from '~components/Toggle/Switch'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { useUser } from '~features/user/queries'
 
 import { useMutateFormSettings } from '../mutations'
 import { useAdminFormSettings } from '../queries'
@@ -30,7 +30,7 @@ export const FormStatusToggle = (): JSX.Element => {
   } = useAdminForm()
   const { data: formSettings, isLoading: isLoadingFormSettings } =
     useAdminFormSettings()
-
+  const { user } = useUser()
   const { status, responseMode, authType, esrvcId } = formSettings ?? {}
 
   const secretKeyActivationModalProps = useDisclosure()
@@ -54,7 +54,8 @@ export const FormStatusToggle = (): JSX.Element => {
       form_fields?.some(
         (ff) =>
           ff.fieldType === BasicField.Email && ff.autoReplyOptions.hasAutoReply,
-      )
+      ) &&
+      !user?.betaFlags?.respondentCopy
     ) {
       return t('features.adminForm.settings.general.status.noEmailsInMRF')
     }

--- a/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -285,13 +285,6 @@ const MrfEmailNotificationsForm = ({
             </FormErrorMessage>
           )}
         </FormControl>
-        {isTest || user?.betaFlags?.respondentCopy ? (
-          <FormControl isDisabled={isDisabled}>
-            <Box mt={'1.5rem'}>
-              <RespondentCopyToggle />
-            </Box>
-          </FormControl>
-        ) : null}
       </Box>
     </form>
   )

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -24,7 +24,6 @@ import { PaymentPreview } from '../../../../templates/Field/PaymentPreview/Payme
 import { PublicFormPaymentResumeModal } from '../FormPaymentPage/FormPaymentResumeModal'
 
 import { PublicFormSubmitButton } from './PublicFormSubmitButton'
-import { PublicRespondentEmailField } from './PublicRespondentEmailField'
 import { VisibleFormFields } from './VisibleFormFields'
 
 export interface FormFieldsProps {

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -119,12 +119,6 @@ export const FormFields = ({
             />
           </Box>
         )}
-      {/* TODO: (respondent copy): Remove when respondent copy is out of beta */}
-      {form?.hasRespondentCopy && isRespondentCopyEnabled ? (
-        <Box mt="2.5rem" px={{ base: '1rem', md: 0 }}>
-          <PublicRespondentEmailField />
-        </Box>
-      ) : null}
       <PublicFormPaymentResumeModal />
       <PublicFormSubmitButton
         onSubmit={onSubmit ? handleSubmit(onSubmit) : undefined}

--- a/src/app/models/field/__tests__/emailField.spec.ts
+++ b/src/app/models/field/__tests__/emailField.spec.ts
@@ -102,7 +102,7 @@ describe('models.fields.emailField', () => {
     expect(actual.field.toObject()).toEqual(expected)
   })
 
-  it('should set includeFormSummary to false on ResponseMode.Multirespondent forms', async () => {
+  it('should set includeFormSummary to given on ResponseMode.Multirespondent forms', async () => {
     // Arrange
     const mockEmailField = {
       autoReplyOptions: {
@@ -125,7 +125,7 @@ describe('models.fields.emailField', () => {
       _id: expect.anything(),
       autoReplyOptions: {
         // Should be always set to false for MRF forms
-        includeFormSummary: false,
+        includeFormSummary: true,
       },
     })
     expect(actual.field.toObject()).toEqual(expected)

--- a/src/app/models/field/emailField.ts
+++ b/src/app/models/field/emailField.ts
@@ -1,6 +1,5 @@
 import { Schema } from 'mongoose'
 
-import { FormResponseMode } from '../../../../shared/types'
 import { validateEmailDomains } from '../../../../shared/utils/email-domain-validation'
 import { IEmailFieldSchema } from '../../../types'
 
@@ -30,12 +29,6 @@ const createEmailFieldSchema = (): Schema<IEmailFieldSchema> => {
       includeFormSummary: {
         type: Boolean,
         default: false,
-        set: function (this: IEmailFieldSchema, v: boolean) {
-          // Set to false if mrf mode regardless of initial value.
-          return this.parent().responseMode === FormResponseMode.Multirespondent
-            ? false
-            : v
-        },
       },
     },
 

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -81,7 +81,22 @@ describe('Multirespondent Submission Middleware', () => {
     const MOCK_SUBMISSION_ID = new ObjectId().toHexString()
     const MOCK_FEATURE_FLAGS = ['flag1', 'flag2']
 
-    const MOCK_FORM = {
+  const MOCK_FORM = {
+    _id: MOCK_FORM_ID,
+    responseMode: FormResponseMode.Multirespondent,
+    title: 'mock form title',
+    publicKey: 'mockPublicKey',
+    form_fields: [
+      { _id: 'field1', fieldType: 'textfield', title: 'Field 1' },
+      { _id: 'field2', fieldType: 'email', title: 'Field 2' },
+    ],
+    form_logics: [{ _id: 'logic1', logicType: 'showFields' }],
+    workflow: [{ step: 1, edit: ['field1', 'field2'] }],
+    hasRespondentCopy: true,
+    emails: ['test@example.com'],
+    stepOneEmailNotificationFieldId: 'field1',
+    stepsToNotify: [new ObjectId().toHexString()],
+    toObject: jest.fn().mockReturnValue({
       _id: MOCK_FORM_ID,
       responseMode: FormResponseMode.Multirespondent,
       title: 'mock form title',
@@ -96,39 +111,29 @@ describe('Multirespondent Submission Middleware', () => {
       emails: ['test@example.com'],
       stepOneEmailNotificationFieldId: 'field1',
       stepsToNotify: [new ObjectId().toHexString()],
-      toObject: jest.fn().mockReturnValue({
-        _id: MOCK_FORM_ID,
-        responseMode: FormResponseMode.Multirespondent,
-        title: 'mock form title',
-        publicKey: 'mockPublicKey',
-        form_fields: [
-          { _id: 'field1', fieldType: 'textfield', title: 'Field 1' },
-          { _id: 'field2', fieldType: 'email', title: 'Field 2' },
-        ],
-        form_logics: [{ _id: 'logic1', logicType: 'showFields' }],
-        workflow: [{ step: 1, edit: ['field1', 'field2'] }],
-        hasRespondentCopy: true,
-        emails: ['test@example.com'],
-        stepOneEmailNotificationFieldId: 'field1',
-        stepsToNotify: [new ObjectId().toHexString()],
-      }),
-      // Add other required properties to satisfy IPopulatedForm interface
-      admin: { _id: new ObjectId() },
-      permissionList: [],
-      startPage: { title: 'Start', paragraph: 'Start page' },
-      endPage: { title: 'End', paragraph: 'End page' },
-      hasCaptcha: false,
-      hasIssueNotification: false,
-      authType: FormResponseMode.Multirespondent,
-      isSubmitterIdCollectionEnabled: false,
-      isSingleSubmission: false,
-      status: 'ACTIVE',
-      inactiveMessage: '',
-      submissionLimit: null,
-      isListed: true,
-      webhook: { url: '', isRetryEnabled: false },
-      getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
-    } as any
+    }),
+    // Add other required properties to satisfy IPopulatedForm interface
+    admin: {
+      _id: new ObjectId(),
+      agency: {
+        fullName: 'Government Technology Agency',
+      },
+    },
+    permissionList: [],
+    startPage: { title: 'Start', paragraph: 'Start page' },
+    endPage: { title: 'End', paragraph: 'End page' },
+    hasCaptcha: false,
+    hasIssueNotification: false,
+    authType: FormResponseMode.Multirespondent,
+    isSubmitterIdCollectionEnabled: false,
+    isSingleSubmission: false,
+    status: 'ACTIVE',
+    inactiveMessage: '',
+    submissionLimit: null,
+    isListed: true,
+    webhook: { url: '', isRetryEnabled: false },
+    getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+  } as any
 
     const MOCK_MRF_SUBMISSION = {
       form: MOCK_FORM_ID,
@@ -204,20 +209,20 @@ describe('Multirespondent Submission Middleware', () => {
       // Verify that formDef (latestFormDef) is set
       expect(mockReq.formsg.formDef).toEqual(MOCK_FORM)
 
-      // Verify that snapshottedFormDef is set with correct structure
-      expect(mockReq.formsg.snapshottedFormDef).toEqual({
-        _id: MOCK_FORM_ID,
-        title: MOCK_FORM.title,
-        form_fields: MOCK_MRF_SUBMISSION.form_fields, // Should use snapshot from submission
-        form_logics: MOCK_MRF_SUBMISSION.form_logics, // Should use snapshot from submission
-        webhook: MOCK_FORM.webhook, // Should use current form data
-        workflow: MOCK_MRF_SUBMISSION.workflow, // Should use snapshot from submission
-        hasRespondentCopy: MOCK_FORM.hasRespondentCopy, // Should use current form data
-        emails: MOCK_FORM.emails, // Should use current form data
-        stepOneEmailNotificationFieldId:
-          MOCK_FORM.stepOneEmailNotificationFieldId, // Should use current form data
-        stepsToNotify: MOCK_FORM.stepsToNotify, // Should use current form data
-      })
+    // Verify that snapshottedFormDef is set with correct structure
+    expect(mockReq.formsg.snapshottedFormDef).toEqual({
+      _id: MOCK_FORM_ID,
+      title: MOCK_FORM.title,
+      form_fields: MOCK_MRF_SUBMISSION.form_fields, // Should use snapshot from submission
+      form_logics: MOCK_MRF_SUBMISSION.form_logics, // Should use snapshot from submission
+      webhook: MOCK_FORM.webhook, // Should use current form data
+      workflow: MOCK_MRF_SUBMISSION.workflow, // Should use snapshot from submission
+      admin: MOCK_FORM.admin, // Should use current form data
+      emails: MOCK_FORM.emails, // Should use current form data
+      stepOneEmailNotificationFieldId:
+        MOCK_FORM.stepOneEmailNotificationFieldId, // Should use current form data
+      stepsToNotify: MOCK_FORM.stepsToNotify, // Should use current form data
+    })
 
       // Verify that getMultirespondentSubmission was called with the correct submissionId
       expect(getMultirespondentSubmission).toHaveBeenCalledWith(

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -81,22 +81,7 @@ describe('Multirespondent Submission Middleware', () => {
     const MOCK_SUBMISSION_ID = new ObjectId().toHexString()
     const MOCK_FEATURE_FLAGS = ['flag1', 'flag2']
 
-  const MOCK_FORM = {
-    _id: MOCK_FORM_ID,
-    responseMode: FormResponseMode.Multirespondent,
-    title: 'mock form title',
-    publicKey: 'mockPublicKey',
-    form_fields: [
-      { _id: 'field1', fieldType: 'textfield', title: 'Field 1' },
-      { _id: 'field2', fieldType: 'email', title: 'Field 2' },
-    ],
-    form_logics: [{ _id: 'logic1', logicType: 'showFields' }],
-    workflow: [{ step: 1, edit: ['field1', 'field2'] }],
-    hasRespondentCopy: true,
-    emails: ['test@example.com'],
-    stepOneEmailNotificationFieldId: 'field1',
-    stepsToNotify: [new ObjectId().toHexString()],
-    toObject: jest.fn().mockReturnValue({
+    const MOCK_FORM = {
       _id: MOCK_FORM_ID,
       responseMode: FormResponseMode.Multirespondent,
       title: 'mock form title',
@@ -111,29 +96,44 @@ describe('Multirespondent Submission Middleware', () => {
       emails: ['test@example.com'],
       stepOneEmailNotificationFieldId: 'field1',
       stepsToNotify: [new ObjectId().toHexString()],
-    }),
-    // Add other required properties to satisfy IPopulatedForm interface
-    admin: {
-      _id: new ObjectId(),
-      agency: {
-        fullName: 'Government Technology Agency',
+      toObject: jest.fn().mockReturnValue({
+        _id: MOCK_FORM_ID,
+        responseMode: FormResponseMode.Multirespondent,
+        title: 'mock form title',
+        publicKey: 'mockPublicKey',
+        form_fields: [
+          { _id: 'field1', fieldType: 'textfield', title: 'Field 1' },
+          { _id: 'field2', fieldType: 'email', title: 'Field 2' },
+        ],
+        form_logics: [{ _id: 'logic1', logicType: 'showFields' }],
+        workflow: [{ step: 1, edit: ['field1', 'field2'] }],
+        hasRespondentCopy: true,
+        emails: ['test@example.com'],
+        stepOneEmailNotificationFieldId: 'field1',
+        stepsToNotify: [new ObjectId().toHexString()],
+      }),
+      // Add other required properties to satisfy IPopulatedForm interface
+      admin: {
+        _id: new ObjectId(),
+        agency: {
+          fullName: 'Government Technology Agency',
+        },
       },
-    },
-    permissionList: [],
-    startPage: { title: 'Start', paragraph: 'Start page' },
-    endPage: { title: 'End', paragraph: 'End page' },
-    hasCaptcha: false,
-    hasIssueNotification: false,
-    authType: FormResponseMode.Multirespondent,
-    isSubmitterIdCollectionEnabled: false,
-    isSingleSubmission: false,
-    status: 'ACTIVE',
-    inactiveMessage: '',
-    submissionLimit: null,
-    isListed: true,
-    webhook: { url: '', isRetryEnabled: false },
-    getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
-  } as any
+      permissionList: [],
+      startPage: { title: 'Start', paragraph: 'Start page' },
+      endPage: { title: 'End', paragraph: 'End page' },
+      hasCaptcha: false,
+      hasIssueNotification: false,
+      authType: FormResponseMode.Multirespondent,
+      isSubmitterIdCollectionEnabled: false,
+      isSingleSubmission: false,
+      status: 'ACTIVE',
+      inactiveMessage: '',
+      submissionLimit: null,
+      isListed: true,
+      webhook: { url: '', isRetryEnabled: false },
+      getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+    } as any
 
     const MOCK_MRF_SUBMISSION = {
       form: MOCK_FORM_ID,
@@ -209,20 +209,20 @@ describe('Multirespondent Submission Middleware', () => {
       // Verify that formDef (latestFormDef) is set
       expect(mockReq.formsg.formDef).toEqual(MOCK_FORM)
 
-    // Verify that snapshottedFormDef is set with correct structure
-    expect(mockReq.formsg.snapshottedFormDef).toEqual({
-      _id: MOCK_FORM_ID,
-      title: MOCK_FORM.title,
-      form_fields: MOCK_MRF_SUBMISSION.form_fields, // Should use snapshot from submission
-      form_logics: MOCK_MRF_SUBMISSION.form_logics, // Should use snapshot from submission
-      webhook: MOCK_FORM.webhook, // Should use current form data
-      workflow: MOCK_MRF_SUBMISSION.workflow, // Should use snapshot from submission
-      admin: MOCK_FORM.admin, // Should use current form data
-      emails: MOCK_FORM.emails, // Should use current form data
-      stepOneEmailNotificationFieldId:
-        MOCK_FORM.stepOneEmailNotificationFieldId, // Should use current form data
-      stepsToNotify: MOCK_FORM.stepsToNotify, // Should use current form data
-    })
+      // Verify that snapshottedFormDef is set with correct structure
+      expect(mockReq.formsg.snapshottedFormDef).toEqual({
+        _id: MOCK_FORM_ID,
+        title: MOCK_FORM.title,
+        form_fields: MOCK_MRF_SUBMISSION.form_fields, // Should use snapshot from submission
+        form_logics: MOCK_MRF_SUBMISSION.form_logics, // Should use snapshot from submission
+        webhook: MOCK_FORM.webhook, // Should use current form data
+        workflow: MOCK_MRF_SUBMISSION.workflow, // Should use snapshot from submission
+        admin: MOCK_FORM.admin, // Should use current form data
+        emails: MOCK_FORM.emails, // Should use current form data
+        stepOneEmailNotificationFieldId:
+          MOCK_FORM.stepOneEmailNotificationFieldId, // Should use current form data
+        stepsToNotify: MOCK_FORM.stepsToNotify, // Should use current form data
+      })
 
       // Verify that getMultirespondentSubmission was called with the correct submissionId
       expect(getMultirespondentSubmission).toHaveBeenCalledWith(

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -4,6 +4,7 @@ import { okAsync } from 'neverthrow'
 import {
   BasicField,
   FieldResponsesV3,
+  FormFieldDto,
   FormWorkflowStepDto,
   WorkflowStatus,
   WorkflowType,
@@ -134,6 +135,33 @@ describe('multirespondent-submission.service', () => {
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[0]],
           stepOneEmailNotificationFieldId: emailFieldId1,
+          admin: {
+            agency: {
+              fullName: 'Government Technology Agency',
+            },
+          },
+          form_fields: [
+            {
+              _id: emailFieldId1,
+              fieldType: BasicField.Email,
+              title: 'Email Field 1',
+            },
+            {
+              _id: emailFieldId2,
+              fieldType: BasicField.Email,
+              title: 'Email Field 2',
+            },
+            {
+              _id: yesNoFieldId1,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 1',
+            },
+            {
+              _id: yesNoFieldId2,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 2',
+            },
+          ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
@@ -246,6 +274,33 @@ describe('multirespondent-submission.service', () => {
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
           stepOneEmailNotificationFieldId: emailFieldId1,
+          admin: {
+            agency: {
+              fullName: 'Government Technology Agency',
+            },
+          },
+          form_fields: [
+            {
+              _id: emailFieldId1,
+              fieldType: BasicField.Email,
+              title: 'Email Field 1',
+            },
+            {
+              _id: emailFieldId2,
+              fieldType: BasicField.Email,
+              title: 'Email Field 2',
+            },
+            {
+              _id: yesNoFieldId1,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 1',
+            },
+            {
+              _id: yesNoFieldId2,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 2',
+            },
+          ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
@@ -365,6 +420,33 @@ describe('multirespondent-submission.service', () => {
           emails: [expectedEmails[3]],
           stepsToNotify: [stepTwoId, stepThreeId],
           stepOneEmailNotificationFieldId: emailFieldId1,
+          admin: {
+            agency: {
+              fullName: 'Government Technology Agency',
+            },
+          },
+          form_fields: [
+            {
+              _id: emailFieldId1,
+              fieldType: BasicField.Email,
+              title: 'Email Field 1',
+            },
+            {
+              _id: emailFieldId2,
+              fieldType: BasicField.Email,
+              title: 'Email Field 2',
+            },
+            {
+              _id: yesNoFieldId1,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 1',
+            },
+            {
+              _id: yesNoFieldId2,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 2',
+            },
+          ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
@@ -478,6 +560,33 @@ describe('multirespondent-submission.service', () => {
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
           stepOneEmailNotificationFieldId: emailFieldId1,
+          admin: {
+            agency: {
+              fullName: 'Government Technology Agency',
+            },
+          },
+          form_fields: [
+            {
+              _id: emailFieldId1,
+              fieldType: BasicField.Email,
+              title: 'Email Field 1',
+            },
+            {
+              _id: emailFieldId2,
+              fieldType: BasicField.Email,
+              title: 'Email Field 2',
+            },
+            {
+              _id: yesNoFieldId1,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 1',
+            },
+            {
+              _id: yesNoFieldId2,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 2',
+            },
+          ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber: currentWorkflowStep,
         encryptedPayload: {
@@ -587,6 +696,33 @@ describe('multirespondent-submission.service', () => {
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
           stepOneEmailNotificationFieldId: emailFieldId1,
+          admin: {
+            agency: {
+              fullName: 'Government Technology Agency',
+            },
+          },
+          form_fields: [
+            {
+              _id: emailFieldId1,
+              fieldType: BasicField.Email,
+              title: 'Email Field 1',
+            },
+            {
+              _id: emailFieldId2,
+              fieldType: BasicField.Email,
+              title: 'Email Field 2',
+            },
+            {
+              _id: yesNoFieldId1,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 1',
+            },
+            {
+              _id: yesNoFieldId2,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 2',
+            },
+          ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
@@ -715,6 +851,33 @@ describe('multirespondent-submission.service', () => {
           emails: [expectedEmails[1], expectedEmails[2]],
           stepsToNotify: [stepThreeId, stepFourId, stepFiveId],
           stepOneEmailNotificationFieldId: emailFieldId1,
+          admin: {
+            agency: {
+              fullName: 'Government Technology Agency',
+            },
+          },
+          form_fields: [
+            {
+              _id: emailFieldId1,
+              fieldType: BasicField.Email,
+              title: 'Email Field 1',
+            },
+            {
+              _id: emailFieldId2,
+              fieldType: BasicField.Email,
+              title: 'Email Field 2',
+            },
+            {
+              _id: yesNoFieldId1,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 1',
+            },
+            {
+              _id: yesNoFieldId2,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 2',
+            },
+          ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber: currentStepNumber,
         encryptedPayload: {
@@ -828,6 +991,33 @@ describe('multirespondent-submission.service', () => {
           workflow: threeStepApprovalWorkflow,
           emails: [expectedEmails[1]],
           stepOneEmailNotificationFieldId: emailFieldId1,
+          admin: {
+            agency: {
+              fullName: 'Government Technology Agency',
+            },
+          },
+          form_fields: [
+            {
+              _id: emailFieldId1,
+              fieldType: BasicField.Email,
+              title: 'Email Field 1',
+            },
+            {
+              _id: emailFieldId2,
+              fieldType: BasicField.Email,
+              title: 'Email Field 2',
+            },
+            {
+              _id: yesNoFieldId1,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 1',
+            },
+            {
+              _id: yesNoFieldId2,
+              fieldType: BasicField.YesNo,
+              title: 'Yes/No Field 2',
+            },
+          ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber,
         encryptedPayload: {
@@ -1426,234 +1616,6 @@ describe('multirespondent-submission.service', () => {
           notExpectedStepOneEmail,
         ),
       ).toBe(false)
-    })
-  })
-
-  describe('sendRespondentCopyEmail', () => {
-    it('should not send respondent copy if respondent emails are not present on performMultiRespondentPostSubmissionCreateActions', async () => {
-      // Arrange
-      const sendMrfRespondentCopyEmailSpy = jest.spyOn(
-        MailService,
-        'sendMrfRespondentCopyEmail',
-      )
-
-      const singleStepWorkflow: FormWorkflowStepDto[] = [
-        {
-          _id: new ObjectId().toHexString(),
-          workflow_type: WorkflowType.Static,
-          emails: [],
-          edit: [],
-        },
-      ]
-
-      const emptyRespondentEmails: string[] = []
-
-      // Act
-      await performMultiRespondentPostSubmissionCreateActions({
-        submission: {
-          _id: mockSubmissionId,
-        } as unknown as IMultirespondentSubmissionSchema,
-        submissionId: mockSubmissionId,
-        form: {
-          _id: mockFormId,
-          workflow: singleStepWorkflow,
-          emails: ['email1@example.com'],
-        } as IPopulatedMultirespondentForm,
-        encryptedPayload: {
-          encryptedContent: 'encryptedContent',
-          version: 1,
-          submissionPublicKey: 'submissionPublicKey',
-          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
-        } as MultirespondentSubmissionDto,
-        logMeta: {} as any,
-        respondentEmails: emptyRespondentEmails,
-      })
-
-      // Assert
-      expect(sendMrfRespondentCopyEmailSpy).not.toHaveBeenCalled()
-    })
-
-    it('should not send respondent copy if respondent emails are not present on performMultiRespondentPostSubmissionUpdateActions', async () => {
-      // Arrange
-      const sendMrfRespondentCopyEmailSpy = jest.spyOn(
-        MailService,
-        'sendMrfRespondentCopyEmail',
-      )
-
-      const singleStepWorkflow: FormWorkflowStepDto[] = [
-        {
-          _id: new ObjectId().toHexString(),
-          workflow_type: WorkflowType.Static,
-          emails: [],
-          edit: [],
-        },
-      ]
-
-      const emptyRespondentEmails: string[] = []
-
-      // Act
-      await performMultiRespondentPostSubmissionUpdateActions({
-        submission: {
-          _id: mockSubmissionId,
-        } as unknown as IMultirespondentSubmissionSchema,
-        submissionId: mockSubmissionId,
-        snapshottedFormDef: {
-          _id: mockFormId,
-          workflow: singleStepWorkflow,
-          emails: ['email1@example.com'],
-        } as SnapshottedFormDef,
-        currentStepNumber: 1,
-        encryptedPayload: {
-          encryptedContent: 'encryptedContent',
-          version: 1,
-          submissionPublicKey: 'submissionPublicKey',
-          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
-        } as MultirespondentSubmissionDto,
-        logMeta: {} as any,
-        respondentEmails: emptyRespondentEmails,
-      })
-
-      // Assert
-      expect(sendMrfRespondentCopyEmailSpy).not.toHaveBeenCalled()
-    })
-
-    it('sends respondent copy on first step submission when respondent emails are present', async () => {
-      // Arrange
-      const sendMrfRespondentCopyEmailSpy = jest.spyOn(
-        MailService,
-        'sendMrfRespondentCopyEmail',
-      )
-
-      const singleStepWorkflow: FormWorkflowStepDto[] = [
-        {
-          _id: new ObjectId().toHexString(),
-          workflow_type: WorkflowType.Static,
-          emails: [],
-          edit: [],
-        },
-      ]
-
-      const respondentEmails = ['test@example.com', 'test1@example.com']
-
-      // Act
-      await performMultiRespondentPostSubmissionCreateActions({
-        submission: {
-          _id: mockSubmissionId,
-        } as unknown as IMultirespondentSubmissionSchema,
-        submissionId: mockSubmissionId,
-        form: {
-          _id: mockFormId,
-          workflow: singleStepWorkflow,
-          emails: ['email1@example.com'],
-        } as IPopulatedMultirespondentForm,
-        encryptedPayload: {
-          encryptedContent: 'encryptedContent',
-          version: 1,
-          submissionPublicKey: 'submissionPublicKey',
-          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
-        } as MultirespondentSubmissionDto,
-        logMeta: {} as any,
-        respondentEmails: respondentEmails,
-      })
-
-      // Assert
-      expect(sendMrfRespondentCopyEmailSpy).toHaveBeenCalledTimes(1)
-      expect(
-        sendMrfRespondentCopyEmailSpy.mock.calls[0][0].emails,
-      ).toContainValues(respondentEmails)
-      expect(sendMrfRespondentCopyEmailSpy.mock.calls[0][0].emails.length).toBe(
-        2,
-      )
-    })
-
-    it('sends respondent copy on subsequent step submission when respondent emails are present', async () => {
-      // Arrange
-      const sendMrfRespondentCopyEmailSpy = jest.spyOn(
-        MailService,
-        'sendMrfRespondentCopyEmail',
-      )
-
-      const mockFormId = new ObjectId().toHexString()
-      const mockSubmissionId = new ObjectId().toHexString()
-
-      const stepOneEmailNotificationFieldId = new ObjectId().toHexString()
-      const stepOneEditEmailFieldId = new ObjectId().toHexString()
-
-      const expectedStepOneEmail = 'expected_step_one_email@example.com'
-      const notExpectedStepOneEmail = 'not_expected_step_one_email@example.com'
-      const expectedStaticEmail = 'expected_static_email@example.com'
-      const expectedStepTwoEmail = 'expected_step_two_static_email@example.com'
-
-      const stepOneId = new ObjectId().toHexString()
-      const stepTwoId = new ObjectId().toHexString()
-
-      const workflow: FormWorkflowStepDto[] = [
-        {
-          _id: stepOneId,
-          workflow_type: WorkflowType.Dynamic,
-          field: stepOneEditEmailFieldId,
-          edit: [stepOneEditEmailFieldId],
-        },
-        {
-          _id: stepTwoId,
-          workflow_type: WorkflowType.Static,
-          emails: [expectedStepTwoEmail],
-          edit: [],
-        },
-      ]
-
-      const snapshottedFormDef = {
-        _id: mockFormId,
-        workflow,
-        emails: [expectedStaticEmail],
-        stepsToNotify: [stepOneId, stepTwoId], // Including step one in stepsToNotify
-        stepOneEmailNotificationFieldId,
-      } as SnapshottedFormDef
-      const respondentEmails = ['test@example.com', 'test1@example.com']
-
-      const submissionResponses: FieldResponsesV3 = {
-        [stepOneEmailNotificationFieldId]: {
-          fieldType: BasicField.Email,
-          answer: {
-            value: expectedStepOneEmail,
-          },
-        },
-        [stepOneEditEmailFieldId]: {
-          fieldType: BasicField.Email,
-          answer: {
-            value: notExpectedStepOneEmail,
-          },
-        },
-      }
-
-      // Act
-      await performMultiRespondentPostSubmissionUpdateActions({
-        submission: {
-          _id: mockSubmissionId,
-        } as unknown as IMultirespondentSubmissionSchema,
-        submissionId: mockSubmissionId,
-        snapshottedFormDef,
-        currentStepNumber: workflow.length - 1,
-        encryptedPayload: {
-          encryptedContent: 'encryptedContent',
-          version: 1,
-          submissionPublicKey: 'submissionPublicKey',
-          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
-          responses: submissionResponses,
-          workflowStep: workflow.length - 1,
-        } as MultirespondentSubmissionDto,
-        logMeta: {} as any,
-        respondentEmails: respondentEmails,
-      })
-
-      // Assert
-      expect(sendMrfRespondentCopyEmailSpy).toHaveBeenCalledTimes(1)
-      expect(
-        sendMrfRespondentCopyEmailSpy.mock.calls[0][0].emails,
-      ).toContainValues(respondentEmails)
-      expect(sendMrfRespondentCopyEmailSpy.mock.calls[0][0].emails.length).toBe(
-        2,
-      )
     })
   })
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -58,7 +58,7 @@ import {
   UpdateMultirespondentSubmissionHandlerRequest,
   UpdateMultirespondentSubmissionHandlerType,
 } from './multirespondent-submission.types'
-import { createPublicMultirespondentSubmissionDto, extractRespondentCopyEmails } from './multirespondent-submission.utils'
+import { createPublicMultirespondentSubmissionDto } from './multirespondent-submission.utils'
 
 const logger = createLoggerWithLabel(module)
 
@@ -132,12 +132,6 @@ const submitMultirespondentForm = async (
     mrfStep: submission.workflowStep,
   })
 
-  // Find respondent copy emails
-  const respondentEmails = extractRespondentCopyEmails({
-    responses: req.body.responses,
-    formFields: form.form_fields,
-  })
-
   await performMultiRespondentPostSubmissionCreateActions({
     submission,
     submissionId: submission._id.toString(),
@@ -145,7 +139,6 @@ const submitMultirespondentForm = async (
     encryptedPayload,
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
-    respondentEmails,
   })
 }
 
@@ -241,7 +234,6 @@ const updateMultirespondentSubmission = async (
     encryptedPayload,
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
-    respondentEmails: req.formsg.respondentEmails,
   })
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -58,7 +58,7 @@ import {
   UpdateMultirespondentSubmissionHandlerRequest,
   UpdateMultirespondentSubmissionHandlerType,
 } from './multirespondent-submission.types'
-import { createPublicMultirespondentSubmissionDto } from './multirespondent-submission.utils'
+import { createPublicMultirespondentSubmissionDto, extractRespondentCopyEmails } from './multirespondent-submission.utils'
 
 const logger = createLoggerWithLabel(module)
 
@@ -132,6 +132,12 @@ const submitMultirespondentForm = async (
     mrfStep: submission.workflowStep,
   })
 
+  // Find respondent copy emails
+  const respondentEmails = extractRespondentCopyEmails({
+    responses: req.body.responses,
+    formFields: form.form_fields,
+  })
+
   await performMultiRespondentPostSubmissionCreateActions({
     submission,
     submissionId: submission._id.toString(),
@@ -139,7 +145,7 @@ const submitMultirespondentForm = async (
     encryptedPayload,
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
-    respondentEmails: req.formsg.respondentEmails,
+    respondentEmails,
   })
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -133,7 +133,7 @@ const getSnapshottedFormDef = (
   form_logics: mrfSubmission.form_logics,
   workflow: mrfSubmission.workflow,
   webhook: currentFormDef.webhook,
-  hasRespondentCopy: currentFormDef.hasRespondentCopy,
+  admin: currentFormDef.admin,
   emails: currentFormDef.emails,
   stepOneEmailNotificationFieldId:
     currentFormDef.stepOneEmailNotificationFieldId,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -462,8 +462,8 @@ const sendMrfRespondentCopyEmails = ({
   respondentCopyRecipientData,
 }: {
   form: Pick<
-    IPopulatedMultirespondentForm,
-    '_id' | 'title' | 'hasRespondentCopy' | 'admin'
+    IPopulatedMultirespondentForm | SnapshottedFormDef,
+    '_id' | 'title' | 'admin'
   > & {
     form_fields: FormFieldSchema[] | FormFieldDto[]
   }
@@ -476,7 +476,6 @@ const sendMrfRespondentCopyEmails = ({
     formFields: form.form_fields,
     responses,
   })
-
   return ResultAsync.combine(
     respondentCopyRecipientData.map((autoReplyMailData) =>
       MailService.sendMrfRespondentCopyEmail({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -34,6 +34,7 @@ import {
 import { getMultirespondentSubmissionModel } from '../../../models/submission.server.model'
 import { MailSendError } from '../../../services/mail/mail.errors'
 import MailService from '../../../services/mail/mail.service'
+import { AutoReplyMailData } from '../../../services/mail/mail.types'
 import { transformMongoError } from '../../../utils/handle-mongo-error'
 import { DatabaseError } from '../../core/core.errors'
 import { isFormMultirespondent } from '../../form/form.utils'
@@ -56,6 +57,7 @@ import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
 import { MultirespondentSubmissionContent } from './multirespondent-submission.types'
 import {
+  extractRespondentCopyEmails,
   getEmailFromResponses,
   getQuestionTitleAnswerString,
   retrieveWorkflowStepEmailAddresses,
@@ -457,7 +459,7 @@ const sendMrfRespondentCopyEmails = ({
   responses,
   submissionId,
   attachments,
-  respondentEmails,
+  recipientData,
 }: {
   form: Pick<
     IPopulatedMultirespondentForm,
@@ -468,21 +470,23 @@ const sendMrfRespondentCopyEmails = ({
   responses: FieldResponsesV3
   submissionId: string
   attachments?: IAttachmentInfo[]
-  respondentEmails: string[]
+  recipientData: AutoReplyMailData[]
 }): ResultAsync<true, InvalidWorkflowTypeError | MailSendError> => {
   const formQuestionAnswers = getQuestionTitleAnswerString({
     formFields: form.form_fields,
     responses,
   })
 
+  //TODO: remove and loop
+  const autoreplyMailData = recipientData[0]
+
   return MailService.sendMrfRespondentCopyEmail({
-    emails: respondentEmails,
     formId: form._id,
     formTitle: form.title,
     responseId: submissionId,
     formQuestionAnswers,
     attachments: attachments,
-    respondentCopy: form.hasRespondentCopy,
+    autoReplyMailData: autoreplyMailData,
   }).orElse((error) => {
     logger.error({
       message: 'Failed to send respondent copy email',
@@ -637,7 +641,6 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   encryptedPayload,
   logMeta,
   attachments,
-  respondentEmails,
 }: {
   submission: IMultirespondentSubmissionSchema
   submissionId: string
@@ -645,7 +648,6 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
   attachments?: IAttachmentInfo[]
-  respondentEmails?: string[]
 }): ResultAsync<boolean, InvalidWorkflowTypeError | MailSendError> => {
   const { submissionSecretKey, responses } = encryptedPayload
   const currentStepNumber = 0
@@ -658,13 +660,19 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
     submissionId,
   }
 
-  if (respondentEmails && respondentEmails.length > 0) {
+  // Find respondent copy recipient data
+  const recipientData = extractRespondentCopyEmails({
+    responses: encryptedPayload.responses,
+    formFields: form.form_fields,
+  })
+
+  if (recipientData && recipientData.length > 0) {
     sendMrfRespondentCopyEmails({
       form,
       responses,
       submissionId,
       attachments,
-      respondentEmails,
+      recipientData,
     }).mapErr((error) => {
       logger.error({
         message: 'Send multirespondent respondent copy email error',

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1,4 +1,5 @@
 import { flatten, uniq } from 'lodash'
+import moment from 'moment'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import Mail from 'nodemailer/lib/mailer'
@@ -466,7 +467,7 @@ const sendMrfOutcomeEmails = ({
 const sendMrfRespondentCopyEmails = ({
   form,
   responses,
-  submissionId,
+  submission,
   attachments,
   respondentCopyRecipientData,
 }: {
@@ -477,13 +478,19 @@ const sendMrfRespondentCopyEmails = ({
     form_fields: FormFieldSchema[] | FormFieldDto[]
   }
   responses: FieldResponsesV3
-  submissionId: string
+  submission: IMultirespondentSubmissionSchema
   attachments?: IAttachmentInfo[]
   respondentCopyRecipientData: AutoReplyMailData[]
 }): ResultAsync<
   true,
   InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError
 > => {
+  const submissionId: string = submission.id
+  const submissionTime = moment(submission.created)
+    .tz('Asia/Singapore')
+    .format('ddd, DD MMM YYYY hh:mm:ss A')
+  const formUrl: string = `${config.app.appUrl}/${form._id}`
+
   const formQuestionAnswers = getQuestionTitleAnswerString({
     formFields: form.form_fields,
     responses,
@@ -500,9 +507,9 @@ const sendMrfRespondentCopyEmails = ({
   const renderData: AutoreplySummaryRenderData = {
     refNo: submissionId,
     formTitle: form.title,
-    submissionTime: 'working submissionTime',
+    submissionTime: submissionTime,
     formData: pdfFormData,
-    formUrl: `working formUrl`,
+    formUrl: formUrl,
   }
 
   // Step 1: generate PDF if needed
@@ -724,7 +731,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
     sendMrfRespondentCopyEmails({
       form,
       responses,
-      submissionId,
+      submission,
       attachments,
       respondentCopyRecipientData,
     }).mapErr((error) => {
@@ -989,7 +996,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     sendMrfRespondentCopyEmails({
       form: snapshottedFormDef,
       responses,
-      submissionId,
+      submission,
       attachments,
       respondentCopyRecipientData,
     }).mapErr((error) => {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -463,7 +463,7 @@ const sendMrfRespondentCopyEmails = ({
 }: {
   form: Pick<
     IPopulatedMultirespondentForm,
-    '_id' | 'title' | 'hasRespondentCopy'
+    '_id' | 'title' | 'hasRespondentCopy' | 'admin'
   > & {
     form_fields: FormFieldSchema[] | FormFieldDto[]
   }
@@ -486,6 +486,7 @@ const sendMrfRespondentCopyEmails = ({
         formQuestionAnswers,
         attachments,
         autoReplyMailData,
+        agencyName: form.admin.agency.fullName,
       }).orElse((error) => {
         logger.error({
           message: 'Failed to send respondent copy email',
@@ -927,11 +928,6 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     submissionId,
   }
 
-  // console.log('responses')
-  // console.log(responses)
-
-  // console.log(`snapshottedFormDef`)
-  // console.log(snapshottedFormDef)
   //Find respondent copy recipient data
   const respondentCopyRecipientData = extractRespondentCopyEmails({
     responses: responses,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -990,7 +990,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     submissionId,
   }
 
-  //Find respondent copy recipient data
+  // Find respondent copy recipient data
   const respondentCopyRecipientData = extractRespondentCopyEmails({
     responses: responses,
     formFields: snapshottedFormDef.form_fields,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -68,7 +68,7 @@ import { MultirespondentSubmissionContent } from './multirespondent-submission.t
 import {
   extractRespondentCopyEmails,
   getEmailFromResponses,
-  getPdfFormData,
+  getPdfResponsesData,
   getQuestionTitleAnswerString,
   retrieveWorkflowStepEmailAddresses,
 } from './multirespondent-submission.utils'
@@ -496,8 +496,8 @@ const sendMrfRespondentCopyEmails = ({
     responses,
   })
 
-  // function to prepare answers for pdf html
-  const pdfFormData = getPdfFormData({
+  // Prepare repsonses for pdf html
+  const pdfFormData = getPdfResponsesData({
     formFields: form.form_fields,
     responses,
   })

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -32,9 +32,9 @@ import {
   CustomLoggerParams,
 } from '../../../config/logger'
 import { getMultirespondentSubmissionModel } from '../../../models/submission.server.model'
-import { MailSendError } from '../../../services/mail/mail.errors'
+import { AutoreplyPdfGenerationError, MailSendError } from '../../../services/mail/mail.errors'
 import MailService from '../../../services/mail/mail.service'
-import { AutoReplyMailData } from '../../../services/mail/mail.types'
+import { AutoReplyMailData, AutoreplySummaryRenderData } from '../../../services/mail/mail.types'
 import { transformMongoError } from '../../../utils/handle-mongo-error'
 import { DatabaseError } from '../../core/core.errors'
 import { isFormMultirespondent } from '../../form/form.utils'
@@ -59,9 +59,12 @@ import { MultirespondentSubmissionContent } from './multirespondent-submission.t
 import {
   extractRespondentCopyEmails,
   getEmailFromResponses,
+  getPdfFormData,
   getQuestionTitleAnswerString,
   retrieveWorkflowStepEmailAddresses,
 } from './multirespondent-submission.utils'
+import Mail from 'nodemailer/lib/mailer'
+import { generateAutoreplyPdf } from '../../../services/mail/mail.utils'
 
 const logger = createLoggerWithLabel(module)
 const MultirespondentSubmission = getMultirespondentSubmissionModel(mongoose)
@@ -471,36 +474,65 @@ const sendMrfRespondentCopyEmails = ({
   submissionId: string
   attachments?: IAttachmentInfo[]
   respondentCopyRecipientData: AutoReplyMailData[]
-}): ResultAsync<true, InvalidWorkflowTypeError | MailSendError> => {
+}): ResultAsync<true, InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError> => {
   const formQuestionAnswers = getQuestionTitleAnswerString({
     formFields: form.form_fields,
     responses,
   })
-  return ResultAsync.combine(
-    respondentCopyRecipientData.map((autoReplyMailData) =>
-      MailService.sendMrfRespondentCopyEmail({
-        formId: form._id,
-        formTitle: form.title,
-        responseId: submissionId,
-        formQuestionAnswers,
-        attachments,
-        autoReplyMailData,
-        agencyName: form.admin.agency.fullName,
-      }).orElse((error) => {
-        logger.error({
-          message: 'Failed to send respondent copy email',
-          meta: {
-            action: 'sendMrfRespondentCopyEmail',
-            formId: form._id,
-            submissionId,
-            autoReplyMailData,
-          },
-          error,
+
+  // function to prepare answers for pdf html
+  const pdfFormData = getPdfFormData({ formFields: form.form_fields, responses })
+  const hasFormSummary = respondentCopyRecipientData.some((autoReplyMailData) => autoReplyMailData.includeFormSummary)
+  const renderData: AutoreplySummaryRenderData = {
+    refNo: submissionId,
+    formTitle: form.title,
+    submissionTime: 'working submissionTime',
+    formData: pdfFormData,
+    formUrl: `working formUrl`,
+  }
+
+  // Step 1: generate PDF if needed
+  const pdfResult: ResultAsync<Mail.Attachment | undefined, AutoreplyPdfGenerationError> = hasFormSummary
+    ? generateAutoreplyPdf(renderData, true).map((pdfBuffer) => ({
+        filename: 'response.pdf',
+        content: Buffer.copyBytesFrom(pdfBuffer),
+      }))
+    : okAsync<Mail.Attachment | undefined>(undefined)
+
+  return pdfResult.andThen((responsePdf) => {
+    const recipientAttachments = [
+      ...(attachments ?? []),
+      ...(responsePdf ? [responsePdf] : []),
+]
+    return ResultAsync.combine(
+      respondentCopyRecipientData.map((autoReplyMailData) => {
+        return MailService.sendMrfRespondentCopyEmail({
+          formId: form._id,
+          formTitle: form.title,
+          responseId: submissionId,
+          attachments:autoReplyMailData.includeFormSummary ? recipientAttachments : [],
+          autoReplyMailData,
+          agencyName: form.admin.agency.fullName,
+          ...(autoReplyMailData.includeFormSummary && { formQuestionAnswers }),
+        }).orElse((error) => {
+          logger.error({
+            message: 'Failed to send respondent copy email',
+            meta: {
+              action: 'sendMrfRespondentCopyEmail',
+              formId: form._id,
+              submissionId,
+              autoReplyMailData,
+            },
+            error,
+          })
+          return okAsync(true) //continue even if one email fails
         })
-        return okAsync(false)
-      }),
-    ),
-  ).map(() => true)
+      })
+    ).map(() => true) as ResultAsync<
+      true,
+      InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError
+    >
+  })
 }
 
 const saveAttachmentsToDbIfExists = ({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -678,8 +678,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
         message: 'Send multirespondent respondent copy email error',
         meta: logMeta,
         error,
-      })
-      return error
+      }) // return nothing; since successful submission does not depend on this respondent copy emails sent
     })
   }
 
@@ -900,7 +899,6 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   encryptedPayload,
   logMeta,
   attachments,
-  respondentEmails,
 }: {
   submission: IMultirespondentSubmissionSchema
   submissionId: string
@@ -909,7 +907,6 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
   attachments?: IAttachmentInfo[]
-  respondentEmails?: string[]
 }): ResultAsync<
   boolean,
   | InvalidWorkflowTypeError
@@ -927,13 +924,19 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     submissionId,
   }
 
-  if (respondentEmails && respondentEmails.length > 0) {
+  // Find respondent copy recipient data
+  const recipientData = extractRespondentCopyEmails({
+    responses: encryptedPayload.responses,
+    formFields: snapshottedFormDef.form_fields,
+  })
+
+  if (recipientData && recipientData.length > 0) {
     sendMrfRespondentCopyEmails({
       form: snapshottedFormDef,
       responses,
       submissionId,
       attachments,
-      respondentEmails,
+      recipientData,
     }).mapErr((error) => {
       logger.error({
         message: 'Send multirespondent respondent copy email error',

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -459,7 +459,7 @@ const sendMrfRespondentCopyEmails = ({
   responses,
   submissionId,
   attachments,
-  recipientData,
+  respondentCopyRecipientData,
 }: {
   form: Pick<
     IPopulatedMultirespondentForm,
@@ -470,35 +470,37 @@ const sendMrfRespondentCopyEmails = ({
   responses: FieldResponsesV3
   submissionId: string
   attachments?: IAttachmentInfo[]
-  recipientData: AutoReplyMailData[]
+  respondentCopyRecipientData: AutoReplyMailData[]
 }): ResultAsync<true, InvalidWorkflowTypeError | MailSendError> => {
   const formQuestionAnswers = getQuestionTitleAnswerString({
     formFields: form.form_fields,
     responses,
   })
 
-  //TODO: remove and loop
-  const autoreplyMailData = recipientData[0]
-
-  return MailService.sendMrfRespondentCopyEmail({
-    formId: form._id,
-    formTitle: form.title,
-    responseId: submissionId,
-    formQuestionAnswers,
-    attachments: attachments,
-    autoReplyMailData: autoreplyMailData,
-  }).orElse((error) => {
-    logger.error({
-      message: 'Failed to send respondent copy email',
-      meta: {
-        action: 'sendMrfRespondentCopyEmail',
+  return ResultAsync.combine(
+    respondentCopyRecipientData.map((autoReplyMailData) =>
+      MailService.sendMrfRespondentCopyEmail({
         formId: form._id,
-        submissionId,
-      },
-      error,
-    })
-    return errAsync(error)
-  })
+        formTitle: form.title,
+        responseId: submissionId,
+        formQuestionAnswers,
+        attachments,
+        autoReplyMailData,
+      }).orElse((error) => {
+        logger.error({
+          message: 'Failed to send respondent copy email',
+          meta: {
+            action: 'sendMrfRespondentCopyEmail',
+            formId: form._id,
+            submissionId,
+            autoReplyMailData,
+          },
+          error,
+        })
+        return okAsync(false)
+      }),
+    ),
+  ).map(() => true)
 }
 
 const saveAttachmentsToDbIfExists = ({
@@ -661,18 +663,19 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   }
 
   // Find respondent copy recipient data
-  const recipientData = extractRespondentCopyEmails({
+  const respondentCopyRecipientData = extractRespondentCopyEmails({
     responses: encryptedPayload.responses,
     formFields: form.form_fields,
+    activeFields: form.workflow[currentStepNumber].edit,
   })
 
-  if (recipientData && recipientData.length > 0) {
+  if (respondentCopyRecipientData && respondentCopyRecipientData.length > 0) {
     sendMrfRespondentCopyEmails({
       form,
       responses,
       submissionId,
       attachments,
-      recipientData,
+      respondentCopyRecipientData,
     }).mapErr((error) => {
       logger.error({
         message: 'Send multirespondent respondent copy email error',
@@ -924,19 +927,25 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     submissionId,
   }
 
-  // Find respondent copy recipient data
-  const recipientData = extractRespondentCopyEmails({
-    responses: encryptedPayload.responses,
+  // console.log('responses')
+  // console.log(responses)
+
+  // console.log(`snapshottedFormDef`)
+  // console.log(snapshottedFormDef)
+  //Find respondent copy recipient data
+  const respondentCopyRecipientData = extractRespondentCopyEmails({
+    responses: responses,
     formFields: snapshottedFormDef.form_fields,
+    activeFields: snapshottedFormDef.workflow[currentStepNumber].edit,
   })
 
-  if (recipientData && recipientData.length > 0) {
+  if (respondentCopyRecipientData && respondentCopyRecipientData.length > 0) {
     sendMrfRespondentCopyEmails({
       form: snapshottedFormDef,
       responses,
       submissionId,
       attachments,
-      recipientData,
+      respondentCopyRecipientData,
     }).mapErr((error) => {
       logger.error({
         message: 'Send multirespondent respondent copy email error',

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -744,7 +744,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
         message: 'Send multirespondent respondent copy email error',
         meta: logMeta,
         error,
-      }) // return nothing; since successful submission does not depend on this respondent copy emails sent
+      }) // return nothing; since successful submission does not depend on respondent copy emails being sent
     })
   }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1,6 +1,7 @@
 import { flatten, uniq } from 'lodash'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
+import Mail from 'nodemailer/lib/mailer'
 
 import {
   BasicField,
@@ -32,9 +33,16 @@ import {
   CustomLoggerParams,
 } from '../../../config/logger'
 import { getMultirespondentSubmissionModel } from '../../../models/submission.server.model'
-import { AutoreplyPdfGenerationError, MailSendError } from '../../../services/mail/mail.errors'
+import {
+  AutoreplyPdfGenerationError,
+  MailSendError,
+} from '../../../services/mail/mail.errors'
 import MailService from '../../../services/mail/mail.service'
-import { AutoReplyMailData, AutoreplySummaryRenderData } from '../../../services/mail/mail.types'
+import {
+  AutoReplyMailData,
+  AutoreplySummaryRenderData,
+} from '../../../services/mail/mail.types'
+import { generateAutoreplyPdf } from '../../../services/mail/mail.utils'
 import { transformMongoError } from '../../../utils/handle-mongo-error'
 import { DatabaseError } from '../../core/core.errors'
 import { isFormMultirespondent } from '../../form/form.utils'
@@ -63,8 +71,6 @@ import {
   getQuestionTitleAnswerString,
   retrieveWorkflowStepEmailAddresses,
 } from './multirespondent-submission.utils'
-import Mail from 'nodemailer/lib/mailer'
-import { generateAutoreplyPdf } from '../../../services/mail/mail.utils'
 
 const logger = createLoggerWithLabel(module)
 const MultirespondentSubmission = getMultirespondentSubmissionModel(mongoose)
@@ -474,15 +480,23 @@ const sendMrfRespondentCopyEmails = ({
   submissionId: string
   attachments?: IAttachmentInfo[]
   respondentCopyRecipientData: AutoReplyMailData[]
-}): ResultAsync<true, InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError> => {
+}): ResultAsync<
+  true,
+  InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError
+> => {
   const formQuestionAnswers = getQuestionTitleAnswerString({
     formFields: form.form_fields,
     responses,
   })
 
   // function to prepare answers for pdf html
-  const pdfFormData = getPdfFormData({ formFields: form.form_fields, responses })
-  const hasFormSummary = respondentCopyRecipientData.some((autoReplyMailData) => autoReplyMailData.includeFormSummary)
+  const pdfFormData = getPdfFormData({
+    formFields: form.form_fields,
+    responses,
+  })
+  const hasFormSummary = respondentCopyRecipientData.some(
+    (autoReplyMailData) => autoReplyMailData.includeFormSummary,
+  )
   const renderData: AutoreplySummaryRenderData = {
     refNo: submissionId,
     formTitle: form.title,
@@ -492,7 +506,10 @@ const sendMrfRespondentCopyEmails = ({
   }
 
   // Step 1: generate PDF if needed
-  const pdfResult: ResultAsync<Mail.Attachment | undefined, AutoreplyPdfGenerationError> = hasFormSummary
+  const pdfResult: ResultAsync<
+    Mail.Attachment | undefined,
+    AutoreplyPdfGenerationError
+  > = hasFormSummary
     ? generateAutoreplyPdf(renderData, true).map((pdfBuffer) => ({
         filename: 'response.pdf',
         content: Buffer.copyBytesFrom(pdfBuffer),
@@ -503,14 +520,16 @@ const sendMrfRespondentCopyEmails = ({
     const recipientAttachments = [
       ...(attachments ?? []),
       ...(responsePdf ? [responsePdf] : []),
-]
+    ]
     return ResultAsync.combine(
       respondentCopyRecipientData.map((autoReplyMailData) => {
         return MailService.sendMrfRespondentCopyEmail({
           formId: form._id,
           formTitle: form.title,
           responseId: submissionId,
-          attachments:autoReplyMailData.includeFormSummary ? recipientAttachments : [],
+          attachments: autoReplyMailData.includeFormSummary
+            ? recipientAttachments
+            : [],
           autoReplyMailData,
           agencyName: form.admin.agency.fullName,
           ...(autoReplyMailData.includeFormSummary && { formQuestionAnswers }),
@@ -527,7 +546,7 @@ const sendMrfRespondentCopyEmails = ({
           })
           return okAsync(true) //continue even if one email fails
         })
-      })
+      }),
     ).map(() => true) as ResultAsync<
       true,
       InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -720,11 +720,16 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
     submissionId,
   }
 
+  // Find active fields for current step
+  const activeFields = form.workflow[currentStepNumber]
+    ? form.workflow[currentStepNumber].edit
+    : []
+
   // Find respondent copy recipient data
   const respondentCopyRecipientData = extractRespondentCopyEmails({
     responses: encryptedPayload.responses,
     formFields: form.form_fields,
-    activeFields: form.workflow[currentStepNumber].edit,
+    activeFields,
   })
 
   if (respondentCopyRecipientData && respondentCopyRecipientData.length > 0) {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -1,4 +1,3 @@
-import { keyBy } from 'lodash'
 import moment from 'moment'
 import { err, ok, Result } from 'neverthrow'
 
@@ -386,21 +385,27 @@ export const getQuestionTitleAnswerString = ({
   return questionAnswerPair
 }
 
-// '69031bf600ab799b70e1bd56': { fieldType: 'email', answer: { value: 'scott@open.gov.sg' } }
 export const extractRespondentCopyEmails = ({
   responses,
   formFields,
+  activeFields,
 }: {
   responses: FieldResponsesV3
-  formFields: FormFieldSchema[]
+  formFields: FormFieldSchema[] | FormFieldDto[]
+  activeFields: string[]
 }): AutoReplyMailData[] => {
-  const fieldsById = keyBy(formFields, '_id')
-  return Object.entries(responses).flatMap(([fieldId, response]) => {
-    const field = fieldsById[fieldId]
+  return activeFields.flatMap((fieldId) => {
+    const fieldIdString = fieldId.toString()
+    const field = formFields.find((f) => f._id.toString() === fieldIdString)
+    const response = responses[fieldIdString]
+
     if (
+      // checks if field is an email field
       field &&
       field.fieldType === BasicField.Email &&
       field.autoReplyOptions?.hasAutoReply &&
+      response &&
+      // checks if response has an answer (email)
       typeof response.answer === 'object' &&
       'value' in response.answer &&
       typeof response.answer.value === 'string'

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -358,16 +358,16 @@ export const getQuestionTitleAnswerStringSingleField = ({
       })
   }
 
-  // Add Ndi responses if they exist
-  for (const key in responses) {
-    if (startsWithSPCPFieldTitle(key)) {
-      const value = responses[key] as NdiResponseV3
-      questionAnswerPair.push({
-        question: key,
-        answer: value.answer,
-      })
-    }
-  }
+  // Add Ndi responses if they exist TODO: fix rebased implementation of Ndi responses
+  // for (const key in response) {
+  //   if (startsWithSPCPFieldTitle(key)) {
+  //     const value = response as NdiResponseV3
+  //     questionAnswerPair.push({
+  //       question: key,
+  //       answer: value.answer,
+  //     })
+  //   }
+  // }
   return questionAnswerPair
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -391,7 +391,7 @@ export const extractRespondentCopyEmails = ({
   responses,
   formFields,
 }: {
-  responses: ParsedClearFormFieldResponsesV3
+  responses: FieldResponsesV3
   formFields: FormFieldSchema[]
 }): AutoReplyMailData[] => {
   const fieldsById = keyBy(formFields, '_id')

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -1,8 +1,6 @@
 import moment from 'moment'
 import { err, ok, Result } from 'neverthrow'
 
-import { AutoReplyMailData } from '../../../services/mail/mail.types'
-
 import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from '../../../../../shared/constants/form'
 import {
   BasicField,
@@ -25,6 +23,8 @@ import {
   MultirespondentSubmissionData,
 } from '../../../../types'
 import { ParsedClearFormFieldResponsesV3 } from '../../../../types/api'
+import { AutoReplyMailData } from '../../../services/mail/mail.types'
+import { convertToSignaturePngDataUri } from '../../../utils/convert-vector-array-to-png'
 import { validateFieldV3 } from '../../../utils/field-validation'
 import { FieldIdSet } from '../../../utils/logic-adaptor'
 import { QuestionAnswer } from '../../../views/templates/MrfWorkflowCompletionEmail'
@@ -35,7 +35,6 @@ import {
   ValidateFieldErrorV3,
 } from '../submission.errors'
 import { buildMrfMetadata } from '../submission.utils'
-import { convertToSignaturePngDataUri } from '../../../utils/convert-vector-array-to-png'
 
 /**
  * Creates and returns a MultirespondentSubmissionDto object from submissionData and
@@ -393,8 +392,7 @@ export const getPdfFormData = ({
 }: {
   formFields: FormFieldSchema[] | FormFieldDto[]
   responses: FieldResponsesV3
-  }): EmailRespondentConfirmationField[] => {
-  
+}): EmailRespondentConfirmationField[] => {
   const pdfFormData: EmailRespondentConfirmationField[] = []
   if (!formFields || !responses) return []
 
@@ -408,27 +406,28 @@ export const getPdfFormData = ({
 
     switch (response.fieldType) {
       case BasicField.Signature:
-        const signatureAnswer = convertToSignaturePngDataUri(response.answer.value)
-        
         pdfFormData.push({
           question: questionTitle,
-          answer: signatureAnswer,
+          answer: convertToSignaturePngDataUri(response.answer.value),
           fieldType,
-          answerTemplate: [SIGNATURE_CAPTURED_STRING]
+          answerTemplate: [SIGNATURE_CAPTURED_STRING],
         })
         break
-      default:
+      default: {
         const x = [formField] as FormFieldSchema[] | FormFieldDto[]
-        const y = getQuestionTitleAnswerString({ formFields: x, responses: responses })[0]
+        const y = getQuestionTitleAnswerString({
+          formFields: x,
+          responses: responses,
+        })[0]
         pdfFormData.push({
           question: y.question,
           answerTemplate: [y.answer],
         })
+      }
     }
   }
 
   return pdfFormData
-
 }
 
 export const extractRespondentCopyEmails = ({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -351,12 +351,12 @@ export const getQuestionTitleAnswerStringSingleField = ({
       return questionAnswerPair
     default:
       answer = response.answer
-
-      questionAnswerPair.push({
-        question: questionTitle,
-        answer,
-      })
   }
+
+  questionAnswerPair.push({
+    question: questionTitle,
+    answer,
+  })
   return questionAnswerPair
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -1,5 +1,8 @@
+import { keyBy } from 'lodash'
 import moment from 'moment'
 import { err, ok, Result } from 'neverthrow'
+
+import { AutoReplyMailData } from 'src/app/services/mail/mail.types'
 
 import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from '../../../../../shared/constants/form'
 import {
@@ -381,4 +384,37 @@ export const getQuestionTitleAnswerString = ({
     }
   }
   return questionAnswerPair
+}
+
+// '69031bf600ab799b70e1bd56': { fieldType: 'email', answer: { value: 'scott@open.gov.sg' } }
+export const extractRespondentCopyEmails = ({
+  responses,
+  formFields,
+}: {
+  responses: ParsedClearFormFieldResponsesV3
+  formFields: FormFieldSchema[]
+}): AutoReplyMailData[] => {
+  const fieldsById = keyBy(formFields, '_id')
+  return Object.entries(responses).flatMap(([fieldId, response]) => {
+    const field = fieldsById[fieldId]
+    if (
+      field &&
+      field.fieldType === BasicField.Email &&
+      field.autoReplyOptions?.hasAutoReply &&
+      typeof response.answer === 'object' &&
+      'value' in response.answer &&
+      typeof response.answer.value === 'string'
+    ) {
+      const options = field.autoReplyOptions
+      return [
+        {
+          email: response.answer.value,
+          subject: options.autoReplySubject,
+          body: options.autoReplyMessage,
+          includeFormSummary: options.includeFormSummary,
+        },
+      ]
+    }
+    return [] // no respondent copy emails found
+  })
 }

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -400,9 +400,9 @@ export const getPdfFormData = ({
     const questionTitle = formField.title
     const response = responses[formField._id]
 
-    const { fieldType } = response
-
     if (!response || !questionTitle) continue
+
+    const { fieldType } = response
 
     switch (response.fieldType) {
       case BasicField.Signature:

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -357,17 +357,6 @@ export const getQuestionTitleAnswerStringSingleField = ({
         answer,
       })
   }
-
-  // Add Ndi responses if they exist TODO: fix rebased implementation of Ndi responses
-  // for (const key in response) {
-  //   if (startsWithSPCPFieldTitle(key)) {
-  //     const value = response as NdiResponseV3
-  //     questionAnswerPair.push({
-  //       question: key,
-  //       answer: value.answer,
-  //     })
-  //   }
-  // }
   return questionAnswerPair
 }
 
@@ -400,17 +389,34 @@ export const getQuestionTitleAnswerString = ({
 
     questionAnswerPairs = [...questionAnswerPairs, ...questionAnswerPair]
   }
+
+  // Add Ndi responses if they exist
+  for (const key in responses) {
+    if (startsWithSPCPFieldTitle(key)) {
+      const value = responses[key] as NdiResponseV3
+      questionAnswerPairs.push({
+        question: key,
+        answer: value.answer,
+      })
+    }
+  }
   return questionAnswerPairs
 }
 
-export const getPdfFormData = ({
+/**
+ * Prepares responses data from MRF responses to PDF html format
+ * @param formFields - The form fields schema
+ * @param responses - The mrf responses to the form fields
+ * @returns list of EmailRespondentConfirmationField used for email & pdf generation
+ */
+export const getPdfResponsesData = ({
   formFields,
   responses,
 }: {
   formFields: FormFieldSchema[] | FormFieldDto[]
   responses: FieldResponsesV3
 }): EmailRespondentConfirmationField[] => {
-  let pdfFormData: EmailRespondentConfirmationField[] = []
+  let pdfResponseData: EmailRespondentConfirmationField[] = []
   if (!formFields || !responses) return []
 
   for (const formField of formFields) {
@@ -433,12 +439,30 @@ export const getPdfFormData = ({
         }
       })
 
-    pdfFormData = [...pdfFormData, ...emailFieldForPdf]
+    pdfResponseData = [...pdfResponseData, ...emailFieldForPdf]
   }
 
-  return pdfFormData
+  // Add Ndi responses if they exist
+  for (const key in responses) {
+    if (startsWithSPCPFieldTitle(key)) {
+      const value = responses[key] as NdiResponseV3
+      pdfResponseData.push({
+        question: key,
+        answerTemplate: [value.answer],
+      })
+    }
+  }
+  return pdfResponseData
 }
 
+/**
+ * Extracts email data to be sent respondent copies to from a multirespondent submission.
+ * Email inputs from email confirmation-enabled email fields that are assigned in the current step are extracted
+ * @param responses - The multirespondent submission's field responses
+ * @param formFields - The form fields schema
+ * @param activeFields - The active field Ids assigned in the current step
+ * @returns AutoReplyMailData[] - list of email data to be sent respondent copies to
+ */
 export const extractRespondentCopyEmails = ({
   responses,
   formFields,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -5,6 +5,7 @@ import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from '../../../../../shared/consta
 import {
   BasicField,
   FieldResponsesV3,
+  FieldResponseV3,
   FormFieldDto,
   FormWorkflowStepDto,
   MultirespondentSubmissionDto,
@@ -226,151 +227,135 @@ export const validateMrfFieldResponses = ({
   return ok(responses)
 }
 
-/*
- * Extracts question-answer pairs from form fields and responses.
- * @param formFields - The form fields schema
- * @param responses - The responses to the form fields
+/**
+ * Extracts question-answer pairs from a form field and a response.
+ * Used for email body/pdf outputs and individualResponsePage displays
+ * Returns an array since some fields (e.g. table, children) will have
+ * multiple questionAnswerPairs per response
+ * @param formField - form field schema
+ * @param response - response of the form field
  * @returns An array of QuestionAnswer objects
  */
-export const getQuestionTitleAnswerString = ({
-  formFields,
-  responses,
+export const getQuestionTitleAnswerStringSingleField = ({
+  formField,
+  response,
 }: {
-  formFields: FormFieldSchema[] | FormFieldDto[]
-  responses: FieldResponsesV3
+  formField: FormFieldSchema | FormFieldDto
+  response: FieldResponseV3
 }): QuestionAnswer[] => {
-  const questionAnswerPair = []
-  if (!formFields || !responses) {
-    return []
-  }
-  for (const formField of formFields) {
-    const MyInfoPrefix = 'myInfo' in formField ? '[MyInfo] ' : ''
-    const questionTitle = `${MyInfoPrefix}${formField.title}`
-    const response = responses[formField._id]
+  let questionTitle = formField.title
+  let answer = ''
+  let answerArray: string[] = []
+  const questionAnswerPair: QuestionAnswer[] = []
+  switch (response.fieldType) {
+    case BasicField.Attachment:
+      questionTitle = `[Attachment] ${questionTitle}`
+      answer = response.answer.answer
+      break
+    case BasicField.Address: {
+      const {
+        postalCode,
+        blockNumber,
+        streetName,
+        buildingName,
+        levelNumber,
+        unitNumber,
+      } = response.answer.addressSubFields
+      answerArray = [
+        blockNumber,
+        streetName,
+        buildingName,
+        levelNumber,
+        unitNumber,
+        postalCode,
+      ] // move postal code to end of array
+      answer = handleAddressResponseDisplay(Object.values(answerArray)).join(
+        ', ',
+      )
+      break
+    }
+    case BasicField.Email:
+    case BasicField.Mobile:
+      answer = response.answer.value
+      break
+    case BasicField.Table:
+      if (formField.fieldType !== BasicField.Table || !response.answer) break
+      // eslint-disable-next-line no-case-declarations
+      const idToColTitleMap = formField.columns.reduce(
+        (acc, col) => {
+          acc[col._id] = col.title
+          return acc
+        },
+        {} as Record<string, string>,
+      )
 
-    if (!response || !questionTitle) continue
-
-    let answer = ''
-    let answerArray: string[] = []
-    switch (response.fieldType) {
-      case BasicField.Attachment:
-        answer = response.answer.answer
-        questionAnswerPair.push({
-          question: `[Attachment] ${questionTitle}`,
-          answer,
-        })
-        continue
-      case BasicField.Address: {
-        const {
-          postalCode,
-          blockNumber,
-          streetName,
-          buildingName,
-          levelNumber,
-          unitNumber,
-        } = response.answer.addressSubFields
-        answerArray = [
-          blockNumber,
-          streetName,
-          buildingName,
-          levelNumber,
-          unitNumber,
-          postalCode,
-        ] // move postal code to end of array
-        questionAnswerPair.push({
-          question: `${questionTitle}`,
-          answer: handleAddressResponseDisplay(Object.values(answerArray)).join(
-            ', ',
-          ),
-        })
-        continue
-      }
-      case BasicField.Email:
-      case BasicField.Mobile:
-        answer = response.answer.value
-        break
-      case BasicField.Table:
-        if (formField.fieldType !== BasicField.Table || !response.answer)
-          continue
-        // eslint-disable-next-line no-case-declarations
-        const idToColTitleMap = formField.columns.reduce(
-          (acc, col) => {
-            acc[col._id] = col.title
-            return acc
-          },
-          {} as Record<string, string>,
+      for (const row of response.answer) {
+        const validColumns = Object.entries(row).filter(
+          ([colId]) => colId in idToColTitleMap,
         )
 
-        for (const row of response.answer) {
-          const validColumns = Object.entries(row).filter(
-            ([colId]) => colId in idToColTitleMap,
-          )
-
-          const delimitedColumnTitles = validColumns
-            .map(([colId]) => {
-              const colTitle = idToColTitleMap[colId]
-              return `${colTitle}`
-            })
-            .join('; ')
-
-          const delimitedColumnAnswers = validColumns
-            .map(([, colAns]) => colAns ?? '')
-            .join('; ')
-
-          const question = `[Table] ${formField.title} (${delimitedColumnTitles})`
-          const answer = delimitedColumnAnswers
-
-          questionAnswerPair.push({
-            question,
-            answer,
+        const delimitedColumnTitles = validColumns
+          .map(([colId]) => {
+            const colTitle = idToColTitleMap[colId]
+            return `${colTitle}`
           })
-        }
-        continue
-      case BasicField.Radio:
-        answer =
-          'value' in response.answer
-            ? response.answer.value
-            : 'othersInput' in response.answer
-              ? response.answer.othersInput
-              : ''
-        break
-      case BasicField.Checkbox:
-        // eslint-disable-next-line no-case-declarations
-        const selectedAnswers =
-          (response.answer.othersInput
-            ? [...response.answer.value, response.answer.othersInput]
-            : [...response.answer.value]
-          ).filter((val) => val !== CLIENT_CHECKBOX_OTHERS_INPUT_VALUE) ?? []
+          .join('; ')
 
-        answer = selectedAnswers.toString()
-        break
-      case BasicField.Signature:
+        const delimitedColumnAnswers = validColumns
+          .map(([, colAns]) => colAns ?? '')
+          .join('; ')
+
+        const question = `[Table] ${formField.title} (${delimitedColumnTitles})`
+        const answer = delimitedColumnAnswers
+
         questionAnswerPair.push({
-          question: `[signature] ${questionTitle}`,
-          answer: SIGNATURE_CAPTURED_STRING,
+          question,
+          answer,
         })
-        continue
-      case BasicField.Children:
-        if (!response.answer.childFields || !response.answer.child) {
-          continue
-        }
-        for (const [index, child] of response.answer.child.entries()) {
-          questionAnswerPair.push({
-            question: `Child ${index + 1}: ${response.answer.childFields.toString()}`,
-            answer: child
-              ? child.toString()
-              : response.answer.childFields.map(() => '').toString(),
-          })
-        }
-        continue
-      default:
-        answer = response.answer
-    }
+      }
+      return questionAnswerPair
+    case BasicField.Radio:
+      answer =
+        'value' in response.answer
+          ? response.answer.value
+          : 'othersInput' in response.answer
+            ? response.answer.othersInput
+            : ''
+      break
+    case BasicField.Checkbox:
+      // eslint-disable-next-line no-case-declarations
+      const selectedAnswers =
+        (response.answer.othersInput
+          ? [...response.answer.value, response.answer.othersInput]
+          : [...response.answer.value]
+        ).filter((val) => val !== CLIENT_CHECKBOX_OTHERS_INPUT_VALUE) ?? []
 
-    questionAnswerPair.push({
-      question: questionTitle,
-      answer,
-    })
+      answer = selectedAnswers.toString()
+      break
+    case BasicField.Signature:
+      questionTitle = `[signature] ${questionTitle}`
+      answer = SIGNATURE_CAPTURED_STRING
+      break
+    case BasicField.Children:
+      if (!response.answer.childFields || !response.answer.child) {
+        break
+      }
+      for (const [index, child] of response.answer.child.entries()) {
+        questionAnswerPair.push({
+          question: `Child ${index + 1}: ${response.answer.childFields.toString()}`,
+          answer: child
+            ? child.toString()
+            : response.answer.childFields.map(() => '').toString(),
+        })
+      }
+      return questionAnswerPair
+    default:
+      answer = response.answer
+
+      questionAnswerPair.push({
+        question: questionTitle,
+        answer,
+      })
   }
 
   // Add Ndi responses if they exist
@@ -386,6 +371,38 @@ export const getQuestionTitleAnswerString = ({
   return questionAnswerPair
 }
 
+/*
+ * Extracts question-answer pairs from form fields and responses.
+ * @param formFields - The form fields schema
+ * @param responses - The responses to the form fields
+ * @returns An array of QuestionAnswer objects
+ */
+export const getQuestionTitleAnswerString = ({
+  formFields,
+  responses,
+}: {
+  formFields: FormFieldSchema[] | FormFieldDto[]
+  responses: FieldResponsesV3
+}): QuestionAnswer[] => {
+  let questionAnswerPairs: QuestionAnswer[] = []
+  if (!formFields || !responses) {
+    return []
+  }
+  for (const formField of formFields) {
+    const questionTitle = formField.title
+    const response = responses[formField._id]
+
+    if (!response || !questionTitle) continue
+    const questionAnswerPair = getQuestionTitleAnswerStringSingleField({
+      formField,
+      response,
+    })
+
+    questionAnswerPairs = [...questionAnswerPairs, ...questionAnswerPair]
+  }
+  return questionAnswerPairs
+}
+
 export const getPdfFormData = ({
   formFields,
   responses,
@@ -393,7 +410,7 @@ export const getPdfFormData = ({
   formFields: FormFieldSchema[] | FormFieldDto[]
   responses: FieldResponsesV3
 }): EmailRespondentConfirmationField[] => {
-  const pdfFormData: EmailRespondentConfirmationField[] = []
+  let pdfFormData: EmailRespondentConfirmationField[] = []
   if (!formFields || !responses) return []
 
   for (const formField of formFields) {
@@ -401,30 +418,22 @@ export const getPdfFormData = ({
     const response = responses[formField._id]
 
     if (!response || !questionTitle) continue
+    const emailFieldForPdf: EmailRespondentConfirmationField[] =
+      getQuestionTitleAnswerStringSingleField({
+        formField,
+        response,
+      }).map((questionAnswerPair) => {
+        return {
+          question: questionAnswerPair.question,
+          fieldType: response.fieldType,
+          answerTemplate: [questionAnswerPair.answer],
+          ...(response.fieldType === BasicField.Signature && {
+            answer: convertToSignaturePngDataUri(response.answer.value),
+          }),
+        }
+      })
 
-    const { fieldType } = response
-
-    switch (response.fieldType) {
-      case BasicField.Signature:
-        pdfFormData.push({
-          question: questionTitle,
-          answer: convertToSignaturePngDataUri(response.answer.value),
-          fieldType,
-          answerTemplate: [SIGNATURE_CAPTURED_STRING],
-        })
-        break
-      default: {
-        const x = [formField] as FormFieldSchema[] | FormFieldDto[]
-        const y = getQuestionTitleAnswerString({
-          formFields: x,
-          responses: responses,
-        })[0]
-        pdfFormData.push({
-          question: y.question,
-          answerTemplate: [y.answer],
-        })
-      }
-    }
+    pdfFormData = [...pdfFormData, ...emailFieldForPdf]
   }
 
   return pdfFormData

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import { err, ok, Result } from 'neverthrow'
 
-import { AutoReplyMailData } from 'src/app/services/mail/mail.types'
+import { AutoReplyMailData } from '../../../services/mail/mail.types'
 
 import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from '../../../../../shared/constants/form'
 import {
@@ -20,6 +20,7 @@ import { SIGNATURE_CAPTURED_STRING } from '../../../../../shared/utils/signature
 import { stripDropdownFieldOptionsToRecipientsMap } from '../../../../../shared/utils/strip-dropdown-field-optionsToRecipientsMap'
 import { stripWorkflowEmails } from '../../../../../shared/utils/strip-workflow-emails'
 import {
+  EmailRespondentConfirmationField,
   FormFieldSchema,
   MultirespondentSubmissionData,
 } from '../../../../types'
@@ -34,6 +35,7 @@ import {
   ValidateFieldErrorV3,
 } from '../submission.errors'
 import { buildMrfMetadata } from '../submission.utils'
+import { convertToSignaturePngDataUri } from '../../../utils/convert-vector-array-to-png'
 
 /**
  * Creates and returns a MultirespondentSubmissionDto object from submissionData and
@@ -383,6 +385,50 @@ export const getQuestionTitleAnswerString = ({
     }
   }
   return questionAnswerPair
+}
+
+export const getPdfFormData = ({
+  formFields,
+  responses,
+}: {
+  formFields: FormFieldSchema[] | FormFieldDto[]
+  responses: FieldResponsesV3
+  }): EmailRespondentConfirmationField[] => {
+  
+  const pdfFormData: EmailRespondentConfirmationField[] = []
+  if (!formFields || !responses) return []
+
+  for (const formField of formFields) {
+    const questionTitle = formField.title
+    const response = responses[formField._id]
+
+    const { fieldType } = response
+
+    if (!response || !questionTitle) continue
+
+    switch (response.fieldType) {
+      case BasicField.Signature:
+        const signatureAnswer = convertToSignaturePngDataUri(response.answer.value)
+        
+        pdfFormData.push({
+          question: questionTitle,
+          answer: signatureAnswer,
+          fieldType,
+          answerTemplate: [SIGNATURE_CAPTURED_STRING]
+        })
+        break
+      default:
+        const x = [formField] as FormFieldSchema[] | FormFieldDto[]
+        const y = getQuestionTitleAnswerString({ formFields: x, responses: responses })[0]
+        pdfFormData.push({
+          question: y.question,
+          answerTemplate: [y.answer],
+        })
+    }
+  }
+
+  return pdfFormData
+
 }
 
 export const extractRespondentCopyEmails = ({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -460,6 +460,7 @@ export const extractRespondentCopyEmails = ({
         {
           email: response.answer.value,
           subject: options.autoReplySubject,
+          sender: options.autoReplySender,
           body: options.autoReplyMessage,
           includeFormSummary: options.includeFormSummary,
         },

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -1184,7 +1184,7 @@ export class MailService {
     formId: string
     formTitle: string
     responseId: string
-    formQuestionAnswers?: QuestionAnswer[]
+    formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
     autoReplyMailData: AutoReplyMailData
     agencyName: string
@@ -1192,13 +1192,13 @@ export class MailService {
     const htmlData = {
       formTitle,
       responseId: responseId.toString(),
-      formQuestionAnswers,
       body:
         autoReplyMailData.body ||
         DEFAULT_RESPONDENT_COPY_EMAIL.content.replace(
           '{agencyName}',
           agencyName,
         ),
+      ...(autoReplyMailData.includeFormSummary && { formQuestionAnswers }),
     }
 
     const generatedHtml = fromPromise(

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -1179,6 +1179,7 @@ export class MailService {
     formQuestionAnswers,
     attachments,
     autoReplyMailData,
+    agencyName,
   }: {
     formId: string
     formTitle: string
@@ -1186,12 +1187,18 @@ export class MailService {
     formQuestionAnswers?: QuestionAnswer[]
     attachments?: Mail.Attachment[]
     autoReplyMailData: AutoReplyMailData
+    agencyName: string
   }) => {
     const htmlData = {
       formTitle,
       responseId: responseId.toString(),
       formQuestionAnswers,
-      body: autoReplyMailData.body,
+      body:
+        autoReplyMailData.body ||
+        DEFAULT_RESPONDENT_COPY_EMAIL.content.replace(
+          '{agencyName}',
+          agencyName,
+        ),
     }
 
     const generatedHtml = fromPromise(

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -29,6 +29,7 @@ import {
   EmailAddressVerificationOtpHtmlData,
 } from '../../views/templates/EmailAddressVerificationOtp'
 import { FormDeactivatedNotification } from '../../views/templates/FormDeactivatedNotification'
+import { MrfRespondentCopyEmail } from '../../views/templates/MrfRespondentCopyEmail'
 import MrfWorkflowCompletionEmail, {
   QuestionAnswer,
   WorkflowOutcome,
@@ -46,6 +47,7 @@ import {
   MailSendError,
 } from './mail.errors'
 import {
+  AutoReplyMailData,
   AutoreplySummaryRenderData,
   BounceNotificationHtmlData,
   FormDeactivatedNotificationHtmlData,
@@ -1171,32 +1173,29 @@ export class MailService {
   }
 
   sendMrfRespondentCopyEmail = ({
-    emails,
     formId,
     formTitle,
     responseId,
     formQuestionAnswers,
     attachments,
-    respondentCopy,
+    autoReplyMailData,
   }: {
-    emails: string[]
     formId: string
     formTitle: string
     responseId: string
-    formQuestionAnswers: QuestionAnswer[]
+    formQuestionAnswers?: QuestionAnswer[]
     attachments?: Mail.Attachment[]
-    respondentCopy: boolean
+    autoReplyMailData: AutoReplyMailData
   }) => {
     const htmlData = {
       formTitle,
-      formId,
       responseId: responseId.toString(),
       formQuestionAnswers,
-      respondentCopy: respondentCopy,
+      body: autoReplyMailData.body,
     }
 
     const generatedHtml = fromPromise(
-      render(MrfWorkflowCompletionEmail(htmlData)),
+      render(MrfRespondentCopyEmail(htmlData)),
       (e) => {
         logger.error({
           message: 'Failed to render MrfRespondentCopyEmail',
@@ -1214,9 +1213,11 @@ export class MailService {
 
     return generatedHtml.andThen((mailHtml) => {
       const mail: MailOptions = {
-        to: emails,
-        from: this.#senderFromString,
-        subject: `Thank you for submitting ${formTitle} (${responseId})`,
+        to: autoReplyMailData.email,
+        from: autoReplyMailData.sender || this.#senderFromString,
+        subject:
+          autoReplyMailData.subject ||
+          `Thank you for submitting ${formTitle} (${responseId})`,
         html: mailHtml,
         attachments,
       }
@@ -1225,32 +1226,6 @@ export class MailService {
         formId,
         mailId: 'workflowNotification',
       })
-    })
-  }
-
-  sendRespondentCopyEmail = ({
-    emails,
-    formId,
-    formTitle,
-    responseId,
-    mailHtml,
-  }: {
-    emails: string[]
-    formId: string
-    formTitle: string
-    responseId: string
-    mailHtml: string
-  }) => {
-    const mail: MailOptions = {
-      to: emails,
-      from: this.#senderFromString,
-      subject: `Thank you for submitting ${formTitle} (${responseId})`,
-      html: mailHtml,
-    }
-
-    return this.#sendNodeMail(mail, {
-      formId,
-      mailId: 'workflowNotification',
     })
   }
 }

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -1191,7 +1191,7 @@ export class MailService {
   }) => {
     const htmlData = {
       formTitle,
-      responseId: responseId.toString(),
+      responseId,
       body:
         autoReplyMailData.body ||
         DEFAULT_RESPONDENT_COPY_EMAIL.content.replace(
@@ -1218,13 +1218,18 @@ export class MailService {
       },
     )
 
+    const senderName = autoReplyMailData.sender || agencyName
+    const emailSender = `${senderName.replace('(', '\\(')} <${this.#senderMail}>`
+
+    const emailSubject =
+      autoReplyMailData.subject ||
+      `Thank you for submitting ${formTitle} (${responseId})`
+
     return generatedHtml.andThen((mailHtml) => {
       const mail: MailOptions = {
         to: autoReplyMailData.email,
-        from: autoReplyMailData.sender || this.#senderFromString,
-        subject:
-          autoReplyMailData.subject ||
-          `Thank you for submitting ${formTitle} (${responseId})`,
+        from: emailSender,
+        subject: emailSubject,
         html: mailHtml,
         attachments,
       }

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -1184,7 +1184,7 @@ export class MailService {
     formId: string
     formTitle: string
     responseId: string
-    formQuestionAnswers: QuestionAnswer[]
+    formQuestionAnswers?: QuestionAnswer[]
     attachments?: Mail.Attachment[]
     autoReplyMailData: AutoReplyMailData
     agencyName: string
@@ -1198,7 +1198,7 @@ export class MailService {
           '{agencyName}',
           agencyName,
         ),
-      ...(autoReplyMailData.includeFormSummary && { formQuestionAnswers }),
+      formQuestionAnswers,
     }
 
     const generatedHtml = fromPromise(

--- a/src/app/views/templates/MrfRespondentCopyEmail.tsx
+++ b/src/app/views/templates/MrfRespondentCopyEmail.tsx
@@ -52,10 +52,10 @@ export const MrfRespondentCopyEmail = ({
 
     const renderResponseId = () => (
         <>
-          <Text style={{ ...secondaryTextStyle, marginBottom: '40px' }}>{'---'}</Text>
+          <Hr style={{ margin: '40px 0' }} />
           <Text style={{ ...primaryTextStyle, ...questionMargin }}>Response ID</Text>
           <Text style={{ ...secondaryTextStyle,  marginBottom: '40px' }}>{responseId}</Text>
-          <Text style={{ ...secondaryTextStyle, marginBottom: '40px' }}>{'---'}</Text>
+          <Hr style={{ margin: '40px 0' }} />
         </>
     )
 

--- a/src/app/views/templates/MrfRespondentCopyEmail.tsx
+++ b/src/app/views/templates/MrfRespondentCopyEmail.tsx
@@ -22,7 +22,6 @@ import {
   questionMargin,
   answerMargin,
 } from './mrfWorkflowCompletionEmailStyle'
-import { DEFAULT_RESPONDENT_COPY_EMAIL } from '../../../../shared/constants/mail'
 
 export type QuestionAnswer = {
   question: string
@@ -33,7 +32,7 @@ export type RespondentCopyEmilData = {
     formTitle: string
     responseId: string
     formQuestionAnswers: QuestionAnswer[] | undefined
-    body?: string
+    body: string
 }
 
 export const MrfRespondentCopyEmail = ({
@@ -43,7 +42,6 @@ export const MrfRespondentCopyEmail = ({
     body,
 }: RespondentCopyEmilData): JSX.Element => {
     let headingText = 'Thank you for submitting this form'
-    let emailBody = body || DEFAULT_RESPONDENT_COPY_EMAIL.content.replace('{agencyName}', 'FormSG') //TODO: add agency name
   
     const renderQuestionAnswer = (qa: QuestionAnswer) => (
         <>
@@ -73,7 +71,7 @@ export const MrfRespondentCopyEmail = ({
               {headingText}
             </Heading>
             <Text style={{ ...secondaryTextStyle, marginBottom: '40px', whiteSpace: 'pre-line' }}>
-              {emailBody}
+              {body}
             </Text>
             {renderResponseId()}
               {formQuestionAnswers ? (

--- a/src/app/views/templates/MrfRespondentCopyEmail.tsx
+++ b/src/app/views/templates/MrfRespondentCopyEmail.tsx
@@ -31,7 +31,7 @@ export type QuestionAnswer = {
 export type RespondentCopyEmilData = {
     formTitle: string
     responseId: string
-    formQuestionAnswers: QuestionAnswer[] | undefined
+    formQuestionAnswers?: QuestionAnswer[]
     body: string
 }
 

--- a/src/app/views/templates/MrfRespondentCopyEmail.tsx
+++ b/src/app/views/templates/MrfRespondentCopyEmail.tsx
@@ -1,0 +1,95 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+import { FORMSG_LOGO_URL } from '../../constants/formsg-logo'
+
+import {
+  secondaryTextStyle,
+  containerStyle,
+  headingTextStyle,
+  mainStyle,
+  sectionStyle,
+  primaryTextStyle,
+  questionMargin,
+  answerMargin,
+} from './mrfWorkflowCompletionEmailStyle'
+import { DEFAULT_RESPONDENT_COPY_EMAIL } from '../../../../shared/constants/mail'
+
+export type QuestionAnswer = {
+  question: string
+  answer: string
+}
+
+export type RespondentCopyEmilData = {
+    formTitle: string
+    responseId: string
+    formQuestionAnswers: QuestionAnswer[] | undefined
+    body?: string
+}
+
+export const MrfRespondentCopyEmail = ({
+    formTitle,
+    responseId,
+    formQuestionAnswers,
+    body,
+}: RespondentCopyEmilData): JSX.Element => {
+    let headingText = 'Thank you for submitting this form'
+    let emailBody = body || DEFAULT_RESPONDENT_COPY_EMAIL.content.replace('{agencyName}', 'FormSG') //TODO: add agency name
+  
+    const renderQuestionAnswer = (qa: QuestionAnswer) => (
+        <>
+          <Text style={{ ...primaryTextStyle, ...questionMargin }}>{qa.question}</Text>
+          <Text style={{ ...secondaryTextStyle, ...answerMargin }}>{qa.answer}</Text>
+        </>
+    )
+
+    const renderResponseId = () => (
+        <>
+          <Text style={{ ...secondaryTextStyle, marginBottom: '40px' }}>{'---'}</Text>
+          <Text style={{ ...primaryTextStyle, ...questionMargin }}>Response ID</Text>
+          <Text style={{ ...secondaryTextStyle,  marginBottom: '40px' }}>{responseId}</Text>
+          <Text style={{ ...secondaryTextStyle, marginBottom: '40px' }}>{'---'}</Text>
+        </>
+    )
+
+    return (
+    <Html>
+      <Head /> 
+      <Preview>{headingText}</Preview>
+      <Body style={mainStyle}>
+        <Container style={containerStyle}>
+          <Section style={sectionStyle}>
+            <Img style={{ height: '24px', marginBottom: '40px' }} src={FORMSG_LOGO_URL} alt="FormSG" />
+            <Heading style={{ ...headingTextStyle, marginBottom: '40px' }}>
+              {headingText}
+            </Heading>
+            <Text style={{ ...secondaryTextStyle, marginBottom: '40px', whiteSpace: 'pre-line' }}>
+              {emailBody}
+            </Text>
+            {renderResponseId()}
+              {formQuestionAnswers ? (
+                <>
+                  <Text style={{ ...primaryTextStyle, ...answerMargin }}>Responses for {formTitle}</Text>
+                  <>
+                    {formQuestionAnswers.map(renderQuestionAnswer)}
+                  </>
+              </>
+            ) : null}
+            <Text style={{ ...secondaryTextStyle, marginTop: '24px' }}>
+              For more details, please contact the respondent(s) or form administrator.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>        
+    )
+}

--- a/src/app/views/templates/MrfWorkflowCompletionEmail.tsx
+++ b/src/app/views/templates/MrfWorkflowCompletionEmail.tsx
@@ -39,7 +39,6 @@ export type WorkflowEmailData = {
   responseId: string
   formQuestionAnswers: QuestionAnswer[]
   outcome?: WorkflowOutcome | undefined 
-  respondentCopy?: boolean | undefined
 }
 
 export const MrfWorkflowCompletionEmail = ({
@@ -47,14 +46,10 @@ export const MrfWorkflowCompletionEmail = ({
   responseId = '64303c45828035f732088a41', 
   formQuestionAnswers = [], 
   outcome,
-  respondentCopy,
 }: WorkflowEmailData): JSX.Element => {
   let headingText =  
     outcome ? `The outcome for ${formTitle}.` : `${formTitle} has been completed by all respondents.`
-  
-  if (respondentCopy) {
-    headingText = 'Thank you for submitting this form'
-  }
+
 
   const renderQuestionAnswer = (qa: QuestionAnswer) => (
     <>
@@ -84,13 +79,11 @@ export const MrfWorkflowCompletionEmail = ({
             <Heading style={{...headingTextStyle, marginBottom: '40px'}}>
                 Responses for {formTitle} 
               </Heading>
-            {respondentCopy === false ? null : (
               <>
                 <Text style={{ ...primaryTextStyle, ...questionMargin }}>Response ID</Text>
                 <Text style={{ ...secondaryTextStyle, ...answerMargin }}>{responseId}</Text>
                 {formQuestionAnswers.map(renderQuestionAnswer)}
               </>
-              )}
             <Text style={{ ...secondaryTextStyle, marginTop: '24px' }}>
               For more details, please contact the respondent(s) or form administrator.
             </Text>

--- a/src/types/api/multirespondent_submission.ts
+++ b/src/types/api/multirespondent_submission.ts
@@ -22,7 +22,7 @@ export type SnapshottedFormDef = Pick<
   | 'emails'
   | 'stepOneEmailNotificationFieldId'
   | 'stepsToNotify'
-  | 'hasRespondentCopy'
+  | 'admin'
   | 'webhook'
   | 'title'
   | 'workflow'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Phase 2 of Respondent copy v3 implementation

Closes FRM-2172

## Solution
<!-- How did you solve the problem? -->

Allow Email confirmation to be toggled on
- [x] When toggled, email confirmation will be fired whenever the email field is assigned in that step
- [x] This feature is gated behind the respondent copy flag
- [x] Forms can be opened even if email confirmation is enabled; removing the info box that warns admins
- [x] PDF is included when responses are to be included in respondent copy
- [x] Change helper text from black to grey

V2 clean up
- [x] Hide multi-select input field
- [x] Hide toggle
- [x] Ensure no logic is actively related to form def hasRespondentCopy variable

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Description | **BEFORE** | **AFTER** |
| --- | --- | --- |
| Enabled behaviour of email confirmation toggle | <img width="778" height="380" alt="image" src="https://github.com/user-attachments/assets/f2228852-a5ee-4945-a748-8b02b8d84a50" /> | <img width="641" height="271" alt="image" src="https://github.com/user-attachments/assets/b8753d11-170d-42d9-902f-63824aff7332" /> |
| MRF rc email (default settings) | | <img width="803" height="610" alt="image" src="https://github.com/user-attachments/assets/d963b563-05b4-4779-a261-381dcbd8c40f" /> |
| MRF rc email (custom) |  | <img width="721" height="614" alt="image" src="https://github.com/user-attachments/assets/54716406-1603-4cbb-b03e-926904293762" /> | 

## Tests
<!-- What tests should be run to confirm functionality? -->

**Respondent copy v3 test setup**
- [x] Create a MRF form
- [x] Add 2 email fields to the form, and enable `Email confirmation` on both fields
- [x] On the 2nd email field, enable `Include a copy of responses`
- [x] On the 2nd email field, add custom subject, sender name and content
- [x] Add a 3 step workflow, assigning 1 email field to 1 step respectively
   - [x] Step 1 should have assigned email field (no responses)
   - [x] Step 2 should have assigned email field (responses)
   - [x] Step 3 should have no fields assigned

**Send a respondent copy without responses**
- [x] Attempt to make a step 1 submission with your personal email
- [x] Observe that a respondent copy is received with no responses
- [x] Observe that the subject, sender name and content is default

**Send a respondent copy with responses**
- [x] Attempt to make a step 2 submission with your personal email
- [x] Observe that a respondent copy is received with responses, and a PDF included
- [x] Observe that the subject, sender name and content is customised as per the email field settings

**Confirm no emails get sent when email fields are not assigned**
- [x] Attempt to make a step 3 submission
- [x] Observe that no respondent copy emails are received
