### PR TITLE
chore: modify respondent copy helper text v1

### DIFF
--- a/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
+++ b/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
@@ -40,7 +40,7 @@ export const enSG: Fields = {
         'The entered email does not belong to an allowed email domain',
     },
     respondentCopyHelperText:
-      'A copy of your responses will be sent to this email address',
+      'A copy of the responses will be sent to this email address',
   },
   verification: {
     button: {


### PR DESCRIPTION
Admins have report confusion in MRF workflows, where respondents will be confused that only what is inputted will be received via email.

Previous:

<img width="594" height="260" alt="image" src="https://github.com/user-attachments/assets/a298e886-d9ad-465d-a04e-945b23ebf994" />

After:
"A copy of the responses will be sent to this email address"