### PR TITLE
feat: expose growthbook attributes on admin nav bar

### DIFF
--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -173,8 +173,8 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
 
   const growthbook = useGrowthBook()
 
-  // Set GrowthBook attributes for targeting rules
-  useEffect(() => {
+  // Set GrowthBook attributes for targeting rules synchronously
+  useMemo(() => {
     if (growthbook && user?.email) {
       growthbook.setAttributes({
         ...growthbook.getAttributes(),

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -295,13 +295,13 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
     // TODO: Remove forum link after H4PG2026
     ...(isForumSGEnabled
       ? [
-        {
-          label: 'Forum',
-          href: FORUMSG_URL,
-          MobileIcon: MdForum,
-          shouldShowNotification: true,
-        },
-      ]
+          {
+            label: 'Forum',
+            href: FORUMSG_URL,
+            MobileIcon: MdForum,
+            shouldShowNotification: true,
+          },
+        ]
       : []),
   ]
 

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -14,7 +14,7 @@ import {
   Icon,
   useDisclosure,
 } from '@chakra-ui/react'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
+import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from '~shared/constants'
 import { SeenFlags } from '~shared/types'
@@ -171,6 +171,19 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   const { updateLastSeenFlagMutation } = useUserMutations()
   const toast = useToast({ status: 'success', isClosable: true })
 
+  const growthbook = useGrowthBook()
+
+  // Set GrowthBook attributes for targeting rules
+  useEffect(() => {
+    if (growthbook && user?.email) {
+      growthbook.setAttributes({
+        ...growthbook.getAttributes(),
+        adminEmail: user.email,
+        adminAgency: user.agency?.shortName,
+      })
+    }
+  }, [growthbook, user?.email, user?.agency?.shortName])
+
   const whatsNewFeatureDrawerDisclosure = useDisclosure()
 
   const ROLLOUT_ANNOUNCEMENT_KEY = useMemo(
@@ -282,13 +295,13 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
     // TODO: Remove forum link after H4PG2026
     ...(isForumSGEnabled
       ? [
-          {
-            label: 'Forum',
-            href: FORUMSG_URL,
-            MobileIcon: MdForum,
-            shouldShowNotification: true,
-          },
-        ]
+        {
+          label: 'Forum',
+          href: FORUMSG_URL,
+          MobileIcon: MdForum,
+          shouldShowNotification: true,
+        },
+      ]
       : []),
   ]
 

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Box,

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -13,7 +13,7 @@ import {
   Stack,
   useDisclosure,
 } from '@chakra-ui/react'
-import { useFeatureValue, useGrowthBook } from '@growthbook/growthbook-react'
+import { useFeatureValue } from '@growthbook/growthbook-react'
 
 import { Workspace } from '~shared/types/workspace'
 
@@ -49,19 +49,6 @@ export const WorkspacePage = (): JSX.Element => {
   const { user } = useUser()
   const { data: dashboardForms, isLoading: isDashboardLoading } = useDashboard()
   const { data: workspaces, isLoading: isWorkspaceLoading } = useWorkspace()
-
-  const growthbook = useGrowthBook()
-
-  useEffect(() => {
-    if (growthbook && user?.email) {
-      growthbook.setAttributes({
-        // Only update the `adminEmail` & `adminAgency` attribute, keep the rest the same
-        ...growthbook.getAttributes(),
-        adminEmail: user.email,
-        adminAgency: user.agency.shortName,
-      })
-    }
-  }, [growthbook, user?.email, user?.agency?.shortName])
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.

--- a/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/frontend/src/features/workspace/WorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Box,
@@ -13,7 +13,7 @@ import {
   Stack,
   useDisclosure,
 } from '@chakra-ui/react'
-import { useFeatureValue } from '@growthbook/growthbook-react'
+import { useFeatureValue, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { Workspace } from '~shared/types/workspace'
 
@@ -49,6 +49,19 @@ export const WorkspacePage = (): JSX.Element => {
   const { user } = useUser()
   const { data: dashboardForms, isLoading: isDashboardLoading } = useDashboard()
   const { data: workspaces, isLoading: isWorkspaceLoading } = useWorkspace()
+
+  const growthbook = useGrowthBook()
+
+  useEffect(() => {
+    if (growthbook && user?.email) {
+      growthbook.setAttributes({
+        // Only update the `adminEmail` & `adminAgency` attribute, keep the rest the same
+        ...growthbook.getAttributes(),
+        adminEmail: user.email,
+        adminAgency: user.agency.shortName,
+      })
+    }
+  }, [growthbook, user?.email, user?.agency?.shortName])
 
   const bannerContent = useMemo(
     // Use || instead of ?? so that we fall through even if previous banners are empty string.


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Growthbook feature flag `forumsg` is unable to utilize rules to serve different values specific to `adminEmail` or `adminAgency`. This is because these attributes are not set in the AdminNavBar component.

## Solution
<!-- How did you solve the problem? -->

Set growthbook attributes `adminEmail` and `adminAgency` in AdminNavBar.tsx.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible 
