### PR TITLE
fix: prune hidden logic fields from email data field (part 3/3 of standardize email payload hidden fields)

### DIFF
--- a/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -64,18 +64,34 @@ describe('email-submission.util', () => {
       '',
     ) as ProcessedFieldResponse
 
+    const response3 = getResponse(
+      String(new ObjectId()),
+      '',
+    ) as ProcessedFieldResponse
+
+    const response4 = getResponse(
+      String(new ObjectId()),
+      '',
+    ) as ProcessedFieldResponse
+
     response1.fieldType = BasicField.YesNo
-    response2.fieldType = BasicField.YesNo
+    response2.fieldType = BasicField.ShortText
     response1.isVisible = true
-    response2.isVisible = false
+    response2.isVisible = true
+    response3.fieldType = BasicField.LongText
+    response3.isVisible = false
+    response4.fieldType = BasicField.Mobile
+    response4.isVisible = undefined
 
     const hashedFields = new Set([
+      new ObjectId().toHexString(),
+      new ObjectId().toHexString(),
       new ObjectId().toHexString(),
       new ObjectId().toHexString(),
     ])
     const authType = FormAuthType.NIL
     const submissionEmailObj = new SubmissionEmailObj(
-      [response1, response2],
+      [response1, response2, response3, response4],
       hashedFields,
       authType,
     )
@@ -105,6 +121,61 @@ describe('email-submission.util', () => {
         FormAuthType.NIL,
       )
       expect(emailData.dataCollationData).toEqual([])
+      expect(emailData.formData).toEqual([
+        generateSingleAnswerFormData(response),
+      ])
+    })
+
+    it('should exclude non-visible fields from formData', () => {
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        isVisible: false,
+      })
+
+      const emailData = new SubmissionEmailObj(
+        [response],
+        new Set(),
+        FormAuthType.NIL,
+      )
+
+      expect(emailData.dataCollationData).toEqual([
+        generateSingleAnswerJson(response),
+      ])
+      expect(emailData.formData).toEqual([])
+    })
+
+    it('should include undefined isVisible fields from formData', () => {
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        isVisible: undefined,
+      })
+
+      const emailData = new SubmissionEmailObj(
+        [response],
+        new Set(),
+        FormAuthType.NIL,
+      )
+
+      expect(emailData.dataCollationData).toEqual([
+        generateSingleAnswerJson(response),
+      ])
+      expect(emailData.formData).toEqual([
+        generateSingleAnswerFormData(response),
+      ])
+    })
+
+    it('should include isVisible true fields from formData', () => {
+      const response = generateNewSingleAnswerResponse(BasicField.ShortText, {
+        isVisible: true,
+      })
+
+      const emailData = new SubmissionEmailObj(
+        [response],
+        new Set(),
+        FormAuthType.NIL,
+      )
+
+      expect(emailData.dataCollationData).toEqual([
+        generateSingleAnswerJson(response),
+      ])
       expect(emailData.formData).toEqual([
         generateSingleAnswerFormData(response),
       ])
@@ -381,6 +452,20 @@ describe('email-submission.util', () => {
           ),
           answer: (response2 as ResponseFormattedForEmail).answer,
         },
+        // Data collation data stil includes isVisible false fields
+        {
+          question: getJsonPrefixedQuestion(
+            response3 as ResponseFormattedForEmail,
+          ),
+          answer: (response3 as ResponseFormattedForEmail).answer,
+        },
+        // Data collation data stil includes isVisible undefined fields
+        {
+          question: getJsonPrefixedQuestion(
+            response4 as ResponseFormattedForEmail,
+          ),
+          answer: (response4 as ResponseFormattedForEmail).answer,
+        },
       ]
       expect(submissionEmailObj.dataCollationData).toEqual(correctJson)
     })
