### PR TITLE
fix(backend): pin node version 22.22.2

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,5 +1,5 @@
-FROM node:jod-alpine3.22 
-LABEL maintainer=FormSG<formsg@data.gov.sg>
+FROM node:22.22.2-alpine3.22
+LABEL maintainer=FormSG<form@open.gov.sg>
 
 WORKDIR /opt/formsg
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM node:jod-alpine3.22 AS base 
+FROM node:22.22.2-alpine3.22 AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # Install pnpm
@@ -47,7 +47,7 @@ RUN --mount=type=secret,id=dd_api_key \
 
 # This stage builds the final container
 FROM base
-LABEL maintainer=FormSG<formsg@open.gov.sg>
+LABEL maintainer=FormSG<form@open.gov.sg>
 WORKDIR /opt/formsg
 
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The `node:jod-alpine3.22` is a floating tag that references the latest v22 release.
This behaves poorly with pnpm-managed node versions (#9192)

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Pin the container image version explicitly (e.g. `node:22.22.2-alpine3.22`

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC: Verify that FormSG still behaves normally**
- [ ] Admins can log in
- [ ] Forms can be submitted
- [ ] No unusual errors appear in backend logs

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->