### PR TITLE
feat: remove disable form activation if mrf form has respondent copy

### DIFF
--- a/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
+++ b/frontend/src/features/admin-form/settings/components/FormStatusToggle.tsx
@@ -46,17 +46,6 @@ export const FormStatusToggle = (): JSX.Element => {
         'features.adminForm.settings.general.status.supplySingpassEServiceId',
       )
     }
-
-    // For MRF, prevent form activation if form has an email confirmation field.
-    if (
-      formSettings?.responseMode === FormResponseMode.Multirespondent &&
-      form_fields?.some(
-        (ff) =>
-          ff.fieldType === BasicField.Email && ff.autoReplyOptions.hasAutoReply,
-      )
-    ) {
-      return t('features.adminForm.settings.general.status.noEmailsInMRF')
-    }
   }, [authType, esrvcId, formSettings?.responseMode, form_fields, status, t])
 
   const { mutateFormStatus } = useMutateFormSettings()


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Missed this during removing the betaFlags and featureFlags in preparation for respondent copy MRF GA.

Removed the betaFlag condition, when the entire condition should have been removed 
<img width="1537" height="198" alt="image" src="https://github.com/user-attachments/assets/c3ae2320-80f9-4781-9532-0c790f34b526" />


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
