### PR TITLE
chore: Update recaptcha copy on settings to make it comprehensible for new admins

### DIFF
--- a/__tests__/e2e/helpers/createForm.ts
+++ b/__tests__/e2e/helpers/createForm.ts
@@ -50,7 +50,7 @@ import {
   getTitleWithQuestionNumber,
 } from '../utils'
 
-import { closeModals } from './closeModals';
+import { closeModals } from './closeModals'
 
 type CreateFormReturn = {
   form: IFormSchema
@@ -268,7 +268,7 @@ const addGeneralSettings = async (
   // Turn off captcha, since we can't test for that
   await page
     .locator('label', {
-      has: page.locator('[aria-label="Enable reCAPTCHA"]'),
+      has: page.locator('[aria-label="Enable human verification (reCAPTCHA)"]'),
     })
     .click()
 

--- a/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -19,7 +19,7 @@ export const enSG = {
     input: {
       label: 'Maximum number of responses allowed',
       description:
-        'Your form will automatically close once it reaches the set limit. Enable reCAPTCHA to prevent spam submissions from triggering this limit.',
+        'Your form will automatically close once it reaches the set limit.',
     },
     limitLessThanCurrent:
       'Submission limit must be greater than current submission count ({currentResponseCount})',
@@ -33,9 +33,9 @@ export const enSG = {
       "Respondents can save what they've filled in and continue later on the same browser.",
   },
   captcha: {
-    label: 'Enable reCAPTCHA',
+    label: 'Enable human verification (reCAPTCHA)',
     description:
-      'If you expect non-English-speaking respondents, they may have difficulty understanding the reCAPTCHA selection instructions.',
+      'Respondents may need to complete an image challenge to submit the form.',
   },
   issueNotifications: {
     label: 'Receive email notifications for issues reported by respondents',


### PR DESCRIPTION
## Problem
Most admins do not know what reCaptcha is. However, they understand the idea of anti-bot or human verification measures. 

## Solution
Update the copy to make it more comprehensible. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<img width="578" height="104" alt="image" src="https://github.com/user-attachments/assets/b9f8a77e-d8b2-4729-8bc3-980f59e97554" />

<img width="578" height="167" alt="image" src="https://github.com/user-attachments/assets/e264c184-46d3-4e9a-8cf9-e6d3f6ba5b84" />

**AFTER**:
<img width="721" height="107" alt="image" src="https://github.com/user-attachments/assets/fb9260db-76e9-4014-9e55-6dc0f28287dd" />

<img width="721" height="176" alt="image" src="https://github.com/user-attachments/assets/7a1662ea-56bc-42dd-9869-495d7e00dc5a" />
