### PR TITLE
feat(i18n): extract builder and field row text in create flow

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Box, Flex } from '@chakra-ui/react'
 
 import InlineMessage from '~components/InlineMessage'
@@ -20,6 +21,9 @@ interface BuilderAndDesignContentProps {
 export const BuilderAndDesignContent = ({
   placeholderProps,
 }: BuilderAndDesignContentProps): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.sidebar.fields.builderAndDesignContent',
+  })
   const { data: settings } = useAdminFormSettings()
 
   const setFieldsToInactive = useFieldBuilderStore(setToInactiveSelector)
@@ -38,8 +42,7 @@ export const BuilderAndDesignContent = ({
             mt={{ base: 0, md: '2rem' }}
             mb={{ base: 0, md: '-1rem' }}
           >
-            Webhooks are enabled on this form. Please ensure the webhook server
-            is able to handle any field changes.
+            {t('webhookEnabledWarning')}
           </InlineMessage>
         ) : null}
         <FormBuilder placeholderProps={placeholderProps} display="flex" />

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/BuilderAndDesignPlaceholder.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/BuilderAndDesignPlaceholder.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Box, Flex, Text } from '@chakra-ui/react'
 import { isEmpty } from 'lodash'
 
@@ -14,6 +15,10 @@ export const BuilderAndDesignPlaceholder = ({
   placeholderProps,
   isDraggingOver,
 }: BuilderDesignPlaceholderProps): JSX.Element | null => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.sidebar.fields.builderAndDesignPlaceholder',
+  })
+
   const renderedContents = useMemo(() => {
     switch (placeholderProps.droppableId) {
       case FIELD_LIST_DROP_ID:
@@ -36,11 +41,11 @@ export const BuilderAndDesignPlaceholder = ({
             justify="center"
             align="center"
           >
-            <Text textStyle="subhead-2">Drop your field here</Text>
+            <Text textStyle="subhead-2">{t('dropFieldHere')}</Text>
           </Flex>
         )
     }
-  }, [placeholderProps.droppableId])
+  }, [placeholderProps.droppableId, t])
 
   if (isEmpty(placeholderProps) || !isDraggingOver) return null
 

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Box,
   ButtonProps,
@@ -19,7 +20,13 @@ import { useIsMobile } from '~hooks/useIsMobile'
 import MagicFormBuilderButton from '../../MagicFormBuilder/components/MagicFormBuilderButton'
 import { useMagicFormBuilder } from '../../MagicFormBuilder/useMagicFormBuilder'
 
-const OrDivider = ({ isMobile }: { isMobile: boolean }) => (
+const OrDivider = ({
+  isMobile,
+  orText,
+}: {
+  isMobile: boolean
+  orText: string
+}) => (
   <Flex
     width="100%"
     maxW={isMobile ? '12rem' : '18rem'}
@@ -35,7 +42,7 @@ const OrDivider = ({ isMobile }: { isMobile: boolean }) => (
       px="1.5rem"
       textAlign={'center'}
     >
-      OR
+      {orText}
     </Text>
     <Box flexGrow={1} height="1px" bgColor="black" />
   </Flex>
@@ -50,18 +57,19 @@ export const EmptyFormPlaceholder = forwardRef<
   EmptyFormPlaceholderProps,
   'button'
 >(({ isDraggingOver, onClick, ...props }, ref): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.sidebar.fields.emptyFormPlaceholder',
+  })
   const isMobile = useIsMobile()
 
   const { toggleIsModalOpen } = useMagicFormBuilder()
 
   const placeholderText = useMemo(() => {
     if (isDraggingOver) {
-      return 'Drop your field here'
+      return t('dropFieldHere')
     }
-    return isMobile
-      ? 'Tap here to add a field'
-      : 'Drag a field from the Builder on the left to start'
-  }, [isDraggingOver, isMobile])
+    return isMobile ? t('tapToAddField') : t('dragFromBuilderToStart')
+  }, [isDraggingOver, isMobile, t])
 
   const isMfbTextEnabled = useFeatureIsOn(featureFlags.mfb)
   const isMfbVisionEnabled = useFeatureIsOn(featureFlags.mfbVision)
