### PR TITLE
feat: remove signature field feature flag

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -1,9 +1,5 @@
 import { Box } from '@chakra-ui/react'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
 import { Droppable } from '@hello-pangea/dnd'
-
-import { featureFlags } from '~shared/constants'
-import { BasicField } from '~shared/types'
 
 import {
   BASIC_FIELDS_CONTENT_AND_DESCRIPTIONS,

--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/BasicFieldPanel.tsx
@@ -30,7 +30,6 @@ import { filterFieldsBySearchValue } from './utils'
 export const BasicFieldPanel = ({ searchValue }: { searchValue: string }) => {
   const { isLoading } = useCreateTabForm()
 
-  const isSignatureFieldEnabled = useFeatureIsOn(featureFlags.signatureField)
   const filteredCreateBasicFreeTextFields = filterFieldsBySearchValue(
     searchValue,
     BASIC_FIELDS_FREE_TEXT,
@@ -178,12 +177,6 @@ export const BasicFieldPanel = ({ searchValue }: { searchValue: string }) => {
                 {filteredCreateBasicPersonalFields.map(
                   ({ fieldType, originalIndex }) => {
                     const shouldDisableField = isLoading
-
-                    if (
-                      fieldType === BasicField.Signature &&
-                      !isSignatureFieldEnabled
-                    )
-                      return null
                     return (
                       <DraggableBasicFieldListOption
                         index={originalIndex}

--- a/shared/constants/feature-flags.ts
+++ b/shared/constants/feature-flags.ts
@@ -18,7 +18,6 @@ export const featureFlags = {
   respondentCopy: 'respondent-copy' as const,
   statusTracker: 'status-tracker' as const,
   designDrawerFormTitle: 'design-drawer-form-title' as const,
-  signatureField: 'signature-field' as const,
   adminPrintPdf: 'admin-print-pdf' as const,
   ogpSuiteSso: 'ogp-suite-sso' as const,
   enableIntranetSgidLogin: 'enable-intranet-sgid-login' as const,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Signature Field feature has been made to general availability and no longer is required to be conditionally available based on user whitelist (betaFlag) or feature flag.

Fixes FRM-2232

## Solution
<!-- How did you solve the problem? -->

Removing conditional display of signature field on field list drawer based on `signature-field` feature flag

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

**Test signature field with feature flag off**
- [ ] On test env, turn off growthbook feature flag: `signatureField`
- [ ]  Successfully create a signature field on the form
