### PR TITLE
fix(sdk): update repository provenance

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -43,6 +43,7 @@ jobs:
     defaults:
       run:
         shell: bash
+    environment: 'publish-sdk'
     steps:
       - name: Checkout
         uses: actions/checkout@v4.3.1

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -45,6 +45,11 @@
     "lint": "eslint src/ --quiet --fix",
     "lint-ci": "eslint src/ --quiet"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opengovsg/FormSG.git",
+    "directory": "packages/sdk"
+  },
   "dependencies": {
     "axios": "^1.15.0",
     "tweetnacl": "^1.0.3",


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Missing [repository information](https://github.com/opengovsg/FormSG/actions/runs/24498850760/job/71601467923#step:10:106) in SDK's package.json causes a publishing provenance failure

Related to FRM-2362, #9305, #9311 

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Add repository provenance information 
- Enforce `publish-sdk` environment

## Before & After Screenshots

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
