### PR TITLE
fix(frontend): save draft header hover style

### DIFF
--- a/apps/frontend/src/features/public-form/components/FormStartPage/FormHeaderSaveDraftButton.tsx
+++ b/apps/frontend/src/features/public-form/components/FormStartPage/FormHeaderSaveDraftButton.tsx
@@ -24,10 +24,11 @@ export const FormHeaderSaveDraftButton = ({
     ? t('features.publicForm.components.saveDraft.tooltip.lastSaved', {
         lastSavedDateTimeString: draftLastSavedDateTimeString,
       })
-    : t('features.publicForm.components.saveDraft.tooltip.default')
+    : ''
 
   return (
     <Tooltip
+      isDisabled={!tooltipLabel}
       placement={isMobile ? 'top' : 'left'}
       label={<Text data-chromatic="ignore">{tooltipLabel}</Text>}
     >

--- a/apps/frontend/src/features/public-form/components/FormStartPage/FormHeaderSaveDraftButton.tsx
+++ b/apps/frontend/src/features/public-form/components/FormStartPage/FormHeaderSaveDraftButton.tsx
@@ -46,7 +46,7 @@ export const FormHeaderSaveDraftButton = ({
       ) : (
         <Button
           onClick={onSaveDraft}
-          variant="inverseOutline"
+          outline="1px solid"
           colorScheme={colorScheme}
           leftIcon={<BiSave fontSize="1.25rem" />}
           aria-label={t(


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Issue 1: The current save draft header style does not have the on hover styling applied, which is inconsistent with the other buttons on the form filling page.  

Issue 2: The tooltip is displayed with "Save a draft" when no draft exists. This is not required since the button already has the label text. 

Closes FRM-2335

## Solution
<!-- How did you solve the problem? -->
Issue 1: The button uses the `inverseOutline` variant to achieve the white outline, which does not support the hover styling. 
Instead, we should use the default variant which supports the hover styling, but add the outline style instead. 

Issue 2: Remove the tooltip if a draft does not exist. 

eg, when hovering (no tooltip + the hover makes the bg darker) 
<img width="200" height="123" alt="image" src="https://github.com/user-attachments/assets/61de2469-eb9d-41f0-801a-29c04d0830ac" />


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Header save draft tooltip does not show when no draft 
- [ ] Enable save draft for form and go to submission page. 
- [ ] Assert the tooltip does not appear when no draft has been made and the button is hovered over. 
- [ ] Save a draft. 
- [ ] Assert the tooltip for last saved appears. 

TC2: Header save draft button hover works 
- [ ] Enable save draft for form and go to submission page. 
- [ ] Assert the header save draft button hover animation works when hovered over. 