### PR TITLE
fix: hide hidden fields local pdf

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponseNavbar.tsx
@@ -28,6 +28,7 @@ import { noPrintCss } from '~utils/noPrintCss'
 import IconButton from '~components/IconButton'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { getVisibleResponses } from '~features/logic/utils'
 import { useUser } from '~features/user/queries'
 
 import { useUnlockedResponses } from '../ResponsesPage/storage/UnlockedResponses/UnlockedResponsesProvider'
@@ -182,7 +183,16 @@ export const IndividualResponseNavbar = (): JSX.Element => {
                       },
                     )
                     if (submission && form) {
-                      await downloadResponsePdf({ form, submission })
+                      await downloadResponsePdf({
+                        form,
+                        submission: {
+                          ...submission,
+                          responses: getVisibleResponses(submission.responses, {
+                            formFields: form.form_fields,
+                            formLogics: form.form_logics,
+                          }),
+                        },
+                      })
                     }
                   }}
                   variant="clear"

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -14,6 +14,7 @@ import {
   trackDownloadResponseSuccess,
   trackPartialDecryptionFailure,
 } from '~features/analytics/AnalyticsService'
+import { getVisibleResponses } from '~features/logic/utils'
 import { useUser } from '~features/user/queries'
 
 import { generateResponsePdfBlob } from '../../IndividualResponsePage/utils/generateResponsePdf'
@@ -317,7 +318,10 @@ const useDecryptionWorkers = ({
                     submission: {
                       refNo,
                       submissionTime,
-                      responses: decryptedResponses,
+                      responses: getVisibleResponses(decryptedResponses, {
+                        formFields: adminForm.form_fields,
+                        formLogics: adminForm.form_logics,
+                      }),
                     },
                   })
                   pdfZip.file(pdfTitle, pdfBlob)

--- a/apps/frontend/src/features/logic/utils/logic-adaptor.ts
+++ b/apps/frontend/src/features/logic/utils/logic-adaptor.ts
@@ -1,17 +1,28 @@
 import { DeepPartialSkipArrayKey, UnpackNestedValue } from 'react-hook-form'
+import { FieldType, FormField } from '@opengovsg/formsg-sdk/dist/types'
 import { CamelCasedProperties } from 'type-fest'
 
-import { FormDto } from 'formsg-shared/types'
+import {
+  BasicField,
+  FormDto,
+  FormFieldDto,
+  LogicableField,
+} from 'formsg-shared/types'
 import { isNonEmpty } from 'formsg-shared/utils/isNonEmpty'
 import {
   FieldIdSet,
   getLogicUnitPreventingSubmit as sharedGetLogicUnitPreventingSubmit,
   getVisibleFieldIds as sharedGetVisibleFieldIds,
+  LOGIC_MAP,
+  LogicFieldResponse,
+  LogicFieldServerResponse,
 } from 'formsg-shared/utils/logic'
 
 import { FormFieldValues } from '~templates/Field'
 
 import { filterHiddenInputs } from '~features/public-form/utils'
+
+import { ALLOWED_LOGIC_FIELDS } from '../constants'
 
 import { isLogicableField, isNotLogicableField } from './typeguards'
 
@@ -113,4 +124,60 @@ export const getVisibleFieldIds = (
     form_fields: formFields,
     form_logics: formLogics,
   })
+}
+
+const isBasicFieldType = (fieldType: FieldType): fieldType is BasicField => {
+  return (Object.values(BasicField) as string[]).includes(fieldType)
+}
+
+const responsesToLogicFieldResponses = (
+  responses: FormField[],
+): LogicFieldResponse[] => {
+  return responses
+    .map((response) => {
+      if (!isBasicFieldType(response.fieldType)) {
+        return null
+      }
+      if (ALLOWED_LOGIC_FIELDS.has(response.fieldType)) {
+        return {
+          _id: response._id,
+          fieldType: response.fieldType as LogicableField,
+          answer: response.answer ?? '',
+        }
+      } else {
+        return {
+          _id: response._id,
+          fieldType: response.fieldType as Exclude<BasicField, LogicableField>,
+        }
+      }
+    })
+    .filter(isNonEmpty)
+}
+
+const getVisibleFieldIdsFromResponses = (
+  responses: FormField[],
+  {
+    formFields,
+    formLogics,
+  }: CamelCasedProperties<Pick<FormDto, 'form_fields' | 'form_logics'>>,
+): FieldIdSet => {
+  const logicFieldResponses = responsesToLogicFieldResponses(responses)
+  return sharedGetVisibleFieldIds(logicFieldResponses, {
+    form_fields: formFields,
+    form_logics: formLogics,
+  })
+}
+
+export const getVisibleResponses = (
+  responses: FormField[],
+  {
+    formFields,
+    formLogics,
+  }: CamelCasedProperties<Pick<FormDto, 'form_fields' | 'form_logics'>>,
+): FormField[] => {
+  const visibleFieldIds = getVisibleFieldIdsFromResponses(responses, {
+    formFields,
+    formLogics,
+  })
+  return responses.filter((response) => visibleFieldIds.has(response._id))
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Fields hidden by logic are still shown in client generated pdf.  

## Solution
<!-- How did you solve the problem? -->
Filter for the visible fields based on the current form definition (form logics and form fields). We need to use the current form definition since storage mode does not store the form definition at the time of submission. 

Note: Due to the following edge case affecting storage mode forms which do not store the form definition at the time of submission, this could introduce issues where the generated PDF shows/hides fields different from the time of submission - which is undesirable for data integrity reasons. 

Example: 
1. admin creates storage mode form. 
2. admin defines logic eg, yes value shows fields A and B. 
3. respondent submits with yes value, the fields A and B should be shown. 
4. admin changes logic where no value shows fields A and B. 
5. admin triggers a PDF generation, the PDF generation looks up the latest logic. This excludes fields A and B due to the change. 
6. the PDF at point of submission at step 3 and PDF at step 5 are different, where PDF at step 5 is incorrect. 

Possible future approaches: 
1. hide the logic on local pdf download for mrf and do not hide on storage mode (causes product edge case where pdf hidden fields for mrf and storage mode defer) 
2. hide for both modes based on the current latest form logics definition and accept that the pdf hidden fields is based on the current form definition (this causes the above mentioned issue where the generated pdf for storage may not reflect the logic settings at the time of submission, which is undesirable if data integrity of the pdf is crucial)  
3. not hide the hidden fields on local pdf download (causes product edge case where client generated PDF differs from the emailed pdf - can choose to display the hidden fields back on emailed pdf to keep it consistent if desired) 
4. store form logics and form fields for storage mode submissions (this is not backwards compatible since previous submissions have lost this data and non-trivial change affecting all subsequent submissions)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  