### PR TITLE
fix(frontend): bulk download attachment behaviour

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -175,6 +175,8 @@ const useDecryptionWorkers = ({
       const submissionDecryptPromises: Promise<DecryptedData>[] = []
 
       let timeSinceLastXAttachmentDownload = 0
+      // Promise chain as a makeshift queue which serializes `saveAs()` calls to prevent dropped downloads
+      let saveQueue: Promise<void> = Promise.resolve()
 
       await reader.read().then(
         (read = async (result) => {
@@ -241,11 +243,17 @@ const useDecryptionWorkers = ({
               // Step 3: Save the downloaded and decrypted attachment blobs for each submission (if required).
               // This step is done with delays in between groups of files to space out downloads to avoid browser blocking downloads.
               .then(async (decryptResult) => {
-                if (
-                  downloadAttachments &&
-                  decryptResult.attachmentDownloadBlob &&
-                  decryptResult.parsedSubmission?._id
-                ) {
+                if (!downloadAttachments) {
+                  return decryptResult
+                }
+                // Chain onto the queue so saves run one at a time
+                saveQueue = saveQueue.then(async () => {
+                  if (
+                    !decryptResult.attachmentDownloadBlob ||
+                    !decryptResult.parsedSubmission?._id
+                  ) {
+                    return
+                  }
                   attachmentsToSaveCount += 1
 
                   // Ensure attachments downloads are spaced out to avoid browser blocking downloads
@@ -271,8 +279,8 @@ const useDecryptionWorkers = ({
                     decryptResult.attachmentDownloadBlob,
                     decryptResult.parsedSubmission._id,
                   )
-                }
-                return decryptResult
+                })
+                return saveQueue.then(() => decryptResult)
               })
               // Step 4: Update the progress bar only once the attachments for the decrypted submission have been downloaded (if needed).
               .finally(() => {

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -137,7 +137,7 @@ const useDecryptionWorkers = ({
         formTitle: adminForm.title,
         downloadAttachments,
         num_workers: numWorkers,
-        expectedNumSubmissions: NUM_OF_METADATA_ROWS,
+        expectedNumSubmissions: responsesCount,
         adminId: user?._id,
       }
       // Trigger analytics here before starting decryption worker

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/downloadAndDecryptAttachment.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/downloadAndDecryptAttachment.ts
@@ -52,5 +52,9 @@ export const downloadAndDecryptAttachmentsAsZip = async (
   }
 
   await Promise.all(downloadPromises)
+  // If the attachments zip is empty, skip the generation of an empty archive to save resources
+  if (Object.keys(zip.files).length === 0) {
+    return undefined
+  }
   return await zip.generateAsync({ type: 'blob' })
 }

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -171,7 +171,7 @@ async function _downloadAndDecryptSubmissionAttachments({
   decryptedResponses,
 }: _DownloadAndDecryptSubmissionAttachmentsParams): Promise<
   | {
-      downloadedAttachmentsBlob: Blob
+      downloadedAttachmentsBlob?: Blob
       isDownloadSuccessful: boolean
     }
   | {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When bulk downloading a large number of attachments, some attachments may be dropped.

Closes FRM-2349.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Correctly log the number of expected submissions
- Submissions without Attachments will not produce a ZIP file

**Bug Fixes**:

- A makeshift queue was implemented using Promises to serialise and batch downloads correctly.

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Downloading attachments works**
- [ ] Download attachments from an existing Storage / MRF mode form
- [ ] All the submissions with attachments should have a corresponding ZIP file.

**TC2: Form Response Download Functions still work**
- [ ] Download CSV and PDFs from an existing Storage / MRF mode form
- [ ] Every submission should have a matching PDF
- [ ] Every submission should show up in the CSV

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

