### PR TITLE
fix: allow singpass mrf if auth type is defined

### DIFF
--- a/frontend/src/features/admin-form/settings/SettingsAuthPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsAuthPage.tsx
@@ -17,7 +17,7 @@ export const SettingsAuthPage = (): JSX.Element => {
     if (isLoading || !settings) return false
     // TODO: FRM-2151 remove when Singpass MRF is out of beta
     if (settings.responseMode === FormResponseMode.Multirespondent) {
-      return !user?.betaFlags?.singpassMrf
+      return !user?.betaFlags?.singpassMrf && settings.authType === 'NIL'
     }
     return false
   }, [isLoading, settings, user?.betaFlags?.singpassMrf])

--- a/frontend/src/features/admin-form/settings/SettingsAuthPage.tsx
+++ b/frontend/src/features/admin-form/settings/SettingsAuthPage.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { FormResponseMode } from '~shared/types'
 
 import { useUser } from '~features/user/queries'
@@ -11,12 +13,16 @@ export const SettingsAuthPage = (): JSX.Element => {
   const { data: settings, isLoading } = useAdminFormSettings()
   const { user } = useUser()
 
-  // TODO: FRM-2151 remove when Singpass MRF is out of beta
-  if (
-    !isLoading &&
-    settings?.responseMode === FormResponseMode.Multirespondent &&
-    !user?.betaFlags?.singpassMrf
-  ) {
+  const hideAuthSection = useMemo(() => {
+    if (isLoading || !settings) return false
+    // TODO: FRM-2151 remove when Singpass MRF is out of beta
+    if (settings.responseMode === FormResponseMode.Multirespondent) {
+      return !user?.betaFlags?.singpassMrf
+    }
+    return false
+  }, [isLoading, settings, user?.betaFlags?.singpassMrf])
+
+  if (hideAuthSection) {
     return <AuthUnsupportedMsg />
   }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-2215

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Temporarily show the AuthSection for MRF forms if the authType is defined.
- This is in addition to users having the `singpassMrf` beta flag.

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
