### PR TITLE
feat(bulk-local-pdf): add download pdf bulk support (part 8)

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -32,7 +32,7 @@ import { useUser } from '~features/user/queries'
 
 import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
 
-import generateResponsePdf from './utils/generateResponsePdf'
+import { downloadResponsePdf } from './utils/generateResponsePdf'
 import { useIndividualSubmission } from './queries'
 
 export const IndividualResponseNavbar = (): JSX.Element => {
@@ -182,7 +182,7 @@ export const IndividualResponseNavbar = (): JSX.Element => {
                       },
                     )
                     if (submission && form) {
-                      await generateResponsePdf({ form, submission })
+                      await downloadResponsePdf({ form, submission })
                     }
                   }}
                   variant="clear"

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
@@ -1,3 +1,4 @@
+import { flushSync } from 'react-dom'
 import { createRoot } from 'react-dom/client'
 import html2pdf from 'html2pdf.js'
 
@@ -5,8 +6,67 @@ import { AugmentedDecryptedResponse } from '../../ResponsesPage/storage/utils/au
 import PrintableResponse from '../PrintableResponse'
 
 const A4_WIDTH = '210mm'
+const A4_PDF_OPTIONS = {
+  margin: 0,
+  image: { type: 'jpeg', quality: 1 },
+  html2canvas: { scale: 2 },
+  jsPDF: {
+    format: 'a4',
+    orientation: 'portrait',
+  },
+} as const
 
