### PR TITLE
feat: draggable form field

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -249,7 +249,6 @@ const FieldRowContainer = ({
     <Draggable
       index={index}
       isDragDisabled={isDragDisabled}
-      disableInteractiveElementBlocking
       draggableId={field._id}
     >
       {(provided, snapshot) => (

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -294,6 +294,7 @@ const FieldRowContainer = ({
               onClick={handleFieldClick}
               onKeyDown={handleKeydown}
               ref={ref}
+              {...provided.dragHandleProps}
             >
               <Fade in={isActive}>
                 <chakra.button

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -294,6 +294,7 @@ const FieldRowContainer = ({
               onKeyDown={handleKeydown}
               ref={ref}
               {...provided.dragHandleProps}
+              sx={{ '& label': { cursor: 'inherit' } }}
             >
               <Fade in={isActive}>
                 <chakra.button

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -261,7 +261,7 @@ const FieldRowContainer = ({
           ref={provided.innerRef}
         >
           <Tooltip
-            hidden={!isHiddenByLogic}
+            hidden={false}
             placement="top"
             label="This field may be hidden by your form logic"
           >
@@ -294,6 +294,7 @@ const FieldRowContainer = ({
               onClick={handleFieldClick}
               onKeyDown={handleKeydown}
               ref={ref}
+              {...provided.dragHandleProps}
             >
               <Fade in={isActive}>
                 <chakra.button

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -261,7 +261,7 @@ const FieldRowContainer = ({
           ref={provided.innerRef}
         >
           <Tooltip
-            hidden={false}
+            hidden={!isHiddenByLogic}
             placement="top"
             label="This field may be hidden by your form logic"
           >
@@ -294,7 +294,6 @@ const FieldRowContainer = ({
               onClick={handleFieldClick}
               onKeyDown={handleKeydown}
               ref={ref}
-              {...provided.dragHandleProps}
             >
               <Fade in={isActive}>
                 <chakra.button

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -301,7 +301,6 @@ const FieldRowContainer = ({
                   disabled={isDragDisabled}
                   display="flex"
                   tabIndex={isActive ? 0 : -1}
-                  {...provided.dragHandleProps}
                   borderRadius="4px"
                   _disabled={{
                     cursor: 'not-allowed',
@@ -315,6 +314,7 @@ const FieldRowContainer = ({
                   transition="color 0.2s ease"
                   _hover={{
                     color: 'secondary.300',
+                    cursor: 'grab',
                     _disabled: {
                       color: 'secondary.200',
                     },

--- a/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -275,6 +275,11 @@ const SignatureCanvas = ({
                   pointerEvents={schema.disabled ? 'none' : 'auto'} // disable canvas interaction
                   width="100%"
                   height="100%"
+                  // contentEditable marks this as an interactive element for
+                  // @hello-pangea/dnd, preventing drag initiation from the canvas
+                  contentEditable={!schema.disabled}
+                  suppressContentEditableWarning
+                  sx={{ cursor: 'default' }}
                 >
                   <canvas
                     ref={pfCanvasRef}

--- a/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -275,10 +275,15 @@ const SignatureCanvas = ({
                   pointerEvents={schema.disabled ? 'none' : 'auto'} // disable canvas interaction
                   width="100%"
                   height="100%"
-                  // contentEditable marks this as an interactive element for
-                  // @hello-pangea/dnd, preventing drag initiation from the canvas
-                  contentEditable={!schema.disabled}
-                  suppressContentEditableWarning
+                  onPointerDown={(event) => {
+                    if (!schema.disabled) event.stopPropagation()
+                  }}
+                  onMouseDown={(event) => {
+                    if (!schema.disabled) event.stopPropagation()
+                  }}
+                  onTouchStart={(event) => {
+                    if (!schema.disabled) event.stopPropagation()
+                  }}
                   sx={{ cursor: 'default' }}
                 >
                   <canvas


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Users aren't aware that it is possible to drag fields in the form builder to re-arrange the order of fields. The 6 square dots are often missed. 

Closes FRM-2242

## Solution
<!-- How did you solve the problem? -->

- Make the entire field container draggable

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| ---- | ------------ | -----------|
| Field container draggability | <img height="400" alt="drag_before" src="https://github.com/user-attachments/assets/a895e320-1990-43b8-a4f2-1966aca2c5c5" /> | <img height="400" alt="drag_after" src="https://github.com/user-attachments/assets/d96dc279-450b-4991-94c3-051e59405605" /> |


## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Drag and re-arrange fields in the form builder**
- [x] In a new/existing form builder, verify that mouse down and drag action drags the field container successfully and fields are able to be re-arranged
- [x] Verify that on mouse down on interactive elements (textarea, canvas etc.) the field container is not draggable; instead mouse down allows you to interact with the element