@@ -408,6 +493,18 @@ describe('email-submission.util', () => {
           ),
           answer: (response2 as ResponseFormattedForEmail).answer,
           fieldType: response2.fieldType,
+        },
+        // Form data stil includes isVisible undefined fields
+        {
+          question: getFormDataPrefixedQuestion(
+            response4 as ResponseFormattedForEmail,
+            hashedFields,
+          ),
+          answerTemplate: (response2 as ResponseFormattedForEmail).answer.split(
+            '\n',
+          ),
+          answer: (response4 as ResponseFormattedForEmail).answer,
+          fieldType: response4.fieldType,
         },
       ]
       expect(submissionEmailObj.formData).toEqual(correctFormData)

--- a/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -494,14 +494,17 @@ const getDataCollationFormattedResponse = (
 }
 
 /**
- * Function to extract information for email form field from response
- * Form field is used to send responses to admin
+ * Used to format response for email payload.
+ * Used for both respondent copy and admin notification emails which are standardized to be the same.
  */
 const getFormFormattedResponse = (
   response: ResponseFormattedForEmail,
   hashedFields: Set<MyInfoKey>,
-): EmailDataField => {
-  const { answer, fieldType } = response
+): EmailDataField | undefined => {
+  const { answer, fieldType, isVisible } = response
+  if (isVisible === false) {
+    return undefined
+  }
   const answerSplitByNewLine = answer.split('\n')
 
   if (fieldType === BasicField.Signature) {
@@ -558,13 +561,15 @@ export class SubmissionEmailObj {
    * Used to send email responses.
    */
   get formData(): EmailDataField[] {
-    return this.parsedResponses.flatMap((response) =>
-      createFormattedDataForOneField(
-        response,
-        this.hashedFields,
-        getFormFormattedResponse,
-      ),
-    )
+    return this.parsedResponses
+      .flatMap((response) =>
+        createFormattedDataForOneField(
+          response,
+          this.hashedFields,
+          getFormFormattedResponse,
+        ),
+      )
+      .filter((field): field is EmailDataField => field !== undefined)
   }
 }
 


### PR DESCRIPTION
Part 3 of 3 (standardise email payload hidden fields): [#9126, #9128, #9129]

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The respondent and admin email and PDF contain hidden logic fields, which should not be included and should be removed from the email payload.  

### Updated behavior for email payload 
| Recipient / Format | Email Body | PDF Copy | JSON |
| :--- | :--- | :--- | :--- |
| **Respondent** | Hidden fields hidden | Hidden fields hidden | N/A |
| **Admin** | Hidden fields hidden | Hidden fields hidden | Hidden fields shown (same as previous) |

Closes FRM-2264.

| Before | After |
| :-- | --: |
| <img width="350" height="534" alt="image" src="https://github.com/user-attachments/assets/944fed92-afbf-475b-889b-5578cdbc9f38" /> | <img width="350" height="612" alt="image" src="https://github.com/user-attachments/assets/a0b53134-48ff-4088-9b5e-9d2bce861653" /> |

## Solution
<!-- How did you solve the problem? -->
### Diagram of current flow in red:  
<img width="1690" height="1028" alt="image" src="https://github.com/user-attachments/assets/48d11166-083a-4b5f-8bbe-f4df3ceb0e41" />

In part 2, we updated `formData` towards the common `emailResponses` type in green shown in the diagram by updating the functions to use the generic `EmailFieldData` type. 

In this PR, we update `formData` to prune the hidden logic fields, achieving our intended updated behavior to remove the hidden logic fields in admin & respondent email payload (shown in the table above) 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Storage mode respondent email and admin email exclude hidden logic fields 
- [ ] Make a storage mode form with admin email notification & respondent email copy (with PDF and field summary). 
- [ ] Add logic to the form such that fields can be hidden. 
- [ ] Submit the form with hidden fields. 
- [ ] Assert the respondent copy email and pdf does not include the hidden fields. 
- [ ] Assert the admin email and pdf does not include the hidden fields. 
- [ ] Resubmit the form showing the hidden fields. 
- [ ] Assert the respondent copy email and pdf includes the hidable logic fields. 
- [ ] Assert the admin email and pdf includes the hidable logic fields. 

TC2: MRF 
- [ ] Repeat the above TC1 for MRF with 1 step.
- [ ] Repeat the above TC1 with MRF with 2 steps, where the fields can be hidden by the second step submitter.