### PR TITLE
fix: hidden signature field blocks submission

### DIFF
--- a/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -32,7 +32,7 @@ export const SignatureField = ({
   isHighContrast,
 }: SignatureFieldProps): JSX.Element => {
   const formContext = useFormContext<SignatureFieldInput>()
-  const { getValues, setValue } = formContext
+  const { register, unregister, setValue } = formContext
   const { isSubmitting, isValid, errors } = useFormState<SignatureFieldInput>()
   const [showSignaturePlaceholder, setShowSignaturePlaceholder] = useState(true)
 
@@ -55,8 +55,13 @@ export const SignatureField = ({
   )
 
   useEffect(() => {
-    formContext.register(schema._id, signatureValidationRules)
-  }, [formContext, schema._id, signatureValidationRules])
+    register(schema._id, signatureValidationRules)
+
+    // when unmounting, unregister the field so that submission will not be blocked by signature validation errors
+    return () => {
+      unregister(schema._id)
+    }
+  }, [register, schema._id, signatureValidationRules, unregister])
 
   // perfect freehand variables
   const pfCanvasRef = useRef<HTMLCanvasElement>(null)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When a (required) signature field is hidden by logic, submission of the form is being blocked. This is due to 'required' validation error preventing successful submission

Closes FRM-2180

## Solution
<!-- How did you solve the problem? -->

Unregister signature field component when it is being unmounted:
- unmounting is tracked within the component in `useEffect`, logic can be composed in the `return`
- Since signature field is an uncontrolled component, unmounting it from the DOM does not change the fact that it is still registered in RHF, so manual unregistering is required.

This isn't needed for other fields since they are controlled components, and unregistering upon unmounting is handled in [useEditLogicBlock](https://github.com/opengovsg/FormSG/blob/c97a4f53e21b29c35faad9e53f02a66e88393bac/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx#L39) `shouldUnregister: true`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

**Successfully submit a form with a hidden signature field**
- [x] Create a single respondent form with a signature field and a Yes/No field
- [x] Add logic to hide signature field when 'Yes' is selected
- [x] Attempt to make a successful submission