### PR TITLE
fix(bulk-local-pdf): parallel local response decryption with web workers (part 4) 

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -111,7 +111,7 @@ const useDecryptionWorkers = ({
       let errorCount = 0
       let unverifiedCount = 0
       let attachmentErrorCount = 0
-      let receivedRecordCount = 0
+      let currentSubmissionIndex = 0 // used to iterate through the workers
 
       const logMeta = {
         action: 'downloadEncryptedReponses',
@@ -158,7 +158,7 @@ const useDecryptionWorkers = ({
       await reader.read().then(
         (read = async (result) => {
           if (result.done) return
-          const { workerApi } = workerPool[receivedRecordCount % numWorkers]
+          const { workerApi } = workerPool[currentSubmissionIndex % numWorkers]
           submissionDecryptPromises.push(
             workerApi
               .decryptIntoCsv({
@@ -183,7 +183,6 @@ const useDecryptionWorkers = ({
                   case CsvRecordStatus.Ok: {
                     try {
                       csvGenerator.addRecord(decryptResult.submissionData)
-                      receivedRecordCount++
                     } catch (e) {
                       errorCount++
                       console.error('Error in getResponseInstance', e)
@@ -198,6 +197,7 @@ const useDecryptionWorkers = ({
                 return decryptResult
               }),
           )
+          currentSubmissionIndex += 1 // used to assign the next submission to the next worker
           return reader.read().then(read)
         }),
       )

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -112,6 +112,7 @@ const useDecryptionWorkers = ({
       let unverifiedCount = 0
       let attachmentErrorCount = 0
       let currentSubmissionIndex = 0 // used to iterate through the workers
+      let attachmentsToSaveCount = 0 // used for scheduling delays between attachment zip file saves
 
       const logMeta = {
         action: 'downloadEncryptedReponses',
@@ -155,10 +156,13 @@ const useDecryptionWorkers = ({
       let decryptionProgress = 0
       const submissionDecryptPromises: Promise<MaterializedCsvRecord>[] = []
 
+      let timeSinceLastXAttachmentDownload = 0
+
       await reader.read().then(
         (read = async (result) => {
           if (result.done) return
           const { workerApi } = workerPool[currentSubmissionIndex % numWorkers]
+          // Step 1: Use worker to decrypt the submission (and download and decrypt attachments if needed).
           submissionDecryptPromises.push(
             workerApi
               .decryptIntoCsv({
@@ -168,6 +172,7 @@ const useDecryptionWorkers = ({
                 formId: adminForm._id,
                 hostOrigin: window.location.origin,
               })
+              // Step 2: Update the Csv record status based on the decryption result.
               .then(async (decryptResult) => {
                 switch (decryptResult.status) {
                   case CsvRecordStatus.Error:
@@ -191,10 +196,42 @@ const useDecryptionWorkers = ({
                 }
                 return decryptResult
               })
-              .then((decryptResult) => {
+              // Step 3: Save the downloaded and decrypted attachment blobs for each submission (if required).
+              // This step is done with delays in between groups of files to space out downloads to avoid browser blocking downloads.
+              .then(async (decryptResult) => {
+                if (downloadAttachments && decryptResult.downloadBlob) {
+                  attachmentsToSaveCount += 1
+
+                  // Ensure attachments downloads are spaced out to avoid browser blocking downloads
+                  if (
+                    attachmentsToSaveCount % ATTACHMENT_DOWNLOAD_CONVOY_SIZE ===
+                    0
+                  ) {
+                    const now = new Date().getTime()
+                    const elapsedSinceXDownloads =
+                      now - timeSinceLastXAttachmentDownload
+
+                    const waitTime = Math.max(
+                      0,
+                      ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME -
+                        elapsedSinceXDownloads,
+                    )
+                    if (waitTime > 0) {
+                      await waitForMs(waitTime)
+                    }
+                    timeSinceLastXAttachmentDownload = now
+                  }
+                  await downloadResponseAttachment(
+                    decryptResult.downloadBlob,
+                    decryptResult.id,
+                  )
+                }
+                return decryptResult
+              })
+              // Step 4: Update the progress bar only once the attachments for the decrypted submission have been downloaded (if needed).
+              .finally(() => {
                 decryptionProgress += 1
                 onProgress(decryptionProgress)
-                return decryptResult
               }),
           )
           currentSubmissionIndex += 1 // used to assign the next submission to the next worker
@@ -203,37 +240,8 @@ const useDecryptionWorkers = ({
       )
 
       return new Promise<DownloadResult>((resolve, reject) => {
-        // Step 1: Decrypt all submissions and their attachments (into blobs), add the submissions into the csv.
+        // Step 1: Decrypt all submissions and their attachments (into blobs), add the submissions into the csv object and save the attachments into user's computer.
         Promise.all(submissionDecryptPromises)
-          // Step 2: Download the attachment blobs for each submission.
-          // This step is done separately to allow for spacing out the downloads to avoid browser blocking downloads.
-          .then((decryptResults) => {
-            let timeSinceLastXAttachmentDownload = 0
-            decryptResults.forEach(async (decryptResult, index) => {
-              if (downloadAttachments && decryptResult.downloadBlob) {
-                // Ensure attachments downloads are spaced out to avoid browser blocking downloads
-                if (index % ATTACHMENT_DOWNLOAD_CONVOY_SIZE === 0) {
-                  const now = new Date().getTime()
-                  const elapsedSinceXDownloads =
-                    now - timeSinceLastXAttachmentDownload
-
-                  const waitTime = Math.max(
-                    0,
-                    ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME -
-                      elapsedSinceXDownloads,
-                  )
-                  if (waitTime > 0) {
-                    await waitForMs(waitTime)
-                  }
-                  timeSinceLastXAttachmentDownload = now
-                }
-                await downloadResponseAttachment(
-                  decryptResult.downloadBlob,
-                  decryptResult.id,
-                )
-              }
-            })
-          })
           .catch((err) => {
             if (!downloadStartTime) {
               // No start time, means did not even start http request.
@@ -279,7 +287,7 @@ const useDecryptionWorkers = ({
             killWorkers(workerPool)
             reject(err)
           })
-          // Step 3: Generate the actual CSV file.
+          // Step 2: Generate the actual CSV file from the csv object.
           .finally(() => {
             const checkComplete = () => {
               // If all the records could not be decrypted

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -25,6 +25,7 @@ import {
   CleanableDecryptionWorkerApi,
   CsvRecordStatus,
   DownloadResult,
+  MaterializedCsvRecord,
 } from './types'
 
 const NUM_OF_METADATA_ROWS = 5
@@ -151,30 +152,23 @@ const useDecryptionWorkers = ({
       const reader = stream.getReader()
       let read: (result: ReadableStreamReadResult<string>) => void
       const downloadStartTime = performance.now()
+      let decryptionProgress = 0
+      const submissionDecryptPromises: Promise<MaterializedCsvRecord>[] = []
 
-      let progress = 0
-      let timeSinceLastXAttachmentDownload = 0
-
-      return new Promise<DownloadResult>((resolve, reject) => {
-        reader
-          .read()
-          .then(
-            (read = async (result) => {
-              if (result.done) return
-              try {
-                // round-robin scheduling
-                const { workerApi } =
-                  workerPool[receivedRecordCount % numWorkers]
-                const decryptResult = await workerApi.decryptIntoCsv({
-                  line: result.value,
-                  secretKey,
-                  downloadAttachments,
-                  formId: adminForm._id,
-                  hostOrigin: window.location.origin,
-                })
-                progress += 1
-                onProgress(progress)
-
+      await reader.read().then(
+        (read = async (result) => {
+          if (result.done) return
+          const { workerApi } = workerPool[receivedRecordCount % numWorkers]
+          submissionDecryptPromises.push(
+            workerApi
+              .decryptIntoCsv({
+                line: result.value,
+                secretKey,
+                downloadAttachments,
+                formId: adminForm._id,
+                hostOrigin: window.location.origin,
+              })
+              .then(async (decryptResult) => {
                 switch (decryptResult.status) {
                   case CsvRecordStatus.Error:
                     errorCount++
@@ -194,38 +188,52 @@ const useDecryptionWorkers = ({
                       errorCount++
                       console.error('Error in getResponseInstance', e)
                     }
-
-                    if (downloadAttachments && decryptResult.downloadBlob) {
-                      // Ensure attachments downloads are spaced out to avoid browser blocking downloads
-                      if (progress % ATTACHMENT_DOWNLOAD_CONVOY_SIZE === 0) {
-                        const now = new Date().getTime()
-                        const elapsedSinceXDownloads =
-                          now - timeSinceLastXAttachmentDownload
-
-                        const waitTime = Math.max(
-                          0,
-                          ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME -
-                            elapsedSinceXDownloads,
-                        )
-                        if (waitTime > 0) {
-                          await waitForMs(waitTime)
-                        }
-                        timeSinceLastXAttachmentDownload = now
-                      }
-                      await downloadResponseAttachment(
-                        decryptResult.downloadBlob,
-                        decryptResult.id,
-                      )
-                    }
                   }
                 }
-              } catch (e) {
-                console.error('Error parsing JSON', e)
-              }
-              // recurse through the stream
-              return reader.read().then(read)
-            }),
+                return decryptResult
+              })
+              .then((decryptResult) => {
+                decryptionProgress += 1
+                onProgress(decryptionProgress)
+                return decryptResult
+              }),
           )
+          return reader.read().then(read)
+        }),
+      )
+
+      return new Promise<DownloadResult>((resolve, reject) => {
+        // Step 1: Decrypt all submissions and their attachments (into blobs), add the submissions into the csv.
+        Promise.all(submissionDecryptPromises)
+          // Step 2: Download the attachment blobs for each submission.
+          // This step is done separately to allow for spacing out the downloads to avoid browser blocking downloads.
+          .then((decryptResults) => {
+            let timeSinceLastXAttachmentDownload = 0
+            decryptResults.forEach(async (decryptResult, index) => {
+              if (downloadAttachments && decryptResult.downloadBlob) {
+                // Ensure attachments downloads are spaced out to avoid browser blocking downloads
+                if (index % ATTACHMENT_DOWNLOAD_CONVOY_SIZE === 0) {
+                  const now = new Date().getTime()
+                  const elapsedSinceXDownloads =
+                    now - timeSinceLastXAttachmentDownload
+
+                  const waitTime = Math.max(
+                    0,
+                    ATTACHMENT_DOWNLOAD_CONVOY_MINIMUM_SEPARATION_TIME -
+                      elapsedSinceXDownloads,
+                  )
+                  if (waitTime > 0) {
+                    await waitForMs(waitTime)
+                  }
+                  timeSinceLastXAttachmentDownload = now
+                }
+                await downloadResponseAttachment(
+                  decryptResult.downloadBlob,
+                  decryptResult.id,
+                )
+              }
+            })
+          })
           .catch((err) => {
             if (!downloadStartTime) {
               // No start time, means did not even start http request.
@@ -264,7 +272,6 @@ const useDecryptionWorkers = ({
                 err,
               )
             }
-
             console.error(
               'Failed to download data, is there a network issue?',
               err,
@@ -272,6 +279,7 @@ const useDecryptionWorkers = ({
             killWorkers(workerPool)
             reject(err)
           })
+          // Step 3: Generate the actual CSV file.
           .finally(() => {
             const checkComplete = () => {
               // If all the records could not be decrypted
@@ -347,7 +355,6 @@ const useDecryptionWorkers = ({
                 setTimeout(checkComplete, 100)
               }
             }
-
             checkComplete()
           })
       })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Previously, despite use of multiple web worker nodes, the decryption is being done sequentially and not in parallel which is a bug. 

Explanation: The function below iterates recursively to eventually process all the reader chunks, where each chunk represents a single submission to decrypt. 
However, since the submission decryption is first awaited before carrying on to the next submission to decrypt, despite having many workers, it will never process multiple submissions in parallel.  
```
let i = 0
      return new Promise<DownloadResult>((resolve, reject) => {
        reader
          .read()
          .then(
            (read = async (result) => {
              if (result.done) return // no more chunks
              try {
                // round-robin scheduling
                const { workerApi } =
                  workerPool[receivedRecordCount % numWorkers]
                const decryptResult = await workerApi.decryptIntoCsv({ // awaiting here blocks assigning of next chunk to next available worker. 
                  line: result.value,
                  secretKey,
                  downloadAttachments,
                  formId: adminForm._id,
                  hostOrigin: window.location.origin,
                }).then(() => {read.read() // advances to the next chunk}} 
```
Assuming 2 workers and 4 chunks: 
The previous faulty flow is: 
web worker 1: assign chunk 1 
await decryption of chunk 1 by worker 1 
web worker 2: assign chunk 2
await decryption of chunk 2 by worker 2
web worker 1: assign chunk 3
await decryption of chunk 3 by worker 1
web worker 2: assign chunk 4
await decryption of chunk 4 by worker 2
done 

This leads to this "staircase" issue
<img width="2562" height="378" alt="image" src="https://github.com/user-attachments/assets/29dee62a-fd05-4760-8671-4c4216be5eaf" />

Hence, the decryption is slow. 

Fixes FRM-2229

## Solution
<!-- How did you solve the problem? -->
Remove the await before assigning the next chunk to the next worker. 

This makes the flow become: 
web worker 1: assign chunk 1 
web worker 2: assign chunk 2
web worker 1: assign chunk 3
web worker 2: assign chunk 4
After the chunks are assigned - they can be executed in parallel by the workers. 
await(completion of all 4 chunks by the workers) 
continue logic 

once the decryption is done and the blobs are generated in memory 
next, another `then()` proceeds to download them using the convoy method to prevent browser blockage, see: https://github.com/opengovsg/FormSG/pull/7451. 
done 

<img width="596" height="118" alt="image" src="https://github.com/user-attachments/assets/422b0e40-de25-4927-8510-7c571f08ff55" />
For example, after this change - the order of decryption completion can now be interleaved - compared to previously where it must be sequential 1->2->3->4

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Pre-req: 
- [x] Create 2 forms - one MRF and one storage mode form with attachment field + make multiple submissions for both forms. 

TC1: Bulk attachment downloads  and csv work for storage mode 
- [x] Download csv + attachments from the storage form. Assert the files are downloaded and csv is correctly 
formatted.  
- [x] Download csv only from the storage form. Assert the csv is correctly formatted.  
- [x] Assert that the progress modal % reflects the decryption status correctly. 

TC2: Bulk attachment downloads  and csv work for MRF mode 
- [x] Download csv + attachments from the mrf form. Assert the files are downloaded and csv is correctly 
formatted.  
- [x] Download csv only from the mrf form. Assert the csv is correctly formatted.  
- [x] Assert that the progress modal % reflects the decryption status correctly. 