### PR TITLE
feat: remove forumsg link from FormSG

### DIFF
--- a/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BiCommentDetail } from 'react-icons/bi'
 import { GoDotFill } from 'react-icons/go'
-import { MdForum } from 'react-icons/md'
 import { useMutation } from 'react-query'
 import { Link as ReactLink } from 'react-router-dom'
 import {
@@ -15,10 +14,9 @@ import {
   Icon,
   useDisclosure,
 } from '@chakra-ui/react'
-import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
+import { useGrowthBook } from '@growthbook/growthbook-react'
 import { delay } from 'lodash'
 
-import { featureFlags } from 'formsg-shared/constants'
 import { SeenFlags } from 'formsg-shared/types'
 
 import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'

--- a/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -24,7 +24,7 @@ import { SeenFlags } from 'formsg-shared/types'
 import { BxsHelpCircle } from '~assets/icons/BxsHelpCircle'
 import { BxsRocket } from '~assets/icons/BxsRocket'
 import BrandMarkSvg from '~assets/svgs/brand/brand-mark-colour.svg?react'
-import { FEATURE_REQUEST, FORM_GUIDE, FORUMSG_URL } from '~constants/links'
+import { FEATURE_REQUEST, FORM_GUIDE } from '~constants/links'
 import {
   EMERGENCY_CONTACT_KEY_PREFIX,
   ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
@@ -279,9 +279,6 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
 
   const { t } = useTranslation()
 
-  //TODO: Remove forum link after H4PG2026
-  const isForumSGEnabled = useFeatureIsOn(featureFlags.forumsg)
-
   const navLinks: AdminNavBarLinkProps[] = [
     {
       label: t('features.app.adminNavBar.linkLabel.featureRequest'),
@@ -293,16 +290,6 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
       href: FORM_GUIDE,
       MobileIcon: BxsHelpCircle,
     },
-    // TODO: Remove forum link after H4PG2026
-    ...(isForumSGEnabled
-      ? [
-          {
-            label: 'Forum',
-            href: FORUMSG_URL,
-            MobileIcon: MdForum,
-          },
-        ]
-      : []),
   ]
 
   return (

--- a/apps/frontend/src/constants/links.ts
+++ b/apps/frontend/src/constants/links.ts
@@ -77,6 +77,3 @@ export const OGP_SGID = 'https://go.gov.sg/sgid-formsg'
 export const OGP_FORMSG_REPO = 'https://github.com/opengovsg/formsg'
 
 export const FORMSG_UAT = 'https://uat.form.gov.sg'
-
-// TODO: Remove forum link after H4PG2026
-export const FORUMSG_URL = 'https://go.gov.sg/forumsg'

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -31,7 +31,6 @@ export const featureFlags = {
   ogpHeader: 'enable-ogp-header' as const,
   ogpAwareness: 'ogp-awareness' as const,
   ogpSpinner: 'ogp-spinner' as const,
-  forumsg: 'forumsg' as const,
   wogadLogin: 'wogad-login' as const,
   mrfResponseLimit: 'mrf-response-limit' as const,
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Removing forumsg link from nav links after product is no longer being maintained after H4PG2026

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
