### PR TITLE
feat: add admin pdf copy for storage mode

### DIFF
--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -28,7 +28,14 @@ export const featureFlags = {
   singpassMrf: 'singpass-mrf' as const,
   enableSaveDraftButtonFloating: 'enable-save-draft-button-floating' as const,
   enableSaveDraftButtonHeader: 'enable-save-draft-button-header' as const,
+  adminEmailPdf: 'admin-email-pdf' as const,
   ogpHeader: 'enable-ogp-header' as const,
   ogpAwareness: 'ogp-awareness' as const,
   ogpSpinner: 'ogp-spinner' as const,
+}
+
+export enum AdminEmailPdfFeatureValue {
+  OFF = 'OFF',
+  SIGNATURES_ONLY = 'SIGNATURES_ONLY',
+  ON = 'ON',
 }

--- a/src/app/modules/payments/payments.service.ts
+++ b/src/app/modules/payments/payments.service.ts
@@ -242,6 +242,7 @@ export const performPaymentPostSubmissionActions = (
                 performEncryptPostSubmissionActions({
                   submission,
                   responses: payment.responses,
+                  emailFields: [], // TODO [EMAIL-CONFIRMATION-BUG]: Email confirmation email to email fields does not work for payment forms, this is an existing issue to be fixed.
                 })
                   .andThen(() =>
                     // If successfully sent email confirmations, delete response data from payment document.

--- a/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -455,7 +455,9 @@ describe('submission.service', () => {
         form: mockForm,
         recipientData,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
         responsesData: MOCK_AUTOREPLY_DATA,
       })
 
@@ -467,7 +469,9 @@ describe('submission.service', () => {
       expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith({
         form: mockForm,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
         responsesData: MOCK_AUTOREPLY_DATA,
         autoReplyMailDatas: expectedAutoReplyData,
       })
@@ -496,7 +500,9 @@ describe('submission.service', () => {
         form: mockForm,
         recipientData,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
         responsesData: MOCK_AUTOREPLY_DATA,
       })
 
@@ -541,7 +547,9 @@ describe('submission.service', () => {
         form: mockForm,
         recipientData,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
         responsesData: MOCK_AUTOREPLY_DATA,
       })
 
@@ -592,7 +600,9 @@ describe('submission.service', () => {
         form: mockForm,
         recipientData,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
         responsesData: MOCK_AUTOREPLY_DATA,
       })
 
@@ -601,7 +611,9 @@ describe('submission.service', () => {
       expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith({
         form: mockForm,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
         responsesData: MOCK_AUTOREPLY_DATA,
         autoReplyMailDatas: expectedAutoReplyData,
       })
@@ -655,8 +667,10 @@ describe('submission.service', () => {
         form: mockForm,
         recipientData,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
-        responsesData: undefined,
+        submissionAttachments: MOCK_ATTACHMENTS,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
+        responsesData: [],
       })
 
       const expectedAutoReplyData = [
@@ -667,14 +681,91 @@ describe('submission.service', () => {
       expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith({
         form: mockForm,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
         responsesData: [],
+        autoReplyMailDatas: expectedAutoReplyData,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
+      })
+      expect(result._unsafeUnwrap()).toBe(true)
+    })
+
+    it('should call mail service with pdfAttachment when a pdfAttachment is provided', async () => {
+      const mockForm = {
+        _id: MOCK_FORM_ID,
+        form_fields: [
+          {
+            ...generateDefaultField(BasicField.Email),
+            autoReplyOptions: AUTOREPLY_OPTIONS_1,
+          },
+          {
+            ...generateDefaultField(BasicField.Email),
+            autoReplyOptions: AUTOREPLY_OPTIONS_2,
+          },
+        ],
+      } as unknown as IPopulatedForm
+      MockMailService.sendAutoReplyEmails.mockResolvedValueOnce([
+        {
+          status: 'fulfilled',
+          value: ok(true),
+        },
+        {
+          status: 'fulfilled',
+          value: ok(true),
+        },
+      ])
+
+      const responses = [
+        {
+          ...generateNewSingleAnswerResponse(BasicField.Email, {
+            _id: mockForm.form_fields![0]._id,
+            answer: MOCK_EMAIL_1,
+          }),
+        },
+        {
+          ...generateNewSingleAnswerResponse(BasicField.Email, {
+            _id: mockForm.form_fields![1]._id,
+            answer: MOCK_EMAIL_2,
+          }),
+        },
+      ]
+      const recipientData = extractEmailConfirmationData(
+        responses,
+        mockForm.form_fields,
+      )
+
+      const MOCK_PDF_ATTACHMENT = {
+        content: Buffer.from('mock pdf buffer'),
+        filename: 'response.pdf',
+      }
+      const result = await SubmissionService.sendEmailConfirmations({
+        form: mockForm,
+        recipientData,
+        submission: MOCK_SUBMISSION,
+        submissionAttachments: undefined,
+        responsesData: MOCK_AUTOREPLY_DATA,
+        isPaymentEnabled: false,
+        pdfAttachment: MOCK_PDF_ATTACHMENT,
+      })
+
+      const expectedAutoReplyData = [
+        EXPECTED_AUTOREPLY_DATA_1,
+        EXPECTED_AUTOREPLY_DATA_2,
+      ]
+
+      expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith({
+        form: mockForm,
+        submission: MOCK_SUBMISSION,
+        submissionAttachments: undefined,
+        pdfAttachment: MOCK_PDF_ATTACHMENT,
+        isPaymentEnabled: false,
+        responsesData: MOCK_AUTOREPLY_DATA,
         autoReplyMailDatas: expectedAutoReplyData,
       })
       expect(result._unsafeUnwrap()).toBe(true)
     })
 
-    it('should call mail service with attachments undefined when there are no attachments', async () => {
+    it('should call mail service with submissionAttachments undefined and pdfAttachment undefined when there are no submissionAttachments or pdfAttachment', async () => {
       const mockForm = {
         _id: MOCK_FORM_ID,
         form_fields: [
@@ -721,8 +812,10 @@ describe('submission.service', () => {
         form: mockForm,
         recipientData,
         submission: MOCK_SUBMISSION,
-        attachments: undefined,
+        submissionAttachments: undefined,
         responsesData: MOCK_AUTOREPLY_DATA,
+        isPaymentEnabled: false,
+        pdfAttachment: undefined,
       })
 
       const expectedAutoReplyData = [
@@ -733,7 +826,9 @@ describe('submission.service', () => {
       expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith({
         form: mockForm,
         submission: MOCK_SUBMISSION,
-        attachments: undefined,
+        submissionAttachments: undefined,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
         responsesData: MOCK_AUTOREPLY_DATA,
         autoReplyMailDatas: expectedAutoReplyData,
       })
@@ -780,8 +875,10 @@ describe('submission.service', () => {
         form: mockForm,
         recipientData,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
         responsesData: MOCK_AUTOREPLY_DATA,
+        isPaymentEnabled: false,
+        pdfAttachment: undefined,
       })
 
       const expectedAutoReplyData = [
@@ -792,7 +889,9 @@ describe('submission.service', () => {
       expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith({
         form: mockForm,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
         responsesData: MOCK_AUTOREPLY_DATA,
         autoReplyMailDatas: expectedAutoReplyData,
       })
@@ -849,8 +948,10 @@ describe('submission.service', () => {
         form: mockForm,
         recipientData,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
         responsesData: MOCK_AUTOREPLY_DATA,
+        isPaymentEnabled: false,
+        pdfAttachment: undefined,
       })
 
       const expectedAutoReplyData = [
@@ -861,9 +962,11 @@ describe('submission.service', () => {
       expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith({
         form: mockForm,
         submission: MOCK_SUBMISSION,
-        attachments: MOCK_ATTACHMENTS,
+        submissionAttachments: MOCK_ATTACHMENTS,
         responsesData: MOCK_AUTOREPLY_DATA,
         autoReplyMailDatas: expectedAutoReplyData,
+        pdfAttachment: undefined,
+        isPaymentEnabled: false,
       })
       expect(result._unsafeUnwrapErr()).toEqual(
         new SendEmailConfirmationError(),
@@ -2747,7 +2850,11 @@ describe('submission.service', () => {
 
       // Act
       // empty string for version id to simulate failure
-      const actualResult = await downloadCleanFile('invalid-key', '')
+      const actualResult = await downloadCleanFile(
+        'invalid-key',
+        '',
+        'mock-bucket-name',
+      )
 
       // Assert
       expect(awsSpy).not.toHaveBeenCalled()
@@ -2761,7 +2868,11 @@ describe('submission.service', () => {
 
       // Act
       // empty string for version id to simulate failure
-      const actualResult = await downloadCleanFile(MOCK_VALID_UUID, '')
+      const actualResult = await downloadCleanFile(
+        MOCK_VALID_UUID,
+        '',
+        'mock-bucket-name',
+      )
 
       // Assert
       expect(awsSpy).toHaveBeenCalledOnce()
@@ -2796,7 +2907,11 @@ describe('submission.service', () => {
 
       // Act
       // empty strings for invalid keys and version ids
-      const actualResult = await downloadCleanFile(MOCK_VALID_UUID, versionId)
+      const actualResult = await downloadCleanFile(
+        MOCK_VALID_UUID,
+        versionId,
+        'mock-bucket-name',
+      )
 
       // Assert
       expect(awsSpy).toHaveBeenCalledOnce()

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -33,11 +33,10 @@ import {
   FormFieldSchema,
   IAttachmentInfo,
   IPopulatedEncryptedForm,
+  SgidFieldTitle,
 } from 'src/types'
 import { EncryptSubmissionDto, FormCompleteDto } from 'src/types/api'
 
-import { SubmissionEmailObj } from '../../email-submission/email-submission.util'
-import { ProcessedFieldResponse } from '../../submission.types'
 import {
   generateHashedSubmitterId,
   getCookieNameByAuthType,
@@ -492,9 +491,6 @@ describe('encrypt-submission.controller', () => {
         checkHasSingleSubmissionValidationFailureSpy,
       ).not.toHaveBeenCalled()
 
-      // Assert email notification should be sent
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
-
       // Assert that status is not called, which defaults to intended 200 OK
       expect(mockRes.status).not.toHaveBeenCalled()
       // Assert that response does not any error codes
@@ -502,6 +498,7 @@ describe('encrypt-submission.controller', () => {
         (mockRes.json as jest.Mock).mock.calls[0][0].errorCodes,
       ).not.toBeDefined()
 
+      // Assert that post submission actions are performed
       expect(performEncryptPostSubmissionActionsSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -567,9 +564,6 @@ describe('encrypt-submission.controller', () => {
       )
       expect(saveIfSubmitterIdIsUniqueSpy).toHaveBeenCalledTimes(1)
 
-      // Assert email notification should be sent
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
-
       // Assert that status is not called, which defaults to intended 200 OK
       expect(mockRes.status).not.toHaveBeenCalled()
       // Assert that response does not any error codes
@@ -584,6 +578,7 @@ describe('encrypt-submission.controller', () => {
         ),
       )
 
+      // Assert that post submission actions are performed
       expect(performEncryptPostSubmissionActionsSpy).toHaveBeenCalledTimes(1)
     })
 
@@ -731,9 +726,6 @@ describe('encrypt-submission.controller', () => {
       // Act
       await submitEncryptModeFormForTest(mockReq, mockRes)
 
-      // Assert email notification should be sent
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
-
       // Assert that status is not called, which defaults to intended 200 OK
       expect(mockRes.status).not.toHaveBeenCalled()
       // Assert that response does not have the single submission validation failure flag
@@ -748,8 +740,10 @@ describe('encrypt-submission.controller', () => {
         ),
       )
 
+      // Assert that post submission actions are performed
       expect(performEncryptPostSubmissionActionsSpy).toHaveBeenCalledTimes(1)
     })
+
     it('should return json response with single submission validation failure flag when submissionId is not unique and does not save submission', async () => {
       jest
         .spyOn(EncryptSubmission, 'saveIfSubmitterIdIsUnique')
@@ -1129,7 +1123,7 @@ describe('encrypt-submission.controller', () => {
       expect(savedSubmission!.verifiedContent).toBeUndefined()
     })
 
-    it('should not include nric in email notification and not store nric if form isSubmitterIdCollectionEnabled is false for MyInfo authType', async () => {
+    it('should not include nric field in email fields to be included in notification email and not store nric if form isSubmitterIdCollectionEnabled is false for MyInfo authType', async () => {
       // Arrange
       const mockFormId = new ObjectId()
       const mockMyInfoAuthTypeAndSubmitterIdCollectionDisabledForm = {
@@ -1165,6 +1159,11 @@ describe('encrypt-submission.controller', () => {
       ) as unknown as SubmitEncryptModeFormHandlerRequest
       const mockRes = expressHandler.mockResponse()
 
+      const performEncryptPostSubmissionActionsSpy = jest.spyOn(
+        EncryptSubmissionService,
+        'performEncryptPostSubmissionActions',
+      )
+
       // Act
       await submitEncryptModeFormForTest(MOCK_REQ, mockRes)
 
@@ -1181,14 +1180,21 @@ describe('encrypt-submission.controller', () => {
 
       // Assert
       // email notification should be sent
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+      expect(performEncryptPostSubmissionActionsSpy).toHaveBeenCalledTimes(1)
       // Assert nric is not contained - formData empty array since no parsed responses to be included in email
       expect(
-        MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData,
-      ).toEqual([])
+        performEncryptPostSubmissionActionsSpy.mock.calls[0][0].emailFields,
+      ).not.toContain(
+        expect.objectContaining({
+          answer: MOCK_NRIC,
+          fieldType: BasicField.Nric,
+          isVisible: true,
+          question: SgidFieldTitle.SgidNric,
+        }),
+      )
     })
 
-    it('should include nric in email notification and store nric in verifiedContent if form isSubmitterIdCollectionEnabled is true for SgId authType', async () => {
+    it('should include nric in email fields to be included in notification email and store nric in verifiedContent if form isSubmitterIdCollectionEnabled is true for SgId authType', async () => {
       // Arrange
       const mockFormId = new ObjectId()
       const mockSgidAuthTypeAndSubmitterIdCollectionEnabledForm = {
@@ -1230,6 +1236,11 @@ describe('encrypt-submission.controller', () => {
       }
       const expectedVerifiedContent = { sgidUinFin: MOCK_NRIC }
 
+      const performEncryptPostSubmissionActionsSpy = jest.spyOn(
+        EncryptSubmissionService,
+        'performEncryptPostSubmissionActions',
+      )
+
       // Act
       await submitEncryptModeFormForTest(MOCK_REQ, mockRes)
 
@@ -1252,17 +1263,23 @@ describe('encrypt-submission.controller', () => {
         JSON.stringify(expectedVerifiedContent),
       )
 
-      // email notification should be sent with nric included
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledTimes(1)
+      // email fields for generating email notification include nric
+      expect(performEncryptPostSubmissionActionsSpy).toHaveBeenCalledTimes(1)
       expect(
-        MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData[0]
-          .answer,
-      ).toEqual(MOCK_NRIC)
+        performEncryptPostSubmissionActionsSpy.mock.calls[0][0].emailFields[0],
+      ).toEqual(
+        expect.objectContaining({
+          answer: MOCK_NRIC,
+          fieldType: BasicField.Nric,
+          isVisible: true,
+          question: SgidFieldTitle.SgidNric,
+        }),
+      )
     })
   })
 
-  describe('emailData', () => {
-    it('should have the isVisible field set to true for form fields', async () => {
+  describe('passes the required correct data used to generate content for post-submission notification emails', () => {
+    it('passes the required isVisible values in email fields, submission attachments, and respondent emails', async () => {
       // Arrange
       const performEncryptPostSubmissionActionsSpy = jest.spyOn(
         EncryptSubmissionService,
@@ -1296,7 +1313,29 @@ describe('encrypt-submission.controller', () => {
           fieldType: 'textarea',
           isVisible: true,
         },
+        {
+          id: new ObjectId(),
+          question: 'Short answer',
+          answer: 'this is a short answer',
+          fieldType: 'textfield',
+          isVisible: false,
+        },
       ]
+
+      const mockUnencryptedAttachments: IAttachmentInfo[] = [
+        {
+          filename: 'test.pdf',
+          content: Buffer.from('this is a test file'),
+          fieldId: 'test-field-id',
+        },
+        {
+          filename: 'test2.pdf',
+          content: Buffer.from('this is another test file'),
+          fieldId: 'test-field-id-2',
+        },
+      ]
+
+      const mockRespondentEmails = ['test@example.com', 'test2@example.com']
 
       const mockReq = merge(
         expressHandler.mockRequest({
@@ -1311,274 +1350,31 @@ describe('encrypt-submission.controller', () => {
               encryptedContent: 'encryptedContent',
               version: 1,
             },
+            unencryptedAttachments: mockUnencryptedAttachments,
             formDef: {},
             encryptedFormDef: mockEncryptForm,
+            respondentEmails: mockRespondentEmails,
           } as unknown as EncryptSubmissionDto,
         } as unknown as FormCompleteDto,
       ) as unknown as SubmitEncryptModeFormHandlerRequest
       const mockRes = expressHandler.mockResponse()
-
-      // Setup the SubmissionEmailObj
-      const emailData = new SubmissionEmailObj(
-        mockResponses as any as ProcessedFieldResponse[],
-        new Set(),
-        FormAuthType.NIL,
-      )
-
       // Act
       await submitEncryptModeFormForTest(mockReq, mockRes)
 
       // Assert
       expect(
-        performEncryptPostSubmissionActionsSpy.mock.calls[0][0].emailData,
-      ).toEqual(emailData)
-    })
-  })
+        performEncryptPostSubmissionActionsSpy.mock.calls[0][0].emailFields,
+      ).toEqual(mockResponses)
 
-  describe('submitEncryptModeForm', () => {
-    beforeEach(() => {
-      jest.clearAllMocks()
-      MockMailService.sendSubmissionToAdmin.mockReturnValue(okAsync(true))
-    })
+      expect(
+        performEncryptPostSubmissionActionsSpy.mock.calls[0][0]
+          .submissionAttachments,
+      ).toEqual(mockUnencryptedAttachments)
 
-    it('should call sendSubmissionToAdmin with no attachments', async () => {
-      // Arrange
-      jest
-        .spyOn(MailService, 'sendSubmissionToAdmin')
-        .mockReturnValue(okAsync(true))
-
-      const mockFormId = new ObjectId()
-      const mockForm = {
-        _id: mockFormId,
-        title: 'Test Form',
-        authType: FormAuthType.NIL,
-        form_fields: [] as FormFieldSchema[],
-        emails: ['test@example.com'],
-        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
-      } as IPopulatedEncryptedForm
-
-      const mockAttachments: IAttachmentInfo[] = []
-
-      const mockReq = merge(
-        expressHandler.mockRequest({
-          params: { formId: mockFormId.toHexString() },
-          body: {
-            responses: [],
-            attachments: mockAttachments,
-          },
-        }),
-        {
-          formsg: {
-            encryptedPayload: {
-              encryptedContent: 'mockEncryptedContent',
-              version: 1,
-            },
-            formDef: {},
-            encryptedFormDef: mockForm,
-            unencryptedAttachments: mockAttachments,
-          } as unknown as EncryptSubmissionDto,
-        } as unknown as FormCompleteDto,
-      ) as unknown as SubmitEncryptModeFormHandlerRequest
-
-      const mockRes = expressHandler.mockResponse()
-
-      // Act
-      await submitEncryptModeFormForTest(mockReq, mockRes)
-
-      // Assert (done)
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
-        expect.objectContaining({
-          attachments: mockAttachments,
-        }),
-      )
-    })
-
-    it('should call sendSubmissionToAdmin with the attachments', async () => {
-      // Arrange
-      jest
-        .spyOn(MailService, 'sendSubmissionToAdmin')
-        .mockReturnValue(okAsync(true))
-
-      const mockFormId = new ObjectId()
-      const mockForm = {
-        _id: mockFormId,
-        title: 'Test Form',
-        authType: FormAuthType.NIL,
-        form_fields: [] as FormFieldSchema[],
-        emails: ['test@example.com'],
-        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
-      } as IPopulatedEncryptedForm
-
-      const mockAttachments: IAttachmentInfo[] = [
-        {
-          filename: 'test.pdf',
-          content: Buffer.from('this is a test file'),
-          fieldId: 'test-field-id',
-        },
-      ]
-
-      const mockReq = merge(
-        expressHandler.mockRequest({
-          params: { formId: mockFormId.toHexString() },
-          body: {
-            responses: [],
-            attachments: mockAttachments,
-          },
-        }),
-        {
-          formsg: {
-            encryptedPayload: {
-              encryptedContent: 'mockEncryptedContent',
-              version: 1,
-            },
-            formDef: {},
-            encryptedFormDef: mockForm,
-            unencryptedAttachments: mockAttachments,
-          } as unknown as EncryptSubmissionDto,
-        } as unknown as FormCompleteDto,
-      ) as unknown as SubmitEncryptModeFormHandlerRequest
-
-      const mockRes = expressHandler.mockResponse()
-
-      // Act
-      await submitEncryptModeFormForTest(mockReq, mockRes)
-
-      // Assert (done)
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
-        expect.objectContaining({
-          attachments: mockAttachments,
-        }),
-      )
-    })
-
-    it('should pass expected dataCollationData to sendSubmissionToAdmin', async () => {
-      // Arrange
-      const mockFormId = new ObjectId()
-      const signatureFieldId = new ObjectId()
-      const mockForm = {
-        _id: mockFormId,
-        title: 'Test Form',
-        authType: FormAuthType.NIL,
-        form_fields: [] as FormFieldSchema[],
-        emails: ['test@example.com'],
-        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
-      } as IPopulatedEncryptedForm
-
-      const mockResponses = [
-        {
-          _id: new ObjectId(),
-          question: '[MyInfo] Test Question',
-          answer: 'Test Answer',
-          fieldType: 'text',
-          isVisible: true,
-        },
-        {
-          _id: signatureFieldId,
-          question: 'Signature Question',
-          answerArray: ['draw', '[[[10,20,0.5]],[[40,40,0.5]]]'],
-          fieldType: 'signature',
-          isVisible: true,
-        },
-      ]
-
-      const mockReq = merge(
-        expressHandler.mockRequest({
-          params: { formId: mockFormId.toHexString() },
-          body: {
-            responses: mockResponses,
-          },
-        }),
-        {
-          formsg: {
-            encryptedPayload: {
-              encryptedContent: 'mockEncryptedContent',
-              version: 1,
-            },
-            formDef: {},
-            encryptedFormDef: mockForm,
-          } as unknown as EncryptSubmissionDto,
-        } as unknown as FormCompleteDto,
-      ) as unknown as SubmitEncryptModeFormHandlerRequest
-
-      const mockRes = expressHandler.mockResponse()
-
-      // Act
-      await submitEncryptModeFormForTest(mockReq, mockRes)
-
-      // Assert
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
-        expect.objectContaining({
-          dataCollationData: expect.arrayContaining([
-            expect.objectContaining({
-              question: 'Test Question',
-              answer: 'Test Answer',
-            }),
-            expect.objectContaining({
-              question: '[signature] Signature Question',
-              answer: `Signature captured`,
-            }),
-          ]),
-        }),
-      )
-    })
-
-    it('should strip [MyInfo] prefix from expected dataCollationData to sendSubmissionToAdmin', async () => {
-      // Arrange
-      const mockFormId = new ObjectId()
-      const mockForm = {
-        _id: mockFormId,
-        title: 'Test Form',
-        authType: FormAuthType.NIL,
-        form_fields: [] as FormFieldSchema[],
-        emails: ['test@example.com'],
-        getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
-      } as IPopulatedEncryptedForm
-
-      const mockResponses = [
-        {
-          _id: new ObjectId(),
-          question: '[MyInfo] Name',
-          answer: 'Test Answer',
-          fieldType: 'text',
-          isVisible: true,
-        },
-      ]
-
-      const mockReq = merge(
-        expressHandler.mockRequest({
-          params: { formId: mockFormId.toHexString() },
-          body: {
-            responses: mockResponses,
-          },
-        }),
-        {
-          formsg: {
-            encryptedPayload: {
-              encryptedContent: 'mockEncryptedContent',
-              version: 1,
-            },
-            formDef: {},
-            encryptedFormDef: mockForm,
-          } as unknown as EncryptSubmissionDto,
-        } as unknown as FormCompleteDto,
-      ) as unknown as SubmitEncryptModeFormHandlerRequest
-
-      const mockRes = expressHandler.mockResponse()
-
-      // Act
-      await submitEncryptModeFormForTest(mockReq, mockRes)
-
-      // Assert
-      expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
-        expect.objectContaining({
-          dataCollationData: expect.arrayContaining([
-            expect.objectContaining({
-              question: 'Name',
-              answer: 'Test Answer',
-            }),
-          ]),
-        }),
-      )
+      expect(
+        performEncryptPostSubmissionActionsSpy.mock.calls[0][0]
+          .respondentEmails,
+      ).toEqual(mockRespondentEmails)
     })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -2,13 +2,43 @@
 import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
 import mongoose from 'mongoose'
+import { errAsync, ok, okAsync } from 'neverthrow'
+import {
+  BasicField,
+  EmailResponse,
+  FormAuthType,
+  FormResponseMode,
+  MyInfoAttribute,
+  PaymentChannel,
+} from 'shared/types'
 
 import { getEncryptSubmissionModel } from 'src/app/models/submission.server.model'
-import { IPopulatedEncryptedForm } from 'src/types'
+import * as FormService from 'src/app/modules/form/form.service'
+import { AutoreplyPdfGenerationError } from 'src/app/services/mail/mail.errors'
+import MailService from 'src/app/services/mail/mail.service'
+import * as MailUtils from 'src/app/services/mail/mail.utils'
+import {
+  FormFieldSchema,
+  IAttachmentInfo,
+  IEncryptedSubmissionSchema,
+  IPopulatedEncryptedForm,
+  SgidFieldTitle,
+} from 'src/types'
 
-import { createEncryptSubmissionWithoutSave } from '../encrypt-submission.service'
+import { ProcessedFieldResponse } from '../../submission.types'
+import {
+  createEncryptSubmissionWithoutSave,
+  performEncryptPostSubmissionActions,
+} from '../encrypt-submission.service'
 
 const EncryptSubmission = getEncryptSubmissionModel(mongoose)
+
+jest.mock('src/app/services/mail/mail.service')
+jest.mock('src/app/modules/form/form.service')
+jest.mock('src/app/services/mail/mail.utils')
+const MockMailService = jest.mocked(MailService)
+const MockFormService = jest.mocked(FormService)
+const MockMailUtils = jest.mocked(MailUtils)
 
 describe('encrypt-submission.service', () => {
   beforeAll(async () => await dbHandler.connect())
@@ -51,6 +81,659 @@ describe('encrypt-submission.service', () => {
       )
       expect(result.version).toEqual(MOCK_VERSION)
       expect(foundInDatabase).toBeNull()
+    })
+  })
+
+  describe('performEncryptPostSubmissionActions', () => {
+    const MOCK_NON_PAYMENT_ENCRYPT_FORM = {
+      _id: new ObjectId(),
+      title: 'Test Form',
+      responseMode: FormResponseMode.Encrypt,
+      authType: FormAuthType.NIL,
+      form_fields: [] as FormFieldSchema[],
+      emails: ['test@example.com'],
+      getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      payments_channel: {
+        channel: PaymentChannel.Unconnected,
+      },
+      payments_field: {
+        enabled: false,
+      },
+    } as IPopulatedEncryptedForm
+
+    const MOCK_PAYMENT_ENCRYPT_FORM = {
+      _id: new ObjectId(),
+      title: 'Test Form',
+      responseMode: FormResponseMode.Encrypt,
+      authType: FormAuthType.NIL,
+      form_fields: [] as FormFieldSchema[],
+      emails: ['test@example.com'],
+      getUniqueMyInfoAttrs: () => [] as MyInfoAttribute[],
+      payments_channel: {
+        channel: PaymentChannel.Stripe,
+      },
+      payments_field: {
+        enabled: true,
+      },
+    } as IPopulatedEncryptedForm
+
+    const MOCK_SUBMISSION_ATTACHMENTS = [
+      {
+        filename: 'test.pdf',
+        content: 'something',
+      },
+      {
+        filename: 'test2.pdf',
+        content: 'something else',
+      },
+    ]
+    const MOCK_NRIC = 'S1234567A'
+
+    const MOCK_PDF_ATTACHMENT_BUFFER = Buffer.from('mock pdf buffer')
+    const MOCK_PDF_ATTACHMENT = {
+      filename: 'response.pdf',
+      content: MOCK_PDF_ATTACHMENT_BUFFER,
+    }
+
+    describe('pdfAttachment generation and passing to sendSubmissionToAdmin and sendEmailConfirmations', () => {
+      beforeEach(() => {
+        jest.clearAllMocks()
+        MockMailService.sendSubmissionToAdmin.mockReturnValue(okAsync(true))
+        MockMailService.sendAutoReplyEmails.mockResolvedValue([
+          {
+            status: 'fulfilled',
+            value: ok(true),
+          },
+        ])
+        MockMailUtils.generateAutoreplyPdf.mockReturnValue(
+          okAsync(MOCK_PDF_ATTACHMENT_BUFFER),
+        )
+      })
+
+      it('should send email confirmations and sendSubmissionToAdmin without pdf attachment when pdf generation fails', async () => {
+        // Arrange
+        MockMailUtils.generateAutoreplyPdf.mockReturnValue(
+          errAsync(new AutoreplyPdfGenerationError()),
+        )
+        const mockSubmission = {
+          _id: new ObjectId(),
+          form: new ObjectId(),
+          created: new Date(),
+        } as IEncryptedSubmissionSchema
+        const mockResponses: ProcessedFieldResponse[] = [
+          {
+            _id: new ObjectId().toHexString(),
+            question: SgidFieldTitle.SgidNric,
+            answer: MOCK_NRIC,
+            fieldType: BasicField.Nric,
+          },
+        ]
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          okAsync(MOCK_NON_PAYMENT_ENCRYPT_FORM),
+        )
+
+        // Act
+        await performEncryptPostSubmissionActions({
+          submission: mockSubmission,
+          responses: mockResponses,
+          emailFields: mockResponses,
+          submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+          respondentEmails: ['email1@example.com', 'email2@example.com'], // presence of respondent emails means that form summary is enabled
+        })
+
+        // Assert
+        expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledOnce()
+        expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+            pdfAttachment: undefined,
+          }),
+        )
+        expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+            pdfAttachment: undefined,
+          }),
+        )
+      })
+
+      it('should not generate pdf attachment if payment is enabled and not pass to either sendSubmissionToAdmin or sendEmailConfirmations', async () => {
+        // Arrange
+        const mockSubmission = {
+          _id: new ObjectId(),
+          form: new ObjectId(),
+          created: new Date(),
+        } as IEncryptedSubmissionSchema
+        const mockResponses: ProcessedFieldResponse[] = [
+          {
+            _id: new ObjectId().toHexString(),
+            question: SgidFieldTitle.SgidNric,
+            answer: MOCK_NRIC,
+            fieldType: BasicField.Nric,
+          },
+        ]
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          okAsync(MOCK_PAYMENT_ENCRYPT_FORM),
+        )
+
+        // Act
+        await performEncryptPostSubmissionActions({
+          submission: mockSubmission,
+          responses: mockResponses,
+          emailFields: mockResponses,
+          submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+          respondentEmails: ['email1@example.com', 'email2@example.com'],
+        })
+
+        // Assert
+        expect(MockMailUtils.generateAutoreplyPdf).not.toHaveBeenCalled()
+        expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+            pdfAttachment: undefined,
+          }),
+        )
+        expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+            pdfAttachment: undefined,
+          }),
+        )
+      })
+
+      it('should generate pdf attachment and pass pdf attachment to both sendSubmissionToAdmin and sendEmailConfirmation if form summary is enabled and payment is not enabled', async () => {
+        // Arrange
+        const mockSubmission = {
+          _id: new ObjectId(),
+          form: new ObjectId(),
+          created: new Date(),
+        } as IEncryptedSubmissionSchema
+        const mockResponses: ProcessedFieldResponse[] = [
+          {
+            _id: new ObjectId().toHexString(),
+            question: SgidFieldTitle.SgidNric,
+            answer: MOCK_NRIC,
+            fieldType: BasicField.Nric,
+          },
+        ]
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          okAsync(MOCK_NON_PAYMENT_ENCRYPT_FORM),
+        )
+
+        // Act
+        await performEncryptPostSubmissionActions({
+          submission: mockSubmission,
+          responses: mockResponses,
+          emailFields: mockResponses,
+          submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+          respondentEmails: ['email1@example.com', 'email2@example.com'], // presence of respondent emails means that form summary is enabled
+        })
+
+        // Assert
+        expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledOnce()
+        expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+            pdfAttachment: MOCK_PDF_ATTACHMENT,
+          }),
+        )
+        expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+            pdfAttachment: MOCK_PDF_ATTACHMENT,
+          }),
+        )
+      })
+
+      it('should generate pdf attachment and pass pdf attachment to only sendSubmissionToAdmin if form summary and payment both are not enabled', async () => {
+        // Arrange
+        const mockSubmission = {
+          _id: new ObjectId(),
+          form: new ObjectId(),
+          created: new Date(),
+        } as IEncryptedSubmissionSchema
+        const mockResponsesWithoutAutoReplyEmailFields: ProcessedFieldResponse[] =
+          [
+            {
+              _id: new ObjectId().toHexString(),
+              question: SgidFieldTitle.SgidNric,
+              answer: MOCK_NRIC,
+              fieldType: BasicField.Nric,
+            },
+          ]
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          okAsync(MOCK_NON_PAYMENT_ENCRYPT_FORM),
+        )
+
+        // Act
+        await performEncryptPostSubmissionActions({
+          submission: mockSubmission,
+          responses: mockResponsesWithoutAutoReplyEmailFields,
+          emailFields: mockResponsesWithoutAutoReplyEmailFields,
+          submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+          respondentEmails: [],
+        })
+
+        // Assert
+        expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledOnce()
+        expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pdfAttachment: MOCK_PDF_ATTACHMENT,
+            submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+          }),
+        )
+        expect(MockMailService.sendAutoReplyEmails).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('sendEmailConfirmations', () => {
+      beforeEach(() => {
+        jest.clearAllMocks()
+        MockMailService.sendSubmissionToAdmin.mockReturnValue(okAsync(true))
+        MockMailService.sendAutoReplyEmails.mockResolvedValue([
+          {
+            status: 'fulfilled',
+            value: ok(true),
+          },
+        ])
+        MockMailUtils.generateAutoreplyPdf.mockReturnValue(
+          okAsync(MOCK_PDF_ATTACHMENT_BUFFER),
+        )
+      })
+
+      it('should sendEmailConfirmations if there are respondent emails', async () => {
+        // Arrange
+        const mockSubmission = {
+          _id: new ObjectId(),
+          form: new ObjectId(),
+          created: new Date(),
+        } as IEncryptedSubmissionSchema
+        const mockResponsesWithoutAutoReplyEmailFields: ProcessedFieldResponse[] =
+          [
+            {
+              _id: new ObjectId().toHexString(),
+              question: SgidFieldTitle.SgidNric,
+              answer: MOCK_NRIC,
+              fieldType: BasicField.Nric,
+            },
+          ]
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          okAsync(MOCK_NON_PAYMENT_ENCRYPT_FORM),
+        )
+
+        // Act
+        await performEncryptPostSubmissionActions({
+          submission: mockSubmission,
+          responses: mockResponsesWithoutAutoReplyEmailFields,
+          emailFields: mockResponsesWithoutAutoReplyEmailFields,
+          submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+          respondentEmails: ['email1@example.com', 'email2@example.com'],
+        })
+
+        // Assert
+        expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledOnce()
+        expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith(
+          expect.objectContaining({
+            autoReplyMailDatas: [
+              { email: 'email1@example.com', includeFormSummary: true },
+              { email: 'email2@example.com', includeFormSummary: true },
+            ],
+          }),
+        )
+      })
+
+      it('should sendEmailConfirmations if there are email fields with auto reply enabled', async () => {
+        // Arrange
+        const mockSubmission = {
+          _id: new ObjectId(),
+          form: new ObjectId(),
+          created: new Date(),
+        } as IEncryptedSubmissionSchema
+        const emailFieldId = new ObjectId().toHexString()
+        const emailResponse = {
+          _id: emailFieldId,
+          question: 'Email of respondent',
+          answer: 'email1@example.com',
+          fieldType: BasicField.Email,
+        } as EmailResponse
+        const emailFieldId2 = new ObjectId().toHexString()
+        const emailResponse2 = {
+          _id: emailFieldId2,
+          question: 'Email of respondent',
+          answer: 'email2@example.com',
+          fieldType: BasicField.Email,
+        } as EmailResponse
+        const mockResponses: ProcessedFieldResponse[] = [
+          {
+            _id: new ObjectId().toHexString(),
+            question: SgidFieldTitle.SgidNric,
+            answer: MOCK_NRIC,
+            fieldType: BasicField.Nric,
+          },
+          emailResponse,
+          emailResponse2,
+        ]
+
+        const emailField = {
+          _id: emailFieldId,
+          fieldType: BasicField.Email,
+          autoReplyOptions: {
+            hasAutoReply: true,
+            autoReplySubject: 'Test Subject',
+            autoReplySender: 'test@example.com',
+            autoReplyMessage: 'Test Message',
+            includeFormSummary: true,
+          },
+        }
+
+        const emailField2 = {
+          _id: emailFieldId2,
+          fieldType: BasicField.Email,
+          autoReplyOptions: {
+            hasAutoReply: true,
+            autoReplySubject: 'Test Subject',
+            autoReplySender: 'test@example.com',
+            autoReplyMessage: 'Test Message',
+            includeFormSummary: false,
+          },
+        }
+
+        const mockNonPaymentEncryptFormWithEmailField = {
+          ...MOCK_NON_PAYMENT_ENCRYPT_FORM,
+          form_fields: [
+            ...MOCK_NON_PAYMENT_ENCRYPT_FORM.form_fields,
+            emailField,
+            emailField2,
+          ],
+        } as IPopulatedEncryptedForm
+
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          okAsync(mockNonPaymentEncryptFormWithEmailField),
+        )
+
+        // Act
+        await performEncryptPostSubmissionActions({
+          submission: mockSubmission,
+          responses: mockResponses,
+          emailFields: mockResponses,
+          submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+          respondentEmails: [],
+        })
+
+        // Assert
+        expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledOnce()
+        expect(MockMailService.sendAutoReplyEmails).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+            pdfAttachment: MOCK_PDF_ATTACHMENT,
+            autoReplyMailDatas: [
+              {
+                body: emailField.autoReplyOptions.autoReplyMessage,
+                email: emailResponse.answer,
+                includeFormSummary:
+                  emailField.autoReplyOptions.includeFormSummary,
+                sender: emailField.autoReplyOptions.autoReplySender,
+                subject: emailField.autoReplyOptions.autoReplySubject,
+              },
+              {
+                body: emailField2.autoReplyOptions.autoReplyMessage,
+                email: emailResponse2.answer,
+                includeFormSummary:
+                  emailField2.autoReplyOptions.includeFormSummary,
+                sender: emailField2.autoReplyOptions.autoReplySender,
+                subject: emailField2.autoReplyOptions.autoReplySubject,
+              },
+            ],
+          }),
+        )
+      })
+
+      it('should not sendEmailConfirmations if there are no respondent emails and no email fields with auto reply enabled', async () => {
+        // Arrange
+        const mockSubmission = {
+          _id: new ObjectId(),
+          form: new ObjectId(),
+          created: new Date(),
+        } as IEncryptedSubmissionSchema
+        const mockResponsesWithoutAutoReplyEmailFields: ProcessedFieldResponse[] =
+          [
+            {
+              _id: new ObjectId().toHexString(),
+              question: SgidFieldTitle.SgidNric,
+              answer: MOCK_NRIC,
+              fieldType: BasicField.Nric,
+            },
+          ]
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          okAsync(MOCK_NON_PAYMENT_ENCRYPT_FORM),
+        )
+
+        // Act
+        await performEncryptPostSubmissionActions({
+          submission: mockSubmission,
+          responses: mockResponsesWithoutAutoReplyEmailFields,
+          emailFields: mockResponsesWithoutAutoReplyEmailFields,
+          submissionAttachments: MOCK_SUBMISSION_ATTACHMENTS,
+          respondentEmails: [],
+        })
+
+        // Assert
+        expect(MockMailService.sendAutoReplyEmails).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('sendSubmissionToAdmin', () => {
+      beforeEach(() => {
+        jest.clearAllMocks()
+        MockMailService.sendSubmissionToAdmin.mockReturnValue(okAsync(true))
+        MockFormService.retrieveFullFormById.mockReturnValue(
+          okAsync(MOCK_NON_PAYMENT_ENCRYPT_FORM),
+        )
+        MockMailUtils.generateAutoreplyPdf.mockReturnValue(
+          okAsync(Buffer.from('mock pdf buffer')),
+        )
+      })
+
+      describe('emailFields', () => {
+        it('should include nric field in notification email if provided', async () => {
+          // Arrange
+          const MOCK_NRIC = 'S1234567A'
+          const mockSubmission = {
+            _id: new ObjectId(),
+            form: new ObjectId(),
+            created: new Date(),
+          } as IEncryptedSubmissionSchema
+
+          const mockResponses: ProcessedFieldResponse[] = [
+            {
+              _id: new ObjectId().toHexString(),
+              question: SgidFieldTitle.SgidNric,
+              answer: MOCK_NRIC,
+              fieldType: BasicField.Nric,
+            },
+          ]
+
+          // Act
+          const postSubmissionActionStatus =
+            await performEncryptPostSubmissionActions({
+              submission: mockSubmission,
+              responses: mockResponses,
+              emailFields: mockResponses,
+              submissionAttachments: [],
+              respondentEmails: [],
+            })
+
+          // Assert
+          expect(postSubmissionActionStatus).toEqual(ok(true))
+
+          expect(
+            MockMailService.sendSubmissionToAdmin.mock.calls[0][0].formData,
+          ).toEqual([
+            {
+              answer: MOCK_NRIC,
+              fieldType: BasicField.Nric,
+              answerTemplate: [MOCK_NRIC],
+              question: SgidFieldTitle.SgidNric,
+            },
+          ])
+        })
+      })
+
+      describe('submissionAttachments', () => {
+        it('should call sendSubmissionToAdmin with no submission attachments submission has no attachments', async () => {
+          // Arrange
+          const noAttachments: IAttachmentInfo[] = []
+
+          const mockSubmission = {
+            _id: new ObjectId(),
+            form: new ObjectId(),
+            created: new Date(),
+          } as IEncryptedSubmissionSchema
+
+          // Act
+          const postSubmissionActionStatus =
+            await performEncryptPostSubmissionActions({
+              submission: mockSubmission,
+              responses: [],
+              emailFields: [],
+              submissionAttachments: noAttachments,
+              respondentEmails: [],
+            })
+
+          // Assert
+          expect(postSubmissionActionStatus).toEqual(ok(true))
+
+          expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+            expect.objectContaining({
+              submissionAttachments: noAttachments,
+            }),
+          )
+        })
+
+        it('should call sendSubmissionToAdmin with submmission attachments when submission has attachments', async () => {
+          // Arrange
+          const twoAttachments: IAttachmentInfo[] = [
+            {
+              filename: 'test.pdf',
+              content: Buffer.from('this is a test file'),
+              fieldId: 'test-field-id',
+            },
+          ]
+
+          const mockSubmission = {
+            _id: new ObjectId(),
+            form: new ObjectId(),
+            created: new Date(),
+          } as IEncryptedSubmissionSchema
+
+          // Act
+          await performEncryptPostSubmissionActions({
+            submission: mockSubmission,
+            responses: [],
+            emailFields: [],
+            submissionAttachments: twoAttachments,
+            respondentEmails: [],
+          })
+
+          // Assert
+          expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+            expect.objectContaining({
+              submissionAttachments: twoAttachments,
+            }),
+          )
+        })
+      })
+
+      describe('dataCollationData', () => {
+        it('should pass expected dataCollationData to sendSubmissionToAdmin', async () => {
+          // Arrange
+          const mockResponses: ProcessedFieldResponse[] = [
+            {
+              _id: new ObjectId().toHexString(),
+              question: '[MyInfo] Test Question',
+              answer: 'Test Answer',
+              fieldType: BasicField.ShortText,
+            },
+            {
+              _id: new ObjectId().toHexString(),
+              question: 'Signature Question',
+              answerArray: ['draw', '[[[10,20,0.5]],[[40,40,0.5]]]'],
+              fieldType: BasicField.Signature,
+            },
+          ]
+
+          const mockSubmission = {
+            _id: new ObjectId(),
+            form: new ObjectId(),
+            created: new Date(),
+          } as IEncryptedSubmissionSchema
+
+          // Act
+          await performEncryptPostSubmissionActions({
+            submission: mockSubmission,
+            responses: mockResponses,
+            emailFields: mockResponses,
+            submissionAttachments: [],
+            respondentEmails: [],
+          })
+
+          // Assert
+          expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+            expect.objectContaining({
+              dataCollationData: expect.arrayContaining([
+                expect.objectContaining({
+                  question: 'Test Question',
+                  answer: 'Test Answer',
+                }),
+                expect.objectContaining({
+                  question: '[signature] Signature Question',
+                  answer: `Signature captured`,
+                }),
+              ]),
+            }),
+          )
+        })
+
+        it('should strip [MyInfo] prefix from expected dataCollationData to sendSubmissionToAdmin', async () => {
+          // Arrange
+          const mockResponses: ProcessedFieldResponse[] = [
+            {
+              _id: new ObjectId().toHexString(),
+              question: '[MyInfo] Name',
+              answer: 'Test Answer',
+              fieldType: BasicField.ShortText,
+              isVisible: true,
+            },
+          ]
+
+          const mockSubmission = {
+            _id: new ObjectId(),
+            form: new ObjectId(),
+            created: new Date(),
+          } as IEncryptedSubmissionSchema
+
+          // Act
+          await performEncryptPostSubmissionActions({
+            submission: mockSubmission,
+            responses: mockResponses,
+            emailFields: mockResponses,
+            submissionAttachments: [],
+            respondentEmails: [],
+          })
+
+          // Assert
+          expect(MockMailService.sendSubmissionToAdmin).toHaveBeenCalledWith(
+            expect.objectContaining({
+              dataCollationData: expect.arrayContaining([
+                expect.objectContaining({
+                  question: 'Name',
+                  answer: 'Test Answer',
+                }),
+              ]),
+            }),
+          )
+        })
+      })
     })
   })
 })

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -17,7 +17,6 @@ import {
 } from '../../../../../shared/types'
 import {
   IAttachmentInfo,
-  IEncryptedForm,
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
   StripePaymentMetadataDto,
@@ -35,7 +34,6 @@ import getPaymentModel from '../../../models/payment.server.model'
 import { getEncryptPendingSubmissionModel } from '../../../models/pending_submission.server.model'
 import { getEncryptSubmissionModel } from '../../../models/submission.server.model'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
-import MailService from '../../../services/mail/mail.service'
 import * as TurnstileMiddleware from '../../../services/turnstile/turnstile.middleware'
 import { Pipeline } from '../../../utils/pipeline-middleware'
 import { createReqMeta } from '../../../utils/request'
@@ -55,9 +53,6 @@ import { SgidService } from '../../sgid/sgid.service'
 import { getOidcService } from '../../spcp/spcp.oidc.service'
 import { getPopulatedUserById } from '../../user/user.service'
 import * as VerifiedContentService from '../../verified-content/verified-content.service'
-import { MYINFO_PREFIX } from '../email-submission/email-submission.constants'
-import * as EmailSubmissionService from '../email-submission/email-submission.service'
-import { SubmissionEmailObj } from '../email-submission/email-submission.util'
 import * as EncryptSubmissionMiddleware from '../encrypt-submission/encrypt-submission.middleware'
 import ParsedResponsesObject from '../ParsedResponsesObject.class'
 import * as ReceiverMiddleware from '../receiver/receiver.middleware'
@@ -694,6 +689,9 @@ const _createPaymentSubmission = async ({
   })
 }
 
+/**
+ * @param emailFields fields and their responses that will be included in email notifications to admins and respondents.
+ */
 const _createSubmission = async ({
   req,
   res,
@@ -778,50 +776,7 @@ const _createSubmission = async ({
   })
 
   const createdTime = submission.created || new Date()
-
-  const logMetaWithSubmission = {
-    ...logMeta,
-    submissionId,
-    responseMetadata,
-  }
-
-  const emailData = new SubmissionEmailObj(
-    emailFields,
-    new Set(), // the MyInfo prefixes are already inserted in middleware
-    form.authType,
-  )
-
-  // Since we insert the [MyInfo] prefix in `encrypt-submission.middleware.ts`:L434
-  // we want to remove it for the dataCollationData
-  const dataCollationData = emailData.dataCollationData.map((item) => ({
-    question: item.question.startsWith(MYINFO_PREFIX)
-      ? item.question.slice(MYINFO_PREFIX.length)
-      : item.question,
-    answer: item.answer,
-  }))
-
-  const emailAttachments = [...(unencryptedAttachments ?? [])]
-  // We don't await for email submission, as the submission gets saved for encrypt
-  // submissions regardless, the email is more of a notification and shouldn't
-  // stop the storage of the data in the db
-  if (((form as IEncryptedForm)?.emails || []).length > 0) {
-    logger.info({
-      message: 'Sending admin notification mail',
-      meta: logMetaWithSubmission,
-    })
-
-    void MailService.sendSubmissionToAdmin({
-      replyToEmails: EmailSubmissionService.extractEmailAnswers(emailFields),
-      form,
-      submission: {
-        created: createdTime,
-        id: submission.id,
-      },
-      attachments: emailAttachments,
-      formData: emailData.formData,
-      dataCollationData,
-    })
-  }
+  const submissionAttachments = [...(unencryptedAttachments ?? [])]
 
   // TODO 6395 make responseMetadata mandatory
   if (responseMetadata) {
@@ -846,10 +801,10 @@ const _createSubmission = async ({
   return await performEncryptPostSubmissionActions({
     submission,
     responses,
-    growthbook: req.growthbook,
-    emailData,
-    attachments: emailAttachments,
+    emailFields,
+    submissionAttachments,
     respondentEmails,
+    growthbook: req.growthbook,
   })
 }
 

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -3,34 +3,40 @@ import mongoose from 'mongoose'
 import { err, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import Mail from 'nodemailer/lib/mailer'
 
-import { AutoReplyMailData } from 'src/app/services/mail/mail.types'
-
-import { featureFlags } from '../../../../../shared/constants'
 import {
   DateString,
   FormResponseMode,
+  PaymentChannel,
   SubmissionType,
 } from '../../../../../shared/types'
 import {
+  EmailAdminDataField,
   FieldResponse,
+  FormFieldSchema,
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
   IPopulatedForm,
 } from '../../../../types'
+import config, { isTest } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { getEncryptSubmissionModel } from '../../../models/submission.server.model'
+import { AutoreplyPdfGenerationError } from '../../../services/mail/mail.errors'
+import MailService from '../../../services/mail/mail.service'
+import { AutoReplyMailData } from '../../../services/mail/mail.types'
+import { generateAutoreplyPdf } from '../../../services/mail/mail.utils'
 import { createQueryWithDateParam } from '../../../utils/date'
 import { getMongoErrorMessage } from '../../../utils/handle-mongo-error'
 import { DatabaseError, PossibleDatabaseError } from '../../core/core.errors'
 import { FormNotFoundError } from '../../form/form.errors'
 import * as FormService from '../../form/form.service'
 import { isFormEncryptMode } from '../../form/form.utils'
-import * as UserService from '../../user/user.service'
 import {
   WebhookPushToQueueError,
   WebhookValidationError,
 } from '../../webhook/webhook.errors'
 import { WebhookFactory } from '../../webhook/webhook.factory'
+import { MYINFO_PREFIX } from '../email-submission/email-submission.constants'
+import * as EmailSubmissionService from '../email-submission/email-submission.service'
 import { SubmissionEmailObj } from '../email-submission/email-submission.util'
 import {
   ResponseModeError,
@@ -39,7 +45,11 @@ import {
   UnsupportedSettingsError,
 } from '../submission.errors'
 import { sendEmailConfirmations } from '../submission.service'
-import { extractEmailConfirmationData } from '../submission.utils'
+import { ProcessedFieldResponse } from '../submission.types'
+import {
+  extractEmailConfirmationData,
+  isAdminEmailPdfEnabled,
+} from '../submission.utils'
 
 import { CHARTS_MAX_SUBMISSION_RESULTS } from './encrypt-submission.constants'
 import { SaveEncryptSubmissionParams } from './encrypt-submission.types'
@@ -131,11 +141,100 @@ export const createEncryptSubmissionWithoutSave = ({
   })
 }
 
+const checkIfAdminPdfIsRequired = (
+  isPaymentEnabled: boolean,
+  formFields: FormFieldSchema[],
+  growthbook?: GrowthBook,
+): boolean => {
+  const isGbFlagEnabled =
+    isAdminEmailPdfEnabled({ growthbook, formFields }) || isTest
+
+  if (!isGbFlagEnabled) {
+    return false
+  }
+  return !isPaymentEnabled
+}
+
+const checkIfRespondentFormSummaryIsRequired = ({
+  autoReplyMailDatas,
+  isPaymentEnabled,
+}: {
+  autoReplyMailDatas: AutoReplyMailData[]
+  isPaymentEnabled: boolean
+}): boolean => {
+  return (
+    !isPaymentEnabled &&
+    autoReplyMailDatas.some((data) => data.includeFormSummary)
+  )
+}
+
+const generatePdfAttachmentIfRequired = ({
+  isPaymentEnabled,
+  autoReplyMailDatas,
+  submission,
+  form,
+  responsesData,
+  growthbook,
+}: {
+  isPaymentEnabled: boolean
+  autoReplyMailDatas: AutoReplyMailData[]
+  submission: IEncryptedSubmissionSchema
+  form: IPopulatedEncryptedForm
+  responsesData: EmailAdminDataField[]
+  growthbook?: GrowthBook
+}): ResultAsync<Mail.Attachment | undefined, AutoreplyPdfGenerationError> => {
+  const isAdminPdfRequired = checkIfAdminPdfIsRequired(
+    isPaymentEnabled,
+    form.form_fields,
+    growthbook,
+  )
+  const isRespondentCopyPdfRequired = checkIfRespondentFormSummaryIsRequired({
+    isPaymentEnabled,
+    autoReplyMailDatas,
+  })
+  if (!isAdminPdfRequired && !isRespondentCopyPdfRequired) {
+    return okAsync(undefined)
+  }
+
+  const autoReplyData = {
+    refNo: submission.id,
+    formTitle: form.title,
+    submissionDateTime: submission.created ?? new Date(),
+    responsesData,
+    formUrl: `${config.app.appUrl}/${form._id}`,
+  }
+
+  const DEFAULT_RESPONSE_PDF_FILENAME = 'response.pdf'
+  return generateAutoreplyPdf(autoReplyData, true)
+    .map((pdfBuffer) => ({
+      filename: DEFAULT_RESPONSE_PDF_FILENAME,
+      content: Buffer.copyBytesFrom(pdfBuffer),
+    }))
+    .mapErr((error) => {
+      logger.error({
+        message:
+          'Failed to include required PDF attachment for email notifications',
+        meta: {
+          action: 'generatePdfAttachmentIfRequired',
+          submissionId: submission.id,
+          formId: form._id,
+          formResponseMode: form.responseMode,
+          isAdminPdfRequired,
+          isRespondentCopyPdfRequired,
+        },
+        error,
+      })
+      return error
+    })
+}
+
 /**
  * Performs the post-submission actions for encrypt submissions. This is to be
  * called when the submission is completed
  * @param submission the completed submission
  * @param responses the verified field responses sent with the original submission request
+ * @param emailFields fields and their responses that will be included in email notifications. May be undefined if the form is payment form.
+ * @param submissionAttachments files from attachment fields in the submission that will be included in email notifications.
  * @returns ok(true) if all actions were completed successfully
  * @returns err(FormNotFoundError) if the form or form admin does not exist
  * @returns err(ResponseModeError) if the form is not encrypt mode
@@ -148,17 +247,17 @@ export const createEncryptSubmissionWithoutSave = ({
 export const performEncryptPostSubmissionActions = ({
   submission,
   responses,
-  growthbook,
-  emailData,
-  attachments,
+  emailFields,
+  submissionAttachments,
   respondentEmails,
+  growthbook,
 }: {
   submission: IEncryptedSubmissionSchema
   responses: FieldResponse[]
-  growthbook?: GrowthBook
-  emailData?: SubmissionEmailObj
-  attachments?: Mail.Attachment[]
+  emailFields: ProcessedFieldResponse[]
+  submissionAttachments?: Mail.Attachment[]
   respondentEmails?: string[]
+  growthbook?: GrowthBook
 }): ResultAsync<
   true,
   | FormNotFoundError
@@ -174,82 +273,115 @@ export const performEncryptPostSubmissionActions = ({
     submissionId: submission.id,
   }
 
-  return (
-    FormService.retrieveFullFormById(submission.form)
-      .andThen(checkFormIsEncryptMode)
-      .andThen((form) => {
-        // Fire webhooks if available
-        // To avoid being coupled to latency of receiving system,
-        // do not await on webhook
-        const webhookUrl = form.webhook?.url
-        if (!webhookUrl) return okAsync(form)
+  return FormService.retrieveFullFormById(submission.form)
+    .andThen(checkFormIsEncryptMode)
+    .andThen((form) => {
+      // Fire webhooks if available
+      // To avoid being coupled to latency of receiving system,
+      // do not await on webhook
+      const webhookUrl = form.webhook?.url
+      if (!webhookUrl) return okAsync(form)
 
-        return WebhookFactory.sendInitialWebhook(
-          submission,
-          webhookUrl,
-          !!form.webhook?.isRetryEnabled,
-        ).andThen(() => okAsync(form))
-      })
-      // TODO [PDF-LAMBDA-GENERATION]: Remove setting of Growthbook targetting once pdf generation rollout is complete
-      .map(async (form) => {
-        await UserService.getPopulatedUserById(form.admin).map(
-          async (admin) => {
-            await growthbook?.setAttributes({
-              ...growthbook?.getAttributes(),
-              formId: submission.form.toString(),
-              adminEmail: admin.email,
-              adminAgency: admin.agency.shortName,
-            })
-          },
-        )
-        return form
-      })
-      .andThen((form) => {
-        const respondentCopyEmailData: AutoReplyMailData[] = respondentEmails
-          ? respondentEmails?.map((val) => {
-              return {
-                email: val,
-                includeFormSummary: true,
-              }
-            })
-          : []
-
-        // TODO [PDF-LAMBDA-GENERATION]: Remove setting of Growthbook targetting once pdf generation rollout is complete
-        const isUseLambdaOutput =
-          growthbook?.isOn(featureFlags.lambdaPdfGeneration) ?? false
-        logger.info({
-          message: 'Growthbook flag for lambda pdf generation',
-          meta: {
-            ...logMeta,
-            isUseLambdaOutput,
-            growthbookAttributes: growthbook?.getAttributes(),
-            lambdaPdfGenerationGrowthbookValue: growthbook?.getFeatureValue(
-              featureFlags.lambdaPdfGeneration,
-              undefined,
-            ),
-          },
-        })
-
-        return sendEmailConfirmations({
-          form,
-          submission,
-          attachments,
-          responsesData: emailData?.autoReplyData,
-          recipientData: [
-            ...extractEmailConfirmationData(responses, form.form_fields),
-            ...respondentCopyEmailData,
-          ],
-          isUseLambdaOutput,
-        }).mapErr((error) => {
-          logger.error({
-            message: 'Error while sending email confirmations',
-            meta: {
-              action: 'sendEmailAutoReplies',
-            },
-            error,
+      return WebhookFactory.sendInitialWebhook(
+        submission,
+        webhookUrl,
+        !!form.webhook?.isRetryEnabled,
+      ).andThen(() => okAsync(form))
+    })
+    .andThen((form) => {
+      const respondentCopyEmailData: AutoReplyMailData[] = respondentEmails
+        ? respondentEmails?.map((val) => {
+            return {
+              email: val,
+              includeFormSummary: true,
+            }
           })
-          return error
-        })
+        : []
+
+      const { formData, dataCollationData } = new SubmissionEmailObj(
+        emailFields,
+        new Set(), // the MyInfo prefixes are already inserted in middleware
+        form.authType,
+      )
+      // Since we insert the [MyInfo] prefix in `encrypt-submission.middleware.ts`:L434
+      // we want to remove it for the dataCollationData
+      const formattedDataCollationData = dataCollationData.map((item) => ({
+        question: item.question.startsWith(MYINFO_PREFIX)
+          ? item.question.slice(MYINFO_PREFIX.length)
+          : item.question,
+        answer: item.answer,
+      }))
+      const recipientEmailDatas = [
+        ...extractEmailConfirmationData(responses, form.form_fields),
+        ...respondentCopyEmailData,
+      ]
+
+      const isPaymentEnabled =
+        form.responseMode === FormResponseMode.Encrypt &&
+        form.payments_channel.channel !== PaymentChannel.Unconnected &&
+        form.payments_field.enabled === true
+
+      const pdfAttachmentResult = generatePdfAttachmentIfRequired({
+        isPaymentEnabled,
+        autoReplyMailDatas: recipientEmailDatas,
+        submission,
+        form,
+        responsesData: formData,
+        growthbook,
+      }).orElse(() => okAsync(undefined))
+
+      return pdfAttachmentResult.andThen((pdfAttachment) => {
+        return ResultAsync.combine([
+          MailService.sendSubmissionToAdmin({
+            replyToEmails:
+              EmailSubmissionService.extractEmailAnswers(emailFields),
+            form,
+            submission: {
+              created: submission.created,
+              id: submission.id,
+            },
+            submissionAttachments,
+            formData,
+            dataCollationData: formattedDataCollationData,
+            pdfAttachment: checkIfAdminPdfIsRequired(
+              isPaymentEnabled,
+              form.form_fields,
+              growthbook,
+            )
+              ? pdfAttachment
+              : undefined,
+          }).mapErr((error) => {
+            logger.error({
+              message:
+                'Error while sending submission notification email to admin',
+              meta: logMeta,
+              error,
+            })
+            return error
+          }),
+          sendEmailConfirmations({
+            form,
+            submission,
+            submissionAttachments,
+            recipientData: recipientEmailDatas,
+            responsesData: formData,
+            pdfAttachment: checkIfRespondentFormSummaryIsRequired({
+              isPaymentEnabled,
+              autoReplyMailDatas: recipientEmailDatas,
+            })
+              ? pdfAttachment
+              : undefined,
+            isPaymentEnabled,
+          }).mapErr((error) => {
+            logger.error({
+              message: 'Error while sending email confirmations to respondents',
+              meta: logMeta,
+              error,
+            })
+            return error
+          }),
+        ])
       })
-  )
+    })
+    .map(() => true)
 }

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1,6 +1,6 @@
 import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
-import { okAsync } from 'neverthrow'
+import { errAsync, okAsync } from 'neverthrow'
 import {
   BasicField,
   FieldResponsesV3,
@@ -10,7 +10,9 @@ import {
   WorkflowType,
 } from 'shared/types'
 
+import { AutoreplyPdfGenerationError } from 'src/app/services/mail/mail.errors'
 import MailService from 'src/app/services/mail/mail.service'
+import * as MailUtils from 'src/app/services/mail/mail.utils'
 import {
   IMultirespondentSubmissionSchema,
   IPopulatedMultirespondentForm,
@@ -21,19 +23,40 @@ import {
   MrfReminderInvalidWorkflowStepError,
   MrfReminderRecipientEmailsEmptyError,
 } from '../../submission.errors'
+import * as MultirespondentSubmissionService from '../multirespondent-submission.service'
 import {
   getPendingStepRecipientEmailsFromSubmittedStepsMeta,
   performMultiRespondentPostSubmissionCreateActions,
   performMultiRespondentPostSubmissionUpdateActions,
   sendNextStepReminderEmail,
 } from '../multirespondent-submission.service'
-import * as MultirespondentSubmissionService from '../multirespondent-submission.service'
 
 jest.mock('src/app/modules/datadog/datadog.utils')
+jest.mock('src/app/services/mail/mail.utils')
+
+const MockMailUtils = jest.mocked(MailUtils)
+const MOCK_PDF_ATTACHMENT_BUFFER = Buffer.from('mock pdf buffer')
+const EXPECTED_MOCK_PDF_ATTACHMENT = {
+  filename: 'response.pdf',
+  content: MOCK_PDF_ATTACHMENT_BUFFER,
+}
+const MOCK_SUBMISSION_ATTACHMENTS = [
+  {
+    filename: 'attachment_1.pdf',
+    content: Buffer.from('mock pdf buffer'),
+    fieldId: new ObjectId().toHexString(),
+  },
+]
 
 describe('multirespondent-submission.service', () => {
   beforeAll(async () => {
     await dbHandler.connect()
+  })
+
+  beforeEach(() => {
+    MockMailUtils.generateAutoreplyPdf.mockReturnValue(
+      okAsync(Buffer.from('mock pdf buffer')),
+    )
   })
 
   afterEach(async () => {
@@ -47,6 +70,1081 @@ describe('multirespondent-submission.service', () => {
 
   const mockFormId = new ObjectId().toHexString()
   const mockSubmissionId = new ObjectId().toHexString()
+
+  describe('pdf attachment', () => {
+    describe('pdf attachment is not generated when not needed', () => {
+      describe('first step', () => {
+        it('should not generate pdf when there is no active form summary included email field and workflow is incomplete', async () => {
+          // Arrange
+          const emailFieldWithoutFormSummaryStep1 = {
+            _id: new ObjectId().toHexString(),
+            fieldType: BasicField.Email,
+            title: 'Step 1 Email Field',
+            autoReplyOptions: {
+              hasAutoReply: true,
+              includeFormSummary: false,
+              autoReplySubject: 'Test Subject',
+              autoReplyMessage: 'Test Message',
+              autoReplySender: 'Test Sender',
+            },
+          }
+          const emailFieldWithFormSummaryStep2 = {
+            _id: new ObjectId().toHexString(),
+            fieldType: BasicField.Email,
+            title: 'Step 2 Email Field',
+            autoReplyOptions: {
+              hasAutoReply: true,
+              includeFormSummary: true,
+              autoReplySubject: 'Test Subject',
+              autoReplyMessage: 'Test Message',
+              autoReplySender: 'Test Sender',
+            },
+          }
+
+          const workflow = [
+            {
+              _id: new ObjectId().toHexString(),
+              workflow_type: WorkflowType.Static,
+              emails: [],
+              edit: [emailFieldWithoutFormSummaryStep1._id],
+            },
+            {
+              _id: new ObjectId().toHexString(),
+              workflow_type: WorkflowType.Static,
+              emails: ['step2_respondent_email@example.com'],
+              edit: [emailFieldWithFormSummaryStep2._id],
+            },
+          ]
+
+          // Act
+          await performMultiRespondentPostSubmissionCreateActions({
+            submission: {
+              _id: mockSubmissionId,
+            } as unknown as IMultirespondentSubmissionSchema,
+            submissionId: mockSubmissionId,
+            form: {
+              _id: mockFormId,
+              title: 'Test Form',
+              form_fields: [
+                emailFieldWithoutFormSummaryStep1,
+                emailFieldWithFormSummaryStep2,
+              ],
+              stepsToNotify: [workflow[0]._id, workflow[1]._id],
+              workflow,
+              admin: {
+                agency: {
+                  fullName: 'Government Technology Agency',
+                },
+              },
+            } as unknown as IPopulatedMultirespondentForm,
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+              submissionPublicKey: 'submissionPublicKey',
+              encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+              responses: {
+                [emailFieldWithoutFormSummaryStep1._id]: {
+                  fieldType: BasicField.Email,
+                  answer: {
+                    value: 'expected1@example.com',
+                  },
+                },
+              },
+            } as MultirespondentSubmissionDto,
+            logMeta: {} as any,
+            attachments: MOCK_SUBMISSION_ATTACHMENTS,
+          })
+
+          // Assert
+          expect(MockMailUtils.generateAutoreplyPdf).not.toHaveBeenCalled()
+        })
+        it('should not generate pdf when there is no active form summary included email field and workflow is complete but has no emails to notify for outcome', async () => {
+          // Arrange
+          const emailFieldWithoutFormSummaryStep1 = {
+            _id: new ObjectId().toHexString(),
+            fieldType: BasicField.Email,
+            title: 'Step 1 Email Field',
+            autoReplyOptions: {
+              hasAutoReply: true,
+              includeFormSummary: false,
+              autoReplySubject: 'Test Subject',
+              autoReplyMessage: 'Test Message',
+              autoReplySender: 'Test Sender',
+            },
+          }
+
+          const workflow = [
+            {
+              _id: new ObjectId().toHexString(),
+              workflow_type: WorkflowType.Static,
+              emails: [], // step 1 has no emails to notify for outcome
+              edit: [emailFieldWithoutFormSummaryStep1._id],
+            },
+          ]
+
+          const step1Id = new ObjectId().toHexString()
+
+          // Act
+          await performMultiRespondentPostSubmissionCreateActions({
+            submission: {
+              _id: mockSubmissionId,
+            } as unknown as IMultirespondentSubmissionSchema,
+            submissionId: mockSubmissionId,
+            form: {
+              _id: mockFormId,
+              title: 'Test Form',
+              form_fields: [emailFieldWithoutFormSummaryStep1],
+              stepsToNotify: [step1Id],
+              workflow,
+              admin: {
+                agency: {
+                  fullName: 'Government Technology Agency',
+                },
+              },
+            } as unknown as IPopulatedMultirespondentForm,
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+              submissionPublicKey: 'submissionPublicKey',
+              encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+              responses: {
+                [emailFieldWithoutFormSummaryStep1._id]: {
+                  fieldType: BasicField.Email,
+                  answer: {
+                    value: 'expected1@example.com',
+                  },
+                },
+              },
+            } as MultirespondentSubmissionDto,
+            logMeta: {} as any,
+            attachments: MOCK_SUBMISSION_ATTACHMENTS,
+          })
+
+          // Assert
+          expect(MockMailUtils.generateAutoreplyPdf).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('subsequent steps', () => {
+        it('should not generate pdf when there is no active form summary included email field and workflow is incomplete', async () => {
+          // Arrange
+          const emailFieldWithFormSummaryStep1 = {
+            _id: new ObjectId().toHexString(),
+            fieldType: BasicField.Email,
+            title: 'Step 1 Email Field',
+            autoReplyOptions: {
+              hasAutoReply: true,
+              includeFormSummary: true,
+              autoReplySubject: 'Test Subject',
+              autoReplyMessage: 'Test Message',
+              autoReplySender: 'Test Sender',
+            },
+          }
+          const emailFieldWithoutFormSummaryStep2 = {
+            _id: new ObjectId().toHexString(),
+            fieldType: BasicField.Email,
+            title: 'Step 2 Email Field',
+            autoReplyOptions: {
+              hasAutoReply: true,
+              includeFormSummary: false,
+              autoReplySubject: 'Test Subject',
+              autoReplyMessage: 'Test Message',
+              autoReplySender: 'Test Sender',
+            },
+          }
+
+          const workflow = [
+            {
+              _id: new ObjectId().toHexString(),
+              workflow_type: WorkflowType.Static,
+              emails: [],
+              edit: [emailFieldWithFormSummaryStep1._id],
+            },
+            {
+              _id: new ObjectId().toHexString(),
+              workflow_type: WorkflowType.Static,
+              emails: ['step2_respondent_email@example.com'],
+              edit: [emailFieldWithoutFormSummaryStep2._id],
+            },
+            {
+              _id: new ObjectId().toHexString(),
+              workflow_type: WorkflowType.Static,
+              emails: ['step3_respondent_email@example.com'],
+              edit: [emailFieldWithFormSummaryStep1._id],
+            },
+          ]
+
+          // Act
+          await performMultiRespondentPostSubmissionUpdateActions({
+            submission: {
+              _id: mockSubmissionId,
+            } as unknown as IMultirespondentSubmissionSchema,
+            submissionId: mockSubmissionId,
+            snapshottedFormDef: {
+              _id: mockFormId,
+              title: 'Test Form',
+              form_fields: [
+                emailFieldWithFormSummaryStep1,
+                emailFieldWithoutFormSummaryStep2,
+              ],
+              stepsToNotify: [workflow[1]._id],
+              workflow,
+              admin: {
+                agency: {
+                  fullName: 'Government Technology Agency',
+                },
+              },
+            } as unknown as SnapshottedFormDef,
+            currentStepNumber: 1, // submitted step 2
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+              submissionPublicKey: 'submissionPublicKey',
+              encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+              responses: {
+                [emailFieldWithFormSummaryStep1._id]: {
+                  fieldType: BasicField.Email,
+                  answer: {
+                    value: 'expected1@example.com',
+                  },
+                },
+                [emailFieldWithoutFormSummaryStep2._id]: {
+                  fieldType: BasicField.Email,
+                  answer: {
+                    value: 'expected2@example.com',
+                  },
+                },
+              },
+            } as MultirespondentSubmissionDto,
+            logMeta: {} as any,
+            attachments: MOCK_SUBMISSION_ATTACHMENTS,
+          })
+
+          // Assert
+          expect(MockMailUtils.generateAutoreplyPdf).not.toHaveBeenCalled()
+        })
+
+        it('should not generate pdf when there is no active form summary included email field and workflow is complete but has no emails to notify for outcome', async () => {
+          // Arrange
+          const emailFieldWithFormSummaryStep1 = {
+            _id: new ObjectId().toHexString(),
+            fieldType: BasicField.Email,
+            title: 'Step 1 Email Field',
+            autoReplyOptions: {
+              hasAutoReply: true,
+              includeFormSummary: true,
+              autoReplySubject: 'Test Subject',
+              autoReplyMessage: 'Test Message',
+              autoReplySender: 'Test Sender',
+            },
+          }
+          const emailFieldWithoutFormSummaryStep2 = {
+            _id: new ObjectId().toHexString(),
+            fieldType: BasicField.Email,
+            title: 'Step 2 Email Field',
+            autoReplyOptions: {
+              hasAutoReply: true,
+              includeFormSummary: false,
+              autoReplySubject: 'Test Subject',
+              autoReplyMessage: 'Test Message',
+              autoReplySender: 'Test Sender',
+            },
+          }
+
+          const workflow = [
+            {
+              _id: new ObjectId().toHexString(),
+              workflow_type: WorkflowType.Static,
+              emails: [],
+              edit: [emailFieldWithFormSummaryStep1._id],
+            },
+            {
+              _id: new ObjectId().toHexString(),
+              workflow_type: WorkflowType.Static,
+              emails: ['step2_respondent_email@example.com'],
+              edit: [emailFieldWithoutFormSummaryStep2._id],
+            },
+          ]
+
+          // Act
+          await performMultiRespondentPostSubmissionUpdateActions({
+            submission: {
+              _id: mockSubmissionId,
+            } as unknown as IMultirespondentSubmissionSchema,
+            submissionId: mockSubmissionId,
+            snapshottedFormDef: {
+              _id: mockFormId,
+              title: 'Test Form',
+              form_fields: [
+                emailFieldWithFormSummaryStep1,
+                emailFieldWithoutFormSummaryStep2,
+              ],
+              stepsToNotify: [],
+              emails: [],
+              workflow,
+              admin: {
+                agency: {
+                  fullName: 'Government Technology Agency',
+                },
+              },
+            } as unknown as SnapshottedFormDef,
+            currentStepNumber: 1, // submitted step 2
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+              submissionPublicKey: 'submissionPublicKey',
+              encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+              responses: {
+                [emailFieldWithFormSummaryStep1._id]: {
+                  fieldType: BasicField.Email,
+                  answer: {
+                    value: 'expected1@example.com',
+                  },
+                },
+                [emailFieldWithoutFormSummaryStep2._id]: {
+                  fieldType: BasicField.Email,
+                  answer: {
+                    value: 'expected2@example.com',
+                  },
+                },
+              },
+            } as MultirespondentSubmissionDto,
+            logMeta: {} as any,
+            attachments: MOCK_SUBMISSION_ATTACHMENTS,
+          })
+
+          // Assert
+          expect(MockMailUtils.generateAutoreplyPdf).not.toHaveBeenCalled()
+        })
+      })
+    })
+  })
+
+  describe('respondent copy emails are sent', () => {
+    describe('first step', () => {
+      it('sends respondent copy without pdf when email field auto reply enabled but form summary is not included', async () => {
+        // Arrange
+        const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfRespondentCopyEmail',
+        )
+
+        const emailFieldWithoutFormSummaryStep1 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 1 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: false,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+        const emailFieldWithFormSummaryStep2 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 2 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+
+        const workflow = [
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [emailFieldWithoutFormSummaryStep1._id],
+          },
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: ['step2_respondent_email@example.com'],
+            edit: [emailFieldWithFormSummaryStep2._id],
+          },
+        ]
+
+        // Act
+        await performMultiRespondentPostSubmissionCreateActions({
+          submission: {
+            _id: mockSubmissionId,
+          } as unknown as IMultirespondentSubmissionSchema,
+          submissionId: mockSubmissionId,
+          form: {
+            _id: mockFormId,
+            title: 'Test Form',
+            form_fields: [
+              emailFieldWithoutFormSummaryStep1,
+              emailFieldWithFormSummaryStep2,
+            ],
+            stepsToNotify: [workflow[0]._id, workflow[1]._id],
+            workflow,
+            admin: {
+              agency: {
+                fullName: 'Government Technology Agency',
+              },
+            },
+          } as unknown as IPopulatedMultirespondentForm,
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {
+              [emailFieldWithoutFormSummaryStep1._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected1@example.com',
+                },
+              },
+            },
+          } as MultirespondentSubmissionDto,
+          logMeta: {} as any,
+          attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        })
+
+        // Assert
+        // that sent to correct destination emails
+        expect(sendMrfRespondentCopyEmailSpy).toHaveBeenCalledTimes(1)
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].autoReplyMailData
+            .email,
+        ).toEqual('expected1@example.com')
+        // does not attach pdf and submission attachments since form summary is not included for active respondent copy email field
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].attachments,
+        ).toEqual([])
+      })
+      it('sends respondent copy emails with pdf when email field auto reply enabled and form summary is included', async () => {
+        // Arrange
+        const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfRespondentCopyEmail',
+        )
+
+        const emailFieldWithFormSummaryStep1 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 1 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+        const emailFieldWithFormSummaryStep2 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 2 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+
+        const workflow = [
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [emailFieldWithFormSummaryStep1._id],
+          },
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: ['step2_respondent_email@example.com'],
+            edit: [emailFieldWithFormSummaryStep2._id],
+          },
+        ]
+
+        // Act
+        await performMultiRespondentPostSubmissionCreateActions({
+          submission: {
+            _id: mockSubmissionId,
+          } as unknown as IMultirespondentSubmissionSchema,
+          submissionId: mockSubmissionId,
+          form: {
+            _id: mockFormId,
+            title: 'Test Form',
+            form_fields: [
+              emailFieldWithFormSummaryStep1,
+              emailFieldWithFormSummaryStep2,
+            ],
+            stepsToNotify: [workflow[0]._id, workflow[1]._id],
+            workflow,
+            admin: {
+              agency: {
+                fullName: 'Government Technology Agency',
+              },
+            },
+          } as unknown as IPopulatedMultirespondentForm,
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {
+              [emailFieldWithFormSummaryStep1._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected1@example.com',
+                },
+              },
+            },
+          } as MultirespondentSubmissionDto,
+          logMeta: {} as any,
+          attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        })
+
+        // Assert
+        // that sent to correct destination emails
+        expect(sendMrfRespondentCopyEmailSpy).toHaveBeenCalledTimes(1)
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].autoReplyMailData
+            .email,
+        ).toEqual('expected1@example.com')
+        // attaches pdf and submission attachments
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].attachments,
+        ).toEqual([
+          ...MOCK_SUBMISSION_ATTACHMENTS,
+          EXPECTED_MOCK_PDF_ATTACHMENT,
+        ])
+      })
+      it('does not send respondent copy emails when email field auto reply is not enabled', async () => {
+        // Arrange
+        const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfRespondentCopyEmail',
+        )
+
+        const emailFieldWithoutAutoReplyStep1 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 1 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: false,
+            includeFormSummary: false,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+        const emailFieldWithFormSummaryStep2 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 2 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+
+        const workflow = [
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [emailFieldWithoutAutoReplyStep1._id],
+          },
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: ['step2_respondent_email@example.com'],
+            edit: [emailFieldWithFormSummaryStep2._id],
+          },
+        ]
+
+        // Act
+        await performMultiRespondentPostSubmissionCreateActions({
+          submission: {
+            _id: mockSubmissionId,
+          } as unknown as IMultirespondentSubmissionSchema,
+          submissionId: mockSubmissionId,
+          form: {
+            _id: mockFormId,
+            title: 'Test Form',
+            form_fields: [
+              emailFieldWithoutAutoReplyStep1,
+              emailFieldWithFormSummaryStep2,
+            ],
+            stepsToNotify: [workflow[0]._id, workflow[1]._id],
+            workflow,
+            admin: {
+              agency: {
+                fullName: 'Government Technology Agency',
+              },
+            },
+          } as unknown as IPopulatedMultirespondentForm,
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {
+              [emailFieldWithoutAutoReplyStep1._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected1@example.com',
+                },
+              },
+            },
+          } as MultirespondentSubmissionDto,
+          logMeta: {} as any,
+          attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        })
+
+        // Assert
+        expect(sendMrfRespondentCopyEmailSpy).not.toHaveBeenCalled()
+      })
+
+      it('sends respondent copy despite pdf generation error', async () => {
+        // Arrange
+        MockMailUtils.generateAutoreplyPdf.mockReturnValue(
+          errAsync(new AutoreplyPdfGenerationError()),
+        )
+        const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfRespondentCopyEmail',
+        )
+        const emailFieldWithFormSummaryStep1 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 1 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+
+        const workflow = [
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [emailFieldWithFormSummaryStep1._id],
+          },
+        ]
+
+        // Act
+        await performMultiRespondentPostSubmissionCreateActions({
+          submission: {
+            _id: mockSubmissionId,
+          } as unknown as IMultirespondentSubmissionSchema,
+          submissionId: mockSubmissionId,
+          form: {
+            _id: mockFormId,
+            title: 'Test Form',
+            form_fields: [emailFieldWithFormSummaryStep1],
+            stepsToNotify: [workflow[0]._id],
+            workflow,
+            admin: {
+              agency: {
+                fullName: 'Government Technology Agency',
+              },
+            },
+          } as unknown as IPopulatedMultirespondentForm,
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {
+              [emailFieldWithFormSummaryStep1._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected1@example.com',
+                },
+              },
+            },
+          } as MultirespondentSubmissionDto,
+          logMeta: {} as any,
+          attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        })
+
+        // Assert
+        // that sent to correct destination emails
+        expect(sendMrfRespondentCopyEmailSpy).toHaveBeenCalledTimes(1)
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].autoReplyMailData
+            .email,
+        ).toEqual('expected1@example.com')
+        // still sends without pdf attachment
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].attachments,
+        ).toEqual([...MOCK_SUBMISSION_ATTACHMENTS])
+      })
+    })
+
+    describe('subsequent steps', () => {
+      it('sends respondent copy without pdf when email field auto reply enabled but form summary is not included', async () => {
+        // Arrange
+        const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfRespondentCopyEmail',
+        )
+
+        const emailFieldWithFormSummaryStep1 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 1 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+        const emailFieldWithoutFormSummaryStep2 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 2 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: false,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+
+        const workflow = [
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [emailFieldWithFormSummaryStep1._id],
+          },
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: ['step2_respondent_email@example.com'],
+            edit: [emailFieldWithoutFormSummaryStep2._id],
+          },
+        ]
+
+        // Act
+        await performMultiRespondentPostSubmissionUpdateActions({
+          submission: {
+            _id: mockSubmissionId,
+          } as unknown as IMultirespondentSubmissionSchema,
+          submissionId: mockSubmissionId,
+          snapshottedFormDef: {
+            _id: mockFormId,
+            title: 'Test Form',
+            form_fields: [
+              emailFieldWithFormSummaryStep1,
+              emailFieldWithoutFormSummaryStep2,
+            ],
+            stepsToNotify: [workflow[0]._id, workflow[1]._id],
+            workflow,
+            admin: {
+              agency: {
+                fullName: 'Government Technology Agency',
+              },
+            },
+          } as unknown as SnapshottedFormDef,
+          currentStepNumber: 1, // step 2
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {
+              [emailFieldWithFormSummaryStep1._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected1@example.com',
+                },
+              },
+              [emailFieldWithoutFormSummaryStep2._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected2@example.com',
+                },
+              },
+            },
+          } as MultirespondentSubmissionDto,
+          logMeta: {} as any,
+          attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        })
+
+        // Assert
+        // that sent to correct destination emails
+        expect(sendMrfRespondentCopyEmailSpy).toHaveBeenCalledTimes(1)
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].autoReplyMailData
+            .email,
+        ).toEqual('expected2@example.com')
+        // does not attach pdf and submission attachments since form summary is not included for active respondent copy email field
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].attachments,
+        ).toEqual([])
+      })
+      it('sends respondent copy emails with pdf when email field auto reply enabled and form summary is included', async () => {
+        // Arrange
+        const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfRespondentCopyEmail',
+        )
+
+        const emailFieldWithFormSummaryStep1 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 1 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+        const emailFieldWithFormSummaryStep2 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 2 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+
+        const emailField2WithFormSummaryStep2 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 2 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+
+        const workflow = [
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [emailFieldWithFormSummaryStep1._id],
+          },
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: ['step2_respondent_email@example.com'],
+            edit: [
+              emailField2WithFormSummaryStep2._id,
+              emailFieldWithFormSummaryStep2._id,
+            ],
+          },
+        ]
+
+        // Act
+        await performMultiRespondentPostSubmissionUpdateActions({
+          submission: {
+            _id: mockSubmissionId,
+          } as unknown as IMultirespondentSubmissionSchema,
+          submissionId: mockSubmissionId,
+          snapshottedFormDef: {
+            _id: mockFormId,
+            title: 'Test Form',
+            form_fields: [
+              emailFieldWithFormSummaryStep1,
+              emailField2WithFormSummaryStep2,
+              emailFieldWithFormSummaryStep2,
+            ],
+            stepsToNotify: [workflow[0]._id, workflow[1]._id],
+            workflow,
+            admin: {
+              agency: {
+                fullName: 'Government Technology Agency',
+              },
+            },
+          } as unknown as SnapshottedFormDef,
+          currentStepNumber: 1, // step 2
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {
+              [emailFieldWithFormSummaryStep1._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected1@example.com',
+                },
+              },
+              [emailField2WithFormSummaryStep2._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected2@example.com',
+                },
+              },
+              [emailFieldWithFormSummaryStep2._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected3@example.com',
+                },
+              },
+            },
+          } as MultirespondentSubmissionDto,
+          logMeta: {} as any,
+          attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        })
+
+        // Assert
+        // that sent to correct destination emails
+        expect(sendMrfRespondentCopyEmailSpy).toHaveBeenCalledTimes(2)
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls.map(
+            (call) => call[0].autoReplyMailData.email,
+          ),
+        ).toContainValues(['expected2@example.com', 'expected3@example.com'])
+        // attaches pdf and submission attachments
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].attachments,
+        ).toEqual([
+          ...MOCK_SUBMISSION_ATTACHMENTS,
+          EXPECTED_MOCK_PDF_ATTACHMENT,
+        ])
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[1][0].attachments,
+        ).toEqual([
+          ...MOCK_SUBMISSION_ATTACHMENTS,
+          EXPECTED_MOCK_PDF_ATTACHMENT,
+        ])
+      })
+      it('does not send respondent copy emails when email field auto reply is not enabled', async () => {
+        // Arrange
+        const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfRespondentCopyEmail',
+        )
+
+        const emailFieldWithFormSummaryStep1 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 1 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+        const emailFieldNoAutoReplyStep2 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 2 Email Field',
+        }
+
+        const emailFieldWithFormSummaryStep2 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 2 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+          required: false,
+        }
+
+        const workflow = [
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [emailFieldWithFormSummaryStep1._id],
+          },
+          {
+            _id: new ObjectId().toHexString(),
+            workflow_type: WorkflowType.Static,
+            emails: ['step2_respondent_email@example.com'],
+            edit: [
+              emailFieldWithFormSummaryStep2._id,
+              emailFieldNoAutoReplyStep2._id,
+            ],
+          },
+        ]
+
+        // Act
+        await performMultiRespondentPostSubmissionUpdateActions({
+          submission: {
+            _id: mockSubmissionId,
+          } as unknown as IMultirespondentSubmissionSchema,
+          submissionId: mockSubmissionId,
+          snapshottedFormDef: {
+            _id: mockFormId,
+            title: 'Test Form',
+            form_fields: [
+              emailFieldWithFormSummaryStep1,
+              emailFieldNoAutoReplyStep2,
+              emailFieldWithFormSummaryStep2,
+            ],
+            stepsToNotify: [workflow[0]._id, workflow[1]._id],
+            workflow,
+            admin: {
+              agency: {
+                fullName: 'Government Technology Agency',
+              },
+            },
+          } as unknown as SnapshottedFormDef,
+          currentStepNumber: 1, // step 2
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {
+              [emailFieldWithFormSummaryStep1._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected1@example.com',
+                },
+              },
+              [emailFieldNoAutoReplyStep2._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected2@example.com',
+                },
+              },
+            },
+          } as MultirespondentSubmissionDto,
+          logMeta: {} as any,
+          attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        })
+
+        // Assert
+        expect(sendMrfRespondentCopyEmailSpy).not.toHaveBeenCalled()
+      })
+    })
+  })
 
   describe('mrf approval email notification when approval step exists', () => {
     it('workflow continues and does not send approved outcome email when mrf is approved for mid step of multiple step MRF', async () => {
@@ -303,6 +1401,7 @@ describe('multirespondent-submission.service', () => {
           ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber: currentWorkflowStep,
+        attachments: MOCK_SUBMISSION_ATTACHMENTS,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
           version: 1,
@@ -318,6 +1417,13 @@ describe('multirespondent-submission.service', () => {
       expect(sendMrfApprovalEmailSpy).toHaveBeenCalledTimes(1)
       expect(sendMrfWorkflowCompletionEmailSpy).not.toHaveBeenCalled()
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].attachments).toEqual([
+        ...MOCK_SUBMISSION_ATTACHMENTS,
+        EXPECTED_MOCK_PDF_ATTACHMENT,
+      ])
       // is approve email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeFalse()
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
@@ -464,6 +1570,12 @@ describe('multirespondent-submission.service', () => {
       expect(sendMrfApprovalEmailSpy).toHaveBeenCalledTimes(1)
       expect(sendMrfWorkflowCompletionEmailSpy).not.toHaveBeenCalled()
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].attachments).toEqual([
+        EXPECTED_MOCK_PDF_ATTACHMENT,
+      ])
       // is approve email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeFalse()
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
@@ -604,6 +1716,12 @@ describe('multirespondent-submission.service', () => {
       expect(sendMrfApprovalEmailSpy).toHaveBeenCalledTimes(1)
       expect(sendMrfWorkflowCompletionEmailSpy).not.toHaveBeenCalled()
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].attachments).toEqual([
+        EXPECTED_MOCK_PDF_ATTACHMENT,
+      ])
       // is approve email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeFalse()
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
@@ -725,6 +1843,7 @@ describe('multirespondent-submission.service', () => {
           ] as FormFieldDto[],
         } as SnapshottedFormDef,
         currentStepNumber: currentStepNumber,
+        attachments: MOCK_SUBMISSION_ATTACHMENTS,
         encryptedPayload: {
           encryptedContent: 'encryptedContent',
           version: 1,
@@ -740,6 +1859,13 @@ describe('multirespondent-submission.service', () => {
       expect(sendMrfApprovalEmailSpy).toHaveBeenCalledTimes(1)
       expect(sendMrfWorkflowCompletionEmailSpy).not.toHaveBeenCalled()
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].attachments).toEqual([
+        ...MOCK_SUBMISSION_ATTACHMENTS,
+        EXPECTED_MOCK_PDF_ATTACHMENT,
+      ])
       // is rejected email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeTrue()
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
@@ -895,6 +2021,12 @@ describe('multirespondent-submission.service', () => {
       expect(sendMrfApprovalEmailSpy).toHaveBeenCalledTimes(1)
       expect(sendMrfWorkflowCompletionEmailSpy).not.toHaveBeenCalled()
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].attachments).toEqual([
+        EXPECTED_MOCK_PDF_ATTACHMENT,
+      ])
       // is rejected email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeTrue()
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
@@ -1035,6 +2167,12 @@ describe('multirespondent-submission.service', () => {
       expect(sendMrfApprovalEmailSpy).toHaveBeenCalledTimes(1)
       expect(sendMrfWorkflowCompletionEmailSpy).not.toHaveBeenCalled()
       expect(sendMRFWorkflowStepEmailSpy).not.toHaveBeenCalled()
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(sendMrfApprovalEmailSpy.mock.calls[0][0].attachments).toEqual([
+        EXPECTED_MOCK_PDF_ATTACHMENT,
+      ])
       // is rejected email and destination emails are correct
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].isRejected).toBeTrue()
       expect(sendMrfApprovalEmailSpy.mock.calls[0][0].emails).toContainValues(
@@ -1047,7 +2185,63 @@ describe('multirespondent-submission.service', () => {
   })
 
   describe('mrf completion email notification when no approval step exists', () => {
-    it('sends completion email when single step mrf is completed', async () => {
+    it('sends completion email without pdf attachment when pdf generation fails', async () => {
+      // Arrange
+      MockMailUtils.generateAutoreplyPdf.mockReturnValue(
+        errAsync(new AutoreplyPdfGenerationError()),
+      )
+      const sendMrfWorkflowCompletionEmailSpy = jest.spyOn(
+        MailService,
+        'sendMrfWorkflowCompletionEmail',
+      )
+      const singleStepWorkflow: FormWorkflowStepDto[] = [
+        {
+          _id: new ObjectId().toHexString(),
+          workflow_type: WorkflowType.Static,
+          emails: [],
+          edit: [],
+        },
+      ]
+
+      // Act
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission: {
+          _id: mockSubmissionId,
+        } as unknown as IMultirespondentSubmissionSchema,
+        submissionId: mockSubmissionId,
+        form: {
+          _id: mockFormId,
+          workflow: singleStepWorkflow,
+          emails: ['email1@example.com'],
+        } as IPopulatedMultirespondentForm,
+        encryptedPayload: {
+          encryptedContent: 'encryptedContent',
+          version: 1,
+          submissionPublicKey: 'submissionPublicKey',
+          encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+        } as MultirespondentSubmissionDto,
+        attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        logMeta: {} as any,
+      })
+
+      // Assert
+      expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // submission attachments is sent without pdf attachment
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].attachments,
+      ).toEqual([...MOCK_SUBMISSION_ATTACHMENTS])
+      // the correct destination emails are included
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
+      ).toContainValues(['email1@example.com'])
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.length,
+      ).toBe(1)
+    })
+
+    it('sends completion email with pdf attachment when single step mrf is completed', async () => {
       // Arrange
       const sendMrfWorkflowCompletionEmailSpy = jest.spyOn(
         MailService,
@@ -1080,11 +2274,19 @@ describe('multirespondent-submission.service', () => {
           submissionPublicKey: 'submissionPublicKey',
           encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
         } as MultirespondentSubmissionDto,
+        attachments: MOCK_SUBMISSION_ATTACHMENTS,
         logMeta: {} as any,
       })
 
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].attachments,
+      ).toEqual([...MOCK_SUBMISSION_ATTACHMENTS, EXPECTED_MOCK_PDF_ATTACHMENT])
+      // the correct destination emails are included
       expect(
         sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
       ).toContainValues(['email1@example.com'])
@@ -1186,6 +2388,12 @@ describe('multirespondent-submission.service', () => {
 
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].attachments,
+      ).toEqual([EXPECTED_MOCK_PDF_ATTACHMENT])
       // The emails sent to should only be the expected emails exactly
       expect(
         sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
@@ -1377,6 +2585,12 @@ describe('multirespondent-submission.service', () => {
 
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].attachments,
+      ).toEqual([EXPECTED_MOCK_PDF_ATTACHMENT])
       expect(
         sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
       ).toContainValues(expectedEmails)
@@ -1441,10 +2655,17 @@ describe('multirespondent-submission.service', () => {
           workflowStep: workflow.length - 1,
         } as MultirespondentSubmissionDto,
         logMeta: {} as any,
+        attachments: MOCK_SUBMISSION_ATTACHMENTS,
       })
 
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].attachments,
+      ).toEqual([...MOCK_SUBMISSION_ATTACHMENTS, EXPECTED_MOCK_PDF_ATTACHMENT])
       expect(
         sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
       ).toContainValues(expectedEmails)
@@ -1515,6 +2736,12 @@ describe('multirespondent-submission.service', () => {
 
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].attachments,
+      ).toEqual([EXPECTED_MOCK_PDF_ATTACHMENT])
       expect(
         sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
       ).toContainValues(expectedEmails)
@@ -1605,6 +2832,13 @@ describe('multirespondent-submission.service', () => {
 
       // Assert
       expect(sendMrfWorkflowCompletionEmailSpy).toHaveBeenCalledTimes(1)
+      // pdf generation is invoked
+      expect(MockMailUtils.generateAutoreplyPdf).toHaveBeenCalledTimes(1)
+      // pdf attachment is included and submission attachments are correct
+      expect(
+        sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].attachments,
+      ).toEqual([EXPECTED_MOCK_PDF_ATTACHMENT])
+      // the correct destination emails are included
       expect(
         sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
       ).toContainValues(expectedEmails)

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -20,12 +20,14 @@ import {
   NumberResponseV3,
   ShortTextResponseV3,
   SignatureFieldResponseV3,
+  SignatureVectorArray,
   SubmissionType,
   TableResponseV3,
   WorkflowStatus,
   WorkflowType,
 } from 'shared/types'
 
+import { convertToSignaturePngDataUri } from 'src/app/utils/convert-vector-array-to-png'
 import {
   FormFieldSchema,
   IAddressCompoundFieldSchema,
@@ -45,7 +47,8 @@ import { ValidateFieldErrorV3 } from '../../submission.errors'
 import {
   createMultirespondentSubmissionDto,
   createPublicMultirespondentSubmissionDto,
-  getQuestionTitleAnswerString,
+  extractRespondentCopyEmailDatas,
+  getQuestionAnswerPairsForMultipleFields,
   retrieveWorkflowStepEmailAddresses,
   validateMrfFieldResponses,
 } from '../multirespondent-submission.utils'
@@ -57,6 +60,93 @@ describe('multirespondent-submission.utils', () => {
     emails: ['example@example.com'],
     edit: [],
   }
+
+  describe('extractRespondentCopyEmailDatas', () => {
+    it('should return email data for only current step email fields with auto reply enabled and has answer', () => {
+      // Arrange
+      const inactiveEmailField = new ObjectId().toHexString()
+      const activeEmailField = new ObjectId().toHexString()
+      const activeEmailFieldNoAnswer = new ObjectId().toHexString()
+      const activeEmailFieldNoAutoReply = new ObjectId().toHexString()
+      const shortTextFieldId = new ObjectId().toHexString()
+      const autoReplyOptionDefaults = {
+        autoReplySubject: 'Test Subject',
+        autoReplySender: 'Test Sender',
+        autoReplyMessage: 'Test Body',
+        includeFormSummary: true,
+        hasAutoReply: true,
+      }
+      const formFields = [
+        generateDefaultField(BasicField.Email, {
+          _id: inactiveEmailField,
+          autoReplyOptions: autoReplyOptionDefaults,
+        }),
+        generateDefaultField(BasicField.Email, {
+          _id: activeEmailField,
+          autoReplyOptions: autoReplyOptionDefaults,
+        }),
+        generateDefaultField(BasicField.Email, {
+          _id: activeEmailFieldNoAnswer,
+          autoReplyOptions: autoReplyOptionDefaults,
+        }),
+        generateDefaultField(BasicField.ShortText, {
+          _id: shortTextFieldId,
+          autoReplyOptions: autoReplyOptionDefaults,
+        }),
+        generateDefaultField(BasicField.Email, {
+          _id: activeEmailFieldNoAutoReply,
+          autoReplyOptions: {
+            ...autoReplyOptionDefaults,
+            hasAutoReply: false,
+          },
+        }),
+      ]
+
+      // Act
+      const result = extractRespondentCopyEmailDatas({
+        responses: {
+          [inactiveEmailField]: {
+            fieldType: BasicField.Email,
+            answer: {
+              value: 'notexpectedsinceinactive@email.com',
+            },
+          },
+          [activeEmailField]: {
+            fieldType: BasicField.Email,
+            answer: {
+              value: 'expected@email.com',
+            },
+          },
+          [shortTextFieldId]: {
+            fieldType: BasicField.ShortText,
+            answer: 'short text answer',
+          },
+          [activeEmailFieldNoAutoReply]: {
+            fieldType: BasicField.Email,
+            answer: { value: 'notexpectedsincenoautoReply@email.com' },
+          },
+        },
+        formFields,
+        currentStepActiveFields: [
+          activeEmailField,
+          shortTextFieldId,
+          activeEmailFieldNoAnswer,
+          activeEmailFieldNoAutoReply,
+        ],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        {
+          email: 'expected@email.com',
+          subject: 'Test Subject',
+          sender: 'Test Sender',
+          body: 'Test Body',
+          includeFormSummary: true,
+        },
+      ])
+    })
+  })
 
   describe('createPublicMultirespondentSubmissionDto', () => {
     const getAllTypesFormFieldsWithDropdownOptionsToRecipientsMap = () => {
@@ -430,12 +520,23 @@ describe('multirespondent-submission.utils', () => {
         } as EmailResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionAnswerPairsForMultipleFields({
+        formFields,
+        responses,
+      })
 
       expect(result).toEqual([
-        { question: 'Short Text', answer: 'Test answer' },
-        { question: 'Number', answer: '42' },
-        { question: 'Email', answer: 'test@example.com' },
+        {
+          question: 'Short Text',
+          answer: 'Test answer',
+          fieldType: BasicField.ShortText,
+        },
+        { question: 'Number', answer: '42', fieldType: BasicField.Number },
+        {
+          question: 'Email',
+          answer: 'test@example.com',
+          fieldType: BasicField.Email,
+        },
       ])
     })
 
@@ -454,10 +555,17 @@ describe('multirespondent-submission.utils', () => {
         } as AttachmentResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionAnswerPairsForMultipleFields({
+        formFields,
+        responses,
+      })
 
       expect(result).toEqual([
-        { question: '[Attachment] File Upload', answer: 'file.pdf' },
+        {
+          question: '[Attachment] File Upload',
+          answer: 'file.pdf',
+          fieldType: BasicField.Attachment,
+        },
       ])
     })
 
@@ -499,24 +607,31 @@ describe('multirespondent-submission.utils', () => {
         } as TableResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionAnswerPairsForMultipleFields({
+        formFields,
+        responses,
+      })
 
       expect(result).toEqual([
         {
           question: '[Table] Table of Name and Age (Name; Age)',
           answer: 'Alice; 30',
+          fieldType: BasicField.Table,
         },
         {
           question: '[Table] Table of Name and Age (Name; Age)',
           answer: 'Bob; 25',
+          fieldType: BasicField.Table,
         },
         {
           question: '[Table] Table of Hobbies (Hobby; Years)',
           answer: 'Swimming; 5',
+          fieldType: BasicField.Table,
         },
         {
           question: '[Table] Table of Hobbies (Hobby; Years)',
           answer: 'Reading; 10',
+          fieldType: BasicField.Table,
         },
       ])
     })
@@ -539,10 +654,17 @@ describe('multirespondent-submission.utils', () => {
         } as CheckboxResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionAnswerPairsForMultipleFields({
+        formFields,
+        responses,
+      })
 
       expect(result).toEqual([
-        { question: 'Checkbox', answer: 'Option 1,Option 2,Custom Option' },
+        {
+          question: 'Checkbox',
+          answer: 'Option 1,Option 2,Custom Option',
+          fieldType: BasicField.Checkbox,
+        },
       ])
     })
 
@@ -570,17 +692,64 @@ describe('multirespondent-submission.utils', () => {
         } as AddressResponseV3,
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionAnswerPairsForMultipleFields({
+        formFields,
+        responses,
+      })
 
       expect(result).toEqual([
         {
           question: 'Address',
           answer: '161, BUKIT BATOK STREET 11, #1-1, SINGAPORE 650161',
+          fieldType: BasicField.Address,
         },
       ])
     })
 
-    it('should handle signature fields correctly', () => {
+    it('should handle signature fields correctly when includeSignatureDataPngUri is true', () => {
+      const formFields: FormFieldSchema[] = [
+        {
+          _id: '1',
+          title: 'Signature',
+          fieldType: BasicField.Signature,
+        } as ISignatureFieldSchema,
+      ]
+
+      const MOCK_SIGNATURE_VALUE: SignatureVectorArray = [
+        [[10, 20, 0.5]],
+        [[40, 40, 0.5]],
+      ]
+
+      const responses: FieldResponsesV3 = {
+        '1': {
+          fieldType: BasicField.Signature,
+          answer: {
+            type: 'draw',
+            value: MOCK_SIGNATURE_VALUE,
+          } as SignatureFieldResponseV3,
+        },
+      }
+
+      const result = getQuestionAnswerPairsForMultipleFields({
+        formFields,
+        responses,
+        includeSignatureDataPngDataUri: true,
+      })
+
+      const expectedSignatureDataPngDataUri =
+        convertToSignaturePngDataUri(MOCK_SIGNATURE_VALUE)
+
+      expect(result).toEqual([
+        {
+          question: '[signature] Signature',
+          answer: 'Signature captured',
+          fieldType: BasicField.Signature,
+          signatureDataPngDataUri: expectedSignatureDataPngDataUri,
+        },
+      ])
+    })
+
+    it('should handle signature fields correctly when includeSignatureDataPngUri is false', () => {
       const formFields: FormFieldSchema[] = [
         {
           _id: '1',
@@ -599,12 +768,17 @@ describe('multirespondent-submission.utils', () => {
         },
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionAnswerPairsForMultipleFields({
+        formFields,
+        responses,
+      })
 
       expect(result).toEqual([
         {
           question: '[signature] Signature',
           answer: 'Signature captured',
+          fieldType: BasicField.Signature,
+          signatureDataPngDataUri: undefined,
         },
       ])
     })
@@ -618,12 +792,16 @@ describe('multirespondent-submission.utils', () => {
         },
       }
 
-      const result = getQuestionTitleAnswerString({ formFields, responses })
+      const result = getQuestionAnswerPairsForMultipleFields({
+        formFields,
+        responses,
+      })
 
       expect(result).toEqual([
         {
           question: 'SingPass Validated NRIC (Step 1)',
           answer: 'S1234567A',
+          fieldType: BasicField.Nric,
         },
       ])
     })
@@ -845,7 +1023,10 @@ describe('multirespondent-submission.utils', () => {
       } as ShortTextResponseV3,
     }
 
-    const result = getQuestionTitleAnswerString({ formFields, responses })
+    const result = getQuestionAnswerPairsForMultipleFields({
+      formFields,
+      responses,
+    })
 
     expect(result).toEqual([])
   })
@@ -859,13 +1040,13 @@ describe('multirespondent-submission.utils', () => {
       } as IShortTextFieldSchema,
     ]
 
-    const undefinedResult = getQuestionTitleAnswerString({
+    const undefinedResult = getQuestionAnswerPairsForMultipleFields({
       formFields,
       responses: undefined as unknown as FieldResponsesV3,
     })
     expect(undefinedResult).toEqual([])
 
-    const nullResult = getQuestionTitleAnswerString({
+    const nullResult = getQuestionAnswerPairsForMultipleFields({
       formFields,
       responses: null as unknown as FieldResponsesV3,
     })

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -139,6 +139,7 @@ const submitMultirespondentForm = async (
     encryptedPayload,
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
+    growthbook: req.growthbook,
   })
 }
 
@@ -234,6 +235,7 @@ const updateMultirespondentSubmission = async (
     encryptedPayload,
     logMeta,
     attachments: req.formsg.unencryptedAttachments,
+    growthbook: req.growthbook,
   })
 }
 

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1,4 +1,4 @@
-import { flatten, uniq } from 'lodash'
+import { GrowthBook } from '@growthbook/growthbook'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import Mail from 'nodemailer/lib/mailer'
@@ -27,7 +27,7 @@ import {
   MultirespondentSubmissionDto,
   SnapshottedFormDef,
 } from '../../../../types/api'
-import config from '../../../config/config'
+import config, { isTest } from '../../../config/config'
 import {
   createLoggerWithLabel,
   CustomLoggerParams,
@@ -38,11 +38,7 @@ import {
   MailSendError,
 } from '../../../services/mail/mail.errors'
 import MailService from '../../../services/mail/mail.service'
-import { AutoReplyMailData } from '../../../services/mail/mail.types'
-import {
-  AutoReplyData,
-  generateAutoreplyPdf,
-} from '../../../services/mail/mail.utils'
+import { generateAutoreplyPdf } from '../../../services/mail/mail.utils'
 import { transformMongoError } from '../../../utils/handle-mongo-error'
 import { DatabaseError } from '../../core/core.errors'
 import { isFormMultirespondent } from '../../form/form.utils'
@@ -60,15 +56,18 @@ import {
 } from '../submission.errors'
 import { uploadAttachments } from '../submission.service'
 import { AttachmentMetadata } from '../submission.types'
-import { getMrfSubmissionWorkflowStatus } from '../submission.utils'
+import {
+  getMrfSubmissionWorkflowStatus,
+  isAdminEmailPdfEnabled,
+} from '../submission.utils'
 import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
 import { MultirespondentSubmissionContent } from './multirespondent-submission.types'
 import {
-  extractRespondentCopyEmails,
+  extractRespondentCopyEmailDatas,
   getEmailFromResponses,
-  getPdfResponsesData,
-  getQuestionTitleAnswerString,
+  getQuestionAnswerPairsForMultipleFields,
+  getResponsesDataFromMrfResponses,
   retrieveWorkflowStepEmailAddresses,
 } from './multirespondent-submission.utils'
 
@@ -315,6 +314,101 @@ export const sendNextStepReminderEmail = ({
   })
 }
 
+const getEmailsToNotifyAboutMrfOutcome = ({
+  form,
+  responses,
+  currentStepNumber,
+  submissionId,
+}: {
+  form: Pick<
+    IPopulatedMultirespondentForm,
+    | '_id'
+    | 'emails'
+    | 'stepOneEmailNotificationFieldId'
+    | 'stepsToNotify'
+    | 'workflow'
+  > & {
+    form_fields: FormFieldSchema[] | FormFieldDto[]
+  }
+  responses: FieldResponsesV3
+  currentStepNumber: number
+  submissionId: string
+}): Result<string[], InvalidWorkflowTypeError> => {
+  const logMeta = {
+    action: 'getMrfOutcomeEmailsToNotify',
+    formId: form._id?.toString(),
+    submissionId,
+  }
+
+  // Emails to notify under the 'others' setting
+  const othersEmailsToNotify =
+    form.emails && Array.isArray(form.emails) ? form.emails : []
+
+  // Emails to notify under the 'Respondent in step 1' setting
+  const stepOneEmailNotificationFieldId = form.stepOneEmailNotificationFieldId
+  const respondentInStepOneToNotify = stepOneEmailNotificationFieldId
+    ? getEmailFromResponses(stepOneEmailNotificationFieldId, responses)
+    : null
+
+  const respondentInStepOneEmailToNotify = respondentInStepOneToNotify
+    ? [respondentInStepOneToNotify]
+    : []
+
+  // Emails to notify under the 'Other respondents in your workflow' setting
+  const stepsToNotifyUpToCurrentStep = form.workflow.slice(
+    1, // exclude first step since notification is indicated by `stepOneEmailNotificationFieldId`
+    currentStepNumber + 1,
+  )
+  const validWorkflowStepsToNotify = (form.stepsToNotify ?? [])
+    .map((stepId) =>
+      stepsToNotifyUpToCurrentStep.find(
+        (step) => step._id.toString() === stepId,
+      ),
+    )
+    .filter(
+      (workflowStep) => workflowStep !== undefined,
+    ) as FormWorkflowStepDto[]
+
+  const otherRespondentsInYourWorkflowEmailsToNotifyResult = Result.combine(
+    validWorkflowStepsToNotify.flatMap((workflowStep) => {
+      return retrieveWorkflowStepEmailAddresses(form, workflowStep, responses)
+    }),
+  ).map((emails) => emails.flat())
+
+  if (otherRespondentsInYourWorkflowEmailsToNotifyResult.isErr()) {
+    logger.error({
+      message:
+        'Failed to retrieve workflow step email addresses from non-step 1 workflow steps',
+      meta: logMeta,
+      error: otherRespondentsInYourWorkflowEmailsToNotifyResult.error,
+    })
+    return err(otherRespondentsInYourWorkflowEmailsToNotifyResult.error)
+  }
+
+  const otherRespondentsInYourWorkflowEmailsToNotify =
+    otherRespondentsInYourWorkflowEmailsToNotifyResult.value
+  return ok([
+    ...othersEmailsToNotify,
+    ...respondentInStepOneEmailToNotify,
+    ...otherRespondentsInYourWorkflowEmailsToNotify,
+  ])
+}
+
+const checkIsWorkflowCompleted = ({
+  currentStepNumber,
+  form,
+  isRejected,
+}: {
+  currentStepNumber: number
+  form: Pick<IPopulatedMultirespondentForm, 'workflow'>
+  isRejected: boolean
+}) => {
+  const lastStepNumber = form.workflow.length - 1
+  const isLastStepSubmitted = currentStepNumber === lastStepNumber
+
+  return isRejected || isLastStepSubmitted
+}
+
 const sendMrfOutcomeEmails = ({
   currentStepNumber,
   form,
@@ -323,6 +417,7 @@ const sendMrfOutcomeEmails = ({
   isApproval = false,
   isRejected = false,
   attachments,
+  pdfResult,
 }: {
   currentStepNumber: number
   form: Pick<
@@ -341,82 +436,68 @@ const sendMrfOutcomeEmails = ({
   isApproval?: boolean
   isRejected?: boolean
   attachments?: IAttachmentInfo[]
-}): ResultAsync<true, InvalidWorkflowTypeError | MailSendError> => {
+  pdfResult: ResultAsync<
+    Mail.Attachment | undefined,
+    AutoreplyPdfGenerationError
+  >
+}): ResultAsync<
+  true,
+  InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError
+> => {
   const logMeta = {
     action: 'sendMrfOutcomeEmails',
     formId: form._id?.toString(),
     submissionId,
   }
-  const emailsToNotify =
-    form.emails && Array.isArray(form.emails) ? form.emails : []
-
-  const stepOneEmailNotificationFieldId = form.stepOneEmailNotificationFieldId
-  const stepOneEmailToNotify = stepOneEmailNotificationFieldId
-    ? getEmailFromResponses(stepOneEmailNotificationFieldId, responses)
-    : null
-  if (stepOneEmailToNotify) emailsToNotify.push(stepOneEmailToNotify)
-
-  const stepsToNotifyUpToCurrentStep = form.workflow.slice(
-    1, // exclude first step since notification is indicated by `stepOneEmailNotificationFieldId`
-    currentStepNumber + 1,
-  )
-
-  const validWorkflowStepsToNotify = (form.stepsToNotify ?? [])
-    .map((stepId) =>
-      stepsToNotifyUpToCurrentStep.find(
-        (step) => step._id.toString() === stepId,
-      ),
-    )
-    .filter(
-      (workflowStep) => workflowStep !== undefined,
-    ) as FormWorkflowStepDto[]
 
   return (
     // Step 1: Fetch email address from all workflow steps that are selected to notify
-    Result.combine(
-      validWorkflowStepsToNotify.map((workflowStep) =>
-        retrieveWorkflowStepEmailAddresses(form, workflowStep, responses),
-      ),
-    )
-      .mapErr((error) => {
-        logger.error({
-          message: 'Failed to retrieve workflow step email addresses',
-          meta: logMeta,
-          error,
-        })
-        return error
-      })
-      .map((workflowStepEmailsToNotifyList) => {
-        return flatten(workflowStepEmailsToNotifyList)
-      })
-      // Step 2: Combine static emails and workflow step emails that are selected to notify
-      .map((workflowStepEmailsToNotify) => {
-        return uniq([...workflowStepEmailsToNotify, ...emailsToNotify])
+    getEmailsToNotifyAboutMrfOutcome({
+      form,
+      responses,
+      currentStepNumber,
+      submissionId,
+    })
+      .asyncAndThen((destinationEmails) => {
+        return pdfResult
+          .orElse(() => okAsync(undefined))
+          .map((responsePdf) => {
+            return {
+              destinationEmails,
+              responsePdf,
+            }
+          })
       })
       // Step 3: Send outcome emails based on type
-      .asyncAndThen((destinationEmails) => {
+      .andThen(({ destinationEmails, responsePdf }) => {
         if (!destinationEmails || destinationEmails.length <= 0) {
           logger.info({
             message: 'No destination email found for MRF outcome email',
             meta: logMeta,
           })
-          return okAsync(true)
+          return okAsync(true as const)
         }
 
-        const lastStepNumber = form.workflow.length - 1
-        const isLastStep = currentStepNumber === lastStepNumber
-        const isWorkflowCompleted = isLastStep
+        const isWorkflowCompleted = checkIsWorkflowCompleted({
+          currentStepNumber,
+          form,
+          isRejected,
+        })
 
-        if (!isWorkflowCompleted && !isRejected) {
-          return okAsync(true)
+        if (!isWorkflowCompleted) {
+          return okAsync(true as const)
         }
 
-        const formQuestionAnswers = getQuestionTitleAnswerString({
+        const formQuestionAnswers = getQuestionAnswerPairsForMultipleFields({
           formFields: form.form_fields,
           responses,
         })
 
-        const emailAttachments = [...(attachments ?? [])]
+        const emailAttachments = []
+        emailAttachments.push(...(attachments ?? []))
+        if (responsePdf) {
+          emailAttachments.push(responsePdf)
+        }
 
         if (isApproval) {
           return MailService.sendMrfApprovalEmail({
@@ -440,6 +521,7 @@ const sendMrfOutcomeEmails = ({
             return errAsync(error)
           })
         }
+
         return MailService.sendMrfWorkflowCompletionEmail({
           emails: destinationEmails,
           formId: form._id,
@@ -468,7 +550,9 @@ const sendMrfRespondentCopyEmails = ({
   responses,
   submission,
   attachments,
-  respondentCopyRecipientData,
+  formFields,
+  currentStepActiveFields,
+  pdfResult,
 }: {
   form: Pick<
     IPopulatedMultirespondentForm | SnapshottedFormDef,
@@ -479,81 +563,73 @@ const sendMrfRespondentCopyEmails = ({
   responses: FieldResponsesV3
   submission: IMultirespondentSubmissionSchema
   attachments?: IAttachmentInfo[]
-  respondentCopyRecipientData: AutoReplyMailData[]
+  formFields: FormFieldSchema[] | FormFieldDto[]
+  currentStepActiveFields: string[]
+  pdfResult: ResultAsync<
+    Mail.Attachment | undefined,
+    AutoreplyPdfGenerationError
+  >
 }): ResultAsync<
   true,
   InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError
 > => {
-  const submissionId: string = submission.id
-  const formQuestionAnswers = getQuestionTitleAnswerString({
-    formFields: form.form_fields,
+  const respondentCopyEmailDatas = extractRespondentCopyEmailDatas({
     responses,
+    formFields,
+    currentStepActiveFields,
   })
-
-  // Prepare repsonses for pdf html
-  const pdfFormData = getPdfResponsesData({
-    formFields: form.form_fields,
-    responses,
-  })
-  const hasFormSummary = respondentCopyRecipientData.some(
-    (autoReplyMailData) => autoReplyMailData.includeFormSummary,
-  )
-
-  const autoReplyData: AutoReplyData = {
-    refNo: submissionId,
-    formTitle: form.title,
-    submissionDateTime: submission.created || new Date(),
-    responsesData: pdfFormData,
-    formUrl: `${config.app.appUrl}/${form._id}`,
+  // if no respondent copy email data, continue without sending any emails
+  if (!respondentCopyEmailDatas) {
+    return okAsync(true)
   }
 
-  // Step 1: generate PDF if needed
-  const pdfResult: ResultAsync<
-    Mail.Attachment | undefined,
-    AutoreplyPdfGenerationError
-  > = hasFormSummary
-    ? generateAutoreplyPdf(autoReplyData, true).map((pdfBuffer) => ({
-        filename: 'response.pdf',
-        content: Buffer.copyBytesFrom(pdfBuffer),
-      }))
-    : okAsync<Mail.Attachment | undefined>(undefined)
+  const submissionId: string = submission.id
 
-  return pdfResult.andThen((responsePdf) => {
-    const recipientAttachments = [
-      ...(attachments ?? []),
-      ...(responsePdf ? [responsePdf] : []),
-    ]
-    return ResultAsync.combine(
-      respondentCopyRecipientData.map((autoReplyMailData) => {
-        return MailService.sendMrfRespondentCopyEmail({
-          formId: form._id,
-          formTitle: form.title,
-          responseId: submissionId,
-          attachments: autoReplyMailData.includeFormSummary
-            ? recipientAttachments
-            : [],
-          autoReplyMailData,
-          agencyName: form.admin.agency.fullName,
-          ...(autoReplyMailData.includeFormSummary && { formQuestionAnswers }),
-        }).orElse((error) => {
-          logger.error({
-            message: 'Failed to send respondent copy email',
-            meta: {
-              action: 'sendMrfRespondentCopyEmail',
-              formId: form._id,
-              submissionId,
-              autoReplyMailData,
-            },
-            error,
-          })
-          return okAsync(true) //continue even if one email fails
-        })
-      }),
-    ).map(() => true) as ResultAsync<
-      true,
-      InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError
-    >
+  const formQuestionAnswers = getQuestionAnswerPairsForMultipleFields({
+    formFields: form.form_fields,
+    responses,
   })
+
+  return pdfResult
+    .orElse(() => okAsync(undefined))
+    .andThen((responsePdf) => {
+      const recipientAttachments = [
+        ...(attachments ?? []),
+        ...(responsePdf ? [responsePdf] : []),
+      ]
+      return ResultAsync.combine(
+        respondentCopyEmailDatas.map((autoReplyMailData) => {
+          return MailService.sendMrfRespondentCopyEmail({
+            formId: form._id,
+            formTitle: form.title,
+            responseId: submissionId,
+            attachments: autoReplyMailData.includeFormSummary
+              ? recipientAttachments
+              : [],
+            autoReplyMailData,
+            agencyName: form.admin.agency.fullName,
+            ...(autoReplyMailData.includeFormSummary && {
+              formQuestionAnswers,
+            }),
+          }).orElse((error) => {
+            logger.error({
+              message: 'Failed to send respondent copy email',
+              meta: {
+                action: 'sendMrfRespondentCopyEmail',
+                formId: form._id,
+                submissionId,
+                autoReplyMailData,
+              },
+              error,
+            })
+            return okAsync(true) //continue even if one email fails
+          })
+        }),
+      ).map(() => true) as ResultAsync<
+        true,
+        InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError
+      >
+    })
 }
 
 const saveAttachmentsToDbIfExists = ({
@@ -689,6 +765,172 @@ export const createMultiRespondentFormSubmission = ({
     })
 }
 
+interface CheckIfRespondentFormSummaryIsRequiredArgs {
+  responses: FieldResponsesV3
+  formFields: FormFieldSchema[] | FormFieldDto[]
+  currentStepActiveFields: string[]
+}
+
+const checkIfRespondentFormSummaryIsRequired = ({
+  responses,
+  formFields,
+  currentStepActiveFields,
+}: CheckIfRespondentFormSummaryIsRequiredArgs): boolean => {
+  const respondentCopyEmailDatas = extractRespondentCopyEmailDatas({
+    responses,
+    formFields,
+    currentStepActiveFields,
+  })
+  return (
+    respondentCopyEmailDatas &&
+    respondentCopyEmailDatas.some((emailData) => emailData.includeFormSummary)
+  )
+}
+
+interface CheckIsWorkflowCompletionEmailPdfRequiredArgs {
+  currentStepNumber: number
+  form: Pick<
+    IPopulatedMultirespondentForm,
+    | '_id'
+    | 'workflow'
+    | 'emails'
+    | 'stepsToNotify'
+    | 'stepOneEmailNotificationFieldId'
+  > & {
+    form_fields: FormFieldSchema[] | FormFieldDto[]
+  }
+  responses: FieldResponsesV3
+  isRejected: boolean
+  submissionId: string
+  growthbook?: GrowthBook
+}
+
+const checkIsWorkflowCompletionEmailPdfRequired = ({
+  currentStepNumber,
+  form,
+  responses,
+  isRejected,
+  submissionId,
+  growthbook,
+}: CheckIsWorkflowCompletionEmailPdfRequiredArgs) => {
+  const isGbFlagEnabled =
+    isAdminEmailPdfEnabled({
+      growthbook,
+      formFields: form.form_fields as FormFieldSchema[],
+    }) || isTest
+
+  if (!isGbFlagEnabled) {
+    return false
+  }
+  const isWorkflowCompleted = checkIsWorkflowCompleted({
+    currentStepNumber,
+    form,
+    isRejected,
+  })
+
+  const hasEmailsToSendMrfOutcomeNotification =
+    getEmailsToNotifyAboutMrfOutcome({
+      form,
+      responses,
+      currentStepNumber,
+      submissionId,
+    })
+
+  return (
+    isWorkflowCompleted &&
+    hasEmailsToSendMrfOutcomeNotification.isOk() &&
+    hasEmailsToSendMrfOutcomeNotification.value.length > 0
+  )
+}
+
+type CheckIsPdfGenerationRequiredArgs = Omit<
+  CheckIfRespondentFormSummaryIsRequiredArgs,
+  'formFields'
+> &
+  CheckIsWorkflowCompletionEmailPdfRequiredArgs
+
+const generatePdfAttachmentIfRequired = ({
+  submission,
+  form,
+  responses,
+  currentStepActiveFields,
+  currentStepNumber,
+  isRejected,
+  growthbook,
+}: CheckIsPdfGenerationRequiredArgs & {
+  submission: IMultirespondentSubmissionSchema
+  form: Pick<
+    IPopulatedMultirespondentForm,
+    | '_id'
+    | 'title'
+    | 'workflow'
+    | 'emails'
+    | 'stepsToNotify'
+    | 'stepOneEmailNotificationFieldId'
+  > & {
+    form_fields: FormFieldSchema[] | FormFieldDto[]
+  }
+}): ResultAsync<Mail.Attachment | undefined, AutoreplyPdfGenerationError> => {
+  const submissionId = submission.id
+
+  const isRespondentCopyPdfRequired = checkIfRespondentFormSummaryIsRequired({
+    responses,
+    formFields: form.form_fields,
+    currentStepActiveFields,
+  })
+  const isWorkflowCompletionEmailPdfRequired =
+    checkIsWorkflowCompletionEmailPdfRequired({
+      currentStepNumber,
+      form,
+      responses,
+      isRejected,
+      submissionId,
+      growthbook,
+    })
+
+  if (!isRespondentCopyPdfRequired && !isWorkflowCompletionEmailPdfRequired) {
+    return okAsync(undefined)
+  }
+
+  const responsesData = getResponsesDataFromMrfResponses({
+    formFields: form.form_fields,
+    responses,
+  })
+
+  const autoReplyData = {
+    refNo: submissionId,
+    formTitle: form.title,
+    submissionDateTime: submission.created ?? new Date(),
+    responsesData,
+    formUrl: `${config.app.appUrl}/${form._id}`,
+  }
+
+  const DEFAULT_RESPONSE_PDF_FILENAME = 'response.pdf'
+  const pdfResult = generateAutoreplyPdf(autoReplyData, true)
+    .map((pdfBuffer) => ({
+      filename: DEFAULT_RESPONSE_PDF_FILENAME,
+      content: Buffer.copyBytesFrom(pdfBuffer),
+    }))
+    .mapErr((error) => {
+      logger.error({
+        message:
+          'Failed to include required PDF attachment for email notifications',
+        meta: {
+          action: 'generatePdfAttachmentIfRequired',
+          submissionId,
+          formId: form._id,
+          formResponseMode: FormResponseMode.Multirespondent,
+          isRespondentCopyPdfRequired,
+          isWorkflowCompletionEmailPdfRequired,
+        },
+        error,
+      })
+      return error
+    })
+
+  return pdfResult
+}
+
 export const performMultiRespondentPostSubmissionCreateActions = ({
   submission,
   submissionId,
@@ -696,6 +938,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   encryptedPayload,
   logMeta,
   attachments,
+  growthbook,
 }: {
   submission: IMultirespondentSubmissionSchema
   submissionId: string
@@ -703,6 +946,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
   attachments?: IAttachmentInfo[]
+  growthbook?: GrowthBook
 }): ResultAsync<boolean, InvalidWorkflowTypeError | MailSendError> => {
   const { submissionSecretKey, responses } = encryptedPayload
   const currentStepNumber = 0
@@ -715,33 +959,53 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
     submissionId,
   }
 
-  // Find active fields for current step
-  const activeFields = form.workflow[currentStepNumber]
-    ? form.workflow[currentStepNumber].edit
-    : []
-
-  // Find respondent copy recipient data
-  const respondentCopyRecipientData = extractRespondentCopyEmails({
-    responses: encryptedPayload.responses,
-    formFields: form.form_fields,
-    activeFields,
+  const pdfResult = generatePdfAttachmentIfRequired({
+    submission,
+    form,
+    responses,
+    currentStepActiveFields: form.workflow[currentStepNumber]?.edit ?? [],
+    currentStepNumber,
+    isRejected: false, // first step cannot be an approval step and thus cannot be rejected.
+    submissionId,
+    growthbook,
   })
 
-  if (respondentCopyRecipientData && respondentCopyRecipientData.length > 0) {
-    sendMrfRespondentCopyEmails({
+  const sendMrfRespondentCopyEmailsPdfResult =
+    checkIfRespondentFormSummaryIsRequired({
+      responses,
+      formFields: form.form_fields,
+      currentStepActiveFields: form.workflow[currentStepNumber]?.edit ?? [],
+    })
+      ? pdfResult
+      : okAsync(undefined)
+
+  const sendMrfOutcomeEmailsPdfResult =
+    checkIsWorkflowCompletionEmailPdfRequired({
+      currentStepNumber,
       form,
       responses,
-      submission,
-      attachments,
-      respondentCopyRecipientData,
-    }).mapErr((error) => {
-      logger.error({
-        message: 'Send multirespondent respondent copy email error',
-        meta: logMeta,
-        error,
-      }) // return nothing; since successful submission does not depend on respondent copy emails being sent
+      isRejected: false,
+      submissionId,
+      growthbook,
     })
-  }
+      ? pdfResult
+      : okAsync(undefined)
+
+  sendMrfRespondentCopyEmails({
+    form,
+    responses,
+    submission,
+    attachments,
+    formFields: form.form_fields,
+    currentStepActiveFields: form.workflow[currentStepNumber]?.edit ?? [],
+    pdfResult: sendMrfRespondentCopyEmailsPdfResult,
+  }).mapErr((error) => {
+    logger.error({
+      message: 'Send multirespondent respondent copy email error',
+      meta: logMeta,
+      error,
+    })
+  })
 
   const webhookUrl = form.webhook?.url
   if (webhookUrl) {
@@ -793,6 +1057,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
         responses,
         submissionId,
         attachments,
+        pdfResult: sendMrfOutcomeEmailsPdfResult,
       })
     })
     .mapErr((error) => {
@@ -960,6 +1225,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   encryptedPayload,
   logMeta,
   attachments,
+  growthbook,
 }: {
   submission: IMultirespondentSubmissionSchema
   submissionId: string
@@ -968,6 +1234,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
   attachments?: IAttachmentInfo[]
+  growthbook?: GrowthBook
 }): ResultAsync<
   boolean,
   | InvalidWorkflowTypeError
@@ -983,29 +1250,6 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     currentWorkflowStep: currentStepNumber,
     formId: snapshottedFormDef._id,
     submissionId,
-  }
-
-  // Find respondent copy recipient data
-  const respondentCopyRecipientData = extractRespondentCopyEmails({
-    responses: responses,
-    formFields: snapshottedFormDef.form_fields,
-    activeFields: snapshottedFormDef.workflow[currentStepNumber].edit,
-  })
-
-  if (respondentCopyRecipientData && respondentCopyRecipientData.length > 0) {
-    sendMrfRespondentCopyEmails({
-      form: snapshottedFormDef,
-      responses,
-      submission,
-      attachments,
-      respondentCopyRecipientData,
-    }).mapErr((error) => {
-      logger.error({
-        message: 'Send multirespondent respondent copy email error',
-        meta: logMeta,
-        error,
-      }) // return nothing; since successful submission does not depend on this respondent copy emails sent
-    })
   }
 
   const isStepRejectedResult = checkIsStepRejected({
@@ -1054,6 +1298,57 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
       })
   }
 
+  const pdfResult = generatePdfAttachmentIfRequired({
+    submission,
+    form: snapshottedFormDef,
+    responses,
+    currentStepNumber,
+    isRejected: isStepRejected,
+    submissionId,
+    currentStepActiveFields:
+      snapshottedFormDef.workflow[currentStepNumber]?.edit ?? [],
+    growthbook,
+  })
+
+  const sendMrfRespondentCopyEmailsPdfResult =
+    checkIfRespondentFormSummaryIsRequired({
+      responses,
+      formFields: snapshottedFormDef.form_fields,
+      currentStepActiveFields:
+        snapshottedFormDef.workflow[currentStepNumber]?.edit ?? [],
+    })
+      ? pdfResult
+      : okAsync(undefined)
+
+  const sendMrfOutcomeEmailsPdfResult =
+    checkIsWorkflowCompletionEmailPdfRequired({
+      currentStepNumber,
+      form: snapshottedFormDef,
+      responses,
+      isRejected: isStepRejected,
+      submissionId,
+      growthbook,
+    })
+      ? pdfResult
+      : okAsync(undefined)
+
+  sendMrfRespondentCopyEmails({
+    form: snapshottedFormDef,
+    responses,
+    submission,
+    attachments,
+    formFields: snapshottedFormDef.form_fields,
+    currentStepActiveFields:
+      snapshottedFormDef.workflow[currentStepNumber]?.edit ?? [],
+    pdfResult: sendMrfRespondentCopyEmailsPdfResult,
+  }).mapErr((error) => {
+    logger.error({
+      message: 'Send multirespondent respondent copy email error',
+      meta: logMeta,
+      error,
+    })
+  })
+
   if (isStepRejected) {
     return sendMrfOutcomeEmails({
       currentStepNumber,
@@ -1063,6 +1358,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
       isApproval: true,
       isRejected: true,
       attachments: attachments,
+      pdfResult: sendMrfOutcomeEmailsPdfResult,
     }).mapErr((error) => {
       logger.error({
         message: 'Send mrf outcome email error',
@@ -1079,6 +1375,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     submissionId,
     isApproval: checkIsFormApproval(snapshottedFormDef),
     attachments: attachments,
+    pdfResult: sendMrfOutcomeEmailsPdfResult,
   })
     .mapErr((error) => {
       logger.error({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import { err, ok, Result } from 'neverthrow'
 
-import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from '../../../../../shared/constants/form'
+import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from '../../../../../shared/constants'
 import {
   BasicField,
   FieldResponsesV3,
@@ -28,7 +28,6 @@ import { AutoReplyMailData } from '../../../services/mail/mail.types'
 import { convertToSignaturePngDataUri } from '../../../utils/convert-vector-array-to-png'
 import { validateFieldV3 } from '../../../utils/field-validation'
 import { FieldIdSet } from '../../../utils/logic-adaptor'
-import { QuestionAnswer } from '../../../views/templates/MrfWorkflowCompletionEmail'
 import { startsWithSPCPFieldTitle } from '../../spcp/spcp.util'
 import {
   InvalidWorkflowTypeError,
@@ -228,25 +227,87 @@ export const validateMrfFieldResponses = ({
 }
 
 /**
- * Extracts question-answer pairs from a form field and a response.
+ * Extracts email data to be sent respondent copies to from a multirespondent submission.
+ * @param responses - The multirespondent submission's field responses.
+ * @param formFields - The schema of the form fields present in the form.
+ * @param currentStepActiveFields - The active field Ids assigned in the current step.
+ * @returns AutoReplyMailData[] - list of email data to be sent respondent copies to.
+ */
+export const extractRespondentCopyEmailDatas = ({
+  responses,
+  formFields,
+  currentStepActiveFields,
+}: {
+  responses: FieldResponsesV3
+  formFields: FormFieldSchema[] | FormFieldDto[]
+  currentStepActiveFields: string[]
+}): AutoReplyMailData[] => {
+  return currentStepActiveFields.flatMap((fieldId) => {
+    const fieldIdString = fieldId.toString()
+    const field = formFields.find((f) => f._id.toString() === fieldIdString)
+    const response = responses[fieldIdString]
+
+    if (
+      // checks if field is an email field
+      field &&
+      field.fieldType === BasicField.Email &&
+      field.autoReplyOptions?.hasAutoReply &&
+      response &&
+      // checks if response has an answer (email)
+      typeof response.answer === 'object' &&
+      'value' in response.answer &&
+      typeof response.answer.value === 'string'
+    ) {
+      const {
+        autoReplyMessage,
+        autoReplySubject,
+        autoReplySender,
+        includeFormSummary,
+      } = field.autoReplyOptions
+      return [
+        {
+          email: response.answer.value,
+          subject: autoReplySubject,
+          sender: autoReplySender,
+          body: autoReplyMessage,
+          includeFormSummary,
+        },
+      ]
+    }
+    return [] // no respondent copy emails found
+  })
+}
+
+export type QuestionAnswerPair = {
+  question: string
+  answer: string
+  signatureDataPngDataUri?: string
+  fieldType: BasicField
+}
+
+/**
+ * Given a single form field and its response, extracts question-answer pairs.
  * Used for email body/pdf outputs and individualResponsePage displays
  * Returns an array since some fields (e.g. table, children) will have
- * multiple questionAnswerPairs per response
- * @param formField - form field schema
- * @param response - response of the form field
- * @returns An array of QuestionAnswer objects
+ * multiple question-answer pairs per response
+ * @param formField - Single form field schema. Does not include Ndi responses, @see getQuestionAnswerPairsForMultipleFields on how to include ndi responses.
+ * @param response - Response for the given form field
+ * @returns An array of QuestionAnswer objects representing the extracted question-answer pairs for the given form field.
  */
-export const getQuestionTitleAnswerStringSingleField = ({
+const getQuestionAnswerPairsForOneField = ({
   formField,
   response,
+  includeSignatureDataPngDataUri,
 }: {
   formField: FormFieldSchema | FormFieldDto
   response: FieldResponseV3
-}): QuestionAnswer[] => {
+  includeSignatureDataPngDataUri: boolean
+}): QuestionAnswerPair[] => {
   let questionTitle = formField.title
   let answer = ''
   let answerArray: string[] = []
-  const questionAnswerPair: QuestionAnswer[] = []
+  const questionAnswerPairs: QuestionAnswerPair[] = []
+
   switch (response.fieldType) {
     case BasicField.Attachment:
       questionTitle = `[Attachment] ${questionTitle}`
@@ -308,12 +369,13 @@ export const getQuestionTitleAnswerStringSingleField = ({
         const question = `[Table] ${formField.title} (${delimitedColumnTitles})`
         const answer = delimitedColumnAnswers
 
-        questionAnswerPair.push({
+        questionAnswerPairs.push({
           question,
           answer,
+          fieldType: response.fieldType,
         })
       }
-      return questionAnswerPair
+      return questionAnswerPairs
     case BasicField.Radio:
       answer =
         'value' in response.answer
@@ -332,71 +394,85 @@ export const getQuestionTitleAnswerStringSingleField = ({
 
       answer = selectedAnswers.toString()
       break
-    case BasicField.Signature:
-      questionTitle = `[signature] ${questionTitle}`
-      answer = SIGNATURE_CAPTURED_STRING
-      break
+    case BasicField.Signature: {
+      const signatureQuestionAnswer = {
+        question: `[signature] ${questionTitle}`,
+        answer: SIGNATURE_CAPTURED_STRING,
+        signatureDataPngDataUri: includeSignatureDataPngDataUri
+          ? convertToSignaturePngDataUri(response.answer.value)
+          : undefined,
+        fieldType: response.fieldType,
+      }
+      return [signatureQuestionAnswer]
+    }
     case BasicField.Children:
       if (!response.answer.childFields || !response.answer.child) {
         break
       }
       for (const [index, child] of response.answer.child.entries()) {
-        questionAnswerPair.push({
+        questionAnswerPairs.push({
           question: `Child ${index + 1}: ${response.answer.childFields.toString()}`,
           answer: child
             ? child.toString()
             : response.answer.childFields.map(() => '').toString(),
+          fieldType: response.fieldType,
         })
       }
-      return questionAnswerPair
+      return questionAnswerPairs
     default:
       answer = response.answer
   }
 
-  questionAnswerPair.push({
+  questionAnswerPairs.push({
     question: questionTitle,
     answer,
+    fieldType: response.fieldType,
   })
-  return questionAnswerPair
+  return questionAnswerPairs
 }
 
-/*
- * Extracts question-answer pairs from form fields and responses.
- * @param formFields - The form fields schema
- * @param responses - The responses to the form fields
- * @returns An array of QuestionAnswer objects
+/**
+ * Given multiple form fields and their responses, extracts question-answer pairs.
+ * @param formFields - List of form fields schemas
+ * @param responses - Corresponding list of responses to the given form fields
+ * @returns An array of QuestionAnswer pairs representing the extracted question-answer pairs for the all the given form fields.
  */
-export const getQuestionTitleAnswerString = ({
+export const getQuestionAnswerPairsForMultipleFields = ({
   formFields,
   responses,
+  includeSignatureDataPngDataUri = false,
 }: {
   formFields: FormFieldSchema[] | FormFieldDto[]
   responses: FieldResponsesV3
-}): QuestionAnswer[] => {
-  let questionAnswerPairs: QuestionAnswer[] = []
+  includeSignatureDataPngDataUri?: boolean
+}): QuestionAnswerPair[] => {
+  const questionAnswerPairs: QuestionAnswerPair[] = []
   if (!formFields || !responses) {
     return []
   }
-  for (const formField of formFields) {
-    const questionTitle = formField.title
-    const response = responses[formField._id]
+  for (const currentFormField of formFields) {
+    const questionTitle = currentFormField.title
+    const response = responses[currentFormField._id]
 
     if (!response || !questionTitle) continue
-    const questionAnswerPair = getQuestionTitleAnswerStringSingleField({
-      formField,
-      response,
-    })
+    const questionAnswerPairsForCurrentFormField =
+      getQuestionAnswerPairsForOneField({
+        formField: currentFormField,
+        response,
+        includeSignatureDataPngDataUri,
+      })
 
-    questionAnswerPairs = [...questionAnswerPairs, ...questionAnswerPair]
+    questionAnswerPairs.push(...questionAnswerPairsForCurrentFormField)
   }
 
   // Add Ndi responses if they exist
   for (const key in responses) {
     if (startsWithSPCPFieldTitle(key)) {
-      const value = responses[key] as NdiResponseV3
+      const { answer, fieldType } = responses[key] as NdiResponseV3
       questionAnswerPairs.push({
         question: key,
-        answer: value.answer,
+        answer,
+        fieldType,
       })
     }
   }
@@ -409,97 +485,27 @@ export const getQuestionTitleAnswerString = ({
  * @param responses - The mrf responses to the form fields
  * @returns list of EmailRespondentConfirmationField used for email & pdf generation
  */
-export const getPdfResponsesData = ({
+export const getResponsesDataFromMrfResponses = ({
   formFields,
   responses,
 }: {
   formFields: FormFieldSchema[] | FormFieldDto[]
   responses: FieldResponsesV3
 }): EmailRespondentConfirmationField[] => {
-  let pdfResponseData: EmailRespondentConfirmationField[] = []
   if (!formFields || !responses) return []
 
-  for (const formField of formFields) {
-    const questionTitle = formField.title
-    const response = responses[formField._id]
+  const questionAnswerPairs = getQuestionAnswerPairsForMultipleFields({
+    formFields,
+    responses,
+    includeSignatureDataPngDataUri: true,
+  })
 
-    if (!response || !questionTitle) continue
-    const emailFieldForPdf: EmailRespondentConfirmationField[] =
-      getQuestionTitleAnswerStringSingleField({
-        formField,
-        response,
-      }).map((questionAnswerPair) => {
-        return {
-          question: questionAnswerPair.question,
-          fieldType: response.fieldType,
-          answerTemplate: [questionAnswerPair.answer],
-          ...(response.fieldType === BasicField.Signature && {
-            answer: convertToSignaturePngDataUri(response.answer.value),
-          }),
-        }
-      })
-
-    pdfResponseData = [...pdfResponseData, ...emailFieldForPdf]
-  }
-
-  // Add Ndi responses if they exist
-  for (const key in responses) {
-    if (startsWithSPCPFieldTitle(key)) {
-      const value = responses[key] as NdiResponseV3
-      pdfResponseData.push({
-        question: key,
-        answerTemplate: [value.answer],
-        fieldType: value.fieldType,
-      })
+  return questionAnswerPairs.map((questionAnswerPair) => {
+    return {
+      question: questionAnswerPair.question,
+      answerTemplate: [questionAnswerPair.answer],
+      answer: questionAnswerPair.signatureDataPngDataUri,
+      fieldType: questionAnswerPair.fieldType,
     }
-  }
-  return pdfResponseData
-}
-
-/**
- * Extracts email data to be sent respondent copies to from a multirespondent submission.
- * Email inputs from email confirmation-enabled email fields that are assigned in the current step are extracted
- * @param responses - The multirespondent submission's field responses
- * @param formFields - The form fields schema
- * @param activeFields - The active field Ids assigned in the current step
- * @returns AutoReplyMailData[] - list of email data to be sent respondent copies to
- */
-export const extractRespondentCopyEmails = ({
-  responses,
-  formFields,
-  activeFields,
-}: {
-  responses: FieldResponsesV3
-  formFields: FormFieldSchema[] | FormFieldDto[]
-  activeFields: string[]
-}): AutoReplyMailData[] => {
-  return activeFields.flatMap((fieldId) => {
-    const fieldIdString = fieldId.toString()
-    const field = formFields.find((f) => f._id.toString() === fieldIdString)
-    const response = responses[fieldIdString]
-
-    if (
-      // checks if field is an email field
-      field &&
-      field.fieldType === BasicField.Email &&
-      field.autoReplyOptions?.hasAutoReply &&
-      response &&
-      // checks if response has an answer (email)
-      typeof response.answer === 'object' &&
-      'value' in response.answer &&
-      typeof response.answer.value === 'string'
-    ) {
-      const options = field.autoReplyOptions
-      return [
-        {
-          email: response.answer.value,
-          subject: options.autoReplySubject,
-          sender: options.autoReplySender,
-          body: options.autoReplyMessage,
-          includeFormSummary: options.includeFormSummary,
-        },
-      ]
-    }
-    return [] // no respondent copy emails found
   })
 }

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -450,17 +450,19 @@ export const uploadAttachments = (
 export const sendEmailConfirmations = <S extends ISubmissionSchema>({
   form,
   submission,
-  responsesData = [],
-  attachments,
+  responsesData,
+  submissionAttachments,
   recipientData,
-  isUseLambdaOutput,
+  pdfAttachment,
+  isPaymentEnabled,
 }: {
   form: IPopulatedForm
   submission: S
-  responsesData?: EmailRespondentConfirmationField[]
-  attachments?: Mail.Attachment[]
+  responsesData: EmailRespondentConfirmationField[]
+  submissionAttachments?: Mail.Attachment[]
   recipientData: AutoReplyMailData[]
-  isUseLambdaOutput: boolean
+  pdfAttachment?: Mail.Attachment
+  isPaymentEnabled: boolean
 }): ResultAsync<true, SendEmailConfirmationError> => {
   const logMeta = {
     action: 'sendEmailConfirmations',
@@ -473,10 +475,11 @@ export const sendEmailConfirmations = <S extends ISubmissionSchema>({
   const sentEmailsPromise = MailService.sendAutoReplyEmails({
     form,
     submission,
-    attachments,
+    submissionAttachments,
     responsesData,
     autoReplyMailDatas: recipientData,
-    isUseLambdaOutput,
+    pdfAttachment,
+    isPaymentEnabled,
   })
   return ResultAsync.fromPromise(sentEmailsPromise, (error) => {
     logger.error({

--- a/src/app/modules/submission/submission.utils.ts
+++ b/src/app/modules/submission/submission.utils.ts
@@ -1,3 +1,4 @@
+import { GrowthBook } from '@growthbook/growthbook'
 import { encode as encodeBase64 } from '@stablelib/base64'
 import crypto from 'crypto'
 import StatusCodes from 'http-status-codes'
@@ -14,7 +15,11 @@ import {
 import mongoose from 'mongoose'
 import { err, ok, Result } from 'neverthrow'
 
-import { MULTIRESPONDENT_FORM_SUBMISSION_VERSION } from '../../../../shared/constants'
+import {
+  AdminEmailPdfFeatureValue,
+  featureFlags,
+  MULTIRESPONDENT_FORM_SUBMISSION_VERSION,
+} from '../../../../shared/constants'
 import { FIELDS_TO_REJECT } from '../../../../shared/constants/field/basic'
 import { MYINFO_ATTRIBUTE_MAP } from '../../../../shared/constants/field/myinfo'
 import {
@@ -940,4 +945,27 @@ export const buildMrfMetadata = ({
     lastSubmittedAt,
     hasNextStepRecipientEmails,
   }
+}
+
+export const isAdminEmailPdfEnabled = ({
+  growthbook,
+  formFields,
+}: {
+  growthbook?: GrowthBook
+  formFields: FormFieldSchema[]
+}) => {
+  if (!growthbook) {
+    return false
+  }
+  const adminEmailPdfFeatureValue = growthbook.getFeatureValue(
+    featureFlags.adminEmailPdf,
+    AdminEmailPdfFeatureValue.OFF,
+  )
+  if (adminEmailPdfFeatureValue === AdminEmailPdfFeatureValue.ON) {
+    return true
+  }
+  if (adminEmailPdfFeatureValue === AdminEmailPdfFeatureValue.SIGNATURES_ONLY) {
+    return formFields.some((field) => field.fieldType === BasicField.Signature)
+  }
+  return false
 }

--- a/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -2,7 +2,6 @@ import { cloneDeep } from 'lodash'
 import moment from 'moment-timezone'
 import { err, ok, okAsync } from 'neverthrow'
 import Mail, { Attachment } from 'nodemailer/lib/mailer'
-import { FormResponseMode, PaymentChannel } from 'shared/types'
 
 import { MailSendError } from 'src/app/services/mail/mail.errors'
 import { MailService } from 'src/app/services/mail/mail.service'
@@ -13,12 +12,7 @@ import {
   SendAutoReplyEmailsArgs,
 } from 'src/app/services/mail/mail.types'
 import * as MailUtils from 'src/app/services/mail/mail.utils'
-import {
-  BounceType,
-  IPopulatedEncryptedForm,
-  IPopulatedForm,
-  ISubmissionSchema,
-} from 'src/types'
+import { BounceType, IPopulatedForm, ISubmissionSchema } from 'src/types'
 
 const MOCK_VALID_EMAIL = 'to@example.com'
 const MOCK_VALID_EMAIL_2 = 'to2@example.com'
@@ -365,6 +359,12 @@ describe('mail.service', () => {
     })
   })
 
+  const MOCK_PDF_ATTACHMENT = {
+    filename: 'test.pdf',
+    content: Buffer.from('this is a test file'),
+    fieldId: 'test-field-id',
+  }
+
   describe('sendSubmissionToAdmin', () => {
     let expectedHtml: string
 
@@ -379,13 +379,8 @@ describe('mail.service', () => {
         id: 'mockSubmissionId',
         created: new Date(),
       },
-      attachments: [
-        {
-          filename: 'test.pdf',
-          content: Buffer.from('this is a test file'),
-          fieldId: 'test-field-id',
-        },
-      ],
+      submissionAttachments: [],
+      pdfAttachment: MOCK_PDF_ATTACHMENT,
       dataCollationData: [
         {
           question: 'some question',
@@ -420,7 +415,12 @@ describe('mail.service', () => {
         from: MOCK_SENDER_STRING,
         subject: `formsg-auto: ${MOCK_VALID_SUBMISSION_PARAMS.form.title} (#${MOCK_VALID_SUBMISSION_PARAMS.submission.id})`,
         html: expectedHtml,
-        attachments: MOCK_VALID_SUBMISSION_PARAMS.attachments,
+        attachments: [
+          ...MOCK_VALID_SUBMISSION_PARAMS.submissionAttachments,
+          ...(MOCK_VALID_SUBMISSION_PARAMS.pdfAttachment
+            ? [MOCK_VALID_SUBMISSION_PARAMS.pdfAttachment]
+            : []),
+        ],
         headers: {
           // Hardcode in tests in case something changes this.
           'X-Formsg-Email-Type': 'Admin (response)',
@@ -443,6 +443,50 @@ describe('mail.service', () => {
       expectedHtml = (
         await MailUtils.generateSubmissionToAdminHtml(htmlData)
       )._unsafeUnwrap()
+    })
+
+    it('should include submission attachments and pdf if it is provided', async () => {
+      const mockValidSubmissionParamsWithPdf = cloneDeep(
+        MOCK_VALID_SUBMISSION_PARAMS,
+      )
+      mockValidSubmissionParamsWithPdf.pdfAttachment =
+        cloneDeep(MOCK_PDF_ATTACHMENT)
+
+      const submissionAttachmentsAndPdf = [
+        ...MOCK_VALID_SUBMISSION_PARAMS.submissionAttachments,
+        MOCK_PDF_ATTACHMENT,
+      ]
+      // Act
+      await mailService.sendSubmissionToAdmin(mockValidSubmissionParamsWithPdf)
+
+      // Assert
+      expect(sendMailSpy).toHaveBeenCalledOnce()
+      expect(sendMailSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: submissionAttachmentsAndPdf,
+        }),
+      )
+    })
+
+    it('should include submission attachments but not include pdf attachment if it is not provided', async () => {
+      const mockValidSubmissionParamsWithPdf = {
+        ...cloneDeep(MOCK_VALID_SUBMISSION_PARAMS),
+        pdfAttachment: undefined,
+      }
+
+      const submissionAttachmentsWithoutPdf = [
+        ...MOCK_VALID_SUBMISSION_PARAMS.submissionAttachments,
+      ]
+      // Act
+      await mailService.sendSubmissionToAdmin(mockValidSubmissionParamsWithPdf)
+
+      // Assert
+      expect(sendMailSpy).toHaveBeenCalledOnce()
+      expect(sendMailSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: submissionAttachmentsWithoutPdf,
+        }),
+      )
     })
 
     it('should send submission mail to admin successfully if form.emails is an array with a single string', async () => {
@@ -699,6 +743,7 @@ describe('mail.service', () => {
 
     const MOCK_SENDER_NAME = 'John Doe'
     const MOCK_AUTOREPLY_PARAMS: SendAutoReplyEmailsArgs = {
+      isPaymentEnabled: false,
       form: {
         title: 'Test form title',
         _id: 'mockFormId',
@@ -718,13 +763,16 @@ describe('mail.service', () => {
           answerTemplate: ['some answer template'],
         },
       ],
-      attachments: ['something'] as Attachment[],
+      submissionAttachments: ['something'] as Attachment[],
       autoReplyMailDatas: [
         {
           email: MOCK_VALID_EMAIL_2,
         },
       ],
-      isUseLambdaOutput: false,
+    }
+    const MOCK_AUTOREPLY_PARAMS_PAYMENT_ENABLED: SendAutoReplyEmailsArgs = {
+      ...MOCK_AUTOREPLY_PARAMS,
+      isPaymentEnabled: true,
     }
     const DEFAULT_AUTO_REPLY_BODY =
       `To whom it may concern,\n\nThank you for submitting this form.\n\nRegards,\n${MOCK_AUTOREPLY_PARAMS.form.admin.agency.fullName}`.split(
@@ -896,7 +944,13 @@ describe('mail.service', () => {
       // Arrange
       sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
 
+      const MOCK_PDF_ATTACHMENT = {
+        content: MOCK_PDF,
+        filename: 'response.pdf',
+      }
+
       const customDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
+      customDataParams.pdfAttachment = MOCK_PDF_ATTACHMENT
       customDataParams.autoReplyMailDatas[0].includeFormSummary = true
 
       const expectedRenderData: AutoreplySummaryRenderData = {
@@ -921,11 +975,8 @@ describe('mail.service', () => {
         html: expectedMailBody,
         // Attachments should be concatted with mock pdf response
         attachments: [
-          ...(MOCK_AUTOREPLY_PARAMS.attachments ?? []),
-          {
-            content: MOCK_PDF,
-            filename: 'response.pdf',
-          },
+          ...(MOCK_AUTOREPLY_PARAMS.submissionAttachments ?? []),
+          MOCK_PDF_ATTACHMENT,
         ],
       }
       const expectedResponse = await Promise.allSettled([ok(true)])
@@ -941,23 +992,18 @@ describe('mail.service', () => {
       expect(sendMailSpy).toHaveBeenCalledWith(expectedArg)
     })
 
-    it('should send single autoreply mail with PDF if autoReply.includeFormSummary == true and no active payment field', async () => {
+    it('should send single autoreply mail with PDF if autoReply.includeFormSummary == true, pdfAttachment is provided and no active payment field', async () => {
       // Arrange
       sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
 
+      const MOCK_PDF_ATTACHMENT = {
+        content: MOCK_PDF,
+        filename: 'response.pdf',
+      }
+
       const customDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
+      customDataParams.pdfAttachment = MOCK_PDF_ATTACHMENT
       customDataParams.autoReplyMailDatas[0].includeFormSummary = true
-      const formDef = {
-        ...customDataParams.form,
-        responseMode: FormResponseMode.Encrypt,
-        payments_channel: {
-          channel: PaymentChannel.Stripe,
-        },
-        payments_field: {
-          enabled: false,
-        },
-      } as IPopulatedEncryptedForm as IPopulatedForm
-      customDataParams.form = formDef
 
       const expectedRenderData: AutoreplySummaryRenderData = {
         formData: MOCK_AUTOREPLY_PARAMS.responsesData,
@@ -981,11 +1027,8 @@ describe('mail.service', () => {
         html: expectedMailBody,
         // Attachments should be concatted with mock pdf response
         attachments: [
-          ...(MOCK_AUTOREPLY_PARAMS.attachments ?? []),
-          {
-            content: MOCK_PDF,
-            filename: 'response.pdf',
-          },
+          ...(MOCK_AUTOREPLY_PARAMS.submissionAttachments ?? []),
+          MOCK_PDF_ATTACHMENT,
         ],
       }
       const expectedResponse = await Promise.allSettled([ok(true)])
@@ -1001,27 +1044,22 @@ describe('mail.service', () => {
       expect(sendMailSpy).toHaveBeenCalledWith(expectedArg)
     })
 
-    it('should send single autoreply mail without PDF if autoReply.includeFormSummary == true and has active payment field', async () => {
+    it('should send single autoreply mail without PDF if autoReply.includeFormSummary == true and has active payment field, even if PDF attachment is generated', async () => {
       // Arrange
       sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
 
-      const customDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS)
+      const MOCK_PDF_ATTACHMENT = {
+        content: MOCK_PDF,
+        filename: 'response.pdf',
+      }
+
+      const customDataParams = cloneDeep(MOCK_AUTOREPLY_PARAMS_PAYMENT_ENABLED)
+      customDataParams.pdfAttachment = MOCK_PDF_ATTACHMENT
       customDataParams.autoReplyMailDatas[0].includeFormSummary = true
-      const formDef = {
-        ...customDataParams.form,
-        responseMode: FormResponseMode.Encrypt,
-        payments_channel: {
-          channel: PaymentChannel.Stripe,
-        },
-        payments_field: {
-          enabled: true,
-        },
-      } as IPopulatedEncryptedForm as IPopulatedForm
-      customDataParams.form = formDef
 
       const expectedMailBody = (
         await MailUtils.generateAutoreplyHtml({
-          submissionId: MOCK_AUTOREPLY_PARAMS.submission.id,
+          submissionId: MOCK_AUTOREPLY_PARAMS_PAYMENT_ENABLED.submission.id,
           autoReplyBody: DEFAULT_AUTO_REPLY_BODY,
         })
       )._unsafeUnwrap()
@@ -1030,7 +1068,10 @@ describe('mail.service', () => {
         ...defaultExpectedArg,
         html: expectedMailBody,
         // Attachments should not be concatted with mock pdf response
-        attachments: [...(MOCK_AUTOREPLY_PARAMS.attachments ?? [])],
+        attachments: [
+          ...(MOCK_AUTOREPLY_PARAMS_PAYMENT_ENABLED.submissionAttachments ??
+            []),
+        ],
       }
       const expectedResponse = await Promise.allSettled([ok(true)])
 
@@ -1151,6 +1192,144 @@ describe('mail.service', () => {
       // is non-4xx error.
       expect(sendMailSpy).toHaveBeenCalledTimes(2)
       expect(sendMailSpy).toHaveBeenCalledWith(expectedArg)
+    })
+
+    it('should include pdf attachment for mailData if includeFormSummary is true, isPaymentEnabled is false and pdfAttachment is provided', async () => {
+      // Arrange
+      const pdfAttachment = {
+        filename: 'test.pdf',
+        content: Buffer.from('pdfcontent'),
+      }
+      const customDataParams = {
+        ...cloneDeep(MOCK_AUTOREPLY_PARAMS),
+        isPaymentEnabled: false,
+        pdfAttachment,
+      }
+
+      customDataParams.autoReplyMailDatas = [
+        {
+          email: MOCK_VALID_EMAIL,
+          includeFormSummary: true,
+        },
+      ]
+
+      const submissionAttachments = customDataParams.submissionAttachments ?? []
+      const expectedSubmissionAttachmentsAndPdf = [
+        ...submissionAttachments,
+        pdfAttachment,
+      ]
+
+      sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
+
+      // Act
+      const result = await mailService.sendAutoReplyEmails(customDataParams)
+
+      // Assert
+      expect(result[0].status).toBe('fulfilled')
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      expect(sendMailSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expectedSubmissionAttachmentsAndPdf,
+        }),
+      )
+    })
+
+    it('should still send mail when pdf should be included but is not provided', async () => {
+      // Arrange
+      const customDataParams = {
+        ...cloneDeep(MOCK_AUTOREPLY_PARAMS),
+        isPaymentEnabled: false,
+        pdfAttachment: undefined,
+      }
+
+      customDataParams.autoReplyMailDatas = [
+        {
+          email: MOCK_VALID_EMAIL,
+          includeFormSummary: true,
+        },
+      ]
+
+      const expectedSubmissionAttachmentsWithoutPdf =
+        customDataParams.submissionAttachments ?? []
+
+      sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
+
+      // Act
+      const result = await mailService.sendAutoReplyEmails(customDataParams)
+
+      // Assert
+      expect(result[0].status).toBe('fulfilled')
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      expect(sendMailSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expectedSubmissionAttachmentsWithoutPdf,
+        }),
+      )
+    })
+
+    it('should not include any attachment for mailData if includeFormSummary is false', async () => {
+      // Arrange
+      const customDataParams = {
+        ...cloneDeep(MOCK_AUTOREPLY_PARAMS),
+        isPaymentEnabled: false,
+        pdfAttachment: undefined,
+      }
+
+      customDataParams.autoReplyMailDatas = [
+        {
+          email: MOCK_VALID_EMAIL,
+          includeFormSummary: false,
+        },
+      ]
+
+      const expectedNoAttachments: [] = []
+
+      sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
+
+      // Act
+      const result = await mailService.sendAutoReplyEmails(customDataParams)
+
+      // Assert
+      expect(result[0].status).toBe('fulfilled')
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      expect(sendMailSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expectedNoAttachments,
+        }),
+      )
+    })
+
+    it('should not include pdf attachment for mailData if isPaymentEnabled is true', async () => {
+      // Arrange
+      const customDataParams = {
+        ...cloneDeep(MOCK_AUTOREPLY_PARAMS),
+        isPaymentEnabled: true,
+        pdfAttachment: undefined,
+      }
+
+      customDataParams.autoReplyMailDatas = [
+        {
+          email: MOCK_VALID_EMAIL,
+          includeFormSummary: true,
+        },
+      ]
+
+      const expectedSubmissionAttachmentsWithoutPdf =
+        customDataParams.submissionAttachments ?? []
+
+      sendMailSpy.mockResolvedValueOnce('mockedSuccessResponse')
+
+      // Act
+      const result = await mailService.sendAutoReplyEmails(customDataParams)
+
+      // Assert
+      expect(result[0].status).toBe('fulfilled')
+      expect(sendMailSpy).toHaveBeenCalledTimes(1)
+      expect(sendMailSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expectedSubmissionAttachmentsWithoutPdf,
+        }),
+      )
     })
   })
 

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -2,13 +2,12 @@ import { render } from '@react-email/render'
 import tracer from 'dd-trace'
 import { get, inRange, isEmpty } from 'lodash'
 import moment from 'moment-timezone'
-import { err, errAsync, fromPromise, Result, ResultAsync } from 'neverthrow'
+import { errAsync, fromPromise, okAsync, Result, ResultAsync } from 'neverthrow'
 import Mail from 'nodemailer/lib/mailer'
 import promiseRetry from 'promise-retry'
 import validator from 'validator'
 
 import { DEFAULT_RESPONDENT_COPY_EMAIL } from '../../../../shared/constants/mail'
-import { FormResponseMode, PaymentChannel } from '../../../../shared/types'
 import { centsToDollars } from '../../../../shared/utils/payments'
 import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
 import { HASH_EXPIRE_AFTER_SECONDS } from '../../../../shared/utils/verification'
@@ -16,7 +15,6 @@ import {
   BounceType,
   EmailAdminDataField,
   IFormHasEmailSchema,
-  IPopulatedEncryptedForm,
   IPopulatedForm,
   ISubmissionSchema,
 } from '../../../types'
@@ -62,9 +60,7 @@ import {
   SubmissionToAdminHtmlData,
 } from './mail.types'
 import {
-  AutoReplyData,
   generateAutoreplyHtml,
-  generateAutoreplyPdf,
   generateIssueReportedNotificationHtml,
   generateLoginOtpHtml,
   generatePaymentConfirmationHtml,
@@ -679,7 +675,8 @@ export class MailService {
    * @param args.replyToEmails emails to set replyTo, if any
    * @param args.form the form document to retrieve some email data from
    * @param args.submission the submission document to retrieve some email data from
-   * @param args.attachments attachments to append to the email, if any
+   * @param args.submissionAttachments files from attachment fields in the submission to be included in the email notifications.
+   * @param args.pdfAttachment response PDF attachment to be included in the email notifications.
    * @param args.dataCollationData the data to use in the data collation tool to be appended to the end of the email
    * @param args.formData the form data to display to in the body in table form
    */
@@ -687,20 +684,43 @@ export class MailService {
     replyToEmails,
     form,
     submission,
-    attachments,
+    submissionAttachments = [],
     dataCollationData,
     formData,
+    pdfAttachment,
   }: {
     replyToEmails?: string[]
     form: Pick<IFormHasEmailSchema, '_id' | 'title' | 'emails'>
     submission: Pick<ISubmissionSchema, 'id' | 'created'>
-    attachments?: Mail.Attachment[]
+    submissionAttachments?: Mail.Attachment[]
     formData: EmailAdminDataField[]
     dataCollationData?: {
       question: string
       answer: string | number
     }[]
+    pdfAttachment?: Mail.Attachment
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
+    const logMeta = {
+      action: 'sendSubmissionToAdmin',
+      formId: form._id,
+      submissionId: submission.id,
+    }
+
+    const adminEmailsToNotify = form.emails
+    if (!adminEmailsToNotify) {
+      return okAsync(true)
+    }
+
+    const attachmentsToInclude = [
+      ...submissionAttachments,
+      ...(pdfAttachment ? [pdfAttachment] : []),
+    ]
+
+    logger.info({
+      message: 'Sending admin notification mail',
+      meta: logMeta,
+    })
+
     const refNo = String(submission.id)
     const formTitle = form.title
     const submissionTime = moment(submission.created)
@@ -740,7 +760,7 @@ export class MailService {
         from: this.#senderFromString,
         subject: `formsg-auto: ${formTitle} (#${refNo})`,
         html: mailHtml,
-        attachments,
+        attachments: attachmentsToInclude,
         headers: {
           [EMAIL_HEADERS.formId]: String(form._id),
           [EMAIL_HEADERS.submissionId]: refNo,
@@ -775,7 +795,8 @@ export class MailService {
    * @param args.attachments attachments to append to the email, if any
    * @param args.responsesData the array of response data to use in rendering
    * the mail body or summary pdf
-   * @param args.isUseLambdaOutput whether to use the lambda output for the pdf generation
+   * @param args.submissionAttachments files from attachment fields in the submission that will be included in email notifications.
+   * @param args.pdfAttachment response PDF attachment to be included in the email notifications.
    * @param args.autoReplyMailDatas array of objects that contains autoreply mail data to override with defaults
    * @param args.autoReplyMailDatas[].email contains the recipient of the mail
    * @param args.autoReplyMailDatas[].subject if available, sends the mail out with this subject instead of the default subject
@@ -787,8 +808,9 @@ export class MailService {
     submission,
     responsesData,
     autoReplyMailDatas,
-    attachments = [],
-    isUseLambdaOutput,
+    submissionAttachments = [],
+    pdfAttachment,
+    isPaymentEnabled,
   }: SendAutoReplyEmailsArgs): Promise<
     PromiseSettledResult<
       Result<
@@ -797,48 +819,7 @@ export class MailService {
       >
     >[]
   > => {
-    // Create a copy of attachments for attaching of autoreply pdf if needed.
-    const attachmentsWithAutoreplyPdf = [...attachments]
-    const isEncryptForm = form?.responseMode === FormResponseMode.Encrypt
-    const encryptFormDef = form as IPopulatedEncryptedForm
-    const isPaymentEnabled =
-      isEncryptForm &&
-      encryptFormDef.payments_channel.channel !== PaymentChannel.Unconnected &&
-      encryptFormDef.payments_field.enabled === true
-
-    const autoReplyData: AutoReplyData = {
-      refNo: submission.id,
-      formTitle: form.title,
-      submissionDateTime: submission.created || new Date(),
-      responsesData,
-      formUrl: `${this.#appUrl}/${form._id}`,
-    }
-    // Generate autoreply pdf and append into attachments if any of the mail has
-    // to include a form summary.
-    if (
-      autoReplyMailDatas.some((data) => data.includeFormSummary) &&
-      !isPaymentEnabled
-    ) {
-      const pdfBufferResult = await generateAutoreplyPdf(
-        autoReplyData,
-        isUseLambdaOutput,
-      )
-      if (pdfBufferResult.isErr()) {
-        return Promise.allSettled([err(pdfBufferResult.error)])
-      }
-      attachmentsWithAutoreplyPdf.push({
-        filename: 'response.pdf',
-        content: Buffer.copyBytesFrom(pdfBufferResult.value),
-      })
-    }
-
-    // strip answer from renderData to always use answerTemplate for email body responses
-    const strippedResponsesData = responsesData.map(
-      ({ question, answerTemplate }) => ({
-        question,
-        answerTemplate,
-      }),
-    )
+    // Data to render both the submission details mail HTML body and PDF.
 
     const strippedRenderData: AutoreplySummaryRenderData = {
       refNo: submission.id,
@@ -846,8 +827,33 @@ export class MailService {
       submissionTime: moment(submission.created)
         .tz('Asia/Singapore')
         .format('ddd, DD MMM YYYY hh:mm:ss A'),
-      formData: strippedResponsesData,
+      // strip answer from renderData to always use answerTemplate for email body responses
+      formData: responsesData.map(({ question, answerTemplate }) => ({
+        question,
+        answerTemplate,
+      })),
       formUrl: `${this.#appUrl}/${form._id}`,
+    }
+
+    const getAttachmentsToInclude = (mailData: AutoReplyMailData) => {
+      const shouldPdfAttachmentBeIncluded =
+        !isPaymentEnabled && mailData.includeFormSummary
+
+      if (shouldPdfAttachmentBeIncluded && !pdfAttachment) {
+        logger.error({
+          message:
+            'Could not find PDF attachment required for autoReply email. Continuing to send without PDF attachment.',
+          meta: {
+            action: 'sendAutoReplyEmails',
+            formId: String(form._id),
+            submissionId: String(submission.id),
+          },
+        })
+      }
+
+      return pdfAttachment && shouldPdfAttachmentBeIncluded
+        ? [...submissionAttachments, pdfAttachment]
+        : [...submissionAttachments]
     }
 
     // Prepare mail sending for each autoreply mail.
@@ -856,9 +862,7 @@ export class MailService {
         return this.#sendSingleAutoreplyMail({
           form,
           submission,
-          attachments: mailData.includeFormSummary
-            ? attachmentsWithAutoreplyPdf
-            : attachments,
+          attachments: getAttachmentsToInclude(mailData),
           autoReplyMailData: mailData,
           formSummaryRenderData: strippedRenderData,
           index,
@@ -1067,7 +1071,7 @@ export class MailService {
     responseId: string
     formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
-  }) => {
+  }): ResultAsync<true, MailGenerationError | MailSendError> => {
     const htmlData = {
       formTitle,
       responseId: responseId.toString(),
@@ -1126,7 +1130,7 @@ export class MailService {
     isRejected: boolean
     formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
-  }) => {
+  }): ResultAsync<true, MailGenerationError | MailSendError> => {
     const outcome = isRejected
       ? WorkflowOutcome.NOT_APPROVED
       : WorkflowOutcome.APPROVED

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -28,7 +28,7 @@ export type SendSingleAutoreplyMailArgs = {
 export type SendAutoReplyEmailsArgs = {
   form: IPopulatedForm
   submission: Pick<ISubmissionSchema, 'id' | 'created'>
-  attachments?: Mail.Attachment[]
+  submissionAttachments?: Mail.Attachment[]
   responsesData: (Pick<
     EmailAdminDataField,
     'question' | 'answerTemplate' | 'fieldType'
@@ -36,7 +36,8 @@ export type SendAutoReplyEmailsArgs = {
     answer?: EmailAdminDataField['answer']
   })[]
   autoReplyMailDatas: AutoReplyMailData[]
-  isUseLambdaOutput: boolean
+  pdfAttachment?: Mail.Attachment
+  isPaymentEnabled: boolean
 }
 
 export type MailServiceParams = {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Signatures do not provide utility by themselves and need to be signed against content to be of utility. Hence, a pdf copy should be included for admins so the signature can be verified against the form fields submitted.  

A feature flag is included to protect against excessive pdf generation load. 
There are 3 flags: ['ON', 'OFF', 'SIGNATURES_ONLY'] to control when pdfs should be generated. 

Closes FRM-2219

## Solution
<!-- How did you solve the problem? -->
Generate and include pdf in admin storage workflow completion. 
To reduce load, the same pdf is reused for any potential respondent pdf copy. Hence, hoisting to the post submission actions of the check for if generation is needed and generation is done. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: PDF is not included in storage admin email when flag is disabled    
- [x] Set GB flag to 'OFF' 
- [x] Create a storage form without signature field and with admin email notif.
- [x] Submit the form. Assert the admin email is received and does not contain PDF. 
- [x] Submit the form. Assert the admin email is received and does not contain PDF. 

TC2: PDF is included in storage admin email when flag is enabled    
- [x] Set GB flag to 'ON' 
- [x] Create a storage form without signature field and with admin email notif.
- [x] Submit the form. Assert the admin email is received and contains PDF. 

TC3: PDF is included in storage admin email when flag is signatures only   
- [x] Set GB flag to 'SIGNATURES_ONLY' 
- [x] Create a storage form without signature field and with admin email notif.
- [x] Add an email mode with respondent copy to the form. 
- [x] Submit the form. Assert the admin email is received and does not contain PDF. However, assert the respondent copy email is received and contains PDF. 
- [x] Add a signature field to the storage form. 
- [x] Submit the form. Assert the admin email is received and contains PDF. Assert the respondent copy email is received and contains PDF also. 