### PR TITLE
feat(bulk-local-pdf): replace pdf generation with html2pdf (part 0, anytime before part 8)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,7 @@
         "file-saver": "^2.0.5",
         "framer-motion": "^11.1.7",
         "fuzzysort": "^3.1.0",
+        "html2pdf.js": "^0.12.1",
         "http-status-codes": "^2.2.0",
         "i18next": "^21.6.16",
         "i18next-browser-languagedetector": "^6.1.4",
@@ -5040,6 +5041,12 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/papaparse": {
       "version": "5.3.14",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.14.tgz",
@@ -5064,6 +5071,13 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
       "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
       "dev": true
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -5202,6 +5216,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.2",
@@ -6562,6 +6583,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7716,6 +7746,26 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -8350,6 +8400,18 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -8515,6 +8577,15 @@
       "dependencies": {
         "hyphenate-style-name": "^1.0.2",
         "isobject": "^3.0.1"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -9078,6 +9149,16 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dot-case": {
@@ -10318,6 +10399,23 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
@@ -10353,6 +10451,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -11425,6 +11529,29 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2pdf.js": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.12.1.tgz",
+      "integrity": "sha512-3rBWQ96H5oOU9jtoz3MnE/epGi27ig9h8aonBk4JTpvUERM3lMRxhIRckhJZEi4wE0YfRINoYOIDY0hLY0CHgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "html2canvas": "^1.0.0",
+        "jspdf": "^3.0.0"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -11695,6 +11822,12 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -12328,6 +12461,23 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
+      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jszip": {
@@ -16451,6 +16601,13 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
@@ -16718,6 +16875,16 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -17328,6 +17495,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
@@ -17718,6 +17895,16 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
@@ -17783,6 +17970,15 @@
       "dev": true,
       "dependencies": {
         "memoizerific": "^1.11.3"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -18722,6 +18918,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {
@@ -23190,6 +23395,11 @@
         "undici-types": "~6.19.2"
       }
     },
+    "@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="
+    },
     "@types/papaparse": {
       "version": "5.3.14",
       "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.14.tgz",
@@ -23214,6 +23424,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
       "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
       "dev": true
+    },
+    "@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "optional": true
     },
     "@types/range-parser": {
       "version": "1.2.7",
@@ -23347,6 +23563,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
+    },
+    "@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
     },
     "@types/unist": {
       "version": "3.0.2",
@@ -24276,6 +24498,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -24968,6 +25195,22 @@
         }
       }
     },
+    "canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "optional": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      }
+    },
     "ccount": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -25404,6 +25647,12 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "core-js": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "optional": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -25543,6 +25792,14 @@
       "requires": {
         "hyphenate-style-name": "^1.0.2",
         "isobject": "^3.0.1"
+      }
+    },
+    "css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "requires": {
+        "utrie": "^1.0.2"
       }
     },
     "css.escape": {
@@ -25984,6 +26241,15 @@
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
       "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw=="
+    },
+    "dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "optional": true,
+      "requires": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "dot-case": {
       "version": "3.0.4",
@@ -26908,6 +27174,23 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "requires": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+          "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+        }
+      }
+    },
     "fast-shallow-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
@@ -26931,6 +27214,11 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true
+    },
+    "fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -27665,6 +27953,24 @@
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.0.tgz",
       "integrity": "sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow=="
     },
+    "html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "requires": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      }
+    },
+    "html2pdf.js": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.12.1.tgz",
+      "integrity": "sha512-3rBWQ96H5oOU9jtoz3MnE/epGi27ig9h8aonBk4JTpvUERM3lMRxhIRckhJZEi4wE0YfRINoYOIDY0hLY0CHgQ==",
+      "requires": {
+        "html2canvas": "^1.0.0",
+        "jspdf": "^3.0.0"
+      }
+    },
     "http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -27863,6 +28169,11 @@
       "requires": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -28267,6 +28578,20 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
+      }
+    },
+    "jspdf": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
+      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "requires": {
+        "@babel/runtime": "^7.28.4",
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "jszip": {
@@ -31138,6 +31463,12 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "optional": true
+    },
     "regexp.prototype.flags": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
@@ -31329,6 +31660,12 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
       "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
       "dev": true
+    },
+    "rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "optional": true
     },
     "rimraf": {
       "version": "3.0.2",
@@ -31763,6 +32100,12 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "optional": true
+    },
     "stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
