### PR TITLE
feat: replace admin email data type with generic email data type  (part 2/3 of standardize email payload hidden fields)

### DIFF
--- a/__tests__/unit/backend/helpers/generate-email-data.ts
+++ b/__tests__/unit/backend/helpers/generate-email-data.ts
@@ -1,7 +1,7 @@
 import { pick } from 'lodash'
 
 import { ProcessedSingleAnswerResponse } from 'src/app/modules/submission/submission.types'
-import { EmailAdminDataField, EmailDataCollationToolField } from 'src/types'
+import { EmailDataField, EmailDataCollationToolField } from 'src/types'
 
 export const generateSingleAnswerJson = (
   response: ProcessedSingleAnswerResponse,
@@ -9,7 +9,7 @@ export const generateSingleAnswerJson = (
 
 export const generateSingleAnswerFormData = (
   response: ProcessedSingleAnswerResponse,
-): EmailAdminDataField => ({
+): EmailDataField => ({
   ...pick(response, ['question', 'answer', 'fieldType']),
   answerTemplate: response.answer.split('\n'),
 })

--- a/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -10,7 +10,7 @@ import {
   SubmissionType,
 } from '../../../../../shared/types'
 import {
-  EmailAdminDataField,
+  EmailDataField,
   IAttachmentInfo,
   IEmailSubmissionSchema,
   IPopulatedEmailForm,
@@ -47,7 +47,7 @@ const logger = createLoggerWithLabel(module)
  * @returns errAsync(SubmissionHashError) if error occurred while hashing
  */
 export const hashSubmission = (
-  formData: EmailAdminDataField[],
+  formData: EmailDataField[],
   attachments: IAttachmentInfo[],
 ): ResultAsync<SubmissionHash, SubmissionHashError> => {
   const baseString = concatAttachmentsAndResponses(formData, attachments)

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -11,8 +11,8 @@ import {
   SIGNATURE_CAPTURED_STRING,
 } from '../../../../../shared/utils/signature'
 import {
-  EmailDataField,
   EmailDataCollationToolField,
+  EmailDataField,
   EmailDataFields,
   IAttachmentInfo,
   MapRouteError,
@@ -555,7 +555,7 @@ export class SubmissionEmailObj {
   }
 
   /**
-   * Used to send email responses.  
+   * Used to send email responses.
    */
   get formData(): EmailDataField[] {
     return this.parsedResponses.flatMap((response) =>

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -11,7 +11,7 @@ import {
   SIGNATURE_CAPTURED_STRING,
 } from '../../../../../shared/utils/signature'
 import {
-  EmailAdminDataField,
+  EmailDataField,
   EmailDataCollationToolField,
   EmailDataFields,
   IAttachmentInfo,
@@ -416,7 +416,7 @@ export const mapRouteError: MapRouteError = (error) => {
  * @returns concatenated response to hash
  */
 export const concatAttachmentsAndResponses = (
-  formData: EmailAdminDataField[],
+  formData: EmailDataField[],
   attachments: IAttachmentInfo[],
 ): string => {
   let response = ''
@@ -500,7 +500,7 @@ const getDataCollationFormattedResponse = (
 const getFormFormattedResponse = (
   response: ResponseFormattedForEmail,
   hashedFields: Set<MyInfoKey>,
-): EmailAdminDataField => {
+): EmailDataField => {
   const { answer, fieldType } = response
   const answerSplitByNewLine = answer.split('\n')
 
@@ -555,9 +555,9 @@ export class SubmissionEmailObj {
   }
 
   /**
-   * Getter function to return formData which is used to send responses to admin
+   * Used to send email responses.  
    */
-  get formData(): EmailAdminDataField[] {
+  get formData(): EmailDataField[] {
     return this.parsedResponses.flatMap((response) =>
       createFormattedDataForOneField(
         response,

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -10,7 +10,7 @@ import {
   SubmissionType,
 } from '../../../../../shared/types'
 import {
-  EmailAdminDataField,
+  EmailDataField,
   FieldResponse,
   FormFieldSchema,
   IEncryptedSubmissionSchema,
@@ -180,7 +180,7 @@ const generatePdfAttachmentIfRequired = ({
   autoReplyMailDatas: AutoReplyMailData[]
   submission: IEncryptedSubmissionSchema
   form: IPopulatedEncryptedForm
-  responsesData: EmailAdminDataField[]
+  responsesData: EmailDataField[]
   growthbook?: GrowthBook
 }): ResultAsync<Mail.Attachment | undefined, AutoreplyPdfGenerationError> => {
   const isAdminPdfRequired = checkIfAdminPdfIsRequired(

--- a/src/app/modules/submission/submission.service.ts
+++ b/src/app/modules/submission/submission.service.ts
@@ -22,7 +22,7 @@ import {
   SubmissionType,
 } from '../../../../shared/types'
 import {
-  EmailRespondentConfirmationField,
+  EmailDataField,
   IEncryptSubmissionModel,
   IMultirespondentSubmissionModel,
   IPopulatedForm,
@@ -458,7 +458,7 @@ export const sendEmailConfirmations = <S extends ISubmissionSchema>({
 }: {
   form: IPopulatedForm
   submission: S
-  responsesData: EmailRespondentConfirmationField[]
+  responsesData: EmailDataField[]
   submissionAttachments?: Mail.Attachment[]
   recipientData: AutoReplyMailData[]
   pdfAttachment?: Mail.Attachment

--- a/src/app/services/mail/mail.service.ts
+++ b/src/app/services/mail/mail.service.ts
@@ -13,7 +13,7 @@ import { getPaymentInvoiceDownloadUrlPath } from '../../../../shared/utils/urls'
 import { HASH_EXPIRE_AFTER_SECONDS } from '../../../../shared/utils/verification'
 import {
   BounceType,
-  EmailAdminDataField,
+  EmailDataField,
   IFormHasEmailSchema,
   IPopulatedForm,
   ISubmissionSchema,
@@ -693,7 +693,7 @@ export class MailService {
     form: Pick<IFormHasEmailSchema, '_id' | 'title' | 'emails'>
     submission: Pick<ISubmissionSchema, 'id' | 'created'>
     submissionAttachments?: Mail.Attachment[]
-    formData: EmailAdminDataField[]
+    formData: EmailDataField[]
     dataCollationData?: {
       question: string
       answer: string | number

--- a/src/app/services/mail/mail.types.ts
+++ b/src/app/services/mail/mail.types.ts
@@ -3,7 +3,7 @@ import { OperationOptions } from 'retry'
 
 import { AutoReplyOptions } from '../../../../shared/types'
 import {
-  EmailAdminDataField,
+  EmailDataField,
   IFormSchema,
   IPopulatedForm,
   ISubmissionSchema,
@@ -30,10 +30,10 @@ export type SendAutoReplyEmailsArgs = {
   submission: Pick<ISubmissionSchema, 'id' | 'created'>
   submissionAttachments?: Mail.Attachment[]
   responsesData: (Pick<
-    EmailAdminDataField,
+    EmailDataField,
     'question' | 'answerTemplate' | 'fieldType'
   > & {
-    answer?: EmailAdminDataField['answer']
+    answer?: EmailDataField['answer']
   })[]
   autoReplyMailDatas: AutoReplyMailData[]
   pdfAttachment?: Mail.Attachment
@@ -61,8 +61,8 @@ export type AutoreplySummaryRenderData = {
   refNo: ISubmissionSchema['_id']
   formTitle: IFormSchema['title']
   submissionTime: string
-  formData: (Pick<EmailAdminDataField, 'question' | 'answerTemplate'> & {
-    answer?: EmailAdminDataField['answer']
+  formData: (Pick<EmailDataField, 'question' | 'answerTemplate'> & {
+    answer?: EmailDataField['answer']
   })[]
   formUrl: string
 }
@@ -75,7 +75,7 @@ export type SubmissionToAdminHtmlData = {
   refNo: string
   formTitle: string
   submissionTime: string
-  formData: EmailAdminDataField[]
+  formData: EmailDataField[]
   dataCollationData?: {
     question: string
     answer: string | number

--- a/src/types/email_mode_data.ts
+++ b/src/types/email_mode_data.ts
@@ -12,14 +12,16 @@ export type EmailDataCollationToolField = {
   answer: string
 }
 
-export type EmailAdminDataField = {
+export type EmailDataField = {
   question: string
   answer: string
   fieldType: BasicField
   answerTemplate: string[]
 }
 
-export type EmailDataFields = EmailDataCollationToolField | EmailAdminDataField
+export type EmailDataFields =
+  | EmailDataCollationToolField
+  | EmailDataField
 
 export interface IAttachmentInfo {
   filename: string

--- a/src/types/email_mode_data.ts
+++ b/src/types/email_mode_data.ts
@@ -19,9 +19,7 @@ export type EmailDataField = {
   answerTemplate: string[]
 }
 
-export type EmailDataFields =
-  | EmailDataCollationToolField
-  | EmailDataField
+export type EmailDataFields = EmailDataCollationToolField | EmailDataField
 
 export interface IAttachmentInfo {
   filename: string


### PR DESCRIPTION
Part 2 of 3 (standardise email payload hidden fields): [#9126, #9128, #9129]

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The concept of a specific "admin email data" type no longer exists, since the respondent data and admin data have been standardized to be the same. 
Hence, we should make the admin email data type generic. 

### Updated behavior for email payload 
| Recipient / Format | Email Body | PDF Copy | JSON |
| :--- | :--- | :--- | :--- |
| **Respondent** | Hidden fields hidden | Hidden fields hidden | N/A |
| **Admin** | Hidden fields hidden | Hidden fields hidden | Hidden fields shown (same as previous) |

As seen in this table, the email body and pdf copy have the exact same fields, which is standardized. 

Closes FRM-2294. 

## Solution
<!-- How did you solve the problem? -->
### Diagram of current flow in red:  
<img width="1690" height="1028" alt="image" src="https://github.com/user-attachments/assets/48d11166-083a-4b5f-8bbe-f4df3ceb0e41" />

We are moving towards the common `emailResponses` type in green shown in the diagram - which is used by both sending email to admin, respondent and the shared PDF. This happens to be the formData which type name is now updated to a generic `EmailDataField` instead of specific `AdminEmailDataField`. 

The following specific changes are made in this PR: 
1. Rename the `AdminEmailDataField` to `EmailDataField`. 
2. When sending email to respondent, change the type to accept the generic `EmailDataField` instead of using the old specific respondent email data type. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: Storage mode forms (Regression) 
- [ ] Create a storage mode form with admin submission email and respondent email copy with PDF and field summary. 
- [ ] Make a submission and ensure the email with PDF can be received for both admin and respondent. The output should be the same as previous.  