### PR TITLE
feat: enable save draft instrumentation basic

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -876,11 +876,19 @@ export const PublicFormProvider = ({
             'features.publicForm.components.saveDraft.toast.restoredOnlyUnchangedFields',
           )
         : t('features.publicForm.components.saveDraft.toast.restoredAllFields')
+      console.log({
+        message: restoreDraftMessage,
+        meta: {
+          action: 'restoreDraft',
+          formId,
+          hasChangedDraftFields,
+        },
+      })
       toast({
         description: restoreDraftMessage,
       })
     },
-    [t, toast],
+    [t, toast, formId],
   )
   const hasUnrestorableFields = Boolean(changedFieldIds?.length > 0)
 

--- a/frontend/src/features/public-form/components/FloatingToolBar/FloatingToolbar.tsx
+++ b/frontend/src/features/public-form/components/FloatingToolBar/FloatingToolbar.tsx
@@ -40,7 +40,17 @@ export const FloatingToolBar = (): JSX.Element | null => {
       <FloatingIssueFeedbackButton isPreview={isPreview} formId={formId} />
       {isSaveDraftEnabled && enableFloatingSaveDraftButton && (
         <FloatingSaveDraftButton
-          onSaveDraft={onSaveDraft}
+          onSaveDraft={() => {
+            console.log({
+              message: 'User clicked save draft from floating toolbar',
+              meta: {
+                action: 'saveDraft',
+                variant: 'FloatingToolbar',
+                formId,
+              },
+            })
+            onSaveDraft()
+          }}
           draftLastSavedDateTimeString={draftLastSavedDateTimeString}
         />
       )}

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -46,8 +46,12 @@ export const MiniHeader = ({
   isOpen,
   isTemplate,
 }: MiniHeaderProps): JSX.Element => {
-  const { isSaveDraftEnabled, onSaveDraft, draftLastSavedDateTimeString } =
-    usePublicFormContext()
+  const {
+    isSaveDraftEnabled,
+    onSaveDraft,
+    draftLastSavedDateTimeString,
+    formId,
+  } = usePublicFormContext()
 
   const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
   const gb = useGrowthBook()
@@ -96,7 +100,17 @@ export const MiniHeader = ({
             </Flex>
             {isSaveDraftEnabled && enableFormHeaderSaveDraftButton && (
               <FormHeaderSaveDraftButton
-                onSaveDraft={onSaveDraft}
+                onSaveDraft={() => {
+                  console.log({
+                    message: 'User clicked save draft from form header',
+                    meta: {
+                      action: 'saveDraft',
+                      variant: 'FormHeader',
+                      formId,
+                    },
+                  })
+                  onSaveDraft()
+                }}
                 draftLastSavedDateTimeString={draftLastSavedDateTimeString}
               />
             )}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Users are finding it difficult to discover the Save Draft button, based on current studies.

We need a way to improve the discoverability of the button with quantitative metrics.

Closes FRM-2174

## Solution
<!-- How did you solve the problem? -->

Instrument the saving and restoring of drafts with logging statements (pending RUM improvements).

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Log when a draft is restored
- Log when a draft is saved using either the FormHeader or the FloatingToolbar

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
