### PR TITLE
feat(i18n): extract text for admin form settings

### DIFF
--- a/apps/frontend/src/features/admin-form/settings/SettingsAuthPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsAuthPage.tsx
@@ -1,10 +1,16 @@
+import { useTranslation } from 'react-i18next'
+
 import AuthSettingsSection from './components/AuthSettingsSection'
 import { CategoryHeader } from './components/CategoryHeader'
 
 export const SettingsAuthPage = (): JSX.Element => {
+  const { t } = useTranslation()
+
   return (
     <>
-      <CategoryHeader>Singpass</CategoryHeader>
+      <CategoryHeader>
+        {t('features.adminForm.settings.singpass.title')}
+      </CategoryHeader>
       <AuthSettingsSection />
     </>
   )

--- a/apps/frontend/src/features/admin-form/settings/SettingsPaymentsPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsPaymentsPage.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next'
+
 import { FormResponseMode } from 'formsg-shared/types'
 
 import { CategoryHeader } from './components/CategoryHeader'
@@ -6,6 +8,7 @@ import { PaymentsUnsupportedMsg } from './components/PaymentSettingsSection/Paym
 import { useAdminFormSettings } from './queries'
 
 export const SettingsPaymentsPage = (): JSX.Element => {
+  const { t } = useTranslation()
   const { data: settings, isLoading } = useAdminFormSettings()
 
   // Payments are only supported in storage mode; show message if form response mode is enything else.
@@ -15,7 +18,9 @@ export const SettingsPaymentsPage = (): JSX.Element => {
 
   return (
     <>
-      <CategoryHeader>Payments</CategoryHeader>
+      <CategoryHeader>
+        {t('features.adminForm.settings.payments.title')}
+      </CategoryHeader>
       <PaymentSettingsSection />
     </>
   )

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Skeleton } from '@chakra-ui/react'
 import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
@@ -13,6 +14,7 @@ import { WebhooksUnsupportedMsg } from './components/WebhooksSection/WebhooksUns
 import { useAdminFormSettings } from './queries'
 
 export const SettingsWebhooksPage = (): JSX.Element => {
+  const { t } = useTranslation()
   const gb = useGrowthBook()
   const { data: settings, isLoading } = useAdminFormSettings()
   const userRes = useUser()
@@ -42,7 +44,9 @@ export const SettingsWebhooksPage = (): JSX.Element => {
 
   return (
     <Skeleton isLoaded={!isLoading}>
-      <CategoryHeader>Webhooks</CategoryHeader>
+      <CategoryHeader>
+        {t('features.adminForm.settings.webhooks.title')}
+      </CategoryHeader>
       <WebhooksSection />
     </Skeleton>
   )

--- a/apps/frontend/src/features/admin-form/settings/hooks/useSecretKeyForm.ts
+++ b/apps/frontend/src/features/admin-form/settings/hooks/useSecretKeyForm.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 import { useForm, UseFormSetError, UseFormSetValue } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 
 import { isKeypairValid, SECRET_KEY_REGEX } from '~utils/secretKeyValidation'
 
@@ -27,6 +28,8 @@ export const useSecretKeyForm = ({
   onSubmit,
   hasAck = false,
 }: UseSecretKeyFormProps) => {
+  const { t } = useTranslation()
+
   const {
     formState: { errors },
     setError,
@@ -44,31 +47,36 @@ export const useSecretKeyForm = ({
     e.stopPropagation()
   }
 
-  const processFile = (
-    file: File,
-    setError: UseFormSetError<SecretKeyFormInputs>,
-    setValue: UseFormSetValue<SecretKeyFormInputs>,
-  ) => {
-    const reader = new FileReader()
-    reader.onload = async (e) => {
-      if (!e.target) return
-      const text = e.target.result?.toString()
+  const processFile = useCallback(
+    (
+      file: File,
+      setError: UseFormSetError<SecretKeyFormInputs>,
+      setValue: UseFormSetValue<SecretKeyFormInputs>,
+    ) => {
+      const reader = new FileReader()
+      reader.onload = async (e) => {
+        if (!e.target) return
+        const text = e.target.result?.toString()
 
-      if (!text || !SECRET_KEY_REGEX.test(text)) {
-        return setError(
-          SECRET_KEY_NAME,
-          {
-            type: 'invalidFile',
-            message: 'Selected file seems to be invalid',
-          },
-          { shouldFocus: true },
-        )
+        if (!text || !SECRET_KEY_REGEX.test(text)) {
+          return setError(
+            SECRET_KEY_NAME,
+            {
+              type: 'invalidFile',
+              message: t(
+                'features.adminForm.settings.secretKeyVerification.errors.invalidFile',
+              ),
+            },
+            { shouldFocus: true },
+          )
+        }
+
+        setValue(SECRET_KEY_NAME, text, { shouldValidate: true })
       }
-
-      setValue(SECRET_KEY_NAME, text, { shouldValidate: true })
-    }
-    reader.readAsText(file)
-  }
+      reader.readAsText(file)
+    },
+    [t],
+  )
 
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
@@ -80,7 +88,7 @@ export const useSecretKeyForm = ({
 
       processFile(file, setError, setValue)
     },
-    [setError, setValue],
+    [processFile, setError, setValue],
   )
 
   const handleDragEnter = (e: React.DragEvent) => {
@@ -114,7 +122,9 @@ export const useSecretKeyForm = ({
           SECRET_KEY_NAME,
           {
             type: 'invalidKey',
-            message: 'The secret key provided is invalid',
+            message: t(
+              'features.adminForm.settings.secretKeyVerification.errors.invalidKey',
+            ),
           },
           { shouldFocus: true },
         )
@@ -137,7 +147,7 @@ export const useSecretKeyForm = ({
 
       processFile(file, setError, setValue)
     },
-    [setError, setValue],
+    [processFile, setError, setValue],
   )
 
   // Reset form before closing.

--- a/apps/frontend/src/features/admin-form/settings/hooks/useSecretKeyForm.ts
+++ b/apps/frontend/src/features/admin-form/settings/hooks/useSecretKeyForm.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from 'react'
 import { useForm, UseFormSetError, UseFormSetValue } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 
 import { isKeypairValid, SECRET_KEY_REGEX } from '~utils/secretKeyValidation'
 
@@ -27,6 +28,8 @@ export const useSecretKeyForm = ({
   onSubmit,
   hasAck = false,
 }: UseSecretKeyFormProps) => {
+  const { t } = useTranslation()
+
   const {
     formState: { errors },
     setError,
@@ -44,31 +47,36 @@ export const useSecretKeyForm = ({
     e.stopPropagation()
   }
 
-  const processFile = (
-    file: File,
-    setError: UseFormSetError<SecretKeyFormInputs>,
-    setValue: UseFormSetValue<SecretKeyFormInputs>,
-  ) => {
-    const reader = new FileReader()
-    reader.onload = async (e) => {
-      if (!e.target) return
-      const text = e.target.result?.toString()
+  const processFile = useCallback(
+    (
+      file: File,
+      setError: UseFormSetError<SecretKeyFormInputs>,
+      setValue: UseFormSetValue<SecretKeyFormInputs>,
+    ) => {
+      const reader = new FileReader()
+      reader.onload = async (e) => {
+        if (!e.target) return
+        const text = e.target.result?.toString()
 
-      if (!text || !SECRET_KEY_REGEX.test(text)) {
-        return setError(
-          SECRET_KEY_NAME,
-          {
-            type: 'invalidFile',
-            message: 'Selected file seems to be invalid',
-          },
-          { shouldFocus: true },
-        )
+        if (!text || !SECRET_KEY_REGEX.test(text)) {
+          return setError(
+            SECRET_KEY_NAME,
+            {
+              type: 'invalidFile',
+              message: t(
+                'features.adminForm.settings.secretKey.errors.invalidFile',
+              ),
+            },
+            { shouldFocus: true },
+          )
+        }
+
+        setValue(SECRET_KEY_NAME, text, { shouldValidate: true })
       }
-
-      setValue(SECRET_KEY_NAME, text, { shouldValidate: true })
-    }
-    reader.readAsText(file)
-  }
+      reader.readAsText(file)
+    },
+    [t],
+  )
 
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
@@ -80,7 +88,7 @@ export const useSecretKeyForm = ({
 
       processFile(file, setError, setValue)
     },
-    [setError, setValue],
+    [processFile, setError, setValue],
   )
 
   const handleDragEnter = (e: React.DragEvent) => {
@@ -114,7 +122,9 @@ export const useSecretKeyForm = ({
           SECRET_KEY_NAME,
           {
             type: 'invalidKey',
-            message: 'The secret key provided is invalid',
+            message: t(
+              'features.adminForm.settings.secretKey.errors.invalidKey',
+            ),
           },
           { shouldFocus: true },
         )
@@ -137,7 +147,7 @@ export const useSecretKeyForm = ({
 
       processFile(file, setError, setValue)
     },
-    [setError, setValue],
+    [processFile, setError, setValue],
   )
 
   // Reset form before closing.

--- a/apps/frontend/src/features/admin-form/settings/mutations.ts
+++ b/apps/frontend/src/features/admin-form/settings/mutations.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQueryClient } from 'react-query'
 import { useParams } from 'react-router-dom'
-import simplur from 'simplur'
 
 import {
   FormAuthType,
@@ -16,7 +15,6 @@ import { PAYMENT_DELETE_DEFAULT } from 'formsg-shared/utils/payments'
 
 import { ApiError } from '~typings/core'
 
-import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
 import { useToast } from '~hooks/useToast'
 import { convertUnicodeLocaleToLanguage } from '~utils/multiLanguage'
 import { formatOrdinal } from '~utils/stringFormat'
@@ -56,7 +54,9 @@ import {
 export const useMutateFormSettings = () => {
   const { t } = useTranslation()
   const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+  if (!formId) {
+    throw new Error(t('features.adminForm.settings.mutations.missingFormId'))
+  }
 
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
@@ -130,9 +130,13 @@ export const useMutateFormSettings = () => {
         const isNowPublic = newData.status === FormStatus.Public
         const toastStatusPublicMessage =
           newData.responseMode === FormResponseMode.Encrypt
-            ? `Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.`
-            : 'Your form is now open.'
-        const toastStatusClosedMessage = 'Your form is closed to new responses.'
+            ? t(
+                'features.adminForm.settings.mutations.formStatus.openStorageMode',
+              )
+            : t('features.adminForm.settings.mutations.formStatus.open')
+        const toastStatusClosedMessage = t(
+          'features.adminForm.settings.mutations.formStatus.closed',
+        )
         const toastStatusMessage = isNowPublic
           ? toastStatusPublicMessage
           : toastStatusClosedMessage
@@ -156,7 +160,7 @@ export const useMutateFormSettings = () => {
           ? t(successToastI18nKey, {
               submissionLimit: formatOrdinal(newData.submissionLimit),
             })
-          : 'The submission limit on your form is removed.'
+          : t('features.adminForm.settings.general.limit.toast.successRemoved')
         handleSuccess({ newData, toastDescription: toastStatusMessage })
       },
       onError: handleError,
@@ -171,8 +175,8 @@ export const useMutateFormSettings = () => {
         handleSuccess({
           newData,
           toastDescription: newData.hasMultiLang
-            ? 'Multi-language enabled. Respondents can now select other languages to view your form in.'
-            : 'Multi-language disabled.',
+            ? t('features.adminForm.settings.mutations.multiLang.enabled')
+            : t('features.adminForm.settings.mutations.multiLang.disabled'),
         })
       },
       onError: handleError,
@@ -197,8 +201,14 @@ export const useMutateFormSettings = () => {
           const isSelectedLanguageSupported = supportedLanguages.includes(
             newSupportedLanguages.selectedLanguage,
           )
-            ? `Respondents will now be able to select and view your form in ${languageToDisplay}.`
-            : `${languageToDisplay} is now hidden. Respondents will not be able to see it.`
+            ? t(
+                'features.adminForm.settings.mutations.supportedLanguages.selectable',
+                { language: languageToDisplay },
+              )
+            : t(
+                'features.adminForm.settings.mutations.supportedLanguages.hidden',
+                { language: languageToDisplay },
+              )
 
           handleSuccess({
             newData,
@@ -217,9 +227,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `Saving of draft responses is now ${
-            newData.isSaveDraftEnabled ? 'enabled' : 'disabled'
-          } on your form.`,
+          toastDescription: newData.isSaveDraftEnabled
+            ? t('features.adminForm.settings.mutations.saveDraft.enabled')
+            : t('features.adminForm.settings.mutations.saveDraft.disabled'),
         })
       },
       onError: handleError,
@@ -232,9 +242,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `reCAPTCHA is now ${
-            newData.hasCaptcha ? 'enabled' : 'disabled'
-          } on your form.`,
+          toastDescription: newData.hasCaptcha
+            ? t('features.adminForm.settings.mutations.captcha.enabled')
+            : t('features.adminForm.settings.mutations.captcha.disabled'),
         })
       },
       onError: handleError,
@@ -248,9 +258,13 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `Email notifications for issues reported are now ${
-            newData.hasIssueNotification ? 'enabled' : 'disabled'
-          } on your form.`,
+          toastDescription: newData.hasIssueNotification
+            ? t(
+                'features.adminForm.settings.mutations.issueNotification.enabled',
+              )
+            : t(
+                'features.adminForm.settings.mutations.issueNotification.disabled',
+              ),
         })
       },
       onError: handleError,
@@ -267,7 +281,9 @@ export const useMutateFormSettings = () => {
 
         // Show toast on success.
         toast({
-          description: "Your form's title has been updated.",
+          description: t(
+            'features.adminForm.settings.mutations.formTitleUpdated',
+          ),
         })
       },
       onError: (error: Error) => {
@@ -286,7 +302,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: "Your form's inactive message has been updated.",
+          toastDescription: t(
+            'features.adminForm.settings.mutations.inactiveMessageUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -299,7 +317,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: 'Emails successfully updated.',
+          toastDescription: t(
+            'features.adminForm.settings.mutations.emailsUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -313,7 +333,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: 'Emails successfully updated.',
+          toastDescription: t(
+            'features.adminForm.settings.mutations.emailsUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -359,25 +381,14 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: 'E-service ID successfully updated.',
+          toastDescription: t(
+            'features.adminForm.settings.mutations.esrvcIdUpdated',
+          ),
         })
       },
       onError: handleError,
     },
   )
-
-  const generateFormAuthTypeMutationToastMessageText = (
-    prevAuthType: FormAuthType | undefined,
-    nextAuthType: FormAuthType,
-  ) => {
-    if (prevAuthType === FormAuthType.NIL) {
-      return 'Singpass authentication successfully enabled.'
-    }
-    if (nextAuthType === FormAuthType.NIL) {
-      return 'Singpass authentication successfully disabled.'
-    }
-    return 'Singpass authentication successfully updated.'
-  }
 
   const mutateFormAuthType = useMutation<
     FormSettings,
@@ -415,12 +426,15 @@ export const useMutateFormSettings = () => {
       },
       onSuccess: (newData, newAuthType, context) => {
         const prevAuthType = context?.previousSettings?.authType
+        const toastDescription =
+          prevAuthType === FormAuthType.NIL
+            ? t('features.adminForm.settings.mutations.authType.enabled')
+            : newAuthType === FormAuthType.NIL
+              ? t('features.adminForm.settings.mutations.authType.disabled')
+              : t('features.adminForm.settings.mutations.authType.updated')
         handleSuccess({
           newData,
-          toastDescription: generateFormAuthTypeMutationToastMessageText(
-            prevAuthType,
-            newAuthType,
-          ),
+          toastDescription,
         })
       },
       onError: (error, _newData, context) => {
@@ -452,8 +466,8 @@ export const useMutateFormSettings = () => {
         handleSuccess({
           newData,
           toastDescription: newData.isSubmitterIdCollectionEnabled
-            ? 'NRIC/FIN/UEN collection is now enabled on your form.'
-            : 'NRIC/FIN/UEN collection is now disabled on your form.',
+            ? t('features.adminForm.settings.mutations.submitterId.enabled')
+            : t('features.adminForm.settings.mutations.submitterId.disabled'),
         })
       },
       onError: handleError,
@@ -472,8 +486,12 @@ export const useMutateFormSettings = () => {
         handleSuccess({
           newData,
           toastDescription: newData.isSingleSubmission
-            ? 'Single submission per NRIC/FIN/UEN is now enabled on your form.'
-            : 'Single submission per NRIC/FIN/UEN is now disabled on your form.',
+            ? t(
+                'features.adminForm.settings.mutations.singleSubmission.enabled',
+              )
+            : t(
+                'features.adminForm.settings.mutations.singleSubmission.disabled',
+              ),
         })
       },
       onError: handleError,
@@ -488,8 +506,8 @@ export const useMutateFormSettings = () => {
       onSuccess: (_newData, variable) => {
         generateSuccessToast(
           variable
-            ? 'Your CSV has been uploaded successfully.'
-            : 'Your CSV has been removed successfully.',
+            ? t('features.adminForm.settings.mutations.whitelist.uploaded')
+            : t('features.adminForm.settings.mutations.whitelist.removed'),
         )
       },
       onError: (error: Error) => {
@@ -504,9 +522,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData, nextUrl) => {
         handleSuccess({
           newData,
-          toastDescription: `Webhook URL successfully ${
-            nextUrl ? 'updated' : 'removed'
-          }.`,
+          toastDescription: nextUrl
+            ? t('features.adminForm.settings.mutations.webhookUrl.updated')
+            : t('features.adminForm.settings.mutations.webhookUrl.removed'),
         })
       },
       onError: handleError,
@@ -519,9 +537,11 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData, nextEnabled) => {
         handleSuccess({
           newData,
-          toastDescription: `Webhook retries have been ${
-            nextEnabled ? 'en' : 'dis'
-          }abled.`,
+          toastDescription: nextEnabled
+            ? t('features.adminForm.settings.mutations.webhookRetries.enabled')
+            : t(
+                'features.adminForm.settings.mutations.webhookRetries.disabled',
+              ),
         })
       },
       onError: handleError,
@@ -535,7 +555,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `Business information has been updated.`,
+          toastDescription: t(
+            'features.adminForm.settings.mutations.businessInfoUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -549,7 +571,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `GST setting has been updated.`,
+          toastDescription: t(
+            'features.adminForm.settings.mutations.gstUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -583,8 +607,11 @@ export const useMutateFormSettings = () => {
 }
 
 export const useMutateStripeAccount = () => {
+  const { t } = useTranslation()
   const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+  if (!formId) {
+    throw new Error(t('features.adminForm.settings.mutations.missingFormId'))
+  }
   const queryClient = useQueryClient()
 
   const linkStripeAccountMutation = useMutation(

--- a/apps/frontend/src/features/admin-form/settings/mutations.ts
+++ b/apps/frontend/src/features/admin-form/settings/mutations.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQueryClient } from 'react-query'
 import { useParams } from 'react-router-dom'
-import simplur from 'simplur'
 
 import {
   FormAuthType,
@@ -16,7 +15,6 @@ import { PAYMENT_DELETE_DEFAULT } from 'formsg-shared/utils/payments'
 
 import { ApiError } from '~typings/core'
 
-import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
 import { useToast } from '~hooks/useToast'
 import { convertUnicodeLocaleToLanguage } from '~utils/multiLanguage'
 import { formatOrdinal } from '~utils/stringFormat'
@@ -56,7 +54,9 @@ import {
 export const useMutateFormSettings = () => {
   const { t } = useTranslation()
   const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+  if (!formId) {
+    throw new Error(t('features.adminForm.settings.mutations.missingFormId'))
+  }
 
   const queryClient = useQueryClient()
   const toast = useToast({ status: 'success', isClosable: true })
@@ -130,9 +130,13 @@ export const useMutateFormSettings = () => {
         const isNowPublic = newData.status === FormStatus.Public
         const toastStatusPublicMessage =
           newData.responseMode === FormResponseMode.Encrypt
-            ? `Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.`
-            : 'Your form is now open.'
-        const toastStatusClosedMessage = 'Your form is closed to new responses.'
+            ? t(
+                'features.adminForm.settings.mutations.formStatus.openStorageMode',
+              )
+            : t('features.adminForm.settings.mutations.formStatus.open')
+        const toastStatusClosedMessage = t(
+          'features.adminForm.settings.mutations.formStatus.closed',
+        )
         const toastStatusMessage = isNowPublic
           ? toastStatusPublicMessage
           : toastStatusClosedMessage
@@ -149,11 +153,13 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         // Show toast on success.
         const toastStatusMessage = newData.submissionLimit
-          ? simplur`Your form will now automatically close on the ${[
-              newData.submissionLimit,
-              formatOrdinal,
-            ]} submission.`
-          : 'The submission limit on your form is removed.'
+          ? t(
+              'features.adminForm.settings.mutations.submissionLimit.withOrdinal',
+              {
+                ordinal: formatOrdinal(newData.submissionLimit),
+              },
+            )
+          : t('features.adminForm.settings.mutations.submissionLimit.removed')
         handleSuccess({ newData, toastDescription: toastStatusMessage })
       },
       onError: handleError,
@@ -168,8 +174,8 @@ export const useMutateFormSettings = () => {
         handleSuccess({
           newData,
           toastDescription: newData.hasMultiLang
-            ? 'Multi-language enabled. Respondents can now select other languages to view your form in.'
-            : 'Multi-language disabled.',
+            ? t('features.adminForm.settings.mutations.multiLang.enabled')
+            : t('features.adminForm.settings.mutations.multiLang.disabled'),
         })
       },
       onError: handleError,
@@ -194,8 +200,14 @@ export const useMutateFormSettings = () => {
           const isSelectedLanguageSupported = supportedLanguages.includes(
             newSupportedLanguages.selectedLanguage,
           )
-            ? `Respondents will now be able to select and view your form in ${languageToDisplay}.`
-            : `${languageToDisplay} is now hidden. Respondents will not be able to see it.`
+            ? t(
+                'features.adminForm.settings.mutations.supportedLanguages.selectable',
+                { language: languageToDisplay },
+              )
+            : t(
+                'features.adminForm.settings.mutations.supportedLanguages.hidden',
+                { language: languageToDisplay },
+              )
 
           handleSuccess({
             newData,
@@ -214,9 +226,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `Saving of draft responses is now ${
-            newData.isSaveDraftEnabled ? 'enabled' : 'disabled'
-          } on your form.`,
+          toastDescription: newData.isSaveDraftEnabled
+            ? t('features.adminForm.settings.mutations.saveDraft.enabled')
+            : t('features.adminForm.settings.mutations.saveDraft.disabled'),
         })
       },
       onError: handleError,
@@ -229,9 +241,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `reCAPTCHA is now ${
-            newData.hasCaptcha ? 'enabled' : 'disabled'
-          } on your form.`,
+          toastDescription: newData.hasCaptcha
+            ? t('features.adminForm.settings.mutations.captcha.enabled')
+            : t('features.adminForm.settings.mutations.captcha.disabled'),
         })
       },
       onError: handleError,
@@ -245,9 +257,13 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `Email notifications for issues reported are now ${
-            newData.hasIssueNotification ? 'enabled' : 'disabled'
-          } on your form.`,
+          toastDescription: newData.hasIssueNotification
+            ? t(
+                'features.adminForm.settings.mutations.issueNotification.enabled',
+              )
+            : t(
+                'features.adminForm.settings.mutations.issueNotification.disabled',
+              ),
         })
       },
       onError: handleError,
@@ -264,7 +280,9 @@ export const useMutateFormSettings = () => {
 
         // Show toast on success.
         toast({
-          description: "Your form's title has been updated.",
+          description: t(
+            'features.adminForm.settings.mutations.formTitleUpdated',
+          ),
         })
       },
       onError: (error: Error) => {
@@ -283,7 +301,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: "Your form's inactive message has been updated.",
+          toastDescription: t(
+            'features.adminForm.settings.mutations.inactiveMessageUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -296,7 +316,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: 'Emails successfully updated.',
+          toastDescription: t(
+            'features.adminForm.settings.mutations.emailsUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -310,7 +332,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: 'Emails successfully updated.',
+          toastDescription: t(
+            'features.adminForm.settings.mutations.emailsUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -356,25 +380,14 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: 'E-service ID successfully updated.',
+          toastDescription: t(
+            'features.adminForm.settings.mutations.esrvcIdUpdated',
+          ),
         })
       },
       onError: handleError,
     },
   )
-
-  const generateFormAuthTypeMutationToastMessageText = (
-    prevAuthType: FormAuthType | undefined,
-    nextAuthType: FormAuthType,
-  ) => {
-    if (prevAuthType === FormAuthType.NIL) {
-      return 'Singpass authentication successfully enabled.'
-    }
-    if (nextAuthType === FormAuthType.NIL) {
-      return 'Singpass authentication successfully disabled.'
-    }
-    return 'Singpass authentication successfully updated.'
-  }
 
   const mutateFormAuthType = useMutation<
     FormSettings,
@@ -412,12 +425,15 @@ export const useMutateFormSettings = () => {
       },
       onSuccess: (newData, newAuthType, context) => {
         const prevAuthType = context?.previousSettings?.authType
+        const toastDescription =
+          prevAuthType === FormAuthType.NIL
+            ? t('features.adminForm.settings.mutations.authType.enabled')
+            : newAuthType === FormAuthType.NIL
+              ? t('features.adminForm.settings.mutations.authType.disabled')
+              : t('features.adminForm.settings.mutations.authType.updated')
         handleSuccess({
           newData,
-          toastDescription: generateFormAuthTypeMutationToastMessageText(
-            prevAuthType,
-            newAuthType,
-          ),
+          toastDescription,
         })
       },
       onError: (error, _newData, context) => {
@@ -449,8 +465,8 @@ export const useMutateFormSettings = () => {
         handleSuccess({
           newData,
           toastDescription: newData.isSubmitterIdCollectionEnabled
-            ? 'NRIC/FIN/UEN collection is now enabled on your form.'
-            : 'NRIC/FIN/UEN collection is now disabled on your form.',
+            ? t('features.adminForm.settings.mutations.submitterId.enabled')
+            : t('features.adminForm.settings.mutations.submitterId.disabled'),
         })
       },
       onError: handleError,
@@ -469,8 +485,12 @@ export const useMutateFormSettings = () => {
         handleSuccess({
           newData,
           toastDescription: newData.isSingleSubmission
-            ? 'Single submission per NRIC/FIN/UEN is now enabled on your form.'
-            : 'Single submission per NRIC/FIN/UEN is now disabled on your form.',
+            ? t(
+                'features.adminForm.settings.mutations.singleSubmission.enabled',
+              )
+            : t(
+                'features.adminForm.settings.mutations.singleSubmission.disabled',
+              ),
         })
       },
       onError: handleError,
@@ -485,8 +505,8 @@ export const useMutateFormSettings = () => {
       onSuccess: (_newData, variable) => {
         generateSuccessToast(
           variable
-            ? 'Your CSV has been uploaded successfully.'
-            : 'Your CSV has been removed successfully.',
+            ? t('features.adminForm.settings.mutations.whitelist.uploaded')
+            : t('features.adminForm.settings.mutations.whitelist.removed'),
         )
       },
       onError: (error: Error) => {
@@ -501,9 +521,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData, nextUrl) => {
         handleSuccess({
           newData,
-          toastDescription: `Webhook URL successfully ${
-            nextUrl ? 'updated' : 'removed'
-          }.`,
+          toastDescription: nextUrl
+            ? t('features.adminForm.settings.mutations.webhookUrl.updated')
+            : t('features.adminForm.settings.mutations.webhookUrl.removed'),
         })
       },
       onError: handleError,
@@ -516,9 +536,11 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData, nextEnabled) => {
         handleSuccess({
           newData,
-          toastDescription: `Webhook retries have been ${
-            nextEnabled ? 'en' : 'dis'
-          }abled.`,
+          toastDescription: nextEnabled
+            ? t('features.adminForm.settings.mutations.webhookRetries.enabled')
+            : t(
+                'features.adminForm.settings.mutations.webhookRetries.disabled',
+              ),
         })
       },
       onError: handleError,
@@ -532,7 +554,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `Business information has been updated.`,
+          toastDescription: t(
+            'features.adminForm.settings.mutations.businessInfoUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -546,7 +570,9 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         handleSuccess({
           newData,
-          toastDescription: `GST setting has been updated.`,
+          toastDescription: t(
+            'features.adminForm.settings.mutations.gstUpdated',
+          ),
         })
       },
       onError: handleError,
@@ -580,8 +606,11 @@ export const useMutateFormSettings = () => {
 }
 
 export const useMutateStripeAccount = () => {
+  const { t } = useTranslation()
   const { formId } = useParams()
-  if (!formId) throw new Error('No formId provided')
+  if (!formId) {
+    throw new Error(t('features.adminForm.settings.mutations.missingFormId'))
+  }
   const queryClient = useQueryClient()
 
   const linkStripeAccountMutation = useMutation(

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
@@ -34,6 +34,79 @@ export const enSG = {
       submitButton: 'Download file',
     },
   },
+  secretKeyVerification: {
+    errors: {
+      invalidFile: 'Selected file seems to be invalid',
+      invalidKey: 'The secret key provided is invalid',
+    },
+  },
+  mutations: {
+    missingFormId: 'No form ID was provided.',
+    formStatus: {
+      openStorageMode:
+        'Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.',
+      open: 'Your form is now open.',
+      closed: 'Your form is closed to new responses.',
+    },
+    multiLang: {
+      enabled:
+        'Multi-language enabled. Respondents can now select other languages to view your form in.',
+      disabled: 'Multi-language disabled.',
+    },
+    supportedLanguages: {
+      selectable:
+        'Respondents will now be able to select and view your form in {{language}}.',
+      hidden:
+        '{{language}} is now hidden. Respondents will not be able to see it.',
+    },
+    saveDraft: {
+      enabled: 'Saving of draft responses is now enabled on your form.',
+      disabled: 'Saving of draft responses is now disabled on your form.',
+    },
+    captcha: {
+      enabled: 'reCAPTCHA is now enabled on your form.',
+      disabled: 'reCAPTCHA is now disabled on your form.',
+    },
+    issueNotification: {
+      enabled:
+        'Email notifications for issues reported are now enabled on your form.',
+      disabled:
+        'Email notifications for issues reported are now disabled on your form.',
+    },
+    formTitleUpdated: "Your form's title has been updated.",
+    inactiveMessageUpdated: "Your form's inactive message has been updated.",
+    emailsUpdated: 'Emails successfully updated.',
+    esrvcIdUpdated: 'E-service ID successfully updated.',
+    authType: {
+      enabled: 'Singpass authentication successfully enabled.',
+      disabled: 'Singpass authentication successfully disabled.',
+      updated: 'Singpass authentication successfully updated.',
+    },
+    submitterId: {
+      enabled: 'NRIC/FIN/UEN collection is now enabled on your form.',
+      disabled: 'NRIC/FIN/UEN collection is now disabled on your form.',
+    },
+    singleSubmission: {
+      enabled:
+        'Single submission per NRIC/FIN/UEN is now enabled on your form.',
+      disabled:
+        'Single submission per NRIC/FIN/UEN is now disabled on your form.',
+    },
+    whitelist: {
+      uploaded: 'Your CSV has been uploaded successfully.',
+      removed: 'Your CSV has been removed successfully.',
+    },
+    webhookUrl: {
+      updated: 'Webhook URL successfully updated.',
+      removed: 'Webhook URL successfully removed.',
+    },
+    webhookRetries: {
+      enabled: 'Webhook retries have been enabled.',
+      disabled: 'Webhook retries have been disabled.',
+    },
+    businessInfoUpdated: 'Business information has been updated.',
+    gstUpdated: 'GST setting has been updated.',
+  },
   emailNotifications,
   webhooks,
   payments,

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
@@ -8,6 +8,84 @@ export const enSG = {
   singpass: {
     title: 'Singpass',
   },
+  secretKey: {
+    errors: {
+      invalidFile: 'Selected file seems to be invalid',
+      invalidKey: 'The secret key provided is invalid',
+    },
+  },
+  mutations: {
+    missingFormId: 'No form ID was provided.',
+    formStatus: {
+      openStorageMode:
+        'Your form is now open.\n\nStore your secret key in a safe place. If you lose your secret key, all your responses will be lost permanently.',
+      open: 'Your form is now open.',
+      closed: 'Your form is closed to new responses.',
+    },
+    submissionLimit: {
+      withOrdinal:
+        'Your form will now automatically close on the {{ordinal}} submission.',
+      removed: 'The submission limit on your form is removed.',
+    },
+    multiLang: {
+      enabled:
+        'Multi-language enabled. Respondents can now select other languages to view your form in.',
+      disabled: 'Multi-language disabled.',
+    },
+    supportedLanguages: {
+      selectable:
+        'Respondents will now be able to select and view your form in {{language}}.',
+      hidden:
+        '{{language}} is now hidden. Respondents will not be able to see it.',
+    },
+    saveDraft: {
+      enabled: 'Saving of draft responses is now enabled on your form.',
+      disabled: 'Saving of draft responses is now disabled on your form.',
+    },
+    captcha: {
+      enabled: 'reCAPTCHA is now enabled on your form.',
+      disabled: 'reCAPTCHA is now disabled on your form.',
+    },
+    issueNotification: {
+      enabled:
+        'Email notifications for issues reported are now enabled on your form.',
+      disabled:
+        'Email notifications for issues reported are now disabled on your form.',
+    },
+    formTitleUpdated: "Your form's title has been updated.",
+    inactiveMessageUpdated: "Your form's inactive message has been updated.",
+    emailsUpdated: 'Emails successfully updated.',
+    esrvcIdUpdated: 'E-service ID successfully updated.',
+    authType: {
+      enabled: 'Singpass authentication successfully enabled.',
+      disabled: 'Singpass authentication successfully disabled.',
+      updated: 'Singpass authentication successfully updated.',
+    },
+    submitterId: {
+      enabled: 'NRIC/FIN/UEN collection is now enabled on your form.',
+      disabled: 'NRIC/FIN/UEN collection is now disabled on your form.',
+    },
+    singleSubmission: {
+      enabled:
+        'Single submission per NRIC/FIN/UEN is now enabled on your form.',
+      disabled:
+        'Single submission per NRIC/FIN/UEN is now disabled on your form.',
+    },
+    whitelist: {
+      uploaded: 'Your CSV has been uploaded successfully.',
+      removed: 'Your CSV has been removed successfully.',
+    },
+    webhookUrl: {
+      updated: 'Webhook URL successfully updated.',
+      removed: 'Webhook URL successfully removed.',
+    },
+    webhookRetries: {
+      enabled: 'Webhook retries have been enabled.',
+      disabled: 'Webhook retries have been disabled.',
+    },
+    businessInfoUpdated: 'Business information has been updated.',
+    gstUpdated: 'GST setting has been updated.',
+  },
   emailNotifications,
   webhooks,
   payments,

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -25,6 +25,7 @@ export const enSG = {
         'Your form will now automatically close on the {submissionLimit} submission.',
       successMrf:
         'Your form will now automatically close on the {submissionLimit} started workflow.',
+      successRemoved: 'The submission limit on your form is removed.',
     },
     limitLessThanCurrent:
       'Submission limit must be greater than current submission count ({currentResponseCount})',

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
@@ -23,6 +23,7 @@ export interface General extends HasTitle {
     toast: {
       successStorageMode: string
       successMrf: string
+      successRemoved: string
     }
     limitLessThanCurrent: string
   }

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/index.ts
@@ -36,11 +36,80 @@ export interface SecretKeyModalStrings {
   }
 }
 
+export interface SecretKeyVerificationStrings {
+  errors: {
+    invalidFile: string
+    invalidKey: string
+  }
+}
+
+export interface SettingsMutationsStrings {
+  missingFormId: string
+  formStatus: {
+    openStorageMode: string
+    open: string
+    closed: string
+  }
+  multiLang: {
+    enabled: string
+    disabled: string
+  }
+  supportedLanguages: {
+    selectable: string
+    hidden: string
+  }
+  saveDraft: {
+    enabled: string
+    disabled: string
+  }
+  captcha: {
+    enabled: string
+    disabled: string
+  }
+  issueNotification: {
+    enabled: string
+    disabled: string
+  }
+  formTitleUpdated: string
+  inactiveMessageUpdated: string
+  emailsUpdated: string
+  esrvcIdUpdated: string
+  authType: {
+    enabled: string
+    disabled: string
+    updated: string
+  }
+  submitterId: {
+    enabled: string
+    disabled: string
+  }
+  singleSubmission: {
+    enabled: string
+    disabled: string
+  }
+  whitelist: {
+    uploaded: string
+    removed: string
+  }
+  webhookUrl: {
+    updated: string
+    removed: string
+  }
+  webhookRetries: {
+    enabled: string
+    disabled: string
+  }
+  businessInfoUpdated: string
+  gstUpdated: string
+}
+
 export interface Settings {
   general: General
   singpass: HasTitle
   tabs: SettingsTabsStrings
   secretKeyModal: SecretKeyModalStrings
+  secretKeyVerification: SecretKeyVerificationStrings
+  mutations: SettingsMutationsStrings
   emailNotifications: EmailNotifications
   webhooks: Webhooks
   payments: Payments

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/index.ts
@@ -9,9 +9,82 @@ export type HasTitle = {
   title: string
 }
 
+export interface SecretKeyFormStrings {
+  errors: {
+    invalidFile: string
+    invalidKey: string
+  }
+}
+
+export interface SettingsMutationsStrings {
+  missingFormId: string
+  formStatus: {
+    openStorageMode: string
+    open: string
+    closed: string
+  }
+  submissionLimit: {
+    withOrdinal: string
+    removed: string
+  }
+  multiLang: {
+    enabled: string
+    disabled: string
+  }
+  supportedLanguages: {
+    selectable: string
+    hidden: string
+  }
+  saveDraft: {
+    enabled: string
+    disabled: string
+  }
+  captcha: {
+    enabled: string
+    disabled: string
+  }
+  issueNotification: {
+    enabled: string
+    disabled: string
+  }
+  formTitleUpdated: string
+  inactiveMessageUpdated: string
+  emailsUpdated: string
+  esrvcIdUpdated: string
+  authType: {
+    enabled: string
+    disabled: string
+    updated: string
+  }
+  submitterId: {
+    enabled: string
+    disabled: string
+  }
+  singleSubmission: {
+    enabled: string
+    disabled: string
+  }
+  whitelist: {
+    uploaded: string
+    removed: string
+  }
+  webhookUrl: {
+    updated: string
+    removed: string
+  }
+  webhookRetries: {
+    enabled: string
+    disabled: string
+  }
+  businessInfoUpdated: string
+  gstUpdated: string
+}
+
 export interface Settings {
   general: General
   singpass: HasTitle
+  secretKey: SecretKeyFormStrings
+  mutations: SettingsMutationsStrings
   emailNotifications: EmailNotifications
   webhooks: Webhooks
   payments: Payments


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #8453 

## Solution
- Collate text strings within the affected files 
- Transfer them to appropriate `en-sg` file
- Clean up legacy package `simplur` in favour of i18n pluralisation. But in this PR, theres no pluralization being done too.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
