### PR TITLE
feat(backend): add forms top up

### DIFF
--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -270,6 +270,7 @@ const config: Config = {
   sessionSecret: basicVars.core.sessionSecret,
   otpLifeSpan: basicVars.core.otpLifeSpan,
   submissionsTopUp: basicVars.core.submissionsTopUp,
+  formsTopUp: basicVars.core.formsTopUp,
   isGeneralMaintenance: basicVars.banner.isGeneralMaintenance,
   isLoginBanner: basicVars.banner.isLoginBanner,
   siteBannerContent: basicVars.banner.siteBannerContent,

--- a/apps/backend/src/app/config/schema.ts
+++ b/apps/backend/src/app/config/schema.ts
@@ -364,6 +364,12 @@ export const optionalVarsSchema: Schema<IOptionalVarsSchema> = {
       default: 0,
       env: 'SUBMISSIONS_TOP_UP',
     },
+    formsTopUp: {
+      doc: 'Number of forms to top up forms statistic by',
+      format: 'int',
+      default: 0,
+      env: 'FORMS_TOP_UP',
+    },
     nodeEnv: {
       doc: 'Express environment mode',
       format: [Environment.Prod, Environment.Dev, Environment.Test],

--- a/apps/backend/src/app/modules/analytics/analytics.service.ts
+++ b/apps/backend/src/app/modules/analytics/analytics.service.ts
@@ -1,7 +1,7 @@
 import * as TE from 'fp-ts/TaskEither'
 import mongoose from 'mongoose'
 
-import { submissionsTopUp } from '../../config/config'
+import { formsTopUp, submissionsTopUp } from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import getAgencyModel from '../../models/agency.server.model'
 import getFormModel from '../../models/form.server.model'
@@ -66,7 +66,10 @@ export const getSubmissionCount = (): TE.TaskEither<DatabaseError, number> => {
  */
 export const getFormCount = (): TE.TaskEither<DatabaseError, number> => {
   return TE.tryCatch(
-    () => FormModel.estimatedDocumentCount().exec(),
+    () =>
+      FormModel.estimatedDocumentCount()
+        .exec()
+        .then((value) => value + formsTopUp),
     (error) => {
       logger.error({
         message: 'Database error when retrieving form collection count',

--- a/apps/backend/src/types/config.ts
+++ b/apps/backend/src/types/config.ts
@@ -107,6 +107,7 @@ export type Config = {
   bounceLifeSpan: number
   formsgSdkMode: PackageMode
   submissionsTopUp: number
+  formsTopUp: number
   customCloudWatchGroup: string
   isGeneralMaintenance: string
   isLoginBanner: string
@@ -187,6 +188,7 @@ export interface IOptionalVarsSchema {
     port: number
     otpLifeSpan: number
     submissionsTopUp: number
+    formsTopUp: number
     nodeEnv: Environment
     useMockPostmanSms: boolean
   }

--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -6,124 +6,452 @@
       "portMappings": [
         { "containerPort": 4545, "hostPort": 4545, "protocol": "tcp" }
       ],
-      "cpu": "<FORMSG_APP_RESERVED_CPU>", 
+      "cpu": "<FORMSG_APP_RESERVED_CPU>",
       "environment": [
-        { "name": "DD_SERVICE", "value": "formsg" }, 
+        { "name": "DD_SERVICE", "value": "formsg" },
         { "name": "DD_ENV", "value": "<DD_ENV>" }
       ],
       "secrets": [
-        { "name": "IS_IAC_MIGRATED", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/IS_IAC_MIGRATED" },
-        { "name": "WOGAA_SECRET_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAA_SECRET_KEY" },
-        { "name": "SIGNING_SECRET_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SIGNING_SECRET_KEY" },
-        { "name": "WEBHOOK_SQS_URL", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WEBHOOK_SQS_URL" },
-        { "name": "VERIFICATION_SECRET_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/VERIFICATION_SECRET_KEY" },
-        { "name": "TURNSTILE_CAPTCHA_PRIVATE", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/TURNSTILE_CAPTCHA_PRIVATE" },
-        { "name": "POSTMAN_MOP_CAMPAIGN_API_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_MOP_CAMPAIGN_API_KEY" },
-        { "name": "POSTMAN_INTERNAL_CAMPAIGN_API_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_INTERNAL_CAMPAIGN_API_KEY" },
-        { "name": "SGID_CLIENT_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_CLIENT_SECRET" },
-        { "name": "SGID_PRIVATE_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_PRIVATE_KEY" },
-        { "name": "SGID_JWT_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_JWT_SECRET" },
-        { "name": "PAYMENT_STRIPE_SECRET_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_STRIPE_SECRET_KEY" },
-        { "name": "PAYMENT_STRIPE_WEBHOOK_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_STRIPE_WEBHOOK_SECRET" },
-        { "name": "AZURE_OPENAI_API_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/AZURE_OPENAI_API_KEY" },
-        { "name": "SINGPASS_ESRVC_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SINGPASS_ESRVC_ID" },
-        { "name": "MYINFO_CLIENT_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_CLIENT_SECRET" },
-        { "name": "MYINFO_JWT_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_JWT_SECRET" },
-        { "name": "SESSION_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SESSION_SECRET" },
-        { "name": "SES_USER", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_USER" },
-        { "name": "SES_PASS", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_PASS" },
-        { "name": "SES_CONFIG_SET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_CONFIG_SET" },
+        {
+          "name": "IS_IAC_MIGRATED",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/IS_IAC_MIGRATED"
+        },
+        {
+          "name": "WOGAA_SECRET_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAA_SECRET_KEY"
+        },
+        {
+          "name": "SIGNING_SECRET_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SIGNING_SECRET_KEY"
+        },
+        {
+          "name": "WEBHOOK_SQS_URL",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WEBHOOK_SQS_URL"
+        },
+        {
+          "name": "VERIFICATION_SECRET_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/VERIFICATION_SECRET_KEY"
+        },
+        {
+          "name": "TURNSTILE_CAPTCHA_PRIVATE",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/TURNSTILE_CAPTCHA_PRIVATE"
+        },
+        {
+          "name": "POSTMAN_MOP_CAMPAIGN_API_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_MOP_CAMPAIGN_API_KEY"
+        },
+        {
+          "name": "POSTMAN_INTERNAL_CAMPAIGN_API_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_INTERNAL_CAMPAIGN_API_KEY"
+        },
+        {
+          "name": "SGID_CLIENT_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_CLIENT_SECRET"
+        },
+        {
+          "name": "SGID_PRIVATE_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_PRIVATE_KEY"
+        },
+        {
+          "name": "SGID_JWT_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_JWT_SECRET"
+        },
+        {
+          "name": "PAYMENT_STRIPE_SECRET_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_STRIPE_SECRET_KEY"
+        },
+        {
+          "name": "PAYMENT_STRIPE_WEBHOOK_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_STRIPE_WEBHOOK_SECRET"
+        },
+        {
+          "name": "AZURE_OPENAI_API_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/AZURE_OPENAI_API_KEY"
+        },
+        {
+          "name": "SINGPASS_ESRVC_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SINGPASS_ESRVC_ID"
+        },
+        {
+          "name": "MYINFO_CLIENT_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_CLIENT_SECRET"
+        },
+        {
+          "name": "MYINFO_JWT_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_JWT_SECRET"
+        },
+        {
+          "name": "SESSION_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SESSION_SECRET"
+        },
+        {
+          "name": "SES_USER",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_USER"
+        },
+        {
+          "name": "SES_PASS",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_PASS"
+        },
+        {
+          "name": "SES_CONFIG_SET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_CONFIG_SET"
+        },
         { "name": "DB_HOST", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/DB_HOST" },
-        { "name": "CUSTOM_CLOUDWATCH_LOG_GROUP", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CUSTOM_CLOUDWATCH_LOG_GROUP" },
-        { "name": "SECRET_ENV", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SECRET_ENV" },
-        { "name": "GOGOV_API_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GOGOV_API_KEY" },
-        { "name": "CRON_PAYMENT_API_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CRON_PAYMENT_API_SECRET" },
-        { "name": "SLACK_API_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SLACK_API_SECRET" },
-        { "name": "GROWTHBOOK_CLIENT_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GROWTHBOOK_CLIENT_KEY" },
-        { "name": "SSM_ENV_SITE_NAME", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SSM_ENV_SITE_NAME" },
-        { "name": "GA_TRACKING_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GA_TRACKING_ID" },
-        { "name": "WOGAA_START_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAA_START_ENDPOINT" },
-        { "name": "WOGAA_FEEDBACK_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAA_FEEDBACK_ENDPOINT" },
-        { "name": "WOGAA_SUBMIT_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAA_SUBMIT_ENDPOINT" },
-        { "name": "TURNSTILE_CAPTCHA", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/TURNSTILE_CAPTCHA" },
-        { "name": "GOOGLE_CAPTCHA", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GOOGLE_CAPTCHA" },
-        { "name": "GOOGLE_CAPTCHA_PUBLIC", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GOOGLE_CAPTCHA_PUBLIC" },
-        { "name": "POSTMAN_MOP_CAMPAIGN_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_MOP_CAMPAIGN_ID" },
-        { "name": "POSTMAN_INTERNAL_CAMPAIGN_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_INTERNAL_CAMPAIGN_ID" },
-        { "name": "POSTMAN_BASE_URL", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_BASE_URL" },
-        { "name": "SGID_CLIENT_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_CLIENT_ID" },
-        { "name": "SGID_ADMIN_LOGIN_REDIRECT_URI", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_ADMIN_LOGIN_REDIRECT_URI" },
-        { "name": "SGID_FORM_LOGIN_REDIRECT_URI", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_FORM_LOGIN_REDIRECT_URI" },
-        { "name": "SGID_PUBLIC_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_PUBLIC_KEY" },
-        { "name": "SGID_HOSTNAME", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_HOSTNAME" },
-        { "name": "PAYMENT_STRIPE_PUBLISHABLE_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_STRIPE_PUBLISHABLE_KEY" },
-        { "name": "PAYMENT_STRIPE_CLIENT_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_STRIPE_CLIENT_ID" },
-        { "name": "PAYMENT_GUIDE_LINK", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_GUIDE_LINK" },
-        { "name": "PAYMENT_LANDING_GUIDE_LINK", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_LANDING_GUIDE_LINK" },
-        { "name": "AZURE_OPENAI_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/AZURE_OPENAI_ENDPOINT" },
-        { "name": "AZURE_OPENAI_DEPLOYMENT_NAME", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/AZURE_OPENAI_DEPLOYMENT_NAME" },
-        { "name": "AZURE_OPENAI_API_VERSION", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/AZURE_OPENAI_API_VERSION" },
-        { "name": "SPCP_COOKIE_MAX_AGE_PRESERVED", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SPCP_COOKIE_MAX_AGE_PRESERVED" },
-        { "name": "SPCP_COOKIE_DOMAIN", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SPCP_COOKIE_DOMAIN" },
-        { "name": "MYINFO_CLIENT_CONFIG", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_CLIENT_CONFIG" },
-        { "name": "MYINFO_CERT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_CERT" },
-        { "name": "MYINFO_FORMSG_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_FORMSG_KEY" },
-        { "name": "MYINFO_CLIENT_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_CLIENT_ID" },
-        { "name": "SP_OIDC_NDI_DISCOVERY_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_NDI_DISCOVERY_ENDPOINT" },
-        { "name": "SP_OIDC_NDI_JWKS_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_NDI_JWKS_ENDPOINT" },
-        { "name": "SP_OIDC_RP_CLIENT_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_CLIENT_ID" },
-        { "name": "SP_OIDC_RP_REDIRECT_URL", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_REDIRECT_URL" },
-        { "name": "SP_OIDC_RP_JWKS_PUBLIC", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_JWKS_PUBLIC" },
-        { "name": "SP_OIDC_RP_JWKS_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_JWKS_SECRET" },
-        { "name": "CP_OIDC_NDI_DISCOVERY_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_NDI_DISCOVERY_ENDPOINT" },
-        { "name": "CP_OIDC_NDI_JWKS_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_NDI_JWKS_ENDPOINT" },
-        { "name": "CP_OIDC_RP_CLIENT_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_RP_CLIENT_ID" },
-        { "name": "CP_OIDC_RP_REDIRECT_URL", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_RP_REDIRECT_URL" },
-        { "name": "CP_OIDC_RP_JWKS_PUBLIC", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_RP_JWKS_PUBLIC" },
-        { "name": "CP_OIDC_RP_JWKS_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_RP_JWKS_SECRET" },
-        { "name": "SINGPASS_IDP_ENDPOINT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SINGPASS_IDP_ENDPOINT" },
-        { "name": "INTRANET_IP_LIST", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/INTRANET_IP_LIST" },
-        { "name": "APP_DESC", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/APP_DESC" },
-        { "name": "APP_NAME", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/APP_NAME" },
-        { "name": "APP_TWITTER_IMAGE", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/APP_TWITTER_IMAGE" },
+        {
+          "name": "CUSTOM_CLOUDWATCH_LOG_GROUP",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CUSTOM_CLOUDWATCH_LOG_GROUP"
+        },
+        {
+          "name": "SECRET_ENV",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SECRET_ENV"
+        },
+        {
+          "name": "GOGOV_API_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GOGOV_API_KEY"
+        },
+        {
+          "name": "CRON_PAYMENT_API_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CRON_PAYMENT_API_SECRET"
+        },
+        {
+          "name": "SLACK_API_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SLACK_API_SECRET"
+        },
+        {
+          "name": "GROWTHBOOK_CLIENT_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GROWTHBOOK_CLIENT_KEY"
+        },
+        {
+          "name": "SSM_ENV_SITE_NAME",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SSM_ENV_SITE_NAME"
+        },
+        {
+          "name": "GA_TRACKING_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GA_TRACKING_ID"
+        },
+        {
+          "name": "WOGAA_START_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAA_START_ENDPOINT"
+        },
+        {
+          "name": "WOGAA_FEEDBACK_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAA_FEEDBACK_ENDPOINT"
+        },
+        {
+          "name": "WOGAA_SUBMIT_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAA_SUBMIT_ENDPOINT"
+        },
+        {
+          "name": "TURNSTILE_CAPTCHA",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/TURNSTILE_CAPTCHA"
+        },
+        {
+          "name": "GOOGLE_CAPTCHA",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GOOGLE_CAPTCHA"
+        },
+        {
+          "name": "GOOGLE_CAPTCHA_PUBLIC",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GOOGLE_CAPTCHA_PUBLIC"
+        },
+        {
+          "name": "POSTMAN_MOP_CAMPAIGN_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_MOP_CAMPAIGN_ID"
+        },
+        {
+          "name": "POSTMAN_INTERNAL_CAMPAIGN_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_INTERNAL_CAMPAIGN_ID"
+        },
+        {
+          "name": "POSTMAN_BASE_URL",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/POSTMAN_BASE_URL"
+        },
+        {
+          "name": "SGID_CLIENT_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_CLIENT_ID"
+        },
+        {
+          "name": "SGID_ADMIN_LOGIN_REDIRECT_URI",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_ADMIN_LOGIN_REDIRECT_URI"
+        },
+        {
+          "name": "SGID_FORM_LOGIN_REDIRECT_URI",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_FORM_LOGIN_REDIRECT_URI"
+        },
+        {
+          "name": "SGID_PUBLIC_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_PUBLIC_KEY"
+        },
+        {
+          "name": "SGID_HOSTNAME",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SGID_HOSTNAME"
+        },
+        {
+          "name": "PAYMENT_STRIPE_PUBLISHABLE_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_STRIPE_PUBLISHABLE_KEY"
+        },
+        {
+          "name": "PAYMENT_STRIPE_CLIENT_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_STRIPE_CLIENT_ID"
+        },
+        {
+          "name": "PAYMENT_GUIDE_LINK",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_GUIDE_LINK"
+        },
+        {
+          "name": "PAYMENT_LANDING_GUIDE_LINK",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_LANDING_GUIDE_LINK"
+        },
+        {
+          "name": "AZURE_OPENAI_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/AZURE_OPENAI_ENDPOINT"
+        },
+        {
+          "name": "AZURE_OPENAI_DEPLOYMENT_NAME",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/AZURE_OPENAI_DEPLOYMENT_NAME"
+        },
+        {
+          "name": "AZURE_OPENAI_API_VERSION",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/AZURE_OPENAI_API_VERSION"
+        },
+        {
+          "name": "SPCP_COOKIE_MAX_AGE_PRESERVED",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SPCP_COOKIE_MAX_AGE_PRESERVED"
+        },
+        {
+          "name": "SPCP_COOKIE_DOMAIN",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SPCP_COOKIE_DOMAIN"
+        },
+        {
+          "name": "MYINFO_CLIENT_CONFIG",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_CLIENT_CONFIG"
+        },
+        {
+          "name": "MYINFO_CERT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_CERT"
+        },
+        {
+          "name": "MYINFO_FORMSG_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_FORMSG_KEY"
+        },
+        {
+          "name": "MYINFO_CLIENT_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_CLIENT_ID"
+        },
+        {
+          "name": "SP_OIDC_NDI_DISCOVERY_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_NDI_DISCOVERY_ENDPOINT"
+        },
+        {
+          "name": "SP_OIDC_NDI_JWKS_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_NDI_JWKS_ENDPOINT"
+        },
+        {
+          "name": "SP_OIDC_RP_CLIENT_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_CLIENT_ID"
+        },
+        {
+          "name": "SP_OIDC_RP_REDIRECT_URL",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_REDIRECT_URL"
+        },
+        {
+          "name": "SP_OIDC_RP_JWKS_PUBLIC",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_JWKS_PUBLIC"
+        },
+        {
+          "name": "SP_OIDC_RP_JWKS_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_JWKS_SECRET"
+        },
+        {
+          "name": "CP_OIDC_NDI_DISCOVERY_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_NDI_DISCOVERY_ENDPOINT"
+        },
+        {
+          "name": "CP_OIDC_NDI_JWKS_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_NDI_JWKS_ENDPOINT"
+        },
+        {
+          "name": "CP_OIDC_RP_CLIENT_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_RP_CLIENT_ID"
+        },
+        {
+          "name": "CP_OIDC_RP_REDIRECT_URL",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_RP_REDIRECT_URL"
+        },
+        {
+          "name": "CP_OIDC_RP_JWKS_PUBLIC",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_RP_JWKS_PUBLIC"
+        },
+        {
+          "name": "CP_OIDC_RP_JWKS_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_RP_JWKS_SECRET"
+        },
+        {
+          "name": "SINGPASS_IDP_ENDPOINT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SINGPASS_IDP_ENDPOINT"
+        },
+        {
+          "name": "INTRANET_IP_LIST",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/INTRANET_IP_LIST"
+        },
+        {
+          "name": "APP_DESC",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/APP_DESC"
+        },
+        {
+          "name": "APP_NAME",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/APP_NAME"
+        },
+        {
+          "name": "APP_TWITTER_IMAGE",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/APP_TWITTER_IMAGE"
+        },
         { "name": "APP_URL", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/APP_URL" },
-        { "name": "IMAGE_S3_BUCKET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/IMAGE_S3_BUCKET" },
-        { "name": "STATIC_ASSETS_S3_BUCKET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/STATIC_ASSETS_S3_BUCKET" },
-        { "name": "LOGO_S3_BUCKET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/LOGO_S3_BUCKET" },
-        { "name": "ATTACHMENT_S3_BUCKET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/ATTACHMENT_S3_BUCKET" },
-        { "name": "FORMSG_SDK_MODE", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/FORMSG_SDK_MODE" },
-        { "name": "MAIL_FROM", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MAIL_FROM" },
-        { "name": "BOUNCE_LIFE_SPAN", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/BOUNCE_LIFE_SPAN" },
-        { "name": "SES_MAX_MESSAGES", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_MAX_MESSAGES" },
-        { "name": "SES_POOL", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_POOL" },
-        { "name": "MAIL_SOCKET_TIMEOUT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MAIL_SOCKET_TIMEOUT" },
-        { "name": "SES_PORT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_PORT" },
-        { "name": "SES_HOST", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_HOST" },
+        {
+          "name": "IMAGE_S3_BUCKET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/IMAGE_S3_BUCKET"
+        },
+        {
+          "name": "STATIC_ASSETS_S3_BUCKET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/STATIC_ASSETS_S3_BUCKET"
+        },
+        {
+          "name": "LOGO_S3_BUCKET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/LOGO_S3_BUCKET"
+        },
+        {
+          "name": "ATTACHMENT_S3_BUCKET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/ATTACHMENT_S3_BUCKET"
+        },
+        {
+          "name": "FORMSG_SDK_MODE",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/FORMSG_SDK_MODE"
+        },
+        {
+          "name": "MAIL_FROM",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MAIL_FROM"
+        },
+        {
+          "name": "BOUNCE_LIFE_SPAN",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/BOUNCE_LIFE_SPAN"
+        },
+        {
+          "name": "SES_MAX_MESSAGES",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_MAX_MESSAGES"
+        },
+        {
+          "name": "SES_POOL",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_POOL"
+        },
+        {
+          "name": "MAIL_SOCKET_TIMEOUT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MAIL_SOCKET_TIMEOUT"
+        },
+        {
+          "name": "SES_PORT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_PORT"
+        },
+        {
+          "name": "SES_HOST",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SES_HOST"
+        },
         { "name": "PORT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PORT" },
-        { "name": "OTP_LIFE_SPAN", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/OTP_LIFE_SPAN" },
-        { "name": "SUBMISSIONS_TOP_UP", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SUBMISSIONS_TOP_UP" },
-        { "name": "NODE_ENV", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/NODE_ENV" },
-        { "name": "SUBMISSIONS_RATE_LIMIT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SUBMISSIONS_RATE_LIMIT" },
-        { "name": "SEND_AUTH_OTP_RATE_LIMIT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SEND_AUTH_OTP_RATE_LIMIT" },
-        { "name": "DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT" },
-        { "name": "GOGOV_BASE_URL", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GOGOV_BASE_URL" },
-        { "name": "PAYMENT_PROOF_S3_BUCKET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_PROOF_S3_BUCKET" },
-        { "name": "DOWNLOAD_FORM_WHITELIST_RATE_LIMIT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/DOWNLOAD_FORM_WHITELIST_RATE_LIMIT" },
-        { "name": "UPLOAD_FORM_WHITELIST_RATE_LIMIT", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/UPLOAD_FORM_WHITELIST_RATE_LIMIT" },
-        { "name": "KILL_EMAIL_MODE_FEEDBACK_FORMID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/KILL_EMAIL_MODE_FEEDBACK_FORMID" },
-        { "name": "OGP_IP_LIST", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/OGP_IP_LIST" },
-        { "name": "RBI_IP_LIST", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/RBI_IP_LIST" },
-        { "name": "SSO_CLIENT_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SSO_CLIENT_ID" }, 
-        { "name": "SSO_CLIENT_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SSO_CLIENT_SECRET" }, 
-        { "name": "SSO_DISCOVERY_URL", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SSO_DISCOVERY_URL" },
-        { "name": "WOGAD_CLIENT_ID", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAD_CLIENT_ID" },
-        { "name": "WOGAD_CLIENT_SECRET", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAD_CLIENT_SECRET" },
-        { "name": "WOGAD_AUTHORITY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAD_AUTHORITY" },
-        { "name": "GUARDDUTY_QUARANTINE_S3_BUCKET", "valueFrom": "/virus-scanner-guardduty/<ENVIRONMENT_SITE_NAME>/GUARDDUTY_QUARANTINE_S3_BUCKET" },
-        { "name": "GUARDDUTY_CLEAN_S3_BUCKET", "valueFrom": "/virus-scanner-guardduty/<ENVIRONMENT_SITE_NAME>/GUARDDUTY_CLEAN_S3_BUCKET" },
-        { "name": "GUARDDUTY_LAMBDA_FUNCTION_NAME", "valueFrom": "/virus-scanner-guardduty/<ENVIRONMENT_SITE_NAME>/GUARDDUTY_LAMBDA_FUNCTION_NAME" }, 
-        { "name": "PDF_GENERATOR_LAMBDA_FUNCTION_NAME", "valueFrom": "/pdf-generator/<ENVIRONMENT_SITE_NAME>/PDF_GENERATOR_LAMBDA_FUNCTION_NAME" }
-      ], 
+        {
+          "name": "OTP_LIFE_SPAN",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/OTP_LIFE_SPAN"
+        },
+        {
+          "name": "SUBMISSIONS_TOP_UP",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SUBMISSIONS_TOP_UP"
+        },
+        {
+          "name": "FORMS_TOP_UP",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/FORMS_TOP_UP"
+        },
+        {
+          "name": "NODE_ENV",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/NODE_ENV"
+        },
+        {
+          "name": "SUBMISSIONS_RATE_LIMIT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SUBMISSIONS_RATE_LIMIT"
+        },
+        {
+          "name": "SEND_AUTH_OTP_RATE_LIMIT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SEND_AUTH_OTP_RATE_LIMIT"
+        },
+        {
+          "name": "DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/DOWNLOAD_PAYMENT_RECEIPT_RATE_LIMIT"
+        },
+        {
+          "name": "GOGOV_BASE_URL",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/GOGOV_BASE_URL"
+        },
+        {
+          "name": "PAYMENT_PROOF_S3_BUCKET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/PAYMENT_PROOF_S3_BUCKET"
+        },
+        {
+          "name": "DOWNLOAD_FORM_WHITELIST_RATE_LIMIT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/DOWNLOAD_FORM_WHITELIST_RATE_LIMIT"
+        },
+        {
+          "name": "UPLOAD_FORM_WHITELIST_RATE_LIMIT",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/UPLOAD_FORM_WHITELIST_RATE_LIMIT"
+        },
+        {
+          "name": "KILL_EMAIL_MODE_FEEDBACK_FORMID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/KILL_EMAIL_MODE_FEEDBACK_FORMID"
+        },
+        {
+          "name": "OGP_IP_LIST",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/OGP_IP_LIST"
+        },
+        {
+          "name": "RBI_IP_LIST",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/RBI_IP_LIST"
+        },
+        {
+          "name": "SSO_CLIENT_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SSO_CLIENT_ID"
+        },
+        {
+          "name": "SSO_CLIENT_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SSO_CLIENT_SECRET"
+        },
+        {
+          "name": "SSO_DISCOVERY_URL",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SSO_DISCOVERY_URL"
+        },
+        {
+          "name": "WOGAD_CLIENT_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAD_CLIENT_ID"
+        },
+        {
+          "name": "WOGAD_CLIENT_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAD_CLIENT_SECRET"
+        },
+        {
+          "name": "WOGAD_AUTHORITY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/WOGAD_AUTHORITY"
+        },
+        {
+          "name": "GUARDDUTY_QUARANTINE_S3_BUCKET",
+          "valueFrom": "/virus-scanner-guardduty/<ENVIRONMENT_SITE_NAME>/GUARDDUTY_QUARANTINE_S3_BUCKET"
+        },
+        {
+          "name": "GUARDDUTY_CLEAN_S3_BUCKET",
+          "valueFrom": "/virus-scanner-guardduty/<ENVIRONMENT_SITE_NAME>/GUARDDUTY_CLEAN_S3_BUCKET"
+        },
+        {
+          "name": "GUARDDUTY_LAMBDA_FUNCTION_NAME",
+          "valueFrom": "/virus-scanner-guardduty/<ENVIRONMENT_SITE_NAME>/GUARDDUTY_LAMBDA_FUNCTION_NAME"
+        },
+        {
+          "name": "PDF_GENERATOR_LAMBDA_FUNCTION_NAME",
+          "valueFrom": "/pdf-generator/<ENVIRONMENT_SITE_NAME>/PDF_GENERATOR_LAMBDA_FUNCTION_NAME"
+        }
+      ],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {
@@ -154,7 +482,10 @@
       "mountPoints": [],
       "volumesFrom": [],
       "secrets": [
-        { "name": "DD_API_KEY", "valueFrom": "/<ENVIRONMENT_SITE_NAME>/DD_API_KEY" }
+        {
+          "name": "DD_API_KEY",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/DD_API_KEY"
+        }
       ],
       "logConfiguration": {
         "logDriver": "awslogs",

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -79,6 +79,7 @@ These are configured by creating groups of environment variables formatted like 
 | `NODE_ENV`           | [Express environment mode](https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production). Defaults to `'production'`. This should always be set to a production environment |
 | `SESSION_SECRET`     | Secret for `express-session` for session management. This should always be set to a secret and random value in a production environment.                                                                   |
 | `SUBMISSIONS_TOP_UP` | Use this to inflate the number of submissions displayed on the landing page. Defaults to `0`.                                                                                                              |
+| `FORMS_TOP_UP` | Use this to inflate the number of submissions displayed on the landing page. Defaults to `0`.                                                                                                              |
 
 **Banners**
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

form and submission numbers on the landing page are not accurate after email mode forms + submissions were moved to archival storage

<img width="1163" height="368" alt="image" src="https://github.com/user-attachments/assets/ef102e15-8ddc-4d01-841e-b3025f1d63a0" />


Closes FRM-2334

## Solution
<!-- How did you solve the problem? -->

Add archival storage numbers to `SUBMISSIONS_TOP_UP` config variable, and `FORMS_TOP_UP` config variable (new). These values are set in form-infra, updating in the PR: https://github.com/opengovsg/formsg-infra/pull/118

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible 