### PR TITLE
feat: add agency to gb attributes

### DIFF
--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -621,7 +621,7 @@ export const PublicFormProvider = ({
         // Only update the `formId` attribute, keep the rest the same
         ...growthbook.getAttributes(),
         formId,
-        agencyName: data?.form.admin.agency.shortName,
+        adminAgency: data?.form.admin.agency.shortName,
       })
     }
   }, [growthbook, formId, data?.form.admin.agency.shortName])

--- a/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -621,9 +621,10 @@ export const PublicFormProvider = ({
         // Only update the `formId` attribute, keep the rest the same
         ...growthbook.getAttributes(),
         formId,
+        agencyName: data?.form.admin.agency.shortName,
       })
     }
-  }, [growthbook, formId])
+  }, [growthbook, formId, data?.form.admin.agency.shortName])
 
   // Scroll to top of page when user has finished their submission.
   useLayoutEffect(() => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Some features should be rolled out on an agency-by-agency basis.

Closes FRM-2216

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Add agency (short name) as an targetable attribute in GrowthBook

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
