### PR TITLE
feat: prune allow list

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,21 +79,15 @@
     },
     "onlyBuiltDependencies": [
       "bcrypt",
-      "@datadog/native-appsec",
-      "@datadog/native-iast-taint-tracking",
-      "@datadog/native-metrics",
-      "@datadog/pprof",
-      "aws-sdk",
-      "aws-lambda-ric",
       "canvas",
-      "dd-trace",
-      "esbuild",
-      "fsevents",
-      "protobufjs",
-      "sharp",
-      "unix-dgram",
-      "msw",
+      "aws-lambda-ric",
       "microtime"
+    ],
+    "__onlyBuiltDependenciesComments": [
+      "bcrypt is required for the backend",
+      "canvas is required for signatures field",
+      "aws-lambda-ric is required for the virus scanner guardduty",
+      "microtime is required for frontend tests to run"
     ]
   },
   "config": {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Post-install / build scripts are a common source of security vulnerabilities. (see: [axios supply chain compromise](https://github.com/axios/axios/issues/10636) used a post install script to compromise affected systems)
pnpm follows a block by default policy for post install / build scripts to safeguard against this, hence pruning and only install allow list as necessary reduces exposure to this attack vector. 

## Solution
<!-- How did you solve the problem? -->
Prune unneeded onlyBuiltDependencies, maintain a comments array to document why each build is used for/needed.

**Summary of why items are excluded / included:** 
"onlyBuiltDependencies": [
      "bcrypt", ✅  needed for backend usage
      "@datadog/native-appsec", ❌ verified metrics and logs are piped without it
      "@datadog/native-iast-taint-tracking", ❌ verified metrics and logs are piped without it
      "@datadog/native-metrics", ❌ verified metrics and logs are piped without it
      "@datadog/pprof", ❌ verified metrics and logs are piped without it
      "aws-sdk", ❌ aws items eg, virus scan, email SES etc work without it
      "aws-lambda-ric", ✅ needed for virus scanner to launch 
      "canvas", ✅ needed for signature fields
      "dd-trace", ❌ verified metrics and logs are piped without it
      "esbuild", ❌  used by chromatic, ts-jest, react email which work without it 
      "fsevents", ❌ not needed, used a optional deps by a couple deps 
      "protobufjs", ❌ not needed, used by dd-trace which still pipes logs and metrics without it 
      "sharp", ❌ not needed, only used as optional dep by next, which is used by react-email. verified react email renders fine without it. 
      "unix-dgram", ❌ not needed, only used by hotshots as optional dep
      "msw", ❌  not needed, only used by frontend tests which run fine without it 
      "microtime" ✅ needed for some frontend tests (~4) to run 
    ] 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
- [x] Datadog logs, metrics etc are piped correctly 
- [x] Frontend tests can run 
- [x] Backend tests can run 
- [x] playwright e2e tests can run
- [x] AWS services work eg, email, virus scan
- [x] PDF generation works locally and via email 
- [x] Payments works  
- [x] Emails rendered using react-email works eg, respondent email field OTP  