### PR TITLE
feat(frontend): enable admin rum

### DIFF
--- a/apps/backend/src/app/config/features/growthbook.config.ts
+++ b/apps/backend/src/app/config/features/growthbook.config.ts
@@ -4,6 +4,8 @@ import { isTest } from '../config'
 
 export enum GrowthbookFeature {
   ENABLE_AUTH_CALLBACK_FORWARDING = 'enable-auth-callback-forwarding',
+  DD_SAMPLE_RATE_ADMIN = 'dd-sample-rate-admin',
+  DD_SAMPLE_RATE_PUBLIC = 'dd-sample-rate-public',
 }
 
 export interface IGrowthbook {

--- a/apps/backend/src/app/loaders/express/constants.ts
+++ b/apps/backend/src/app/loaders/express/constants.ts
@@ -1,7 +1,6 @@
 import { RequestHandler } from 'express'
 
 import config from '../../config/config'
-import { envScriptCspHash } from '../../modules/frontend/frontend.service'
 
 export const CSP_CORE_DIRECTIVES = {
   imgSrc: [
@@ -36,7 +35,6 @@ export const CSP_CORE_DIRECTIVES = {
     'https://www.gstatic.cn/recaptcha/releases/',
     (_req: Parameters<RequestHandler>[0], res: Parameters<RequestHandler>[1]) =>
       `'nonce-${res.locals.nonce}'`,
-    envScriptCspHash,
   ],
   connectSrc: [
     "'self'",

--- a/apps/backend/src/app/modules/frontend/frontend.controller.ts
+++ b/apps/backend/src/app/modules/frontend/frontend.controller.ts
@@ -9,7 +9,7 @@ import { ControllerHandler } from '../core/core.types'
 import * as FormService from '../form/form.service'
 import { createMetatags } from '../form/public-form/public-form.service'
 
-import { envScript, getClientEnvVars } from './frontend.service'
+import { getClientEnvVars, getEnvScriptHtml } from './frontend.service'
 
 const logger = createLoggerWithLabel(module)
 
@@ -24,12 +24,14 @@ type MetaTags = {
   image: string
 }
 const replaceWithMetaTags = ({
-  title,
-  description,
-  image,
-}: MetaTags): string => {
+  envScriptHtml,
+  tags: { title, description, image },
+}: {
+  envScriptHtml: string
+  tags: MetaTags
+}): string => {
   return reactHtml
-    .replace('<!-- __ENV_INJECTION__ -->', envScript)
+    .replace('<!-- __ENV_INJECTION__ -->', envScriptHtml)
     .replace(/(__OG_TITLE__)/g, escape(title))
     .replace(/(__OG_DESCRIPTION__)/g, escape(description))
     .replace(/(__OG_IMAGE__)/g, escape(image))
@@ -48,7 +50,11 @@ const serveFormReact =
       tags = await getPublicFormMetaTags(get(req.params, 'formId') ?? '')
     }
 
-    const reactHtmlWithMetaTags = replaceWithMetaTags(tags)
+    const envScriptHtml = getEnvScriptHtml({
+      growthbook: req.growthbook,
+      nonce: String(res.locals.nonce ?? ''),
+    })
+    const reactHtmlWithMetaTags = replaceWithMetaTags({ envScriptHtml, tags })
 
     return (
       res

--- a/apps/backend/src/app/modules/frontend/frontend.service.ts
+++ b/apps/backend/src/app/modules/frontend/frontend.service.ts
@@ -1,11 +1,13 @@
 import { GrowthBook } from '@growthbook/growthbook'
-import { featureFlags } from 'formsg-shared/constants/feature-flags'
 import { ClientEnvVars, FrontendRuntimeEnv } from 'formsg-shared/types/core'
 
 import config from '../../config/config'
 import { captchaConfig } from '../../config/features/captcha.config'
 import { goGovConfig } from '../../config/features/gogov.config'
-import { growthbookConfig } from '../../config/features/growthbook.config'
+import {
+  growthbookConfig,
+  GrowthbookFeature,
+} from '../../config/features/growthbook.config'
 import { paymentConfig } from '../../config/features/payment.config'
 import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
 import { turnstileConfig } from '../../config/features/turnstile.config'
@@ -20,10 +22,15 @@ export const getFrontendRuntimeEnv = (
   ddRumEnv: process.env.DD_ENV ?? '',
   ddSampleRate: 5,
   ddSampleRateAdmin:
-    growthbook?.getFeatureValue<number>(featureFlags.ddSampleRateAdmin, 0) ?? 0,
+    growthbook?.getFeatureValue<number>(
+      GrowthbookFeature.DD_SAMPLE_RATE_ADMIN,
+      0,
+    ) ?? 0,
   ddSampleRatePublic:
-    growthbook?.getFeatureValue<number>(featureFlags.ddSampleRatePublic, 0) ??
-    0,
+    growthbook?.getFeatureValue<number>(
+      GrowthbookFeature.DD_SAMPLE_RATE_PUBLIC,
+      0,
+    ) ?? 0,
 })
 
 const serializeForInlineScript = (value: FrontendRuntimeEnv): string =>

--- a/apps/backend/src/app/modules/frontend/frontend.service.ts
+++ b/apps/backend/src/app/modules/frontend/frontend.service.ts
@@ -1,4 +1,5 @@
-import crypto from 'crypto'
+import { GrowthBook } from '@growthbook/growthbook'
+import { featureFlags } from 'formsg-shared/constants/feature-flags'
 import { ClientEnvVars, FrontendRuntimeEnv } from 'formsg-shared/types/core'
 
 import config from '../../config/config'
@@ -9,13 +10,20 @@ import { paymentConfig } from '../../config/features/payment.config'
 import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
 import { turnstileConfig } from '../../config/features/turnstile.config'
 
-export const getFrontendRuntimeEnv = (): FrontendRuntimeEnv => ({
+export const getFrontendRuntimeEnv = (
+  growthbook?: GrowthBook,
+): FrontendRuntimeEnv => ({
   appUrl: config.app.appUrl,
   apiBaseUrl: '/api/v3',
   gaTrackingId: process.env.GA_TRACKING_ID ?? '',
   formsgSdkMode: config.formsgSdkMode,
   ddRumEnv: process.env.DD_ENV ?? '',
   ddSampleRate: 5,
+  ddSampleRateAdmin:
+    growthbook?.getFeatureValue<number>(featureFlags.ddSampleRateAdmin, 0) ?? 0,
+  ddSampleRatePublic:
+    growthbook?.getFeatureValue<number>(featureFlags.ddSampleRatePublic, 0) ??
+    0,
 })
 
 const serializeForInlineScript = (value: FrontendRuntimeEnv): string =>
@@ -24,10 +32,18 @@ const serializeForInlineScript = (value: FrontendRuntimeEnv): string =>
     .replace(/>/g, '\\u003e')
     .replace(/&/g, '\\u0026')
 
-// Computed once at startup — values are static for the container lifetime
-const envScriptContent = `window.__ENV__=${serializeForInlineScript(getFrontendRuntimeEnv())}`
-export const envScript = `<script>${envScriptContent}</script>`
-export const envScriptCspHash = `'sha256-${crypto.createHash('sha256').update(envScriptContent).digest('base64')}'`
+// Built per-request because growthbook flag values can vary; the inline script
+// is allowed by CSP via the request-scoped nonce (see CSP_CORE_DIRECTIVES).
+export const getEnvScriptHtml = ({
+  growthbook,
+  nonce,
+}: {
+  growthbook?: GrowthBook
+  nonce: string
+}): string =>
+  `<script nonce="${nonce}">window.__ENV__=${serializeForInlineScript(
+    getFrontendRuntimeEnv(growthbook),
+  )}</script>`
 
 export const getClientEnvVars = (): ClientEnvVars => {
   return {

--- a/apps/frontend/datadog-chunk.ts
+++ b/apps/frontend/datadog-chunk.ts
@@ -41,16 +41,24 @@ const ddBeforeSend: RumInitConfiguration['beforeSend'] = (event) => {
 // the entry route. The admin / public rates come from growthbook flags
 // (ddSampleRateAdmin / ddSampleRatePublic), defaulting to 0 when absent.
 //
-// `/` is treated as an admin path because most landing-page traffic is admins
-// on their way to log in. `/:formId/use-template` redirects logged-in admins
-// to `/admin/*`, so it counts as admin too.
+// Admin entry points:
+//   - `/` and `/admin(/...)` — the admin portal proper (landing also counts
+//     because it's where admins arrive on their way to log in).
+//   - `/login(/...)` — login flow.
+//   - `/dashboard(/...)` — admin dashboard.
+//   - `/:formId/use-template` — redirects logged-in admins into `/admin/*`.
 const ADMIN_PATH_REGEX = /^\/$|^\/admin(\/|$)/
-const PUBLIC_FORM_PATH_REGEX = /^\/[a-fA-F0-9]{24}(\/|$)/
+const LOGIN_PATH_REGEX = /^\/login(\/|$)/
+const DASHBOARD_PATH_REGEX = /^\/dashboard(\/|$)/
 const USE_TEMPLATE_PATH_REGEX = /^\/[a-fA-F0-9]{24}\/use-template(\/|$)/
+const PUBLIC_FORM_PATH_REGEX = /^\/[a-fA-F0-9]{24}(\/|$)/
 
 const path = window.location.pathname
 const isAdmin =
-  ADMIN_PATH_REGEX.test(path) || USE_TEMPLATE_PATH_REGEX.test(path)
+  ADMIN_PATH_REGEX.test(path) ||
+  LOGIN_PATH_REGEX.test(path) ||
+  DASHBOARD_PATH_REGEX.test(path) ||
+  USE_TEMPLATE_PATH_REGEX.test(path)
 const isPublicForm = !isAdmin && PUBLIC_FORM_PATH_REGEX.test(path)
 
 const sessionSampleRate = isAdmin

--- a/apps/frontend/datadog-chunk.ts
+++ b/apps/frontend/datadog-chunk.ts
@@ -2,7 +2,8 @@
  * This file compiles to datadog-chunk.js and initializes Datadog RUM when it is loaded.
  *
  * Build-time vars (import.meta.env): VITE_APP_DD_RUM_APP_ID, VITE_APP_DD_RUM_CLIENT_TOKEN, VITE_APP_VERSION
- * Runtime vars (window.__ENV__): ddRumEnv, appUrl, ddSampleRate
+ * Runtime vars (window.__ENV__): ddRumEnv, appUrl, ddSampleRate,
+ *   ddSampleRateAdmin, ddSampleRatePublic
  */
 
 import { datadogRum, RumInitConfiguration } from '@datadog/browser-rum'
@@ -36,6 +37,28 @@ const ddBeforeSend: RumInitConfiguration['beforeSend'] = (event) => {
   return true
 }
 
+// Session sample rate is decided once at session start, so we pick it based on
+// the entry route. The admin / public rates come from growthbook flags
+// (ddSampleRateAdmin / ddSampleRatePublic), defaulting to 0 when absent.
+//
+// `/` is treated as an admin path because most landing-page traffic is admins
+// on their way to log in. `/:formId/use-template` redirects logged-in admins
+// to `/admin/*`, so it counts as admin too.
+const ADMIN_PATH_REGEX = /^\/$|^\/admin(\/|$)/
+const PUBLIC_FORM_PATH_REGEX = /^\/[a-fA-F0-9]{24}(\/|$)/
+const USE_TEMPLATE_PATH_REGEX = /^\/[a-fA-F0-9]{24}\/use-template(\/|$)/
+
+const path = window.location.pathname
+const isAdmin =
+  ADMIN_PATH_REGEX.test(path) || USE_TEMPLATE_PATH_REGEX.test(path)
+const isPublicForm = !isAdmin && PUBLIC_FORM_PATH_REGEX.test(path)
+
+const sessionSampleRate = isAdmin
+  ? (window.__ENV__?.ddSampleRateAdmin ?? 0)
+  : isPublicForm
+    ? (window.__ENV__?.ddSampleRatePublic ?? 0)
+    : (window.__ENV__?.ddSampleRate ?? 5)
+
 // Init Datadog RUM
 datadogRum.init({
   applicationId: '@VITE_APP_DD_RUM_APP_ID',
@@ -45,7 +68,7 @@ datadogRum.init({
   service: 'formsg-react',
   allowedTracingUrls: [window.__ENV__?.appUrl ?? window.location.origin],
   version: '@VITE_APP_VERSION',
-  sessionSampleRate: window.__ENV__?.ddSampleRate ?? 5,
+  sessionSampleRate,
   sessionReplaySampleRate: 100,
   trackUserInteractions: true,
   defaultPrivacyLevel: 'mask-user-input',

--- a/apps/frontend/datadog-chunk.ts
+++ b/apps/frontend/datadog-chunk.ts
@@ -67,6 +67,14 @@ const sessionSampleRate = isAdmin
     ? (window.__ENV__?.ddSampleRatePublic ?? 0)
     : (window.__ENV__?.ddSampleRate ?? 5)
 
+// In production, route RUM events through our own backend so the browser
+// doesn't talk to Datadog directly. Other envs go direct to Datadog so we
+// don't have to stand up the proxy route in every deployment.
+const ddProxyUrl =
+  window.__ENV__?.ddRumEnv === 'production'
+    ? `${window.__ENV__?.appUrl ?? window.location.origin}/api/v1/proxy/datadog/rum`
+    : undefined
+
 // Init Datadog RUM
 datadogRum.init({
   applicationId: '@VITE_APP_DD_RUM_APP_ID',
@@ -74,6 +82,7 @@ datadogRum.init({
   env: window.__ENV__?.ddRumEnv ?? '',
   site: 'datadoghq.com',
   service: 'formsg-react',
+  proxy: ddProxyUrl,
   allowedTracingUrls: [window.__ENV__?.appUrl ?? window.location.origin],
   version: '@VITE_APP_VERSION',
   sessionSampleRate,

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -36,7 +36,7 @@ datadogLogs.init({
   clientToken: import.meta.env.VITE_APP_DD_RUM_CLIENT_TOKEN || '',
   env: window.__ENV__?.ddRumEnv ?? import.meta.env.VITE_APP_DD_RUM_ENV,
   site: 'datadoghq.com',
-  service: 'formsg',
+  service: 'formsg-react',
   // Specify a version number to identify the deployed version of your application in Datadog
   version: import.meta.env.VITE_APP_VERSION,
   forwardErrorsToLogs: true,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -37,6 +37,8 @@ export const featureFlags = {
   useTemplateTour: 'use-template-tour' as const,
   useTemplateWallScroll: 'use-template-wall-scroll' as const,
   useTemplateWallSubmit: 'use-template-wall-submit' as const,
+  ddSampleRateAdmin: 'dd-sample-rate-admin' as const,
+  ddSampleRatePublic: 'dd-sample-rate-public' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {

--- a/packages/shared/types/core.ts
+++ b/packages/shared/types/core.ts
@@ -5,6 +5,11 @@ export type FrontendRuntimeEnv = {
   formsgSdkMode: 'staging' | 'production' | 'development' | 'test'
   ddRumEnv: string
   ddSampleRate: number
+  // Per-route Datadog session sampling, resolved server-side from growthbook.
+  // Optional so older clients / dev fallbacks (apps/frontend/src/env.ts) keep
+  // typechecking; consumers should default to 0 when absent.
+  ddSampleRateAdmin?: number
+  ddSampleRatePublic?: number
 }
 
 export interface ErrorDto {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

- We don't have observability of FormSG admin actions (`/admin/*` routes)
- We have unnecessary and unused observability of other FormSG pages

Closes FRM-2392.

## Solution
<!-- How did you solve the problem? -->

Introduce a dynamically configurable observability mechanism to enable a better user and admin experience.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Use the initial view route to determine the `sessionSampleRate`
  - Admin routes (`/admin/*`) will be sampled at `dd-sample-rate-admin` (default: 100%)
  - Public routes will be sampled at `dd-sample-rate-public` (default: 0%)
  - All other routes will be sampled at the current value of 5%

**Improvements**:

- Use a request-scoped nonce in the Content Security Policy directive ([compatible with relevant browsers](https://caniuse.com/contentsecuritypolicy2))
- Deprecate computing the script CSP hash (which isn't feasible because feature flag values can change dynamically)
- Enable RUM on intranet environments by detecting and proxying RUM events to `/api/v1/proxy/datadog/rum` (setup in CloudFlare worker route)

**Bug fixes**:
- update the datadogLogs service tag for the frontend to `formsg-react`
- this should improve our ability to differentiate frontend (`formsg-react`) and backend (`formsg`) logs

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Check that fresh visits to public pages do not trigger RUM**
- [ ] Open an existing FormSG form in a new incognito tab directly
- [ ] Using the Network tab in the Web Inspector, check for requests to `/rum` or `/replay`
- [ ] There should be no RUM / Session Replay requests.

**TC1: Check that fresh visits to admin pages not trigger RUM**
- [ ] Open the FormSG home page
- [ ] Log in to the dashboard
- [ ] Using the Network tab in the Web Inspector, check for requests to `/rum` or `/replay`
- [ ] There should be several RUM / Session Replay requests.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New feature flags**:

- `dd-sample-rate-admin`: Sample Rate for Admin routes (`/admin/*`) (default: 100%)
- `dd-sample-rate-public`: Sample Rate for Public routes (default: 0%)

**New infrastructure**:

- [x] `proxy-datadog-rum`: CloudFlare Worker [deployed](https://dash.cloudflare.com/39ed63a4c3545f14aac6ef38ece0e6cc/workers/services/view/proxy-datadog-rum/production)