### PR TITLE
feat(bulk-local-pdf): decouple bulk download options in decryption worker (part 6)

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
@@ -22,6 +22,8 @@ export type AttachmentsDownloadMap = Map<
 
 export type CsvRecordData = FormField
 
+export type MaterializedCsvRecord = SetRequired<CsvRecord, 'submissionData'>
+
 export type DecryptedSubmissionData = {
   created: string
   submissionId: string
@@ -29,12 +31,9 @@ export type DecryptedSubmissionData = {
   record: CsvRecordData[]
 }
 
-export type MaterializedCsvRecord = SetRequired<CsvRecord, 'submissionData'>
-
-export type LineData = {
-  line: string
+export interface SubmissionDataForDecryption {
+  submissionStreamDtoString: string
   secretKey: string
-  downloadAttachments?: boolean
   formId: string
   hostOrigin: string
 }
@@ -42,6 +41,23 @@ export type LineData = {
 export type CleanableDecryptionWorkerApi = {
   workerApi: Remote<DecryptionWorkerApi>
   cleanup: () => void
+}
+
+/**
+ * Options for bulk download.
+ */
+export interface DownloadOptions {
+  isDownloadAttachments: boolean
+  isDownloadCsv: boolean
+}
+
+/**
+ * Decrypted formatted data returned by the decryption worker.
+ */
+export type DecryptedData = {
+  materializedCsvRecord?: MaterializedCsvRecord
+  attachmentDownloadBlob?: Blob
+  submissionId?: string
 }
 
 /** Download result after downloading storage mode responses */

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -24,8 +24,8 @@ import {
 import {
   CleanableDecryptionWorkerApi,
   CsvRecordStatus,
+  DecryptedData,
   DownloadResult,
-  MaterializedCsvRecord,
 } from './types'
 
 const NUM_OF_METADATA_ROWS = 5
@@ -154,7 +154,7 @@ const useDecryptionWorkers = ({
       let read: (result: ReadableStreamReadResult<string>) => void
       const downloadStartTime = performance.now()
       let decryptionProgress = 0
-      const submissionDecryptPromises: Promise<MaterializedCsvRecord>[] = []
+      const submissionDecryptPromises: Promise<DecryptedData>[] = []
 
       let timeSinceLastXAttachmentDownload = 0
 
@@ -165,16 +165,17 @@ const useDecryptionWorkers = ({
           // Step 1: Use worker to decrypt the submission (and download and decrypt attachments if needed).
           submissionDecryptPromises.push(
             workerApi
-              .decryptIntoCsv({
-                line: result.value,
+              .getDecryptedData({
+                isDownloadAttachments: downloadAttachments,
+                isDownloadCsv: true,
+                submissionStreamDtoString: result.value,
                 secretKey,
-                downloadAttachments,
                 formId: adminForm._id,
                 hostOrigin: window.location.origin,
               })
               // Step 2: Update the Csv record status based on the decryption result.
               .then(async (decryptResult) => {
-                switch (decryptResult.status) {
+                switch (decryptResult.materializedCsvRecord?.status) {
                   case CsvRecordStatus.Error:
                     errorCount++
                     break
@@ -187,7 +188,9 @@ const useDecryptionWorkers = ({
                     break
                   case CsvRecordStatus.Ok: {
                     try {
-                      csvGenerator.addRecord(decryptResult.submissionData)
+                      csvGenerator.addRecord(
+                        decryptResult.materializedCsvRecord.submissionData,
+                      )
                     } catch (e) {
                       errorCount++
                       console.error('Error in getResponseInstance', e)
@@ -199,7 +202,11 @@ const useDecryptionWorkers = ({
               // Step 3: Save the downloaded and decrypted attachment blobs for each submission (if required).
               // This step is done with delays in between groups of files to space out downloads to avoid browser blocking downloads.
               .then(async (decryptResult) => {
-                if (downloadAttachments && decryptResult.downloadBlob) {
+                if (
+                  downloadAttachments &&
+                  decryptResult.attachmentDownloadBlob &&
+                  decryptResult.submissionId
+                ) {
                   attachmentsToSaveCount += 1
 
                   // Ensure attachments downloads are spaced out to avoid browser blocking downloads
@@ -222,8 +229,8 @@ const useDecryptionWorkers = ({
                     timeSinceLastXAttachmentDownload = now
                   }
                   await downloadResponseAttachment(
-                    decryptResult.downloadBlob,
-                    decryptResult.id,
+                    decryptResult.attachmentDownloadBlob,
+                    decryptResult.submissionId,
                   )
                 }
                 return decryptResult

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
@@ -20,7 +20,6 @@ import {
 
 /** @class CsvRecord represents the CSV data to be passed back, along with helper functions */
 export class CsvRecord {
-  downloadBlob?: Blob
   submissionData?: DecryptedSubmissionData
 
   #statusMessage: string
@@ -56,15 +55,6 @@ export class CsvRecord {
   setStatus(status: CsvRecordStatus, msg: string) {
     this.status = status
     this.#statusMessage = msg
-  }
-
-  /**
-   * Sets the ZIP attachment blob to be downloaded
-   *
-   * @param blob A blob containing a ZIP file of all the submission attachments downloaded
-   */
-  setDownloadBlob(blob: Blob) {
-    this.downloadBlob = blob
   }
 
   /**

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.ts
@@ -21,7 +21,6 @@ import {
 /** @class CsvRecord represents the CSV data to be passed back, along with helper functions */
 export class CsvRecord {
   downloadBlob?: Blob
-  downloadBlobURL?: string
   submissionData?: DecryptedSubmissionData
 
   #statusMessage: string

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -11,8 +11,10 @@ import {
   AttachmentsDownloadMap,
   CsvRecordData,
   CsvRecordStatus,
-  LineData,
+  DecryptedData,
+  DownloadOptions,
   MaterializedCsvRecord,
+  SubmissionDataForDecryption,
 } from '../types'
 import { CsvRecord } from '../utils/CsvRecord.class'
 import { downloadAndDecryptAttachmentsAsZip } from '../utils/downloadAndDecryptAttachment'
@@ -131,18 +133,20 @@ async function decryptSubmissionData({
   }
 }
 
-function getAttachmentDecryptionKey({
-  submission,
-  mrfSubmissionSecretKey,
-  secretKey,
-}: {
+type GetAttachmentDecryptionKeyParams = {
   submission: {
     submissionType: SubmissionType
     mrfVersion?: number
   }
   mrfSubmissionSecretKey?: string
   secretKey: string
-}) {
+}
+
+function getAttachmentDecryptionKey({
+  submission,
+  mrfSubmissionSecretKey,
+  secretKey,
+}: GetAttachmentDecryptionKeyParams) {
   const { submissionType, mrfVersion } = submission
   if (!mrfSubmissionSecretKey) {
     // If no mrf submission secret key present, it is a storage mode form. So, use form secret key.
@@ -156,15 +160,16 @@ function getAttachmentDecryptionKey({
   return mrfSubmissionSecretKey
 }
 
-async function downloadAndDecryptSubmissionAttachments({
-  attachmentDecryptionKey,
-  attachmentMetadata,
-  decryptedResponses,
-}: {
+type _DownloadAndDecryptSubmissionAttachmentsParams = {
   attachmentDecryptionKey: string
   attachmentMetadata: Record<string, string>
   decryptedResponses: FormField[]
-}): Promise<
+}
+async function _downloadAndDecryptSubmissionAttachments({
+  attachmentDecryptionKey,
+  attachmentMetadata,
+  decryptedResponses,
+}: _DownloadAndDecryptSubmissionAttachmentsParams): Promise<
   | {
       downloadedAttachmentsBlob: Blob
       isDownloadSuccessful: boolean
@@ -210,21 +215,51 @@ async function downloadAndDecryptSubmissionAttachments({
   }
 }
 
+async function downloadAndDecryptSubmissionAttachments(
+  downloadAndDecryptSubmissionAttachmentsParams: Pick<
+    _DownloadAndDecryptSubmissionAttachmentsParams,
+    'attachmentMetadata' | 'decryptedResponses'
+  > &
+    GetAttachmentDecryptionKeyParams,
+) {
+  const attachmentDecryptionKey = getAttachmentDecryptionKey(
+    downloadAndDecryptSubmissionAttachmentsParams,
+  )
+
+  return await _downloadAndDecryptSubmissionAttachments({
+    attachmentDecryptionKey,
+    attachmentMetadata:
+      downloadAndDecryptSubmissionAttachmentsParams.attachmentMetadata,
+    decryptedResponses:
+      downloadAndDecryptSubmissionAttachmentsParams.decryptedResponses,
+  })
+}
+
+type LineData = {
+  isDownloadAttachments: boolean
+  formId: string
+  hostOrigin: string
+  isDownloadAttachmentsSuccessful: boolean
+} & DecryptionResult
+
 /**
  * Decrypts given data into a {@type CsvRecord} and posts the result back to the
  * main thread.
  * @param data The data to decrypt into a csvRecord.
  */
-async function decryptIntoCsv(data: LineData): Promise<MaterializedCsvRecord> {
-  const { line, secretKey, downloadAttachments, formId, hostOrigin } = data
-  let csvRecord: CsvRecord
+async function getMaterializedCsvRecord(
+  lineData: LineData,
+): Promise<MaterializedCsvRecord> {
+  const {
+    isDownloadAttachments,
+    isParseSuccessful,
+    isDecryptionSuccessful,
+    formId,
+    hostOrigin,
+    isDownloadAttachmentsSuccessful,
+  } = lineData
 
-  let submission: SubmissionStreamDto
-  try {
-    submission = SubmissionStreamDto.parse(JSON.parse(line))
-  } catch (error) {
-    const errorMessage = 'Error parsing submission'
-    console.error(errorMessage, error)
+  if (!isParseSuccessful) {
     const ERROR_CSV_RECORD = new CsvRecord(
       CsvRecordStatus.Error,
       formatInTimeZone(new Date(), 'Asia/Singapore', 'dd MMM yyyy hh:mm:ss z'),
@@ -232,52 +267,50 @@ async function decryptIntoCsv(data: LineData): Promise<MaterializedCsvRecord> {
       CsvRecordStatus.Error,
       CsvRecordStatus.Error,
     )
-    csvRecord = ERROR_CSV_RECORD
-    csvRecord.setStatus(CsvRecordStatus.Error, errorMessage)
-    csvRecord.materializeSubmissionData()
-    return csvRecord as MaterializedCsvRecord
+    ERROR_CSV_RECORD.setStatus(
+      CsvRecordStatus.Error,
+      'Error parsing submission',
+    )
+    ERROR_CSV_RECORD.materializeSubmissionData()
+    return ERROR_CSV_RECORD as MaterializedCsvRecord
   }
 
-  csvRecord = new CsvRecord(
-    submission._id,
-    submission.created,
+  const { parsedSubmission } = lineData
+
+  const csvRecord = new CsvRecord(
+    parsedSubmission._id,
+    parsedSubmission.created,
     CsvRecordStatus.Unknown,
     formId,
     hostOrigin,
-    submission.submissionType === SubmissionType.Encrypt
-      ? submission.payment
+    parsedSubmission.submissionType === SubmissionType.Encrypt
+      ? parsedSubmission.payment
       : undefined,
-    submission.submissionType === SubmissionType.Multirespondent
+    parsedSubmission.submissionType === SubmissionType.Multirespondent
       ? {
-          workflowStatus: submission.mrfMeta.workflowStatus,
+          workflowStatus: parsedSubmission.mrfMeta.workflowStatus,
           workflowCurrentStepNumber:
-            submission.mrfMeta.workflowCurrentStepNumber,
-          workflowNumTotalSteps: submission.mrfMeta.workflowNumTotalSteps,
-          lastSubmittedAt: submission.mrfMeta.lastSubmittedAt,
+            parsedSubmission.mrfMeta.workflowCurrentStepNumber,
+          workflowNumTotalSteps: parsedSubmission.mrfMeta.workflowNumTotalSteps,
+          lastSubmittedAt: parsedSubmission.mrfMeta.lastSubmittedAt,
           hasNextStepRecipientEmails:
-            submission.mrfMeta.hasNextStepRecipientEmails,
+            parsedSubmission.mrfMeta.hasNextStepRecipientEmails,
         }
       : undefined,
   )
 
-  const decryptSubmissionDataResult = await decryptSubmissionData({
-    submissionData: submission,
-    secretKey,
-  })
-
-  if (!decryptSubmissionDataResult.isSubmissionDecryptionSuccessful) {
+  if (!isDecryptionSuccessful) {
     csvRecord.setStatus(CsvRecordStatus.Error, 'Decryption Error')
     csvRecord.materializeSubmissionData()
     return csvRecord as MaterializedCsvRecord
   }
 
-  const { decryptedResponses, mrfSubmissionSecretKey } =
-    decryptSubmissionDataResult
+  const { decryptedResponses } = lineData
 
+  // Short-circuit signature verification for multirespondent submission
   if (
-    // Short-circuit signature verification for multirespondent submission
-    submission.submissionType === SubmissionType.Multirespondent ||
-    verifySignature(decryptedResponses, submission.created)
+    parsedSubmission.submissionType === SubmissionType.Multirespondent ||
+    verifySignature(decryptedResponses, parsedSubmission.created)
   ) {
     csvRecord.setStatus(CsvRecordStatus.Ok, 'Success')
     csvRecord.setRecord(decryptedResponses)
@@ -285,21 +318,8 @@ async function decryptIntoCsv(data: LineData): Promise<MaterializedCsvRecord> {
     csvRecord.setStatus(CsvRecordStatus.Unverified, 'Unverified')
   }
 
-  if (downloadAttachments) {
-    const attachmentDecryptionKey = getAttachmentDecryptionKey({
-      submission,
-      mrfSubmissionSecretKey,
-      secretKey,
-    })
-
-    const attachmentDownloadBlob =
-      await downloadAndDecryptSubmissionAttachments({
-        attachmentDecryptionKey,
-        attachmentMetadata: submission.attachmentMetadata,
-        decryptedResponses,
-      })
-
-    if (!attachmentDownloadBlob.isDownloadSuccessful) {
+  if (isDownloadAttachments) {
+    if (!isDownloadAttachmentsSuccessful) {
       csvRecord.setStatus(
         CsvRecordStatus.AttachmentError,
         'Attachment Download Error',
@@ -311,14 +331,135 @@ async function decryptIntoCsv(data: LineData): Promise<MaterializedCsvRecord> {
       CsvRecordStatus.Ok,
       'Success (with Downloaded Attachment)',
     )
-    csvRecord.setDownloadBlob(attachmentDownloadBlob.downloadedAttachmentsBlob)
   }
   csvRecord.materializeSubmissionData()
   return csvRecord as MaterializedCsvRecord
 }
 
+type DecryptionResult =
+  | {
+      isParseSuccessful: false
+      isDecryptionSuccessful: false
+    }
+  | {
+      isParseSuccessful: true
+      parsedSubmission: SubmissionStreamDto
+      isDecryptionSuccessful: false
+    }
+  | {
+      isParseSuccessful: true
+      parsedSubmission: SubmissionStreamDto
+      isDecryptionSuccessful: true
+      decryptedResponses: FormField[]
+      mrfSubmissionSecretKey?: string
+    }
+
+async function parseAndDecryptSubmissionData({
+  submissionStreamDtoString,
+  secretKey,
+}: SubmissionDataForDecryption): Promise<DecryptionResult> {
+  let submission: SubmissionStreamDto
+
+  try {
+    submission = SubmissionStreamDto.parse(
+      JSON.parse(submissionStreamDtoString),
+    )
+  } catch (error) {
+    console.error('Error parsing submission', error)
+    return {
+      isParseSuccessful: false,
+      isDecryptionSuccessful: false,
+    }
+  }
+
+  const decryptSubmissionDataResult = await decryptSubmissionData({
+    submissionData: submission,
+    secretKey,
+  })
+
+  if (!decryptSubmissionDataResult.isSubmissionDecryptionSuccessful) {
+    return {
+      isParseSuccessful: true,
+      parsedSubmission: submission,
+      isDecryptionSuccessful: false,
+    }
+  }
+
+  return {
+    isParseSuccessful: true,
+    parsedSubmission: submission,
+    isDecryptionSuccessful: true,
+    decryptedResponses: decryptSubmissionDataResult.decryptedResponses,
+    mrfSubmissionSecretKey: decryptSubmissionDataResult.mrfSubmissionSecretKey,
+  }
+}
+
+type GetDecryptedDataParams = DownloadOptions & SubmissionDataForDecryption
+
+async function getDecryptedData(
+  getDecryptedDataParams: GetDecryptedDataParams,
+): Promise<DecryptedData> {
+  let materializedCsvRecord: MaterializedCsvRecord | undefined
+  let attachmentDownloadBlob: Blob | undefined
+  let isDownloadAndDecryptSubmissionAttachmentsSuccessful = false
+
+  const { secretKey } = getDecryptedDataParams
+
+  const decryptedSubmissionResult = await parseAndDecryptSubmissionData(
+    getDecryptedDataParams,
+  )
+
+  const { isDownloadAttachments, isDownloadCsv } = getDecryptedDataParams
+  const { isDecryptionSuccessful, isParseSuccessful } =
+    decryptedSubmissionResult
+
+  if (isDownloadAttachments) {
+    if (isDecryptionSuccessful) {
+      const { parsedSubmission, decryptedResponses, mrfSubmissionSecretKey } =
+        decryptedSubmissionResult
+      const { attachmentMetadata } = parsedSubmission
+      const downloadAndDecryptSubmissionAttachmentsResult =
+        await downloadAndDecryptSubmissionAttachments({
+          attachmentMetadata,
+          decryptedResponses,
+          submission: parsedSubmission,
+          secretKey,
+          mrfSubmissionSecretKey,
+        })
+      const { isDownloadSuccessful } =
+        downloadAndDecryptSubmissionAttachmentsResult
+      isDownloadAndDecryptSubmissionAttachmentsSuccessful = isDownloadSuccessful
+
+      if (isDownloadSuccessful) {
+        attachmentDownloadBlob =
+          downloadAndDecryptSubmissionAttachmentsResult.downloadedAttachmentsBlob
+      }
+    }
+  }
+
+  if (isDownloadCsv) {
+    const { formId, hostOrigin } = getDecryptedDataParams
+    materializedCsvRecord = await getMaterializedCsvRecord({
+      isDownloadAttachments,
+      formId,
+      hostOrigin,
+      isDownloadAttachmentsSuccessful:
+        isDownloadAndDecryptSubmissionAttachmentsSuccessful,
+      ...decryptedSubmissionResult,
+    })
+  }
+
+  return {
+    materializedCsvRecord,
+    attachmentDownloadBlob,
+    submissionId: isParseSuccessful
+      ? decryptedSubmissionResult.parsedSubmission._id
+      : undefined,
+  }
+}
+
 const exports = {
-  decryptIntoCsv,
+  getDecryptedData,
 }
 
 expose(exports)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
In the ideal responses bulk download in the results page design, admins should be able to choose a combination of what to download via a checkbox between csv, attachments and pdf (to implement in subsequent PRs). 

See: 
<img width="365" height="224" alt="image" src="https://github.com/user-attachments/assets/69edf7ba-0ba0-47bd-aaf7-b4352521c64c" />

However, the current implementation of the decryption worker tightly couples the csv and attachment generation - placing the attachment blob within the csv record despite not needing to. This causes 2 issues:
1. Currently unable to support separate csv and attachment downloading. 
2. Makes extension of this decryption worker to support more options (specifically pdf) challenging.

Fixes FRM-2234
 
## Solution
<!-- How did you solve the problem? -->
Hence, the decryption worker is refactored to split the csv generation, attachment downloading, decryption, parsing to its own functions and remove the placement of unnecessary attachment blob in `CsvRecord` class.  
Another function is then used to conditionally trigger the csv generation/attachment downloading based on if it is required (determined by passing a boolean flag eg, `isCsvDownloaded`, `isAttachmentDownloaded`). 
This allows the FE to pass these flags to select what combination to download and enabling the design shown in the screenshot. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Pre-req: 
- [x] Create 2 forms - one MRF and one storage mode form with attachment field + make multiple submissions for both forms. 

TC1: Bulk attachment downloads  and csv work for storage mode 
- [x] Download csv + attachments from the storage form. Assert the files are downloaded and csv is correctly 
formatted.  
- [x] Download csv only from the storage form. Assert the csv is correctly formatted.  

TC2: Bulk attachment downloads  and csv work for MRF mode 
- [x] Download csv + attachments from the mrf form. Assert the files are downloaded and csv is correctly 
formatted.  
- [x] Download csv only from the mrf form. Assert the csv is correctly formatted.  