### PR TITLE
feat: remove option descriptions from create form modal

### DIFF
--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormResponseOptions.tsx
@@ -72,7 +72,6 @@ export const FormResponseOptions = forwardRef<
           <Tile.Subtitle>{storage.subtitle}</Tile.Subtitle>
           <OptionDescription
             listItems={[
-              { text: storage.optionDescriptionItems.supportSingpassMyinfo },
               { text: storage.optionDescriptionItems.supportWebhooks },
             ]}
           />
@@ -101,9 +100,6 @@ export const FormResponseOptions = forwardRef<
             listItems={[
               {
                 text: mrf.optionDescriptionItems.supportApprovalWorkflow,
-              },
-              {
-                text: mrf.optionDescriptionItems.supportEmailRouting,
               },
             ]}
           />

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -30,7 +30,6 @@ export const enSG: CreateFormModal = {
         subtitle:
           'Forms with just one respondent per submission support the following:',
         optionDescriptionItems: {
-          supportSingpassMyinfo: 'Singpass & Myinfo',
           supportWebhooks: 'Webhooks for integrations',
           sensitivity:
             'Up to Confidential (Cloud-Eligible) and Sensitive (High) data',
@@ -42,7 +41,6 @@ export const enSG: CreateFormModal = {
           'Forms with two or more respondents per submission support the following:',
         optionDescriptionItems: {
           supportApprovalWorkflow: 'Approval workflows',
-          supportEmailRouting: 'Email routing',
           sensitivity:
             'Up to Confidential (Cloud-Eligible) and Sensitive (High) data',
         },

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
@@ -26,7 +26,6 @@ export interface CreateFormModal {
         title: string
         subtitle: string
         optionDescriptionItems: {
-          supportSingpassMyinfo: string
           supportWebhooks: string
           sensitivity: string
         }
@@ -36,7 +35,6 @@ export interface CreateFormModal {
         subtitle: string
         optionDescriptionItems: {
           supportApprovalWorkflow: string
-          supportEmailRouting: string
           sensitivity: string
         }
       }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Improvements to Create Form Modal

## Solution
<!-- How did you solve the problem? -->

In Create Form Modal
1. Remove 'Singpass & Myinfo' from single respondent section
2. Remove 'Email Routing' from multi respondent section

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** |**AFTER** |
| --- | ---- | ---- |
| Create Form Modal | <img width="815" height="659" alt="image" src="https://github.com/user-attachments/assets/64e99e14-0a96-4b5a-ab02-72fd33cbd4ce" /> |  <img width="863" height="764" alt="image" src="https://github.com/user-attachments/assets/ba2d8265-3790-4115-889e-401a2f5c4dec" /> |
