### PR TITLE
feat: add template_form_id to form level metadata

### DIFF
--- a/shared/types/form/form.ts
+++ b/shared/types/form/form.ts
@@ -30,6 +30,8 @@ import {
 } from './workflow'
 import { ErrorCode } from '../errorCodes'
 
+import { Schema } from 'mongoose'
+
 export type FormId = Tagged<string, 'FormId'>
 
 export enum FormColorTheme {
@@ -113,6 +115,7 @@ export interface FormMetadata {
   mfb_text_prompt_count?: number
   num_mrf_reminder_emails_sent?: number
   mfb_vision_prompt_count?: number
+  template_form_id?: Schema.Types.ObjectId
 }
 
 export type FormPaymentsChannel = {

--- a/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -4046,7 +4046,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { overrideEmails: ['andanother@example.com'] },
+        { overrideEmails: ['andanother@example.com'], isFromTemplate: true },
       )
     })
 
@@ -4118,7 +4118,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { overrideEmails: ['andanother@example.com'] },
+        { overrideEmails: ['andanother@example.com'], isFromTemplate: true },
       )
     })
 
@@ -4268,7 +4268,7 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
-        { overrideEmails: ['andanother@example.com'] },
+        { overrideEmails: ['andanother@example.com'], isFromTemplate: true },
       )
     })
   })

--- a/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1050,6 +1050,7 @@ export const handleCopyTemplateForm: ControllerHandler<
           // Step 3: Duplicate form.
           AdminFormService.duplicateForm(originalForm, userId, overrideParams, {
             overrideEmails: [user.email],
+            isFromTemplate: true,
           })
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -661,6 +661,8 @@ type DuplicateFormOpts = {
   workspaceId?: string
   // If defined, overrides the emails of MRF workflows and dropdown fields with the given overrideEmails
   overrideEmails?: string[]
+  // If duplicated from a use-template
+  isFromTemplate?: boolean
 }
 
 /**
@@ -681,7 +683,7 @@ export const duplicateForm = (
     overrideParams,
     newAdminId,
   )
-  const { workspaceId, overrideEmails } = opts ?? {}
+  const { workspaceId, overrideEmails, isFromTemplate } = opts ?? {}
 
   // Set startPage.logo to default irregardless.
   overrideProps.startPage = {
@@ -718,6 +720,13 @@ export const duplicateForm = (
         )
       }
     })
+  }
+
+  // if created from template, track original form id in metadata
+  if (isFromTemplate) {
+    duplicateParams.metadata = {
+      template_form_id: originalForm._id,
+    }
   }
 
   if (workspaceId)

--- a/src/app/modules/form/admin-form/admin-form.types.ts
+++ b/src/app/modules/form/admin-form/admin-form.types.ts
@@ -33,6 +33,7 @@ export type OverrideProps = {
   publicKey?: string
   submissionLimit?: number | null
   workflow?: IMultirespondentForm['workflow']
+  metadata?: IForm['metadata']
 }
 
 export type EditFormFieldResult = Result<FormFieldSchema[], EditFieldError>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When forms are duplicated using `use-template`, there is no information on which parent form is was templated from. This makes forms duplicated from our template experiment difficult to track.

## Solution
<!-- How did you solve the problem? -->

Add `template_form_id` to form metadata, so as to be able to know which parent form it was duplicated form for metrics tracking.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**AFTER**:
Duplicated form from `use-template`
<img width="864" height="731" alt="image" src="https://github.com/user-attachments/assets/e6b3f058-f429-46b1-adf8-a92ee757cd32" />


## Tests
<!-- What tests should be run to confirm functionality? -->

**Verify `template_form_id` exists**
- [ ] With an existing form, visit the link to use its template: `Share` -> `Use template`
- [ ] On the template preview page, click `Use this template`
- [ ] Successfully duplicate the form
- [ ] Search in the DB for the newly duplicated form id, observe that there is `metadata.template_form_id` collected
