### PR TITLE
feat(frontend): vertically stack save draft and submission buttons on mobile

### DIFF
--- a/apps/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -169,7 +169,7 @@ export const PublicFormSubmitButton = ({
         isOpen={isSingleSubmissionOnlyModalOpen}
         onClose={onSingleSubmissionModalClose}
       />
-      <Flex w="100" gap="1rem">
+      <Flex flexDir={isMobile ? 'column' : 'row'} w="100" gap="1rem">
         {isSaveDraftEnabled && (
           <PublicFormSaveDraftButton flex={1} isFullWidth={isMobile} />
         )}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
On mobile, the save draft and submit button should be stacked, for the following reasons: 
- larger tap area
- want users to see save draft first if its enabled

This change has been deployed to stg-alt3.form.gov.sg for review. 

Closes FRM-2338

## Solution
<!-- How did you solve the problem? -->
Change the `flexDir` to `column` if `isMobile`.   

eg, on mobile 
<img width="300" height="584" alt="image" src="https://github.com/user-attachments/assets/d5667607-e8f0-42b8-abb5-b936e8c85515" />
eg, on desktop screen 
<img width="800" height="694" alt="image" src="https://github.com/user-attachments/assets/bdf033e9-cb5f-45a0-8564-9ec8c78c1bb7" />

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  