### PR TITLE
chore: update logform typing and bump winston

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -121,7 +121,7 @@
     "uuid": "^11.1.0",
     "uuid-by-string": "^4.0.0",
     "validator": "^13.15.23",
-    "winston": "^3.13.0",
+    "winston": "^3.19.0",
     "winston-cloudwatch": "^6.3.0",
     "zod": "^3.24.3"
   },

--- a/apps/backend/src/app/config/logger.ts
+++ b/apps/backend/src/app/config/logger.ts
@@ -2,7 +2,7 @@
 import omit from 'lodash/omit'
 import logform from 'logform'
 import path from 'path'
-import tripleBeam from 'triple-beam'
+import { SPLAT } from 'triple-beam'
 import { inspect } from 'util'
 import { v4 as uuidv4 } from 'uuid'
 import { format, Logger, LoggerOptions, loggers, transports } from 'winston'
@@ -37,8 +37,10 @@ export type CustomLoggerParams = {
 const errorHunter = logform.format((info) => {
   if (info.error) return info
 
-  const splat = info[tripleBeam.SPLAT as any] || []
-  info.error = splat.find((obj: any) => obj instanceof Error)
+  const splat = info[SPLAT]
+  if (Array.isArray(splat)) {
+    info.error = splat.find((obj: any) => obj instanceof Error)
+  }
 
   return info
 })
@@ -47,9 +49,8 @@ const errorHunter = logform.format((info) => {
  * Formats the error in the transformable info to a console.error-like format.
  */
 const errorPrinter = logform.format((info) => {
-  if (!info.error) return info
+  if (!info.error || !(info.error instanceof Error)) return info
 
-  // Handle case where Error has no stack.
   const errorMsg = info.error.stack || info.error.toString()
   info.message += `\n${errorMsg}`
 
@@ -106,9 +107,10 @@ export const customFormat = format.printf((info) => {
   // e.g. logger.info('param1', 'param2')
   // The second parameter onwards will be passed into the `splat` key and
   // require formatting (because that is just how the library is written).
-  const splatSymbol = Symbol.for('splat') as unknown as string
-  const splatArgs = info[splatSymbol] || []
-  const rest = splatArgs.map((data: any) => formatWithInspect(data)).join(' ')
+  const splatArgs = info[SPLAT]
+  const rest = Array.isArray(splatArgs)
+    ? splatArgs.map((data: any) => formatWithInspect(data)).join(' ')
+    : ''
   const msg = formatWithInspect(info.message)
 
   return `${info.timestamp} ${info.level} [${info.label}]: ${msg}\t${duration}\t${rest}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,7 @@ importers:
         version: 1.18.2
       express-winston:
         specifier: ^4.2.0
-        version: 4.2.0(winston@3.13.0)
+        version: 4.2.0(winston@3.19.0)
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -380,11 +380,11 @@ importers:
         specifier: ^13.15.23
         version: 13.15.26
       winston:
-        specifier: ^3.13.0
-        version: 3.13.0
+        specifier: ^3.19.0
+        version: 3.19.0
       winston-cloudwatch:
         specifier: ^6.3.0
-        version: 6.3.0(@aws-sdk/client-cloudwatch-logs@3.758.0)(winston@3.13.0)
+        version: 6.3.0(@aws-sdk/client-cloudwatch-logs@3.758.0)(winston@3.19.0)
       zod:
         specifier: ^3.24.3
         version: 3.25.34
@@ -2736,8 +2736,8 @@ packages:
     resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
     engines: {node: '>=18'}
 
-  '@dabh/diagnostics@2.0.3':
-    resolution: {integrity: sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==}
+  '@dabh/diagnostics@2.0.8':
+    resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
 
   '@datadog/browser-core@4.50.1':
     resolution: {integrity: sha512-2ypS19XngsMu6W4qUBtDwvImFz886Im+PziOnEycO1w41TVS5LH8/vWBMvjSf8Suer+CeRjRN9IOu0ocRx9BVw==}
@@ -5020,6 +5020,9 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@so-ric/colorspace@1.1.6':
+    resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
   '@socket.io/component-emitter@3.1.0':
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
 
@@ -7224,14 +7227,26 @@ packages:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
+  color-convert@3.1.3:
+    resolution: {integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==}
+    engines: {node: '>=14.6'}
+
   color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
+
   color-string@1.9.1:
     resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
 
   color-support@1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
@@ -7240,18 +7255,16 @@ packages:
   color2k@2.0.3:
     resolution: {integrity: sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==}
 
-  color@3.2.1:
-    resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
-
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  color@5.0.3:
+    resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
+    engines: {node: '>=18'}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
-  colorspace@1.1.4:
-    resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -10701,6 +10714,10 @@ packages:
 
   logform@2.6.0:
     resolution: {integrity: sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==}
+    engines: {node: '>= 12.0.0'}
+
+  logform@2.7.0:
+    resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
   long@5.2.1:
@@ -14618,12 +14635,12 @@ packages:
       '@aws-sdk/client-cloudwatch-logs': ^3.0.0
       winston: ^3.0.0
 
-  winston-transport@4.7.0:
-    resolution: {integrity: sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==}
+  winston-transport@4.9.0:
+    resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
     engines: {node: '>= 12.0.0'}
 
-  winston@3.13.0:
-    resolution: {integrity: sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==}
+  winston@3.19.0:
+    resolution: {integrity: sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==}
     engines: {node: '>= 12.0.0'}
 
   word-wrap@1.2.5:
@@ -18004,9 +18021,9 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.3': {}
 
-  '@dabh/diagnostics@2.0.3':
+  '@dabh/diagnostics@2.0.8':
     dependencies:
-      colorspace: 1.1.4
+      '@so-ric/colorspace': 1.1.6
       enabled: 2.0.0
       kuler: 2.0.0
 
@@ -20790,6 +20807,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@so-ric/colorspace@1.1.6':
+    dependencies:
+      color: 5.0.3
+      text-hex: 1.0.0
+
   '@socket.io/component-emitter@3.1.0': {}
 
   '@sparticuz/chromium@138.0.2':
@@ -23503,23 +23525,29 @@ snapshots:
     dependencies:
       color-name: 1.1.4
 
+  color-convert@3.1.3:
+    dependencies:
+      color-name: 2.1.0
+
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
+
+  color-name@2.1.0: {}
 
   color-string@1.9.1:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
+    optional: true
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.0
 
   color-support@1.1.3: {}
 
   color2k@2.0.3: {}
-
-  color@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
-      color-string: 1.9.1
 
   color@4.2.3:
     dependencies:
@@ -23527,12 +23555,12 @@ snapshots:
       color-string: 1.9.1
     optional: true
 
-  colorette@2.0.20: {}
-
-  colorspace@1.1.4:
+  color@5.0.3:
     dependencies:
-      color: 3.2.1
-      text-hex: 1.0.0
+      color-convert: 3.1.3
+      color-string: 2.1.4
+
+  colorette@2.0.20: {}
 
   combined-stream@1.0.8:
     dependencies:
@@ -25250,11 +25278,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express-winston@4.2.0(winston@3.13.0):
+  express-winston@4.2.0(winston@3.19.0):
     dependencies:
       chalk: 2.4.2
       lodash: 4.17.23
-      winston: 3.13.0
+      winston: 3.19.0
 
   express@4.21.2:
     dependencies:
@@ -26444,7 +26472,8 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-arrayish@0.3.2: {}
+  is-arrayish@0.3.2:
+    optional: true
 
   is-async-function@2.1.1:
     dependencies:
@@ -28160,6 +28189,15 @@ snapshots:
       uni-global: 1.0.0
 
   logform@2.6.0:
+    dependencies:
+      '@colors/colors': 1.6.0
+      '@types/triple-beam': 1.3.2
+      fecha: 4.2.3
+      ms: 2.1.3
+      safe-stable-stringify: 2.4.3
+      triple-beam: 1.3.0
+
+  logform@2.7.0:
     dependencies:
       '@colors/colors': 1.6.0
       '@types/triple-beam': 1.3.2
@@ -31307,6 +31345,7 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
+    optional: true
 
   simplur@3.0.1: {}
 
@@ -33057,7 +33096,7 @@ snapshots:
 
   wildstring@1.0.9: {}
 
-  winston-cloudwatch@6.3.0(@aws-sdk/client-cloudwatch-logs@3.758.0)(winston@3.13.0):
+  winston-cloudwatch@6.3.0(@aws-sdk/client-cloudwatch-logs@3.758.0)(winston@3.19.0):
     dependencies:
       '@aws-sdk/client-cloudwatch-logs': 3.758.0
       async: 3.2.6
@@ -33067,27 +33106,27 @@ snapshots:
       lodash.find: 4.6.0
       lodash.isempty: 4.4.0
       lodash.iserror: 3.1.1
-      winston: 3.13.0
+      winston: 3.19.0
 
-  winston-transport@4.7.0:
+  winston-transport@4.9.0:
     dependencies:
-      logform: 2.6.0
+      logform: 2.7.0
       readable-stream: 3.6.2
       triple-beam: 1.3.0
 
-  winston@3.13.0:
+  winston@3.19.0:
     dependencies:
       '@colors/colors': 1.6.0
-      '@dabh/diagnostics': 2.0.3
+      '@dabh/diagnostics': 2.0.8
       async: 3.2.6
       is-stream: 2.0.1
-      logform: 2.6.0
+      logform: 2.7.0
       one-time: 1.0.0
       readable-stream: 3.6.2
       safe-stable-stringify: 2.4.3
       stack-trace: 0.0.10
       triple-beam: 1.3.0
-      winston-transport: 4.7.0
+      winston-transport: 4.9.0
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
bump winston from v3.13.0 to v3.19.0 to close https://github.com/opengovsg/FormSG/pull/8781. 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
 No - this PR is backwards compatible  