### PR TITLE
fix(copy): update Webhooks text to have more clarity entire payload is sent

### DIFF
--- a/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
@@ -3,7 +3,7 @@ export const enSG = {
   input: {
     label: 'Endpoint URL',
     description:
-      'FormSG will POST encrypted form responses in real-time to the HTTPS endpoint specified here. Ensure that your external system can support the classification and sensitivity.',
+      'FormSG will POST entire encrypted form responses in real-time to the HTTPS endpoint specified. Ensure that your external system can support the classification and sensitivity.',
   },
   retry: {
     label: 'Enable retries',

--- a/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
@@ -3,7 +3,7 @@ export const enSG = {
   input: {
     label: 'Endpoint URL',
     description:
-      'FormSG will POST entire encrypted form responses in real-time to the HTTPS endpoint specified. Ensure that your external system can support the classification and sensitivity.',
+      'FormSG will POST the entire encrypted form response in real-time to the HTTPS endpoint specified. Ensure that the external system can support the classification and sensitivity.',
   },
   retry: {
     label: 'Enable retries',


### PR DESCRIPTION
Admins have raised concerns that the settings copy is not clear that the entire encrypted payload is sent externally via webhook. While this is behavior existing, this provides more clarity.