### PR TITLE
docs(readme): remove button for beanstalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 ---
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
-[![Build Status](https://github.com/opengovsg/FormSG/actions/workflows/deploy-eb.yml/badge.svg)](https://github.com/opengovsg/FormSG/actions/workflows/deploy-eb.yml)
 [![Coverage Status](https://coveralls.io/repos/github/opengovsg/FormSG/badge.svg?branch=develop)](https://coveralls.io/github/opengovsg/FormSG?branch=develop)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-opengovsg%2FFormSG-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/opengovsg/FormSG)
 
@@ -14,6 +13,7 @@
 For comprehensive self-hosting guides, configuration references, and deployment instructions, visit our **[FormSG Self-Hosting Guide](https://ogp-international.gitbook.io/ogp-international-hub/self-hosting/formsg)**.
 
 The GitBook documentation is actively maintained and provides:
+
 - Deployment guides for AWS and other platforms
 - Configuration reference for all environment variables
 - Component customization guides
@@ -23,7 +23,7 @@ The GitBook documentation is actively maintained and provides:
 ## Table of Contents
 
 - [Contributing](#contributing)
-    - [IMPORTANT NOTE TO ALL CONTRIBUTORS](#important-note-to-all-contributors)
+  - [IMPORTANT NOTE TO ALL CONTRIBUTORS](#important-note-to-all-contributors)
 - [Features](#features)
 - [Local Development (Docker)](#local-development-docker)
   - [Prerequisites](#prerequisites)
@@ -104,30 +104,32 @@ npm run build:frontend
 
 Run the following shell commands to build the Docker image. The first time will usually take 10 or so minutes. These commands runs the backend services specified under [docker-compose.yml](docker-compose.yml) and the React frontend on the native host.
 
-This command runs: 
+This command runs:
+
 - backend server
 - frontend server
-- emulated serverless ClamAV (legacy) virus scanner function 
-- emulated serverless GuardDuty virus scanner function 
-- emulated serverless pdf generation function  
+- emulated serverless ClamAV (legacy) virus scanner function
+- emulated serverless GuardDuty virus scanner function
+- emulated serverless pdf generation function
 
 ```bash
 npm run dev
 ```
 
-Alternatively, you can run required components independently - which is what the main dev team usually does: 
+Alternatively, you can run required components independently - which is what the main dev team usually does:
+
 ```bash
-# Frontend server 
+# Frontend server
 npm run dev:frontend (frontend react server, compulsory)
 
-# Backend server 
-docker compose up 
+# Backend server
+docker compose up
 
-# PDF generation function (only needed if you're using features requiring PDF generation, eg, payment invoice/auto-reply PDF) 
-npm run dev:pdf-gen 
+# PDF generation function (only needed if you're using features requiring PDF generation, eg, payment invoice/auto-reply PDF)
+npm run dev:pdf-gen
 
 # Virus scanners - run both (only needed if you're uploading attachments)
-npm run dev:virus-scanner 
+npm run dev:virus-scanner
 
 npm run dev:virus-scanner-guardduty
 ```


### PR DESCRIPTION
## Problem and Solution
We no longer use EB for deployments,
so remove the button accordingly
