### PR TITLE
docs(readme): correct deepwiki repo link casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/opengovsg/formsg)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/opengovsg/FormSG)
 
 ## 📚 Documentation
 


### PR DESCRIPTION
## Problem and Solution
Ensure link in DeepWiki badge uses exact casing,
to better ensure regular indexing of DeepWiki
