### PR TITLE
feat: remove red dot from forumsg nav bar link

### DIFF
--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -56,11 +56,7 @@ type AdminNavBarLinkProps = {
   MobileIcon: As
 }
 
-const AdminNavBarLink = ({
-  MobileIcon,
-  href,
-  label,
-}: AdminNavBarLinkProps) => {
+const AdminNavBarLink = ({ MobileIcon, href, label }: AdminNavBarLinkProps) => {
   const isMobile = useIsMobile()
 
   if (isMobile && MobileIcon) {

--- a/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -54,14 +54,12 @@ type AdminNavBarLinkProps = {
   label: string
   href: string
   MobileIcon: As
-  shouldShowNotification?: boolean
 }
 
 const AdminNavBarLink = ({
   MobileIcon,
   href,
   label,
-  shouldShowNotification,
 }: AdminNavBarLinkProps) => {
   const isMobile = useIsMobile()
 
@@ -75,14 +73,6 @@ const AdminNavBarLink = ({
           aria-label={label}
           icon={<Icon as={MobileIcon} fontSize="1.25rem" color="primary.500" />}
         />
-        {shouldShowNotification && (
-          <Icon
-            as={GoDotFill}
-            color="danger.500"
-            position="absolute"
-            ml="-15px"
-          />
-        )}
       </Box>
     )
   }
@@ -99,9 +89,6 @@ const AdminNavBarLink = ({
       >
         {label}
       </Link>
-      {shouldShowNotification && (
-        <Icon as={GoDotFill} color="danger.500" position="absolute" ml="-5px" />
-      )}
     </Box>
   )
 }
@@ -299,7 +286,6 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
             label: 'Forum',
             href: FORUMSG_URL,
             MobileIcon: MdForum,
-            shouldShowNotification: true,
           },
         ]
       : []),


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Removing the red dot from ForumSG navbar link because UTs have found that the red dot causes link to be too easily discovered.

## Solution
<!-- How did you solve the problem? -->

Removed red dot from ForumSG nav bar link

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

<img width="508" height="160" alt="image" src="https://github.com/user-attachments/assets/ccec677c-e3e0-4175-b44c-e0c8c4df9d6e" />

**AFTER**:
<!-- [insert screenshot here] -->

<img width="539" height="156" alt="image" src="https://github.com/user-attachments/assets/79e13a85-27f6-43d0-b06b-07510e0b4303" />
