### PR TITLE
build: release v7.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [7.16.1](https://github.com/opengovsg/formsg/compare/v7.16.0...v7.16.1) (2026-05-04)
+
+
+### Miscellaneous
+
+* Merge pull request #9368 from opengovsg/feat/nric-whitelist-mrf ([#9368](https://github.com/opengovsg/formsg/commit/9ac05e2c5a69c62e0eb7292b038ca27931bc40ea))
+
 ## [7.16.0](https://github.com/opengovsg/formsg/compare/v7.15.0...v7.16.0) (2026-05-04)
 
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-backend",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
@@ -936,6 +936,9 @@ describe('Form Model', () => {
           emails: [],
           stepOneEmailNotificationFieldId: '',
           hasStatusTracker: false,
+          whitelistedSubmitterIds: {
+            isWhitelistEnabled: false,
+          },
         },
         FORM_DEFAULTS,
       )

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -453,6 +453,16 @@ const MultirespondentFormSchema = new Schema<IMultirespondentFormSchema>({
     ],
     required: true,
   },
+  whitelistedSubmitterIds: {
+    type: whitelistedSubmitterIdNestedPath,
+    get: (v: { isWhitelistEnabled: boolean }) => ({
+      // remove the ObjectId link to whitelist collection's document by default unless asked for.
+      isWhitelistEnabled: v.isWhitelistEnabled,
+    }),
+    default: () => ({
+      isWhitelistEnabled: false,
+    }),
+  },
   stepOneEmailNotificationFieldId: {
     type: String,
     default: '',
@@ -462,6 +472,12 @@ const MultirespondentFormSchema = new Schema<IMultirespondentFormSchema>({
     default: false,
   },
 })
+
+MultirespondentFormSchema.methods.getWhitelistedSubmitterIds = function () {
+  return this.get('whitelistedSubmitterIds', null, {
+    getters: false,
+  })
+}
 
 MultirespondentFormSchema.methods.getDuplicateParams = function (
   overrideProps: OverrideProps,

--- a/apps/backend/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/apps/backend/src/app/modules/form/__tests__/form.service.spec.ts
@@ -2,17 +2,20 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
 import {
   BasicField,
+  FormAuthType,
   FormResponseMode,
   FormStatus,
   PublicFormDto,
   SubmissionType,
   WorkflowType,
 } from 'formsg-shared/types'
+import * as CryptoUtils from 'formsg-shared/utils/crypto'
 import { merge, times } from 'lodash'
 import mongoose from 'mongoose'
 import { okAsync } from 'neverthrow'
 
 import getFormModel from 'src/app/models/form.server.model'
+import getFormWhitelistSubmitterIdsModel from 'src/app/models/form_whitelist.server.model'
 import getSubmissionModel from 'src/app/models/submission.server.model'
 import { IFormSchema, IPopulatedForm } from 'src/types'
 
@@ -22,6 +25,7 @@ import { MissingSubmitterIdError } from '../../submission/submission.errors'
 import {
   FormDeletedError,
   FormNotFoundError,
+  FormWhitelistSettingNotFoundError,
   PrivateFormError,
 } from '../form.errors'
 import * as FormService from '../form.service'
@@ -29,6 +33,7 @@ import * as FormService from '../form.service'
 const MOCK_FORM_ID = new ObjectId()
 const Form = getFormModel(mongoose)
 const Submission = getSubmissionModel(mongoose)
+const FormWhitelistSubmitterIds = getFormWhitelistSubmitterIdsModel(mongoose)
 
 const mockMultirespondentSubmissionForForm = (
   formId: mongoose.Types.ObjectId,
@@ -64,6 +69,9 @@ const MOCK_ENCRYPTED_FORM_PARAMS = {
   responseMode: FormResponseMode.Encrypt,
 }
 
+jest.mock('formsg-shared/utils/crypto')
+const MockCryptoUtils = jest.mocked(CryptoUtils)
+
 jest.mock('src/app/services/sms/sms.service')
 const MockSmsService = jest.mocked(SmsService)
 
@@ -80,6 +88,319 @@ describe('FormService', () => {
   afterAll(async () => {
     await dbHandler.clearDatabase()
     await dbHandler.closeDatabase()
+  })
+
+  describe('checkHasRespondentNotWhitelistedFailure', () => {
+    it('should check for submitterId whitelisting for multirespondent mode forms', async () => {
+      const mockWhitelistId = new ObjectId().toHexString()
+      const mockCipherText = 'mockCipherText'
+      const findEncryptionPropertiesByIdSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'findEncryptionPropertiesById')
+        .mockResolvedValueOnce({
+          myPublicKey: 'mockMyPublicKey',
+          myPrivateKey: 'mockMyPrivateKey',
+          nonce: Buffer.from('mock-nonce-value').toString('base64'),
+        })
+      const checkIfSubmitterIdIsWhitelistedSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'checkIfSubmitterIdIsWhitelisted')
+        .mockResolvedValueOnce({ _id: mockWhitelistId } as any)
+      MockCryptoUtils.encryptString.mockReturnValueOnce({
+        cipherText: mockCipherText,
+      } as any)
+
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Multirespondent,
+        authType: FormAuthType.SP,
+        publicKey: 'mockPublicKey',
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: mockWhitelistId,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(findEncryptionPropertiesByIdSpy).toHaveBeenCalledWith(
+        mockWhitelistId,
+      )
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toBe(false)
+
+      findEncryptionPropertiesByIdSpy.mockRestore()
+      checkIfSubmitterIdIsWhitelistedSpy.mockRestore()
+    })
+
+    it('should check for submitterId whitelisting for encrypt mode forms', async () => {
+      const mockWhitelistId = new ObjectId().toHexString()
+      const mockCipherText = 'mockCipherText'
+      const findEncryptionPropertiesByIdSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'findEncryptionPropertiesById')
+        .mockResolvedValueOnce({
+          myPublicKey: 'mockMyPublicKey',
+          myPrivateKey: 'mockMyPrivateKey',
+          nonce: Buffer.from('mock-nonce-value').toString('base64'),
+        })
+      const checkIfSubmitterIdIsWhitelistedSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'checkIfSubmitterIdIsWhitelisted')
+        .mockResolvedValueOnce({ _id: mockWhitelistId } as any)
+      MockCryptoUtils.encryptString.mockReturnValueOnce({
+        cipherText: mockCipherText,
+      } as any)
+
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.SP,
+        publicKey: 'mockPublicKey',
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: mockWhitelistId,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(findEncryptionPropertiesByIdSpy).toHaveBeenCalledWith(
+        mockWhitelistId,
+      )
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toBe(false)
+
+      findEncryptionPropertiesByIdSpy.mockRestore()
+      checkIfSubmitterIdIsWhitelistedSpy.mockRestore()
+    })
+    it('should return false if form is not encrypt or multirespondent mode', async () => {
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Email,
+        authType: FormAuthType.SP,
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toBe(false)
+    })
+
+    it('should return false if form auth type is nil', async () => {
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.NIL,
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toBe(false)
+    })
+
+    it('should return false if form whitelist setting is disabled', async () => {
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.SP,
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: false,
+          encryptedWhitelistedSubmitterIds: undefined,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toBe(false)
+    })
+
+    it('should return MissingSubmitterIdError if submitterId is not set but form whitelist setting is enabled', async () => {
+      const mockWhitelistId = new ObjectId().toHexString()
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.SP,
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: mockWhitelistId,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        undefined,
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(MissingSubmitterIdError)
+    })
+
+    it('should return FormWhitelistSettingNotFoundError if form whitelist setting is enabled but whitelist id is not set', async () => {
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.SP,
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: undefined,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        FormWhitelistSettingNotFoundError,
+      )
+    })
+
+    it('should return ApplicationError if form does not have a public key', async () => {
+      const mockWhitelistId = new ObjectId().toHexString()
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.SP,
+        publicKey: undefined,
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: mockWhitelistId,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ApplicationError)
+    })
+
+    it('should return false if submitterId is whitelisted', async () => {
+      const mockWhitelistId = new ObjectId().toHexString()
+      const findEncryptionPropertiesByIdSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'findEncryptionPropertiesById')
+        .mockResolvedValueOnce({
+          myPublicKey: 'mockMyPublicKey',
+          myPrivateKey: 'mockMyPrivateKey',
+          nonce: Buffer.from('mock-nonce-value').toString('base64'),
+        })
+      const checkIfSubmitterIdIsWhitelistedSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'checkIfSubmitterIdIsWhitelisted')
+        .mockResolvedValueOnce({ _id: mockWhitelistId } as any)
+      MockCryptoUtils.encryptString.mockReturnValueOnce({
+        cipherText: 'mockCipherText',
+      } as any)
+
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.SP,
+        publicKey: 'mockPublicKey',
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: mockWhitelistId,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toBe(false)
+
+      findEncryptionPropertiesByIdSpy.mockRestore()
+      checkIfSubmitterIdIsWhitelistedSpy.mockRestore()
+    })
+
+    it('should return true if submitterId is not whitelisted', async () => {
+      const mockWhitelistId = new ObjectId().toHexString()
+      const findEncryptionPropertiesByIdSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'findEncryptionPropertiesById')
+        .mockResolvedValueOnce({
+          myPublicKey: 'mockMyPublicKey',
+          myPrivateKey: 'mockMyPrivateKey',
+          nonce: Buffer.from('mock-nonce-value').toString('base64'),
+        })
+      const checkIfSubmitterIdIsWhitelistedSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'checkIfSubmitterIdIsWhitelisted')
+        .mockResolvedValueOnce(false)
+      MockCryptoUtils.encryptString.mockReturnValueOnce({
+        cipherText: 'mockCipherText',
+      } as any)
+
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.SP,
+        publicKey: 'mockPublicKey',
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: mockWhitelistId,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(result.isOk()).toBe(true)
+      expect(result._unsafeUnwrap()).toBe(true)
+
+      findEncryptionPropertiesByIdSpy.mockRestore()
+      checkIfSubmitterIdIsWhitelistedSpy.mockRestore()
+    })
+
+    it('should return ApplicationError if error occurs while checking if submitterId is whitelisted', async () => {
+      const mockWhitelistId = new ObjectId().toHexString()
+      const findEncryptionPropertiesByIdSpy = jest
+        .spyOn(FormWhitelistSubmitterIds, 'findEncryptionPropertiesById')
+        .mockRejectedValueOnce(new Error('db error'))
+
+      const form = {
+        _id: new ObjectId(),
+        responseMode: FormResponseMode.Encrypt,
+        authType: FormAuthType.SP,
+        publicKey: 'mockPublicKey',
+        getWhitelistedSubmitterIds: () => ({
+          isWhitelistEnabled: true,
+          encryptedWhitelistedSubmitterIds: mockWhitelistId,
+        }),
+      } as unknown as IPopulatedForm
+
+      const result = await FormService.checkHasRespondentNotWhitelistedFailure(
+        form,
+        'mockSubmitterId',
+      )
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(ApplicationError)
+      expect(result._unsafeUnwrapErr().message).toBe(
+        'Error while checking if submitterId is whitelisted',
+      )
+
+      findEncryptionPropertiesByIdSpy.mockRestore()
+    })
   })
 
   describe('checkHasSingleSubmissionValidationFailure', () => {

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -5466,7 +5466,7 @@ describe('admin-form.controller', () => {
       )
       MockAuthService.checkFormForPermissions.mockReturnValueOnce(adminCheck)
 
-      MockEncryptSubmissionService.checkFormIsEncryptMode.mockReturnValueOnce(
+      MockEmailSubmissionService.checkFormIsNotEmailMode.mockReturnValueOnce(
         ok(MOCK_FORM as IPopulatedEncryptedForm),
       )
 

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -1940,7 +1940,7 @@ export const handleGetWhitelistSetting: ControllerHandler<
       })),
     )
     .andThen(AuthService.checkFormForPermissions(PermissionLevel.Read))
