### PR TITLE
feat: Update copy for workflow approval toggle

### DIFF
--- a/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -131,11 +131,11 @@ export const enSG: Workflow = {
       'This Yes/No field was deleted, please select another Yes/No field',
     notRequired: 'Approval not required in this step',
     toggle: {
-      label: 'This respondent is an approver',
+      label: 'Make this step an approval',
       description:
-        'If they select Yes, the form continues to the next step. If they select No, it stops here.',
+        'If respondent selects Yes, the form is Approved and continues to the next step. If they select No, the form is Not approved and stops at this step.',
       tooltip:
-        'Use this for steps that involve any type of decision, such as reviews or endorsements',
+        'Use this for steps that involve any type of decision, such as reviews or endorsements. Decision will be shown on dashboard and tracking links.',
       placeholder: 'Select a Yes/No field from your form',
     },
     validation: {


### PR DESCRIPTION
## Problem
The workflow approval toggle is one of the more confusing parts for admins when setting up. It is currently presented as a role and a gate. However, it fails to mention the following:

- Which response (yes/no) counts as "approved" and "not approved"
- The approval outcome will be reflected in various touch points like the results page and the status tracking link

<img width="943" height="754" alt="image" src="https://github.com/user-attachments/assets/ff02349f-bab9-4984-8445-d95384e19d7f" />

## Solution
Update the copy to make it clearer to admins setting up.

<img width="943" height="754" alt="image" src="https://github.com/user-attachments/assets/846f4604-cd3b-4923-92d7-f540e99ec46b" />


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  