### PR TITLE
feat(local-bulk-pdf): split csv and attachment bulk download via checkbox selection (part 7)

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesContext.tsx
@@ -9,7 +9,10 @@ export interface StorageResponsesContextProps {
   setSecretKey: (secretKey: string) => void
   dateRange: DateString[]
   setDateRange: (dateRange: DateString[]) => void
-  downloadParams: Omit<DownloadEncryptedParams, 'downloadAttachments'> | null
+  downloadParams: Omit<
+    DownloadEncryptedParams,
+    'downloadAttachments' | 'isDownloadCsv'
+  > | null
   totalResponsesCount?: number
   dateRangeResponsesCount?: number
   formPublicKey: string | null

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -1,7 +1,16 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useThrottle } from 'react-use'
-import { Box, MenuButton, Text, useDisclosure } from '@chakra-ui/react'
+import {
+  Box,
+  CheckboxGroup,
+  Flex,
+  MenuButton,
+  MenuList,
+  Stack,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
 import simplur from 'simplur'
 
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
@@ -9,17 +18,102 @@ import { BxsChevronUp } from '~assets/icons/BxsChevronUp'
 import { useTimeout } from '~hooks/useTimeout'
 import { useToast } from '~hooks/useToast'
 import Button from '~components/Button'
+import Checkbox from '~components/Checkbox'
 import Menu from '~components/Menu'
 import { NavigationPrompt } from '~templates/NavigationPrompt'
 
 import { useStorageResponsesContext } from '../StorageResponsesContext'
-import { CanceledResult, DownloadResult } from '../types'
+import { CanceledResult, DownloadOptions, DownloadResult } from '../types'
 import useDecryptionWorkers from '../useDecryptionWorkers'
 
 import { DownloadWithAttachmentModal } from './DownloadWithAttachmentModal'
 import { ProgressModal } from './ProgressModal'
 
+const DownloadSelectorCheckbox = ({
+  optionText,
+  isChecked,
+  onChange,
+}: {
+  optionText: string
+  isChecked: boolean
+  onChange: () => void
+}) => {
+  return (
+    <Checkbox isChecked={isChecked} onChange={onChange} px="1rem" py="0.75rem">
+      {optionText}
+    </Checkbox>
+  )
+}
+
+const DownloadSelector = ({
+  onClickNext,
+  onDownload,
+  downloadOptions,
+  setDownloadOptions,
+}: {
+  onClickNext: () => void
+  downloadOptions: DownloadOptions
+  onDownload: () => void
+  setDownloadOptions: (downloadOptions: DownloadOptions) => void
+}) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix:
+      'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadButton.menuItem',
+  })
+
+  const { isDownloadCsv, isDownloadAttachments } = downloadOptions
+  const onlyDownloadCsv = isDownloadCsv && !isDownloadAttachments
+
+  return (
+    <Stack>
+      <CheckboxGroup value={['csv', 'attachments']}>
+        <Stack direction="column">
+          <DownloadSelectorCheckbox
+            optionText={t('csv')}
+            isChecked={isDownloadCsv}
+            onChange={() =>
+              setDownloadOptions({
+                ...downloadOptions,
+                isDownloadCsv: !isDownloadCsv,
+              })
+            }
+          />
+          <DownloadSelectorCheckbox
+            optionText={t('attachments')}
+            isChecked={isDownloadAttachments}
+            onChange={() =>
+              setDownloadOptions({
+                ...downloadOptions,
+                isDownloadAttachments: !isDownloadAttachments,
+              })
+            }
+          />
+        </Stack>
+      </CheckboxGroup>
+      <Flex m="1rem" justify="flex-end">
+        <Button onClick={onlyDownloadCsv ? onDownload : onClickNext}>
+          {onlyDownloadCsv ? 'Start download' : 'Next'}
+        </Button>
+      </Flex>
+    </Stack>
+  )
+}
+
 export const DownloadButton = (): JSX.Element => {
+  const DEFAULT_DOWNLOAD_OPTIONS: DownloadOptions = useMemo(
+    () => ({
+      isDownloadAttachments: false,
+      isDownloadCsv: false,
+    }),
+    [],
+  )
+  const [downloadOptions, setDownloadOptions] = useState<DownloadOptions>(
+    DEFAULT_DOWNLOAD_OPTIONS,
+  )
+  const resetDownloadOptions = useCallback(() => {
+    setDownloadOptions(DEFAULT_DOWNLOAD_OPTIONS)
+  }, [DEFAULT_DOWNLOAD_OPTIONS])
+
   const {
     isOpen: isDownloadModalOpen,
     onClose: onDownloadModalClose,
@@ -61,7 +155,7 @@ export const DownloadButton = (): JSX.Element => {
     DownloadResult | CanceledResult
   >()
 
-  const { handleExportCsvMutation, abortDecryption } = useDecryptionWorkers({
+  const { handleBulkDownloadMutation, abortDecryption } = useDecryptionWorkers({
     onProgress: setDownloadCount,
     mutateProps: {
       onMutate: () => {
@@ -99,26 +193,20 @@ export const DownloadButton = (): JSX.Element => {
       onSettled: (decryptResult) => {
         setProgressModalTimeout(null)
         setDownloadMetadata(decryptResult)
+        resetDownloadOptions()
       },
     },
   })
 
-  const handleExportCsvNoAttachments = useCallback(() => {
+  const handleBulkDownload = useCallback(() => {
     if (!downloadParams) return
     setProgressModalTimeout(5000)
-    return handleExportCsvMutation.mutate({
+    return handleBulkDownloadMutation.mutate({
       ...downloadParams,
-      downloadAttachments: false,
+      downloadAttachments: downloadOptions.isDownloadAttachments,
+      isDownloadCsv: downloadOptions.isDownloadCsv,
     })
-  }, [downloadParams, handleExportCsvMutation])
-
-  const handleExportCsvWithAttachments = useCallback(() => {
-    if (!downloadParams) return
-    return handleExportCsvMutation.mutate({
-      ...downloadParams,
-      downloadAttachments: true,
-    })
-  }, [downloadParams, handleExportCsvMutation])
+  }, [downloadParams, handleBulkDownloadMutation, downloadOptions])
 
   const resetDownload = useCallback(() => {
     setDownloadCount(0)
@@ -162,17 +250,17 @@ export const DownloadButton = (): JSX.Element => {
         confirmButtonText={t(
           'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadButton.navigateAwayPrompt.confirmButtonText',
         )}
-        when={handleExportCsvMutation.isLoading}
+        when={handleBulkDownloadMutation.isLoading}
       />
       {dateRangeResponsesCount !== undefined && (
         <DownloadWithAttachmentModal
           responsesCount={dateRangeResponsesCount}
           isOpen={isDownloadModalOpen}
           onClose={handleModalClose}
-          onDownload={handleExportCsvWithAttachments}
+          onDownload={handleBulkDownload}
           onCancel={handleAttachmentsDownloadCancel}
           downloadPercentage={downloadPercentage}
-          isDownloading={handleExportCsvMutation.isLoading}
+          isDownloading={handleBulkDownloadMutation.isLoading}
           downloadMetadata={downloadMetadata}
         />
       )}
@@ -197,13 +285,13 @@ export const DownloadButton = (): JSX.Element => {
         </ProgressModal>
       )}
       <Box gridArea="export" justifySelf="flex-end">
-        <Menu placement="bottom-end">
-          {({ isOpen }) => (
+        <Menu closeOnSelect={false} placement="bottom-end">
+          {({ isOpen, onClose }) => (
             <>
               <MenuButton
                 as={Button}
                 isDisabled={!downloadParams}
-                isLoading={handleExportCsvMutation.isLoading}
+                isLoading={handleBulkDownloadMutation.isLoading}
                 isActive={isOpen}
                 aria-label={t(
                   'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadButton.label',
@@ -212,18 +300,20 @@ export const DownloadButton = (): JSX.Element => {
               >
                 {t('features.common.download')}
               </MenuButton>
-              <Menu.List>
-                <Menu.Item onClick={handleExportCsvNoAttachments}>
-                  {t(
-                    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadButton.menuItem.csvOnly',
-                  )}
-                </Menu.Item>
-                <Menu.Item onClick={onDownloadModalOpen}>
-                  {t(
-                    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadButton.menuItem.csvWithAttachments',
-                  )}
-                </Menu.Item>
-              </Menu.List>
+              <MenuList>
+                <DownloadSelector
+                  onClickNext={() => {
+                    onClose()
+                    onDownloadModalOpen()
+                  }}
+                  onDownload={() => {
+                    onClose()
+                    handleBulkDownload()
+                  }}
+                  downloadOptions={downloadOptions}
+                  setDownloadOptions={setDownloadOptions}
+                />
+              </MenuList>
             </>
           )}
         </Menu>

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -262,6 +262,7 @@ export const DownloadButton = (): JSX.Element => {
           downloadPercentage={downloadPercentage}
           isDownloading={handleBulkDownloadMutation.isLoading}
           downloadMetadata={downloadMetadata}
+          downloadOptions={downloadOptions}
         />
       )}
       {dateRangeResponsesCount !== undefined && (

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/ConfirmationScreen.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { BiCheck } from 'react-icons/bi'
 import {
   Badge,
@@ -19,6 +19,8 @@ import Button from '~components/Button'
 import InlineMessage from '~components/InlineMessage'
 import { ModalCloseButton } from '~components/Modal'
 
+import { DownloadOptions } from '../../types'
+
 const InlineTextListItem = ({
   children,
 }: {
@@ -37,9 +39,11 @@ interface ConfirmationScreenProps {
   onDownload: () => void
   isDownloading: boolean
   responsesCount: number
+  downloadOptions: DownloadOptions
 }
 
 export const ConfirmationScreen = ({
+  downloadOptions,
   onCancel,
   isDownloading,
   onDownload,
@@ -48,15 +52,20 @@ export const ConfirmationScreen = ({
   const isMobile = useIsMobile()
   const { t } = useTranslation()
 
+  const confirmationScreenKeyPrefix =
+    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen'
+
   return (
     <>
       <ModalCloseButton />
       <ModalHeader color="secondary.700" pr="4.5rem">
         <Wrap shouldWrapChildren direction="row" align="center">
           <Text>
-            {t(
-              'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.title',
-            )}
+            {!downloadOptions.isDownloadCsv
+              ? t(`${confirmationScreenKeyPrefix}.titleAttachmentsOnly`)
+              : t(
+                  `${confirmationScreenKeyPrefix}.titleResponsesAndAttachments`,
+                )}
           </Text>
           <Badge w="fit-content" colorScheme="success">
             {t('features.common.betaBadgeLabel')}
@@ -66,49 +75,45 @@ export const ConfirmationScreen = ({
       <ModalBody whiteSpace="pre-wrap" color="secondary.500">
         <Stack spacing="1rem">
           <Text>
-            Separate zip files will be downloaded, <b>one for each response</b>.
-            You can adjust the date range before proceeding.
+            {downloadOptions.isDownloadAttachments ? (
+              <Trans
+                i18nKey={`${confirmationScreenKeyPrefix}.attachmentsDescription`}
+              />
+            ) : (
+              ''
+            )}
             <br />
             <br />
-            <b>
-              {t(
-                'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.numberOfResponsesAndAttachments',
-              )}
-              :
-            </b>{' '}
+            <b>{t(`${confirmationScreenKeyPrefix}.numberOfResponses`)}:</b>{' '}
             {responsesCount.toLocaleString()}
             <br />
-            <b>
-              {t(
-                'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.estimatedTime',
-              )}
-              :
-            </b>{' '}
-            {t(
-              'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.estimatedTimeReference',
-            )}
+            <b>{t(`${confirmationScreenKeyPrefix}.estimatedTime`)}:</b>{' '}
+            {t(`${confirmationScreenKeyPrefix}.estimatedTimeReference`)}
+            <br />
+            <br />
+            {t(`${confirmationScreenKeyPrefix}.filterResponsesCountHelperText`)}
           </Text>
           <InlineMessage>
             <Stack>
               <Text textStyle="subhead-1">
                 {t(
-                  'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.title',
+                  `${confirmationScreenKeyPrefix}.intensiveOperationWarning.title`,
                 )}
               </Text>
               <List>
                 <InlineTextListItem>
                   {t(
-                    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.doNotUseIE',
+                    `${confirmationScreenKeyPrefix}.intensiveOperationWarning.doNotUseIE`,
                   )}
                 </InlineTextListItem>
                 <InlineTextListItem>
                   {t(
-                    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.ensureStrongNetworkConnectivity',
+                    `${confirmationScreenKeyPrefix}.intensiveOperationWarning.ensureStrongNetworkConnectivity`,
                   )}
                 </InlineTextListItem>
                 <InlineTextListItem>
                   {t(
-                    'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.intensiveOperationWarning.ensureEnoughDiskSpace',
+                    `${confirmationScreenKeyPrefix}.intensiveOperationWarning.ensureEnoughDiskSpace`,
                   )}
                 </InlineTextListItem>
               </List>
@@ -117,7 +122,7 @@ export const ConfirmationScreen = ({
           {responsesCount === 0 && (
             <InlineMessage variant="warning">
               {t(
-                'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.noResponsesInSelectedDateRange',
+                `${confirmationScreenKeyPrefix}.noResponsesInSelectedDateRange`,
               )}
             </InlineMessage>
           )}
@@ -135,9 +140,7 @@ export const ConfirmationScreen = ({
             isLoading={isDownloading}
             isDisabled={responsesCount === 0}
           >
-            {t(
-              'features.adminForm.responses.responsesPage.storage.unlockedResponses.downloadWithAttachmentModal.confirmationScreen.startDownload',
-            )}
+            {t(`${confirmationScreenKeyPrefix}.startDownload`)}
           </Button>
           <Button
             isFullWidth={isMobile}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.stories.tsx
@@ -32,15 +32,37 @@ const Template: StoryFn<DownloadWithAttachmentModalProps> = (args) => {
     />
   )
 }
-export const ConfirmationStateDesktop = Template.bind({})
-ConfirmationStateDesktop.args = {
+export const ConfirmationStateResponseAndAttachmentsDesktop = Template.bind({})
+ConfirmationStateResponseAndAttachmentsDesktop.args = {
   downloadPercentage: 0,
   isDownloading: false,
   responsesCount: 9001,
+  downloadOptions: {
+    isDownloadAttachments: true,
+    isDownloadCsv: true,
+  },
 }
-export const ConfirmationStateMobile = Template.bind({})
-ConfirmationStateMobile.args = ConfirmationStateDesktop.args
-ConfirmationStateMobile.parameters = getMobileViewParameters()
+export const ConfirmationStateResponseAndAttachmentsMobile = Template.bind({})
+ConfirmationStateResponseAndAttachmentsMobile.args =
+  ConfirmationStateResponseAndAttachmentsDesktop.args
+ConfirmationStateResponseAndAttachmentsMobile.parameters =
+  getMobileViewParameters()
+
+export const ConfirmationStateAttachmentsOnlyDesktop = Template.bind({})
+ConfirmationStateAttachmentsOnlyDesktop.args = {
+  downloadPercentage: 0,
+  isDownloading: false,
+  responsesCount: 9001,
+  downloadOptions: {
+    isDownloadAttachments: true,
+    isDownloadCsv: false,
+  },
+}
+
+export const ConfirmationStateAttachmentsOnlyMobile = Template.bind({})
+ConfirmationStateAttachmentsOnlyMobile.args =
+  ConfirmationStateAttachmentsOnlyDesktop.args
+ConfirmationStateAttachmentsOnlyMobile.parameters = getMobileViewParameters()
 
 export const DownloadingStateDesktop = Template.bind({})
 DownloadingStateDesktop.args = {

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadWithAttachmentModal/DownloadWithAttachmentModal.tsx
@@ -11,7 +11,7 @@ import {
 
 import { XMotionBox } from '~templates/MotionBox'
 
-import { CanceledResult, DownloadResult } from '../../types'
+import { CanceledResult, DownloadOptions, DownloadResult } from '../../types'
 import { isCanceledResult } from '../../utils/typeguards'
 import { CompleteScreen, ProgressModalContent } from '../ProgressModal'
 
@@ -27,6 +27,7 @@ export interface DownloadWithAttachmentModalProps
   downloadPercentage: number
   initialState?: [DownloadWithAttachmentFlowStates, number]
   downloadMetadata?: DownloadResult | CanceledResult
+  downloadOptions: DownloadOptions
 }
 
 /** Exported for testing. */
@@ -50,6 +51,7 @@ export const DownloadWithAttachmentModal = ({
   responsesCount,
   downloadPercentage,
   downloadMetadata,
+  downloadOptions,
   initialState = INITIAL_STEP_STATE,
 }: DownloadWithAttachmentModalProps): JSX.Element => {
   const modalSize = useBreakpointValue({
@@ -94,6 +96,7 @@ export const DownloadWithAttachmentModal = ({
         <XMotionBox keyProp={currentStep} custom={direction}>
           {currentStep === DownloadWithAttachmentFlowStates.Confirmation && (
             <ConfirmationScreen
+              downloadOptions={downloadOptions}
               isDownloading={isDownloading}
               responsesCount={responsesCount}
               onCancel={onClose}

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/types.ts
@@ -55,6 +55,10 @@ export interface DownloadOptions {
  * Decrypted formatted data returned by the decryption worker.
  */
 export type DecryptedData = {
+  status: {
+    isDecryptionSuccessful: boolean
+    isDownloadAndDecryptSubmissionAttachmentsSuccessful: boolean
+  }
   materializedCsvRecord?: MaterializedCsvRecord
   attachmentDownloadBlob?: Blob
   submissionId?: string

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -47,6 +47,7 @@ export type DownloadEncryptedParams = EncryptedResponsesStreamParams & {
   responsesCount: number
   // Used to determine if we should add MRF related columns to the CSV.
   isMrf: boolean
+  isDownloadCsv: boolean
 }
 interface UseDecryptionWorkersProps {
   onProgress: (progress: number) => void
@@ -83,6 +84,7 @@ const useDecryptionWorkers = ({
     async ({
       responsesCount,
       downloadAttachments,
+      isDownloadCsv,
       secretKey,
       endDate,
       startDate,
@@ -108,17 +110,24 @@ const useDecryptionWorkers = ({
       const numWorkers = downloadAttachments
         ? 1
         : window.navigator.hardwareConcurrency || 4
-      let errorCount = 0
-      let unverifiedCount = 0
-      let attachmentErrorCount = 0
+
       let currentSubmissionIndex = 0 // used to iterate through the workers
       let attachmentsToSaveCount = 0 // used for scheduling delays between attachment zip file saves
+      const csvOutcomeCounts = {
+        errorCount: 0,
+        unverifiedCount: 0,
+        attachmentErrorCount: 0,
+      }
+      const decryptionOutcomeCounts = {
+        decryptionSuccessCount: 0,
+        decryptionFailureCount: 0,
+      }
 
       const logMeta = {
         action: 'downloadEncryptedReponses',
         formId: adminForm._id,
         formTitle: adminForm.title,
-        downloadAttachments: downloadAttachments,
+        downloadAttachments,
         num_workers: numWorkers,
         expectedNumSubmissions: NUM_OF_METADATA_ROWS,
         adminId: user?._id,
@@ -139,11 +148,13 @@ const useDecryptionWorkers = ({
 
       setWorkers(workerPool)
 
-      const csvGenerator = new EncryptedResponseCsvGenerator(
-        responsesCount,
-        NUM_OF_METADATA_ROWS,
-        isMrf,
-      )
+      const csvGenerator = isDownloadCsv
+        ? new EncryptedResponseCsvGenerator(
+            responsesCount,
+            NUM_OF_METADATA_ROWS,
+            isMrf,
+          )
+        : undefined
 
       const stream = await getEncryptedResponsesStream(
         adminForm._id,
@@ -167,7 +178,7 @@ const useDecryptionWorkers = ({
             workerApi
               .getDecryptedData({
                 isDownloadAttachments: downloadAttachments,
-                isDownloadCsv: true,
+                isDownloadCsv,
                 submissionStreamDtoString: result.value,
                 secretKey,
                 formId: adminForm._id,
@@ -175,25 +186,46 @@ const useDecryptionWorkers = ({
               })
               // Step 2: Update the Csv record status based on the decryption result.
               .then(async (decryptResult) => {
-                switch (decryptResult.materializedCsvRecord?.status) {
-                  case CsvRecordStatus.Error:
-                    errorCount++
-                    break
-                  case CsvRecordStatus.Unverified:
-                    unverifiedCount++
-                    break
-                  case CsvRecordStatus.AttachmentError:
-                    errorCount++
-                    attachmentErrorCount++
-                    break
-                  case CsvRecordStatus.Ok: {
-                    try {
-                      csvGenerator.addRecord(
-                        decryptResult.materializedCsvRecord.submissionData,
-                      )
-                    } catch (e) {
-                      errorCount++
-                      console.error('Error in getResponseInstance', e)
+                // Count general decryption successes and failures
+                const {
+                  isDecryptionSuccessful,
+                  isDownloadAndDecryptSubmissionAttachmentsSuccessful,
+                } = decryptResult.status
+
+                const decryptionFailed =
+                  !isDecryptionSuccessful ||
+                  (downloadAttachments &&
+                    !isDownloadAndDecryptSubmissionAttachmentsSuccessful)
+
+                if (decryptionFailed) {
+                  decryptionOutcomeCounts.decryptionFailureCount++
+                } else {
+                  decryptionOutcomeCounts.decryptionSuccessCount++
+                }
+
+                // Count number of csv success and failures
+                if (isDownloadCsv && csvGenerator) {
+                  const { materializedCsvRecord } = decryptResult
+                  switch (materializedCsvRecord?.status) {
+                    case CsvRecordStatus.Error:
+                      csvOutcomeCounts.errorCount++
+                      break
+                    case CsvRecordStatus.Unverified:
+                      csvOutcomeCounts.unverifiedCount++
+                      break
+                    case CsvRecordStatus.AttachmentError:
+                      csvOutcomeCounts.errorCount++
+                      csvOutcomeCounts.attachmentErrorCount++
+                      break
+                    case CsvRecordStatus.Ok: {
+                      try {
+                        csvGenerator.addRecord(
+                          materializedCsvRecord.submissionData,
+                        )
+                      } catch (e) {
+                        csvOutcomeCounts.errorCount++
+                        console.error('Error in getResponseInstance', e)
+                      }
                     }
                   }
                 }
@@ -297,8 +329,22 @@ const useDecryptionWorkers = ({
           // Step 2: Generate the actual CSV file from the csv object.
           .finally(() => {
             const checkComplete = () => {
+              if (!isDownloadCsv || !csvGenerator) {
+                killWorkers(workerPool)
+                resolve({
+                  expectedCount: responsesCount,
+                  successCount: decryptionOutcomeCounts.decryptionSuccessCount,
+                  errorCount: decryptionOutcomeCounts.decryptionFailureCount,
+                  unverifiedCount: 0, // RATIONALE: For non-CSV downloads, no need to verify fields
+                })
+                return
+              }
               // If all the records could not be decrypted
-              if (errorCount + unverifiedCount === responsesCount) {
+              if (
+                csvOutcomeCounts.errorCount +
+                  csvOutcomeCounts.unverifiedCount ===
+                responsesCount
+              ) {
                 const failureEndTime = performance.now()
                 const timeDifference = failureEndTime - downloadStartTime
 
@@ -306,9 +352,10 @@ const useDecryptionWorkers = ({
                   meta: {
                     ...logMeta,
                     duration: timeDifference,
-                    error_count: errorCount,
-                    unverified_count: unverifiedCount,
-                    attachment_error_count: attachmentErrorCount,
+                    error_count: csvOutcomeCounts.errorCount,
+                    unverified_count: csvOutcomeCounts.unverifiedCount,
+                    attachment_error_count:
+                      csvOutcomeCounts.attachmentErrorCount,
                   },
                 })
 
@@ -317,27 +364,29 @@ const useDecryptionWorkers = ({
                   numWorkers,
                   csvGenerator.length(),
                   timeDifference,
-                  errorCount,
-                  attachmentErrorCount,
+                  csvOutcomeCounts.errorCount,
+                  csvOutcomeCounts.attachmentErrorCount,
                 )
 
                 killWorkers(workerPool)
                 resolve({
                   expectedCount: responsesCount,
                   successCount: csvGenerator.length(),
-                  errorCount,
-                  unverifiedCount,
+                  errorCount: csvOutcomeCounts.errorCount,
+                  unverifiedCount: csvOutcomeCounts.unverifiedCount,
                 })
               } else if (
                 // All results have been decrypted
-                csvGenerator.length() + errorCount + unverifiedCount >=
+                csvGenerator.length() +
+                  csvOutcomeCounts.errorCount +
+                  csvOutcomeCounts.unverifiedCount >=
                 responsesCount
               ) {
                 killWorkers(workerPool)
                 // Generate first three rows of meta-data before download
                 csvGenerator.addMetaDataFromSubmission(
-                  errorCount,
-                  unverifiedCount,
+                  csvOutcomeCounts.errorCount,
+                  csvOutcomeCounts.unverifiedCount,
                 )
                 csvGenerator.downloadCsv(
                   `${adminForm.title}-${adminForm._id}.csv`,
@@ -363,8 +412,8 @@ const useDecryptionWorkers = ({
                 resolve({
                   expectedCount: responsesCount,
                   successCount: csvGenerator.length(),
-                  errorCount,
-                  unverifiedCount,
+                  errorCount: csvOutcomeCounts.errorCount,
+                  unverifiedCount: csvOutcomeCounts.unverifiedCount,
                 })
               } else {
                 setTimeout(checkComplete, 100)
@@ -377,18 +426,18 @@ const useDecryptionWorkers = ({
     [adminForm, onProgress, user?._id, workers],
   )
 
-  const handleExportCsvMutation = useMutation(
+  const handleBulkDownloadMutation = useMutation(
     (params: DownloadEncryptedParams) => downloadEncryptedResponses(params),
     mutateProps,
   )
 
   const abortDecryption = useCallback(() => {
     abortControllerRef.current.abort()
-    handleExportCsvMutation.reset()
+    handleBulkDownloadMutation.reset()
     killWorkers(workers)
-  }, [handleExportCsvMutation, workers])
+  }, [handleBulkDownloadMutation, workers])
 
-  return { handleExportCsvMutation, abortDecryption }
+  return { handleBulkDownloadMutation, abortDecryption }
 }
 
 export default useDecryptionWorkers

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -455,6 +455,10 @@ async function getDecryptedData(
     submissionId: isParseSuccessful
       ? decryptedSubmissionResult.parsedSubmission._id
       : undefined,
+    status: {
+      isDecryptionSuccessful,
+      isDownloadAndDecryptSubmissionAttachmentsSuccessful,
+    },
   }
 }
 

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
@@ -73,8 +73,8 @@ export const enSG: ResponsesResponsesPage = {
         progressModalContent:
           '{dateRangeResponsesCount} responses are being processed. Navigating away from this page will stop the download.',
         menuItem: {
-          csvOnly: 'CSV only',
-          csvWithAttachments: 'CSV with attachments',
+          csv: 'Spreadsheet of responses (.csv)',
+          attachments: 'Respondent-uploaded attachments',
         },
       },
       unlockedResponses: {

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
@@ -21,11 +21,15 @@ export const enSG: ResponsesResponsesPage = {
           backToResponses: 'Back to responses',
         },
         confirmationScreen: {
-          title: 'Download responses and attachments',
-          numberOfResponsesAndAttachments:
-            'Number of responses and attachments',
+          attachmentsDescription:
+            'For attachments, <strong>a separate zip file</strong> will be downloaded for each response.',
+          titleAttachmentsOnly: 'Download attachments',
+          titleResponsesAndAttachments: 'Download responses and attachments',
+          numberOfResponses: 'Number of responses',
           estimatedTime: 'Estimated time',
           estimatedTimeReference: '30-50 mins per 1,000 responses',
+          filterResponsesCountHelperText:
+            'You can reduce the number of downloads at one go by adjusting the date range.',
           intensiveOperationWarning: {
             title:
               'Downloading many attachments can be an intensive operation.',

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
@@ -18,10 +18,13 @@ export interface ResponsesResponsesPage {
           backToResponses: string
         }
         confirmationScreen: {
-          title: string
-          numberOfResponsesAndAttachments: string
+          titleAttachmentsOnly: string
+          titleResponsesAndAttachments: string
+          attachmentsDescription: string
+          numberOfResponses: string
           estimatedTime: string
           estimatedTimeReference: string
+          filterResponsesCountHelperText: string
           intensiveOperationWarning: {
             title: string
             doNotUseIE: string

--- a/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
+++ b/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
@@ -62,8 +62,8 @@ export interface ResponsesResponsesPage {
         }
         progressModalContent: string
         menuItem: {
-          csvOnly: string
-          csvWithAttachments: string
+          csv: string
+          attachments: string
         }
       }
       unlockedResponses: {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Currently, the options for bulk download are (csv only) + (csv & attachments). 
The desired end state is to have a checkbox to choose a combination, and have the accompanying confirmation modal to match. 

## Solution
<!-- How did you solve the problem? -->
Implement the desired UI by Sufyan (designer). 

Fixes FRM-2235

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->
New attachments and responses confirmation modal: 
<img width="661" height="485" alt="image" src="https://github.com/user-attachments/assets/f173a3de-533c-4584-b7f1-aa0d9f40edd8" />

New attachments only modal: 
<img width="697" height="512" alt="image" src="https://github.com/user-attachments/assets/15e7ccbe-3d0e-411c-af68-24a99f40c00b" />

## Tests
<!-- What tests should be run to confirm functionality? -->
2 new chromatic stories are added to verify the combination of possible confirmation modals. eg, 
responses + attachments modal 
attachment only modal

Pre-req: 
- [x] Create 2 forms - one MRF and one storage mode form with attachment field + make multiple submissions for both forms. 

TC1: Bulk attachment downloads and csv work 
- [x] Select the checkboxes for both csv + attachments from the storage form. 
- [x] Observe that the button is `next` and clicking on it will show a modal which displays 'download attachments and responses'. 
- [x] Assert the attachment files are downloaded and csv is correctly
formatted.  
- [x] Repeat for mrf form. 

TC2: Bulk response only downloads work
- [x] Select only csv checkbox from the storage form. 
- [x] Observe the button is `start download`. 
- [x] Click and download the csv. 
- [x] Assert only csv is downloaded and it is correctly formatted.  
- [x] Repeat for mrf form. 

TC3: Bulk attachment only downloads work. 
- [x] Select only attachment checkbox from the storage form. 
- [x] Observe that the button is `next` and clicking on it will show a modal, which displays 'download attachments' 
- [x] Click the download button. 
- [x] Assert only attachment zips are downloaded and there is no csv file.  
- [x] Repeat for mrf form. 