### PR TITLE
fix: bump react router dom version to 6.30.3

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -73,7 +73,7 @@
         "react-markdown": "^9.0.1",
         "react-query": "^3.34.2",
         "react-remove-scroll": "^2.5.10",
-        "react-router-dom": "^6.0.2",
+        "react-router-dom": "^6.30.3",
         "react-roving-tabindex": "^3.2.0",
         "react-swipeable": "^7.0.0",
         "react-table": "^7.7.0",
@@ -3103,6 +3103,15 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-inject": {
@@ -11475,14 +11484,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/history": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
-      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -16330,23 +16331,31 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.2.tgz",
-      "integrity": "sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
       "dependencies": {
-        "history": "^5.1.0"
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.2.tgz",
-      "integrity": "sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
       "dependencies": {
-        "history": "^5.1.0",
-        "react-router": "6.0.2"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8",
@@ -22156,6 +22165,11 @@
       "requires": {
         "@react-dev-inspector/middleware": "2.0.1"
       }
+    },
+    "@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="
     },
     "@rollup/plugin-inject": {
       "version": "5.0.5",
@@ -27967,14 +27981,6 @@
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true
     },
-    "history": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
-      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
-      "requires": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -31328,20 +31334,20 @@
       }
     },
     "react-router": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.2.tgz",
-      "integrity": "sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "requires": {
-        "history": "^5.1.0"
+        "@remix-run/router": "1.23.2"
       }
     },
     "react-router-dom": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.2.tgz",
-      "integrity": "sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "requires": {
-        "history": "^5.1.0",
-        "react-router": "6.0.2"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       }
     },
     "react-roving-tabindex": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
     "react-markdown": "^9.0.1",
     "react-query": "^3.34.2",
     "react-remove-scroll": "^2.5.10",
-    "react-router-dom": "^6.0.2",
+    "react-router-dom": "^6.30.3",
     "react-roving-tabindex": "^3.2.0",
     "react-swipeable": "^7.0.0",
     "react-table": "^7.7.0",

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -2,7 +2,6 @@ import { Inspector, InspectParams } from 'react-dev-inspector'
 import { HelmetProvider } from 'react-helmet-async'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { ReactQueryDevtools } from 'react-query/devtools'
-import { BrowserRouter } from 'react-router-dom'
 import { ChakraProvider } from '@chakra-ui/react'
 import { datadogLogs } from '@datadog/browser-logs'
 
@@ -71,17 +70,15 @@ export const App = (): JSX.Element => {
         <QueryClientProvider client={queryClient}>
           <ReactQueryDevtools initialIsOpen={false} />
           <AppHelmet />
-          <BrowserRouter>
-            <ChakraProvider theme={theme} resetCSS>
-              <TurnstileChallengeProvider>
-                <AuthProvider>
-                  <GrowthBookProvider>
-                    <AppRouter />
-                  </GrowthBookProvider>
-                </AuthProvider>
-              </TurnstileChallengeProvider>
-            </ChakraProvider>
-          </BrowserRouter>
+          <ChakraProvider theme={theme} resetCSS>
+            <TurnstileChallengeProvider>
+              <AuthProvider>
+                <GrowthBookProvider>
+                  <AppRouter />
+                </GrowthBookProvider>
+              </AuthProvider>
+            </TurnstileChallengeProvider>
+          </ChakraProvider>
         </QueryClientProvider>
       </HelmetProvider>
     </>

--- a/frontend/src/app/AppRouter.tsx
+++ b/frontend/src/app/AppRouter.tsx
@@ -1,6 +1,11 @@
 import { Suspense, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { Route, Routes } from 'react-router-dom'
+import {
+  createBrowserRouter,
+  createRoutesFromElements,
+  Route,
+  RouterProvider,
+} from 'react-router-dom'
 import { Box } from '@chakra-ui/react'
 import { useGrowthBook } from '@growthbook/growthbook-react'
 import loadable from '@loadable/component'
@@ -89,9 +94,9 @@ export const AppRouter = (): JSX.Element => {
     }
   }, [growthbook])
 
-  return (
-    <WithSuspense>
-      <Routes>
+  const router = createBrowserRouter(
+    createRoutesFromElements(
+      <Route path="/">
         <Route
           path={LANDING_ROUTE}
           element={<HashRouterElement element={<LandingPage />} />}
@@ -234,7 +239,13 @@ export const AppRouter = (): JSX.Element => {
           }
         />
         <Route path="*" element={<NotFoundErrorPage />} />
-      </Routes>
+      </Route>,
+    ),
+  )
+
+  return (
+    <WithSuspense>
+      <RouterProvider router={router} />
     </WithSuspense>
   )
 }

