### PR TITLE
chore: Update Myinfo casing to be consistent

### DIFF
--- a/frontend/src/components/InlineMessage/InlineMessage.stories.tsx
+++ b/frontend/src/components/InlineMessage/InlineMessage.stories.tsx
@@ -40,6 +40,6 @@ Warning.args = {
 export const Error = InlineMessageTemplate.bind({})
 Error.args = {
   variant: 'error',
-  children: `Only 30 MyInfo fields are allowed (30/30). [Learn more](http://localhost:6006)`,
+  children: `Only 30 Myinfo fields are allowed (30/30). [Learn more](http://localhost:6006)`,
   useMarkdown: true,
 }

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/MyInfoPanel.tsx
@@ -299,7 +299,7 @@ const MyInfoText = ({
 
   return (
     <Text>
-      {`Only 30 MyInfo fields are allowed (${numMyInfoFields}/30). `}
+      {`Only 30 Myinfo fields are allowed (${numMyInfoFields}/30). `}
       <Link isExternal href={GUIDE_MYINFO_BUILDER_FIELD}>
         Learn more
       </Link>


### PR DESCRIPTION
## Problem
The current Myinfo field drawer is showing the wrong casing which is `MyInfo`. On the singpass website, it is `Myinfo`. 

## Solution
Edit casing directly.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="425" height="86" alt="image" src="https://github.com/user-attachments/assets/88516b94-7a3c-4b0d-9b72-6dd2ba3c22d8" />


**AFTER**:
<img width="425" height="86" alt="image" src="https://github.com/user-attachments/assets/052dd1cf-48d2-417b-91c7-0de1f69c57e0" />

