### PR TITLE
fix(frontend): use formsgSdkMode in decryption worker

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -4,6 +4,8 @@ import { datadogLogs } from '@datadog/browser-logs'
 import saveAs from 'file-saver'
 import JSZip from 'jszip'
 
+import { env } from '~/env'
+
 import { waitForMs } from '~utils/waitForMs'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
@@ -192,12 +194,9 @@ const useDecryptionWorkers = ({
                 secretKey,
                 formId: adminForm._id,
                 hostOrigin: window.location.origin,
-                // Resolved here (on the main thread) so the worker doesn't need
-                // to read import.meta.env itself. Mirrors the fallback in
-                // ~utils/formSdk: VITE_APP_FORMSG_SDK_MODE, or NODE_ENV (MODE).
-                formsgSdkMode:
-                  import.meta.env.VITE_APP_FORMSG_SDK_MODE ??
-                  import.meta.env.MODE,
+                // Resolved here (on the main thread) so the worker doesn't
+                // need to import env.ts (which references window).
+                formsgSdkMode: env.formsgSdkMode,
               })
               // Step 2: Update the Csv record status based on the decryption result.
               .then(async (decryptResult) => {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

FormSG SDK doesn't correctly decrypt submissions on STG

Related to #9327 and #9317.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- The keyset is determined by the env variables in the hooks within `useDecryptionWorkers.ts`.

## Before & After Screenshots

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
