### PR TITLE
feat: send emails on no workflow

### DIFF
--- a/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -16,8 +16,6 @@ import Input from '~components/Input'
 import Textarea from '~components/Textarea'
 import Toggle from '~components/Toggle'
 
-import { useUser } from '~features/user/queries'
-
 import { CreatePageDrawerContentContainer } from '../../../../../common'
 import { useCreateTabForm } from '../../../../useCreateTabForm'
 import { SPLIT_TEXTAREA_TRANSFORM } from '../common/constants'
@@ -89,8 +87,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
   const watchedHasAllowedEmailDomains = watch('hasAllowedEmailDomains')
   const watchedHasAutoReply = watch('autoReplyOptions.hasAutoReply')
 
-  const { user } = useUser()
-
   const requiredValidationRule = useMemo(
     () =>
       createBaseValidationRules<EditEmailInputs, 'title'>({
@@ -154,11 +150,6 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         'features.adminForm.sidebar.fields.email.emailConfirmation.includeResponseDescription',
       )
 
-  // TODO: FRM-2172 Remove when respondent copy is out of beta
-  const isToggleEmailConfirmationDisabled =
-    form?.responseMode === FormResponseMode.Multirespondent &&
-    !user?.betaFlags?.respondentCopy
-
   return (
     <CreatePageDrawerContentContainer>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
@@ -190,10 +181,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         />
       </FormControl>
       <Box>
-        <FormControl
-          isReadOnly={isLoading}
-          isDisabled={isToggleEmailConfirmationDisabled}
-        >
+        <FormControl isReadOnly={isLoading}>
           <Toggle
             {...register('autoReplyOptions.hasAutoReply')}
             description={t(

--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -13,7 +13,6 @@ import InlineMessage from '~components/InlineMessage'
 import { Switch } from '~components/Toggle/Switch'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
-import { useUser } from '~features/user/queries'
 
 import { useMutateFormSettings } from '../mutations'
 import { useAdminFormSettings } from '../queries'
@@ -30,7 +29,7 @@ export const FormStatusToggle = (): JSX.Element => {
   } = useAdminForm()
   const { data: formSettings, isLoading: isLoadingFormSettings } =
     useAdminFormSettings()
-  const { user } = useUser()
+
   const { status, responseMode, authType, esrvcId } = formSettings ?? {}
 
   const secretKeyActivationModalProps = useDisclosure()
@@ -54,8 +53,7 @@ export const FormStatusToggle = (): JSX.Element => {
       form_fields?.some(
         (ff) =>
           ff.fieldType === BasicField.Email && ff.autoReplyOptions.hasAutoReply,
-      ) &&
-      !user?.betaFlags?.respondentCopy
+      )
     ) {
       return t('features.adminForm.settings.general.status.noEmailsInMRF')
     }

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -1,10 +1,8 @@
 import { useEffect } from 'react'
 import { SubmitHandler, useFormContext } from 'react-hook-form'
 import { Box, Stack } from '@chakra-ui/react'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
 import { isEmpty } from 'lodash'
 
-import { featureFlags } from '~shared/constants'
 import { FieldResponsesV3 } from '~shared/types'
 import { FormFieldDto } from '~shared/types/field'
 import {
@@ -50,8 +48,6 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
-  // TODO: (respondent copy): Remove when respondent copy is out of beta
-  const isRespondentCopyEnabled = useFeatureIsOn(featureFlags.respondentCopy)
 
   useFetchPrefillQuery()
 

--- a/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -48,7 +48,6 @@ export const FormFields = ({
   colorTheme,
   onSubmit,
 }: FormFieldsProps): JSX.Element => {
-
   useFetchPrefillQuery()
 
   const { defaultFormValues, fieldPrefillMap, form, augmentedFormFields } =

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -790,6 +790,86 @@ describe('multirespondent-submission.service', () => {
           sendMrfRespondentCopyEmailSpy.mock.calls[0][0].attachments,
         ).toEqual([...MOCK_SUBMISSION_ATTACHMENTS])
       })
+
+      it('sends respondent copy + workflow completion email when workflow has 0 steps', async () => {
+        // Arrange
+        const sendMrfRespondentCopyEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfRespondentCopyEmail',
+        )
+        const sendMrfWorkflowCompletionEmailSpy = jest.spyOn(
+          MailService,
+          'sendMrfWorkflowCompletionEmail',
+        )
+
+        const emailFieldWithFormSummaryStep1 = {
+          _id: new ObjectId().toHexString(),
+          fieldType: BasicField.Email,
+          title: 'Step 1 Email Field',
+          autoReplyOptions: {
+            hasAutoReply: true,
+            includeFormSummary: true,
+            autoReplySubject: 'Test Subject',
+            autoReplyMessage: 'Test Message',
+            autoReplySender: 'Test Sender',
+          },
+        }
+
+        const workflow: FormWorkflowStepDto[] = []
+
+        // Act
+        await performMultiRespondentPostSubmissionCreateActions({
+          submission: {
+            _id: mockSubmissionId,
+          } as unknown as IMultirespondentSubmissionSchema,
+          submissionId: mockSubmissionId,
+          form: {
+            _id: mockFormId,
+            title: 'Test Form',
+            form_fields: [emailFieldWithFormSummaryStep1],
+            stepsToNotify: [],
+            workflow,
+            emails: ['expected2@example.com'],
+            stepOneEmailNotificationFieldId: emailFieldWithFormSummaryStep1._id,
+            admin: {
+              agency: {
+                fullName: 'Government Technology Agency',
+              },
+            },
+          } as unknown as IPopulatedMultirespondentForm,
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {
+              [emailFieldWithFormSummaryStep1._id]: {
+                fieldType: BasicField.Email,
+                answer: {
+                  value: 'expected1@example.com',
+                },
+              },
+            },
+          } as MultirespondentSubmissionDto,
+          logMeta: {} as any,
+          attachments: MOCK_SUBMISSION_ATTACHMENTS,
+        })
+
+        // Assert
+        // that respondent copy is sent to correct destination emails
+        expect(sendMrfRespondentCopyEmailSpy).toHaveBeenCalledTimes(1)
+        expect(
+          sendMrfRespondentCopyEmailSpy.mock.calls[0][0].autoReplyMailData
+            .email,
+        ).toEqual('expected1@example.com')
+        // that workflow completion email is also sent to correct destination emails
+        expect(
+          sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails,
+        ).toContainValues(['expected1@example.com', 'expected2@example.com'])
+        expect(
+          sendMrfWorkflowCompletionEmailSpy.mock.calls[0][0].emails.length,
+        ).toBe(2)
+      })
     })
 
     describe('subsequent steps', () => {

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -951,6 +951,11 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   const { submissionSecretKey, responses } = encryptedPayload
   const currentStepNumber = 0
 
+  // if there is no workflow, every field is an active field
+  const currentStepActiveFields: string[] = form.workflow.length
+    ? (form.workflow[currentStepNumber]?.edit ?? [])
+    : form.form_fields.map((field) => field._id)
+
   logMeta = {
     ...logMeta,
     action: 'performMultiRespondentPostSubmissionCreateActions',
@@ -963,7 +968,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
     submission,
     form,
     responses,
-    currentStepActiveFields: form.workflow[currentStepNumber]?.edit ?? [],
+    currentStepActiveFields,
     currentStepNumber,
     isRejected: false, // first step cannot be an approval step and thus cannot be rejected.
     submissionId,
@@ -974,7 +979,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
     checkIfRespondentFormSummaryIsRequired({
       responses,
       formFields: form.form_fields,
-      currentStepActiveFields: form.workflow[currentStepNumber]?.edit ?? [],
+      currentStepActiveFields,
     })
       ? pdfResult
       : okAsync(undefined)
@@ -997,7 +1002,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
     submission,
     attachments,
     formFields: form.form_fields,
-    currentStepActiveFields: form.workflow[currentStepNumber]?.edit ?? [],
+    currentStepActiveFields,
     pdfResult: sendMrfRespondentCopyEmailsPdfResult,
   }).mapErr((error) => {
     logger.error({

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -406,7 +406,7 @@ const checkIsWorkflowCompleted = ({
   const lastStepNumber = form.workflow.length - 1
   const isLastStepSubmitted = currentStepNumber === lastStepNumber
 
-  return isRejected || isLastStepSubmitted
+  return !form.workflow.length || isRejected || isLastStepSubmitted
 }
 
 const sendMrfOutcomeEmails = ({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Admins who create an MRF form without workflow steps do not receive respondent copy emails or workflow completion emails, which they expect for it to happen

Closes FRM-2263

## Solution
<!-- How did you solve the problem? -->

- rc emails are sent by cross-checking if there are respondent copy-enabled email steps in the assigned fields of current workflow step
- workflow completion emails are sent by checking if the `lastStepSubmitted` is the `currentStep`

Send respondent copy & workflow completion emails if there are no workflow steps by:
1. determining all fields to be active within the current submission if there is no workflow (for respondent copy email)
2. determining that workflow is completed if there is no workflow (for workflow completion email) 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

**Respondent copy sent with no workflow in MRF form**
- [ ] Create an MRF form, and add a few fields to the form
- [ ] Specifically add an email field to the form, and toggle on `Email confirmation`
- [ ] Ensure that a workflow **has not been** created for the MRF form
- [ ] Make the form public and attempt a form submission
- [ ] Successfully receive a respondent copy email
- [ ] Regression: Add a signature field to the form, and toggle on `include a copy of responses` in the email field. Attempt another submission and ensure that the PDF copy of responses is also included in the email

**Workflow completion sent with no workflow in MRF form**
- [ ] Using the same form created above earlier (**with no workflow**), add your email under Settings -> Email notifications -> Others
- [ ] Attempt a form submission
- [ ] Successfully receive a workflow completion email

**Regression Test**
- [ ] Add a workflow step to the form, and add add at least the email field to step 1
- [ ] Complete the MRF submission (depending on how many steps you added)
- [ ] Successfully receive a respondent copy email after step 1 submission
- [ ] Successfully receive a workflow completion email after the workflow is completed