### PR TITLE
feat: remove un-neeeded dd tracing and browser installation in the setup

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,17 +33,9 @@ jobs:
           node-version: 22
       - name: Install dependencies
         run: npm ci
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
-      - name: Configure Datadog Test Visibility
-        uses: datadog/test-visibility-github-action@v1.0.5
-        with:
-          languages: js
-          service-name: ${{ secrets.DD_SERVICE }}
-          api-key: ${{ secrets.DD_API_KEY }}
       - name: Build
         env:
-          NODE_OPTIONS: --max-old-space-size=4096 -r ${{ env.DD_TRACE_PACKAGE }}
+          NODE_OPTIONS: --max-old-space-size=4096
           VITE_APP_FORMSG_SDK_MODE: 'test'
         run: npm run build
       - name: Cache build artifacts


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There is unneeded duplication of playwright browser installation and dd instrumentation in the setup step - this is not required since no test results are piped from the setup (which is the intention of this, see: https://github.com/opengovsg/FormSG/issues/7542) and no tests are run. 

## Solution
<!-- How did you solve the problem? -->
Remove these duplications. This change is verified to reduce the time for setup phase by ~1 minute (from 4mins -> 3mins) 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  