### PR TITLE
chore: use published mockpass image instead of building from source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       - SSO_CLIENT_SECRET
 
   mockpass:
-    build: https://github.com/opengovsg/mockpass.git#v4.3.1
+    image: opengovsg/mockpass:4.6.4
     depends_on:
       - backend
     environment:


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Mockpass is currently being built from source, but it uses whatever is the default latest for node-slim.

## Solution
<!-- How did you solve the problem? -->

- Stops mockpass building from source, instead
- uses published Docker image (faster startup time!)
- Node.js version is consistent since it is already baked in

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  