### PR TITLE
fix: mrf respondent copy email body line breaks

### DIFF
--- a/src/app/views/templates/MrfRespondentCopyEmail.tsx
+++ b/src/app/views/templates/MrfRespondentCopyEmail.tsx
@@ -22,6 +22,7 @@ import {
   questionMargin,
   answerMargin,
 } from './mrfWorkflowCompletionEmailStyle'
+import React from 'react'
 
 export type QuestionAnswer = {
   question: string
@@ -58,6 +59,30 @@ export const MrfRespondentCopyEmail = ({
           <Hr style={{ margin: '40px 0' }} />
         </>
     )
+    
+    /**
+     * Explicitly render line breaks and paragraphs in email body, as certain email clients
+     * might not be compatible with CSS white-space property. (e.g. white-space: pre-line)
+     * @param body - email body text with line breaks
+     * @param textStyle - css properties
+     * @returns an array of JSX elements representing paragraphs and line breaks
+     */
+    const renderEmailBody = (
+      body: string,
+      textStyle: React.CSSProperties,
+    ): JSX.Element[] => {
+      return body.split(/\n{2,}/).map((paragraph, i) => (
+      <Text key={i} style={{ ...textStyle, marginBottom: '16px' }}>
+        {paragraph.split('\n').map((line, j) => (
+          <React.Fragment key={j}>
+            {line}
+            <br />
+          </React.Fragment>
+        ))}
+        </Text>
+      ))
+      }
+
 
     return (
     <Html>
@@ -70,9 +95,7 @@ export const MrfRespondentCopyEmail = ({
             <Heading style={{ ...headingTextStyle, marginBottom: '40px' }}>
               {headingText}
             </Heading>
-            <Text style={{ ...secondaryTextStyle, marginBottom: '40px', whiteSpace: 'pre-line' }}>
-              {body}
-            </Text>
+            {renderEmailBody(body, secondaryTextStyle)}
             {renderResponseId()}
               {formQuestionAnswers ? (
                 <>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

In MRF respondent copy emails, email bodies are not accurately handling line breaks. This only affects WOG emails. Specifically, WOG email client isn't compatible with CSS properties handling whitespace.

Fixes FRM-2222

## Solution
<!-- How did you solve the problem? -->

Explicitly define line breaks using `<br>` such that WOG email clients may render the body accurately.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

<img width="504" height="540" alt="image" src="https://github.com/user-attachments/assets/b778ec5b-266b-4585-8b4b-3fd6f58a6b71" />


**AFTER**:
<!-- [insert screenshot here] -->

<img width="1901" height="1009" alt="image" src="https://github.com/user-attachments/assets/0050918f-d84d-4e8a-a64c-ff483f3124ed" />

## Tests
<!-- What tests should be run to confirm functionality? -->

**Test MRF respondent copy email**
- [x] Create an MRF form, add an email field and enable respondent copy (Include a copy of responses.. toggle)
- [x] Inside the email field settings, add a custom body message with line breaks
- [x] Assign the email field to step 1 of the workflow
- [x] Make a submission, and key in your WOG email (@tech.gov.sg)
- [x] Using a COMET or GSIB, check that the linebreaks show as expected, as written in the email field.
