### PR TITLE
fix(ci, sdk): npm upgrade and publishing

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Update npm
         if: ${{ steps.version.outputs.should-publish == 'true' }}
         # npm 11.5.1+ required for OIDC trusted publishing.
-        run: npm install -g npm@latest
+        run: npm install -g npm@~11.10.0
 
       - name: Install dependencies
         if: ${{ steps.version.outputs.should-publish == 'true' }}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The latest version of npm breaks itself whilst installing itself: https://github.com/npm/cli/pull/9152

Related to FRM-2362 and #9305.

## Solution
<!-- How did you solve the problem? -->

Freeze [npm version at 11.10](https://github.com/npm/cli/issues/9151#issuecomment-4131466208) (>= 11.05+ required for OIDC publishing)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Install `npm@11.10` globally before SDK publishing

## Before & After Screenshots

## Tests
<!-- What tests should be run to confirm functionality? -->

- [x] SDK publishing should succeed (will test at release)

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New dev dependencies**:

- `npm` : `11.10`