--- a/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
+++ b/frontend/src/features/admin-form/AdminFormResultsResponsesPage.stories.tsx
@@ -1,5 +1,9 @@
-import { MemoryRouter, Route } from 'react-router'
-import { Routes } from 'react-router-dom'
+import { Route } from 'react-router'
+import {
+  createMemoryRouter,
+  createRoutesFromElements,
+  RouterProvider,
+} from 'react-router-dom'
 import { Meta, StoryFn } from '@storybook/react'
 import { expect, userEvent, waitFor, within } from '@storybook/test'
 
@@ -55,33 +59,27 @@ const MOCK_KEYPAIR = {
 }
 
 const Template: StoryFn = () => {
-  return (
-    <MemoryRouter
-      initialEntries={[
-        `${ADMINFORM_ROUTE}/61540ece3d4a6e50ac0cc6ff/${ADMINFORM_RESULTS_SUBROUTE}`,
-      ]}
-    >
-      <Routes>
+  const router = createMemoryRouter(
+    createRoutesFromElements(
+      <Route path={`${ADMINFORM_ROUTE}/:formId`} element={<AdminFormLayout />}>
         <Route
-          path={`${ADMINFORM_ROUTE}/:formId`}
-          element={<AdminFormLayout />}
+          path={ADMINFORM_RESULTS_SUBROUTE}
+          element={<FormResultsLayout />}
         >
-          <Route
-            path={ADMINFORM_RESULTS_SUBROUTE}
-            element={<FormResultsLayout />}
-          >
-            <Route element={<ResponsesLayout />}>
-              <Route index element={<ResponsesPage />} />
-            </Route>
-            <Route
-              path={RESULTS_FEEDBACK_SUBROUTE}
-              element={<FeedbackPage />}
-            />
+          <Route element={<ResponsesLayout />}>
+            <Route index element={<ResponsesPage />} />
           </Route>
+          <Route path={RESULTS_FEEDBACK_SUBROUTE} element={<FeedbackPage />} />
         </Route>
-      </Routes>
-    </MemoryRouter>
+      </Route>,
+    ),
+    {
+      initialEntries: [
+        `${ADMINFORM_ROUTE}/61540ece3d4a6e50ac0cc6ff/${ADMINFORM_RESULTS_SUBROUTE}`,
+      ],
+    },
   )
+  return <RouterProvider router={router} />
 }
 export const EmailForm = Template.bind({})
 

--- a/frontend/src/templates/NavigationPrompt/useNavigationPrompt.ts
+++ b/frontend/src/templates/NavigationPrompt/useNavigationPrompt.ts
@@ -41,7 +41,7 @@ export const useNavigationPrompt = (when?: boolean) => {
   useEffect(() => {
     if (!when) return
     unblockRef.current = navigationContext.navigator.block((transaction) => {
-      setTargetPath(transaction.location.pathname)
+      setTargetPath(transaction.pathname)
       handleShowModal()
       return false
     })

--- a/frontend/src/templates/NavigationPrompt/useNavigationPrompt.ts
+++ b/frontend/src/templates/NavigationPrompt/useNavigationPrompt.ts
@@ -1,64 +1,32 @@
-import {
-  ContextType,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
-import {
-  Navigator as BaseNavigator,
-  UNSAFE_NavigationContext as NavigationContext,
-} from 'react-router-dom'
-import type { History } from 'history'
-
-interface Navigator extends BaseNavigator {
-  block: History['block']
-}
-
-type NavigationContextWithBlock = ContextType<typeof NavigationContext> & {
-  navigator: Navigator
-}
+import { useCallback, useEffect, useState } from 'react'
+import { BlockerFunction, useBlocker } from 'react-router-dom'
 
 export const useNavigationPrompt = (when?: boolean) => {
-  const navigationContext = useContext(
-    NavigationContext,
-  ) as NavigationContextWithBlock
-
   const [isPromptShown, setIsPromptShown] = useState(false)
-  const [targetPath, setTargetPath] = useState<string>()
 
-  const unblockRef = useRef<() => void>()
+  const shouldBlock = useCallback<BlockerFunction>(() => {
+    return when ?? false
+  }, [when])
 
-  const handleShowModal = useCallback(() => {
-    setIsPromptShown(true)
-  }, [])
+  const blocker = useBlocker(shouldBlock)
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      setIsPromptShown(true)
+    } else if (blocker.state === 'proceeding') {
+      setIsPromptShown(false)
+    }
+  }, [blocker.state])
 
   const onCancel = useCallback(() => {
     setIsPromptShown(false)
-  }, [])
-
-  useEffect(() => {
-    if (!when) return
-    unblockRef.current = navigationContext.navigator.block((transaction) => {
-      setTargetPath(transaction.pathname)
-      handleShowModal()
-      return false
-    })
-    return () => {
-      unblockRef.current && unblockRef.current()
-    }
-  }, [handleShowModal, navigationContext.navigator, when])
+    blocker.reset && blocker.reset()
+  }, [blocker])
 
   const handleConfirm = useCallback(() => {
-    if (unblockRef.current) {
-      unblockRef.current()
-    }
+    blocker.proceed && blocker.proceed()
     setIsPromptShown(false)
-    if (targetPath !== undefined) {
-      navigationContext?.navigator.push(targetPath)
-    }
-  }, [targetPath, navigationContext?.navigator])
+  }, [blocker])
 
   return {
     isPromptShown,

--- a/frontend/src/utils/storybook.tsx
+++ b/frontend/src/utils/storybook.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useEffect } from 'react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import {
+  createMemoryRouter,
+  createRoutesFromElements,
+  Route,
+  RouterProvider,
+} from 'react-router-dom'
 import { Box, BoxProps, Center, useDisclosure } from '@chakra-ui/react'
 import { Decorator } from '@storybook/react'
 import dayjs from 'dayjs'
