### PR TITLE
fix: bug where 0 helper text is rendered when no prompt

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
@@ -163,11 +163,11 @@ const TextPromptModalBodyContent = ({
           })}
         />
         <FormErrorMessage>{errors.prompt?.message}</FormErrorMessage>
-        {!errors.prompt?.message && promptLength && (
+        {!errors.prompt?.message && promptLength > 0 ? (
           <FormHelperText>
             {`(${promptLength}/${MFB_TEXT_PROMPT_MAX_CHAR})`}
           </FormHelperText>
-        )}
+        ) : undefined}
       </FormControl>
       <Box mt="1rem">
         <PromptSelectorBar


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
When there is no prompt, the number 0 is rendered as helper text. This is not expected. 
<img width="681" height="404" alt="image" src="https://github.com/user-attachments/assets/84b87a7a-2947-483a-8907-27ffddfdd9d7" />

## Solution
<!-- How did you solve the problem? -->
Only render helper text when the promptLength > 0
<img width="718" height="636" alt="image" src="https://github.com/user-attachments/assets/950f2496-f09d-4baa-b455-2b7fc9bf0df0" />

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  