### PR TITLE
feat(frontend): add savedraft beta badge

### DIFF
--- a/apps/frontend/src/components/Toggle/Toggle.tsx
+++ b/apps/frontend/src/components/Toggle/Toggle.tsx
@@ -1,10 +1,13 @@
+import { useTranslation } from 'react-i18next'
 import {
+  Badge,
   Box,
   ComponentWithAs,
   CSSObject,
   Flex,
   forwardRef,
   Icon,
+  Text,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
 
@@ -24,6 +27,11 @@ export interface ToggleProps extends Omit<SwitchProps, 'children'> {
    * Main label of the toggle
    */
   label: string
+  /**
+   * Whether to show the beta badge
+   * @default false
+   */
+  betaBadge?: boolean
   /**
    * Secondary description text
    */
@@ -59,10 +67,20 @@ type ToggleWithParts = ComponentWithAs<'input', ToggleProps> & {
   Switch: typeof Switch
 }
 
+const BetaBadge = () => {
+  const { t } = useTranslation()
+  return (
+    <Badge colorScheme="primary" variant="subtle" color="secondary.500">
+      {t('features.common.betaBadgeLabel')}
+    </Badge>
+  )
+}
+
 export const Toggle = forwardRef<ToggleProps, 'input'>(
   (
     {
       label,
+      betaBadge = false,
       description,
       containerStyles,
       labelStyles,
@@ -81,7 +99,15 @@ export const Toggle = forwardRef<ToggleProps, 'input'>(
           <Box __css={styles.textContainer}>
             <Flex alignItems="center">
               <FormLabel.Label sx={{ ...styles.label, ...labelStyles }}>
-                {label}
+                <Text>
+                  {label}
+                  {betaBadge ? (
+                    <>
+                      {' '}
+                      <BetaBadge />
+                    </>
+                  ) : null}
+                </Text>
               </FormLabel.Label>
               {tooltipText && (
                 <Tooltip

--- a/apps/frontend/src/features/admin-form/responses/components/FormResultsNavbar/FormResultsNavbar.tsx
+++ b/apps/frontend/src/features/admin-form/responses/components/FormResultsNavbar/FormResultsNavbar.tsx
@@ -88,7 +88,7 @@ export const FormResultsNavbar = (): JSX.Element => {
               color="secondary.500"
               ml="0.5rem"
             >
-              {t('features.common.beta')}
+              {t('features.common.betaBadgeLabel')}
             </Badge>
           </NavigationTab>
         ) : null}

--- a/apps/frontend/src/features/admin-form/settings/components/FormSaveDraftToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormSaveDraftToggle.tsx
@@ -30,6 +30,7 @@ const FormSaveDraftToggle = () => {
     <Skeleton isLoaded={!isLoadingSettings && !!settings}>
       <Toggle
         label={t('features.adminForm.settings.general.saveDraft.label')}
+        betaBadge
         description={t(
           'features.adminForm.settings.general.saveDraft.description',
         )}

--- a/apps/frontend/src/i18n/locales/features/common/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/common/en-sg.ts
@@ -94,7 +94,6 @@ export const enSG: Common = {
     ariaLabel: 'Click to edit the form',
   },
   moreOptions: 'More options',
-  beta: 'Beta',
   betaBadgeLabel: 'Beta',
   average: 'Average',
   notApplicable: 'N/A',

--- a/apps/frontend/src/i18n/locales/features/common/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/common/en-sg.ts
@@ -95,7 +95,7 @@ export const enSG: Common = {
   },
   moreOptions: 'More options',
   beta: 'Beta',
-  betaBadgeLabel: 'beta',
+  betaBadgeLabel: 'Beta',
   average: 'Average',
   notApplicable: 'N/A',
   file: 'File',

--- a/apps/frontend/src/i18n/locales/features/common/index.ts
+++ b/apps/frontend/src/i18n/locales/features/common/index.ts
@@ -94,7 +94,6 @@ export interface Common {
     ariaLabel: string
   }
   moreOptions: string
-  beta: string
   betaBadgeLabel: string
   average: string
   notApplicable: string


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
To signal to admins that the save draft feature is under beta. 

Closes FRM-2336. 

## Solution
<!-- How did you solve the problem? -->
Add betaBadge support for toggles and enable it for the save draft setting toggle. 

eg, on desktop screen: 
<img width="719" height="82" alt="image" src="https://github.com/user-attachments/assets/a7da7294-b837-404c-9dce-dd5bbf5bc701" />
eg, on iphone SE: 
<img width="241" height="170" alt="image" src="https://github.com/user-attachments/assets/a6c49516-72ee-4ab0-ab9b-3c96dd7317bd" />


**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Beta badge appears for save draft admin toggle 
- [ ] Go to the settings page. 
- [ ] Assert that the save draft toggle has the beta badge. 
- [ ] Try and use mobile screen size. 
- [ ] Assert the save draft badge does not look janky.   