### PR TITLE
feat(sdk): bump axios 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "pnpm": {
     "overrides": {
+      "axios": "^1.15.0",
       "handlebars": "^4.7.9",
       "jspdf": "^4.2.1",
       "fast-xml-parser@<5": "^4.5.5",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,7 +42,7 @@
     "lint-ci": "eslint src/ --quiet"
   },
   "dependencies": {
-    "axios": "^1.6.4",
+    "axios": "^1.15.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  axios: ^1.15.0
   handlebars: ^4.7.9
   jspdf: ^4.2.1
   fast-xml-parser@<5: ^4.5.5
@@ -119,7 +120,7 @@ importers:
         version: 2.1692.0
       axios:
         specifier: ^1.15.0
-        version: 1.15.0
+        version: 1.15.0(debug@4.4.1)
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1(encoding@0.1.13)
@@ -696,7 +697,7 @@ importers:
         version: 2.0.1
       axios:
         specifier: ^1.15.0
-        version: 1.15.0
+        version: 1.15.0(debug@4.4.1)
       broadcast-channel:
         specifier: ^4.13.0
         version: 4.13.0
@@ -1129,8 +1130,8 @@ importers:
   packages/sdk:
     dependencies:
       axios:
-        specifier: ^1.6.4
-        version: 1.13.5(debug@4.4.1)
+        specifier: ^1.15.0
+        version: 1.15.0(debug@4.4.1)
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
@@ -6369,10 +6370,7 @@ packages:
   axios-mock-adapter@1.22.0:
     resolution: {integrity: sha512-dmI0KbkyAhntUR05YY96qg2H6gg0XMl2+qTW0xmYg6Up+BFBAJYRLROMXRdDEL06/Wqwa0TJThAYvFtSFdRCZw==}
     peerDependencies:
-      axios: '>= 0.17.0'
-
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+      axios: ^1.15.0
 
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
@@ -17458,7 +17456,7 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@types/datadog-metrics': 0.6.1
       async-retry: 1.3.3
-      axios: 1.13.5(debug@4.4.1)
+      axios: 1.15.0(debug@4.4.1)
       chalk: 3.0.0
       clipanion: 3.2.1(typanion@3.14.0)
       datadog-metrics: 0.9.3
@@ -17502,7 +17500,7 @@ snapshots:
   '@datadog/datadog-ci-plugin-deployment@5.12.1(@datadog/datadog-ci-base@5.12.1)':
     dependencies:
       '@datadog/datadog-ci-base': 5.12.1(@datadog/datadog-ci-plugin-coverage@5.12.1)(@datadog/datadog-ci-plugin-deployment@5.12.1)(@datadog/datadog-ci-plugin-dora@5.12.1)(@datadog/datadog-ci-plugin-gate@5.12.1)(@datadog/datadog-ci-plugin-junit@5.12.1)(@datadog/datadog-ci-plugin-sarif@5.12.1)(@datadog/datadog-ci-plugin-sbom@5.12.1)(@types/node@24.0.10)
-      axios: 1.13.5(debug@4.4.1)
+      axios: 1.15.0(debug@4.4.1)
       chalk: 3.0.0
       simple-git: 3.33.0
     transitivePeerDependencies:
@@ -17548,7 +17546,7 @@ snapshots:
       '@datadog/datadog-ci-base': 5.12.1(@datadog/datadog-ci-plugin-coverage@5.12.1)(@datadog/datadog-ci-plugin-deployment@5.12.1)(@datadog/datadog-ci-plugin-dora@5.12.1)(@datadog/datadog-ci-plugin-gate@5.12.1)(@datadog/datadog-ci-plugin-junit@5.12.1)(@datadog/datadog-ci-plugin-sarif@5.12.1)(@datadog/datadog-ci-plugin-sbom@5.12.1)(@types/node@24.0.10)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      axios: 1.13.5(debug@4.4.1)
+      axios: 1.15.0(debug@4.4.1)
       chalk: 3.0.0
       packageurl-js: 2.0.1
     transitivePeerDependencies:
@@ -18869,7 +18867,7 @@ snapshots:
 
   '@opengovsg/myinfo-gov-client@4.1.2':
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.0(debug@4.4.1)
       jsonwebtoken: 8.5.1
       node-jose: 2.2.0
       qs: 6.14.0
@@ -19263,7 +19261,7 @@ snapshots:
     dependencies:
       adm-zip: 0.5.16
       archiver: 5.3.2
-      axios: 1.15.0
+      axios: 1.15.0(debug@4.4.1)
       fast-glob: 3.3.2
       https-proxy-agent: 5.0.1(supports-color@8.1.1)
       ignore: 5.3.2
@@ -21863,19 +21861,11 @@ snapshots:
 
   axios-mock-adapter@1.22.0(axios@1.15.0):
     dependencies:
-      axios: 1.15.0
+      axios: 1.15.0(debug@4.4.1)
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
 
-  axios@1.13.5(debug@4.4.1):
-    dependencies:
-      follow-redirects: 1.15.11(debug@4.4.1)
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.0:
+  axios@1.15.0(debug@4.4.1):
     dependencies:
       follow-redirects: 1.15.11(debug@4.4.1)
       form-data: 4.0.5


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Follow up from #9292 
Closes FRM-2361

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Bump axios for SDK
- Override axios for @datadog/datadog-ci

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dependencies**:

- `axios` : ^1.15.0

**New dev dependencies**:

- `axios` : ^1.15.0
