### PR TITLE
chore: remove redundant isSingleSub check to show toggle

### DIFF
--- a/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSingpassSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSingpassSection.tsx
@@ -37,15 +37,13 @@ export const AuthSettingsSingpassSection = ({
           isDisabled={isFormPublic}
         />
       </>
-      {isEncryptMode || isMrf || settings.isSingleSubmission ? (
-        <>
-          <Divider my="2.5rem" />
-          <FormSingleSubmissionToggle
-            settings={settings}
-            isDisabled={isSingpassSettingsDisabled}
-          />
-        </>
-      ) : null}
+      <>
+        <Divider my="2.5rem" />
+        <FormSingleSubmissionToggle
+          settings={settings}
+          isDisabled={isSingpassSettingsDisabled}
+        />
+      </>
       <Divider my="2.5rem" />
       {isEncryptMode ? (
         <FormWhitelistAttachmentField


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Since single submission is now enabled for all form mode types (storage and mrf), we do not need to check before showing the toggle setting anymore. 

## Solution
<!-- How did you solve the problem? -->
Remove redundant check for isMrf || isEncrypt || isSingleSubmission, since (isMrf || isEncrypt) will always evaluate to true now. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: The toggle shows up for both storage mode and mrf form 
- [ ] Go to MRF mode form singpass settings. Assert the isSingleSub toggle is shown only when the singpass mode is selected (ie, singpass is enabled).  
- [ ] Go to storage mode form singpass settings. Assert the isSingleSub toggle is shown only when the singpass mode is selected (ie, singpass is enabled).  