### PR TITLE
fix(backend): enable s3 virus scanner retry

### DIFF
--- a/services/virus-scanner-guardduty/.eslintrc.js
+++ b/services/virus-scanner-guardduty/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['../../.eslintrc'],
+  extends: ['../../apps/backend/.eslintrc'],
   ignorePatterns: ['*.mjs'],
   parserOptions: {
     project: ['./tsconfig.json'],

--- a/services/virus-scanner-guardduty/.eslintrc.js
+++ b/services/virus-scanner-guardduty/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['../../apps/backend/.eslintrc'],
+  extends: ['../../apps/backend/.eslintrc.js'],
   ignorePatterns: ['*.mjs'],
   parserOptions: {
     project: ['./tsconfig.json'],

--- a/services/virus-scanner-guardduty/src/s3.service.ts
+++ b/services/virus-scanner-guardduty/src/s3.service.ts
@@ -257,25 +257,29 @@ export class S3Service {
       objectKey,
     }
 
-    this.logger.info({
-      message: 'Getting object version ID from s3',
-      meta: {
-        ...logMeta,
-        status: 'started',
+    this.logger.info(
+      {
+        meta: {
+          ...logMeta,
+          status: 'started',
+        },
       },
-    })
+      'Getting object version ID from s3',
+    )
 
     let attempt = 0
     const logMissedAttempt = (err: unknown) => {
-      this.logger.warn({
-        message: 'getS3ObjectVersionId attempt failed',
-        meta: {
-          ...logMeta,
-          status: 'missed',
-          attempt,
+      this.logger.warn(
+        {
+          meta: {
+            ...logMeta,
+            status: 'missed',
+            attempt,
+          },
+          err,
         },
-        err,
-      })
+        'getS3ObjectVersionId attempt failed',
+      )
     }
 
     try {
@@ -312,16 +316,18 @@ export class S3Service {
             throw err
           }
 
-          this.logger.info({
-            message: 'Retrieved object version ID from s3',
-            meta: {
-              ...logMeta,
-              status: 'success',
-              attempt,
-              versionId,
-              contentLength: ContentLength,
+          this.logger.info(
+            {
+              meta: {
+                ...logMeta,
+                status: 'success',
+                attempt,
+                versionId,
+                contentLength: ContentLength,
+              },
             },
-          })
+            'Retrieved object version ID from s3',
+          )
 
           return versionId
         },
@@ -333,15 +339,17 @@ export class S3Service {
         },
       )
     } catch (err) {
-      this.logger.error({
-        message: 'Failed to get object version ID from s3 after retries',
-        meta: {
-          ...logMeta,
-          status: 'failed',
-          attempts: attempt,
+      this.logger.error(
+        {
+          meta: {
+            ...logMeta,
+            status: 'failed',
+            attempts: attempt,
+          },
+          err,
         },
-        err,
-      })
+        'Failed to get object version ID from s3 after retries',
+      )
 
       throw err
     }

--- a/services/virus-scanner-guardduty/src/s3.service.ts
+++ b/services/virus-scanner-guardduty/src/s3.service.ts
@@ -251,50 +251,97 @@ export class S3Service {
     bucketName,
     objectKey,
   }: GetS3FileStreamParams): Promise<string> {
-    this.logger.info(
-      {
-        bucketName,
-        objectKey,
+    const logMeta = {
+      action: 'getS3ObjectVersionId',
+      bucketName,
+      objectKey,
+    }
+
+    this.logger.info({
+      message: 'Getting object version ID from s3',
+      meta: {
+        ...logMeta,
+        status: 'started',
       },
-      'Getting object version ID from s3',
-    )
+    })
+
+    let attempt = 0
+    const logMissedAttempt = (err: unknown) => {
+      this.logger.warn({
+        message: 'getS3ObjectVersionId attempt failed',
+        meta: {
+          ...logMeta,
+          status: 'missed',
+          attempt,
+        },
+        err,
+      })
+    }
 
     try {
-      const { VersionId: versionId, ContentLength } = await this.s3Client.send(
-        new HeadObjectCommand({
-          Key: objectKey,
-          Bucket: bucketName,
-        }),
-      )
+      // S3 may briefly return NotFound when strong consistency lags, so retry
+      // with 2s/4s/8s exponential backoff plus jitter before giving up.
+      return await retry(
+        async () => {
+          attempt++
 
-      if (!versionId) {
-        throw new Error('VersionId is empty')
-      }
+          let response
+          try {
+            response = await this.s3Client.send(
+              new HeadObjectCommand({
+                Key: objectKey,
+                Bucket: bucketName,
+              }),
+            )
+          } catch (err) {
+            logMissedAttempt(err)
+            throw err
+          }
 
-      if (!ContentLength || ContentLength === 0) {
-        throw new Error('Body is empty')
-      }
+          const { VersionId: versionId, ContentLength } = response
 
-      this.logger.info(
-        {
-          bucketName,
-          objectKey,
-          versionId,
-          contentLength: ContentLength,
+          if (!versionId) {
+            const err = new Error('VersionId is empty')
+            logMissedAttempt(err)
+            throw err
+          }
+
+          if (!ContentLength || ContentLength === 0) {
+            const err = new Error('Body is empty')
+            logMissedAttempt(err)
+            throw err
+          }
+
+          this.logger.info({
+            message: 'Retrieved object version ID from s3',
+            meta: {
+              ...logMeta,
+              status: 'success',
+              attempt,
+              versionId,
+              contentLength: ContentLength,
+            },
+          })
+
+          return versionId
         },
-        'Retrieved object version ID from s3',
+        {
+          retries: 3,
+          delay: 2000,
+          backoff: (attempt) =>
+            1000 * Math.pow(2, attempt) + Math.floor(Math.random() * 1000),
+        },
       )
-
-      return versionId
     } catch (err) {
-      this.logger.error(
-        {
-          bucketName,
-          objectKey,
-          err,
+      this.logger.error({
+        message: 'Failed to get object version ID from s3 after retries',
+        meta: {
+          ...logMeta,
+          status: 'failed',
+          attempts: attempt,
         },
-        'Failed to get object version ID from s3',
-      )
+        err,
+      })
 
       throw err
     }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

If the attachment cannot be found or has zero-length at submission time, the request immediately fails.
This can cause submission failure and user frustration when S3 is experiencing degraded consistency.

Closes FRM-2400.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Add support for an exponential backoff retry with jitter

**Bug Fixes**:

- Retry fetching a recently uploaded attachment before failing a submission

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC: Upload and Submit an Attachment**
- [x] Open a Form with an Attachment Field
- [x] Upload and Submit the Form
- [x] Submission should Succeed

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