@@ -118,15 +123,17 @@ export const EditFieldDrawerDecorator: Decorator = (storyFn) => {
 
 export const ADMIN_FORM_CREATE_PAGE_FORM_ID = '12345'
 export const AdminFormCreatePageDecorator: Decorator = (storyFn) => {
-  return (
-    <MemoryRouter initialEntries={[`/${ADMIN_FORM_CREATE_PAGE_FORM_ID}`]}>
-      <Routes>
-        <Route path={'/:formId'} element={<AdminFormLayout />}>
-          <Route index element={storyFn()} />
-        </Route>
-      </Routes>
-    </MemoryRouter>
+  const router = createMemoryRouter(
+    createRoutesFromElements(
+      <Route path={'/:formId'} element={<AdminFormLayout />}>
+        <Route index element={storyFn()} />
+      </Route>,
+    ),
+    {
+      initialEntries: [`/${ADMIN_FORM_CREATE_PAGE_FORM_ID}`],
+    },
   )
+  return <RouterProvider router={router} />
 }
 
 export const mockDateDecorator: Decorator = (storyFn, { parameters }) => {
@@ -173,15 +180,15 @@ interface StoryRouterProps {
 export const StoryRouter =
   ({ path, initialEntries }: StoryRouterProps): Decorator =>
   (storyFn, { parameters }) => {
-    return (
-      <MemoryRouter
-        initialEntries={parameters?.router?.initialEntries ?? initialEntries}
-      >
-        <Routes>
-          <Route path={parameters?.router?.path ?? path} element={storyFn()} />
-        </Routes>
-      </MemoryRouter>
+    const router = createMemoryRouter(
+      createRoutesFromElements(
+        <Route path={parameters?.router?.path ?? path} element={storyFn()} />,
+      ),
+      {
+        initialEntries: parameters?.router?.initialEntries ?? initialEntries,
+      },
     )
+    return <RouterProvider router={router} />
   }
 
 /**


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-2237

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Use data router variant of BrowserRouter and MemoryRouter to enable useBlocker
- Rewrite the "unsaved changes" modal using `useBlocker` APIs
- Remove usage of unstable APIs `UNSAFE_NavigationContext` which was blocking the dependency upgrade.

**Bug Fixes**:

- Update `react-router-dom` to `6.30.3`

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC: Check that Form Builder blocks navigation when changes are unsaved**
- [x] Visit an existing form, and make a change to any field
- [x] Without saving, navigate away from the field. An unsaved changes modal should pop up. 
- [x] Clicking Discard should drop the unsaved changes, and allow navigation.
- [x] Clicking Go back should preserve the unsaved changes, and prevent navigation.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `react-router-dom` : `6.30.3`