@@ -32047,6 +32390,12 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true
     },
+    "svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "optional": true
+    },
     "synckit": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
@@ -32099,6 +32448,14 @@
       "dev": true,
       "requires": {
         "memoizerific": "^1.11.3"
+      }
+    },
+    "text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "requires": {
+        "utrie": "^1.0.2"
       }
     },
     "text-table": {
@@ -32740,6 +33097,14 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
+    },
+    "utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "requires": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "uuid": {
       "version": "9.0.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -78,7 +78,6 @@
         "react-swipeable": "^7.0.0",
         "react-table": "^7.7.0",
         "react-textarea-autosize": "^8.3.3",
-        "react-to-print": "^3.1.1",
         "react-use": "^17.3.1",
         "react-use-scrollspy": "^3.0.2",
         "react-virtuoso": "^2.14.0",
@@ -16409,15 +16408,6 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/react-to-print": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-3.1.1.tgz",
-      "integrity": "sha512-N0MUMhpl8nkGri13BjP7zusj3B/j+1eMOTt8N8PYuhBYGzA4PqTXqcihJ9cZw996dvhV6mBdwafIQCg3Ap5bKg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ~19"
-      }
-    },
     "node_modules/react-universal-interface": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
@@ -31312,11 +31302,6 @@
         "use-composed-ref": "^1.0.0",
         "use-latest": "^1.0.0"
       }
-    },
-    "react-to-print": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-3.1.1.tgz",
-      "integrity": "sha512-N0MUMhpl8nkGri13BjP7zusj3B/j+1eMOTt8N8PYuhBYGzA4PqTXqcihJ9cZw996dvhV6mBdwafIQCg3Ap5bKg=="
     },
     "react-universal-interface": {
       "version": "0.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,7 +74,6 @@
     "react-swipeable": "^7.0.0",
     "react-table": "^7.7.0",
     "react-textarea-autosize": "^8.3.3",
-    "react-to-print": "^3.1.1",
     "react-use": "^17.3.1",
     "react-use-scrollspy": "^3.0.2",
     "react-virtuoso": "^2.14.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "file-saver": "^2.0.5",
     "framer-motion": "^11.1.7",
     "fuzzysort": "^3.1.0",
+    "html2pdf.js": "^0.12.1",
     "http-status-codes": "^2.2.0",
     "i18next": "^21.6.16",
     "i18next-browser-languagedetector": "^6.1.4",

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BiChevronLeft, BiChevronRight, BiLeftArrowAlt } from 'react-icons/bi'
 import { FaRegFilePdf } from 'react-icons/fa6'
@@ -8,7 +8,6 @@ import {
   useNavigate,
   useParams,
 } from 'react-router-dom'
