### PR TITLE
feat: remove deprecated autoreply (part 1/3 of standardize email payload hidden fields)

### DIFF
--- a/__tests__/unit/backend/helpers/generate-email-data.ts
+++ b/__tests__/unit/backend/helpers/generate-email-data.ts
@@ -1,23 +1,11 @@
 import { pick } from 'lodash'
 
 import { ProcessedSingleAnswerResponse } from 'src/app/modules/submission/submission.types'
-import {
-  EmailAdminDataField,
-  EmailDataCollationToolField,
-  EmailRespondentConfirmationField,
-} from 'src/types'
+import { EmailAdminDataField, EmailDataCollationToolField } from 'src/types'
 
 export const generateSingleAnswerJson = (
   response: ProcessedSingleAnswerResponse,
 ): EmailDataCollationToolField => pick(response, ['question', 'answer'])
-
-export const generateSingleAnswerAutoreply = (
-  response: ProcessedSingleAnswerResponse,
-): EmailRespondentConfirmationField => ({
-  question: response.question,
-  answerTemplate: response.answer.split('\n'),
-  fieldType: response.fieldType,
-})
 
 export const generateSingleAnswerFormData = (
   response: ProcessedSingleAnswerResponse,

--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -1,5 +1,4 @@
 import {
-  generateSingleAnswerAutoreply,
   generateSingleAnswerFormData,
   generateSingleAnswerJson,
 } from '__tests__/unit/backend/helpers/generate-email-data'
@@ -18,7 +17,7 @@ import {
   MyInfoAttribute,
   TableRow,
 } from '../../../../../../shared/types'
-import { SingleAnswerFieldResponse, SPCPFieldTitle } from '../../../../../types'
+import { SingleAnswerFieldResponse } from '../../../../../types'
 import { ProcessedFieldResponse } from '../../submission.types'
 import {
   ATTACHMENT_PREFIX,
@@ -87,16 +86,12 @@ describe('email-submission.util', () => {
         new Set(),
         FormAuthType.NIL,
       )
-      const expectedAutoReplyData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
-        generateSingleAnswerAutoreply,
-      )
       const expectedDataCollationData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
         generateSingleAnswerJson,
       )
       const expectedFormData = ALL_SINGLE_SUBMITTED_RESPONSES.map(
         generateSingleAnswerFormData,
       )
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
@@ -110,79 +105,6 @@ describe('email-submission.util', () => {
         FormAuthType.NIL,
       )
       expect(emailData.dataCollationData).toEqual([])
-      expect(emailData.autoReplyData).toEqual([
-        generateSingleAnswerAutoreply(response),
-      ])
-      expect(emailData.formData).toEqual([
-        generateSingleAnswerFormData(response),
-      ])
-    })
-
-    it('should exclude non-visible fields from autoreply data', () => {
-      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
-        isVisible: false,
-      })
-
-      const emailData = new SubmissionEmailObj(
-        [response],
-        new Set(),
-        FormAuthType.NIL,
-      )
-
-      expect(emailData.dataCollationData).toEqual([
-        generateSingleAnswerJson(response),
-      ])
-      expect(emailData.autoReplyData).toEqual([])
-      expect(emailData.formData).toEqual([
-        generateSingleAnswerFormData(response),
-      ])
-    })
-
-    it('should include undefined isVisible fields from autoreply data', async () => {
-      // Arrange
-      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
-        isVisible: undefined,
-      })
-
-      // Assert
-      const emailData = new SubmissionEmailObj(
-        [response],
-        new Set(),
-        FormAuthType.NIL,
-      )
-
-      // Assert
-      expect(emailData.dataCollationData).toEqual([
-        generateSingleAnswerJson(response),
-      ])
-      expect(emailData.autoReplyData).toEqual([
-        generateSingleAnswerAutoreply(response),
-      ])
-      expect(emailData.formData).toEqual([
-        generateSingleAnswerFormData(response),
-      ])
-    })
-
-    it('should include isVisible true fields from autoreply data', async () => {
-      // Arrange
-      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
-        isVisible: true,
-      })
-
-      // Assert
-      const emailData = new SubmissionEmailObj(
-        [response],
-        new Set(),
-        FormAuthType.NIL,
-      )
-
-      // Assert
-      expect(emailData.dataCollationData).toEqual([
-        generateSingleAnswerJson(response),
-      ])
-      expect(emailData.autoReplyData).toEqual([
-        generateSingleAnswerAutoreply(response),
-      ])
       expect(emailData.formData).toEqual([
         generateSingleAnswerFormData(response),
       ])
