### PR TITLE
feat: move guardduty scan check timings to env config

### DIFF
--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -1,4 +1,4 @@
-import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm'
+import { SSMClient, GetParameterCommand, ParameterNotFound } from '@aws-sdk/client-ssm'
 import fs from 'fs'
 import { exit } from 'process'
 
@@ -22,9 +22,12 @@ const SHORT_ENV_MAP = {
   vapt: 'vapt',
 }
 
-const SSM_PARAMETER_STORE_KEYS = [
+const SSM_PARAMETER_STORE_COMPULOSRY_KEYS = [
   'GUARDDUTY_CLEAN_S3_BUCKET',
   'GUARDDUTY_QUARANTINE_S3_BUCKET',
+]
+
+const SSM_PARAMETER_STORE_OPTIONAL_KEYS = [
   'GUARDDUTY_SCAN_AWAIT_TIMEOUT',
   'GUARDDUTY_SCAN_CHECK_DELAY',
   'GUARDDUTY_SCAN_CHECK_MAX_BACKOFF',
@@ -55,16 +58,22 @@ async function saveAllParameters() {
   const client = new SSMClient({ region: 'ap-southeast-1' })
   const parameterNamePrefix = `/virus-scanner-guardduty/${SHORT_ENV_MAP[process.env.ENV]}/`
 
+  const SSM_PARAMETER_STORE_KEYS = [...SSM_PARAMETER_STORE_COMPULOSRY_KEYS, ...SSM_PARAMETER_STORE_OPTIONAL_KEYS]
   const requests = SSM_PARAMETER_STORE_KEYS.map((key) => {
     return client
       .send(new GetParameterCommand({ Name: `${parameterNamePrefix}${key}` }))
       .then((res) => {
         return { key, res }
+      }).catch(err => {
+        // Swallow ParameterNotFound errors for optional keys
+        if (SSM_PARAMETER_STORE_OPTIONAL_KEYS.includes(key) && err instanceof ParameterNotFound)
+          return { key, res: undefined }
+        throw err
       })
   })
 
   const resolvedResponses = await Promise.all(requests)
-  const parameterString = resolvedResponses.map(
+  const parameterString = resolvedResponses.filter(({ res }) => res !== undefined).map(
     ({ key, res }) => `${key}=${res.Parameter.Value}`,
   )
 

--- a/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
+++ b/serverless/virus-scanner-guardduty/scripts/envLoader.mjs
@@ -25,6 +25,9 @@ const SHORT_ENV_MAP = {
 const SSM_PARAMETER_STORE_KEYS = [
   'GUARDDUTY_CLEAN_S3_BUCKET',
   'GUARDDUTY_QUARANTINE_S3_BUCKET',
+  'GUARDDUTY_SCAN_AWAIT_TIMEOUT',
+  'GUARDDUTY_SCAN_CHECK_DELAY',
+  'GUARDDUTY_SCAN_CHECK_MAX_BACKOFF',
 ]
 
 // This is a helper for local file runs or jest, as specified in package.json

--- a/serverless/virus-scanner-guardduty/src/config.ts
+++ b/serverless/virus-scanner-guardduty/src/config.ts
@@ -7,7 +7,16 @@ const isTest = process.env.NODE_ENV === 'test'
 export const config = convict({
   environment: {
     env: 'NODE_ENV',
-    format: ['development', 'stg', 'stg-alt', 'stg-alt2', 'stg-alt3', 'uat', 'production', 'test'],
+    format: [
+      'development',
+      'stg',
+      'stg-alt',
+      'stg-alt2',
+      'stg-alt3',
+      'uat',
+      'production',
+      'test',
+    ],
     default: 'development',
   },
   isTestOrDev: {
@@ -22,6 +31,27 @@ export const config = convict({
     env: 'GUARDDUTY_CLEAN_S3_BUCKET',
     format: String,
     default: '',
+  },
+  guarddutyScanCheckTimeout: {
+    env: 'GUARDDUTY_SCAN_AWAIT_TIMEOUT',
+    format: Number,
+    description:
+      'Total amount of time to repeatedly check if GuardDuty has scanned and tagged the file before timing out and marking as failure.',
+    default: 40 * 1000, // 40 seconds.
+  },
+  guarddutyScanCheckDelay: {
+    env: 'GUARDDUTY_SCAN_CHECK_DELAY',
+    format: Number,
+    description:
+      'Initial amount of time to wait before retrying checking if Guardduty has scanned and tagged the file.',
+    default: 200, // 0.2 seconds.
+  },
+  guarddutyScanCheckMaxBackoff: {
+    env: 'GUARDDUTY_SCAN_CHECK_MAX_BACKOFF',
+    format: Number,
+    description:
+      'Maximum amount of time for backoff to for retries for checking if Guardduty has scanned and tagged the file.',
+    default: 2 * 1000, // 2 seconds.
   },
 })
   .validate()

--- a/serverless/virus-scanner-guardduty/src/s3.service.ts
+++ b/serverless/virus-scanner-guardduty/src/s3.service.ts
@@ -9,6 +9,7 @@ import {
 import pino from 'pino'
 import { retry } from 'ts-retry-promise'
 
+import { config } from './config'
 import {
   DeleteS3FileParams,
   GetS3FileStreamParams,
@@ -210,10 +211,10 @@ export class S3Service {
         },
         {
           retries: 'INFINITELY',
-          timeout: 40 * 1000, // 40 seconds.
-          delay: 200, // first delay - 0.2 seconds
+          timeout: config.guarddutyScanCheckTimeout,
+          delay: config.guarddutyScanCheckDelay,
           backoff: 'LINEAR',
-          maxBackOff: 2 * 1000, // max increment in delay - 2 seconds
+          maxBackOff: config.guarddutyScanCheckMaxBackoff,
         },
       )
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Allow configuration and tuning of guardduty timeouts during incidents. 

## Solution
<!-- How did you solve the problem? -->
Move the config for guardduty scan retries to env config. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
 No - this PR is backwards compatible  