-const generateResponsePdf = async ({
+const renderPrintableResponse = (
+  form: {
+    title: string
+    _id: string
+  },
+  submission: {
+    refNo: string
+    submissionTime: string
+    responses: AugmentedDecryptedResponse[]
+  },
+) => {
+  const tempDiv = document.createElement('div')
+  tempDiv.style.width = A4_WIDTH
+  const root = createRoot(tempDiv)
+
+  // RATIONALE: Required to ensure the DOM is flushed before returning the div to render
+  flushSync(() => {
+    root.render(
+      <PrintableResponse
+        formTitle={form.title}
+        formId={form._id}
+        decryptedResponses={submission.responses}
+        responseId={submission.refNo}
+        submissionTime={submission.submissionTime}
+      />,
+    )
+  })
+
+  const cleanup = () => {
+    root.unmount()
+    tempDiv.remove()
+  }
+  return {
+    divToRender: tempDiv,
+    cleanup,
+  }
+}
+
+const getPdfTitle = ({
+  formTitle,
+  formId,
+  submissionId,
+}: {
+  formTitle: string
+  formId: string
+  submissionId: string
+}) => {
+  return `${formTitle}_formId_${formId}_submissionId_${submissionId}_response.pdf`
+}
+
+export const generateResponsePdfBlob = async ({
   form,
   submission,
 }: {
@@ -20,37 +80,51 @@ const generateResponsePdf = async ({
     responses: AugmentedDecryptedResponse[]
   }
 }) => {
-  const tempDiv = document.createElement('div')
-  tempDiv.style.width = A4_WIDTH
-  const root = createRoot(tempDiv)
-  root.render(
-    <PrintableResponse
-      formTitle={form.title}
-      formId={form._id}
-      decryptedResponses={submission.responses}
-      responseId={submission.refNo}
-      submissionTime={submission.submissionTime}
-    />,
-  )
+  const pdfTitle = getPdfTitle({
+    formTitle: form.title,
+    formId: form._id,
+    submissionId: submission.refNo,
+  })
 
-  const pdfTitle = `${form.title}_formId_${form._id}_submissionId_${submission.refNo}_response.pdf`
-  await html2pdf()
-    .set({
-      margin: 0,
-      image: { type: 'jpeg', quality: 1 },
-      html2canvas: { scale: 2 },
-      filename: pdfTitle,
-      jsPDF: {
-        format: 'a4',
-        orientation: 'portrait',
-      },
-    })
-    .from(tempDiv)
-    .save(pdfTitle)
-    .finally(() => {
-      root.unmount()
-      tempDiv.remove()
-    })
+  const { divToRender, cleanup } = renderPrintableResponse(form, submission)
+
+  const pdfBlob = await html2pdf()
+    .set(A4_PDF_OPTIONS)
+    .from(divToRender)
+    .output('blob')
+    .finally(cleanup)
+
+  return {
+    pdfBlob,
+    pdfTitle,
+  }
 }
 
-export default generateResponsePdf
+export const downloadResponsePdf = async ({
+  form,
+  submission,
+}: {
+  form: {
+    title: string
+    _id: string
+  }
+  submission: {
+    refNo: string
+    submissionTime: string
+    responses: AugmentedDecryptedResponse[]
+  }
+}) => {
+  const pdfTitle = getPdfTitle({
+    formTitle: form.title,
+    formId: form._id,
+    submissionId: submission.refNo,
+  })
+
+  const { divToRender, cleanup } = renderPrintableResponse(form, submission)
+
+  await html2pdf()
+    .set(A4_PDF_OPTIONS)
+    .from(divToRender)
+    .save(pdfTitle)
+    .finally(cleanup)
+}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
@@ -11,7 +11,7 @@ export interface StorageResponsesContextProps {
   setDateRange: (dateRange: DateString[]) => void
   downloadParams: Omit<
     DownloadEncryptedParams,
-    'downloadAttachments' | 'isDownloadCsv'
+    'downloadAttachments' | 'isDownloadCsv' | 'isDownloadPdf'
   > | null
   totalResponsesCount?: number
   dateRangeResponsesCount?: number

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -104,6 +104,7 @@ export const DownloadButton = (): JSX.Element => {
     () => ({
       isDownloadAttachments: false,
       isDownloadCsv: false,
+      isDownloadPdf: false,
     }),
     [],
   )
@@ -205,6 +206,7 @@ export const DownloadButton = (): JSX.Element => {
       ...downloadParams,
       downloadAttachments: downloadOptions.isDownloadAttachments,
       isDownloadCsv: downloadOptions.isDownloadCsv,
+      isDownloadPdf: downloadOptions.isDownloadPdf,
     })
   }, [downloadParams, handleBulkDownloadMutation, downloadOptions])
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -61,8 +61,10 @@ const DownloadSelector = ({
       'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadButton.menuItem',
   })
 
-  const { isDownloadCsv, isDownloadAttachments } = downloadOptions
-  const onlyDownloadCsv = isDownloadCsv && !isDownloadAttachments
+  const { isDownloadCsv, isDownloadAttachments, isDownloadPdf } =
+    downloadOptions
+  const onlyDownloadCsv =
+    isDownloadCsv && !isDownloadAttachments && !isDownloadPdf
 
   return (
     <Stack>
@@ -85,6 +87,16 @@ const DownloadSelector = ({
               setDownloadOptions({
                 ...downloadOptions,
                 isDownloadAttachments: !isDownloadAttachments,
+              })
+            }
+          />
+          <DownloadSelectorCheckbox
+            optionText={t('pdfs')}
+            isChecked={isDownloadPdf}
+            onChange={() =>
+              setDownloadOptions({
+                ...downloadOptions,
+                isDownloadPdf: !isDownloadPdf,
               })
             }
           />

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
@@ -50,57 +50,35 @@ export const ConfirmationScreen = ({
   responsesCount,
 }: ConfirmationScreenProps): JSX.Element => {
   const isMobile = useIsMobile()
+  const { t: confirmationScreenTranslation } = useTranslation('translation', {
+    keyPrefix:
+      'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen',
+  })
   const { t } = useTranslation()
 
-  const confirmationScreenKeyPrefix =
-    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen'
-
   const getTitle = () => {
-    if (
-      downloadOptions.isDownloadCsv &&
-      downloadOptions.isDownloadAttachments &&
-      downloadOptions.isDownloadPdf
-    ) {
-      return t(
-        `${confirmationScreenKeyPrefix}.titleResponsesAndAttachmentsAndPdfs`,
-      )
+    const { isDownloadCsv, isDownloadAttachments, isDownloadPdf } =
+      downloadOptions
+    const titleParts = []
+    if (isDownloadCsv)
+      titleParts.push(confirmationScreenTranslation('responsesText'))
+    if (isDownloadAttachments)
+      titleParts.push(confirmationScreenTranslation('attachmentsText'))
+    if (isDownloadPdf)
+      titleParts.push(confirmationScreenTranslation('pdfsText'))
+
+    if (titleParts.length == 0) {
+      return ''
     }
-    if (
-      !downloadOptions.isDownloadCsv &&
-      downloadOptions.isDownloadAttachments &&
-      downloadOptions.isDownloadPdf
-    ) {
-      return t(`${confirmationScreenKeyPrefix}.titleAttachmentsAndPdfs`)
-    }
-    if (
-      downloadOptions.isDownloadCsv &&
-      !downloadOptions.isDownloadAttachments &&
-      downloadOptions.isDownloadPdf
-    ) {
-      return t(`${confirmationScreenKeyPrefix}.titleResponsesAndPdfs`)
-    }
-    if (
-      downloadOptions.isDownloadCsv &&
-      downloadOptions.isDownloadAttachments &&
-      !downloadOptions.isDownloadPdf
-    ) {
-      return t(`${confirmationScreenKeyPrefix}.titleResponsesAndAttachments`)
-    }
-    if (
-      !downloadOptions.isDownloadCsv &&
-      !downloadOptions.isDownloadAttachments &&
-      downloadOptions.isDownloadPdf
-    ) {
-      return t(`${confirmationScreenKeyPrefix}.titlePdfsOnly`)
-    }
-    if (
-      !downloadOptions.isDownloadCsv &&
-      downloadOptions.isDownloadAttachments &&
-      !downloadOptions.isDownloadPdf
-    ) {
-      return t(`${confirmationScreenKeyPrefix}.titleAttachmentsOnly`)
-    }
-    return ''
+
+    const downloadItems =
+      titleParts.length > 2
+        ? `${titleParts.slice(0, -1).join(', ')} ${confirmationScreenTranslation('andText')} ${titleParts[titleParts.length - 1]}`
+        : titleParts.join(` ${confirmationScreenTranslation('andText')} `)
+
+    return confirmationScreenTranslation('downloadTitle', {
+      downloadItems,
+    })
   }
 
   return (
@@ -119,48 +97,50 @@ export const ConfirmationScreen = ({
           {downloadOptions.isDownloadAttachments ? (
             <Text>
               <Trans
-                i18nKey={`${confirmationScreenKeyPrefix}.attachmentsDescription`}
+                t={confirmationScreenTranslation}
+                i18nKey={'attachmentsDescription'}
               />
             </Text>
           ) : undefined}
           {downloadOptions.isDownloadPdf ? (
             <Text>
               <Trans
-                i18nKey={`${confirmationScreenKeyPrefix}.pdfsDescription`}
+                t={confirmationScreenTranslation}
+                i18nKey={'pdfsDescription'}
               />
             </Text>
           ) : undefined}
           <Text>
-            <b>{t(`${confirmationScreenKeyPrefix}.numberOfResponses`)}:</b>{' '}
+            <b>{confirmationScreenTranslation('numberOfResponses')}:</b>{' '}
             {responsesCount.toLocaleString()}
             <br />
-            <b>{t(`${confirmationScreenKeyPrefix}.estimatedTime`)}:</b>{' '}
-            {t(`${confirmationScreenKeyPrefix}.estimatedTimeReference`)}
+            <b>{confirmationScreenTranslation('estimatedTime')}:</b>{' '}
+            {confirmationScreenTranslation('estimatedTimeReference')}
           </Text>
           <Text>
-            {t(`${confirmationScreenKeyPrefix}.filterResponsesCountHelperText`)}
+            {confirmationScreenTranslation('filterResponsesCountHelperText')}
           </Text>
           <InlineMessage>
             <Stack>
               <Text textStyle="subhead-1">
-                {t(
-                  `${confirmationScreenKeyPrefix}.intensiveOperationWarning.title`,
+                {confirmationScreenTranslation(
+                  'intensiveOperationWarning.title',
                 )}
               </Text>
               <List>
                 <InlineTextListItem>
-                  {t(
-                    `${confirmationScreenKeyPrefix}.intensiveOperationWarning.doNotUseIE`,
+                  {confirmationScreenTranslation(
+                    'intensiveOperationWarning.doNotUseIE',
                   )}
                 </InlineTextListItem>
                 <InlineTextListItem>
-                  {t(
-                    `${confirmationScreenKeyPrefix}.intensiveOperationWarning.ensureStrongNetworkConnectivity`,
+                  {confirmationScreenTranslation(
+                    'intensiveOperationWarning.ensureStrongNetworkConnectivity',
                   )}
                 </InlineTextListItem>
                 <InlineTextListItem>
-                  {t(
-                    `${confirmationScreenKeyPrefix}.intensiveOperationWarning.ensureEnoughDiskSpace`,
+                  {confirmationScreenTranslation(
+                    'intensiveOperationWarning.ensureEnoughDiskSpace',
                   )}
                 </InlineTextListItem>
               </List>
@@ -168,9 +148,7 @@ export const ConfirmationScreen = ({
           </InlineMessage>
           {responsesCount === 0 && (
             <InlineMessage variant="warning">
-              {t(
-                `${confirmationScreenKeyPrefix}.noResponsesInSelectedDateRange`,
-              )}
+              {confirmationScreenTranslation('noResponsesInSelectedDateRange')}
             </InlineMessage>
           )}
         </Stack>
@@ -187,7 +165,7 @@ export const ConfirmationScreen = ({
             isLoading={isDownloading}
             isDisabled={responsesCount === 0}
           >
-            {t(`${confirmationScreenKeyPrefix}.startDownload`)}
+            {confirmationScreenTranslation('startDownload')}
           </Button>
           <Button
             isFullWidth={isMobile}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
@@ -55,18 +55,60 @@ export const ConfirmationScreen = ({
   const confirmationScreenKeyPrefix =
     'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen'
 
+  const getTitle = () => {
+    if (
+      downloadOptions.isDownloadCsv &&
+      downloadOptions.isDownloadAttachments &&
+      downloadOptions.isDownloadPdf
+    ) {
+      return t(
+        `${confirmationScreenKeyPrefix}.titleResponsesAndAttachmentsAndPdfs`,
+      )
+    }
+    if (
+      !downloadOptions.isDownloadCsv &&
+      downloadOptions.isDownloadAttachments &&
+      downloadOptions.isDownloadPdf
+    ) {
+      return t(`${confirmationScreenKeyPrefix}.titleAttachmentsAndPdfs`)
+    }
+    if (
+      downloadOptions.isDownloadCsv &&
+      !downloadOptions.isDownloadAttachments &&
+      downloadOptions.isDownloadPdf
+    ) {
+      return t(`${confirmationScreenKeyPrefix}.titleResponsesAndPdfs`)
+    }
+    if (
+      downloadOptions.isDownloadCsv &&
+      downloadOptions.isDownloadAttachments &&
+      !downloadOptions.isDownloadPdf
+    ) {
+      return t(`${confirmationScreenKeyPrefix}.titleResponsesAndAttachments`)
+    }
+    if (
+      !downloadOptions.isDownloadCsv &&
+      !downloadOptions.isDownloadAttachments &&
+      downloadOptions.isDownloadPdf
+    ) {
+      return t(`${confirmationScreenKeyPrefix}.titlePdfsOnly`)
+    }
+    if (
+      !downloadOptions.isDownloadCsv &&
+      downloadOptions.isDownloadAttachments &&
+      !downloadOptions.isDownloadPdf
+    ) {
+      return t(`${confirmationScreenKeyPrefix}.titleAttachmentsOnly`)
+    }
+    return ''
+  }
+
   return (
     <>
       <ModalCloseButton />
       <ModalHeader color="secondary.700" pr="4.5rem">
         <Wrap shouldWrapChildren direction="row" align="center">
-          <Text>
-            {!downloadOptions.isDownloadCsv
-              ? t(`${confirmationScreenKeyPrefix}.titleAttachmentsOnly`)
-              : t(
-                  `${confirmationScreenKeyPrefix}.titleResponsesAndAttachments`,
-                )}
-          </Text>
+          <Text>{getTitle()}</Text>
           <Badge w="fit-content" colorScheme="success">
             {t('features.common.betaBadgeLabel')}
           </Badge>
@@ -74,23 +116,28 @@ export const ConfirmationScreen = ({
       </ModalHeader>
       <ModalBody whiteSpace="pre-wrap" color="secondary.500">
         <Stack spacing="1rem">
-          <Text>
-            {downloadOptions.isDownloadAttachments ? (
+          {downloadOptions.isDownloadAttachments ? (
+            <Text>
               <Trans
                 i18nKey={`${confirmationScreenKeyPrefix}.attachmentsDescription`}
               />
-            ) : (
-              ''
-            )}
-            <br />
-            <br />
+            </Text>
+          ) : undefined}
+          {downloadOptions.isDownloadPdf ? (
+            <Text>
+              <Trans
+                i18nKey={`${confirmationScreenKeyPrefix}.pdfsDescription`}
+              />
+            </Text>
+          ) : undefined}
+          <Text>
             <b>{t(`${confirmationScreenKeyPrefix}.numberOfResponses`)}:</b>{' '}
             {responsesCount.toLocaleString()}
             <br />
             <b>{t(`${confirmationScreenKeyPrefix}.estimatedTime`)}:</b>{' '}
             {t(`${confirmationScreenKeyPrefix}.estimatedTimeReference`)}
-            <br />
-            <br />
+          </Text>
+          <Text>
             {t(`${confirmationScreenKeyPrefix}.filterResponsesCountHelperText`)}
           </Text>
           <InlineMessage>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
@@ -32,6 +32,20 @@ const Template: StoryFn<DownloadWithAttachmentModalProps> = (args) => {
     />
   )
 }
+
+export const ConfirmationScreenResponsesAndAttachmentsAndPdfsDesktop =
+  Template.bind({})
+ConfirmationScreenResponsesAndAttachmentsAndPdfsDesktop.args = {
+  downloadPercentage: 0,
+  isDownloading: false,
+  responsesCount: 9001,
+  downloadOptions: {
+    isDownloadAttachments: true,
+    isDownloadCsv: true,
+    isDownloadPdf: true,
+  },
+}
+
 export const ConfirmationStateResponseAndAttachmentsDesktop = Template.bind({})
 ConfirmationStateResponseAndAttachmentsDesktop.args = {
   downloadPercentage: 0,
@@ -49,6 +63,30 @@ ConfirmationStateResponseAndAttachmentsMobile.args =
 ConfirmationStateResponseAndAttachmentsMobile.parameters =
   getMobileViewParameters()
 
+export const ConfirmationScreenResponsesAndPdfsDesktop = Template.bind({})
+ConfirmationScreenResponsesAndPdfsDesktop.args = {
+  downloadPercentage: 0,
+  isDownloading: false,
+  responsesCount: 9001,
+  downloadOptions: {
+    isDownloadAttachments: false,
+    isDownloadCsv: true,
+    isDownloadPdf: true,
+  },
+}
+
+export const ConfirmationScreenAttachmentsAndPdfsDesktop = Template.bind({})
+ConfirmationScreenAttachmentsAndPdfsDesktop.args = {
+  downloadPercentage: 0,
+  isDownloading: false,
+  responsesCount: 9001,
+  downloadOptions: {
+    isDownloadAttachments: true,
+    isDownloadCsv: false,
+    isDownloadPdf: true,
+  },
+}
+
 export const ConfirmationStateAttachmentsOnlyDesktop = Template.bind({})
 ConfirmationStateAttachmentsOnlyDesktop.args = {
   downloadPercentage: 0,
@@ -65,6 +103,18 @@ export const ConfirmationStateAttachmentsOnlyMobile = Template.bind({})
 ConfirmationStateAttachmentsOnlyMobile.args =
   ConfirmationStateAttachmentsOnlyDesktop.args
 ConfirmationStateAttachmentsOnlyMobile.parameters = getMobileViewParameters()
+
+export const ConfirmationScreenPdfsOnlyDesktop = Template.bind({})
+ConfirmationScreenPdfsOnlyDesktop.args = {
+  downloadPercentage: 0,
+  isDownloading: false,
+  responsesCount: 9001,
+  downloadOptions: {
+    isDownloadAttachments: false,
+    isDownloadCsv: false,
+    isDownloadPdf: true,
+  },
+}
 
 export const DownloadingStateDesktop = Template.bind({})
 DownloadingStateDesktop.args = {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
@@ -40,6 +40,7 @@ ConfirmationStateResponseAndAttachmentsDesktop.args = {
   downloadOptions: {
     isDownloadAttachments: true,
     isDownloadCsv: true,
+    isDownloadPdf: false,
   },
 }
 export const ConfirmationStateResponseAndAttachmentsMobile = Template.bind({})
@@ -56,6 +57,7 @@ ConfirmationStateAttachmentsOnlyDesktop.args = {
   downloadOptions: {
     isDownloadAttachments: true,
     isDownloadCsv: false,
+    isDownloadPdf: false,
   },
 }
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
@@ -2,7 +2,7 @@ import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 import { Remote } from 'comlink'
 import { SetRequired } from 'type-fest'
 
-import { SubmissionMrfMetadata } from '~shared/types'
+import { SubmissionMrfMetadata, SubmissionStreamDto } from '~shared/types'
 
 import { CsvRecord } from './utils/CsvRecord.class'
 import { DecryptionWorkerApi } from './worker/decryption.worker'
@@ -49,6 +49,7 @@ export type CleanableDecryptionWorkerApi = {
 export interface DownloadOptions {
   isDownloadAttachments: boolean
   isDownloadCsv: boolean
+  isDownloadPdf: boolean
 }
 
 /**
@@ -61,7 +62,8 @@ export type DecryptedData = {
   }
   materializedCsvRecord?: MaterializedCsvRecord
   attachmentDownloadBlob?: Blob
-  submissionId?: string
+  parsedSubmission?: SubmissionStreamDto
+  decryptedResponses?: FormField[]
 }
 
 /** Download result after downloading storage mode responses */

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMutation, UseMutationOptions } from 'react-query'
 import { datadogLogs } from '@datadog/browser-logs'
+import saveAs from 'file-saver'
+import JSZip from 'jszip'
 
 import { waitForMs } from '~utils/waitForMs'
 
@@ -13,6 +15,8 @@ import {
   trackPartialDecryptionFailure,
 } from '~features/analytics/AnalyticsService'
 import { useUser } from '~features/user/queries'
+
+import { generateResponsePdfBlob } from '../../IndividualResponsePage/utils/generateResponsePdf'
 
 import { downloadResponseAttachment } from './utils/downloadCsv'
 import { EncryptedResponseCsvGenerator } from './utils/EncryptedResponseCsvGenerator'
@@ -48,6 +52,7 @@ export type DownloadEncryptedParams = EncryptedResponsesStreamParams & {
   // Used to determine if we should add MRF related columns to the CSV.
   isMrf: boolean
   isDownloadCsv: boolean
+  isDownloadPdf: boolean
 }
 interface UseDecryptionWorkersProps {
   onProgress: (progress: number) => void
@@ -85,6 +90,7 @@ const useDecryptionWorkers = ({
       responsesCount,
       downloadAttachments,
       isDownloadCsv,
+      isDownloadPdf,
       secretKey,
       endDate,
       startDate,
@@ -237,7 +243,7 @@ const useDecryptionWorkers = ({
                 if (
                   downloadAttachments &&
                   decryptResult.attachmentDownloadBlob &&
-                  decryptResult.submissionId
+                  decryptResult.parsedSubmission?._id
                 ) {
                   attachmentsToSaveCount += 1
 
@@ -262,7 +268,7 @@ const useDecryptionWorkers = ({
                   }
                   await downloadResponseAttachment(
                     decryptResult.attachmentDownloadBlob,
-                    decryptResult.submissionId,
+                    decryptResult.parsedSubmission._id,
                   )
                 }
                 return decryptResult
@@ -281,6 +287,39 @@ const useDecryptionWorkers = ({
       return new Promise<DownloadResult>((resolve, reject) => {
         // Step 1: Decrypt all submissions and their attachments (into blobs), add the submissions into the csv object and save the attachments into user's computer.
         Promise.all(submissionDecryptPromises)
+          // Step 2: Save the PDFs for each submission into a zip file.
+          .then(async (decryptResults) => {
+            if (isDownloadPdf) {
+              const pdfZip = new JSZip()
+              for (const decryptResult of decryptResults) {
+                const { parsedSubmission, decryptedResponses } = decryptResult
+                if (
+                  decryptedResponses !== undefined &&
+                  parsedSubmission !== undefined
+                ) {
+                  const { _id: refNo, created: submissionTime } =
+                    parsedSubmission
+                  const { pdfBlob, pdfTitle } = await generateResponsePdfBlob({
+                    form: adminForm,
+                    submission: {
+                      refNo,
+                      submissionTime,
+                      responses: decryptedResponses,
+                    },
+                  })
+                  pdfZip.file(pdfTitle, pdfBlob)
+                }
+              }
+              await pdfZip
+                .generateAsync({ type: 'blob' })
+                .then(function (content) {
+                  saveAs(
+                    content,
+                    `${adminForm.title}-formId_${adminForm._id}-response_pdfs.zip`,
+                  )
+                })
+            }
+          })
           .catch((err) => {
             if (!downloadStartTime) {
               // No start time, means did not even start http request.

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -394,7 +394,11 @@ async function parseAndDecryptSubmissionData({
   }
 }
 
-type GetDecryptedDataParams = DownloadOptions & SubmissionDataForDecryption
+type GetDecryptedDataParams = Pick<
+  DownloadOptions,
+  'isDownloadAttachments' | 'isDownloadCsv'
+> &
+  SubmissionDataForDecryption
 
 async function getDecryptedData(
   getDecryptedDataParams: GetDecryptedDataParams,
@@ -452,8 +456,11 @@ async function getDecryptedData(
   return {
     materializedCsvRecord,
     attachmentDownloadBlob,
-    submissionId: isParseSuccessful
-      ? decryptedSubmissionResult.parsedSubmission._id
+    parsedSubmission: isParseSuccessful
+      ? decryptedSubmissionResult.parsedSubmission
+      : undefined,
+    decryptedResponses: isDecryptionSuccessful
+      ? decryptedSubmissionResult.decryptedResponses
       : undefined,
     status: {
       isDecryptionSuccessful,

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
@@ -21,18 +21,24 @@ export const enSG: ResponsesResponsesPage = {
           backToResponses: 'Back to responses',
         },
         confirmationScreen: {
+          pdfsDescription:
+            'For PDFs, all files will be bundled into a <strong>single zip</strong>.',
           attachmentsDescription:
             'For attachments, <strong>a separate zip file</strong> will be downloaded for each response.',
+          titlePdfsOnly: 'Download PDFs',
           titleAttachmentsOnly: 'Download attachments',
           titleResponsesAndAttachments: 'Download responses and attachments',
+          titleResponsesAndPdfs: 'Download responses and PDFs',
+          titleAttachmentsAndPdfs: 'Download attachments and PDFs',
+          titleResponsesAndAttachmentsAndPdfs:
+            'Download responses, attachments and PDFs',
           numberOfResponses: 'Number of responses',
           estimatedTime: 'Estimated time',
           estimatedTimeReference: '30-50 mins per 1,000 responses',
           filterResponsesCountHelperText:
             'You can reduce the number of downloads at one go by adjusting the date range.',
           intensiveOperationWarning: {
-            title:
-              'Downloading many attachments can be an intensive operation.',
+            title: 'Downloading many files can be an intensive operation.',
             doNotUseIE: 'Do not use Internet Explorer',
             ensureStrongNetworkConnectivity:
               'Ensure network connectivity is strong',

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
@@ -79,6 +79,7 @@ export const enSG: ResponsesResponsesPage = {
         menuItem: {
           csv: 'Spreadsheet of responses (.csv)',
           attachments: 'Respondent-uploaded attachments',
+          pdfs: 'PDF copies of responses (.pdf)',
         },
       },
       unlockedResponses: {

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
@@ -25,13 +25,11 @@ export const enSG: ResponsesResponsesPage = {
             'For PDFs, all files will be bundled into a <strong>single zip</strong>.',
           attachmentsDescription:
             'For attachments, <strong>a separate zip file</strong> will be downloaded for each response.',
-          titlePdfsOnly: 'Download PDFs',
-          titleAttachmentsOnly: 'Download attachments',
-          titleResponsesAndAttachments: 'Download responses and attachments',
-          titleResponsesAndPdfs: 'Download responses and PDFs',
-          titleAttachmentsAndPdfs: 'Download attachments and PDFs',
-          titleResponsesAndAttachmentsAndPdfs:
-            'Download responses, attachments and PDFs',
+          downloadTitle: 'Download {downloadItems}',
+          responsesText: 'responses',
+          pdfsText: 'PDFs',
+          attachmentsText: 'attachments',
+          andText: 'and',
           numberOfResponses: 'Number of responses',
           estimatedTime: 'Estimated time',
           estimatedTimeReference: '30-50 mins per 1,000 responses',

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
@@ -18,9 +18,14 @@ export interface ResponsesResponsesPage {
           backToResponses: string
         }
         confirmationScreen: {
+          titlePdfsOnly: string
           titleAttachmentsOnly: string
           titleResponsesAndAttachments: string
+          titleResponsesAndPdfs: string
+          titleAttachmentsAndPdfs: string
+          titleResponsesAndAttachmentsAndPdfs: string
           attachmentsDescription: string
+          pdfsDescription: string
           numberOfResponses: string
           estimatedTime: string
           estimatedTimeReference: string

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
@@ -67,6 +67,7 @@ export interface ResponsesResponsesPage {
         menuItem: {
           csv: string
           attachments: string
+          pdfs: string
         }
       }
       unlockedResponses: {

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
@@ -18,12 +18,11 @@ export interface ResponsesResponsesPage {
           backToResponses: string
         }
         confirmationScreen: {
-          titlePdfsOnly: string
-          titleAttachmentsOnly: string
-          titleResponsesAndAttachments: string
-          titleResponsesAndPdfs: string
-          titleAttachmentsAndPdfs: string
-          titleResponsesAndAttachmentsAndPdfs: string
+          downloadTitle: string
+          responsesText: string
+          pdfsText: string
+          attachmentsText: string
+          andText: string
           attachmentsDescription: string
           pdfsDescription: string
           numberOfResponses: string


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
During audit, pdfs of submissions may be shared with auditors. Currently, generating pdfs for all submissions is a manual process where pdfs need to be generated one by one. Hence, a bulk pdf generation button is required for save user's time. 

## Solution
<!-- How did you solve the problem? -->
Add bulk export of submissions as pdf to bulk download options. 

Fixes FRM-2236

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? --> 
No - this PR is backwards compatible  

## Before & After Screenshots
**AFTER**:
<!-- [insert screenshot here] -->
<img width="344" height="378" alt="image" src="https://github.com/user-attachments/assets/90f10a2c-66ed-4258-9226-e9a7a3a00aaa" />

Added option to download pdfs. 

<img width="676" height="525" alt="image" src="https://github.com/user-attachments/assets/9a0e2735-f16f-4dc0-8ef4-69ef056f1aea" />

Confirmation modal for pdf and attachment downloads.  

## Tests
<!-- What tests should be run to confirm functionality? -->
Pre-req: 
- [ ] Create 2 forms - one MRF and one storage mode form with attachment field + make multiple submissions for both forms. 

TC1: Bulk attachment downloads and csv work 
- [ ] Select the checkboxes for both csv + attachments from the storage form. 
- [ ] Observe that the button is `next` and clicking on it will show a modal which displays 'download attachments and responses'. 
- [ ] Assert the attachment files are downloaded and csv is correctly
formatted.  
- [ ] Repeat for mrf form. 

TC2: Bulk response only downloads work
- [ ] Select only csv checkbox from the storage form. 
- [ ] Observe the button is `start download`. 
- [ ] Click and download the csv. 
- [ ] Assert only csv is downloaded and it is correctly formatted.  
- [ ] Repeat for mrf form. 

TC3: Bulk attachment only downloads work. 
- [ ] Select only attachment checkbox from the storage form. 
- [ ] Observe that the button is `next` and clicking on it will show a modal, which displays 'download attachments' 
- [ ] Click the download button. 
- [ ] Assert only attachment zips are downloaded and there is no csv file or pdfs.  
- [ ] Repeat for mrf form. 

TC4: Bulk pdf only downloads work. 
- [ ] Select only pdf checkbox from the storage form. 
- [ ] Observe that the button is `next` and clicking on it will show a modal, which displays 'download pdfs' 
- [ ] Click the download button. 
- [ ] Assert only 1 pdf zip is downloaded and there is no csv file or attachments.  
- [ ] Repeat for mrf form. 

TC5: Bulk all responses + pdf + attachment downloads work.
- [ ] Select all 3 checkboxes from the storage form. 
- [ ] Observe that the button is `next` and clicking on it will show a modal, which displays 'download responses, attachments and pdfs' 
- [ ] Click the download button. 
- [ ] Assert attachments zips≤ a single pdf zip and single csv file are downloaded and correctly formatted.  
- [ ] Repeat for mrf form. 

TC6: Bulk attachments + pdf downloads work. 
- [ ] Select attachemnt and pdf checkboxes from the storage form. 
- [ ] Observe that the button is `next` and clicking on it will show a modal, which displays 'download attachments and pdfs' 
- [ ] Click the download button. 
- [ ] Assert attachments zips≤ a single pdf zip is downloaded and correctly formatted. there should be no csv file  
- [ ] Repeat for mrf form. 