### PR TITLE
fix(dropdown): close popover when parent container scrolls

### DIFF
--- a/apps/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx
+++ b/apps/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import { Box, useMergeRefs, useOutsideClick } from '@chakra-ui/react'
 import {
   autoUpdate,
@@ -62,6 +62,45 @@ export const SelectPopoverProvider: FCC = ({ children }): JSX.Element => {
       return autoUpdate(reference.current, floating.current, update)
     }
   }, [floating, isOpen, reference, update])
+
+  // Close popover when any scrollable ancestor element scrolls.
+  // This prevents the dropdown from appearing above sticky headers or
+  // floating elements after the trigger has scrolled out of view.
+  useEffect(() => {
+    if (!isOpen || !reference.current) return
+
+    const handleScroll = () => {
+      setIsFocused(false)
+    }
+
+    // Walk up the DOM tree and attach scroll listeners to all scrollable ancestors.
+    const cleanups: (() => void)[] = []
+    let element: HTMLElement | null = (
+      reference.current as HTMLElement
+    ).parentElement
+
+    while (element) {
+      const { overflow, overflowY } = getComputedStyle(element)
+      if (
+        ['auto', 'scroll'].some(
+          (v) => overflow.includes(v) || overflowY.includes(v),
+        )
+      ) {
+        element.addEventListener('scroll', handleScroll, { passive: true })
+        const el = element
+        cleanups.push(() => el.removeEventListener('scroll', handleScroll))
+      }
+      element = element.parentElement
+    }
+
+    // Also listen on window for page-level scrolling.
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    cleanups.push(() => window.removeEventListener('scroll', handleScroll))
+
+    return () => {
+      cleanups.forEach((cleanup) => cleanup())
+    }
+  }, [isOpen, reference, setIsFocused])
 
   useOutsideClick({
     ref: wrapperRef,


### PR DESCRIPTION
## Summary
- Close dropdown popover when any scrollable ancestor scrolls, preventing it from appearing above the sticky header
- Walks up the DOM tree to find all scrollable ancestors and attaches passive scroll listeners
- Uses existing `setIsFocused(false)` to close the popover (same mechanism as outside-click handler)

## Related Issue
Closes #6026

## Approach
Rather than adjusting z-index (which just masks the problem), this fix closes the popover when the user scrolls. This matches the behavior expected by the maintainer as described in the feedback on the earlier PR #6501.

## Changes
| File | Change |
|------|--------|
| `apps/frontend/src/components/Dropdown/components/SelectPopover/SelectPopover.tsx` | Add `useEffect` to close popover on ancestor scroll |

## Implementation Detail
The `useEffect` runs when `isOpen` becomes true. It walks `parentElement` up the DOM from the floating-ui `reference` element, checking `getComputedStyle` for `overflow: auto/scroll` on each ancestor. Each scrollable ancestor gets a passive `scroll` listener. The window also gets a listener for page-level scroll. All listeners are removed in the effect cleanup when `isOpen` becomes false or the component unmounts.

## Test Plan
- [ ] Open a dropdown in the form builder sidebar
- [ ] Scroll the sidebar -- dropdown should close
- [ ] Open a dropdown and scroll the page -- dropdown should close
- [ ] Verify dropdown still works normally (open, select, close on click outside)
- [ ] Verify no memory leaks (listeners cleaned up on unmount)