### PR TITLE
fix(frontend): pdf bulk download progress modal janks

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -16,7 +16,6 @@ import simplur from 'simplur'
 
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
 import { BxsChevronUp } from '~assets/icons/BxsChevronUp'
-import { useTimeout } from '~hooks/useTimeout'
 import { useToast } from '~hooks/useToast'
 import Button from '~components/Button'
 import Checkbox from '~components/Checkbox'
@@ -154,9 +153,6 @@ export const DownloadButton = (): JSX.Element => {
     isClosable: true,
   })
 
-  const [progressModalTimeout, setProgressModalTimeout] = useState<
-    number | null
-  >(null)
   const { downloadParams, dateRangeResponsesCount } =
     useStorageResponsesContext()
 
@@ -180,8 +176,6 @@ export const DownloadButton = (): JSX.Element => {
     dateRangeResponsesCount,
     downloadOptions.isDownloadPdf,
   ])
-
-  useTimeout(onProgressModalOpen, progressModalTimeout)
 
   const [downloadMetadata, setDownloadMetadata] = useState<
     DownloadResult | CanceledResult
@@ -224,7 +218,6 @@ export const DownloadButton = (): JSX.Element => {
         })
       },
       onSettled: (decryptResult) => {
-        setProgressModalTimeout(null)
         setDownloadMetadata(decryptResult)
         resetDownloadOptions()
       },
