### PR TITLE
fix: modal progress bar does not reflect pdf generation time

### DIFF
--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -161,12 +161,25 @@ export const DownloadButton = (): JSX.Element => {
     useStorageResponsesContext()
 
   const [_downloadCount, setDownloadCount] = useState(0)
+  const [_pdfGenerationCount, setPdfGenerationCount] = useState(0)
   const downloadCount = useThrottle(_downloadCount, 1000)
+  const pdfGenerationCount = useThrottle(_pdfGenerationCount, 1000)
 
   const downloadPercentage = useMemo(() => {
     if (!dateRangeResponsesCount) return 0
-    return Math.floor((downloadCount / dateRangeResponsesCount) * 100)
-  }, [downloadCount, dateRangeResponsesCount])
+    const currentDecryptAndPdfCount = downloadCount + pdfGenerationCount
+    const totalDecryptAndPdfCount = downloadOptions.isDownloadPdf
+      ? dateRangeResponsesCount * 2
+      : dateRangeResponsesCount
+    return Math.floor(
+      (currentDecryptAndPdfCount / totalDecryptAndPdfCount) * 100,
+    )
+  }, [
+    downloadCount,
+    pdfGenerationCount,
+    dateRangeResponsesCount,
+    downloadOptions.isDownloadPdf,
+  ])
 
   useTimeout(onProgressModalOpen, progressModalTimeout)
 
@@ -175,7 +188,8 @@ export const DownloadButton = (): JSX.Element => {
   >()
 
   const { handleBulkDownloadMutation, abortDecryption } = useDecryptionWorkers({
-    onProgress: setDownloadCount,
+    onDecryptionProgress: setDownloadCount,
+    onPdfGenerationProgress: setPdfGenerationCount,
     mutateProps: {
       onMutate: () => {
         // Reset metadata if it exists.

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -55,8 +55,8 @@ export type DownloadEncryptedParams = EncryptedResponsesStreamParams & {
   isDownloadPdf: boolean
 }
 interface UseDecryptionWorkersProps {
-  onDecryptionProgress: (progress: number) => void
-  onPdfGenerationProgress: (progress: number) => void
+  onDecryptionProgress: React.Dispatch<React.SetStateAction<number>>
+  onPdfGenerationProgress: React.Dispatch<React.SetStateAction<number>>
   mutateProps: UseMutationOptions<
     DownloadResult,
     unknown,
@@ -172,8 +172,6 @@ const useDecryptionWorkers = ({
       const reader = stream.getReader()
       let read: (result: ReadableStreamReadResult<string>) => void
       const downloadStartTime = performance.now()
-      let decryptionProgress = 0
-      let pdfGenerationProgress = 0
       const submissionDecryptPromises: Promise<DecryptedData>[] = []
 
       let timeSinceLastXAttachmentDownload = 0
@@ -278,8 +276,7 @@ const useDecryptionWorkers = ({
               })
               // Step 4: Update the progress bar only once the attachments for the decrypted submission have been downloaded (if needed).
               .finally(() => {
-                decryptionProgress += 1
-                onDecryptionProgress(decryptionProgress)
+                onDecryptionProgress((prevDecryptionProgress) => prevDecryptionProgress + 1)
               }),
           )
           currentSubmissionIndex += 1 // used to assign the next submission to the next worker
@@ -312,8 +309,7 @@ const useDecryptionWorkers = ({
                   })
                   pdfZip.file(pdfTitle, pdfBlob)
                 }
-                pdfGenerationProgress += 1
-                onPdfGenerationProgress(pdfGenerationProgress)
+                onPdfGenerationProgress((prevPdfGenerationProgress) => prevPdfGenerationProgress + 1)
               }
               await pdfZip
                 .generateAsync({ type: 'blob' })

--- a/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -55,7 +55,8 @@ export type DownloadEncryptedParams = EncryptedResponsesStreamParams & {
   isDownloadPdf: boolean
 }
 interface UseDecryptionWorkersProps {
-  onProgress: (progress: number) => void
+  onDecryptionProgress: (progress: number) => void
+  onPdfGenerationProgress: (progress: number) => void
   mutateProps: UseMutationOptions<
     DownloadResult,
     unknown,
@@ -65,7 +66,8 @@ interface UseDecryptionWorkersProps {
 }
 
 const useDecryptionWorkers = ({
-  onProgress,
+  onDecryptionProgress,
+  onPdfGenerationProgress,
   mutateProps,
 }: UseDecryptionWorkersProps) => {
   const [workers, setWorkers] = useState<CleanableDecryptionWorkerApi[]>([])
@@ -171,6 +173,7 @@ const useDecryptionWorkers = ({
       let read: (result: ReadableStreamReadResult<string>) => void
       const downloadStartTime = performance.now()
       let decryptionProgress = 0
+      let pdfGenerationProgress = 0
       const submissionDecryptPromises: Promise<DecryptedData>[] = []
 
       let timeSinceLastXAttachmentDownload = 0
@@ -276,7 +279,7 @@ const useDecryptionWorkers = ({
               // Step 4: Update the progress bar only once the attachments for the decrypted submission have been downloaded (if needed).
               .finally(() => {
                 decryptionProgress += 1
-                onProgress(decryptionProgress)
+                onDecryptionProgress(decryptionProgress)
               }),
           )
           currentSubmissionIndex += 1 // used to assign the next submission to the next worker
@@ -309,6 +312,8 @@ const useDecryptionWorkers = ({
                   })
                   pdfZip.file(pdfTitle, pdfBlob)
                 }
+                pdfGenerationProgress += 1
+                onPdfGenerationProgress(pdfGenerationProgress)
               }
               await pdfZip
                 .generateAsync({ type: 'blob' })
@@ -462,7 +467,13 @@ const useDecryptionWorkers = ({
           })
       })
     },
-    [adminForm, onProgress, user?._id, workers],
+    [
+      adminForm,
+      onDecryptionProgress,
+      onPdfGenerationProgress,
+      user?._id,
+      workers,
+    ],
   )
 
   const handleBulkDownloadMutation = useMutation(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The download progress bar does not include the progress and time taken for generating the PDFs locally. This causes the bar to be stuck at 100% for extended periods of time causing confusion to users. 

Closes FRM-2274

## Solution
<!-- How did you solve the problem? -->
If PDFs should be generated, double the total count and include the decryption and pdf in the progress. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  