### PR TITLE
feat: mrf response limit v1.0

### DIFF
--- a/apps/backend/__tests__/unit/backend/helpers/jest-express.ts
+++ b/apps/backend/__tests__/unit/backend/helpers/jest-express.ts
@@ -35,19 +35,25 @@ const mockRequest = <P extends Record<string, string>, B, Q = any>({
 const mockResponse = (
   extraArgs: Partial<Record<keyof Response, unknown>> = {},
 ): Response => {
+  const markHeadersSent = function (this: { headersSent: boolean }) {
+    this.headersSent = true
+    return this
+  }
+
   const mockRes = {
     locals: {},
+    headersSent: false,
     status: jest.fn().mockReturnThis(),
-    send: jest.fn().mockReturnThis(),
-    sendStatus: jest.fn().mockReturnThis(),
+    send: jest.fn().mockImplementation(markHeadersSent),
+    sendStatus: jest.fn().mockImplementation(markHeadersSent),
     type: jest.fn().mockReturnThis(),
     pipe: jest.fn().mockReturnThis(),
     emit: jest.fn().mockReturnThis(),
     on: jest.fn().mockReturnThis(),
-    end: jest.fn(),
-    json: jest.fn(),
+    end: jest.fn().mockImplementation(markHeadersSent),
+    json: jest.fn().mockImplementation(markHeadersSent),
     render: jest.fn(),
-    redirect: jest.fn(),
+    redirect: jest.fn().mockImplementation(markHeadersSent),
     cookie: jest.fn(),
     set: jest.fn(),
     clearCookie: jest.fn(),

--- a/apps/backend/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/apps/backend/src/app/modules/form/__tests__/form.service.spec.ts
@@ -5,6 +5,7 @@ import {
   FormResponseMode,
   FormStatus,
   SubmissionType,
+  WorkflowType,
 } from 'formsg-shared/types'
 import { merge, times } from 'lodash'
 import mongoose from 'mongoose'
@@ -26,6 +27,29 @@ import * as FormService from '../form.service'
 const MOCK_FORM_ID = new ObjectId()
 const Form = getFormModel(mongoose)
 const Submission = getSubmissionModel(mongoose)
+
+const mockMultirespondentSubmissionForForm = (
+  formId: mongoose.Types.ObjectId,
+) => {
+  const workflowId = new ObjectId()
+  const fieldId = new ObjectId()
+  return {
+    form: formId,
+    submissionType: SubmissionType.Multirespondent,
+    form_fields: [{ _id: fieldId, fieldType: BasicField.ShortText }],
+    form_logics: [],
+    workflow: [
+      { _id: workflowId, workflow_type: WorkflowType.Static, emails: [] },
+    ],
+    submissionPublicKey: 'mockPublicKey',
+    encryptedSubmissionSecretKey: 'mockEncryptedSubmissionSecretKey',
+    encryptedContent: 'mockEncryptedContent',
+    version: 1,
+    created: new Date('2020-01-01'),
+    workflowStep: 0,
+    submittedSteps: [],
+  }
+}
 
 const MOCK_ADMIN_OBJ_ID = new ObjectId()
 const MOCK_FORM_PARAMS = {
@@ -374,86 +398,162 @@ describe('FormService', () => {
   })
 
   describe('checkFormSubmissionLimitAndDeactivateForm', () => {
-    it('should let requests through when form has no submission limit', async () => {
-      // Arrange
-      const form = {
-        _id: new ObjectId(),
-        submissionLimit: null,
-      } as IPopulatedForm
+    describe('for storage mode forms', () => {
+      it('should let requests through when form has no submission limit', async () => {
+        // Arrange
+        const form = {
+          responseMode: FormResponseMode.Encrypt,
+          _id: new ObjectId(),
+          submissionLimit: null,
+        } as IPopulatedForm
 
-      // Act
-      const actual =
-        await FormService.checkFormSubmissionLimitAndDeactivateForm(form)
+        // Act
+        const actual =
+          await FormService.checkFormSubmissionLimitAndDeactivateForm(form)
 
-      // Assert
-      expect(actual._unsafeUnwrap()).toEqual(form)
-    })
-
-    it('should return the form when the submission limit is not reached', async () => {
-      // Arrange
-      const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-        status: FormStatus.Public,
-        submissionLimit: 10,
+        // Assert
+        expect(actual._unsafeUnwrap()).toEqual(form)
       })
-      const validForm = new Form(formParams)
-      const form = await validForm.save()
 
-      const submissionPromises = times(5, () =>
-        Submission.create({
-          form: form._id,
-          myInfoFields: [],
-          submissionType: SubmissionType.Encrypt,
-          encryptedContent: 'mockEncryptedContent',
-          version: 1,
-          created: new Date('2020-01-01'),
-        }),
-      )
-      await Promise.all(submissionPromises)
+      it('should return the form when the submission limit is not reached', async () => {
+        // Arrange
+        const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
+          status: FormStatus.Public,
+          submissionLimit: 10,
+        })
+        const validForm = new Form(formParams)
+        const form = await validForm.save()
 
-      // Act
-      const actual =
-        await FormService.checkFormSubmissionLimitAndDeactivateForm(
-          form as IPopulatedForm,
+        const submissionPromises = times(5, () =>
+          Submission.create({
+            form: form._id,
+            myInfoFields: [],
+            submissionType: SubmissionType.Encrypt,
+            encryptedContent: 'mockEncryptedContent',
+            version: 1,
+            created: new Date('2020-01-01'),
+          }),
         )
+        await Promise.all(submissionPromises)
 
-      // Assert
-      expect(actual._unsafeUnwrap()).toEqual(validForm)
+        // Act
+        const actual =
+          await FormService.checkFormSubmissionLimitAndDeactivateForm(
+            form as IPopulatedForm,
+          )
+
+        // Assert
+        expect(actual._unsafeUnwrap()).toBe(form)
+      })
+
+      it('should not let requests through and deactivate form when form has reached submission limit', async () => {
+        // Arrange
+        const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
+          status: FormStatus.Public,
+          submissionLimit: 5,
+        })
+        const validForm = new Form(formParams)
+        const form = (await validForm.save()) as IPopulatedForm
+
+        const submissionPromises = times(5, () =>
+          Submission.create({
+            form: form._id,
+            myInfoFields: [],
+            submissionType: SubmissionType.Encrypt,
+            encryptedContent: 'mockEncryptedContent',
+            version: 1,
+            created: new Date('2020-01-01'),
+          }),
+        )
+        await Promise.all(submissionPromises)
+
+        // Act
+        const actual =
+          await FormService.checkFormSubmissionLimitAndDeactivateForm(form)
+
+        // Assert
+        expect(actual._unsafeUnwrapErr()).toEqual(
+          new PrivateFormError(
+            'Submission made after form submission limit was reached',
+            form.title,
+          ),
+        )
+        const updated = await Form.findById(form._id)
+        expect(updated!.status).toBe('PRIVATE')
+      })
     })
 
-    it('should not let requests through and deactivate form when form has reached submission limit', async () => {
-      // Arrange
-      const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
-        status: FormStatus.Public,
-        submissionLimit: 5,
+    describe('for mrf forms', () => {
+      it('should let requests through when form has no submission limit', async () => {
+        // Arrange
+        const form = {
+          _id: new ObjectId(),
+          responseMode: FormResponseMode.Multirespondent,
+          submissionLimit: null,
+        } as IPopulatedForm
+
+        // Act
+        const actual =
+          await FormService.checkFormSubmissionLimitAndDeactivateForm(form)
+
+        // Assert
+        expect(actual._unsafeUnwrap()).toEqual(form)
       })
-      const validForm = new Form(formParams)
-      const form = (await validForm.save()) as IPopulatedForm
 
-      const submissionPromises = times(5, () =>
-        Submission.create({
-          form: form._id,
-          myInfoFields: [],
-          submissionType: SubmissionType.Encrypt,
-          encryptedContent: 'mockEncryptedContent',
-          version: 1,
-          created: new Date('2020-01-01'),
-        }),
-      )
-      await Promise.all(submissionPromises)
+      it('should return the form when the submission limit is not reached', async () => {
+        // Arrange
+        const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
+          responseMode: FormResponseMode.Multirespondent,
+          status: FormStatus.Public,
+          submissionLimit: 10,
+        })
+        const validForm = new Form(formParams)
+        const form = await validForm.save()
 
-      // Act
-      const actual =
-        await FormService.checkFormSubmissionLimitAndDeactivateForm(form)
+        const submissionPromises = times(5, () =>
+          Submission.create(mockMultirespondentSubmissionForForm(form._id)),
+        )
+        await Promise.all(submissionPromises)
 
-      // Assert
-      expect(actual._unsafeUnwrapErr()).toEqual(
-        new PrivateFormError(
-          'Submission made after form submission limit was reached',
-          form.title,
-        ),
-      )
-      const updated = await Form.findById(form._id)
-      expect(updated!.status).toBe('PRIVATE')
+        // Act
+        const actual =
+          await FormService.checkFormSubmissionLimitAndDeactivateForm(
+            form as IPopulatedForm,
+          )
+
+        // Assert
+        expect(actual._unsafeUnwrap()).toBe(form)
+      })
+
+      it('should not let requests through and deactivate form when form has reached submission limit', async () => {
+        // Arrange
+        const formParams = merge({}, MOCK_ENCRYPTED_FORM_PARAMS, {
+          responseMode: FormResponseMode.Multirespondent,
+          status: FormStatus.Public,
+          submissionLimit: 5,
+        })
+        const validForm = new Form(formParams)
+        const form = (await validForm.save()) as IPopulatedForm
+
+        const submissionPromises = times(5, () =>
+          Submission.create(mockMultirespondentSubmissionForForm(form._id)),
+        )
+        await Promise.all(submissionPromises)
+
+        // Act
+        const actual =
+          await FormService.checkFormSubmissionLimitAndDeactivateForm(form)
+
+        // Assert
+        expect(actual._unsafeUnwrapErr()).toEqual(
+          new PrivateFormError(
+            'Submission made after form submission limit was reached',
+            form.title,
+          ),
+        )
+        const updated = await Form.findById(form._id)
+        expect(updated!.status).toBe('PRIVATE')
+      })
     })
   })
 

--- a/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -3,6 +3,7 @@ import { IPersonResponse } from '@opengovsg/myinfo-gov-client'
 import { ObjectId } from 'bson'
 import { Request } from 'express'
 import { ErrorCode, FormAuthType, MyInfoAttribute } from 'formsg-shared/types'
+import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync } from 'neverthrow'
 
 import { spcpMyInfoConfig } from 'src/app/config/features/spcp-myinfo.config'
@@ -127,6 +128,81 @@ describe('public-form.controller', () => {
             [MYINFO_AUTH_CODE_COOKIE_NAME]: MOCK_MYINFO_AUTH_CODE_COOKIE,
           },
         },
+      })
+    })
+
+    describe('submission limit checks', () => {
+      const MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM = {
+        ...BASE_FORM,
+        submissionLimit: 1,
+        authType: FormAuthType.NIL,
+        inactiveMessage:
+          'Submission made after form submission limit was reached',
+      } as unknown as IPopulatedForm
+
+      beforeAll(() => {
+        MockFormService.checkIsIntranetFormAccess.mockReturnValue(false)
+        MockAuthService.getFormIfPublic.mockReturnValue(
+          okAsync(MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM),
+        )
+        MockFormService.checkFormSmsLimitAndDeactivateForm.mockReturnValue(
+          okAsync(MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM),
+        )
+      })
+
+      it('should check for submission limit and return 200 when form not reached submission limit', async () => {
+        // Arrange
+        const mockRes = expressHandler.mockResponse()
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+          okAsync(MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM),
+        )
+
+        // Act
+        await PublicFormController.handleGetPublicForm(
+          MOCK_REQ,
+          mockRes,
+          jest.fn(),
+        )
+
+        // Assert
+        expect(
+          MockFormService.checkFormSubmissionLimitAndDeactivateForm,
+        ).toHaveBeenCalledWith(MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM)
+        expect(mockRes.json).toHaveBeenCalledWith({
+          form: MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM.getPublicView(),
+          isIntranetUser: false,
+        })
+      })
+
+      it('should check for submission limit and return 404 not found when form has reached submission limit', async () => {
+        // Arrange
+        const mockRes = expressHandler.mockResponse()
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValueOnce(
+          errAsync(
+            new PrivateFormError(
+              MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM.inactiveMessage,
+              MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM.title,
+            ),
+          ),
+        )
+
+        // Act
+        await PublicFormController.handleGetPublicForm(
+          MOCK_REQ,
+          mockRes,
+          jest.fn(),
+        )
+
+        // Assert
+        expect(
+          MockFormService.checkFormSubmissionLimitAndDeactivateForm,
+        ).toHaveBeenCalledWith(MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM)
+        expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+        expect(mockRes.json).toHaveBeenCalledWith({
+          isPageFound: true,
+          message: MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM.inactiveMessage,
+          formTitle: MOCK_SUBMISSION_LIMIT_NIL_AUTH_FORM.title,
+        })
       })
     })
 

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -16,9 +16,10 @@ import {
 } from 'formsg-shared/types'
 import { stripWorkflowEmails } from 'formsg-shared/utils/strip-workflow-emails'
 import { StatusCodes } from 'http-status-codes'