@@ -233,7 +226,6 @@ export const DownloadButton = (): JSX.Element => {
 
   const handleBulkDownload = useCallback(() => {
     if (!downloadParams) return
-    setProgressModalTimeout(5000)
     datadogLogs.logger.info('Bulk download used', {
       meta: {
         action: 'bulkDownload',
@@ -252,7 +244,6 @@ export const DownloadButton = (): JSX.Element => {
 
   const resetDownload = useCallback(() => {
     setDownloadCount(0)
-    setProgressModalTimeout(null)
     abortDecryption()
     onProgressModalClose()
   }, [abortDecryption, onProgressModalClose])

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/DownloadButton.tsx
@@ -138,16 +138,13 @@ export const DownloadButton = (): JSX.Element => {
     onOpen: onDownloadModalOpen,
   } = useDisclosure({
     // Reset metadata if it exists.
-    onOpen: () => setDownloadMetadata(undefined),
+    onOpen: () => resetDownloadMetadataAndProgress(),
   })
-  const {
-    isOpen: isProgressModalOpen,
-    onClose: onProgressModalClose,
-    onOpen: onProgressModalOpen,
-  } = useDisclosure({
-    // Reset metadata if it exists.
-    onOpen: () => setDownloadMetadata(undefined),
-  })
+  const { isOpen: isProgressModalOpen, onClose: onProgressModalClose } =
+    useDisclosure({
+      // Reset metadata if it exists.
+      onOpen: () => resetDownloadMetadataAndProgress(),
+    })
 
   const toast = useToast({
     isClosable: true,
@@ -181,13 +178,21 @@ export const DownloadButton = (): JSX.Element => {
     DownloadResult | CanceledResult
   >()
 
+  const resetDownloadProgress = useCallback(() => {
+    setDownloadCount(0)
+    setPdfGenerationCount(0)
+  }, [])
+  const resetDownloadMetadataAndProgress = useCallback(() => {
+    setDownloadMetadata(undefined)
+    resetDownloadProgress()
+  }, [])
+
   const { handleBulkDownloadMutation, abortDecryption } = useDecryptionWorkers({
     onDecryptionProgress: setDownloadCount,
     onPdfGenerationProgress: setPdfGenerationCount,
     mutateProps: {
       onMutate: () => {
-        // Reset metadata if it exists.
-        setDownloadMetadata(undefined)
+        resetDownloadMetadataAndProgress()
       },
       onSuccess: ({ successCount, expectedCount, errorCount }) => {
         if (downloadParams?.responsesCount === 0) {
@@ -219,6 +224,7 @@ export const DownloadButton = (): JSX.Element => {
       },
       onSettled: (decryptResult) => {
         setDownloadMetadata(decryptResult)
+        resetDownloadProgress()
         resetDownloadOptions()
       },
     },
@@ -243,7 +249,7 @@ export const DownloadButton = (): JSX.Element => {
   }, [downloadParams, handleBulkDownloadMutation, downloadOptions])
 
   const resetDownload = useCallback(() => {
-    setDownloadCount(0)
+    resetDownloadProgress()
     abortDecryption()
     onProgressModalClose()
   }, [abortDecryption, onProgressModalClose])
@@ -252,7 +258,7 @@ export const DownloadButton = (): JSX.Element => {
     resetDownload()
     onDownloadModalClose()
     onProgressModalClose()
-    setDownloadMetadata(undefined)
+    resetDownloadMetadataAndProgress()
   }, [onDownloadModalClose, onProgressModalClose, resetDownload])
 
   const handleNoAttachmentsDownloadCancel = useCallback(() => {

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -294,6 +294,9 @@ const useDecryptionWorkers = ({
             if (isDownloadPdf) {
               const pdfZip = new JSZip()
               for (const decryptResult of decryptResults) {
+                if (freshAbortController.signal.aborted) {
+                  return
+                }
                 const { parsedSubmission, decryptedResponses } = decryptResult
                 if (
                   decryptedResponses !== undefined &&
@@ -372,6 +375,9 @@ const useDecryptionWorkers = ({
           })
           // Step 2: Generate the actual CSV file from the csv object.
           .finally(() => {
+            if (freshAbortController.signal.aborted) {
+              return
+            }
             const checkComplete = () => {
               if (!isDownloadCsv || !csvGenerator) {
                 killWorkers(workerPool)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Issue 1: 
<img width="1528" height="880" alt="image" src="https://github.com/user-attachments/assets/315d117c-abe6-47dd-8778-6da7f3ec2b14" />
Due to the progress count not resetting between runs and continuing from the past undefined value, the modal count can exceed 100%. 

Issue 2: 
<img width="1550" height="792" alt="image" src="https://github.com/user-attachments/assets/071d63bc-6483-409e-91dd-d3a8cf48d9ed" />
There is a progress modal timeout that spawns another modal (i believe it is for legacy reasons, where when the csv only button is clicked but is not done after 5s, a modal appears to show the progress). This behavior adds additional complexity to pdf gen / attachments download cases, and hence recommended to remove. 

Issue 3: 
Abort does not work once the function is past the submission streaming stage (eg, during decryption and pdf gen). 

Closes FRM-2333

## Solution
<!-- How did you solve the problem? -->
For issue 1: 
Reset the decryption and pdf states to 0 after each run and before. (commit 2/3 [here](519305db74b26592b36277c09dd543bb834dcc8b)) 
 
For issue 2: 
Remove this spawning behavior (commit 3/3 [here](bc6cde15fe3ade249a4952f0e781906a89a8789a))

For issue 3: 
Add checks for aborted signal from the AbortController, abort by returning when the signal is detected. (commit 1/3 [here](76c680438425530e5161cce334abe88c8aa6a1e9))   

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
TC1: Repeated bulk downloads work correctly 
- [x] Choose a form with many submissions (>100 preferable)
- [x] Try a combination of pdf, attachment, csv bulk downloads
- [x] Repeatedly run the bulk download (eg, 5 times) and ensure the progress modal displays the correct percentage and the download is successful. 
- [x] Assert no double modal pops up.  

TC2: Bulk download aborts work 
- [x] Start an attachment bulk download. Click on cancel. Ensure it works and the main thread is responsive, all threads are killed in chrome://inspect/#workers. 
- [x] Start a PDF bulk download. Click on cancel once it crosses 50%. Ensure that the main thread is responsive, all threads are killed in chrome://inspect/#workers