### PR TITLE
fix(ci): rebuild non-release images

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -174,7 +174,7 @@ jobs:
           fi
           if [ "$CURRENT_SHA" != "$TAG_SHA" ]; then
             echo "image=" >> "$GITHUB_OUTPUT"
-            echo "Branch tip ${CURRENT_SHA} does not match ${VERSION} (${TAG_SHA}); force-push or hotfix detected, will build from scratch"
+            echo "Current commit ${CURRENT_SHA} does not match release tag ${VERSION} commit (${TAG_SHA}); will build from scratch"
             exit 0
           fi
           echo "Looking for pre-built release image: $IMAGE"

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -164,13 +164,26 @@ jobs:
         run: |
           VERSION="v$(jq -r .version package.json)"
           IMAGE="ghcr.io/opengovsg/formsg:release-${VERSION}"
+          CURRENT_SHA="$(git rev-parse HEAD)"
+          TAG_SHA="$(git rev-list -n 1 "$VERSION" 2>/dev/null || true)"
+
+          if [ -z "$TAG_SHA" ]; then
+            echo "image=" >> "$GITHUB_OUTPUT"
+            echo "Release tag ${VERSION} not found locally; will build from scratch"
+            exit 0
+          fi
+          if [ "$CURRENT_SHA" != "$TAG_SHA" ]; then
+            echo "image=" >> "$GITHUB_OUTPUT"
+            echo "Branch tip ${CURRENT_SHA} does not match ${VERSION} (${TAG_SHA}); force-push or hotfix detected, will build from scratch"
+            exit 0
+          fi
           echo "Looking for pre-built release image: $IMAGE"
           if docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
             echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
-            echo "Found pre-built release image, will skip Docker build"
+            echo "Found pre-built release image for tagged commit, will skip Docker build"
           else
             echo "image=" >> "$GITHUB_OUTPUT"
-            echo "No pre-built release image found, will build from scratch"
+            echo "No pre-built release image found for tagged commit, will build from scratch"
           fi
 
       - name: Pull and push pre-built image to ECR


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

After #9317, new development branches can't be built and pushed because the pipeline picks up the previously released image and pushes that instead.

This makes it difficult to test changes still under development.

**For example, suppose we have the following commit tree:** 
- commit A (old) where the version is v7.40.0
- commit B (recent) with a code change with version v7.40.0 
It will not rebuild with the changes in commit B and reuse the previously built commit A image, which is not desired as we want to test the newly added commit B changes and thus want a rebuild. 

## Solution
<!-- How did you solve the problem? -->

- Always rebuild the image
- Unless the commit is tagged with a version: then check if an existing release build exists

If the tagged commit hash of the version is the same as the current commit, then it will reuse the previous build. Otherwise, it will not rebuild and deploy this rebuilt image. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Only release images should be reused

## Before & After Screenshots

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC: Deployments to non-release environments work**
- [ ] Deploy to an environment (e.g. stg-alt2)
- [ ] the latest commit should not match a release if it was not a release commit
- [ ] the image should be rebuilt and deployed

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->