### PR TITLE
feat(bulk-local-pdf): remove faster downloads (part 2)

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMutation, UseMutationOptions } from 'react-query'
 import { datadogLogs } from '@datadog/browser-logs'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
 
 import { waitForMs } from '~utils/waitForMs'
 
@@ -15,10 +14,7 @@ import {
 } from '~features/analytics/AnalyticsService'
 import { useUser } from '~features/user/queries'
 
-import {
-  downloadResponseAttachment,
-  downloadResponseAttachmentURL,
-} from './utils/downloadCsv'
+import { downloadResponseAttachment } from './utils/downloadCsv'
 import { EncryptedResponseCsvGenerator } from './utils/EncryptedResponseCsvGenerator'
 import {
   EncryptedResponsesStreamParams,
@@ -61,19 +57,6 @@ interface UseDecryptionWorkersProps {
   >
 }
 
-function timeout(
-  ms: number,
-  errorMessage = 'Operation timed out',
-): Promise<never> {
-  return new Promise((_, reject) =>
-    setTimeout(() => reject(new Error(errorMessage)), ms),
-  )
-}
-
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
-  return Promise.race([promise, timeout(ms)])
-}
-
 const useDecryptionWorkers = ({
   onProgress,
   mutateProps,
@@ -83,10 +66,6 @@ const useDecryptionWorkers = ({
 
   const { data: adminForm } = useAdminForm()
   const { user } = useUser()
-
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-  const isFasterDownloadsFeatureOn = useFeatureIsOn('faster-downloads')
-  const isFasterDownloadsEnabled = isTest || isFasterDownloadsFeatureOn
 
   useEffect(() => {
     return () => killWorkers(workers)
@@ -186,16 +165,13 @@ const useDecryptionWorkers = ({
                 // round-robin scheduling
                 const { workerApi } =
                   workerPool[receivedRecordCount % numWorkers]
-                const decryptResult = await workerApi.decryptIntoCsv(
-                  {
-                    line: result.value,
-                    secretKey,
-                    downloadAttachments,
-                    formId: adminForm._id,
-                    hostOrigin: window.location.origin,
-                  },
-                  isFasterDownloadsEnabled,
-                )
+                const decryptResult = await workerApi.decryptIntoCsv({
+                  line: result.value,
+                  secretKey,
+                  downloadAttachments,
+                  formId: adminForm._id,
+                  hostOrigin: window.location.origin,
+                })
                 progress += 1
                 onProgress(progress)
 
@@ -376,321 +352,11 @@ const useDecryptionWorkers = ({
           })
       })
     },
-    [adminForm, onProgress, user?._id, workers, isFasterDownloadsEnabled],
-  )
-
-  const downloadEncryptedResponsesFaster = useCallback(
-    async ({
-      responsesCount,
-      downloadAttachments,
-      secretKey,
-      endDate,
-      startDate,
-      isMrf,
-    }: DownloadEncryptedParams) => {
-      if (!adminForm || !responsesCount) {
-        return Promise.resolve({
-          expectedCount: 0,
-          successCount: 0,
-          errorCount: 0,
-        })
-      }
-
-      console.log('Faster downloads is enabled ⚡')
-
-      abortControllerRef.current.abort()
-      const freshAbortController = new AbortController()
-      abortControllerRef.current = freshAbortController
-
-      if (workers.length) killWorkers(workers)
-
-      const numWorkers = window.navigator.hardwareConcurrency || 4
-      let errorCount = 0
-      let unverifiedCount = 0
-      let attachmentErrorCount = 0
-      let unknownStatusCount = 0
-
-      const logMeta = {
-        action: 'downloadEncryptedReponses',
-        formId: adminForm._id,
-        formTitle: adminForm.title,
-        downloadAttachments: downloadAttachments,
-        num_workers: numWorkers,
-        expectedNumSubmissions: NUM_OF_METADATA_ROWS,
-        adminId: user?._id,
-      }
-      // Trigger analytics here before starting decryption worker
-      trackDownloadResponseStart(adminForm, numWorkers, NUM_OF_METADATA_ROWS)
-      datadogLogs.logger.info('Download response start', {
-        meta: {
-          ...logMeta,
-        },
-      })
-
-      const workerPool: CleanableDecryptionWorkerApi[] = []
-      const idleWorkers: number[] = []
-
-      for (let i = workerPool.length; i < numWorkers; i++) {
-        workerPool.push(makeWorkerApiAndCleanup())
-        idleWorkers.push(i)
-      }
-
-      setWorkers(workerPool)
-
-      const csvGenerator = new EncryptedResponseCsvGenerator(
-        responsesCount,
-        NUM_OF_METADATA_ROWS,
-        isMrf,
-      )
-
-      const stream = await getEncryptedResponsesStream(
-        adminForm._id,
-        { downloadAttachments, endDate, startDate },
-        freshAbortController,
-      )
-
-      const processTask = async (value: string, workerIdx: number) => {
-        const { workerApi } = workerPool[workerIdx]
-
-        const decryptResult = await workerApi.decryptIntoCsv(
-          {
-            line: value,
-            secretKey,
-            downloadAttachments,
-            formId: adminForm._id,
-            hostOrigin: window.location.origin,
-          },
-          isFasterDownloadsEnabled,
-        )
-
-        switch (decryptResult.status) {
-          case CsvRecordStatus.Ok:
-            try {
-              csvGenerator.addRecord(decryptResult.submissionData)
-            } catch (e) {
-              errorCount++
-              console.error('Error in getResponseInstance', e)
-            }
-
-            // It's fine to hog on to the worker here while waiting for the browser
-            // rate limit to pass. If decryption is fast, we would wait regardless.
-            // If decryption is slow, we won't hit rate limits.
-            if (downloadAttachments && decryptResult.downloadBlobURL) {
-              await downloadResponseAttachmentURL(
-                decryptResult.downloadBlobURL,
-                decryptResult.id,
-              )
-              URL.revokeObjectURL(decryptResult.downloadBlobURL)
-            }
-            break
-          case CsvRecordStatus.Unknown:
-            unknownStatusCount++
-            break
-          case CsvRecordStatus.Error:
-            errorCount++
-            break
-          case CsvRecordStatus.AttachmentError:
-            errorCount++
-            attachmentErrorCount++
-            break
-          case CsvRecordStatus.Unverified:
-            unverifiedCount++
-            break
-          default: {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const _: never = decryptResult.status
-            throw new Error('Invalid decryptResult status encountered.')
-          }
-        }
-        return workerIdx
-      }
-
-      const readAndQueueTask = async () => {
-        const reader = stream.getReader()
-        let progress = 0
-        let pendingTasks: Promise<number>[] = []
-
-        try {
-          while (progress < responsesCount) {
-            const { done, value } = await reader.read()
-            if (done) break
-
-            progress += 1
-            onProgress(progress)
-
-            while (idleWorkers.length === 0) {
-              const finishedTasks: number[] = []
-              for (let i = 0; i < pendingTasks.length; i++) {
-                try {
-                  const freedWorkerIdx = await withTimeout(pendingTasks[i], 50)
-                  idleWorkers.push(freedWorkerIdx)
-                  finishedTasks.push(i)
-                } catch (e) {
-                  if (
-                    e instanceof Error &&
-                    e.message === 'Operation timed out'
-                  ) {
-                    continue
-                  }
-                  console.error(`Error in task ${i}`, e)
-                }
-              }
-              pendingTasks = pendingTasks.filter(
-                (_, i) => !finishedTasks.includes(i),
-              )
-            }
-
-            const workerIdx = idleWorkers.shift()!
-            pendingTasks.push(processTask(value, workerIdx))
-          }
-          await Promise.all(pendingTasks)
-        } catch (e) {
-          console.error('Error reading stream', e)
-        } finally {
-          reader.releaseLock()
-        }
-      }
-
-      const downloadStartTime = performance.now()
-      return new Promise<DownloadResult>((resolve, reject) => {
-        readAndQueueTask()
-          .catch((err) => {
-            if (!downloadStartTime) {
-              // No start time, means did not even start http request.
-              datadogLogs.logger.info('Download network failure', {
-                meta: {
-                  ...logMeta,
-                  error: {
-                    message: err.message,
-                    name: err.name,
-                    stack: err.stack,
-                  },
-                },
-              })
-
-              trackDownloadNetworkFailure(adminForm, err)
-            } else {
-              const downloadFailedTime = performance.now()
-              const timeDifference = downloadFailedTime - downloadStartTime
-
-              datadogLogs.logger.info('Download response failure', {
-                meta: {
-                  ...logMeta,
-                  duration: timeDifference,
-                  error: {
-                    message: err.message,
-                    name: err.name,
-                    stack: err.stack,
-                  },
-                },
-              })
-
-              trackDownloadResponseFailure(
-                adminForm,
-                numWorkers,
-                NUM_OF_METADATA_ROWS,
-                timeDifference,
-                err,
-              )
-
-              console.error(
-                'Failed to download data, is there a network issue?',
-                err,
-              )
-              killWorkers(workerPool)
-              reject(err)
-            }
-          })
-          .finally(() => {
-            const checkComplete = () => {
-              // If all the records could not be decrypted
-              if (errorCount + unverifiedCount === responsesCount) {
-                const failureEndTime = performance.now()
-                // todo: check the timedifference redeclaration
-                const timeDifference = failureEndTime - downloadStartTime
-
-                datadogLogs.logger.info('Partial decryption failure', {
-                  meta: {
-                    ...logMeta,
-                    duration: timeDifference,
-                    error_count: errorCount,
-                    unverified_count: unverifiedCount,
-                    attachment_error_count: attachmentErrorCount,
-                    unknown_status_count: unknownStatusCount,
-                  },
-                })
-
-                trackPartialDecryptionFailure(
-                  adminForm,
-                  numWorkers,
-                  csvGenerator.length(),
-                  timeDifference,
-                  errorCount,
-                  attachmentErrorCount,
-                )
-
-                killWorkers(workerPool)
-                resolve({
-                  expectedCount: responsesCount,
-                  successCount: csvGenerator.length(),
-                  errorCount,
-                  unverifiedCount,
-                })
-              } else if (
-                // All results have been decrypted
-                csvGenerator.length() + errorCount + unverifiedCount >=
-                responsesCount
-              ) {
-                killWorkers(workerPool)
-                // Generate first three rows of meta-data before download
-                csvGenerator.addMetaDataFromSubmission(
-                  errorCount,
-                  unverifiedCount,
-                )
-                csvGenerator.downloadCsv(
-                  `${adminForm.title}-${adminForm._id}.csv`,
-                )
-
-                const downloadEndTime = performance.now()
-                const timeDifference = downloadEndTime - downloadStartTime
-
-                datadogLogs.logger.info('Download response success', {
-                  meta: {
-                    ...logMeta,
-                    duration: timeDifference,
-                  },
-                })
-
-                trackDownloadResponseSuccess(
-                  adminForm,
-                  numWorkers,
-                  NUM_OF_METADATA_ROWS,
-                  timeDifference,
-                )
-
-                resolve({
-                  expectedCount: responsesCount,
-                  successCount: csvGenerator.length(),
-                  errorCount,
-                  unverifiedCount,
-                })
-              } else {
-                setTimeout(checkComplete, 100)
-              }
-            }
-
-            checkComplete()
-          })
-      })
-    },
-    [adminForm, onProgress, user?._id, workers, isFasterDownloadsEnabled],
+    [adminForm, onProgress, user?._id, workers],
   )
 
   const handleExportCsvMutation = useMutation(
-    (params: DownloadEncryptedParams) =>
-      isFasterDownloadsEnabled
-        ? downloadEncryptedResponsesFaster(params)
-        : downloadEncryptedResponses(params),
+    (params: DownloadEncryptedParams) => downloadEncryptedResponses(params),
     mutateProps,
   )
 

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -135,10 +135,7 @@ async function decryptSubmissionData({
  * main thread.
  * @param data The data to decrypt into a csvRecord.
  */
-async function decryptIntoCsv(
-  data: LineData,
-  isFasterDownloadsEnabled: boolean = false,
-): Promise<MaterializedCsvRecord> {
+async function decryptIntoCsv(data: LineData): Promise<MaterializedCsvRecord> {
   // This needs to be dynamically imported due to sharing code between main app and worker code.
   // Fixes issue raised at https://stackoverflow.com/questions/66472945/referenceerror-refreshreg-is-not-defined
   // Something to do with babel-loader.
@@ -240,11 +237,7 @@ async function decryptIntoCsv(
           CsvRecordStatus.Ok,
           'Success (with Downloaded Attachment)',
         )
-        if (isFasterDownloadsEnabled) {
-          csvRecord.downloadBlobURL = URL.createObjectURL(downloadBlob)
-        } else {
-          csvRecord.setDownloadBlob(downloadBlob)
-        }
+        csvRecord.setDownloadBlob(downloadBlob)
       } catch (error) {
         csvRecord.setStatus(
           CsvRecordStatus.AttachmentError,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, faster downloads which is not being used is blocking refactoring of decryption worker code - since subsequent changes can further invalidate its functionality. 

Faster downloads is not used due to a bug in production where attachments files for mrf do not download properly in bulk (eg, only 10/16 files download), hence, has the feature has been triggered off for the past 8 months. 

Looking into the rationale why this pr was made in the first place - this might not be the ideal/correct fix for the staircase problem (where the root cause seems to be due to the await before assigning the task to the next worker)
eg, assign chunk 1 to worker 1 -> await for it to be done -> assign chunk 2 to worker 2 -> await ... which leads to the staircase pattern described in https://github.com/opengovsg/FormSG/pull/7553. 

Note that this staircase issue is resolved in https://github.com/opengovsg/FormSG/pull/8990 (a subsequent pr).  

Hence, the code should be removed to reduce complexity in future implementations, and its code may still be used for reference if needed since it is still available in version control history.

## Solution
<!-- How did you solve the problem? -->
Remove faster downloads which is not in use. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Pre-req: 
- [ ] Create 2 forms - one MRF and one storage mode form with attachment field + make multiple submissions for both forms. 

TC1: Bulk attachment downloads  and csv work for storage mode 
- [ ] Download csv + attachments from the storage form. Assert the files are downloaded and csv is correctly 
formatted.  
- [ ] Download csv only from the storage form. Assert the csv is correctly formatted.  

TC2: Bulk attachment downloads  and csv work for MRF mode 
- [ ] Download csv + attachments from the mrf form. Assert the files are downloaded and csv is correctly 
formatted.  
- [ ] Download csv only from the mrf form. Assert the csv is correctly formatted.  