### PR TITLE
feat: reserve cpu for formsg app

### DIFF
--- a/.github/workflows/deploy-ecs-prod.yml
+++ b/.github/workflows/deploy-ecs-prod.yml
@@ -26,6 +26,7 @@ jobs:
       ecr-repository: 'formsg'
       # ECS configuration
       ecs-cpu: 1024
+      formsg-app-reserved-cpu: 896
       ecs-memory: 4096
       ecs-cluster-name: 'formsg-prod-ecs'
       ecs-service-name: 'formsg-prod-ecs-service'

--- a/.github/workflows/deploy-ecs-stg-alt.yml
+++ b/.github/workflows/deploy-ecs-stg-alt.yml
@@ -26,6 +26,7 @@ jobs:
       ecr-repository: 'formsg'
       # ECS configuration
       ecs-cpu: 1024
+      formsg-app-reserved-cpu: 896
       ecs-memory: 2048
       ecs-cluster-name: 'formsg-stg-alt-ecs'
       ecs-service-name: 'formsg-stg-alt-ecs-service'

--- a/.github/workflows/deploy-ecs-stg-alt2.yml
+++ b/.github/workflows/deploy-ecs-stg-alt2.yml
@@ -26,6 +26,7 @@ jobs:
       ecr-repository: 'formsg'
       # ECS configuration
       ecs-cpu: 1024
+      formsg-app-reserved-cpu: 896
       ecs-memory: 2048
       ecs-cluster-name: 'formsg-stg-alt2-ecs'
       ecs-service-name: 'formsg-stg-alt2-ecs-service'

--- a/.github/workflows/deploy-ecs-stg-alt3.yml
+++ b/.github/workflows/deploy-ecs-stg-alt3.yml
@@ -26,6 +26,7 @@ jobs:
       ecr-repository: 'formsg'
       # ECS configuration
       ecs-cpu: 1024
+      formsg-app-reserved-cpu: 896
       ecs-memory: 2048
       ecs-cluster-name: 'formsg-stg-alt3-ecs'
       ecs-service-name: 'formsg-stg-alt3-ecs-service'

--- a/.github/workflows/deploy-ecs-stg.yml
+++ b/.github/workflows/deploy-ecs-stg.yml
@@ -26,6 +26,7 @@ jobs:
       ecr-repository: 'formsg'
       # ECS configuration
       ecs-cpu: 1024
+      formsg-app-reserved-cpu: 896
       ecs-memory: 2048
       ecs-cluster-name: 'formsg-stg-ecs'
       ecs-service-name: 'formsg-stg-ecs-service'

--- a/.github/workflows/deploy-ecs-uat.yml
+++ b/.github/workflows/deploy-ecs-uat.yml
@@ -26,6 +26,7 @@ jobs:
       ecr-repository: 'formsg'
       # ECS configuration
       ecs-cpu: 1024
+      formsg-app-reserved-cpu: 896
       ecs-memory: 2048
       ecs-cluster-name: 'formsg-uat-ecs'
       ecs-service-name: 'formsg-uat-ecs-service'

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -71,6 +71,10 @@ on:
         description: 'FormSG SDK mode'
         required: true
         type: string
+      formsg-app-reserved-cpu:
+        description: 'FormSG app reserved CPU units'
+        required: true
+        type: number
       dd-env:
         description: 'Datadog environment'
         required: true
@@ -184,6 +188,7 @@ jobs:
         run: |
           sed -i "s/<AWS_ACCOUNT_ID>/${{ secrets.aws-account-id }}/g" ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<DD_ENV>/${{ inputs.dd-env }}/g' ${{ inputs.ecs-task-definition-path }}
+          sed -i 's/<FORMSG_APP_RESERVED_CPU>/${{ inputs.formsg-app-reserved-cpu }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<CPU>/${{ inputs.ecs-cpu }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<MEMORY>/${{ inputs.ecs-memory }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<ENVIRONMENT_SITE_NAME>/${{ inputs.environment-site-name }}/g' ${{ inputs.ecs-task-definition-path }}

--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -6,6 +6,7 @@
       "portMappings": [
         { "containerPort": 4545, "hostPort": 4545, "protocol": "tcp" }
       ],
+      "cpu": "<FORMSG_APP_RESERVED_CPU>", 
       "environment": [
         { "name": "DD_SERVICE", "value": "formsg" }, 
         { "name": "DD_ENV", "value": "<DD_ENV>" }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

In task definition, the cpu is split between dd-agent and formsg-app, causing overprovisioning (only 3% utilisation) for dd agent and underprovisioning (15%-60% spike) for formsg-app. 


## Solution
<!-- How did you solve the problem? -->
Hence, explicitly reserve 87.5% of cpu units for formsg-app. This should reduce latency. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  