### PR TITLE
fix(ci): include sdk build in dockerfile

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -47,6 +47,7 @@ RUN apk update && apk upgrade && \
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/backend/package.json ./apps/backend/
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/frontend/package.json ./apps/frontend/
 
 RUN pnpm install --frozen-lockfile --filter "!services/*" --filter "!packages/react-email-preview/*"

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -18,6 +18,7 @@ WORKDIR /build
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/backend/package.json ./apps/backend/
 COPY packages/shared/package.json ./packages/shared/
+COPY packages/sdk/package.json ./packages/sdk/
 COPY apps/frontend/package.json ./apps/frontend/
 
 RUN pnpm install --frozen-lockfile --filter "!services/*" --filter "!packages/react-email-preview/*"
@@ -56,6 +57,11 @@ COPY --from=build /build/apps/frontend/dist /opt/formsg/apps/frontend/dist
 COPY --from=build /build/packages/shared/package.json /opt/formsg/packages/shared/
 COPY --from=build /build/packages/shared/node_modules /opt/formsg/packages/shared/node_modules
 COPY --from=build /build/packages/shared/dist /opt/formsg/packages/shared/dist
+# Copy the built formsg-sdk package for the backend to resolve
+COPY --from=build /build/packages/sdk/package.json /opt/formsg/packages/sdk/
+COPY --from=build /build/packages/sdk/node_modules /opt/formsg/packages/sdk/node_modules
+COPY --from=build /build/packages/sdk/cjs-entry.cjs /opt/formsg/packages/sdk/
+COPY --from=build /build/packages/sdk/dist /opt/formsg/packages/sdk/dist
 
 # Copy required node_modules, package.json scripts and built backend dist for the backend start script to run
 COPY --from=build /build/pnpm-workspace.yaml /opt/formsg/pnpm-workspace.yaml


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Fixes the build issue with SDK inclusion in the container.

Related to #9221.

## Solution
<!-- How did you solve the problem? -->

Copy SDK build output into the production container.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Include the build output of SDK into the container build image

## Before & After Screenshots

- It [works](https://github.com/opengovsg/FormSG/actions/runs/23585337726/job/68676988669?pr=9240)!
- Previously [broken](https://github.com/opengovsg/FormSG/actions/runs/23584611046/job/68674651730#step:8:778).

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->