### PR TITLE
feat(backend, shared): default admin email mrf

### DIFF
--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -615,6 +615,45 @@ describe('admin-form.controller', () => {
       )
     })
 
+    it('should inject admin email when creating Multirespondent form with empty emails', async () => {
+      // Arrange
+      const mockRes = expressHandler.mockResponse()
+      const MOCK_MRF_PARAMS: CreateFormBodyDto = {
+        responseMode: FormResponseMode.Multirespondent,
+        publicKey: 'example public key',
+        title: 'example MRF form title',
+        emails: [],
+      }
+      const MOCK_REQ_MRF = expressHandler.mockRequest({
+        session: {
+          user: {
+            _id: MOCK_USER_ID,
+          },
+        },
+        body: {
+          form: MOCK_MRF_PARAMS,
+        },
+      })
+      MockUserService.findUserById.mockReturnValueOnce(okAsync(MOCK_USER))
+      MockAdminFormService.createForm.mockReturnValueOnce(okAsync(MOCK_FORM))
+
+      // Act
+      await AdminFormController.createForm(MOCK_REQ_MRF, mockRes, jest.fn())
+
+      // Assert
+      expect(mockRes.json).toHaveBeenCalledWith(MOCK_FORM)
+      expect(MockUserService.findUserById).toHaveBeenCalledWith(MOCK_USER_ID)
+      // Should inject admin email when creating MRF with empty emails
+      expect(MockAdminFormService.createForm).toHaveBeenCalledWith(
+        {
+          ...MOCK_MRF_PARAMS,
+          admin: MOCK_USER._id,
+          emails: [MOCK_USER.email],
+        },
+        undefined,
+      )
+    })
+
     it(
       'should return 500 when database error occurs during user retrieval',
       async () => {
@@ -3354,6 +3393,7 @@ describe('admin-form.controller', () => {
           responseMode: FormResponseMode.Multirespondent,
           publicKey: 'some public key',
           title: 'mock title',
+          emails: [],
         }
         const mockDupedFormView = {
           title: 'mock view',
@@ -3424,6 +3464,7 @@ describe('admin-form.controller', () => {
           responseMode: FormResponseMode.Multirespondent,
           publicKey: 'some public key',
           title: 'mock title',
+          emails: [],
         }
         const mockDupedFormView = {
           title: 'mock view',
@@ -3482,6 +3523,59 @@ describe('admin-form.controller', () => {
           MOCK_FORM,
           MOCK_USER_ID,
           expectedParams,
+          { workspaceId: undefined, overrideEmails: undefined },
+        )
+      })
+
+      it('should inject admin email when duplicating Multirespondent form with empty emails', async () => {
+        // Arrange
+        const expectedParams: DuplicateFormBodyDto = {
+          responseMode: FormResponseMode.Multirespondent,
+          publicKey: 'example public key',
+          title: 'example title',
+          emails: [],
+        }
+        const mockDupedFormView = {
+          title: 'example view',
+        } as AdminDashboardFormMetaDto
+        const mockDupedForm = merge({}, MOCK_FORM, {
+          title: 'duped form with new title',
+          _id: new ObjectId(),
+          getDashboardView: jest.fn().mockReturnValue(mockDupedFormView),
+        })
+        const mockRes = expressHandler.mockResponse()
+        const mockReqWithParams = merge({}, MOCK_REQ, {
+          body: expectedParams,
+        })
+        MockUserService.getPopulatedUserById.mockReturnValueOnce(
+          okAsync(MOCK_USER),
+        )
+        MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
+          okAsync(MOCK_FORM),
+        )
+        MockAdminFormService.duplicateForm.mockReturnValueOnce(
+          okAsync(mockDupedForm),
+        )
+
+        // Act
+        await AdminFormController.duplicateAdminForm(
+          mockReqWithParams,
+          mockRes,
+          jest.fn(),
+        )
+
+        // Assert
+        // Form is duplicated and admin email is injected
+        expect(mockRes.status).not.toHaveBeenCalled()
+        expect(mockRes.json).toHaveBeenCalledWith(mockDupedFormView)
+        expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+          MOCK_USER_ID,
+        )
+        // The form is duplicated with admin email injected in emails array
+        expect(MockAdminFormService.duplicateForm).toHaveBeenCalledWith(
+          MOCK_FORM,
+          MOCK_USER_ID,
+          { ...expectedParams, emails: [MOCK_USER.email] },
           { workspaceId: undefined, overrideEmails: undefined },
         )
       })
@@ -4046,6 +4140,56 @@ describe('admin-form.controller', () => {
         MOCK_FORM,
         MOCK_USER_ID,
         expectedParams,
+        { overrideEmails: ['andanother@example.com'], isFromTemplate: true },
+      )
+    })
+
+    it('should inject admin email when copying Multirespondent template with empty emails', async () => {
+      // Arrange
+      const expectedParams: DuplicateFormBodyDto = {
+        responseMode: FormResponseMode.Multirespondent,
+        publicKey: 'some public key',
+        title: 'mock new MRF template title',
+        emails: [],
+      }
+      const mockDupedFormView = {
+        title: 'mock MRF template view',
+      } as AdminDashboardFormMetaDto
+      const mockDupedForm = merge({}, MOCK_FORM, {
+        title: 'duped MRF form with new title',
+        _id: new ObjectId(),
+        getDashboardView: jest.fn().mockReturnValue(mockDupedFormView),
+      })
+      const mockRes = expressHandler.mockResponse()
+      const mockReqWithParams = merge({}, MOCK_REQ, {
+        body: expectedParams,
+      })
+      MockUserService.getPopulatedUserById.mockReturnValueOnce(
+        okAsync(MOCK_USER),
+      )
+      MockAuthService.getFormIfPublic.mockReturnValueOnce(okAsync(MOCK_FORM))
+      MockAdminFormService.duplicateForm.mockReturnValueOnce(
+        okAsync(mockDupedForm),
+      )
+
+      // Act
+      await AdminFormController.handleCopyTemplateForm(
+        mockReqWithParams,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.status).not.toHaveBeenCalled()
+      expect(mockRes.json).toHaveBeenCalledWith(mockDupedFormView)
+      expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
+        MOCK_USER_ID,
+      )
+      // Should inject admin email when copying MRF template with empty emails
+      expect(MockAdminFormService.duplicateForm).toHaveBeenCalledWith(
+        MOCK_FORM,
+        MOCK_USER_ID,
+        { ...expectedParams, emails: [MOCK_USER.email] },
         { overrideEmails: ['andanother@example.com'], isFromTemplate: true },
       )
     })

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -3552,6 +3552,12 @@ describe('admin-form.controller', () => {
         MockAuthService.getFormAfterPermissionChecks.mockReturnValueOnce(
           okAsync(MOCK_FORM),
         )
+        const mockCheckFormForPermissions = jest
+          .fn()
+          .mockReturnValue(ok(MOCK_FORM))
+        MockAuthService.checkFormForPermissions.mockReturnValueOnce(
+          mockCheckFormForPermissions,
+        )
         MockAdminFormService.duplicateForm.mockReturnValueOnce(
           okAsync(mockDupedForm),
         )

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -622,7 +622,6 @@ describe('admin-form.controller', () => {
         responseMode: FormResponseMode.Multirespondent,
         publicKey: 'example public key',
         title: 'example MRF form title',
-        emails: [],
       }
       const MOCK_REQ_MRF = expressHandler.mockRequest({
         session: {
@@ -3393,7 +3392,6 @@ describe('admin-form.controller', () => {
           responseMode: FormResponseMode.Multirespondent,
           publicKey: 'some public key',
           title: 'mock title',
-          emails: [],
         }
         const mockDupedFormView = {
           title: 'mock view',
@@ -3464,7 +3462,6 @@ describe('admin-form.controller', () => {
           responseMode: FormResponseMode.Multirespondent,
           publicKey: 'some public key',
           title: 'mock title',
-          emails: [],
         }
         const mockDupedFormView = {
           title: 'mock view',
@@ -3533,7 +3530,6 @@ describe('admin-form.controller', () => {
           responseMode: FormResponseMode.Multirespondent,
           publicKey: 'example public key',
           title: 'example title',
-          emails: [],
         }
         const mockDupedFormView = {
           title: 'example view',

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -3392,6 +3392,7 @@ describe('admin-form.controller', () => {
           responseMode: FormResponseMode.Multirespondent,
           publicKey: 'some public key',
           title: 'mock title',
+          emails: [MOCK_USER.email],
         }
         const mockDupedFormView = {
           title: 'mock view',
@@ -3462,6 +3463,7 @@ describe('admin-form.controller', () => {
           responseMode: FormResponseMode.Multirespondent,
           publicKey: 'some public key',
           title: 'mock title',
+          emails: [MOCK_USER.email],
         }
         const mockDupedFormView = {
           title: 'mock view',
@@ -3530,6 +3532,7 @@ describe('admin-form.controller', () => {
           responseMode: FormResponseMode.Multirespondent,
           publicKey: 'example public key',
           title: 'example title',
+          emails: [MOCK_USER.email],
         }
         const mockDupedFormView = {
           title: 'example view',

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1052,9 +1052,14 @@ export const handleCopyTemplateForm: ControllerHandler<
   return (
     // Step 1: Retrieve currently logged in user.
     UserService.getPopulatedUserById(userId)
-      .andThen((user) =>
-        // Step 2: Check if form is currently public.
-        AuthService.getFormIfPublic(formId).andThen((originalForm) =>
+      .andThen((user) => {
+        // Step 2a: If form is MRF, add admin email to email notifications by default
+        if (overrideParams.responseMode === FormResponseMode.Multirespondent) {
+          overrideParams.emails = [user.email]
+        }
+
+        // Step 2b: Check if form is currently public.
+        return AuthService.getFormIfPublic(formId).andThen((originalForm) =>
           // Step 3: Duplicate form.
           AdminFormService.duplicateForm(originalForm, userId, overrideParams, {
             overrideEmails: [user.email],
@@ -1062,8 +1067,8 @@ export const handleCopyTemplateForm: ControllerHandler<
           })
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),
-        ),
-      )
+        )
+      })
       // Success; return new form's dashboard view.
       .map((dupedDashView) => res.json(dupedDashView))
       // Error; some error occurred in the chain.

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1221,15 +1221,23 @@ export const createForm: ControllerHandler<
     // Step 1: Retrieve currently logged in user.
     UserService.findUserById(sessionUserId)
       // Step 2: Create form with given params and set admin to logged in user.
-      .andThen((user) =>
-        AdminFormService.createForm(
+      .andThen((user) => {
+        // Step 2a: For multirespondent forms, add user's email to emails array if not provided
+        if (
+          formParams.responseMode === FormResponseMode.Multirespondent &&
+          !formParams.emails
+        ) {
+          formParams.emails = [user.email]
+        }
+
+        return AdminFormService.createForm(
           {
             ...formParams,
             admin: user._id,
           },
           workspaceId,
-        ),
-      )
+        )
+      })
       .map((createdForm) => {
         return res
           .status(StatusCodes.OK)

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -920,6 +920,14 @@ export const duplicateAdminForm: ControllerHandler<
 
             const overrideWithDuplicatingAdminEmail =
               !isAdminAllowedToViewWorkflowDetails ? [user.email] : undefined
+
+            // Step 2c: If form is MRF,  add admin email to email notifications by default
+            if (
+              overrideParams.responseMode === FormResponseMode.Multirespondent
+            ) {
+              overrideParams.emails = [user.email]
+            }
+
             return {
               originalForm,
               overrideEmails: overrideWithDuplicatingAdminEmail,

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -348,6 +348,7 @@ export const processDuplicateOverrideProps = (
     case FormResponseMode.Multirespondent:
       overrideProps.publicKey = params.publicKey
       overrideProps.submissionLimit = null
+      overrideProps.emails = params.emails
       break
     case FormResponseMode.Email:
       overrideProps.emails = params.emails

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -442,7 +442,7 @@ export type CreateStorageFormBodyDto = Pick<
 
 export type CreateMultirespondentFormBodyDto = Pick<
   MultirespondentFormDto,
-  'publicKey' | 'responseMode' | 'title'
+  'publicKey' | 'responseMode' | 'title' | 'emails'
 > & { workspaceId?: string }
 
 export type CreateFormBodyDto =

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -423,7 +423,7 @@ export type DuplicateFormOverwriteDto = {
       responseMode: FormResponseMode.Multirespondent
       publicKey: string
       workflow?: FormWorkflowDto
-      emails: string[]
+      emails?: string[]
     }
 )
 
@@ -443,8 +443,8 @@ export type CreateStorageFormBodyDto = Pick<
 
 export type CreateMultirespondentFormBodyDto = Pick<
   MultirespondentFormDto,
-  'publicKey' | 'responseMode' | 'title' | 'emails'
-> & { workspaceId?: string }
+  'publicKey' | 'responseMode' | 'title'
+> & { workspaceId?: string; emails?: string[] }
 
 export type CreateFormBodyDto =
   | CreateEmailFormBodyDto

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -423,6 +423,7 @@ export type DuplicateFormOverwriteDto = {
       responseMode: FormResponseMode.Multirespondent
       publicKey: string
       workflow?: FormWorkflowDto
+      emails: string[]
     }
 )
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When MRF forms are created, the admin's email is not added to email notifications by default. Unlike storage mode, where the admin email by default is added (and configurable) during form mode selection page.

Closes FRM-2329

## Solution
<!-- How did you solve the problem? -->

Add admin email to email notifications (under 'others') by default. Done in the BE utilising authenticated user information. Same behaviour for:
- Creating MRF form
- Duplicating ^
- Copy from template ^

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | --- | --- |
| admin emails in 'others' notifications | <img width="855" height="569" alt="image" src="https://github.com/user-attachments/assets/1bfcad29-4ac2-4cae-8b51-c5c973286cf4" /> | <img width="810" height="486" alt="image" src="https://github.com/user-attachments/assets/a5bc21c8-f126-42c7-ad1b-e0a5e656fb56" /> |

## Tests
<!-- What tests should be run to confirm functionality? -->

**Create MRF form with default admin email added**
- [x] Create a new MRF form
- [x] Confirm that your email is added to 'Others' in email notifications

**Duplicate form with default admin email added**
- [x] (optional) add multiple emails the existing MRF form ^
- [x] Duplicate the form into a new MRF form
- [x] Confirm that only your email is added to 'Others' in email notifications

**Copy-template form with default admin email added**
- [x] With an existing MRF form, copy a template of it to create a new MRF form
- [x] Confirm that only your email is added to 'Others' in email notifications
