### PR TITLE
fix: enforce singpass mrf first step

### DIFF
--- a/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
+++ b/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
@@ -43,6 +43,8 @@ export const QuestionsBlock = ({
       if (!isFillableField) {
         return false
       }
+      // TODO(MRF-MYINFO): Remove this restriction once MyInfo fields are
+      // supported in workflow steps >= 2.
       if (isMyInfoField && !isFirstStep) {
         return false
       }

--- a/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -79,6 +79,7 @@ import {
   FormStatus,
   LogicDto,
   LogicType,
+  MyInfoAttribute,
   PaymentChannel,
   PaymentType,
   SettingsUpdateDto,
@@ -3823,6 +3824,276 @@ describe('admin-form.service', () => {
           fieldOptions: ['option1'],
           optionsToRecipientsMap: {},
         })
+      })
+    })
+  })
+
+  describe('createWorkflowStep', () => {
+    describe('myinfo field restriction', () => {
+      const MYINFO_FIELD_ID = new ObjectId().toHexString()
+      const REGULAR_FIELD_ID = new ObjectId().toHexString()
+      const EMAIL_FIELD_ID = new ObjectId().toHexString()
+
+      const MOCK_FORM_FIELDS = [
+        {
+          _id: MYINFO_FIELD_ID,
+          fieldType: BasicField.ShortText,
+          title: 'MyInfo Name',
+          myInfo: { attr: MyInfoAttribute.Name },
+        },
+        {
+          _id: REGULAR_FIELD_ID,
+          fieldType: BasicField.ShortText,
+          title: 'Regular Field',
+        },
+        {
+          _id: EMAIL_FIELD_ID,
+          fieldType: BasicField.Email,
+          title: 'Email Field',
+        },
+      ]
+
+      it('should reject creating a non-first step with myinfo fields in edit', async () => {
+        // Arrange
+        const mockForm = {
+          _id: new ObjectId().toHexString(),
+          responseMode: FormResponseMode.Multirespondent,
+          form_fields: MOCK_FORM_FIELDS,
+          workflow: [
+            {
+              _id: 'step0',
+              workflow_type: WorkflowType.Static,
+              emails: ['step1@example.com'],
+              edit: [MYINFO_FIELD_ID],
+            },
+          ],
+        } as unknown as IPopulatedForm
+
+        const newStep = {
+          workflow_type: WorkflowType.Static,
+          emails: ['step2@example.com'],
+          edit: [MYINFO_FIELD_ID],
+        }
+
+        // Act
+        const result = await AdminFormService.createWorkflowStep(
+          mockForm,
+          newStep as any,
+        )
+
+        // Assert
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+          MalformedParametersError,
+        )
+      })
+
+      it('should allow creating a non-first step with only regular fields in edit', async () => {
+        // Arrange
+        const mockFormId = new ObjectId().toHexString()
+        const mockUpdatedWorkflow = [
+          {
+            _id: 'step0',
+            workflow_type: WorkflowType.Static,
+            emails: ['step1@example.com'],
+            edit: [MYINFO_FIELD_ID],
+          },
+          {
+            workflow_type: WorkflowType.Static,
+            emails: ['step2@example.com'],
+            edit: [REGULAR_FIELD_ID],
+          },
+        ]
+        const mockForm = {
+          _id: mockFormId,
+          responseMode: FormResponseMode.Multirespondent,
+          form_fields: MOCK_FORM_FIELDS,
+          workflow: [mockUpdatedWorkflow[0]],
+        } as unknown as IPopulatedForm
+
+        jest
+          .spyOn(MultirespondentFormModel, 'findByIdAndUpdate')
+          // @ts-ignore
+          .mockReturnValue({
+            exec: jest.fn().mockResolvedValue({
+              _id: mockFormId,
+              workflow: mockUpdatedWorkflow,
+            }),
+          })
+
+        const newStep = {
+          workflow_type: WorkflowType.Static,
+          emails: ['step2@example.com'],
+          edit: [REGULAR_FIELD_ID],
+        }
+
+        // Act
+        const result = await AdminFormService.createWorkflowStep(
+          mockForm,
+          newStep as any,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+      })
+
+      it('should allow creating the first step with myinfo fields in edit', async () => {
+        // Arrange
+        const mockFormId = new ObjectId().toHexString()
+        const mockUpdatedWorkflow = [
+          {
+            workflow_type: WorkflowType.Static,
+            emails: ['step1@example.com'],
+            edit: [MYINFO_FIELD_ID],
+          },
+        ]
+        const mockForm = {
+          _id: mockFormId,
+          responseMode: FormResponseMode.Multirespondent,
+          form_fields: MOCK_FORM_FIELDS,
+          workflow: [],
+        } as unknown as IPopulatedForm
+
+        jest
+          .spyOn(MultirespondentFormModel, 'findByIdAndUpdate')
+          // @ts-ignore
+          .mockReturnValue({
+            exec: jest.fn().mockResolvedValue({
+              _id: mockFormId,
+              workflow: mockUpdatedWorkflow,
+            }),
+          })
+
+        const newStep = {
+          workflow_type: WorkflowType.Static,
+          emails: ['step1@example.com'],
+          edit: [MYINFO_FIELD_ID],
+        }
+
+        // Act
+        const result = await AdminFormService.createWorkflowStep(
+          mockForm,
+          newStep as any,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+      })
+    })
+  })
+
+  describe('updateFormWorkflowStep', () => {
+    describe('myinfo field restriction', () => {
+      const MYINFO_FIELD_ID = new ObjectId().toHexString()
+      const REGULAR_FIELD_ID = new ObjectId().toHexString()
+
+      const MOCK_FORM_FIELDS = [
+        {
+          _id: MYINFO_FIELD_ID,
+          fieldType: BasicField.ShortText,
+          title: 'MyInfo Name',
+          myInfo: { attr: MyInfoAttribute.Name },
+        },
+        {
+          _id: REGULAR_FIELD_ID,
+          fieldType: BasicField.ShortText,
+          title: 'Regular Field',
+        },
+      ]
+
+      it('should reject updating a non-first step to include myinfo fields in edit', async () => {
+        // Arrange
+        const mockForm = {
+          _id: new ObjectId().toHexString(),
+          responseMode: FormResponseMode.Multirespondent,
+          form_fields: MOCK_FORM_FIELDS,
+          workflow: [
+            {
+              _id: 'step0',
+              workflow_type: WorkflowType.Static,
+              emails: ['step1@example.com'],
+              edit: [MYINFO_FIELD_ID],
+            },
+            {
+              _id: 'step1',
+              workflow_type: WorkflowType.Static,
+              emails: ['step2@example.com'],
+              edit: [REGULAR_FIELD_ID],
+            },
+          ],
+        } as unknown as IPopulatedForm
+
+        const updatedStep = {
+          _id: 'step1',
+          workflow_type: WorkflowType.Static,
+          emails: ['step2@example.com'],
+          edit: [MYINFO_FIELD_ID],
+        }
+
+        // Act
+        const result = await AdminFormService.updateFormWorkflowStep(
+          mockForm,
+          1,
+          updatedStep as any,
+        )
+
+        // Assert
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+          MalformedParametersError,
+        )
+      })
+
+      it('should allow updating a non-first step with only regular fields', async () => {
+        // Arrange
+        const mockFormId = new ObjectId().toHexString()
+        const mockWorkflow = [
+          {
+            _id: 'step0',
+            workflow_type: WorkflowType.Static,
+            emails: ['step1@example.com'],
+            edit: [MYINFO_FIELD_ID],
+          },
+          {
+            _id: 'step1',
+            workflow_type: WorkflowType.Static,
+            emails: ['step2@example.com'],
+            edit: [REGULAR_FIELD_ID],
+          },
+        ]
+        const mockForm = {
+          _id: mockFormId,
+          responseMode: FormResponseMode.Multirespondent,
+          form_fields: MOCK_FORM_FIELDS,
+          workflow: mockWorkflow,
+        } as unknown as IPopulatedForm
+
+        jest
+          .spyOn(MultirespondentFormModel, 'findByIdAndUpdate')
+          // @ts-ignore
+          .mockReturnValue({
+            exec: jest.fn().mockResolvedValue({
+              _id: mockFormId,
+              workflow: mockWorkflow,
+            }),
+          })
+
+        const updatedStep = {
+          _id: 'step1',
+          workflow_type: WorkflowType.Static,
+          emails: ['step2@example.com'],
+          edit: [REGULAR_FIELD_ID],
+        }
+
+        // Act
+        const result = await AdminFormService.updateFormWorkflowStep(
+          mockForm,
+          1,
+          updatedStep as any,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
       })
     })
   })

--- a/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1597,6 +1597,24 @@ export const createWorkflowStep = (
     )
   }
 
