### PR TITLE
feat: update pdf filenames for local pdf gen and email attachment

### DIFF
--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
@@ -54,11 +54,7 @@ const renderPrintableResponse = (
   }
 }
 
-const getPdfTitle = ({
-  submissionId,
-}: {
-  submissionId: string
-}) => {
+const getPdfTitle = ({ submissionId }: { submissionId: string }) => {
   return `RefNo ${submissionId}.pdf`
 }
 

--- a/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
+++ b/frontend/src/features/admin-form/responses/IndividualResponsePage/utils/generateResponsePdf.tsx
@@ -55,15 +55,11 @@ const renderPrintableResponse = (
 }
 
 const getPdfTitle = ({
-  formTitle,
-  formId,
   submissionId,
 }: {
-  formTitle: string
-  formId: string
   submissionId: string
 }) => {
-  return `${formTitle}_formId_${formId}_submissionId_${submissionId}_response.pdf`
+  return `RefNo ${submissionId}.pdf`
 }
 
 export const generateResponsePdfBlob = async ({
@@ -81,8 +77,6 @@ export const generateResponsePdfBlob = async ({
   }
 }) => {
   const pdfTitle = getPdfTitle({
-    formTitle: form.title,
-    formId: form._id,
     submissionId: submission.refNo,
   })
 
@@ -115,8 +109,6 @@ export const downloadResponsePdf = async ({
   }
 }) => {
   const pdfTitle = getPdfTitle({
-    formTitle: form.title,
-    formId: form._id,
     submissionId: submission.refNo,
   })
 

--- a/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -128,10 +128,10 @@ describe('encrypt-submission.service', () => {
       },
     ]
     const MOCK_NRIC = 'S1234567A'
-
+    const MOCK_SUBMISSION_ID = new ObjectId().toHexString()
     const MOCK_PDF_ATTACHMENT_BUFFER = Buffer.from('mock pdf buffer')
     const MOCK_PDF_ATTACHMENT = {
-      filename: 'response.pdf',
+      filename: `RefNo ${MOCK_SUBMISSION_ID}.pdf`,
       content: MOCK_PDF_ATTACHMENT_BUFFER,
     }
 
@@ -156,7 +156,7 @@ describe('encrypt-submission.service', () => {
           errAsync(new AutoreplyPdfGenerationError()),
         )
         const mockSubmission = {
-          _id: new ObjectId(),
+          id: MOCK_SUBMISSION_ID,
           form: new ObjectId(),
           created: new Date(),
         } as IEncryptedSubmissionSchema
@@ -200,7 +200,7 @@ describe('encrypt-submission.service', () => {
       it('should not generate pdf attachment if payment is enabled and not pass to either sendSubmissionToAdmin or sendEmailConfirmations', async () => {
         // Arrange
         const mockSubmission = {
-          _id: new ObjectId(),
+          id: MOCK_SUBMISSION_ID,
           form: new ObjectId(),
           created: new Date(),
         } as IEncryptedSubmissionSchema
@@ -244,7 +244,7 @@ describe('encrypt-submission.service', () => {
       it('should generate pdf attachment and pass pdf attachment to both sendSubmissionToAdmin and sendEmailConfirmation if form summary is enabled and payment is not enabled', async () => {
         // Arrange
         const mockSubmission = {
-          _id: new ObjectId(),
+          id: MOCK_SUBMISSION_ID,
           form: new ObjectId(),
           created: new Date(),
         } as IEncryptedSubmissionSchema
@@ -288,7 +288,7 @@ describe('encrypt-submission.service', () => {
       it('should generate pdf attachment and pass pdf attachment to only sendSubmissionToAdmin if form summary and payment both are not enabled', async () => {
         // Arrange
         const mockSubmission = {
-          _id: new ObjectId(),
+          id: MOCK_SUBMISSION_ID,
           form: new ObjectId(),
           created: new Date(),
         } as IEncryptedSubmissionSchema
@@ -344,7 +344,7 @@ describe('encrypt-submission.service', () => {
       it('should sendEmailConfirmations if there are respondent emails', async () => {
         // Arrange
         const mockSubmission = {
-          _id: new ObjectId(),
+          id: MOCK_SUBMISSION_ID,
           form: new ObjectId(),
           created: new Date(),
         } as IEncryptedSubmissionSchema
@@ -385,7 +385,7 @@ describe('encrypt-submission.service', () => {
       it('should sendEmailConfirmations if there are email fields with auto reply enabled', async () => {
         // Arrange
         const mockSubmission = {
-          _id: new ObjectId(),
+          id: MOCK_SUBMISSION_ID,
           form: new ObjectId(),
           created: new Date(),
         } as IEncryptedSubmissionSchema
@@ -491,7 +491,7 @@ describe('encrypt-submission.service', () => {
       it('should not sendEmailConfirmations if there are no respondent emails and no email fields with auto reply enabled', async () => {
         // Arrange
         const mockSubmission = {
-          _id: new ObjectId(),
+          id: MOCK_SUBMISSION_ID,
           form: new ObjectId(),
           created: new Date(),
         } as IEncryptedSubmissionSchema
@@ -539,7 +539,7 @@ describe('encrypt-submission.service', () => {
           // Arrange
           const MOCK_NRIC = 'S1234567A'
           const mockSubmission = {
-            _id: new ObjectId(),
+            id: MOCK_SUBMISSION_ID,
             form: new ObjectId(),
             created: new Date(),
           } as IEncryptedSubmissionSchema
@@ -585,7 +585,7 @@ describe('encrypt-submission.service', () => {
           const noAttachments: IAttachmentInfo[] = []
 
           const mockSubmission = {
-            _id: new ObjectId(),
+            id: MOCK_SUBMISSION_ID,
             form: new ObjectId(),
             created: new Date(),
           } as IEncryptedSubmissionSchema
@@ -621,7 +621,7 @@ describe('encrypt-submission.service', () => {
           ]
 
           const mockSubmission = {
-            _id: new ObjectId(),
+            id: MOCK_SUBMISSION_ID,
             form: new ObjectId(),
             created: new Date(),
           } as IEncryptedSubmissionSchema
@@ -663,7 +663,7 @@ describe('encrypt-submission.service', () => {
           ]
 
           const mockSubmission = {
-            _id: new ObjectId(),
+            id: MOCK_SUBMISSION_ID,
             form: new ObjectId(),
             created: new Date(),
           } as IEncryptedSubmissionSchema
@@ -707,7 +707,7 @@ describe('encrypt-submission.service', () => {
           ]
 
           const mockSubmission = {
-            _id: new ObjectId(),
+            id: MOCK_SUBMISSION_ID,
             form: new ObjectId(),
             created: new Date(),
           } as IEncryptedSubmissionSchema

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -204,10 +204,9 @@ const generatePdfAttachmentIfRequired = ({
     formUrl: `${config.app.appUrl}/${form._id}`,
   }
 
-  const DEFAULT_RESPONSE_PDF_FILENAME = 'response.pdf'
   return generateAutoreplyPdf(autoReplyData, true)
     .map((pdfBuffer) => ({
-      filename: DEFAULT_RESPONSE_PDF_FILENAME,
+      filename: `RefNo ${submission.id}.pdf`,
       content: Buffer.copyBytesFrom(pdfBuffer),
     }))
     .mapErr((error) => {

--- a/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -34,10 +34,13 @@ import {
 jest.mock('src/app/modules/datadog/datadog.utils')
 jest.mock('src/app/services/mail/mail.utils')
 
+const mockFormId = new ObjectId().toHexString()
+const mockSubmissionId = new ObjectId().toHexString()
+
 const MockMailUtils = jest.mocked(MailUtils)
 const MOCK_PDF_ATTACHMENT_BUFFER = Buffer.from('mock pdf buffer')
 const EXPECTED_MOCK_PDF_ATTACHMENT = {
-  filename: 'response.pdf',
+  filename: `RefNo ${mockSubmissionId}.pdf`,
   content: MOCK_PDF_ATTACHMENT_BUFFER,
 }
 const MOCK_SUBMISSION_ATTACHMENTS = [
@@ -67,9 +70,6 @@ describe('multirespondent-submission.service', () => {
   afterAll(async () => {
     await dbHandler.closeDatabase()
   })
-
-  const mockFormId = new ObjectId().toHexString()
-  const mockSubmissionId = new ObjectId().toHexString()
 
   describe('pdf attachment', () => {
     describe('pdf attachment is not generated when not needed', () => {
@@ -119,7 +119,7 @@ describe('multirespondent-submission.service', () => {
           // Act
           await performMultiRespondentPostSubmissionCreateActions({
             submission: {
-              _id: mockSubmissionId,
+              id: mockSubmissionId,
             } as unknown as IMultirespondentSubmissionSchema,
             submissionId: mockSubmissionId,
             form: {
@@ -187,7 +187,7 @@ describe('multirespondent-submission.service', () => {
           // Act
           await performMultiRespondentPostSubmissionCreateActions({
             submission: {
-              _id: mockSubmissionId,
+              id: mockSubmissionId,
             } as unknown as IMultirespondentSubmissionSchema,
             submissionId: mockSubmissionId,
             form: {
@@ -277,7 +277,7 @@ describe('multirespondent-submission.service', () => {
           // Act
           await performMultiRespondentPostSubmissionUpdateActions({
             submission: {
-              _id: mockSubmissionId,
+              id: mockSubmissionId,
             } as unknown as IMultirespondentSubmissionSchema,
             submissionId: mockSubmissionId,
             snapshottedFormDef: {
@@ -369,7 +369,7 @@ describe('multirespondent-submission.service', () => {
           // Act
           await performMultiRespondentPostSubmissionUpdateActions({
             submission: {
-              _id: mockSubmissionId,
+              id: mockSubmissionId,
             } as unknown as IMultirespondentSubmissionSchema,
             submissionId: mockSubmissionId,
             snapshottedFormDef: {
@@ -472,7 +472,7 @@ describe('multirespondent-submission.service', () => {
         // Act
         await performMultiRespondentPostSubmissionCreateActions({
           submission: {
-            _id: mockSubmissionId,
+            id: mockSubmissionId,
           } as unknown as IMultirespondentSubmissionSchema,
           submissionId: mockSubmissionId,
           form: {
@@ -570,7 +570,7 @@ describe('multirespondent-submission.service', () => {
         // Act
         await performMultiRespondentPostSubmissionCreateActions({
           submission: {
-            _id: mockSubmissionId,
+            id: mockSubmissionId,
           } as unknown as IMultirespondentSubmissionSchema,
           submissionId: mockSubmissionId,
           form: {
@@ -671,7 +671,7 @@ describe('multirespondent-submission.service', () => {
         // Act
         await performMultiRespondentPostSubmissionCreateActions({
           submission: {
-            _id: mockSubmissionId,
+            id: mockSubmissionId,
           } as unknown as IMultirespondentSubmissionSchema,
           submissionId: mockSubmissionId,
           form: {
@@ -745,7 +745,7 @@ describe('multirespondent-submission.service', () => {
         // Act
         await performMultiRespondentPostSubmissionCreateActions({
           submission: {
-            _id: mockSubmissionId,
+            id: mockSubmissionId,
           } as unknown as IMultirespondentSubmissionSchema,
           submissionId: mockSubmissionId,
           form: {
@@ -820,7 +820,7 @@ describe('multirespondent-submission.service', () => {
         // Act
         await performMultiRespondentPostSubmissionCreateActions({
           submission: {
-            _id: mockSubmissionId,
+            id: mockSubmissionId,
           } as unknown as IMultirespondentSubmissionSchema,
           submissionId: mockSubmissionId,
           form: {
@@ -923,7 +923,7 @@ describe('multirespondent-submission.service', () => {
         // Act
         await performMultiRespondentPostSubmissionUpdateActions({
           submission: {
-            _id: mockSubmissionId,
+            id: mockSubmissionId,
           } as unknown as IMultirespondentSubmissionSchema,
           submissionId: mockSubmissionId,
           snapshottedFormDef: {
@@ -1044,7 +1044,7 @@ describe('multirespondent-submission.service', () => {
         // Act
         await performMultiRespondentPostSubmissionUpdateActions({
           submission: {
-            _id: mockSubmissionId,
+            id: mockSubmissionId,
           } as unknown as IMultirespondentSubmissionSchema,
           submissionId: mockSubmissionId,
           snapshottedFormDef: {
@@ -1176,7 +1176,7 @@ describe('multirespondent-submission.service', () => {
         // Act
         await performMultiRespondentPostSubmissionUpdateActions({
           submission: {
-            _id: mockSubmissionId,
+            id: mockSubmissionId,
           } as unknown as IMultirespondentSubmissionSchema,
           submissionId: mockSubmissionId,
           snapshottedFormDef: {
@@ -1305,7 +1305,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -1444,7 +1444,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -1597,7 +1597,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -1744,7 +1744,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -1886,7 +1886,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -2048,7 +2048,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -2195,7 +2195,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -2286,7 +2286,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionCreateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         form: {
@@ -2340,7 +2340,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionCreateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         form: {
@@ -2444,7 +2444,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -2552,7 +2552,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef: {
@@ -2581,7 +2581,6 @@ describe('multirespondent-submission.service', () => {
 
   describe('step one email notification field id', () => {
     const mockFormId = new ObjectId().toHexString()
-    const mockSubmissionId = new ObjectId().toHexString()
 
     it('sends completion email to step one email notification field id, stepsToNotify and static emails when step one email notification field id is set', async () => {
       // Arrange
@@ -2647,7 +2646,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
@@ -2722,7 +2721,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
@@ -2798,7 +2797,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,
@@ -2894,7 +2893,7 @@ describe('multirespondent-submission.service', () => {
       // Act
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: {
-          _id: mockSubmissionId,
+          id: mockSubmissionId,
         } as unknown as IMultirespondentSubmissionSchema,
         submissionId: mockSubmissionId,
         snapshottedFormDef,

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -905,10 +905,9 @@ const generatePdfAttachmentIfRequired = ({
     formUrl: `${config.app.appUrl}/${form._id}`,
   }
 
-  const DEFAULT_RESPONSE_PDF_FILENAME = 'response.pdf'
   const pdfResult = generateAutoreplyPdf(autoReplyData, true)
     .map((pdfBuffer) => ({
-      filename: DEFAULT_RESPONSE_PDF_FILENAME,
+      filename: `RefNo ${submissionId}.pdf`,
       content: Buffer.copyBytesFrom(pdfBuffer),
     }))
     .mapErr((error) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The filenames in local pdf is too long and provides too much info. 
Also, the pdf filenames in the email attachments are not standardized with the local pdf download. 

Closes FRM-2275. 

## Solution
<!-- How did you solve the problem? -->
Standardize the names to `RefNo {submissionId}` following the attachment download convention. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
PDF bulk local download: 
- [ ] Bulk download the pdfs from the results page. 
- [ ] The pdf name should be similar to the screenshot. 
<img width="358" height="165" alt="image" src="https://github.com/user-attachments/assets/47847893-915e-41bd-9b4b-a83142289c0e" />

PDF single local download: 
- [ ] Select a single submission and download the PDF. 
- [ ] The pdf name should be `RefNo {submissionId}`. Verify the submission id matches the selected response. 
<img width="324" height="84" alt="image" src="https://github.com/user-attachments/assets/f16688c9-92b9-4cd4-b4aa-7d1492b7d1ae" />

Email copy attachment:
- [ ] Make a storage mode form with email autoreply respondent + admin notification with signature field.
- [ ] Make a submission. 
- [ ] Assert that the emails received to the respondent and admin are named `RefNo {submissionId}` instead of `response.pdf` previously. 
- [ ] Do the same for MRF with an email autoreply respondent and workflow completion email. 
- [ ] Assert that the emails received to the respondent and admin are named `RefNo {submissionId}` instead of `response.pdf` previously. 