### PR TITLE
fix(all): bump node 22.22.2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-use-node-version=22.22.1
+use-node-version=22.22.2


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Turns out node:jod-alpine3.22 released a new image with node version 22.22.2.
When the musl-linked node version doesn't match the pnpm-specified version, pnpm will download glibc-linked node, which will [cause the build to fail](https://github.com/opengovsg/FormSG/actions/runs/23636854249/job/68847868242?pr=9244#step:8:719).

## Solution
<!-- How did you solve the problem? -->

TODO: pin node versions and upgrade them in lockstep

This commit pins the node version configured by pnpm to `v22.22.2`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  