-import { err, ok, Result } from 'neverthrow'
+import { err, ok, okAsync, Result } from 'neverthrow'
 
 import { IPopulatedMultirespondentForm } from '../../../../types'
+import { isTest } from '../../../config/config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { isMongoError } from '../../../utils/handle-mongo-error'
 import { createReqMeta, getRequestIp } from '../../../utils/request'
@@ -90,9 +91,17 @@ export const handleGetPublicForm: ControllerHandler<
     formId,
   }
 
+  const gb = req.growthbook
+  const isMrfResponseLimitEnabled =
+    isTest || (gb?.isOn(featureFlags.mrfResponseLimit) ?? true)
+
   const formResult = await getFormIfPublic(formId)
     .andThen((form) =>
-      FormService.checkFormSubmissionLimitAndDeactivateForm(form),
+      // TODO(MRF-SUBMISSION-LIMIT): Remove check once mrf submission limit is stable.
+      form.responseMode === FormResponseMode.Encrypt ||
+      isMrfResponseLimitEnabled
+        ? FormService.checkFormSubmissionLimitAndDeactivateForm(form)
+        : okAsync(form),
     )
     .andThen((form) => FormService.checkFormSmsLimitAndDeactivateForm(form))
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -12,6 +12,7 @@ import {
   SubmissionType,
   WorkflowType,
 } from 'formsg-shared/types'
