### PR TITLE
fix(react-email-preview): update paths for template imports in email preview

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - develop
-      - fix/chromatic-failures
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - develop
+      - fix/chromatic-failures
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/packages/react-email-preview/emails/BounceNotification.tsx
+++ b/packages/react-email-preview/emails/BounceNotification.tsx
@@ -1,5 +1,5 @@
-import { BounceNotification } from '../../../src/app/views/templates/BounceNotification'
+import { BounceNotification } from '../../../apps/backend/src/app/views/templates/BounceNotification'
 
-export type { BounceNotificationHtmlData } from '../../../src/app/services/mail/mail.types'
+export type { BounceNotificationHtmlData } from '../../../apps/backend/src/app/services/mail/mail.types'
 
 export default BounceNotification

--- a/packages/react-email-preview/emails/BounceNotification.tsx
+++ b/packages/react-email-preview/emails/BounceNotification.tsx
@@ -1,5 +1,5 @@
-import { BounceNotification } from '../../../apps/backend/src/app/views/templates/BounceNotification'
+import { BounceNotification } from 'formsg-backend/src/app/views/templates/BounceNotification'
 
-export type { BounceNotificationHtmlData } from '../../../apps/backend/src/app/services/mail/mail.types'
+export type { BounceNotificationHtmlData } from 'formsg-backend/src/app/services/mail/mail.types'
 
 export default BounceNotification

--- a/packages/react-email-preview/emails/EmailAddressVerificationOtp.tsx
+++ b/packages/react-email-preview/emails/EmailAddressVerificationOtp.tsx
@@ -1,5 +1,5 @@
-import { EmailAddressVerificationOtp } from '../../../apps/backend/src/app/views/templates/EmailAddressVerificationOtp'
+import { EmailAddressVerificationOtp } from 'formsg-backend/src/app/views/templates/EmailAddressVerificationOtp'
 
-export type { EmailAddressVerificationOtpHtmlData } from '../../../apps/backend/src/app/views/templates/EmailAddressVerificationOtp'
+export type { EmailAddressVerificationOtpHtmlData } from 'formsg-backend/src/app/views/templates/EmailAddressVerificationOtp'
 
 export default EmailAddressVerificationOtp

--- a/packages/react-email-preview/emails/EmailAddressVerificationOtp.tsx
+++ b/packages/react-email-preview/emails/EmailAddressVerificationOtp.tsx
@@ -1,5 +1,5 @@
-import { EmailAddressVerificationOtp } from '../../../src/app/views/templates/EmailAddressVerificationOtp'
+import { EmailAddressVerificationOtp } from '../../../apps/backend/src/app/views/templates/EmailAddressVerificationOtp'
 
-export type { EmailAddressVerificationOtpHtmlData } from '../../../src/app/views/templates/EmailAddressVerificationOtp'
+export type { EmailAddressVerificationOtpHtmlData } from '../../../apps/backend/src/app/views/templates/EmailAddressVerificationOtp'
 
 export default EmailAddressVerificationOtp

--- a/packages/react-email-preview/emails/MrfWorkflowEmail.tsx
+++ b/packages/react-email-preview/emails/MrfWorkflowEmail.tsx
@@ -1,5 +1,5 @@
-import { MrfWorkflowEmail } from '../../../apps/backend/src/app/views/templates/MrfWorkflowEmail'
+import { MrfWorkflowEmail } from 'formsg-backend/src/app/views/templates/MrfWorkflowEmail'
 
-export type { WorkflowEmailData } from '../../../apps/backend/src/app/views/templates/MrfWorkflowEmail'
+export type { WorkflowEmailData } from 'formsg-backend/src/app/views/templates/MrfWorkflowEmail'
 
 export default MrfWorkflowEmail

--- a/packages/react-email-preview/emails/MrfWorkflowEmail.tsx
+++ b/packages/react-email-preview/emails/MrfWorkflowEmail.tsx
@@ -1,5 +1,5 @@
-import { MrfWorkflowEmail } from '../../../src/app/views/templates/MrfWorkflowEmail'
+import { MrfWorkflowEmail } from '../../../apps/backend/src/app/views/templates/MrfWorkflowEmail'
 
-export type { WorkflowEmailData } from '../../../src/app/views/templates/MrfWorkflowEmail'
+export type { WorkflowEmailData } from '../../../apps/backend/src/app/views/templates/MrfWorkflowEmail'
 
 export default MrfWorkflowEmail

--- a/packages/react-email-preview/package.json
+++ b/packages/react-email-preview/package.json
@@ -10,6 +10,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "formsg-backend": "workspace:*",
     "@react-email/components": "^0.0.26",
     "react": "^18.2.0",
     "react-email": "^4.0.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1097,6 +1097,9 @@ importers:
       '@react-email/components':
         specifier: ^0.0.26
         version: 0.0.26(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      formsg-backend:
+        specifier: workspace:*
+        version: link:../../apps/backend
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -14588,8 +14591,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.577.0(@aws-sdk/client-sts@3.577.0)
-      '@aws-sdk/client-sts': 3.577.0
+      '@aws-sdk/client-sso-oidc': 3.577.0
+      '@aws-sdk/client-sts': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
       '@aws-sdk/core': 3.576.0
       '@aws-sdk/credential-provider-node': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -14676,11 +14679,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.577.0(@aws-sdk/client-sts@3.577.0)':
+  '@aws-sdk/client-sso-oidc@3.577.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.577.0
+      '@aws-sdk/client-sts': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
       '@aws-sdk/core': 3.576.0
       '@aws-sdk/credential-provider-node': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -14719,7 +14722,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.693.0)':
@@ -14896,11 +14898,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.577.0':
+  '@aws-sdk/client-sts@3.577.0(@aws-sdk/client-sso-oidc@3.577.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.577.0(@aws-sdk/client-sts@3.577.0)
+      '@aws-sdk/client-sso-oidc': 3.577.0
       '@aws-sdk/core': 3.576.0
       '@aws-sdk/credential-provider-node': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -14939,6 +14941,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.693.0':
@@ -15129,7 +15132,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.577.0(@aws-sdk/client-sso-oidc@3.577.0)(@aws-sdk/client-sts@3.577.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.577.0
+      '@aws-sdk/client-sts': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
       '@aws-sdk/credential-provider-env': 3.577.0
       '@aws-sdk/credential-provider-process': 3.577.0
       '@aws-sdk/credential-provider-sso': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
@@ -15375,7 +15378,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.577.0(@aws-sdk/client-sts@3.577.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.577.0
+      '@aws-sdk/client-sts': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/types': 3.7.2
@@ -15746,7 +15749,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.577.0(@aws-sdk/client-sso-oidc@3.577.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.577.0(@aws-sdk/client-sts@3.577.0)
+      '@aws-sdk/client-sso-oidc': 3.577.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/shared-ini-file-loader': 3.1.12


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Chromatic jobs are failing due to relative import paths being incorrect (in email preview)

## Solution
<!-- How did you solve the problem? -->

Update to the import paths (following `apps/backend/src`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  