### PR TITLE
feat(sdk): enable publishing

### DIFF
--- a/.external.versionrc.js
+++ b/.external.versionrc.js
@@ -8,9 +8,13 @@ const getShortHash = (commit) => {
 }
 module.exports = {
   path: ["packages/sdk"],
+  // Both packageFiles (read current version) and bumpFiles (write new version)
+  // must point at packages/sdk/package.json. If packageFiles is omitted,
+  // commit-and-tag-version falls back to reading the root package.json and
+  // derives the next SDK version from the monorepo version instead.
+  packageFiles: [{ filename: 'packages/sdk/package.json', type: 'json' }],
   bumpFiles: [{ filename: 'packages/sdk/package.json', type: 'json' }],
   infile: 'packages/sdk/CHANGELOG.md',
-  preMajor: true,
   tagPrefix: 'sdk-v',
   writerOpts: {
     groupBy: 'section',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
       shared: ${{ steps.filter.outputs.shared }}
+      sdk: ${{ steps.filter.outputs.sdk }}
     steps:
       - uses: actions/checkout@v4.3.1
         with:
@@ -49,10 +50,17 @@ jobs:
               - pnpm-lock.yaml
             shared:
               - packages/shared/constants/**
-              - packages/shared/modules/** 
+              - packages/shared/modules/**
               - packages/shared/types/**
               - packages/shared/utils/**
               - packages/shared/package.json
+              - pnpm-lock.yaml
+            sdk:
+              - packages/sdk/src/**
+              - packages/sdk/spec/**
+              - packages/sdk/package.json
+              - packages/sdk/tsconfig*.json
+              - packages/sdk/jest.config.js
               - pnpm-lock.yaml
 
   install:
@@ -310,4 +318,37 @@ jobs:
       - run: pnpm test:shared
         env:
           DD_TAGS: layer:shared
+          NODE_OPTIONS: --max-old-space-size=4096 -r ${{ env.DD_TRACE_PACKAGE }}
+
+  sdk_test:
+    # Mirrors the old formsg-javascript-sdk ci.yml `test` job — jest against
+    # packages/sdk/spec/**, no build step required (ts-jest compiles at test
+    # time). Gated on changes in packages/sdk so unrelated PRs are unaffected.
+    needs: [changes, install]
+    if: ${{ needs.changes.outputs.sdk == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.3.1
+        with:
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: ${{ env.PNPM_VERSION }}
+      - name: Use Node.js
+        uses: actions/setup-node@v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Configure Datadog Test Visibility
+        uses: datadog/test-visibility-github-action@7f2b515b64333229315f4701adc590ee6586b270 # v1.0.5
+        with:
+          languages: js
+          service-name: ${{ secrets.DD_SERVICE }}
+          api-key: ${{ secrets.DD_API_KEY }}
+      - run: pnpm test:sdk
+        env:
+          DD_TAGS: layer:sdk
           NODE_OPTIONS: --max-old-space-size=4096 -r ${{ env.DD_TRACE_PACKAGE }}

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,0 +1,118 @@
+name: Publish SDK
+
+# Release job for @opengovsg/formsg-sdk, published from packages/sdk.
+#
+# Modeled after the old non-monorepo publish.yml
+# (github.com/opengovsg/formsg-javascript-sdk), which used npm's OIDC
+# "trusted publisher" flow (no NPM_TOKEN secret) and triggered on push
+# to a dedicated `release` branch. In the monorepo, `release-al2` plays
+# the same role: it is the branch that deploys to prod when a release
+# PR (created by scripts/release_prep.sh) is merged into it.
+#
+# release_prep.sh bumps packages/sdk/package.json via
+# .external.versionrc.js and pushes a `sdk-v<version>` tag before
+# opening the release PR, so by the time this workflow runs there is
+# already a matching tag on the remote — all that is left to do is
+# build, publish to npm via OIDC, and create the GitHub release.
+#
+# The version check in the `Resolve SDK version` step makes this job a
+# no-op for monorepo releases that did not also bump the SDK — npm will
+# already have the current version and the subsequent steps are
+# skipped.
+
+env:
+  NODE_VERSION: '22.22'
+  PNPM_VERSION: '10.30.3'
+  SDK_PACKAGE: '@opengovsg/formsg-sdk'
+
+on:
+  push:
+    branches:
+      - release-al2
+    paths:
+      - 'packages/sdk/**'
+      - '.github/workflows/publish-sdk.yml'
+
+jobs:
+  release:
+    name: Publish @opengovsg/formsg-sdk
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create GitHub release against the existing sdk-v* tag
+      id-token: write  # required for npm OIDC trusted publisher
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Resolve SDK version
+        id: version
+        run: |
+          version=$(jq -r .version < packages/sdk/package.json)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=sdk-v${version}" >> "$GITHUB_OUTPUT"
+          if npm view "${{ env.SDK_PACKAGE }}@${version}" version >/dev/null 2>&1; then
+            echo "Version ${version} already published on npm; skipping release."
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version ${version} not yet on npm; will build and publish."
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update npm
+        if: ${{ steps.version.outputs.should-publish == 'true' }}
+        # npm 11.5.1+ required for OIDC trusted publishing.
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        if: ${{ steps.version.outputs.should-publish == 'true' }}
+        run: pnpm install
+
+      - name: Build SDK
+        if: ${{ steps.version.outputs.should-publish == 'true' }}
+        run: pnpm build:sdk
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
+
+      - name: Test SDK
+        if: ${{ steps.version.outputs.should-publish == 'true' }}
+        run: pnpm test:sdk
+
+      - name: Publish to npm
+        if: ${{ steps.version.outputs.should-publish == 'true' }}
+        working-directory: packages/sdk
+        # Uses OIDC trusted publisher — no NPM_TOKEN required.
+        # `--access public` is a no-op after the first publish, but is kept
+        # for clarity since @opengovsg/formsg-sdk is a scoped package.
+        run: npm publish --access public
+
+      - name: Extract release notes from changelog
+        if: ${{ steps.version.outputs.should-publish == 'true' }}
+        run: |
+          awk '/^## \['"${{ steps.version.outputs.version }}"'\]/{flag=1; next} /^## \[/{flag=0} flag' \
+            packages/sdk/CHANGELOG.md > .sdk_release_notes.md
+
+      - name: Create GitHub release
+        if: ${{ steps.version.outputs.should-publish == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "SDK v${{ steps.version.outputs.version }}" \
+            --notes-file .sdk_release_notes.md

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Notable features include:
 - (Singapore government agencies only) Citizen authentication with [sgID](https://www.id.gov.sg/)
 - (Singapore government agencies only) Corporate authentication with [CorpPass](https://www.corppass.gov.sg/corppass/common/aboutus)
 - (Singapore government agencies only) Automatic prefill of verified data with [MyInfo](https://www.singpass.gov.sg/myinfo/common/aboutus)
-- Webhooks functionality via the official [FormSG JavaScript SDK](https://github.com/opengovsg/formsg-sdk) and contributor-supported [FormSG Ruby SDK](https://github.com/opengovsg/formsg-ruby-sdk)
+- Webhooks functionality via the official [FormSG JavaScript SDK](./packages/sdk/README.md) (published as [`@opengovsg/formsg-sdk`](https://www.npmjs.com/package/@opengovsg/formsg-sdk) from [`packages/sdk`](./packages/sdk)) and contributor-supported [FormSG Ruby SDK](https://github.com/opengovsg/formsg-ruby-sdk)
 - Variable amount and Itemised payments on forms with [stripe](https://stripe.com) integration
 
 ## Local Development (Docker)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,263 @@
+_Please note that this is an SDK for webhooks integration, and_ **_not_** _the FormSG system._
+
+# FormSG JavaScript SDK
+
+This SDK provides convenient utilities for verifying FormSG webhooks and decrypting submissions in JavaScript and Node.js.
+
+This package used to live at [`opengovsg/formsg-javascript-sdk`](https://github.com/opengovsg/formsg-javascript-sdk) and is now developed in the main FormSG monorepo under [`packages/sdk`](./). It is still published to npm as [`@opengovsg/formsg-sdk`](https://www.npmjs.com/package/@opengovsg/formsg-sdk); starting with this migration the major version is bumped to `v7` to track the FormSG monorepo.
+
+Not using JavaScript? Check out our sister SDKs:
+- [formsg-python-sdk](https://github.com/opengovsg/formsg-python-sdk)
+
+## Installation
+
+Install the package with
+
+```bash
+npm install @opengovsg/formsg-sdk --save
+```
+
+## Configuration
+
+```javascript
+const formsg = require('@opengovsg/formsg-sdk')({
+  mode: 'production',
+})
+```
+
+| Option | Default      | Description                                                     |
+| ------ | ------------ | --------------------------------------------------------------- |
+| mode   | 'production' | Set to 'staging' if integrating against FormSG staging servers. |
+
+## Usage
+
+### Webhook Authentication and Decrypting Submissions
+
+```javascript
+// This example uses Express to receive webhooks
+const express = require('express')
+const app = express()
+
+// Instantiating formsg-sdk without parameters default to using the package's
+// production public signing key.
+const formsg = require('@opengovsg/formsg-sdk')()
+
+// This is where your domain is hosted, and should match
+// the URI supplied to FormSG in the form dashboard
+const POST_URI = 'https://my-domain.com/submissions'
+
+// Your form's secret key downloaded from FormSG upon form creation
+const formSecretKey = process.env.FORM_SECRET_KEY
+
+// Set to true if you need to download and decrypt attachments from submissions
+const HAS_ATTACHMENTS = false
+
+app.post(
+  '/submissions',
+  // Endpoint authentication by verifying signatures
+  function (req, res, next) {
+    try {
+      formsg.webhooks.authenticate(req.get('X-FormSG-Signature'), POST_URI)
+      // Continue processing the POST body
+      return next()
+    } catch (e) {
+      return res.status(401).send({ message: 'Unauthorized' })
+    }
+  },
+  // Parse JSON from raw request body
+  express.json(),
+  // Decrypt the submission
+  async function (req, res, next) {
+    // If `verifiedContent` is provided in `req.body.data`, the return object
+    // will include a verified key.
+    const submission = HAS_ATTACHMENTS
+      ? await formsg.crypto.decryptWithAttachments(formSecretKey, req.body.data)
+      : formsg.crypto.decrypt(formSecretKey, req.body.data)
+
+    // If the decryption failed, submission will be `null`.
+    if (submission) {
+      // Continue processing the submission
+    } else {
+      // Could not decrypt the submission
+    }
+  }
+)
+
+app.listen(8080, () => console.log('Running on port 8080'))
+```
+
+## End-to-end Encryption
+
+FormSG uses _end-to-end encryption_ with _elliptic curve cryptography_ to protect submission data and ensure only intended recipients are able to view form submissions. As such, FormSG servers are unable to access the data.
+
+The underlying cryptosystem is `x25519-xsalsa20-poly1305` which is implemented by the [tweetnacl-js](https://github.com/dchest/tweetnacl-js) library. Its source code has been [audited](https://cure53.de/tweetnacl.pdf)) by [Cure53](https://cure53.de/).
+
+### Format of Submission Response
+
+| Key                    | Type                   | Description                                                                                              |
+| ---------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------- |
+| formId                 | string                 | Unique form identifier.                                                                                  |
+| submissionId           | string                 | Unique response identifier, displayed as 'Response ID' to form respondents                               |
+| encryptedContent       | string                 | The encrypted submission in base64.                                                                      |
+| created                | string                 | Creation timestamp.                                                                                      |
+| attachmentDownloadUrls | Record<string, string> | (Optional) Records containing field IDs and URLs where encrypted uploaded attachments can be downloaded. |
+| paymentContent         | Record<string, string> | (Optional) Records containing payment details for forms with payments[1]                                 |
+
+[1] Forms with the deprecated Fixed Payment Type is not supported
+
+### Format of Decrypted Submissions
+
+`formsg.crypto.decrypt(formSecretKey: string, decryptParams: DecryptParams)`
+takes in `decryptParams` as the second argument, and returns an an object with
+the shape
+
+<pre>
+{
+  responses: <a href="./src/types.ts">FormField</a>[]
+  verified?: <a href="https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkt">Record&lt;string, any&gt;</a>
+}
+</pre>
+
+encryptedContent: EncryptedContent
+version: number
+verifiedContent?: EncryptedContent
+
+The `decryptParams.encryptedContent` field decrypts into an array of `FormField` objects, which will be assigned to the `responses` key of the returned object.
+
+Furthermore, if `decryptParams.verifiedContent` exists, the function will
+decrypt and open the signed decrypted content with the package's own
+`signingPublicKey` in
+[`signing-keys.ts`](./src/resource/signing-keys.ts).
+The resulting decrypted verifiedContent will be assigned to the `verified` key
+of the returned object.
+
+> **Note:** <br>
+> If any errors occur, either from the failure to decrypt either `encryptedContent` or `verifiedContent`, or the failure to authenticate the decrypted signed message in `verifiedContent`, `null` will be returned.
+
+Note that due to end-to-end encryption, FormSG servers are unable to verify the data format.
+
+However, the `decrypt` function exposed by this library [validates](./src/util/validate.ts) the decrypted content and will **return `null` if the
+decrypted content does not contain all of the fields displayed in the schema below.**
+
+| Key         | Type     | Description                                                                                              |
+| ----------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| question    | string   | The question listed on the form                                                                          |
+| answer      | string   | The submitter's answer to the question on form. Either this key or `answerArray` must exist.             |
+| answerArray | string[] | The submitter's answer to the question on form. Either this key or `answer` must exist.                  |
+| fieldType   | string   | The type of field for the question.                                                                      |
+| \_id        | string   | A unique identifier of the form field. WARNING: Changes when new fields are created/removed in the form. |
+
+> **Note:** <br>
+> Additional internal fields may be included in webhooks from time to time, which will then be published as part of our official schema once it is stable for public consumption. If you are applying your own validation, you should account for this e.g. by not rejecting the webhook if there are additional fields included.
+
+The full schema can be viewed in
+[`validate.ts`](./src/util/validate.ts).
+
+If the decrypted content is the correct shape, then:
+
+1. the decrypted content (from `decryptParams.encryptedContent`) will be set as the value of the `responses` key.
+2. if `decryptParams.verifiedContent` exists, then an attempt to
+   decrypted the verified content will be called, and the result set as the
+   value of `verified` key. There is no shape validation for the decrypted
+   verified content. **If the verification fails, `null` is returned, even if
+   `decryptParams.encryptedContent` was successfully decrypted.**
+
+### Processing Attachments
+
+`formsg.crypto.decryptWithAttachments(formSecretKey: string, decryptParams: DecryptParams)` (available from version 0.9.0 onwards) behaves similarly except it will return a `Promise<DecryptedContentAndAttachments | null>`.
+
+`DecryptedContentAndAttachments` is an object containing two fields:
+
+- `content`: the standard form decrypted responses (same as the return type of `formsg.crypto.decrypt`)
+- `attachments`: A `Record<string, DecryptedFile>` containing a map of field ids of the attachment fields to a object containing the original user supplied filename and a `Uint8Array` containing the contents of the uploaded file.
+
+If the contents of any file fails to decrypt or there is a mismatch between the attachments and submission (e.g. the submission doesn't contain the original file name), then `null` will be returned.
+
+Attachments are downloaded using S3 pre-signed URLs, with a expiry time of _one hour_. You must call `decryptWithAttachments` within this time window, or else the URL to the encrypted files will become invalid.
+
+Attachments are end-to-end encrypted in the same way as normal form submissions, so any eavesdropper will not be able to view form attachments without your secret key.
+
+_Warning:_ We do not have the ability to scan any attachments for malicious content (e.g. spyware or viruses), so careful handling is needed.
+
+### Processing Local address fields
+
+Address Field is a compound field with 6 inputs in the answerArray. It will always follow the ordinance of [`blockNumber`, `streetName`, `buildingName`, `levelNumber`, `unitNumber`, `postalCode`]
+
+### Format of Payment Content
+
+These fields will be available if the submission is a payment submission, otherwise, the value will be an empty `{}`.
+
+| Key            | Type             | Description                                      |
+| -------------- | ---------------- | ------------------------------------------------ |
+| type           | 'payment_charge' | Payment event associated with this webhook       |
+| status         | string           | Status of the payment intent                     |
+| payer          | string           | The email associated with this email             |
+| url            | string           | The url of the proof of payment for this payment |
+| paymentIntent  | string           | The payment intent associated with this payment  |
+| amount         | string           | The amount charged to the user                   |
+| productService | string           | The product or service name of the payment       |
+| dateTime       | string           | The time of which this payment was transacted    |
+| transactionFee | string           | The fees charged for this transaction            |
+
+
+
+## Verifying Signatures Manually
+
+You can use the following information to create a custom solution, although we recommend using this SDK.
+
+The `X-FormSG-Signature` header contains the following information:
+
+- Epoch timestamp prefixed by `t=`
+- The FormSG submission ID prefixed by `s=`
+- The FormSG form ID, prefixed by `f=`
+- The signature scheme, prefixed by `v1=`. Currently this is the only signature scheme.
+
+```text
+X-FormSG-Signature: t=1582558358788,
+  s=5e53ec96b10ee1010e00380b,
+  f=5e4b8e3d1f61f00036c9937d,
+  v1=rUAgQ9krNZspCrQtfSvRfjME6Nq4+I80apGXnCsNrwPbcq44SBNglWtA1MkpC/VhWtDeJfuV89uV2Aqi42UQBA==
+```
+
+Note that newlines have been added for clarity, but a real signature will be all in one line.
+
+### Steps
+
+#### Step 1 - Extract the key-value pairs from the header
+
+Extract the the timestamp, signature, submission ID and form ID from the header, by using the `,` character as
+a separator to get a list of elements, before splitting each element to get a key-value pair.
+
+#### Step 2 - Prepare the basestring
+
+This is achieved by concatenating the following strings with the `.` fullstop as the delimiter.
+
+- The [href](https://nodejs.org/api/url.html#url_url_href) of the URI
+- The submission ID
+- The form ID
+- The epoch timestamp
+
+```text
+https://my-domain.com/submissions.5e53ec96b10ee1010e00380b.5e4b8e3d1f61f00036c9937d.1582558358788
+```
+
+#### Step 3 - Verify the signature
+
+The signature is signed with [ed25519](http://ed25519.cr.yp.to/).
+
+Verify that the `v1` signature is valid using a library of your choice (we use [tweetnacl-js](https://github.com/dchest/tweetnacl-js)).
+
+| FormSG environment | Public Key in base64                           |
+| ------------------ | ---------------------------------------------- |
+| production         | '3Tt8VduXsjjd4IrpdCd7BAkdZl/vUCstu9UvTX84FWw=' |
+| staging            | 'rjv41kYqZwcbe3r6ymMEEKQ+Vd+DPuogN+Gzq3lP2Og=' |
+
+#### Step 4 - Protect against replay attacks
+
+If the signature is valid, compute the difference between the current timestamp and the received epoch,
+and decide if the difference is within your tolerance. We use a tolerance of 5 minutes.
+
+#### Additional Checks
+
+- Check that request is for an expected form by verifying the form ID
+- Check that the submission ID is new, and that your system has not received it before

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "0.16.1",
+  "version": "7.0.0",
   "main": "./cjs-entry.cjs",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",
@@ -35,6 +35,10 @@
   },
   "description": "Node.js SDK for integrating with FormSG",
   "license": "MIT",
+  "files": [
+    "dist/",
+    "cjs-entry.cjs"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
     "test": "jest",

--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -44,23 +44,45 @@ if [[ " $* " == *" --recut "* ]]; then
   may_force_push=-f
 fi
 
-# Perform the version bumps, generate changelog and create local tag. 
+# Perform the version bumps, generate changelog and create local tags.
+# 1. Monorepo release (.internal.versionrc.js) — bumps apps/*/package.json,
+#    packages/shared/package.json, etc. and creates a `v<version>` tag.
 pnpm exec commit-and-tag-version --config .internal.versionrc.js ${tag_force}
 release_version_num=$(jq -r .version < package.json)
 release_version="v${release_version_num}"
 release_branch=release_${release_version}
 
+# 2. SDK release (.external.versionrc.js) — bumps packages/sdk/package.json,
+#    updates packages/sdk/CHANGELOG.md and creates a `sdk-v<version>` tag.
+#    Only runs if there are new conventional commits touching packages/sdk
+#    since the last sdk-v* tag. If there are none, commit-and-tag-version
+#    exits non-zero and we leave sdk_release_version empty so the downstream
+#    push/recut steps skip it.
+sdk_release_version=
+if pnpm exec commit-and-tag-version --config .external.versionrc.js ${tag_force}; then
+  sdk_release_version_num=$(jq -r .version < packages/sdk/package.json)
+  sdk_release_version="sdk-v${sdk_release_version_num}"
+else
+  echo "No new SDK commits since last sdk-v* tag; skipping external (SDK) version bump."
+fi
+
 if [[ " $* " == *" --recut "* ]]; then
-  git push --delete origin ${release_version}
+  git push --delete origin ${release_version} || true
+  if [[ -n "${sdk_release_version}" ]]; then
+    git push --delete origin ${sdk_release_version} || true
+  fi
   git branch -D ${release_branch}
 fi
 
 git checkout -b ${release_branch}
 git branch -D ${temp_release_branch}
 
-# Push the code and tag to origin
+# Push the code and tags to origin
 git push origin ${may_force_push} HEAD:${release_branch}
 git push origin ${release_version}
+if [[ -n "${sdk_release_version}" ]]; then
+  git push origin ${sdk_release_version}
+fi
 
 # Deploy to staging for verification testing
 git push -f origin HEAD:stg


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Building features and fixes for the FormSG SDK and keeping development in sync with the rest of FormSG is challenging.

Closes FRM-2362.

## Solution
<!-- How did you solve the problem? -->

The FormSG SDK (@opengovsg/formsg-sdk) is moving into the [FormSG monorepo] (https://github.com/opengovsg/FormSG). This allows the FormSG team to stably incorporate new features while rapidly developing fixes on the FormSG application and SDK in lockstep.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Usage**:
1. develop and merge a feature PR to `develop`
2. run `scripts/release_prep.sh` normally
3. approve the release PR to `release-al2`
4. approve the publish-sdk job on `release-al2` if SDK changes are detected
5. the new SDK version will be published automatically to npm

**Features**:

- This release will sync FormSG SDK to `v7.x` to match the application version.

**Improvements**:

- `scripts/release_prep.sh` updated to also bump SDK version if affected
- `.external.versionrc.js` is used by **commit-and-tag-version** to manage SDK versioning rules

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->