-    .andThen((form) => EncryptSubmissionService.checkFormIsEncryptMode(form))
+    .andThen((form) => EmailSubmissionService.checkFormIsNotEmailMode(form))
     .map(async (form) => AdminFormService.getFormWhitelistSetting(form))
     .andThen((formWhitelistedSubmitterIds) => formWhitelistedSubmitterIds)
     .map((formWhitelistedSubmitterIds) => {

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1465,10 +1465,13 @@ export const updateFormWhitelistSetting = (
   originalForm: IPopulatedForm,
   encryptedWhitelistedSubmitterIdsContent: EncryptedStringsMessageContentWithMyPrivateKey | null,
 ) => {
-  if (originalForm.responseMode !== FormResponseMode.Encrypt) {
+  if (
+    originalForm.responseMode !== FormResponseMode.Encrypt &&
+    originalForm.responseMode !== FormResponseMode.Multirespondent
+  ) {
     return errAsync(
       new MalformedParametersError(
-        'Whitelist setting does not exist for non-encrypt mode forms',
+        'Whitelist setting is not supported for non-encrypt and non-multirespondent mode forms',
       ),
     )
   }

--- a/apps/backend/src/app/modules/form/form.service.ts
+++ b/apps/backend/src/app/modules/form/form.service.ts
@@ -293,10 +293,13 @@ export const checkFormSubmissionLimitAndDeactivateForm = (
 
 export const checkHasRespondentNotWhitelistedFailure = (
   form: IPopulatedForm,
-  submitterId: string,
+  submitterId?: string,
 ): ResultAsync<boolean, ApplicationError> => {
-  // check since whitelist is only for encrypt mode forms
-  if (form.responseMode !== FormResponseMode.Encrypt) {
+  // check since whitelist is only for encrypt mode and multirespondent mode forms
+  if (
+    form.responseMode !== FormResponseMode.Encrypt &&
+    form.responseMode !== FormResponseMode.Multirespondent
+  ) {
     return okAsync(false)
   }
   if (form.authType === FormAuthType.NIL) {
@@ -311,6 +314,9 @@ export const checkHasRespondentNotWhitelistedFailure = (
   }
   if (isWhitelistEnabled && !whitelistId) {
     return errAsync(new FormWhitelistSettingNotFoundError())
+  }
+  if (!submitterId) {
+    return errAsync(new MissingSubmitterIdError())
   }
 
   const formPublicKey = form.publicKey

--- a/apps/backend/src/app/modules/submission/email-submission/email-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/email-submission/email-submission.service.ts
@@ -168,6 +168,24 @@ export const checkFormIsEmailMode = (
 }
 
 /**
+ * Since email mode is deprecated, this check is used to ensure that the form is not
+ * email mode for features that do not support email mode.
+ * @param form form to check mode for
+ * @returns ok(form) if form is not email mode, err(ResponseModeError) if form is email mode
+ */
+export const checkFormIsNotEmailMode = (form: IPopulatedForm) => {
+  if (!isEmailModeForm(form)) {
+    return ok(form)
+  }
+  return err(
+    new ResponseModeError(
+      [FormResponseMode.Multirespondent, FormResponseMode.Encrypt],
+      form.responseMode,
+    ),
+  )
+}
+
+/**
  * Creates an email submission without saving it to the database.
  * @param form Form document
  * @param responseHash Hash of response

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -235,6 +235,11 @@ describe('multirespondent-submision.controller', () => {
   })
 
   describe('submitMultirespondentForm', () => {
+    beforeEach(() => {
+      MockFormService.checkHasRespondentNotWhitelistedFailure.mockReturnValue(
+        okAsync(false),
+      )
+    })
     it('returns 200 ok when form validation passes and invokes createMultiRespondentFormSubmission and performMultiRespondentPostSubmissionCreateActions', async () => {
       // Arrange
       const mockReq = expressHandler.mockRequest({

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.ensures.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.ensures.spec.ts
@@ -1,0 +1,109 @@
+import { errAsync, okAsync } from 'neverthrow'
+
+import { IPopulatedForm } from 'src/types'
+
+import { ApplicationError } from '../../../core/core.errors'
+import { FormWhitelistSettingNotFoundError } from '../../../form/form.errors'
+import * as FormService from '../../../form/form.service'
+import { MissingSubmitterIdError } from '../../submission.errors'
+import { ensureSubmitterIdIsWhitelisted } from '../multirespondent-submission.ensures'
+import { SubmitMultirespondentFormHandlerRequest } from '../multirespondent-submission.types'
+
+jest.mock('../../../form/form.service')
+const MockFormService = jest.mocked(FormService)
+
+const createMockReq = (submitterId?: string) =>
+  ({
+    formsg: {
+      encryptedPayload: {
+        submitterId,
+      },
+    },
+  }) as unknown as SubmitMultirespondentFormHandlerRequest
+
+const createMockRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+})
+
+const createMockContext = (submitterId?: string) => ({
+  req: createMockReq(submitterId),
+  res: createMockRes() as any,
+  logMeta: { action: 'test' },
+  form: {} as IPopulatedForm,
+})
+
+describe('Multirespondent Submission Ensures', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  describe('ensureSubmitterIdIsWhitelisted', () => {
+    it('should respond with 500 if form whitelist setting is not found despite whitelist being enabled', async () => {
+      MockFormService.checkHasRespondentNotWhitelistedFailure.mockReturnValueOnce(
+        errAsync(new FormWhitelistSettingNotFoundError()),
+      )
+      const next = jest.fn()
+      const ctx = createMockContext('mockSubmitterId')
+
+      await ensureSubmitterIdIsWhitelisted(ctx, next)
+
+      expect(ctx.res.status).toHaveBeenCalledWith(500)
+      expect(ctx.res.json).toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('should respond with 500 if submitterId is not found despite whitelist being enabled', async () => {
+      MockFormService.checkHasRespondentNotWhitelistedFailure.mockReturnValueOnce(
+        errAsync(new MissingSubmitterIdError()),
+      )
+      const next = jest.fn()
+      const ctx = createMockContext(undefined)
+
+      await ensureSubmitterIdIsWhitelisted(ctx, next)
+
+      expect(ctx.res.status).toHaveBeenCalledWith(500)
+      expect(ctx.res.json).toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('should respond with 500 if unexpected ApplicationError is thrown', async () => {
+      MockFormService.checkHasRespondentNotWhitelistedFailure.mockReturnValueOnce(
+        errAsync(new ApplicationError('Unexpected error')),
+      )
+      const next = jest.fn()
+      const ctx = createMockContext('mockSubmitterId')
+
+      await ensureSubmitterIdIsWhitelisted(ctx, next)
+
+      expect(ctx.res.status).toHaveBeenCalledWith(500)
+      expect(ctx.res.json).toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('should respond with 403 if submitterId is not whitelisted', async () => {
+      MockFormService.checkHasRespondentNotWhitelistedFailure.mockReturnValueOnce(
+        okAsync(true),
+      )
+      const next = jest.fn()
+      const ctx = createMockContext('mockSubmitterId')
+
+      await ensureSubmitterIdIsWhitelisted(ctx, next)
+
+      expect(ctx.res.status).toHaveBeenCalledWith(403)
+      expect(ctx.res.json).toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('should invoke next if submitterId is whitelisted', async () => {
+      MockFormService.checkHasRespondentNotWhitelistedFailure.mockReturnValueOnce(
+        okAsync(false),
+      )
+      const next = jest.fn()
+      const ctx = createMockContext('mockSubmitterId')
+
+      await ensureSubmitterIdIsWhitelisted(ctx, next)
+
+      expect(ctx.res.status).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -393,8 +393,8 @@ describe('Multirespondent Submission Middleware', () => {
       jest.resetAllMocks()
     })
 
-    describe('hashedSubmitterId is set', () => {
-      it('should set hashedSubmitterId in encryptedPayload if is step 1 submission with singpass auth type', async () => {
+    describe('submitterId is set', () => {
+      it('should set submitterId and hashedSubmitterId in encryptedPayload if is step 1 submission with singpass auth type', async () => {
         jest
           .mocked(MyInfoUtil.extractMyInfoLoginJwt)
           .mockReturnValue(ok('mock-jwt-string'))
@@ -451,9 +451,10 @@ describe('Multirespondent Submission Middleware', () => {
         expect(mockReq.formsg.encryptedPayload.hashedSubmitterId).toEqual(
           generateHashedSubmitterId('S1234567A', MOCK_FORM_ID),
         )
+        expect(mockReq.formsg.encryptedPayload.submitterId).toEqual('S1234567A')
       })
 
-      it('should set hashedSubmitterId in encryptedPayload if is step 1 submission with corppass auth type', async () => {
+      it('should set submitterId and hashedSubmitterId in encryptedPayload if is step 1 submission with corppass auth type', async () => {
         jest.mocked(OidcService.getOidcService).mockReturnValue({
           extractJwt: jest.fn().mockReturnValue({
             asyncAndThen: jest.fn().mockReturnValue(
@@ -520,9 +521,10 @@ describe('Multirespondent Submission Middleware', () => {
         expect(mockReq.formsg.encryptedPayload.hashedSubmitterId).toEqual(
           generateHashedSubmitterId('S1234567A', MOCK_FORM_ID),
         )
+        expect(mockReq.formsg.encryptedPayload.submitterId).toEqual('S1234567A')
       })
 
-      it('should not set hashedSubmitterId in encryptedPayload if is step 1 submission with non-singpass auth type', async () => {
+      it('should not set submitterId or hashedSubmitterId in encryptedPayload if is step 1 submission with non-singpass auth type', async () => {
         const mockNext = jest.fn()
 
         const mockReq = createMockReq({
@@ -548,9 +550,12 @@ describe('Multirespondent Submission Middleware', () => {
         expect(mockReq.formsg.encryptedPayload).not.toHaveProperty(
           'hashedSubmitterId',
         )
+        expect(mockReq.formsg.encryptedPayload).not.toHaveProperty(
+          'submitterId',
+        )
       })
 
-      it('should not set hashedSubmitterId in encryptedPayload if is step >=2 submission', async () => {
+      it('should not set submitterId or hashedSubmitterId in encryptedPayload if is step >=2 submission', async () => {
         const mockNext = jest.fn()
 
         const mockReq = createMockReq({
@@ -577,6 +582,9 @@ describe('Multirespondent Submission Middleware', () => {
         expect(mockNext).toHaveBeenCalled()
         expect(mockReq.formsg.encryptedPayload).not.toHaveProperty(
           'hashedSubmitterId',
+        )
+        expect(mockReq.formsg.encryptedPayload).not.toHaveProperty(
+          'submitterId',
         )
       })
 
@@ -616,7 +624,7 @@ describe('Multirespondent Submission Middleware', () => {
         expect(mockNext).not.toHaveBeenCalled()
         expect(mockRes.status).toHaveBeenCalledWith(500)
         expect(mockRes.json).toHaveBeenCalledWith({
-          message: 'Sorry, something went wrong. Please try again.',
+          message: 'Failed to retrieve submitter ID. Please try again.',
         })
       })
     })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -44,6 +44,7 @@ import {
 } from '../submission.service'
 import { mapRouteError } from '../submission.utils'
 
+import { ensureSubmitterIdIsWhitelisted } from './multirespondent-submission.ensures'
 import * as MultirespondentSubmissionMiddleware from './multirespondent-submission.middleware'
 import {
   checkFormIsMultirespondent,
@@ -94,7 +95,11 @@ const submitMultirespondentForm = async (
   const isMrfResponseLimitEnabled =
     isTest || (gb?.isOn(featureFlags.mrfResponseLimit) ?? true)
 
-  const middlewarePipelines = [ensurePublicForm, ensureValidCaptcha]
+  const middlewarePipelines = [
+    ensurePublicForm,
+    ensureValidCaptcha,
+    ensureSubmitterIdIsWhitelisted,
+  ]
   if (isMrfResponseLimitEnabled) {
     middlewarePipelines.push(ensureFormWithinSubmissionLimits)
   }

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.ensures.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.ensures.ts
@@ -1,0 +1,66 @@
+import { IPopulatedForm } from '../../../../types'
+import {
+  createLoggerWithLabel,
+  CustomLoggerParams,
+} from '../../../config/logger'
+import { Middleware } from '../../../utils/pipeline-middleware'
+import { FormRespondentNotWhitelistedError } from '../../form/form.errors'
+import * as FormService from '../../form/form.service'
+import { mapRouteError } from '../submission.utils'
+
+import {
+  ProcessedMultirespondentSubmissionHandlerType,
+  SubmitMultirespondentFormHandlerRequest,
+} from './multirespondent-submission.types'
+
+const logger = createLoggerWithLabel(module)
+
+type FormSubmissionPipelineContext = {
+  req: SubmitMultirespondentFormHandlerRequest
+  res: Parameters<ProcessedMultirespondentSubmissionHandlerType>[1]
+  logMeta: CustomLoggerParams['meta']
+  form: IPopulatedForm
+}
+
+export const ensureSubmitterIdIsWhitelisted: Middleware<
+  FormSubmissionPipelineContext
+> = async ({ logMeta, res, form, req }, next) => {
+  const submitterId = req.formsg?.encryptedPayload?.submitterId
+
+  const hasRespondentNotWhitelistedErrorResult =
+    await FormService.checkHasRespondentNotWhitelistedFailure(form, submitterId)
+
+  if (hasRespondentNotWhitelistedErrorResult.isErr()) {
+    const error = hasRespondentNotWhitelistedErrorResult.error
+    logger.error({
+      message: error.message,
+      meta: logMeta,
+      error,
+    })
+
+    const { statusCode, errorMessage } = mapRouteError(error)
+    res.status(statusCode).json({ message: errorMessage })
+    return
+  }
+
+  const isRespondentNotWhitelisted =
+    hasRespondentNotWhitelistedErrorResult.value
+
+  if (isRespondentNotWhitelisted) {
+    const formRespondentNotWhitelistedError =
+      new FormRespondentNotWhitelistedError()
+    logger.error({
+      message: formRespondentNotWhitelistedError.message,
+      meta: logMeta,
+      error: formRespondentNotWhitelistedError,
+    })
+
+    const { statusCode, errorMessage } = mapRouteError(
+      formRespondentNotWhitelistedError,
+    )
+    res.status(statusCode).json({ message: errorMessage })
+    return
+  }
+
+  return next()
+}

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -925,6 +925,7 @@ export const handleNdiResponses = async (
       }
       const hashedSubmitterId = generateHashedSubmitterId(submitterId, formId)
       req.formsg.encryptedPayload.hashedSubmitterId = hashedSubmitterId
+      req.formsg.encryptedPayload.submitterId = submitterId
       verifiedContent = verifiedContentResult.value
     }
   }

--- a/apps/backend/src/app/modules/submission/submission.errors.ts
+++ b/apps/backend/src/app/modules/submission/submission.errors.ts
@@ -320,7 +320,7 @@ export class MrfReminderRecipientEmailsEmptyError extends ApplicationError {
 }
 
 export class MissingSubmitterIdError extends ApplicationError {
-  constructor(message = 'Failed to retrieve submitter ID from Singpass.') {
+  constructor(message = 'Failed to retrieve submitter ID. Please try again.') {
     super(message, undefined, ErrorCodes.SUBMISSION_MISSING_SUBMITTER_ID)
   }
 }

--- a/apps/backend/src/app/modules/submission/submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/submission.utils.ts
@@ -88,7 +88,9 @@ import {
   ForbiddenFormError,
   FormDeletedError,
   FormNotFoundError,
+  FormRespondentNotWhitelistedError,
   FormRespondentSingleSubmissionValidationError,
+  FormWhitelistSettingNotFoundError,
   PrivateFormError,
 } from '../form/form.errors'
 import { isFormEncryptModeOrMultirespondent } from '../form/form.utils'
@@ -199,15 +201,15 @@ const errorMapper: MapRouteError = (
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: coreErrorMessage,
       }
+    case FormRespondentNotWhitelistedError:
+      return {
+        statusCode: StatusCodes.FORBIDDEN,
+        errorMessage: error.message,
+      }
     case FormRespondentSingleSubmissionValidationError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,
-      }
-    case MissingSubmitterIdError:
-      return {
-        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
-        errorMessage: coreErrorMessage,
       }
     case SgidMissingJwtError:
     case SgidVerifyJwtError:
@@ -353,6 +355,8 @@ const errorMapper: MapRouteError = (
         errorMessage:
           'The form has been updated. Please refresh and submit again.',
       }
+    case FormWhitelistSettingNotFoundError:
+    case MissingSubmitterIdError:
     case PaymentNotFoundError:
     case CreatePresignedPostError:
     case DatabaseError:

--- a/apps/backend/src/types/api/multirespondent_submission.ts
+++ b/apps/backend/src/types/api/multirespondent_submission.ts
@@ -62,6 +62,7 @@ export type MultirespondentSubmissionDto = {
   responseMetadata?: ResponseMetadata
   workflowStep: number
   hashedSubmitterId?: string
+  submitterId?: string
   responses: FieldResponsesV3
   mrfVersion: number
 }

--- a/apps/backend/src/types/form.ts
+++ b/apps/backend/src/types/form.ts
@@ -379,6 +379,7 @@ export interface IMultirespondentForm extends IForm {
   stepsToNotify: string[]
   stepOneEmailNotificationFieldId: string
   hasStatusTracker: boolean
+  whitelistedSubmitterIds?: WhitelistedSubmitterIds
 }
 
 export type IMultirespondentFormSchema = IMultirespondentForm & IFormSchema

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-frontend",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSingpassSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/AuthSettingsSingpassSection.tsx
@@ -21,8 +21,9 @@ export const AuthSettingsSingpassSection = ({
   const isSingpassSettingsDisabled = isFormPublic
   const isSinglepassAuthOptionsDisabled =
     isSingpassSettingsDisabled || containsMyInfoFields
-  const isEncryptMode = settings.responseMode === FormResponseMode.Encrypt
-  const isMrf = settings.responseMode === FormResponseMode.Multirespondent
+  const isEncryptOrMultirespondentMode =
+    settings.responseMode === FormResponseMode.Encrypt ||
+    settings.responseMode === FormResponseMode.Multirespondent
 
   return (
     <>
@@ -30,26 +31,24 @@ export const AuthSettingsSingpassSection = ({
         settings={settings}
         isDisabled={isSinglepassAuthOptionsDisabled}
       />
-      <>
-        <Divider my="2.5rem" />
-        <FormSubmitterIdCollectionToggle
-          settings={settings}
-          isDisabled={isFormPublic}
-        />
-      </>
-      <>
-        <Divider my="2.5rem" />
-        <FormSingleSubmissionToggle
-          settings={settings}
-          isDisabled={isSingpassSettingsDisabled}
-        />
-      </>
       <Divider my="2.5rem" />
-      {isEncryptMode ? (
-        <FormWhitelistAttachmentField
-          settings={settings}
-          isDisabled={isSingpassSettingsDisabled}
-        />
+      <FormSubmitterIdCollectionToggle
+        settings={settings}
+        isDisabled={isFormPublic}
+      />
+      <Divider my="2.5rem" />
+      <FormSingleSubmissionToggle
+        settings={settings}
+        isDisabled={isSingpassSettingsDisabled}
+      />
+      {isEncryptOrMultirespondentMode ? (
+        <>
+          <Divider my="2.5rem" />
+          <FormWhitelistAttachmentField
+            settings={settings}
+            isDisabled={isSingpassSettingsDisabled}
+          />
+        </>
       ) : null}
     </>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormWhitelistAttachmentField.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/FormWhitelistAttachmentField.tsx
@@ -9,7 +9,10 @@ import { useParams } from 'react-router'
 import { Box, Skeleton } from '@chakra-ui/react'
 
 import { KB } from 'formsg-shared/constants'
-import { StorageFormSettings } from 'formsg-shared/types'
+import {
+  MultirespondentFormSettings,
+  StorageFormSettings,
+} from 'formsg-shared/types'
 import { VALID_WHITELIST_FILE_EXTENSIONS } from 'formsg-shared/utils/file-validation'
 
 import { parseCsvFile } from '~utils/parseCsvFile'
@@ -21,7 +24,7 @@ import { useMutateFormSettings } from '../../mutations'
 import { SecretKeyDownloadWhitelistFileModal } from './SecretKeyDownloadWhitelistFileModal'
 
 interface FormWhitelistAttachmentFieldProps {
-  settings: StorageFormSettings
+  settings: StorageFormSettings | MultirespondentFormSettings
   isDisabled: boolean
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-monorepo",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "description": "Form Manager for Government",
   "homepage": "https://form.gov.sg",

--- a/packages/react-email-preview/package.json
+++ b/packages/react-email-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-react-email-preview",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "scripts": {
     "build": "email build",

--- a/packages/shared/constants/form.ts
+++ b/packages/shared/constants/form.ts
@@ -75,6 +75,7 @@ export const MULTIRESPONDENT_FORM_SETTINGS_FIELDS = [
   'stepsToNotify',
   'stepOneEmailNotificationFieldId',
   'hasStatusTracker',
+  'whitelistedSubmitterIds',
 ] as const
 
 // Fields that are necessary for decrypting the cipherTexts given peer's private key

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-shared",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "description": "",
   "scripts": {

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -249,6 +249,7 @@ export interface MultirespondentFormBase extends FormBase {
   stepsToNotify: FormWorkflowStepDto['_id'][]
   stepOneEmailNotificationFieldId?: string
   hasStatusTracker: boolean
+  whitelistedSubmitterIds?: WhitelistedSubmitterIds | null
 }
 
 /**

--- a/services/form-payment-reconciliation/package.json
+++ b/services/form-payment-reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-payment-reconciliation",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "description": "Lambda function for payment reconciliation",
   "main": "index.js",

--- a/services/pdf-gen-sparticuz/package.json
+++ b/services/pdf-gen-sparticuz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-pdf-gen-sparticuz",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "description": "<!-- title: 'AWS NodeJS Example' description: 'This template demonstrates how to deploy a simple NodeJS function running on AWS Lambda using the Serverless Framework.' layout: Doc framework: v4 platform: AWS language: nodeJS priority: 1 authorLink: 'https://github.com/serverless' authorName: 'Serverless, Inc.' authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4' -->",
   "main": "dist/index.js",

--- a/services/virus-scanner-guardduty/package.json
+++ b/services/virus-scanner-guardduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-virus-scanner-guardduty",
-  "version": "7.16.0",
+  "version": "7.16.1",
   "private": true,
   "description": "",
   "scripts": {


### PR DESCRIPTION


### Miscellaneous

* Merge pull request #9368 from opengovsg/feat/nric-whitelist-mrf ([#9368](https://github.com/opengovsg/formsg/commit/9ac05e2c5a69c62e0eb7292b038ca27931bc40ea))


### Tests

### Merge pull request #9368 from opengovsg/feat/nric-whitelist-mrf ([#9368](https://github.com/opengovsg/formsg/commit/9ac05e2c5a69c62e0eb7292b038ca27931bc40ea))
<!-- What tests should be run to confirm functionality? -->
TC1: Whitelist submitter id works for Myinfo MRF >=2 steps 
- [ ] Create MRF with >=2 steps. 
- [ ] Add a whitelist for 1-2 NRICs 
- [ ] Try to login to a form as respondent using another NRIC, assert it is blocked. 
- [ ] Try to use a whitelisted NRIC, assert you can see the form fields as a respondent.
- [ ] Try to submit the form step 1, assert it is successful. 
- [ ] Login again with the whitelisted NRIC and go to the form fields page. 
- [ ] Update the admin whitelist setting to remove the logged in NRiC. 
- [ ] Try to submit the form, it should be blocked with a toast. 

TC2: Works with singpass single submission 
- [ ] Whitelist the logged in NRIC again. 
- [ ] Turn on single submission. 
- [ ] Submit the form with the logged in NRIC, it should now be blocked showing the single submission message as error. 
- [ ] Turn off singpass entirely, leaving the single submission and whitelist in place.
- [ ] Go back and try to submit, the login should be gone and submission for step 1 works. 

TC3: Step 2 and beyond works and is unaffected by the whitelist setting
- [ ] Check your email inbox for the step 2 submissions from TC1. 
- [ ] Remove the logged in ID from step 1 from the whitelist. 
- [ ] Submit the step 2. 
- [ ] Assert you can submit step 2 and it does not require a login id and it does not check based on the whitelist.

TC4: Storage mode is not affected 
- [ ] Try and submit a singpass enabled storage mode form without the whitelist. Assert it works. 
- [ ] Enable whitelist. 
- [ ] Assert login and submit works for whitelisted NRIC.
- [ ] Assert login and submit is blocked with expected error infobox for non-whitelisted NRIC. 