+  // TODO(MRF-MYINFO): Remove this restriction once Myinfo fields are
+  // supported in workflow steps >= 2. Currently, only step 1 (the first
+  // respondent) can include Myinfo fields to prevent approvers from
+  // overriding verified data.
+  if (!isFirstStep) {
+    const editFieldIds = new Set((newWorkflowStep.edit ?? []).map(String))
+    const myInfoFieldInEdit = originalForm.form_fields.find(
+      (field) => field.myInfo?.attr && editFieldIds.has(field._id.toString()),
+    )
+    if (myInfoFieldInEdit) {
+      return errAsync(
+        new MalformedParametersError(
+          'Myinfo fields can only be edited in the first step of the workflow',
+        ),
+      )
+    }
+  }
+
   const selectedApprovalField = newWorkflowStep.approval_field
   if (selectedApprovalField) {
     const yesNoFieldIds = originalForm.form_fields
@@ -1716,6 +1734,24 @@ export const updateFormWorkflowStep = (
         'First step of workflow cannot be an approval step',
       ),
     )
+  }
+
+  // TODO(MRF-MYINFO): Remove this restriction once MyInfo fields are
+  // supported in workflow steps >= 2. Currently, only step 1 (the first
+  // respondent) can include MyInfo fields to prevent approvers from
+  // overriding verified data.
+  if (!isFirstStep) {
+    const editFieldIds = new Set((updatedWorkflowStep.edit ?? []).map(String))
+    const myInfoFieldInEdit = originalForm.form_fields.find(
+      (field) => field.myInfo?.attr && editFieldIds.has(field._id.toString()),
+    )
+    if (myInfoFieldInEdit) {
+      return errAsync(
+        new MalformedParametersError(
+          'MyInfo fields cannot be edited in non-first steps of the workflow',
+        ),
+      )
+    }
   }
 
   const selectedApprovalField = updatedWorkflowStep.approval_field


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Current implementation of Singpass MRF only allows Myinfo fields to be set on the first step of a workflow. This is gated in the FE by only showing Myinfo fields in the `assigned fields to workflow step` for Step 1 only, but there is no BE gate to prevent a user from programmatically updating a workflow 2+ step to include Myinfo fields.

Since Singpass login is only enableed on the first step, Myinfo fields assigned on the 2+ step onwards will be treated as an unverified, editable step which can be confusing to our respondents & admins in email copies.

Closes FRM-2298

## Solution
<!-- How did you solve the problem? -->

Add a check in the BE during workstep creation and updating if any of the editable fields in a 2+ workflow step includes a Myinfo field, and throw an error if so.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
