### PR TITLE
fix(all): enable development host-gateway

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       dockerfile: Dockerfile.development
     depends_on:
       - database
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
     volumes:
       - ./:/opt/formsg
       - /opt/formsg/node_modules

--- a/services/virus-scanner-guardduty/docker-compose.dev.yml
+++ b/services/virus-scanner-guardduty/docker-compose.dev.yml
@@ -8,4 +8,6 @@ services:
       - '8080'
     ports:
       - '9998:8080'
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
     env_file: ./.env.development


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The backend and virus-scanner-guardduty services have issues communicating when using alternative container runtimes.

Closes FRM-2347.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Explicitly declare a binding from `host.docker.internal` to `host-gateway` in docker-compose.yml

**Bug Fixes**:

- This fixes compatibility with alternative container runtimes like [Colima](https://github.com/abiosoft/colima/issues/1262).

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->