### PR TITLE
chore(cleanup): remove puppeteer from backend and cleanup unused local pdf generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,6 @@
         "perfect-freehand": "^1.2.2",
         "promise-retry": "^2.0.1",
         "promise-timeout": "^1.3.0",
-        "puppeteer-core": "24.9.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.1",
         "react-email": "^4.0.11",
@@ -6233,62 +6232,6 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@puppeteer/browsers": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
-      "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.1",
-        "extract-zip": "^2.0.1",
-        "progress": "^2.0.3",
-        "proxy-agent": "^6.5.0",
-        "semver": "^7.7.2",
-        "tar-fs": "^3.0.8",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@react-email/body": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/@react-email/body/-/body-0.0.10.tgz",
@@ -7654,12 +7597,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@tootallnate/quickjs-emscripten": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "license": "MIT"
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
@@ -8241,16 +8178,6 @@
       "version": "15.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.26.1",
@@ -9364,18 +9291,6 @@
         "safer-buffer": "^2.1.0"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "dev": true,
@@ -9739,71 +9654,6 @@
       "license": "Apache-2.0",
       "optional": true
     },
-    "node_modules/bare-fs": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
-      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
-      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
-      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "streamx": "^2.21.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/base-64": {
       "version": "1.0.0",
       "dev": true,
@@ -9853,15 +9703,6 @@
       "version": "5.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/bcrypt": {
       "version": "5.1.1",
@@ -10364,19 +10205,6 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
-    "node_modules/chromium-bidi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
-      "integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mitt": "^3.0.1",
-        "zod": "^3.24.1"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
-      }
-    },
     "node_modules/ci-info": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
@@ -10534,6 +10362,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -11150,15 +10979,6 @@
       "version": "2.1.8",
       "license": "MIT"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -11446,20 +11266,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/degenerator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ast-types": "^0.13.4",
-        "escodegen": "^2.1.0",
-        "esprima": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/delay": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
@@ -11515,12 +11321,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1439962",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1439962.tgz",
-      "integrity": "sha512-jJF48UdryzKiWhJ1bLKr7BFWUQCEIT5uCNbDLqkQJBtkFxYzILJH44WN0PDKMIlGDN7Utb8vyUY85C3w4R/t2g==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/dezalgo": {
       "version": "1.0.4",
@@ -12169,6 +11969,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12188,6 +11989,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -12208,6 +12010,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -12216,6 +12019,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -13106,6 +12910,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -13168,6 +12973,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -13516,26 +13322,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -13635,15 +13421,6 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fecha": {
@@ -14044,6 +13821,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -14106,21 +13884,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/get-symbol-description": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
@@ -14136,20 +13899,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^6.0.2",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/github-from-package": {
@@ -18925,12 +18674,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
-    "node_modules/mitt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "license": "MIT"
-    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -19357,15 +19100,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/neverthrow": {
       "version": "8.0.0",
@@ -20210,60 +19944,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pac-proxy-agent": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
-      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "get-uri": "^6.0.1",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.6",
-        "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-resolver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
-      "license": "MIT",
-      "dependencies": {
-        "degenerator": "^5.0.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -20687,6 +20367,7 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -20761,56 +20442,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-agent": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
-      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.6",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.1.0",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.5"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "license": "MIT"
@@ -20851,67 +20482,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer-core": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.9.0.tgz",
-      "integrity": "sha512-HFdCeH/wx6QPz8EncafbCqJBqaCG1ENW75xg3cLFMRUoqZDgByT6HSueiumetT2uClZxwqj0qS4qMVZwLHRHHw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.10.5",
-        "chromium-bidi": "5.1.0",
-        "debug": "^4.4.1",
-        "devtools-protocol": "0.0.1439962",
-        "typed-query-selector": "^2.12.0",
-        "ws": "^8.18.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/pure-rand": {
@@ -21304,6 +20874,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -22168,29 +21739,6 @@
         "npm": ">= 3.0.0"
       }
     },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/socks/node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -22734,20 +22282,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
       }
     },
     "node_modules/tar-stream": {
@@ -23418,12 +22952,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typed-query-selector": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
-      "license": "MIT"
-    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "license": "MIT"
@@ -24001,6 +23529,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -24064,6 +23593,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -24078,6 +23608,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -24088,7 +23619,8 @@
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -24175,6 +23707,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -24189,6 +23722,7 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -24206,18 +23740,9 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "perfect-freehand": "^1.2.2",
     "promise-retry": "^2.0.1",
     "promise-timeout": "^1.3.0",
-    "puppeteer-core": "24.9.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.1",
     "react-email": "^4.0.11",

--- a/src/app/modules/payments/payment-proof.controller.ts
+++ b/src/app/modules/payments/payment-proof.controller.ts
@@ -53,13 +53,10 @@ export const downloadPaymentInvoice: ControllerHandler<{
           })
         },
       )
