### PR TITLE
feat: add bulk download usage logs

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
+import { datadogLogs } from '@datadog/browser-logs'
 import simplur from 'simplur'
 
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
@@ -219,6 +220,14 @@ export const DownloadButton = (): JSX.Element => {
   const handleBulkDownload = useCallback(() => {
     if (!downloadParams) return
     setProgressModalTimeout(5000)
+    datadogLogs.logger.info('Bulk download used', {
+      meta: {
+        action: 'bulkDownload',
+        isDownloadCsv: downloadOptions.isDownloadCsv,
+        isDownloadAttachments: downloadOptions.isDownloadAttachments,
+        isDownloadPdf: downloadOptions.isDownloadPdf,
+      },
+    })
     return handleBulkDownloadMutation.mutate({
       ...downloadParams,
       downloadAttachments: downloadOptions.isDownloadAttachments,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Track usage of bulk pdf download to evaluate success. 
Closes FRM-2269. 

## Solution
<!-- How did you solve the problem? -->
Add simple logging to Datadog when the bulk download button is clicked - with the download options (csv, attachment, pdf) selections.

## Usage 
Use the `@meta.action: bulkDownload` filter to find the number of clicks. 
isDownloadCsv, isDownloadPdf, isDownloadAttachments meta tags can be used to track the frequency of each usage for ordering of the options.

**Breaking Changes** 
No - this PR is backwards compatible  