### PR TITLE
chore: remove eslint cache generation

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -4,9 +4,6 @@
     "htmlhint",
     "prettier --write"
   ],
-  "apps/frontend/**/*.{ts,tsx,js}": [
-    "prettier --write",
-    "eslint --cache --fix"
-  ],
+  "apps/frontend/**/*.{ts,tsx,js}": ["prettier --write", "eslint --fix"],
   "**/*.json": ["prettier --write"]
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
.eslintcache is generated during the lint staged pre-commit hook. We should remove this as it is causing dev friction and not being used. 

## Solution
<!-- How did you solve the problem? -->
Remove the --cache flag in the lint staged pre-commit hook

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  