### PR TITLE
fix(security): bump axios 1.15.0

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -35,7 +35,7 @@
     "JSONStream": "^1.3.5",
     "aws-info": "^1.2.0",
     "aws-sdk": "^2.1692.0",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "bcrypt": "^5.1.1",
     "bluebird": "^3.5.2",
     "body-parser": "^2.2.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -30,7 +30,7 @@
     "@stripe/react-stripe-js": "^1.15.0",
     "@stripe/stripe-js": "^1.44.1",
     "@types/stopword": "^2.0.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "broadcast-channel": "^4.13.0",
     "browser-image-compression": "^2.0.2",
     "comlink": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: ^2.1692.0
         version: 2.1692.0
       axios:
-        specifier: ^1.13.5
-        version: 1.13.5(debug@4.4.1)
+        specifier: ^1.15.0
+        version: 1.15.0
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1(encoding@0.1.13)
@@ -522,7 +522,7 @@ importers:
         version: 8.26.1(eslint@8.57.1)(typescript@5.9.3)
       axios-mock-adapter:
         specifier: ^1.22.0
-        version: 1.22.0(axios@1.13.5)
+        version: 1.22.0(axios@1.15.0)
       concurrently:
         specifier: ^7.6.0
         version: 7.6.0
@@ -695,8 +695,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       axios:
-        specifier: ^1.13.5
-        version: 1.13.5(debug@4.4.1)
+        specifier: ^1.15.0
+        version: 1.15.0
       broadcast-channel:
         specifier: ^4.13.0
         version: 4.13.0
@@ -6374,6 +6374,9 @@ packages:
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+
   b4a@1.6.4:
     resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}
 
@@ -11969,6 +11972,10 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -18862,7 +18869,7 @@ snapshots:
 
   '@opengovsg/myinfo-gov-client@4.1.2':
     dependencies:
-      axios: 1.13.5(debug@4.4.1)
+      axios: 1.15.0
       jsonwebtoken: 8.5.1
       node-jose: 2.2.0
       qs: 6.14.0
@@ -19256,7 +19263,7 @@ snapshots:
     dependencies:
       adm-zip: 0.5.16
       archiver: 5.3.2
-      axios: 1.13.5(debug@4.4.1)
+      axios: 1.15.0
       fast-glob: 3.3.2
       https-proxy-agent: 5.0.1(supports-color@8.1.1)
       ignore: 5.3.2
@@ -21854,9 +21861,9 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios-mock-adapter@1.22.0(axios@1.13.5):
+  axios-mock-adapter@1.22.0(axios@1.15.0):
     dependencies:
-      axios: 1.13.5(debug@4.4.1)
+      axios: 1.15.0
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
 
@@ -21865,6 +21872,14 @@ snapshots:
       follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.5
       proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.15.11(debug@4.4.1)
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -29268,6 +29283,8 @@ snapshots:
       - supports-color
 
   proxy-from-env@1.1.0: {}
+
+  proxy-from-env@2.1.0: {}
 
   prr@1.0.1: {}
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes FRM-2358.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Bump axios to 1.15.0

Note: this doesn't bump the SDK axios dependency version: the existing ^ match will allow downstream consumers to manage the dependency bump themselves.

## Before & After Screenshots

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `axios` : bump to `1.15.0`
