### PR TITLE
fix(ci): ignore sdk bump commit

### DIFF
--- a/scripts/release_prep.sh
+++ b/scripts/release_prep.sh
@@ -54,16 +54,16 @@ release_branch=release_${release_version}
 
 # 2. SDK release (.external.versionrc.js) — bumps packages/sdk/package.json,
 #    updates packages/sdk/CHANGELOG.md and creates a `sdk-v<version>` tag.
-#    Only runs if there are new conventional commits touching packages/sdk
-#    since the last sdk-v* tag. If there are none, commit-and-tag-version
-#    exits non-zero and we leave sdk_release_version empty so the downstream
-#    push/recut steps skip it.
+#    Only runs if there are new commits touching packages/sdk since the last
+#    sdk-v* tag. commit-and-tag-version does not exit non-zero when zero
+#    commits match the path filter, so we guard explicitly.
 sdk_release_version=
-if pnpm exec commit-and-tag-version --config .external.versionrc.js ${tag_force}; then
+last_sdk_tag=$(git tag --sort=-version:refname -l 'sdk-v*' | head -1)
+if [[ -n "${last_sdk_tag}" ]] && [[ -z "$(git log "${last_sdk_tag}..HEAD" --oneline -- packages/sdk)" ]]; then
+  echo "No new SDK commits since ${last_sdk_tag}; skipping external (SDK) version bump."
+elif pnpm exec commit-and-tag-version --config .external.versionrc.js ${tag_force}; then
   sdk_release_version_num=$(jq -r .version < packages/sdk/package.json)
   sdk_release_version="sdk-v${sdk_release_version_num}"
-else
-  echo "No new SDK commits since last sdk-v* tag; skipping external (SDK) version bump."
 fi
 
 if [[ " $* " == *" --recut "* ]]; then


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When the SDK gets updated, a version bump commit is created.

This creates a self-perpetuating cycle: each bump commit touches packages/sdk/package.json, which becomes the only "SDK commit" triggering the next spurious bump (e.g. sdk-v7.1.1 and sdk-v7.1.3 were both empty releases).

Root cause: commit-and-tag-version exits 0 and performs a patch bump even when zero commits match the path filter. release_prep.sh assumed it would exit non-zero in this case.

Related to #9305, #9311.

## Solution
<!-- How did you solve the problem? -->

Added an explicit git log guard in release_prep.sh that checks for actual commits touching packages/sdk/ since the last sdk-v* tag before invoking commit-and-tag-version.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

## Before & After Screenshots

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