-import { useReactToPrint } from 'react-to-print'
 import {
   Box,
   ButtonGroup,
@@ -33,7 +32,7 @@ import { useUser } from '~features/user/queries'
 
 import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
 
-import PrintableResponse from './PrintableResponse'
+import generateResponsePdf from './utils/generateResponsePdf'
 import { useIndividualSubmission } from './queries'
 
 export const IndividualResponseNavbar = (): JSX.Element => {
@@ -56,7 +55,9 @@ export const IndividualResponseNavbar = (): JSX.Element => {
     isAnyFetching,
   } = useUnlockedResponses()
   const { data: form, isLoading: isFormLoading } = useAdminForm()
-  const { isLoading } = useIndividualSubmission()
+  const { data: submission, isLoading: isSubmissionLoading } =
+    useIndividualSubmission()
+  const isLoading = isFormLoading || isSubmissionLoading
 
   const nextSubmissionId = useMemo(
     () => getNextSubmissionId(submissionId),
@@ -130,12 +131,6 @@ export const IndividualResponseNavbar = (): JSX.Element => {
 
   const isAdminPrintPdfEnabled = useFeatureIsOn(featureFlags.adminPrintPdf)
 
-  const printableResponseRef = useRef<HTMLDivElement>(null)
-  const reactToPrintFn = useReactToPrint({
-    contentRef: printableResponseRef,
-    documentTitle: `${form ? `${form.title}_formId_${form._id}_` : ''}submissionId_${submissionId}_response.pdf`,
-  })
-
   return (
     <Grid
       sx={noPrintCss}
@@ -174,8 +169,8 @@ export const IndividualResponseNavbar = (): JSX.Element => {
                 <IconButton
                   aria-label="Print"
                   icon={<FaRegFilePdf />}
-                  isLoading={isLoading || isFormLoading}
-                  onClick={() => {
+                  isLoading={isLoading}
+                  onClick={async () => {
                     datadogLogs.logger.info(
                       `IndividualResponseNavbar: admin printing pdf`,
                       {
@@ -186,11 +181,12 @@ export const IndividualResponseNavbar = (): JSX.Element => {
                         },
                       },
                     )
-                    reactToPrintFn()
+                    if (submission && form) {
+                      await generateResponsePdf({ form, submission })
+                    }
                   }}
                   variant="clear"
                 />
-                <PrintableResponse ref={printableResponseRef} />
               </Box>
             )}
           </Stack>

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -1,18 +1,12 @@
-import { forwardRef } from 'react'
 import { Box, Text } from '@chakra-ui/react'
 import { FieldType } from '@opengovsg/formsg-sdk/dist/types'
 
 import { BasicField } from '~shared/types/field'
 import { handleAddressResponseDisplay } from '~shared/utils/address'
 
-import { showOnlyWhenPrintCss } from '~utils/showOnlyWhenPrintCss'
-
-import { useAdminForm } from '~features/admin-form/common/queries'
+import { convertToSignatureSvgString } from '~utils/convertSignatureOutput'
 
 import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
-
-import { useIndividualSubmission } from './queries'
-import { SignatureCanvas } from './SignatureCanvas'
 
 const SIGNATURE_PDF_FIXED_WIDTH = 300 // Same as the backend template's signature width
 
@@ -114,15 +108,25 @@ const PrintableDecryptedRow = ({
           ))}
         </>
       )
-    case BasicField.Signature:
-      return (
-        <TableRow>
-          <TableSingleColItem>{row.question}</TableSingleColItem>
-          <TableSingleColItem>
-            <SignatureCanvas row={row} widthPx={SIGNATURE_PDF_FIXED_WIDTH} />
-          </TableSingleColItem>
-        </TableRow>
-      )
+    case BasicField.Signature: {
+      if (row.answerArray && row.answerArray.length > 1) {
+        const signatureVectorArray = JSON.parse(row.answerArray[1] as string)
+        const signatureSvg = convertToSignatureSvgString(signatureVectorArray)
+        return (
+          <TableRow>
+            <TableSingleColItem>{row.question}</TableSingleColItem>
+            <TableSingleColItem>
+              <img
+                src={`data:image/svg+xml;utf8,${encodeURIComponent(signatureSvg)}`}
+                width={SIGNATURE_PDF_FIXED_WIDTH}
+                alt="Signature"
+              />
+            </TableSingleColItem>
+          </TableRow>
+        )
+      }
+      return <></>
+    }
     default:
       return (
         <StandardPrintableRow
@@ -231,22 +235,4 @@ export const PrintableResponse = ({
   )
 }
 
-const PrintableResponseContainer = forwardRef<HTMLDivElement>((_, ref) => {
-  const { data: form } = useAdminForm()
-  const { data, isLoading, isError } = useIndividualSubmission()
-  if (isLoading || isError || !form || !data?.responses) return null
-
-  return (
-    <Box ref={ref} sx={showOnlyWhenPrintCss}>
-      <PrintableResponse
-        formTitle={form.title}
-        formId={form._id}
-        decryptedResponses={data?.responses}
-        responseId={data.refNo}
-        submissionTime={data.submissionTime}
-      />
-    </Box>
-  )
-})
-
-export default PrintableResponseContainer
+export default PrintableResponse

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
@@ -32,7 +32,8 @@ const generateResponsePdf = async ({
       submissionTime={submission.submissionTime}
     />,
   )
-  const pdfTitle = `${form ? `${form.title}_formId_${form._id}_` : ''}submissionId_${submission.refNo}_response.pdf`
+
+  const pdfTitle = `${form.title}_formId_${form._id}_submissionId_${submission.refNo}_response.pdf`
   await html2pdf()
     .set({
       margin: 0,

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
@@ -1,0 +1,55 @@
+import { createRoot } from 'react-dom/client'
+import html2pdf from 'html2pdf.js'
+
+import { AugmentedDecryptedResponse } from '../../ResponsesPage/storage/utils/augmentDecryptedResponses'
+import PrintableResponse from '../PrintableResponse'
+
+const A4_WIDTH = '210mm'
+
+const generateResponsePdf = async ({
+  form,
+  submission,
+}: {
+  form: {
+    title: string
+    _id: string
+  }
+  submission: {
+    refNo: string
+    submissionTime: string
+    responses: AugmentedDecryptedResponse[]
+  }
+}) => {
+  const tempDiv = document.createElement('div')
+  tempDiv.style.width = A4_WIDTH
+  const root = createRoot(tempDiv)
+  root.render(
+    <PrintableResponse
+      formTitle={form.title}
+      formId={form._id}
+      decryptedResponses={submission.responses}
+      responseId={submission.refNo}
+      submissionTime={submission.submissionTime}
+    />,
+  )
+  const pdfTitle = `${form ? `${form.title}_formId_${form._id}_` : ''}submissionId_${submission.refNo}_response.pdf`
+  await html2pdf()
+    .set({
+      margin: 0,
+      image: { type: 'jpeg', quality: 1 },
+      html2canvas: { scale: 2 },
+      filename: pdfTitle,
+      jsPDF: {
+        format: 'a4',
+        orientation: 'portrait',
+      },
+    })
+    .from(tempDiv)
+    .save(pdfTitle)
+    .finally(() => {
+      root.unmount()
+      tempDiv.remove()
+    })
+}
+
+export default generateResponsePdf

--- a/frontend/src/utils/showOnlyWhenPrintCss.ts
+++ b/frontend/src/utils/showOnlyWhenPrintCss.ts
@@ -1,6 +1,0 @@
-export const showOnlyWhenPrintCss = {
-  '@media print': {
-    display: 'block',
-  },
-  display: 'none',
-}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The current pdf generation, using the browser's print, is not compatible with bulk downloads. Furthermore, some devices block usage of this print functionality by web apps due to security reasons. 

## Solution
<!-- How did you solve the problem? -->
Replace the usage of browser's print with save functionality using html2pdf. 

## Tradeoffs 
Known tradeoffs are: 
- since a screenshot is made of react component to generate the pdf, text is not copy-able - this is the same behavior as the previous browser print mechanism. From talking to users, pdf are used mainly for data retention purposes and hence this feature is not critical. However, we will continue to note if this problem is a blocker to our OKRs before deciding on whether to invest more effort into this. 
- there is another solution, https://github.com/opengovsg/FormSG/pull/8959, where text can be copied, but does not support chinese/tamil glyphs without having the user download large font packages (furthermore, each ttf file has max 65k glyphs and hence some special packaging of chinese + tamil glyphs is needed since pdfmake uses pdfkit dependency which does not support fallback). hence, considering the tradeoffs, this current PR's approach may be sufficient for our OKRs. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests 
Note: there is no change to the component being rendered, which should be covered by chromatic stories against regression. 

<!-- What tests should be run to confirm functionality? -->
TC1: PDF generation works for storage mode
- [ ] Make a storage mode form with all fields (especially table, signatures, address and attachment field types) and a variety of singpass myinfo fields
- [ ] Submit the form (include malay and tamil and chinese in your responses as much as possible) 
- [ ] Download the pdf from the results page for the submission
- [ ] Assert it generates correctly. 

TC2: PDF generation works for mrf mode
- [ ] Make a mrf mode form with all fields (especially table, signatures, address and attachment field types) with 2 steps
- [ ] Submit step 1 of the form (include malay and tamil and chinese in your responses as much as possible) 
- [ ] Download the pdf from the results page for the partial submission. 
- [ ] Assert it generates correctly. 
- [ ] Submit step 2 of the form. 
- [ ] Download the pdf from the results page for the submission.
- [ ] Assert it generates correctly. 