@@ -206,11 +128,6 @@ describe('email-submission.util', () => {
         { question: `${TABLE_PREFIX}${question}`, answer: secondRow },
       ]
 
-      const expectedAutoReplyData = [
-        { question, answerTemplate: [firstRow], fieldType: BasicField.Table },
-        { question, answerTemplate: [secondRow], fieldType: BasicField.Table },
-      ]
-
       const expectedFormData = [
         {
           question: `${TABLE_PREFIX}${question}`,
@@ -227,7 +144,6 @@ describe('email-submission.util', () => {
       ]
 
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -244,9 +160,6 @@ describe('email-submission.util', () => {
       const answer = answerArray.join(', ')
 
       const expectedDataCollationData = [{ question, answer }]
-      const expectedAutoReplyData = [
-        { question, answerTemplate: [answer], fieldType },
-      ]
       const expectedFormData = [
         {
           question,
@@ -257,7 +170,6 @@ describe('email-submission.util', () => {
       ]
 
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -275,9 +187,6 @@ describe('email-submission.util', () => {
       const expectedDataCollationData = [
         { question: `${ATTACHMENT_PREFIX}${question}`, answer },
       ]
-      const expectedAutoReplyData = [
-        { question, answerTemplate: [answer], fieldType },
-      ]
       const expectedFormData = [
         {
           question: `${ATTACHMENT_PREFIX}${question}`,
@@ -288,7 +197,6 @@ describe('email-submission.util', () => {
       ]
 
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -307,9 +215,6 @@ describe('email-submission.util', () => {
       const { question, fieldType } = response
 
       const expectedDataCollationData = [{ question, answer }]
-      const expectedAutoReplyData = [
-        { question, answerTemplate: answer.split('\n'), fieldType },
-      ]
       const expectedFormData = [
         {
           question,
@@ -320,7 +225,6 @@ describe('email-submission.util', () => {
       ]
 
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -343,9 +247,6 @@ describe('email-submission.util', () => {
       const expectedDataCollationData = [
         { question: `${TABLE_PREFIX}${question}`, answer },
       ]
-      const expectedAutoReplyData = [
-        { question, answerTemplate: answer.split('\n'), fieldType },
-      ]
       const expectedFormData = [
         {
           question: `${TABLE_PREFIX}${question}`,
@@ -356,7 +257,6 @@ describe('email-submission.util', () => {
       ]
 
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -374,9 +274,6 @@ describe('email-submission.util', () => {
       const answer = answerArray.join(', ')
 
       const expectedDataCollationData = [{ question, answer }]
-      const expectedAutoReplyData = [
-        { question, answerTemplate: answer.split('\n'), fieldType },
-      ]
       const expectedFormData = [
         {
           question,
@@ -387,7 +284,6 @@ describe('email-submission.util', () => {
       ]
 
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -402,12 +298,9 @@ describe('email-submission.util', () => {
         FormAuthType.NIL,
       )
 
-      const { question, answer, fieldType } = response
+      const { question, answer } = response
 
       const expectedDataCollationData = [{ question, answer }]
-      const expectedAutoReplyData = [
-        { question, answerTemplate: [answer], fieldType },
-      ]
       const expectedFormData = [
         {
           question: `${VERIFIED_PREFIX}${question}`,
@@ -418,7 +311,6 @@ describe('email-submission.util', () => {
       ]
 
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -454,18 +346,6 @@ describe('email-submission.util', () => {
           answer: vehicleResponse.answer,
         },
       ]
-      const expectedAutoReplyData = [
-        {
-          question: nameResponse.question,
-          answerTemplate: [nameResponse.answer],
-          fieldType: nameResponse.fieldType,
-        },
-        {
-          question: vehicleResponse.question,
-          answerTemplate: [vehicleResponse.answer],
-          fieldType: vehicleResponse.fieldType,
-        },
-      ]
       const expectedFormData = [
         {
           // Prefixed because its ID was in the Set
@@ -484,7 +364,6 @@ describe('email-submission.util', () => {
       ]
 
       expect(emailData.dataCollationData).toEqual(expectedDataCollationData)
-      expect(emailData.autoReplyData).toEqual(expectedAutoReplyData)
       expect(emailData.formData).toEqual(expectedFormData)
     })
 
@@ -532,52 +411,6 @@ describe('email-submission.util', () => {
         },
       ]
       expect(submissionEmailObj.formData).toEqual(correctFormData)
-    })
-
-    it('should return the response in correct email confirmation format when autoReplyData() method is called', () => {
-      const correctConfirmation = [
-        {
-          question: response1.question,
-          answerTemplate: (response1 as ResponseFormattedForEmail).answer.split(
-            '\n',
-          ),
-          fieldType: response1.fieldType,
-        },
-        // Note that response2 is not shown in Email Confirmation as isVisible is false
-      ]
-      expect(submissionEmailObj.autoReplyData).toEqual(correctConfirmation)
-    })
-
-    it('should mask corppass UID if FormAuthType is Corppass and autoReplyData() method is called', () => {
-      const responseCPUID = getResponse(
-        String(new ObjectId()),
-        'S1234567A',
-      ) as ProcessedFieldResponse
-
-      responseCPUID.question = SPCPFieldTitle.CpUid
-      responseCPUID.isVisible = true
-
-      const submissionEmailObjCP = new SubmissionEmailObj(
-        [response1, response2, responseCPUID],
-        hashedFields,
-        FormAuthType.CP,
-      )
-      const correctConfirmation = [
-        {
-          question: response1.question,
-          answerTemplate: (response1 as ResponseFormattedForEmail).answer.split(
-            '\n',
-          ),
-          fieldType: response1.fieldType,
-        },
-        // Note that response2 is not shown in Email Confirmation as isVisible is false
-        {
-          question: responseCPUID.question,
-          answerTemplate: ['*****567A'],
-          fieldType: responseCPUID.fieldType,
-        },
-      ]
-      expect(submissionEmailObjCP.autoReplyData).toEqual(correctConfirmation)
     })
   })
 })

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -14,11 +14,8 @@ import {
   EmailAdminDataField,
   EmailDataCollationToolField,
   EmailDataFields,
-  EmailDataForOneField,
-  EmailRespondentConfirmationField,
   IAttachmentInfo,
   MapRouteError,
-  SPCPFieldTitle,
 } from '../../../../types'
 import { createLoggerWithLabel } from '../../../config/logger'
 import {
@@ -257,55 +254,6 @@ export const getAnswerForSignature = (
   }
 }
 
-/**
- *  Formats the response for sending to the submitter (autoReplyData),
- *  the table that is sent to the admin (formData),
- *  and the json used by data collation tool (dataCollationData).
- *
- * @param response
- * @param hashedFields Field IDs hashed to verify answers provided by MyInfo
- * @returns an object containing three sets of formatted responses
- */
-export const getFormattedResponse = (
-  response: ResponseFormattedForEmail,
-  hashedFields: Set<string>,
-): EmailDataForOneField => {
-  const { question, answer, fieldType, isVisible } = response
-  const answerSplitByNewLine = answer.split('\n')
-
-  let autoReplyData: EmailRespondentConfirmationField | undefined
-  let dataCollationData: EmailDataCollationToolField | undefined
-  // Auto reply email will contain only visible fields
-  if (isVisible) {
-    autoReplyData = {
-      question, // No prefixes for autoreply
-      answerTemplate: answerSplitByNewLine,
-      fieldType,
-    }
-  }
-
-  // Headers are excluded from JSON data
-  if (fieldType !== BasicField.Section) {
-    dataCollationData = {
-      question: getJsonPrefixedQuestion(response),
-      answer,
-    }
-  }
-
-  // Send all the fields to admin
-  const formData = {
-    question: getFormDataPrefixedQuestion(response, hashedFields),
-    answerTemplate: answerSplitByNewLine,
-    answer,
-    fieldType,
-  }
-  return {
-    autoReplyData,
-    dataCollationData,
-    formData,
-  }
-}
-
 export const mapRouteError: MapRouteError = (error) => {
   switch (error.constructor) {
     case DatabasePayloadSizeError:
@@ -521,56 +469,6 @@ const createFormattedDataForOneField = <T extends EmailDataFields | undefined>(
 }
 
 /**
- * Helper function to mask the front of a string
- * Used to mask NRICs in Corppass Validated UID
- * @param field The string to be masked
- * @param charsToReveal The number of characters at the tail to reveal
- */
-const maskStringHead = (field: string, charsToReveal = 4): string => {
-  // Defensive, in case a negative number is passed in
-  // the entire string is masked
-  if (charsToReveal < 0) return '*'.repeat(field.length)
-
-  return field.length >= charsToReveal
-    ? '*'.repeat(field.length - charsToReveal) + field.substr(-charsToReveal)
-    : field
-}
-
-/**
- * Helper function that masks the UID on the last
- * field of autoReplyData using maskStringHead function
- */
-const maskUidOnLastField = (
-  autoReplyData: EmailRespondentConfirmationField[],
-): EmailRespondentConfirmationField[] => {
-  // Mask corppass UID and show only last 4 chars in autoreply to form filler
-  // This does not affect response email to form admin
-  // Function assumes corppass UID is last in the autoReplyData array
-  // TODO(#1104): Refactor to move validation and construction of parsedResponses in class constructor
-  // This will allow for proper tagging of corppass UID field instead of checking field title and position
-
-  return autoReplyData.map(
-    (autoReplyField: EmailRespondentConfirmationField, index) => {
-      if (
-        autoReplyField.question === SPCPFieldTitle.CpUid && // Check field title
-        index === autoReplyData.length - 1 // Check field position
-      ) {
-        const maskedAnswerTemplate = autoReplyField.answerTemplate.map(
-          (answer) => maskStringHead(answer, 4),
-        )
-        return {
-          question: autoReplyField.question,
-          answerTemplate: maskedAnswerTemplate,
-          fieldType: autoReplyField.fieldType,
-        }
-      } else {
-        return autoReplyField
-      }
-    },
-  )
-}
-
-/**
  * Function to extract information for email json field from response
  * Json field is used for data collation tool
  */
@@ -623,29 +521,6 @@ const getFormFormattedResponse = (
   }
 }
 
-/**
- * Function to extract information for email autoreply field from response
- * Autoreply field is used to send confirmation emails
- */
-const getAutoReplyFormattedResponse = (
-  response: ResponseFormattedForEmail,
-): EmailRespondentConfirmationField | undefined => {
-  const { question, answer, isVisible, answerTemplate } = response
-  const answerSplitByNewLine = answerTemplate ?? answer.split('\n')
-  // Auto reply email will contain only visible fields
-  if (isVisible !== false) {
-    return {
-      question, // No prefixes for autoreply
-      answerTemplate: answerSplitByNewLine,
-      ...(response.fieldType === BasicField.Signature && {
-        answer: response.answer,
-      }), // add signature answer for PDF generation
-      fieldType: response.fieldType,
-    }
-  }
-  return undefined
-}
-
 export class SubmissionEmailObj {
   parsedResponses: ProcessedFieldResponse[]
   hashedFields: Set<MyInfoKey>
@@ -679,27 +554,6 @@ export class SubmissionEmailObj {
     return compact(dataCollationFormattedData)
   }
 
-  /**
-   * Getter function to return autoReplyData for confirmation emails to respondent
-   * If FormAuthType is CP, return a masked version
-   */
-  get autoReplyData(): EmailRespondentConfirmationField[] {
-    // Compact is necessary because getAutoReplyFormattedResponse
-    // will return undefined for non-visible fields
-    const unmaskedAutoReplyData = compact(
-      this.parsedResponses.flatMap((response) =>
-        createFormattedDataForOneField(
-          response,
-          this.hashedFields,
-          getAutoReplyFormattedResponse,
-        ),
-      ),
-    )
-
-    return this.authType === FormAuthType.CP
-      ? maskUidOnLastField(unmaskedAutoReplyData)
-      : unmaskedAutoReplyData
-  }
   /**
    * Getter function to return formData which is used to send responses to admin
    */

--- a/src/types/email_mode_data.ts
+++ b/src/types/email_mode_data.ts
@@ -19,22 +19,7 @@ export type EmailAdminDataField = {
   answerTemplate: string[]
 }
 
-export type EmailDataFields =
-  | EmailRespondentConfirmationField
-  | EmailDataCollationToolField
-  | EmailAdminDataField
-
-export interface EmailData {
-  autoReplyData: EmailRespondentConfirmationField[]
-  dataCollationData: EmailDataCollationToolField[]
-  formData: EmailAdminDataField[]
-}
-
-export interface EmailDataForOneField {
-  autoReplyData?: EmailRespondentConfirmationField
-  dataCollationData?: EmailDataCollationToolField
-  formData: EmailAdminDataField
-}
+export type EmailDataFields = EmailDataCollationToolField | EmailAdminDataField
 
 export interface IAttachmentInfo {
   filename: string


### PR DESCRIPTION
Part 1 of 3 (standardise email payload hidden fields): [#9126, #9128, #9129]

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`EmailSubmissionObj.autoReplyData` is deprecated and no longer being used. (For context, it was used for storage mode autoreply previously, but no longer being used since respondent and admin email payload is standardized. mrf is not affected as it is using a separate flow (seen in diagram))
This is since the payload sent to admins and respondents are now standardized to be the same (see table below). Also, masking is no longer being done and hence the stale code can be removed. 

### Updated Email Behavior (Standardized)

| Recipient / Format | Email Body | PDF Copy | JSON |
| :--- | :--- | :--- | :--- |
| **Respondent** | Hidden fields hidden | Hidden fields hidden | N/A |
| **Admin** | Hidden fields hidden | Hidden fields hidden | Hidden fields shown (same as previous) |

No intended changes to MRF, which is already working as intended without issue in production. 

### Diagram of current usage (as of and after this PR): 
<img width="1690" height="1028" alt="image" src="https://github.com/user-attachments/assets/2d0f9acd-6bdc-4522-be46-8ad17059d520" />
Looking at our current implementation (in red), we are only using `formData` and `autoReplyData` is no longer being used. Hence, it is safe to remove. 

In part 1, we remove stale autoReplyData types which are not being used for sending any email. 

Note that for MRF, the responses are already pre-pruned for hidden logic fields when sent to the backend, hence no changes are needed. It also follows a different flow.  

Closes FRM-2293

## Solution
<!-- How did you solve the problem? -->
Remove deprecated autoreply formatting and its associated test cases and functions. The code should not be currently used. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [ ] Assert the removed code paths and tests are not being used. 