### PR TITLE
fix: remove noisy chromatic diffs due to dynamic dates and form link

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -140,15 +140,15 @@ const getDefaultRows = ({
   responseId: string
   submissionTime: string
 }) => [
-  {
-    question: 'Response ID',
-    answer: responseId,
-  },
-  {
-    question: 'Time Submitted',
-    answer: submissionTime,
-  },
-]
+    {
+      question: 'Response ID',
+      answer: responseId,
+    },
+    {
+      question: 'Time Submitted',
+      answer: submissionTime,
+    },
+  ]
 
 const PrintableResponseRows = ({
   decryptedResponses,
@@ -181,6 +181,10 @@ const PrintableResponseRows = ({
   )
 }
 
+const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
+// RATIONALE: Prevent noisy diffs from being detected during storybook snapshot comparisons due to dynamic form link. 
+const MOCK_CONSTANT_FORM_LINK_FOR_STORYBOOK_TO_HAVE_NO_DIFFS = 'https://form.gov.sg/64e2f7ae841cbe0012e785e7'
+
 export const PrintableResponse = ({
   formTitle,
   formId,
@@ -210,9 +214,8 @@ export const PrintableResponse = ({
           color="white"
           textDecor="underline"
           textDecorationColor="white"
-          data-chromatic="ignore"
         >
-          {window.location.origin}/{formId}
+          {isTest ? MOCK_CONSTANT_FORM_LINK_FOR_STORYBOOK_TO_HAVE_NO_DIFFS : `${window.location.origin}/${formId}`}
         </Text>
       </Box>
       <Box mx="5%" my="30px">

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -182,9 +182,7 @@ const PrintableResponseRows = ({
 }
 
 const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-// RATIONALE: Prevent noisy diffs from being detected during storybook snapshot comparisons due to dynamic form link.
-const MOCK_CONSTANT_FORM_LINK_FOR_STORYBOOK_TO_HAVE_NO_DIFFS =
-  'https://form.gov.sg/64e2f7ae841cbe0012e785e7'
+const MOCK_CONSTANT_FORM_LINK = 'https://form.gov.sg/64e2f7ae841cbe0012e785e7'
 
 export const PrintableResponse = ({
   formTitle,
@@ -216,8 +214,9 @@ export const PrintableResponse = ({
           textDecor="underline"
           textDecorationColor="white"
         >
+          {/* RATIONALE: Prevent noisy diffs from being detected during storybook snapshot comparisons due to dynamic form link. */}
           {isTest
-            ? MOCK_CONSTANT_FORM_LINK_FOR_STORYBOOK_TO_HAVE_NO_DIFFS
+            ? MOCK_CONSTANT_FORM_LINK
             : `${window.location.origin}/${formId}`}
         </Text>
       </Box>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -140,15 +140,15 @@ const getDefaultRows = ({
   responseId: string
   submissionTime: string
 }) => [
-    {
-      question: 'Response ID',
-      answer: responseId,
-    },
-    {
-      question: 'Time Submitted',
-      answer: submissionTime,
-    },
-  ]
+  {
+    question: 'Response ID',
+    answer: responseId,
+  },
+  {
+    question: 'Time Submitted',
+    answer: submissionTime,
+  },
+]
 
 const PrintableResponseRows = ({
   decryptedResponses,
@@ -182,8 +182,9 @@ const PrintableResponseRows = ({
 }
 
 const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-// RATIONALE: Prevent noisy diffs from being detected during storybook snapshot comparisons due to dynamic form link. 
-const MOCK_CONSTANT_FORM_LINK_FOR_STORYBOOK_TO_HAVE_NO_DIFFS = 'https://form.gov.sg/64e2f7ae841cbe0012e785e7'
+// RATIONALE: Prevent noisy diffs from being detected during storybook snapshot comparisons due to dynamic form link.
+const MOCK_CONSTANT_FORM_LINK_FOR_STORYBOOK_TO_HAVE_NO_DIFFS =
+  'https://form.gov.sg/64e2f7ae841cbe0012e785e7'
 
 export const PrintableResponse = ({
   formTitle,
@@ -215,7 +216,9 @@ export const PrintableResponse = ({
           textDecor="underline"
           textDecorationColor="white"
         >
-          {isTest ? MOCK_CONSTANT_FORM_LINK_FOR_STORYBOOK_TO_HAVE_NO_DIFFS : `${window.location.origin}/${formId}`}
+          {isTest
+            ? MOCK_CONSTANT_FORM_LINK_FOR_STORYBOOK_TO_HAVE_NO_DIFFS
+            : `${window.location.origin}/${formId}`}
         </Text>
       </Box>
       <Box mx="5%" my="30px">

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -156,57 +156,57 @@ export function useCommonFormProvider(formId: string) {
 // Hence, we need to map the frontend title-case to upper-case when submitting to backend.
 const transformFormInputCountryRegionToUpperCase =
   (form_fields: Array<{ fieldType: BasicField; _id: string }>) =>
-  (formInputs: Record<string, unknown>) => {
-    const countryRegionFieldIds = new Set(
-      form_fields
-        .filter((field) => field.fieldType === BasicField.CountryRegion)
-        .map((field) => field._id),
-    )
+    (formInputs: Record<string, unknown>) => {
+      const countryRegionFieldIds = new Set(
+        form_fields
+          .filter((field) => field.fieldType === BasicField.CountryRegion)
+          .map((field) => field._id),
+      )
 
-    return Object.keys(formInputs).reduce(
-      (newFormInputs: typeof formInputs, fieldId) => {
-        const currentInput = formInputs[fieldId]
-        if (
-          countryRegionFieldIds.has(fieldId) &&
-          typeof currentInput === 'string'
-        ) {
-          newFormInputs[fieldId] = currentInput.toUpperCase()
-        } else {
-          newFormInputs[fieldId] = currentInput
-        }
-        return newFormInputs
-      },
-      {},
-    )
-  }
+      return Object.keys(formInputs).reduce(
+        (newFormInputs: typeof formInputs, fieldId) => {
+          const currentInput = formInputs[fieldId]
+          if (
+            countryRegionFieldIds.has(fieldId) &&
+            typeof currentInput === 'string'
+          ) {
+            newFormInputs[fieldId] = currentInput.toUpperCase()
+          } else {
+            newFormInputs[fieldId] = currentInput
+          }
+          return newFormInputs
+        },
+        {},
+      )
+    }
 
 // Trim text inputs before sending to backend to match frontend validation
 const transformFormInputTrimTextInputs =
   (form_fields: Array<{ fieldType: BasicField; _id: string }>) =>
-  (formInputs: Record<string, unknown>) => {
-    const textFieldIds = new Set(
-      form_fields
-        .filter(
-          (field) =>
-            field.fieldType === BasicField.ShortText ||
-            field.fieldType === BasicField.LongText,
-        )
-        .map((field) => field._id),
-    )
+    (formInputs: Record<string, unknown>) => {
+      const textFieldIds = new Set(
+        form_fields
+          .filter(
+            (field) =>
+              field.fieldType === BasicField.ShortText ||
+              field.fieldType === BasicField.LongText,
+          )
+          .map((field) => field._id),
+      )
 
-    return Object.keys(formInputs).reduce(
-      (newFormInputs: typeof formInputs, fieldId) => {
-        const currentInput = formInputs[fieldId]
-        if (textFieldIds.has(fieldId) && typeof currentInput === 'string') {
-          newFormInputs[fieldId] = currentInput.trim()
-        } else {
-          newFormInputs[fieldId] = currentInput
-        }
-        return newFormInputs
-      },
-      {},
-    )
-  }
+      return Object.keys(formInputs).reduce(
+        (newFormInputs: typeof formInputs, fieldId) => {
+          const currentInput = formInputs[fieldId]
+          if (textFieldIds.has(fieldId) && typeof currentInput === 'string') {
+            newFormInputs[fieldId] = currentInput.trim()
+          } else {
+            newFormInputs[fieldId] = currentInput
+          }
+          return newFormInputs
+        },
+        {},
+      )
+    }
 
 export const augmentFormFields = (
   formFields: FormFieldDto[],
@@ -448,14 +448,14 @@ export const PublicFormProvider = ({
   const data = useMemo(() => {
     return latestFormData && encryptedPreviousSubmission
       ? {
-          ...latestFormData,
-          form: {
-            ...latestFormData.form,
-            form_fields: encryptedPreviousSubmission.form_fields,
-            form_logics: encryptedPreviousSubmission.form_logics,
-            workflow: encryptedPreviousSubmission.workflow,
-          },
-        }
+        ...latestFormData,
+        form: {
+          ...latestFormData.form,
+          form_fields: encryptedPreviousSubmission.form_fields,
+          form_logics: encryptedPreviousSubmission.form_logics,
+          workflow: encryptedPreviousSubmission.workflow,
+        },
+      }
       : latestFormData
   }, [latestFormData, encryptedPreviousSubmission])
 
@@ -873,8 +873,8 @@ export const PublicFormProvider = ({
     ({ hasChangedDraftFields }: { hasChangedDraftFields: boolean }) => {
       const restoreDraftMessage = hasChangedDraftFields
         ? t(
-            'features.publicForm.components.saveDraft.toast.restoredOnlyUnchangedFields',
-          )
+          'features.publicForm.components.saveDraft.toast.restoredOnlyUnchangedFields',
+        )
         : t('features.publicForm.components.saveDraft.toast.restoredAllFields')
       datadogLogs.logger.log(restoreDraftMessage, {
         meta: {
@@ -1174,12 +1174,12 @@ export const PublicFormProvider = ({
             ),
             ...(form.payments_field.payment_type === PaymentType.Variable
               ? {
-                  payments: {
-                    amount_cents: dollarsToCents(
-                      paymentVariableInputAmountField ?? '0',
-                    ),
-                  },
-                }
+                payments: {
+                  amount_cents: dollarsToCents(
+                    paymentVariableInputAmountField ?? '0',
+                  ),
+                },
+              }
               : {}),
           }
 
@@ -1388,6 +1388,12 @@ export const PublicFormProvider = ({
     return <NotFoundErrorPage />
   }
 
+  const DATE_TIME_FORMAT_STRING = 'do MMM yyyy, h:mm:ss a'
+  const MOCK_CONSTANT_LAST_SAVED_DATETIME_STRING_FOR_STORYBOOK_TO_HAVE_NO_DIFFS = format(new Date('2025-11-14T12:00:00.000Z'), DATE_TIME_FORMAT_STRING)
+  const actualLastSavedDateTimeString = draftSubmission?.lastUpdated ? format(new Date(draftSubmission.lastUpdated), DATE_TIME_FORMAT_STRING) : undefined
+  // RATIONALE: Replace with constant string if actual last saved date time string exists during storybook visual tests to prevent noisy diffs.
+  const draftLastSavedDateTimeString = actualLastSavedDateTimeString && isTest ? MOCK_CONSTANT_LAST_SAVED_DATETIME_STRING_FOR_STORYBOOK_TO_HAVE_NO_DIFFS : actualLastSavedDateTimeString
+
   return (
     <PublicFormContext.Provider
       value={{
@@ -1412,12 +1418,7 @@ export const PublicFormProvider = ({
         previousAttachments,
         setPreviousSubmission,
         isSaveDraftEnabled,
-        draftLastSavedDateTimeString: draftSubmission?.lastUpdated
-          ? format(
-              new Date(draftSubmission.lastUpdated),
-              'do MMM yyyy, h:mm:ss a',
-            )
-          : undefined,
+        draftLastSavedDateTimeString,
         onSaveDraft,
         defaultFormValues,
         augmentedFormFields,

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -156,57 +156,57 @@ export function useCommonFormProvider(formId: string) {
 // Hence, we need to map the frontend title-case to upper-case when submitting to backend.
 const transformFormInputCountryRegionToUpperCase =
   (form_fields: Array<{ fieldType: BasicField; _id: string }>) =>
-    (formInputs: Record<string, unknown>) => {
-      const countryRegionFieldIds = new Set(
-        form_fields
-          .filter((field) => field.fieldType === BasicField.CountryRegion)
-          .map((field) => field._id),
-      )
+  (formInputs: Record<string, unknown>) => {
+    const countryRegionFieldIds = new Set(
+      form_fields
+        .filter((field) => field.fieldType === BasicField.CountryRegion)
+        .map((field) => field._id),
+    )
 
-      return Object.keys(formInputs).reduce(
-        (newFormInputs: typeof formInputs, fieldId) => {
-          const currentInput = formInputs[fieldId]
-          if (
-            countryRegionFieldIds.has(fieldId) &&
-            typeof currentInput === 'string'
-          ) {
-            newFormInputs[fieldId] = currentInput.toUpperCase()
-          } else {
-            newFormInputs[fieldId] = currentInput
-          }
-          return newFormInputs
-        },
-        {},
-      )
-    }
+    return Object.keys(formInputs).reduce(
+      (newFormInputs: typeof formInputs, fieldId) => {
+        const currentInput = formInputs[fieldId]
+        if (
+          countryRegionFieldIds.has(fieldId) &&
+          typeof currentInput === 'string'
+        ) {
+          newFormInputs[fieldId] = currentInput.toUpperCase()
+        } else {
+          newFormInputs[fieldId] = currentInput
+        }
+        return newFormInputs
+      },
+      {},
+    )
+  }
 
 // Trim text inputs before sending to backend to match frontend validation
 const transformFormInputTrimTextInputs =
   (form_fields: Array<{ fieldType: BasicField; _id: string }>) =>
-    (formInputs: Record<string, unknown>) => {
-      const textFieldIds = new Set(
-        form_fields
-          .filter(
-            (field) =>
-              field.fieldType === BasicField.ShortText ||
-              field.fieldType === BasicField.LongText,
-          )
-          .map((field) => field._id),
-      )
+  (formInputs: Record<string, unknown>) => {
+    const textFieldIds = new Set(
+      form_fields
+        .filter(
+          (field) =>
+            field.fieldType === BasicField.ShortText ||
+            field.fieldType === BasicField.LongText,
+        )
+        .map((field) => field._id),
+    )
 
-      return Object.keys(formInputs).reduce(
-        (newFormInputs: typeof formInputs, fieldId) => {
-          const currentInput = formInputs[fieldId]
-          if (textFieldIds.has(fieldId) && typeof currentInput === 'string') {
-            newFormInputs[fieldId] = currentInput.trim()
-          } else {
-            newFormInputs[fieldId] = currentInput
-          }
-          return newFormInputs
-        },
-        {},
-      )
-    }
+    return Object.keys(formInputs).reduce(
+      (newFormInputs: typeof formInputs, fieldId) => {
+        const currentInput = formInputs[fieldId]
+        if (textFieldIds.has(fieldId) && typeof currentInput === 'string') {
+          newFormInputs[fieldId] = currentInput.trim()
+        } else {
+          newFormInputs[fieldId] = currentInput
+        }
+        return newFormInputs
+      },
+      {},
+    )
+  }
 
 export const augmentFormFields = (
   formFields: FormFieldDto[],
@@ -448,14 +448,14 @@ export const PublicFormProvider = ({
   const data = useMemo(() => {
     return latestFormData && encryptedPreviousSubmission
       ? {
-        ...latestFormData,
-        form: {
-          ...latestFormData.form,
-          form_fields: encryptedPreviousSubmission.form_fields,
-          form_logics: encryptedPreviousSubmission.form_logics,
-          workflow: encryptedPreviousSubmission.workflow,
-        },
-      }
+          ...latestFormData,
+          form: {
+            ...latestFormData.form,
+            form_fields: encryptedPreviousSubmission.form_fields,
+            form_logics: encryptedPreviousSubmission.form_logics,
+            workflow: encryptedPreviousSubmission.workflow,
+          },
+        }
       : latestFormData
   }, [latestFormData, encryptedPreviousSubmission])
 
@@ -873,8 +873,8 @@ export const PublicFormProvider = ({
     ({ hasChangedDraftFields }: { hasChangedDraftFields: boolean }) => {
       const restoreDraftMessage = hasChangedDraftFields
         ? t(
-          'features.publicForm.components.saveDraft.toast.restoredOnlyUnchangedFields',
-        )
+            'features.publicForm.components.saveDraft.toast.restoredOnlyUnchangedFields',
+          )
         : t('features.publicForm.components.saveDraft.toast.restoredAllFields')
       datadogLogs.logger.log(restoreDraftMessage, {
         meta: {
@@ -1174,12 +1174,12 @@ export const PublicFormProvider = ({
             ),
             ...(form.payments_field.payment_type === PaymentType.Variable
               ? {
-                payments: {
-                  amount_cents: dollarsToCents(
-                    paymentVariableInputAmountField ?? '0',
-                  ),
-                },
-              }
+                  payments: {
+                    amount_cents: dollarsToCents(
+                      paymentVariableInputAmountField ?? '0',
+                    ),
+                  },
+                }
               : {}),
           }
 
@@ -1389,10 +1389,16 @@ export const PublicFormProvider = ({
   }
 
   const DATE_TIME_FORMAT_STRING = 'do MMM yyyy, h:mm:ss a'
-  const MOCK_CONSTANT_LAST_SAVED_DATETIME_STRING_FOR_STORYBOOK_TO_HAVE_NO_DIFFS = format(new Date('2025-11-14T12:00:00.000Z'), DATE_TIME_FORMAT_STRING)
-  const actualLastSavedDateTimeString = draftSubmission?.lastUpdated ? format(new Date(draftSubmission.lastUpdated), DATE_TIME_FORMAT_STRING) : undefined
+  const MOCK_CONSTANT_LAST_SAVED_DATETIME_STRING_FOR_STORYBOOK_TO_HAVE_NO_DIFFS =
+    format(new Date('2025-11-14T12:00:00.000Z'), DATE_TIME_FORMAT_STRING)
+  const actualLastSavedDateTimeString = draftSubmission?.lastUpdated
+    ? format(new Date(draftSubmission.lastUpdated), DATE_TIME_FORMAT_STRING)
+    : undefined
   // RATIONALE: Replace with constant string if actual last saved date time string exists during storybook visual tests to prevent noisy diffs.
-  const draftLastSavedDateTimeString = actualLastSavedDateTimeString && isTest ? MOCK_CONSTANT_LAST_SAVED_DATETIME_STRING_FOR_STORYBOOK_TO_HAVE_NO_DIFFS : actualLastSavedDateTimeString
+  const draftLastSavedDateTimeString =
+    actualLastSavedDateTimeString && isTest
+      ? MOCK_CONSTANT_LAST_SAVED_DATETIME_STRING_FOR_STORYBOOK_TO_HAVE_NO_DIFFS
+      : actualLastSavedDateTimeString
 
   return (
     <PublicFormContext.Provider

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -106,6 +106,9 @@ interface PublicFormProviderProps {
   isPublicFormPage?: boolean
 }
 
+const DATE_TIME_FORMAT_STRING = 'do MMM yyyy, h:mm:ss a'
+const MOCK_CONSTANT_LAST_SAVED_DATETIME = '2025-11-14T12:00:00.000Z'
+
 export function useCommonFormProvider(formId: string) {
   // For mobile section sidebar
   const {
@@ -1388,17 +1391,15 @@ export const PublicFormProvider = ({
     return <NotFoundErrorPage />
   }
 
-  const DATE_TIME_FORMAT_STRING = 'do MMM yyyy, h:mm:ss a'
-  const MOCK_CONSTANT_LAST_SAVED_DATETIME_STRING_FOR_STORYBOOK_TO_HAVE_NO_DIFFS =
-    format(new Date('2025-11-14T12:00:00.000Z'), DATE_TIME_FORMAT_STRING)
-  const actualLastSavedDateTimeString = draftSubmission?.lastUpdated
-    ? format(new Date(draftSubmission.lastUpdated), DATE_TIME_FORMAT_STRING)
+  // RATIONALE: Prevent noisy diffs from being detected during storybook snapshot comparisons due to dynamic date time.
+  const draftLastSavedDateTime =
+    draftSubmission?.lastUpdated && isTest
+      ? MOCK_CONSTANT_LAST_SAVED_DATETIME
+      : draftSubmission?.lastUpdated
+
+  const draftLastSavedDateTimeString = draftLastSavedDateTime
+    ? format(new Date(draftLastSavedDateTime), DATE_TIME_FORMAT_STRING)
     : undefined
-  // RATIONALE: Replace with constant string if actual last saved date time string exists during storybook visual tests to prevent noisy diffs.
-  const draftLastSavedDateTimeString =
-    actualLastSavedDateTimeString && isTest
-      ? MOCK_CONSTANT_LAST_SAVED_DATETIME_STRING_FOR_STORYBOOK_TO_HAVE_NO_DIFFS
-      : actualLastSavedDateTimeString
 
   return (
     <PublicFormContext.Provider


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

There are noisy chromatic test differences due to dynamic dates for save draft and form link for printable response. 

## Solution
<!-- How did you solve the problem? -->
Mock with constant values to prevent diffs between builds. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  