@@ -102,7 +110,7 @@ export const EmptyFormPlaceholder = forwardRef<
           </Text>
           {isMfbTextEnabled || isMfbVisionEnabled ? (
             <>
-              <OrDivider isMobile={isMobile} />
+              <OrDivider isMobile={isMobile} orText={t('or')} />
               <Box h="2.75rem"></Box>
             </>
           ) : null}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -145,6 +145,9 @@ const FieldRowContainer = ({
   handleBuilderClick,
   isHighlighted,
 }: FieldRowContainerProps): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.sidebar.fields.fieldRowContainer',
+  })
   const isMobile = useIsMobile()
   const numFormFieldMutations = useIsMutating(adminFormKeys.base)
   const updateEditState = useFieldBuilderStore(updateEditStateSelector)
@@ -263,7 +266,7 @@ const FieldRowContainer = ({
           <Tooltip
             hidden={!isHiddenByLogic}
             placement="top"
-            label="This field may be hidden by your form logic"
+            label={t('hiddenByLogicTooltip')}
           >
             <HighlightableFlex
               isHighlighted={isHighlighted} // Offset for focus boxShadow
@@ -382,6 +385,9 @@ const FieldButtonGroup = ({
   handleBuilderClick,
 }: FieldButtonGroupProps) => {
   const { t } = useTranslation()
+  const { t: tToast } = useTranslation('translation', {
+    keyPrefix: 'features.adminForm.toasts.field.duplicate',
+  })
   const setToInactive = useFieldBuilderStore(setToInactiveSelector)
 
   const { data: form } = useCreateTabForm()
@@ -425,13 +431,17 @@ const FieldButtonGroup = ({
       if (thisAttachmentSize > availableAttachmentSize) {
         toast({
           useMarkdown: true,
-          description: `The field "${field.title}" could not be duplicated. The attachment size of **${thisAttachmentSize} MB** exceeds the form's remaining available attachment size of **${availableAttachmentSize} MB**.`,
+          description: tToast('attachmentLimitExceeded', {
+            fieldTitle: field.title,
+            attachmentSizeMb: thisAttachmentSize,
+            availableAttachmentSizeMb: availableAttachmentSize,
+          }),
         })
         return
       }
     }
     duplicateFieldMutation.mutate(field._id)
-  }, [form, fieldBuilderState, field, duplicateFieldMutation, toast])
+  }, [form, fieldBuilderState, field, duplicateFieldMutation, toast, tToast])
 
   const handleDeleteClick = useCallback(() => {
     if (fieldBuilderState === FieldBuilderState.CreatingField) {

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/VerifiableFieldBuilderContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/VerifiableFieldBuilderContainer.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Box, Stack } from '@chakra-ui/react'
 
 import { FormColorTheme, FormFieldWithId } from 'formsg-shared/types'
@@ -18,13 +19,17 @@ export const VerifiableFieldBuilderContainer = ({
   colorTheme = FormColorTheme.Blue,
   children,
 }: VerifiableFieldBuilderContainerProps): JSX.Element => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.common',
+  })
+
   return (
     <FieldContainer schema={schema}>
       <Stack spacing="0.5rem" direction={{ base: 'column', md: 'row' }}>
         {children}
         <Box>
           <Button isDisabled colorScheme={`theme-${colorTheme}`}>
-            Verify
+            {t('verify')}
           </Button>
         </Box>
       </Stack>

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
@@ -27,6 +27,23 @@ export const enSG: Fields = {
     yesNo: 'Yes/No',
     children: 'Children',
   },
+  builderAndDesignContent: {
+    webhookEnabledWarning:
+      'Webhooks are enabled on this form. Please ensure the webhook server is able to handle any field changes.',
+  },
+  builderAndDesignPlaceholder: {
+    dropFieldHere: 'Drop your field here',
+  },
+  emptyFormPlaceholder: {
+    or: 'OR',
+    dropFieldHere: 'Drop your field here',
+    tapToAddField: 'Tap here to add a field',
+    dragFromBuilderToStart:
+      'Drag a field from the Builder on the left to start',
+  },
+  fieldRowContainer: {
+    hiddenByLogicTooltip: 'This field may be hidden by your form logic',
+  },
   commonFieldComponents: {
     title: 'Field Name',
     description: 'Description',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/index.ts
@@ -27,6 +27,21 @@ export interface Fields {
     yesNo: string
     children: string
   }
+  builderAndDesignContent: {
+    webhookEnabledWarning: string
+  }
+  builderAndDesignPlaceholder: {
+    dropFieldHere: string
+  }
+  emptyFormPlaceholder: {
+    or: string
+    dropFieldHere: string
+    tapToAddField: string
+    dragFromBuilderToStart: string
+  }
+  fieldRowContainer: {
+    hiddenByLogicTooltip: string
+  }
   commonFieldComponents: {
     title: string
     description: string

--- a/apps/frontend/src/i18n/locales/features/admin-form/toasts/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/toasts/en-sg.ts
@@ -21,6 +21,8 @@ export const enSG: Toasts = {
       success: 'The {field} was duplicated.',
       successButNoLogic:
         'The {field} was duplicated. Associated logic was not duplicated.',
+      attachmentLimitExceeded:
+        'The field "{fieldTitle}" could not be duplicated. The attachment size of **{attachmentSizeMb} MB** exceeds the form\'s remaining available attachment size of **{availableAttachmentSizeMb} MB**.',
       error:
         'Something went wrong when creating your field. Please refresh and try again.',
     },

--- a/apps/frontend/src/i18n/locales/features/admin-form/toasts/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/toasts/index.ts
@@ -10,7 +10,10 @@ export interface Toasts {
     delete: Toast
     create: Toast
     update: Toast
-    duplicate: Toast & { successButNoLogic: string }
+    duplicate: Toast & {
+      successButNoLogic: string
+      attachmentLimitExceeded: string
+    }
   }
   emailModeMigration: Toast
   respondentCopy: {


### PR DESCRIPTION
## Problem

Closes #8413

Builder/Create flow still had hardcoded English copy in multiple components, so text was not consistently sourced from i18n keys. This creates translation drift risk and leaves localization coverage incomplete for admin-form builder text.

## Solution

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- Extracted hardcoded builder/design copy to i18n keys in:
  - `BuilderAndDesignContent` (webhook warning banner)
  - `BuilderAndDesignPlaceholder` (drop placeholder)
  - `EmptyFormPlaceholder` (`OR`, drag/tap/drop helper text)
  - `FieldRowContainer` (hidden-by-logic tooltip)
  - `VerifiableFieldBuilderContainer` (`Verify` button now reuses common key)
- Extracted duplicate-attachment overflow toast message to i18n with interpolation variables:
  - `fieldTitle`
  - `attachmentSizeMb`
  - `availableAttachmentSizeMb`
- Added corresponding locale keys and TypeScript locale interfaces for:
  - `features.adminForm.sidebar.fields.*`
  - `features.adminForm.toasts.field.duplicate.attachmentLimitExceeded`
- Updated hook dependency arrays where translated strings are memoized/callback-based (`t` / `tToast`) to avoid stale text after locale change and satisfy hook dependency rules.

**Bug Fixes**:

- Completed i18n coverage for targeted Builder/Design strings in #8413 scope.

## Before & After Screenshots

**BEFORE**:
- UI text rendered from hardcoded strings in component files.

**AFTER**:
- Same user-facing English copy (`en-sg`), now rendered via translation keys.
- No layout or interaction changes.

## Tests

Executed locally:

1. `pnpm build:frontend`
   - Pass

2. `COREPACK_ENABLE_AUTO_PIN=0 pnpm --filter formsg-frontend test -- --run`
   - Pass (`31` test files, `220` tests)
   - Existing non-blocking warnings observed from test environment (`mswDecorator` deprecation, React `act(...)` warnings)

3. `COREPACK_ENABLE_AUTO_PIN=0 pnpm --filter formsg-frontend exec eslint <changed-files> --ignore-path .gitignore`
   - Pass

4. `COREPACK_ENABLE_AUTO_PIN=0 pnpm --filter formsg-frontend exec prettier -c <changed-files>`
   - Pass

Manual QA checklist (builder `/admin/form/<formId>`):
- Empty-state text on desktop/mobile.
- Drag-over placeholder text.
- Hidden-by-logic tooltip.
- Duplicate attachment overflow toast interpolation.
- Verify button label.
- Webhook warning banner copy.

## Deploy Notes

**New environment variables**:

- None.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.
