### PR TITLE
fix(backend): enable frontend assets caching

### DIFF
--- a/apps/backend/src/app/loaders/express/index.ts
+++ b/apps/backend/src/app/loaders/express/index.ts
@@ -139,10 +139,22 @@ const loadExpressApp = async (connection: Connection) => {
     }),
   )
 
-  // other static assets (favicon, manifest, robots.txt, etc.) — no caching
+  // other static assets (favicon, manifest, robots.txt, etc.)
+  // Cache known cacheable root files for the cutover window.
+  const cachedRootFiles = [
+    'favicon.ico',
+    'logo192.png',
+    'logo512.png',
+    'manifest.json',
+  ]
   app.use(
     express.static(path.resolve('../frontend/dist'), {
       index: false,
+      setHeaders: (res, filePath) => {
+        if (cachedRootFiles.includes(path.basename(filePath))) {
+          res.setHeader('Cache-Control', 'public, max-age=300')
+        }
+      },
     }),
   )
 

--- a/apps/backend/src/app/loaders/express/index.ts
+++ b/apps/backend/src/app/loaders/express/index.ts
@@ -130,11 +130,12 @@ const loadExpressApp = async (connection: Connection) => {
   app.use('/api', ApiRouter)
 
   // serve static assets. `../frontend/dist` contains an `/assets` folder which should be cached
+  // everything in the `/assets` folder is hash-suffixed and immutable
   // express.static calls next() if the file is not found
   app.use(
     '/assets',
     express.static(path.resolve('../frontend/dist/assets'), {
-      maxAge: '5m',
+      maxAge: '30d',
       immutable: true,
     }),
   )
@@ -142,7 +143,7 @@ const loadExpressApp = async (connection: Connection) => {
   // other static assets (favicon, manifest, robots.txt, etc.)
   // Cache known cacheable root files for the cutover window.
   const cachedRootFiles = [
-    'favicon.ico',
+    'favicon.svg',
     'logo192.png',
     'logo512.png',
     'manifest.json',

--- a/apps/backend/src/app/loaders/express/index.ts
+++ b/apps/backend/src/app/loaders/express/index.ts
@@ -161,7 +161,7 @@ const loadExpressApp = async (connection: Connection) => {
   // If requests for known static asset patterns were not served by
   // the static handlers above, middleware should try to fetch from s3 static bucket or else return 404s
   app.get(
-    /^\/(public|static|\.well-known)\//,
+    /^\/(public|static|assets|\.well-known)\//,
     catchNonExistentStaticRoutesMiddleware,
   )
 

--- a/apps/backend/src/app/loaders/express/index.ts
+++ b/apps/backend/src/app/loaders/express/index.ts
@@ -129,9 +129,22 @@ const loadExpressApp = async (connection: Connection) => {
   // API routes
   app.use('/api', ApiRouter)
 
-  // serve static assets. `../frontend/dist` contains the root files as well as a `/static` folder
+  // serve static assets. `../frontend/dist` contains an `/assets` folder which should be cached
   // express.static calls next() if the file is not found
-  app.use(express.static(path.resolve('../frontend/dist'), { index: false }))
+  app.use(
+    '/assets',
+    express.static(path.resolve('../frontend/dist/assets'), {
+      maxAge: '5m',
+      immutable: true,
+    }),
+  )
+
+  // other static assets (favicon, manifest, robots.txt, etc.) — no caching
+  app.use(
+    express.static(path.resolve('../frontend/dist'), {
+      index: false,
+    }),
+  )
 
   // If requests for known static asset patterns were not served by
   // the static handlers above, middleware should try to fetch from s3 static bucket or else return 404s


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When a new deployment of FormSG is made, users occasionally experience a whiteout.

<img width="1249" height="697" alt="image" src="https://github.com/user-attachments/assets/a8cf0225-065d-45da-8c66-051807420550" />

Closes FRM-2342.

## Solution
<!-- How did you solve the problem? -->

Cache all static assets, particularly the uniquely named code-bundles produced by the Vite build process.

Outcome:
- Enables the CDN to cache 3 MB of gzipped assets = origin traffic saved per page load
- adds up to ~3 seconds of cumulative load time for the client.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Enable CDN caching all static assets located at the path `/assets/*`

## Before & After Screenshots

**BEFORE**:
<img width="966" height="734" alt="image" src="https://github.com/user-attachments/assets/830d6b36-b722-4906-ae73-9dd7076c8026" />

**AFTER**:
<img width="768" height="789" alt="image" src="https://github.com/user-attachments/assets/3069289a-9314-482e-a579-ea02b03e628f" />

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Ensure that FormSG loads correctly**
- [x] Load form.gov.sg
- [x] Verify that the page loads correctly
- [x] Check the Network tab for resource load errors

**TC2: Verify that API routes work correctly**
- [x] Log in to the admin portal. There should be no issues.
- [x] Submit a form. There should be no issues. 

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
