### PR TITLE
chore(auth): remove unused auth functions

### DIFF
--- a/apps/backend/src/app/modules/auth/auth.service.ts
+++ b/apps/backend/src/app/modules/auth/auth.service.ts
@@ -1,5 +1,3 @@
-import bcrypt from 'bcrypt'
-import crypto from 'crypto'
 import { SUPPORT_FORM_LINK } from 'formsg-shared/constants/links'
 import mongoose from 'mongoose'
 import { errAsync, okAsync, Result, ResultAsync } from 'neverthrow'
@@ -38,7 +36,6 @@ import {
   InvalidTokenError,
   MissingTokenError,
 } from './auth.errors'
-import { DEFAULT_SALT_ROUNDS } from './constants'
 
 const logger = createLoggerWithLabel(module)
 const TokenModel = getTokenModel(mongoose)
@@ -369,29 +366,4 @@ export const getUserByApiKey = (
       return errAsync(new InvalidTokenError())
     })
   })
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const getApiKeyHash = (apiKey: string): ResultAsync<string, HashingError> => {
-  return ResultAsync.fromPromise(
-    bcrypt.hash(apiKey, DEFAULT_SALT_ROUNDS),
-    (error) => {
-      logger.error({
-        message: 'bcrypt hash error',
-        meta: {
-          action: 'getApiKeyHash',
-        },
-        error,
-      })
-      return new HashingError()
-    },
-  ).map((hash) => `${hash}`)
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const generateApiKey = (user: IUserSchema): string => {
-  const key = crypto.randomBytes(32).toString('base64')
-  const apiEnv = config.publicApiConfig.apiEnv
-  const apiKeyVersion = config.publicApiConfig.apiKeyVersion
-  return `${apiEnv}_${apiKeyVersion}_${user._id}_${key}`
 }

--- a/apps/backend/src/app/modules/auth/constants.ts
+++ b/apps/backend/src/app/modules/auth/constants.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_SALT_ROUNDS = 2


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Remove unused auth functions, which were previously used as part of an experiment to expose some APIs for external users (https://github.com/opengovsg/FormSG/pull/6376/changes). 

## Solution
<!-- How did you solve the problem? -->
Since this experiment is not being done, these functions should be removed to clean up the codebase. 
Checked with engineering team that this is safe to remove, since this experiment is no longer being pursued, to adhere to chesterson's fence principle. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  