+import { StatusCodes } from 'http-status-codes'
 import { merge, omit } from 'lodash'
 import { Document, Types } from 'mongoose'
 import { errAsync, ok, okAsync } from 'neverthrow'
@@ -23,6 +24,7 @@ import * as AdminFormService from 'src/app/modules/form/admin-form/admin-form.se
 import {
   ForbiddenFormError,
   FormNotFoundError,
+  PrivateFormError,
 } from 'src/app/modules/form/form.errors'
 import * as FormService from 'src/app/modules/form/form.service'
 import * as SubmissionService from 'src/app/modules/submission/submission.service'
@@ -345,6 +347,60 @@ describe('multirespondent-submision.controller', () => {
       })
     })
 
+    it('returns 404 not found when form has reached submission limit', async () => {
+      // Arrange
+      const inactiveMessage =
+        'Submission made after form submission limit was reached'
+      MockFormService.checkFormSubmissionLimitAndDeactivateForm = jest
+        .fn()
+        .mockReturnValueOnce(
+          errAsync(new PrivateFormError(inactiveMessage, 'Mock Form Title')),
+        )
+
+      const mockReq = expressHandler.mockRequest({
+        params: {
+          formId: mockFormId,
+          submissionId: mockSubmissionId,
+        },
+        body: {} as any,
+      })
+      const mockSubmitMrfReq = merge(mockReq, {
+        formsg: {
+          formDef: {
+            _id: mockFormId,
+            authType: FormAuthType.NIL,
+            getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+            inactiveMessage,
+          },
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {},
+            workflowStep: 0,
+          },
+        } as any,
+      })
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitMultirespondentFormForTest(mockSubmitMrfReq, mockRes)
+
+      // Assert
+      expect(
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm,
+      ).toHaveBeenCalledWith(mockSubmitMrfReq.formsg.formDef)
+      expect(
+        MockMultiRespondentSubmissionService.createMultiRespondentFormSubmission,
+      ).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: inactiveMessage,
+      })
+      expect(mockRes.json).toHaveBeenCalledTimes(1)
+    })
+
     it('returns 500 internal server error when submission fails to save', async () => {
       // Arrange
       const submissionSaveError = new SubmissionSaveError()
@@ -647,6 +703,75 @@ describe('multirespondent-submision.controller', () => {
         message:
           'Could not upload attachments for submission. For assistance, please contact the person who asked you to fill in this form.',
       })
+    })
+
+    it('returns 404 not found when form has reached submission limit', async () => {
+      // Arrange
+      const inactiveMessage =
+        'Submission made after form submission limit was reached'
+      MockFormService.checkFormSubmissionLimitAndDeactivateForm = jest
+        .fn()
+        .mockReturnValueOnce(
+          errAsync(new PrivateFormError(inactiveMessage, 'Mock Form Title')),
+        )
+
+      const mockReq = expressHandler.mockRequest({
+        params: {
+          formId: mockFormId,
+          submissionId: mockSubmissionId,
+        },
+        body: {} as any,
+      })
+      const mockSubmitMrfReq = merge(mockReq, {
+        formsg: {
+          formDef: {
+            _id: mockFormId,
+            authType: FormAuthType.NIL,
+            getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+            inactiveMessage,
+          },
+          snapshottedFormDef: {
+            _id: mockFormId,
+            form_fields: [],
+            form_logics: [],
+            workflow: [],
+            emails: [],
+            stepOneEmailNotificationFieldId: '',
+            stepsToNotify: [],
+            hasRespondentCopy: false,
+            title: 'Mock snapshotted form def',
+            webhook: {
+              url: '',
+              isRetryEnabled: false,
+            },
+          } as SnapshottedFormDef,
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {},
+            workflowStep: 0,
+          },
+        } as any,
+      })
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await updateMultirespondentSubmissionForTest(mockSubmitMrfReq, mockRes)
+
+      // Assert
+      expect(
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm,
+      ).toHaveBeenCalledWith(mockSubmitMrfReq.formsg.formDef)
+      expect(
+        MockMultiRespondentSubmissionService.updateMultiRespondentFormSubmission,
+      ).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: inactiveMessage,
+      })
+      expect(mockRes.json).toHaveBeenCalledTimes(1)
     })
 
     it('returns 500 internal server error when submission fails to save', async () => {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -1,4 +1,5 @@
 import { AuthedSessionData } from 'express-session'
+import { featureFlags } from 'formsg-shared/constants'
 import {
   ErrorDto,
   FormResponseMode,
@@ -10,7 +11,7 @@ import { StatusCodes } from 'http-status-codes'
 import { errAsync, okAsync } from 'neverthrow'
 
 import { Environment } from '../../../../types'
-import config from '../../../config/config'
+import config, { isTest } from '../../../config/config'
 import { spcpMyInfoConfig } from '../../../config/features/spcp-myinfo.config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
@@ -88,11 +89,16 @@ const submitMultirespondentForm = async (
 
   setFormTags(form)
 
-  const ensurePipeline = new Pipeline(
-    ensurePublicForm,
-    ensureValidCaptcha,
-    ensureFormWithinSubmissionLimits,
-  )
+  // TODO(MRF-SUBMISSION-LIMIT): Remove this isMrfResponseLimitEnabled check once mrf submission limit is stable.
+  const gb = req.growthbook
+  const isMrfResponseLimitEnabled =
+    isTest || (gb?.isOn(featureFlags.mrfResponseLimit) ?? true)
+
+  const middlewarePipelines = [ensurePublicForm, ensureValidCaptcha]
+  if (isMrfResponseLimitEnabled) {
+    middlewarePipelines.push(ensureFormWithinSubmissionLimits)
+  }
+  const ensurePipeline = new Pipeline(...middlewarePipelines)
 
   const hasEnsuredAll = await ensurePipeline.execute({
     form,
@@ -173,11 +179,16 @@ const updateMultirespondentSubmission = async (
 
   setFormTags(currentForm)
 
-  const ensurePipeline = new Pipeline(
-    ensurePublicForm,
-    ensureValidCaptcha,
-    ensureFormWithinSubmissionLimits,
-  )
+  // TODO(MRF-SUBMISSION-LIMIT): Remove this isMrfResponseLimitEnabled check once mrf submission limit is stable.
+  const gb = req.growthbook
+  const isMrfResponseLimitEnabled =
+    gb?.isOn(featureFlags.mrfResponseLimit) ?? true
+
+  const middlewarePipelines = [ensurePublicForm, ensureValidCaptcha]
+  if (isMrfResponseLimitEnabled) {
+    middlewarePipelines.push(ensureFormWithinSubmissionLimits)
+  }
+  const ensurePipeline = new Pipeline(...middlewarePipelines)
 
   const hasEnsuredAll = await ensurePipeline.execute({
     form: currentForm,

--- a/apps/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -8,8 +8,6 @@ import {
 import { useTranslation } from 'react-i18next'
 import { FormControl, Skeleton } from '@chakra-ui/react'
 
-import { FormResponseMode } from 'formsg-shared/types'
-
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import NumberInput from '~components/NumberInput'
@@ -114,8 +112,6 @@ export const FormLimitToggle = (): JSX.Element => {
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
-  const isMrf = settings?.responseMode === FormResponseMode.Multirespondent
-
   const { data: responseCount, isLoading: isLoadingCount } =
     useFormResponsesCount()
 
@@ -159,7 +155,6 @@ export const FormLimitToggle = (): JSX.Element => {
   return (
     <Skeleton isLoaded={!isLoadingSettings && !!settings} mt="2rem">
       <Toggle
-        isDisabled={isMrf}
         isLoading={mutateFormLimit.isLoading}
         isChecked={isLimit}
         label={t('features.adminForm.settings.general.limit.label')}

--- a/apps/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -12,7 +12,6 @@ import { FormResponseMode } from 'formsg-shared/types'
 
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
-import InlineMessage from '~components/InlineMessage'
 import NumberInput from '~components/NumberInput'
 import Toggle from '~components/Toggle'
 
@@ -166,11 +165,6 @@ export const FormLimitToggle = (): JSX.Element => {
         label={t('features.adminForm.settings.general.limit.label')}
         onChange={() => handleToggleLimit()}
       />
-      {isMrf ? (
-        <InlineMessage variant="warning" mt="0.5rem">
-          {t('features.adminForm.settings.general.limit.notForMRF')}
-        </InlineMessage>
-      ) : null}
       {settings && settings?.submissionLimit !== null && (
         <Skeleton isLoaded={!isLoadingCount}>
           <FormLimitBlock

--- a/apps/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormLimitToggle.tsx
@@ -7,6 +7,10 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FormControl, Skeleton } from '@chakra-ui/react'
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
+
+import { featureFlags } from 'formsg-shared/constants'
+import { FormResponseMode } from 'formsg-shared/types'
 
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -112,6 +116,13 @@ export const FormLimitToggle = (): JSX.Element => {
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
+  // TODO(MRF-SUBMISSION-LIMIT): Remove this isEnabled check once mrf submission limit is stable.
+  const isEncryptedMode = settings?.responseMode === FormResponseMode.Encrypt
+  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
+  const isMrfResponseLimitEnabled =
+    useFeatureIsOn(featureFlags.mrfResponseLimit) || isTest
+  const isEnabled = isEncryptedMode || isMrfResponseLimitEnabled
+
   const { data: responseCount, isLoading: isLoadingCount } =
     useFormResponsesCount()
 
@@ -152,7 +163,7 @@ export const FormLimitToggle = (): JSX.Element => {
     settings,
   ])
 
-  return (
+  return isEnabled ? (
     <Skeleton isLoaded={!isLoadingSettings && !!settings} mt="2rem">
       <Toggle
         isLoading={mutateFormLimit.isLoading}
@@ -169,5 +180,7 @@ export const FormLimitToggle = (): JSX.Element => {
         </Skeleton>
       )}
     </Skeleton>
+  ) : (
+    <></>
   )
 }

--- a/apps/frontend/src/features/admin-form/settings/mutations.ts
+++ b/apps/frontend/src/features/admin-form/settings/mutations.ts
@@ -148,11 +148,14 @@ export const useMutateFormSettings = () => {
     {
       onSuccess: (newData) => {
         // Show toast on success.
+        const successToastI18nKey =
+          newData.responseMode === FormResponseMode.Multirespondent
+            ? 'features.adminForm.settings.general.limit.toast.successMrf'
+            : 'features.adminForm.settings.general.limit.toast.successStorageMode'
         const toastStatusMessage = newData.submissionLimit
-          ? simplur`Your form will now automatically close on the ${[
-              newData.submissionLimit,
-              formatOrdinal,
-            ]} submission.`
+          ? t(successToastI18nKey, {
+              submissionLimit: formatOrdinal(newData.submissionLimit),
+            })
           : 'The submission limit on your form is removed.'
         handleSuccess({ newData, toastDescription: toastStatusMessage })
       },

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -15,7 +15,6 @@ export const enSG = {
   },
   limit: {
     label: 'Set a response limit',
-    notForMRF: 'Response limits cannot be applied for multi-respondent forms.',
     input: {
       label: 'Maximum number of responses allowed',
       description:

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -20,6 +20,12 @@ export const enSG = {
       description:
         'Your form will automatically close once it reaches the set limit.',
     },
+    toast: {
+      successStorageMode:
+        'Your form will now automatically close on the {submissionLimit} submission.',
+      successMrf:
+        'Your form will now automatically close on the {submissionLimit} started workflow.',
+    },
     limitLessThanCurrent:
       'Submission limit must be greater than current submission count ({currentResponseCount})',
   },

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
@@ -16,7 +16,6 @@ export interface General extends HasTitle {
   }
   limit: {
     label: string
-    notForMRF: string
     input: {
       label: string
       description: string

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
@@ -20,6 +20,10 @@ export interface General extends HasTitle {
       label: string
       description: string
     }
+    toast: {
+      successStorageMode: string
+      successMrf: string
+    }
     limitLessThanCurrent: string
   }
   customisation: {

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -33,6 +33,7 @@ export const featureFlags = {
   ogpSpinner: 'ogp-spinner' as const,
   forumsg: 'forumsg' as const,
   wogadLogin: 'wogad-login' as const,
+  mrfResponseLimit: 'mrf-response-limit' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The response limit feature is currently unavailable on Multi-Response Forms (MRFs), creating a parity gap that is blocking the unification of Storage and MRF form types.
Closes FRM-2355

## Solution
<!-- How did you solve the problem? -->
- Enable the "Set a response limit" toggle on MRF settings pages, matching the behaviour of the existing response limit feature on standard forms.
- Remove the infobox that currently states response limits cannot be applied to multi-respondent forms.
- Response limit should be tied to the number of workflows started (not completed submissions).

Out of scope: Allowing in-progress workflows to continue after the form is closed due to a response limit being reached. This will be treated as a V1.5 enhancement.

Automated testing: 
When the submission limit is met, this submission limit is checked and used to deactivate (close) forms in 2 cases: 
- when the user tries to retrieve the public form, the form is deactivated and a 404 is returned. 
- when a submission is made directly to the submission endpoint (potentially without retrieving the public form immediately before), the form is deactivated and 404 is returned. 

Hence, tests are written for the following 2 scenarios for multi respondent forms (service method and controller at the relevant level of abstraction).
Some of these tests are expected to be updated once Response Limit (MRF) v1.5 is in progress.  

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
Submission limit toggle works for MRF
- [ ] Create MRF form with 2 steps 
- [ ] Enable the submission limit toggle on MRF settings and set to submission limit 3. 
- [ ] Submit MRF form entirely ie 2 steps.
- [ ] Ensure that the MRF form is still open. 
- [ ] Submit a second new MRF form and only fill 1 step. 
- [ ] The form should still be open (despite the being "3 steps worth of submissions")
- [ ] Submit a third new MRF form. 
- [ ] The form should now be closed, even for the partially completed workflow and for any new submissions. (This follows the scope of submission limit (MRF) v1.0)  