### PR TITLE
feat: reduce vpcu to 1vcpu

### DIFF
--- a/.github/workflows/deploy-ecs-prod.yml
+++ b/.github/workflows/deploy-ecs-prod.yml
@@ -25,7 +25,7 @@ jobs:
       aws-region: 'ap-southeast-1'
       ecr-repository: 'formsg'
       # ECS configuration
-      ecs-cpu: 2048
+      ecs-cpu: 1024
       ecs-memory: 4096
       ecs-cluster-name: 'formsg-prod-ecs'
       ecs-service-name: 'formsg-prod-ecs-service'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Our current vcpu is underutilised, leading to room for potential cost savings and scaling out instead of scaling up. 

## Solution
<!-- How did you solve the problem? -->
<img width="722" height="70" alt="image" src="https://github.com/user-attachments/assets/98ffaa74-d4fe-449e-a59d-3ac23b198fd0" />

Action: 
Reduce vcpu to 1gb, while keeping memory at 4gb. 

Considerations: 
Our avg cpu is at 10% - which means our autoscaling is never really triggered. After reducing to 1 vcpu, my hypothesis is that the autoscaling will be more likely to kick in, allowing us to scale out as traffic increases. 

Currently, there is no good way to see if its "safe" to reduce - unless load testing is performed, which we do not have a good mechanism for (@scottheng96) 

Hence, i'm relying on some general considerations:
If we are sure that we are just running 1 node instance per task (on non node cluster mode), which we are - it should not exceed 1 vCPU. 
To be sure, we should assert there no side processes running that can consume vCPU. 
To check, the dockerfile is used as a reference starting point. 

Checking the dockerfile.production, we have:
1. puppeteer and its fonts - this is no longer being used since puppeteer launch is no longer called as local pdf generation is removed, hence no new process spawned to use >1 vCPU. 
2. Signatures rendering (cairo, pango, librsvg) - upon research, this does not seem to since it is not using cluster mode internally. 

To note: There is a chance that nodeJS offloads some background operations such as garbage collection to the secondary core, hence 60% util achieved at max occasionally. However, the tradeoff of the utility of the 2nd core and the benefits of more scale out tasks is unclear. It might be that the additional tasks may outweigh the utility of the 2nd core and hence reducing to 1vCPU is justified. 

Conclusion: no good way to determine if its "safe" without load testing. 

Hence, my recommendation is to bump the number of tasks from 20 to 30 (as a safeguard mechanism) [here](https://github.com/opengovsg/formsg-infra/pull/95) while reducing to 1vCPU and monitor latency metrics before making subsequent decisions. 
We can bump back down to 20 instances and rely on auto-scaling if my hypothesis is correct. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  