### PR TITLE
feat(bulk-local-pdf): abstract out decryption function (part 1)

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -70,7 +70,6 @@ async function decryptSubmissionData({
       isSubmissionDecryptionSuccessful: true
     }
   | {
-      errorMessage: string
       isSubmissionDecryptionSuccessful: false
     }
 > {
@@ -86,10 +85,8 @@ async function decryptSubmissionData({
         version,
       })
       if (!decryptedObject) {
-        const errorMessage = `Invalid decryption for storage mode response`
-        console.error(errorMessage)
+        console.error('Invalid decryption for storage mode response')
         return {
-          errorMessage,
           isSubmissionDecryptionSuccessful: false,
         }
       }
@@ -105,10 +102,8 @@ async function decryptSubmissionData({
         version,
       })
       if (!decryptedObject) {
-        const errorMessage = `Invalid decryption for multirespondent response`
-        console.error(errorMessage)
+        console.error('Invalid decryption for multirespondent response')
         return {
-          errorMessage,
           isSubmissionDecryptionSuccessful: false,
         }
       }
@@ -122,10 +117,8 @@ async function decryptSubmissionData({
     default: {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _: never = submissionData
-      const errorMessage = `Invalid submission type encountered.`
-      console.error(errorMessage)
+      console.error('Invalid submission type encountered.')
       return {
-        errorMessage,
         isSubmissionDecryptionSuccessful: false,
       }
     }

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -16,6 +16,10 @@ import {
 } from '../types'
 import { CsvRecord } from '../utils/CsvRecord.class'
 import { downloadAndDecryptAttachmentsAsZip } from '../utils/downloadAndDecryptAttachment'
+import {
+  processDecryptedContent,
+  processDecryptedContentV3,
+} from '../utils/processDecryptedContent'
 
 const queue = new PQueue({ concurrency: 1 })
 
@@ -59,14 +63,17 @@ async function decryptSubmissionData({
 }: {
   submissionData: SubmissionStreamDto
   secretKey: string
-}): Promise<{
-  decryptedResponses: FormField[]
-  mrfSubmissionSecretKey?: string
-}> {
-  const { processDecryptedContent, processDecryptedContentV3 } = await import(
-    '../utils/processDecryptedContent'
-  )
-
+}): Promise<
+  | {
+      decryptedResponses: FormField[]
+      mrfSubmissionSecretKey?: string
+      isSubmissionDecryptionSuccessful: true
+    }
+  | {
+      errorMessage: string
+      isSubmissionDecryptionSuccessful: false
+    }
+> {
   const { encryptedContent, verifiedContent, version, submissionType } =
     submissionData
 
@@ -79,7 +86,12 @@ async function decryptSubmissionData({
         version,
       })
       if (!decryptedObject) {
-        throw new Error('Invalid decryption for storage mode response')
+        const errorMessage = `Invalid decryption for storage mode response`
+        console.error(errorMessage)
+        return {
+          errorMessage,
+          isSubmissionDecryptionSuccessful: false,
+        }
       }
       decryptedResponses = processDecryptedContent(decryptedObject)
       break
@@ -93,7 +105,12 @@ async function decryptSubmissionData({
         version,
       })
       if (!decryptedObject) {
-        throw new Error('Invalid decryption for multirespondent response')
+        const errorMessage = `Invalid decryption for multirespondent response`
+        console.error(errorMessage)
+        return {
+          errorMessage,
+          isSubmissionDecryptionSuccessful: false,
+        }
       }
       mrfSubmissionSecretKey = decryptedObject.submissionSecretKey
       decryptedResponses = await processDecryptedContentV3(
@@ -105,13 +122,18 @@ async function decryptSubmissionData({
     default: {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const _: never = submissionData
-      throw new Error('Invalid submission type encountered.')
+      const errorMessage = `Invalid submission type encountered.`
+      console.error(errorMessage)
+      return {
+        errorMessage,
+        isSubmissionDecryptionSuccessful: false,
+      }
     }
   }
-
   return {
     decryptedResponses,
     mrfSubmissionSecretKey,
+    isSubmissionDecryptionSuccessful: true,
   }
 }
 
@@ -162,81 +184,85 @@ async function decryptIntoCsv(
         : undefined,
     )
 
-    try {
-      const { decryptedResponses, mrfSubmissionSecretKey } =
-        await decryptSubmissionData({
-          submissionData: submission,
-          secretKey,
-        })
+    const decryptSubmissionDataResult = await decryptSubmissionData({
+      submissionData: submission,
+      secretKey,
+    })
 
-      if (
-        // Short-circuit signature verification for multirespondent submission
-        submissionType === SubmissionType.Multirespondent ||
-        verifySignature(decryptedResponses, submissionCreated)
-      ) {
-        csvRecord.setStatus(CsvRecordStatus.Ok, 'Success')
-        csvRecord.setRecord(decryptedResponses)
-      } else {
-        csvRecord.setStatus(CsvRecordStatus.Unverified, 'Unverified')
-      }
-
-      if (downloadAttachments) {
-        // Logic to determine which key to use to decrypt attachments.
-        const attachmentDecryptionKey =
-          // If no submission secret key present, it is a storage mode form. So, use form secret key.
-          !mrfSubmissionSecretKey
-            ? secretKey
-            : // It's an mrf, but old version
-              submissionType === SubmissionType.Multirespondent &&
-                !submission.mrfVersion
-              ? secretKey
-              : mrfSubmissionSecretKey
-
-        let questionCount = 0
-        const extraAttachments: {
-          filename: string
-          blob: Blob
-        }[] = []
-        decryptedResponses.forEach((field) => {
-          // Populate question number
-          if (field.fieldType !== 'section') {
-            ++questionCount
-          }
-          // Populate S3 presigned URL for attachments
-          if (submission.attachmentMetadata[field._id]) {
-            attachmentDownloadUrls.set(questionCount, {
-              url: submission.attachmentMetadata[field._id],
-              filename: field.answer,
-            })
-          }
-        })
-
-        try {
-          downloadBlob = await queue.add(() =>
-            downloadAndDecryptAttachmentsAsZip(
-              attachmentDownloadUrls,
-              attachmentDecryptionKey,
-              extraAttachments,
-            ),
-          )
-          csvRecord.setStatus(
-            CsvRecordStatus.Ok,
-            'Success (with Downloaded Attachment)',
-          )
-          if (isFasterDownloadsEnabled) {
-            csvRecord.downloadBlobURL = URL.createObjectURL(downloadBlob)
-          } else {
-            csvRecord.setDownloadBlob(downloadBlob)
-          }
-        } catch (error) {
-          csvRecord.setStatus(
-            CsvRecordStatus.AttachmentError,
-            'Attachment Download Error',
-          )
-        }
-      }
-    } catch (error) {
+    if (!decryptSubmissionDataResult.isSubmissionDecryptionSuccessful) {
       csvRecord.setStatus(CsvRecordStatus.Error, 'Decryption Error')
+      csvRecord.materializeSubmissionData()
+      return csvRecord as MaterializedCsvRecord
+    }
+
+    const { decryptedResponses, mrfSubmissionSecretKey } =
+      decryptSubmissionDataResult
+
+    if (
+      // Short-circuit signature verification for multirespondent submission
+      submissionType === SubmissionType.Multirespondent ||
+      verifySignature(decryptedResponses, submissionCreated)
+    ) {
+      csvRecord.setStatus(CsvRecordStatus.Ok, 'Success')
+      csvRecord.setRecord(decryptedResponses)
+    } else {
+      csvRecord.setStatus(CsvRecordStatus.Unverified, 'Unverified')
+    }
+
+    if (downloadAttachments) {
+      // Logic to determine which key to use to decrypt attachments.
+      const attachmentDecryptionKey =
+        // If no submission secret key present, it is a storage mode form. So, use form secret key.
+        !mrfSubmissionSecretKey
+          ? secretKey
+          : // It's an mrf, but old version
+            submissionType === SubmissionType.Multirespondent &&
+              !submission.mrfVersion
+            ? secretKey
+            : mrfSubmissionSecretKey
+
+      let questionCount = 0
+      const extraAttachments: {
+        filename: string
+        blob: Blob
+      }[] = []
+      decryptedResponses.forEach((field) => {
+        // Populate question number
+        if (field.fieldType !== 'section') {
+          ++questionCount
+        }
+        // Populate S3 presigned URL for attachments
+        if (submission.attachmentMetadata[field._id]) {
+          attachmentDownloadUrls.set(questionCount, {
+            url: submission.attachmentMetadata[field._id],
+            filename: field.answer,
+          })
+        }
+      })
+
+      try {
+        downloadBlob = await queue.add(() =>
+          downloadAndDecryptAttachmentsAsZip(
+            attachmentDownloadUrls,
+            attachmentDecryptionKey,
+            extraAttachments,
+          ),
+        )
+        csvRecord.setStatus(
+          CsvRecordStatus.Ok,
+          'Success (with Downloaded Attachment)',
+        )
+        if (isFasterDownloadsEnabled) {
+          csvRecord.downloadBlobURL = URL.createObjectURL(downloadBlob)
+        } else {
+          csvRecord.setDownloadBlob(downloadBlob)
+        }
+      } catch (error) {
+        csvRecord.setStatus(
+          CsvRecordStatus.AttachmentError,
+          'Attachment Download Error',
+        )
+      }
     }
   } catch (error) {
     csvRecord = new CsvRecord(

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -1,6 +1,9 @@
+import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 import { expose } from 'comlink'
 import { formatInTimeZone } from 'date-fns-tz'
 import PQueue from 'p-queue'
+
+import { SubmissionStreamDto, SubmissionType } from '~shared/types'
 
 import formsgSdk from '~utils/formSdk'
 
@@ -12,6 +15,7 @@ import {
   MaterializedCsvRecord,
 } from '../types'
 import { CsvRecord } from '../utils/CsvRecord.class'
+import { downloadAndDecryptAttachmentsAsZip } from '../utils/downloadAndDecryptAttachment'
 
 const queue = new PQueue({ concurrency: 1 })
 
@@ -49,6 +53,68 @@ function verifySignature(
   return verified.every((v) => v)
 }
 
+async function decryptSubmissionData({
+  submissionData,
+  secretKey,
+}: {
+  submissionData: SubmissionStreamDto
+  secretKey: string
+}): Promise<{
+  decryptedResponses: FormField[]
+  mrfSubmissionSecretKey?: string
+}> {
+  const { processDecryptedContent, processDecryptedContentV3 } = await import(
+    '../utils/processDecryptedContent'
+  )
+
+  const { encryptedContent, verifiedContent, version, submissionType } =
+    submissionData
+
+  let decryptedResponses, mrfSubmissionSecretKey
+  switch (submissionType) {
+    case SubmissionType.Encrypt: {
+      const decryptedObject = formsgSdk.crypto.decrypt(secretKey, {
+        encryptedContent,
+        verifiedContent,
+        version,
+      })
+      if (!decryptedObject) {
+        throw new Error('Invalid decryption for storage mode response')
+      }
+      decryptedResponses = processDecryptedContent(decryptedObject)
+      break
+    }
+    case SubmissionType.Multirespondent: {
+      const decryptedObject = formsgSdk.cryptoV3.decrypt(secretKey, {
+        encryptedSubmissionSecretKey:
+          submissionData.encryptedSubmissionSecretKey,
+        encryptedContent,
+        verifiedContent,
+        version,
+      })
+      if (!decryptedObject) {
+        throw new Error('Invalid decryption for multirespondent response')
+      }
+      mrfSubmissionSecretKey = decryptedObject.submissionSecretKey
+      decryptedResponses = await processDecryptedContentV3(
+        submissionData.form_fields,
+        decryptedObject,
+      )
+      break
+    }
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _: never = submissionData
+      throw new Error('Invalid submission type encountered.')
+    }
+  }
+
+  return {
+    decryptedResponses,
+    mrfSubmissionSecretKey,
+  }
+}
+
 /**
  * Decrypts given data into a {@type CsvRecord} and posts the result back to the
  * main thread.
@@ -56,41 +122,34 @@ function verifySignature(
  */
 async function decryptIntoCsv(
   data: LineData,
-  isFasterDownloadsEnabled: boolean,
+  isFasterDownloadsEnabled: boolean = false,
 ): Promise<MaterializedCsvRecord> {
   // This needs to be dynamically imported due to sharing code between main app and worker code.
   // Fixes issue raised at https://stackoverflow.com/questions/66472945/referenceerror-refreshreg-is-not-defined
   // Something to do with babel-loader.
-
-  // TODO: May be removed when we move to Webpack 5, where web workers are now first class citizens?
-  const { processDecryptedContent, processDecryptedContentV3 } = await import(
-    '../utils/processDecryptedContent'
-  )
-  const { downloadAndDecryptAttachmentsAsZip } = await import(
-    '../utils/downloadAndDecryptAttachment'
-  )
-
-  const { SubmissionStreamDto, SubmissionType } = await import('~shared/types')
-
   const { line, secretKey, downloadAttachments, formId, hostOrigin } = data
-
-  let csvRecord: CsvRecord
   const attachmentDownloadUrls: AttachmentsDownloadMap = new Map()
   let downloadBlob: Blob
+  let csvRecord: CsvRecord
 
   try {
-    // Validate that the submission is of a valid shape.
     const submission = SubmissionStreamDto.parse(JSON.parse(line))
+    const {
+      _id: submissionId,
+      created: submissionCreated,
+      submissionType,
+    } = submission
+
     csvRecord = new CsvRecord(
-      submission._id,
-      submission.created,
+      submissionId,
+      submissionCreated,
       CsvRecordStatus.Unknown,
       formId,
       hostOrigin,
-      submission.submissionType === SubmissionType.Encrypt
+      submissionType === SubmissionType.Encrypt
         ? submission.payment
         : undefined,
-      submission.submissionType === SubmissionType.Multirespondent
+      submissionType === SubmissionType.Multirespondent
         ? {
             workflowStatus: submission.mrfMeta.workflowStatus,
             workflowCurrentStepNumber:
@@ -102,53 +161,21 @@ async function decryptIntoCsv(
           }
         : undefined,
     )
+
     try {
-      let decryptedSubmission, submissionSecretKey
-      switch (submission.submissionType) {
-        case SubmissionType.Encrypt: {
-          const decryptedObject = formsgSdk.crypto.decrypt(secretKey, {
-            encryptedContent: submission.encryptedContent,
-            verifiedContent: submission.verifiedContent,
-            version: submission.version,
-          })
-          if (!decryptedObject) {
-            throw new Error('Invalid decryption for storage mode response')
-          }
-          decryptedSubmission = processDecryptedContent(decryptedObject)
-          break
-        }
-        case SubmissionType.Multirespondent: {
-          const decryptedObject = formsgSdk.cryptoV3.decrypt(secretKey, {
-            encryptedSubmissionSecretKey:
-              submission.encryptedSubmissionSecretKey,
-            encryptedContent: submission.encryptedContent,
-            verifiedContent: submission.verifiedContent,
-            version: submission.version,
-          })
-          if (!decryptedObject) {
-            throw new Error('Invalid decryption for multirespondent response')
-          }
-          submissionSecretKey = decryptedObject.submissionSecretKey
-          decryptedSubmission = await processDecryptedContentV3(
-            submission.form_fields,
-            decryptedObject,
-          )
-          break
-        }
-        default: {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const _: never = submission
-          throw new Error('Invalid submission type encountered.')
-        }
-      }
+      const { decryptedResponses, mrfSubmissionSecretKey } =
+        await decryptSubmissionData({
+          submissionData: submission,
+          secretKey,
+        })
 
       if (
         // Short-circuit signature verification for multirespondent submission
-        submission.submissionType === SubmissionType.Multirespondent ||
-        verifySignature(decryptedSubmission, submission.created)
+        submissionType === SubmissionType.Multirespondent ||
+        verifySignature(decryptedResponses, submissionCreated)
       ) {
         csvRecord.setStatus(CsvRecordStatus.Ok, 'Success')
-        csvRecord.setRecord(decryptedSubmission)
+        csvRecord.setRecord(decryptedResponses)
       } else {
         csvRecord.setStatus(CsvRecordStatus.Unverified, 'Unverified')
       }
@@ -157,20 +184,20 @@ async function decryptIntoCsv(
         // Logic to determine which key to use to decrypt attachments.
         const attachmentDecryptionKey =
           // If no submission secret key present, it is a storage mode form. So, use form secret key.
-          !submissionSecretKey
+          !mrfSubmissionSecretKey
             ? secretKey
             : // It's an mrf, but old version
-              submission.submissionType === SubmissionType.Multirespondent &&
+              submissionType === SubmissionType.Multirespondent &&
                 !submission.mrfVersion
               ? secretKey
-              : submissionSecretKey
+              : mrfSubmissionSecretKey
 
         let questionCount = 0
         const extraAttachments: {
           filename: string
           blob: Blob
         }[] = []
-        decryptedSubmission.forEach((field) => {
+        decryptedResponses.forEach((field) => {
           // Populate question number
           if (field.fieldType !== 'section') {
             ++questionCount

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -150,28 +150,23 @@ async function decryptIntoCsv(
   // Fixes issue raised at https://stackoverflow.com/questions/66472945/referenceerror-refreshreg-is-not-defined
   // Something to do with babel-loader.
   const { line, secretKey, downloadAttachments, formId, hostOrigin } = data
+  let csvRecord: CsvRecord
   const attachmentDownloadUrls: AttachmentsDownloadMap = new Map()
   let downloadBlob: Blob
-  let csvRecord: CsvRecord
 
   try {
     const submission = SubmissionStreamDto.parse(JSON.parse(line))
-    const {
-      _id: submissionId,
-      created: submissionCreated,
-      submissionType,
-    } = submission
 
     csvRecord = new CsvRecord(
-      submissionId,
-      submissionCreated,
+      submission._id,
+      submission.created,
       CsvRecordStatus.Unknown,
       formId,
       hostOrigin,
-      submissionType === SubmissionType.Encrypt
+      submission.submissionType === SubmissionType.Encrypt
         ? submission.payment
         : undefined,
-      submissionType === SubmissionType.Multirespondent
+      submission.submissionType === SubmissionType.Multirespondent
         ? {
             workflowStatus: submission.mrfMeta.workflowStatus,
             workflowCurrentStepNumber:
@@ -200,8 +195,8 @@ async function decryptIntoCsv(
 
     if (
       // Short-circuit signature verification for multirespondent submission
-      submissionType === SubmissionType.Multirespondent ||
-      verifySignature(decryptedResponses, submissionCreated)
+      submission.submissionType === SubmissionType.Multirespondent ||
+      verifySignature(decryptedResponses, submission.created)
     ) {
       csvRecord.setStatus(CsvRecordStatus.Ok, 'Success')
       csvRecord.setRecord(decryptedResponses)
@@ -216,7 +211,7 @@ async function decryptIntoCsv(
         !mrfSubmissionSecretKey
           ? secretKey
           : // It's an mrf, but old version
-            submissionType === SubmissionType.Multirespondent &&
+            submission.submissionType === SubmissionType.Multirespondent &&
               !submission.mrfVersion
             ? secretKey
             : mrfSubmissionSecretKey


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, the `decryptIntoCsv` function handles the decryption, creation of csv rows and downloading of attachments. This makes it challenging to reuse the same decryption function for other purposes (eg, bulk pdf generation, charts, better dashboards, truly parallel local decryptions)  

Also, the decryption function uses exceptions for flow control, which makes the code hard to understand. this should be avoided, see: https://nus-cs2030s.github.io/2021-s2/19-exception.html#do-not-use-exception-as-a-control-flow-mechanism, https://medium.com/@samanwayghatak/exception-as-control-flow-anti-pattern-e3b46b079cdd

Closes FRM-2223

## Solution
<!-- How did you solve the problem? -->
Abstract the decryption to its own reusable function.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Pre-req: 
- [x] Create 2 forms - one MRF and one storage mode form with attachment field + make multiple submissions for both forms. 

TC1: Bulk attachment downloads  and csv work for storage mode 
- [x] Download csv + attachments from the storage form. Assert the files are downloaded and csv is correctly 
formatted.  
- [x] Download csv only from the storage form. Assert the csv is correctly formatted.  

TC2: Bulk attachment downloads  and csv work for MRF mode 
- [x] Download csv + attachments from the mrf form. Assert the files are downloaded and csv is correctly 
formatted.  
- [x] Download csv only from the mrf form. Assert the csv is correctly formatted.  