### PR TITLE
feat: remove signature beta label

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListOption.tsx
@@ -184,12 +184,6 @@ export const BasicFieldOption = forwardRef<BasicFieldOptionProps, 'button'>(
             <Text noOfLines={1}>Use for approvals</Text>
           </Badge>
         ) : null}
-        {/* TODO: FRM-2054 remove when signature field is out of beta */}
-        {fieldType === BasicField.Signature ? (
-          <Badge colorScheme="primary" variant="subtle" color="secondary.500">
-            Beta
-          </Badge>
-        ) : null}
       </FieldListOption>
     )
   },


### PR DESCRIPTION
Signature field is ready to be out of beta so we can remove the label. It is pending some minor improvements for admins to retrieve the PDF within the email notifications.