-      const isUseLambdaOutput =
-        req.growthbook?.isOn(featureFlags.lambdaPdfGeneration) ?? false
       logger.info({
         message: 'Growthbook flag for lambda pdf generation',
         meta: {
           ...logMeta,
-          isUseLambdaOutput,
           growthbookAttributes: req.growthbook?.getAttributes(),
           lambdaPdfGenerationGrowthbookValue: req.growthbook?.getFeatureValue(
             featureFlags.lambdaPdfGeneration,
@@ -71,10 +68,9 @@ export const downloadPaymentInvoice: ControllerHandler<{
       return {
         payment,
         populatedForm,
-        isUseLambdaOutput,
       }
     })
-    .andThen(({ payment, populatedForm, isUseLambdaOutput }) => {
+    .andThen(({ payment, populatedForm }) => {
       logger.info({
         message: 'Found paymentId in payment document',
         meta: {
@@ -86,7 +82,6 @@ export const downloadPaymentInvoice: ControllerHandler<{
       return PaymentProofService.generatePaymentInvoiceUrl(
         payment,
         populatedForm,
-        isUseLambdaOutput,
       )
     })
     .map((pdfUrl) => {

--- a/src/app/modules/payments/payment-proof.service.ts
+++ b/src/app/modules/payments/payment-proof.service.ts
@@ -228,7 +228,7 @@ const _generatePaymentInvoiceAsPdf = (
     })
 
     return ResultAsync.fromPromise(
-      generatePdfFromHtml(invoiceHtml, isUseLambdaOutput),
+      generatePdfFromHtml(invoiceHtml),
       (error) => new InvoicePdfGenerationError(String(error)),
     )
   })

--- a/src/app/modules/payments/payment-proof.service.ts
+++ b/src/app/modules/payments/payment-proof.service.ts
@@ -180,7 +180,6 @@ const _generatePaymentInvoiceAsPdf = (
   payment: ICompletedPaymentSchema,
   populatedForm: IPopulatedEncryptedForm,
   receiptUrl: string,
-  isUseLambdaOutput: boolean,
 ): ResultAsync<Buffer, StripeFetchError | InvoicePdfGenerationError> => {
   if (!payment.completedPayment?.receiptUrl) {
     return errAsync(new StripeFetchError('Receipt url not ready'))
@@ -237,7 +236,6 @@ const _generatePaymentInvoiceAsPdf = (
 export const generatePaymentInvoiceUrl = (
   payment: IPaymentSchema,
   populatedForm: IPopulatedEncryptedForm,
-  isUseLambdaOutput: boolean,
 ): ResultAsync<
   string,
   | StripeFetchError
@@ -253,7 +251,6 @@ export const generatePaymentInvoiceUrl = (
             completedPayment,
             populatedForm,
             receiptUrl,
-            isUseLambdaOutput,
           ),
         )
         .andThen((pdfBuffer) =>

--- a/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -204,7 +204,7 @@ const generatePdfAttachmentIfRequired = ({
     formUrl: `${config.app.appUrl}/${form._id}`,
   }
 
-  return generateAutoreplyPdf(autoReplyData, true)
+  return generateAutoreplyPdf(autoReplyData)
     .map((pdfBuffer) => ({
       filename: `RefNo ${submission.id}.pdf`,
       content: Buffer.copyBytesFrom(pdfBuffer),

--- a/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -905,7 +905,7 @@ const generatePdfAttachmentIfRequired = ({
     formUrl: `${config.app.appUrl}/${form._id}`,
   }
 
-  const pdfResult = generateAutoreplyPdf(autoReplyData, true)
+  const pdfResult = generateAutoreplyPdf(autoReplyData)
     .map((pdfBuffer) => ({
       filename: `RefNo ${submissionId}.pdf`,
       content: Buffer.copyBytesFrom(pdfBuffer),

--- a/src/app/services/mail/__tests__/mail.utils.spec.ts
+++ b/src/app/services/mail/__tests__/mail.utils.spec.ts
@@ -87,7 +87,6 @@ describe('mail.utils', () => {
       expect(MockConvertHtmlToPdf.generatePdfFromHtml).toHaveBeenCalledOnce()
       expect(MockConvertHtmlToPdf.generatePdfFromHtml).toHaveBeenCalledWith(
         expectedHtml._unsafeUnwrap(),
-        true,
       )
       expect(result._unsafeUnwrap()).toEqual(MOCK_PDF_BUFFER)
     })
@@ -138,7 +137,6 @@ describe('mail.utils', () => {
       expect(MockConvertHtmlToPdf.generatePdfFromHtml).toHaveBeenCalledOnce()
       expect(MockConvertHtmlToPdf.generatePdfFromHtml).toHaveBeenCalledWith(
         expectedHtml._unsafeUnwrap(),
-        true,
       )
       expect(result._unsafeUnwrap()).toEqual(MOCK_PDF_BUFFER)
     })

--- a/src/app/services/mail/__tests__/mail.utils.spec.ts
+++ b/src/app/services/mail/__tests__/mail.utils.spec.ts
@@ -32,7 +32,7 @@ describe('mail.utils', () => {
       }
 
       // Act
-      const result = await generateAutoreplyPdf(autoReplyData, true)
+      const result = await generateAutoreplyPdf(autoReplyData)
 
       // Assert
       expect(MockConvertHtmlToPdf.generatePdfFromHtml).toHaveBeenCalledOnce()
@@ -81,7 +81,7 @@ describe('mail.utils', () => {
       )
 
       // Act
-      const result = await generateAutoreplyPdf(autoReplyData, true)
+      const result = await generateAutoreplyPdf(autoReplyData)
 
       // Assert
       expect(MockConvertHtmlToPdf.generatePdfFromHtml).toHaveBeenCalledOnce()
@@ -131,7 +131,7 @@ describe('mail.utils', () => {
       )
 
       // Act
-      const result = await generateAutoreplyPdf(autoReplyData, true)
+      const result = await generateAutoreplyPdf(autoReplyData)
 
       // Assert
       expect(MockConvertHtmlToPdf.generatePdfFromHtml).toHaveBeenCalledOnce()

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -152,7 +152,6 @@ const generatePdfRenderData = ({
 
 export const generateAutoreplyPdf = (
   autoReplyData: AutoReplyData,
-  isUseLambdaOutput: boolean,
 ): ResultAsync<Buffer, AutoreplyPdfGenerationError> => {
   const pathToTemplate = `${__dirname}/../../views/templates/submit-form-summary-pdf.server.view.html`
 

--- a/src/app/services/mail/mail.utils.ts
+++ b/src/app/services/mail/mail.utils.ts
@@ -171,7 +171,7 @@ export const generateAutoreplyPdf = (
   return safeRenderFile(pathToTemplate, pdfRenderData).andThen(
     (summaryHtml) => {
       return ResultAsync.fromPromise(
-        generatePdfFromHtml(summaryHtml, isUseLambdaOutput),
+        generatePdfFromHtml(summaryHtml),
         (error) => {
           logger.error({
             meta: {

--- a/src/app/utils/__tests__/convert-html-to-pdf.spec.ts
+++ b/src/app/utils/__tests__/convert-html-to-pdf.spec.ts
@@ -135,7 +135,7 @@ describe('convert-html-to-pdf', () => {
       )
 
       // Act
-      const result = await generatePdfFromHtml(MOCK_HTML, true)
+      const result = await generatePdfFromHtml(MOCK_HTML)
 
       // Assert
       // Verify the lambda is invoked with correct parameters

--- a/src/app/utils/__tests__/convert-html-to-pdf.spec.ts
+++ b/src/app/utils/__tests__/convert-html-to-pdf.spec.ts
@@ -1,5 +1,3 @@
-import puppeteer from 'puppeteer-core'
-
 import { aws as AwsConfig } from 'src/app/config/config'
 import {
   PdfGenerationLambdaFailureError,
@@ -8,7 +6,6 @@ import {
 } from 'src/app/modules/core/core.errors'
 import {
   _generatePdfFromHtmlLambdaForTest,
-  _generatePdfFromHtmlLocallyForTest,
   generatePdfFromHtml,
 } from 'src/app/utils/convert-html-to-pdf'
 
@@ -29,44 +26,6 @@ describe('convert-html-to-pdf', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-  })
-
-  describe('generatePdfFromHtmlLocally', () => {
-    const mockPage = {
-      setContent: jest.fn(),
-      pdf: jest.fn().mockResolvedValue(MOCK_PDF_BUFFER),
-    }
-
-    const mockBrowser = {
-      newPage: jest.fn().mockResolvedValue(mockPage),
-      close: jest.fn(),
-    }
-
-    beforeEach(() => {
-      ;(puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser)
-    })
-
-    // TODO: [PDF-LAMBDA-GENERATION]: Remove tests for local pdf generation once lambda is rolled out
-    it('should generate PDF locally using puppeteer', async () => {
-      // Act
-      const result = await _generatePdfFromHtmlLocallyForTest(MOCK_HTML)
-
-      // Assert
-      expect(puppeteer.launch).toHaveBeenCalled()
-      expect(mockPage.setContent).toHaveBeenCalledWith(MOCK_HTML, {
-        waitUntil: 'networkidle0',
-      })
-      expect(mockPage.pdf).toHaveBeenCalledWith({
-        format: 'A4',
-        printBackground: true,
-        margin: {
-          top: '20px',
-          bottom: '40px',
-        },
-      })
-      expect(mockBrowser.close).toHaveBeenCalled()
-      expect(result).toEqual(MOCK_PDF_BUFFER)
-    })
   })
 
   describe('generatePdfFromHtmlLambda', () => {
@@ -150,16 +109,14 @@ describe('convert-html-to-pdf', () => {
     })
   })
 
-  // TODO: [PDF-LAMBDA-GENERATION]: Remove tests for shadowing and using the correct output based on isUseLambdaOutput once lambda is rolled out
   describe('generatePdfFromHtml', () => {
     beforeEach(() => {
       AwsConfig.pdfGeneratorLambda.invoke = jest.fn()
     })
 
-    it('should use lambda output when isUseLambdaOutput is true and not use local output and AwsConfig.pdfGeneratorLambdaFunctionName is defined', async () => {
+    it('should call generatePdfFromHtmlLambda and use its output', async () => {
       // Arrange
       const mockLambdaBuffer = Buffer.from('lambda pdf content')
-      const mockLocalBuffer = Buffer.from('local pdf content')
 
       const DUMMY_PDF_GENERATOR_FUNCTION_NAME =
         'dummy-pdf-generator-function-name'
@@ -177,81 +134,17 @@ describe('convert-html-to-pdf', () => {
         mockLambdaResponse,
       )
 
-      // Mock local response
-      const mockPage = {
-        setContent: jest.fn(),
-        pdf: jest.fn().mockResolvedValue(mockLocalBuffer),
-      }
-      const mockBrowser = {
-        newPage: jest.fn().mockResolvedValue(mockPage),
-        close: jest.fn(),
-      }
-      ;(puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser)
-
       // Act
       const result = await generatePdfFromHtml(MOCK_HTML, true)
 
       // Assert
+      // Verify the lambda is invoked with correct parameters
+      expect(AwsConfig.pdfGeneratorLambda.invoke).toHaveBeenCalledWith({
+        FunctionName: DUMMY_PDF_GENERATOR_FUNCTION_NAME,
+        Payload: JSON.stringify({ html: MOCK_HTML }),
+      })
+      // Verify the result from lambda is returned
       expect(result).toEqual(mockLambdaBuffer)
-      expect(result).not.toEqual(mockLocalBuffer)
-
-      // Verify the lambda invocation parameters
-      expect(AwsConfig.pdfGeneratorLambda.invoke).toHaveBeenCalledWith({
-        FunctionName: DUMMY_PDF_GENERATOR_FUNCTION_NAME,
-        Payload: JSON.stringify({ html: MOCK_HTML }),
-      })
-    })
-
-    it('should generate PDFs using both methods in parallel regardless of isUseLambdaOutput setting if AwsConfig.pdfGeneratorLambdaFunctionName is defined', async () => {
-      // Arrange
-      const mockLambdaBuffer = Buffer.from('lambda pdf content')
-      const mockLocalBuffer = Buffer.from('local pdf content')
-
-      // Mock lambda response
-      const mockLambdaResponse = {
-        Payload: JSON.stringify({
-          statusCode: 200,
-          body: mockLambdaBuffer.toString('base64'),
-        }),
-      }
-
-      // Mock AWS config to ensure lambda function name is defined
-      const DUMMY_PDF_GENERATOR_FUNCTION_NAME =
-        'dummy-pdf-generator-function-name'
-      AwsConfig.pdfGeneratorLambdaFunctionName =
-        DUMMY_PDF_GENERATOR_FUNCTION_NAME
-      ;(AwsConfig.pdfGeneratorLambda.invoke as jest.Mock)
-        .mockResolvedValueOnce(mockLambdaResponse)
-        .mockResolvedValueOnce(mockLambdaResponse)
-
-      // Mock local response
-      const mockPage = {
-        setContent: jest.fn(),
-        pdf: jest.fn().mockResolvedValue(mockLocalBuffer),
-      }
-      const mockBrowser = {
-        newPage: jest.fn().mockResolvedValue(mockPage),
-        close: jest.fn(),
-      }
-      ;(puppeteer.launch as jest.Mock).mockResolvedValue(mockBrowser)
-
-      // Act
-      await Promise.all([
-        generatePdfFromHtml(MOCK_HTML, true),
-        generatePdfFromHtml(MOCK_HTML, false),
-      ])
-
-      // Assert
-      // Both lambda and local generation should be called for each invocation
-      expect(AwsConfig.pdfGeneratorLambda.invoke).toHaveBeenCalledTimes(2)
-      expect(puppeteer.launch).toHaveBeenCalledTimes(0)
-      expect(mockPage.pdf).toHaveBeenCalledTimes(0)
-
-      // Verify the lambda invocation parameters
-      expect(AwsConfig.pdfGeneratorLambda.invoke).toHaveBeenCalledWith({
-        FunctionName: DUMMY_PDF_GENERATOR_FUNCTION_NAME,
-        Payload: JSON.stringify({ html: MOCK_HTML }),
-      })
     })
   })
 })

--- a/src/app/utils/convert-html-to-pdf.ts
+++ b/src/app/utils/convert-html-to-pdf.ts
@@ -97,11 +97,9 @@ const generatePdfFromHtmlLambda = (
  */
 export const generatePdfFromHtml = async (
   summaryHtml: string,
-  isUseLambdaOutput: boolean,
 ): Promise<Buffer> => {
   const logMeta = {
     action: 'generatePdfFromHtml',
-    isUseLambdaOutput,
   }
 
   logger.info({

--- a/src/app/utils/convert-html-to-pdf.ts
+++ b/src/app/utils/convert-html-to-pdf.ts
@@ -1,7 +1,6 @@
 import { err, ok, ResultAsync } from 'neverthrow'
-import puppeteer from 'puppeteer-core'
 
-import config, { aws as AwsConfig } from '../config/config'
+import { aws as AwsConfig } from '../config/config'
 import { createLoggerWithLabel } from '../config/logger'
 import {
   PdfGenerationLambdaFailureError,
@@ -14,42 +13,6 @@ import {
 } from '../modules/datadog/datadog.utils'
 
 const logger = createLoggerWithLabel(module)
-
-// TODO [PDF-LAMBDA-GENERATION]: Remove this local invocation function and associated chromium deps in
-// dev and prod Dockerfiles once pdf generation rollout is complete.
-const generatePdfFromHtmlLocally = async (
-  summaryHtml: string,
-): Promise<Buffer> => {
-  const browser = await puppeteer.launch({
-    args: [
-      '--no-sandbox',
-      '--disable-gpu', // See https://github.com/puppeteer/puppeteer/issues/11640#issuecomment-2361858540
-    ],
-    headless: true,
-    executablePath: config.chromiumBin,
-  })
-  const page = await browser.newPage()
-  await page.setContent(summaryHtml, {
-    waitUntil: 'networkidle0',
-  })
-  const pdfBuffer = await page.pdf({
-    format: 'A4',
-    printBackground: true,
-    margin: {
-      top: '20px',
-      bottom: '40px',
-    },
-  })
-  await browser.close()
-
-  logger.info({
-    message: 'Successfully generated pdf from html using local',
-    meta: {
-      action: 'generatePdfFromHtmlLocally',
-    },
-  })
-  return Buffer.from(pdfBuffer)
-}
 
 const generatePdfFromHtmlLambda = (
   summaryHtml: string,
@@ -180,5 +143,4 @@ export const generatePdfFromHtml = async (
   return lambdaResult.value
 }
 
-export const _generatePdfFromHtmlLocallyForTest = generatePdfFromHtmlLocally
 export const _generatePdfFromHtmlLambdaForTest = generatePdfFromHtmlLambda


### PR DESCRIPTION
Notes to reviewer: 
1. please use review-by-commits
2. deployed to stg-alt3.form.gov.sg for your verification 

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This is an initiative to reduce our engineering load by reducing the packages we need to maintain. Puppeteer-core is a dependency with many transitive dependencies we need to maintain, and should be removed if unused (eg, dep alerts: https://github.com/opengovsg/FormSG/pull/9141) 

This PR removes 28 transitive dependencies we need to maintain version bumps for. 

We have previously [pinned our severless PDF generation](https://github.com/opengovsg/FormSG/issues/8858) without the ability to switch using feature flags. 
Hence, puppeteer-core is no longer used and can be safely removed.  
 
## Solution
<!-- How did you solve the problem? -->
Remove puppeteer core and isUseLambdaOutput which does not toggle anything since we [pinned our severless PDF generation](https://github.com/opengovsg/FormSG/issues/8858). 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests: 
<!-- What tests should be run to confirm functionality? -->
TC1: PDF still works
- [x] Add email notification to a storage mode form. 
- [x] Make a submission and ensure the email is received. 

TC2: Payment proof can still be downloaded
- [x] Submit a payments form. 
- [x] Ensure that payment proof can be downloaded