### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/apps/backend/src/app/config/features/turnstile.config.ts
+++ b/apps/backend/src/app/config/features/turnstile.config.ts
@@ -24,6 +24,22 @@ const turnstileSchema: Schema<ITurnstile> = {
   },
 }
 
-export const turnstileConfig = convict(turnstileSchema)
+const turnstileConfig = convict(turnstileSchema)
   .validate({ allowed: 'strict' })
   .getProperties()
+
+const isAllowedTestEnvironment = ['test', 'development'].includes(
+  process.env.NODE_ENV ?? '',
+)
+
+if (
+  !isAllowedTestEnvironment &&
+  (turnstileConfig.turnstileSiteKey === '3x00000000000000000000FF' ||
+    turnstileConfig.turnstilePrivateKey === '1x0000000000000000000000000000000AA')
+) {
+  throw new Error(
+    'Turnstile test keys are not allowed outside test/development environments',
+  )
+}
+
+export { turnstileConfig }

--- a/apps/backend/src/app/modules/auth/constants.ts
+++ b/apps/backend/src/app/modules/auth/constants.ts
@@ -1,1 +1,13 @@
-export const DEFAULT_SALT_ROUNDS = 2
+const MIN_SALT_ROUNDS = 10
+const FALLBACK_SALT_ROUNDS = 12
+const configuredSaltRounds = Number(process.env.BCRYPT_SALT_ROUNDS)
+
+const defaultSaltRounds =
+  Number.isFinite(configuredSaltRounds) && configuredSaltRounds > 0
+    ? configuredSaltRounds
+    : FALLBACK_SALT_ROUNDS
+
+export const DEFAULT_SALT_ROUNDS =
+  process.env.NODE_ENV === 'test'
+    ? defaultSaltRounds
+    : Math.max(MIN_SALT_ROUNDS, defaultSaltRounds)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `apps/backend/src/app/modules/auth/constants.ts:L1`

The default bcrypt salt rounds is set to 2, which is far below recommended values for production password/OTP hashing. A low work factor significantly reduces attacker effort for offline brute-force if hashes are exposed.

## Solution

Increase the default cost factor to a secure baseline (e.g., 10-12+ depending on performance budget), make it environment-configurable, and enforce a minimum in non-test environments.

## Changes

- `apps/backend/src/app/modules/auth/constants.ts` (modified)
- `apps/backend/src/app/config/features/turnstile.config.ts` (modified)