### PR TITLE
fix(frontend): keep empty attachment zip archives

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/downloadAndDecryptAttachment.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/downloadAndDecryptAttachment.ts
@@ -52,9 +52,5 @@ export const downloadAndDecryptAttachmentsAsZip = async (
   }
 
   await Promise.all(downloadPromises)
-  // If the attachments zip is empty, skip the generation of an empty archive to save resources
-  if (Object.keys(zip.files).length === 0) {
-    return undefined
-  }
   return await zip.generateAsync({ type: 'blob' })
 }

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -171,7 +171,7 @@ async function _downloadAndDecryptSubmissionAttachments({
   decryptedResponses,
 }: _DownloadAndDecryptSubmissionAttachmentsParams): Promise<
   | {
-      downloadedAttachmentsBlob?: Blob
+      downloadedAttachmentsBlob: Blob
       isDownloadSuccessful: boolean
     }
   | {


### PR DESCRIPTION
This reverts commit 9cc6f79a776803cb612c3da394a7b12aa97f44cb.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

In a textbook case study of "[it's not a bug, it's a feature](https://en.wiktionary.org/wiki/it%27s_not_a_bug,_it%27s_a_feature)"...

Related to #9267 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Re-enable empty attachment zip archives

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

