### PR TITLE
feat: enable save draft instrumentation basic again

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -876,7 +876,7 @@ export const PublicFormProvider = ({
             'features.publicForm.components.saveDraft.toast.restoredOnlyUnchangedFields',
           )
         : t('features.publicForm.components.saveDraft.toast.restoredAllFields')
-      datadogLogs.logger?.log(restoreDraftMessage, {
+      datadogLogs.logger.log(restoreDraftMessage, {
         meta: {
           action: 'restoreDraft',
           formId,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -876,8 +876,7 @@ export const PublicFormProvider = ({
             'features.publicForm.components.saveDraft.toast.restoredOnlyUnchangedFields',
           )
         : t('features.publicForm.components.saveDraft.toast.restoredAllFields')
-      console.log({
-        message: restoreDraftMessage,
+      datadogLogs.logger?.log(restoreDraftMessage, {
         meta: {
           action: 'restoreDraft',
           formId,

--- a/frontend/src/features/public-form/components/FloatingToolBar/FloatingToolbar.tsx
+++ b/frontend/src/features/public-form/components/FloatingToolBar/FloatingToolbar.tsx
@@ -42,7 +42,7 @@ export const FloatingToolBar = (): JSX.Element | null => {
       {isSaveDraftEnabled && enableFloatingSaveDraftButton && (
         <FloatingSaveDraftButton
           onSaveDraft={() => {
-            datadogLogs.logger?.log(
+            datadogLogs.logger.log(
               'User clicked save draft from floating toolbar',
               {
                 meta: {

--- a/frontend/src/features/public-form/components/FloatingToolBar/FloatingToolbar.tsx
+++ b/frontend/src/features/public-form/components/FloatingToolBar/FloatingToolbar.tsx
@@ -1,4 +1,5 @@
 import { Stack } from '@chakra-ui/react'
+import { datadogLogs } from '@datadog/browser-logs'
 import { useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants'
@@ -41,14 +42,16 @@ export const FloatingToolBar = (): JSX.Element | null => {
       {isSaveDraftEnabled && enableFloatingSaveDraftButton && (
         <FloatingSaveDraftButton
           onSaveDraft={() => {
-            console.log({
-              message: 'User clicked save draft from floating toolbar',
-              meta: {
-                action: 'saveDraft',
-                variant: 'FloatingToolbar',
-                formId,
+            datadogLogs.logger?.log(
+              'User clicked save draft from floating toolbar',
+              {
+                meta: {
+                  action: 'saveDraft',
+                  variant: 'FloatingToolbar',
+                  formId,
+                },
               },
-            })
+            )
             onSaveDraft()
           }}
           draftLastSavedDateTimeString={draftLastSavedDateTimeString}

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -102,7 +102,7 @@ export const MiniHeader = ({
             {isSaveDraftEnabled && enableFormHeaderSaveDraftButton && (
               <FormHeaderSaveDraftButton
                 onSaveDraft={() => {
-                  datadogLogs.logger?.log(
+                  datadogLogs.logger.log(
                     'User clicked save draft from form header',
                     {
                       meta: {

--- a/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
+import { datadogLogs } from '@datadog/browser-logs'
 import { useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants/feature-flags'
@@ -101,14 +102,16 @@ export const MiniHeader = ({
             {isSaveDraftEnabled && enableFormHeaderSaveDraftButton && (
               <FormHeaderSaveDraftButton
                 onSaveDraft={() => {
-                  console.log({
-                    message: 'User clicked save draft from form header',
-                    meta: {
-                      action: 'saveDraft',
-                      variant: 'FormHeader',
-                      formId,
+                  datadogLogs.logger?.log(
+                    'User clicked save draft from form header',
+                    {
+                      meta: {
+                        action: 'saveDraft',
+                        variant: 'FormHeader',
+                        formId,
+                      },
                     },
-                  })
+                  )
                   onSaveDraft()
                 }}
                 draftLastSavedDateTimeString={draftLastSavedDateTimeString}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Whoops! `console.log` entries are not sent to DataDog, and are exposed to the user instead.

Fixes FRM-2174.

## Solution
<!-- How did you solve the problem? -->

Use the DataDog Browser Logs SDK instead.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Use DataDog Logs instead!

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
