### PR TITLE
fix: respondent copy custom body line breaks

### DIFF
--- a/apps/backend/src/app/views/templates/EmailTemplate.tsx
+++ b/apps/backend/src/app/views/templates/EmailTemplate.tsx
@@ -152,7 +152,7 @@ export const EmailTemplate = ({
                 marginBottom: '40px',
               }}
             >
-              {emailBody?.split('\n').map((line, i, arr) => (
+              {emailBody?.split(/\r?\n/).map((line, i, arr) => (
                 <React.Fragment key={i}>
                   {line}
                   {i < arr.length - 1 && <br />}

--- a/apps/backend/src/app/views/templates/EmailTemplate.tsx
+++ b/apps/backend/src/app/views/templates/EmailTemplate.tsx
@@ -22,6 +22,7 @@ import {
   Section,
   Text,
 } from '@react-email/components'
+import React from 'react'
 
 import { FORMSG_LOGO_URL } from '../../constants/formsg-logo'
 
@@ -149,10 +150,14 @@ export const EmailTemplate = ({
               style={{
                 ...secondaryTextStyle,
                 marginBottom: '40px',
-                whiteSpace: 'pre-line',
               }}
             >
-              {emailBody}
+              {emailBody?.split('\n').map((line, i, arr) => (
+                <React.Fragment key={i}>
+                  {line}
+                  {i < arr.length - 1 && <br />}
+                </React.Fragment>
+              ))}
             </Text>
 
             {/* Section - Form Title */}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

On COMET/GSIB, the custom email body (e.g. for respondent copy) does not format well in outlook. This is because the outlook rendering engine doesn't respect `white-space:pre-line`, leaving the line breaks to be missed and body to be displayed as a chunk

## Solution
<!-- How did you solve the problem? -->

Replace usage of `white-space:pre-line` with explicit `\n` using `React.Fragment`.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | --- | ---- |
| custom body in email | <img width="923" height="621" alt="image" src="https://github.com/user-attachments/assets/0b05e735-3af7-4e31-aa10-1d7b34ed8b3c" /> | <img width="959" height="635" alt="image" src="https://github.com/user-attachments/assets/67032385-6beb-4258-8e10-7e1c1312f2f2" /> |

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Respondent copy on COMET/GSIB**
- [ ] Create an MRF form with an email field, toggle on respondent copy
- [ ] Add a custom body to the respondent copy, Include multiple line breaks for rigour
- [ ] Make a submission, supply an outlook email address for the email field
- [ ] Verify on COMET/GSIB that the respondent copy received has a custom email body that respects the line breaks
