### PR TITLE
fix: issue email sending

### DIFF
--- a/apps/backend/src/app/services/mail/mail.utils.ts
+++ b/apps/backend/src/app/services/mail/mail.utils.ts
@@ -227,7 +227,7 @@ export const generatePaymentConfirmationHtml = ({
 }: {
   htmlData: PaymentConfirmationData
 }): ResultAsync<string, MailGenerationError> => {
-  const pathToTemplate = `${process.cwd()}/src/app/views/templates/payment-confirmation.view.html`
+  const pathToTemplate = `${__dirname}/../../views/templates/payment-confirmation.view.html`
   logger.info({
     message: 'generatePaymentConfirmationHtml',
     meta: {
@@ -258,7 +258,7 @@ export const generateIssueReportedNotificationHtml = ({
 }: {
   htmlData: IssueReportedNotificationData
 }): ResultAsync<string, MailGenerationError> => {
-  const pathToTemplate = `${process.cwd()}/src/app/views/templates/issue-reported-notification.view.html`
+  const pathToTemplate = `${__dirname}/../../views/templates/issue-reported-notification.view.html`
   logger.info({
     message: 'generateIssueReportedNotificationHtml',
     meta: {

--- a/apps/frontend/src/features/public-form/components/FloatingToolBar/FormIssueFeedbackModal.tsx
+++ b/apps/frontend/src/features/public-form/components/FloatingToolBar/FormIssueFeedbackModal.tsx
@@ -134,7 +134,7 @@ export const FormIssueFeedbackModal = ({
               </FormControl>
 
               <FormControl isInvalid={!!errors.email}>
-                <FormLabel pt="1rem">{t('features.common.cancel')}</FormLabel>
+                <FormLabel pt="1rem">{t('features.common.contact')}</FormLabel>
                 <Input
                   type={BasicField.Email}
                   placeholder={t(

--- a/apps/frontend/src/i18n/locales/features/common/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/common/en-sg.ts
@@ -21,6 +21,7 @@ export const enSG: Common = {
   removeReenter: 'Remove and re-enter',
   share: 'Share',
   cancel: 'Cancel',
+  contact: 'Contact',
   title: 'Title',
   question: 'Question',
   option: 'Option',

--- a/apps/frontend/src/i18n/locales/features/common/index.ts
+++ b/apps/frontend/src/i18n/locales/features/common/index.ts
@@ -21,6 +21,7 @@ export interface Common {
   removeReenter: string
   share: string
   cancel: string
+  contact: string
   title: string
   question: string
   option: string

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -123,12 +123,8 @@ export const enSG: PublicForm = {
     },
     formIssueFeedbackModal: {
       title: 'Report an issue',
-      description: {
-        beforeBold: 'Fill this in only ',
-        bold: 'if you are experiencing issues and are unable to submit this form',
-        afterBold:
-          '. If you would like to provide feedback, you can do so after submitting the form.',
-      },
+      description:
+        'Fill this in only <bold>if you are experiencing issues and are unable to submit this form</bold>. If you would like to provide feedback, you can do so after submitting the form.',
       fields: {
         issueLabel: 'Please describe the issue you encountered',
         contactLabel: 'Contact',

--- a/apps/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/index.ts
@@ -109,11 +109,7 @@ export interface PublicForm {
     }
     formIssueFeedbackModal: {
       title: string
-      description: {
-        beforeBold: string
-        bold: string
-        afterBold: string
-      }
+      description: string
       fields: {
         issueLabel: string
         contactLabel: string


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

FormSG hasn't been sending out payment confirmation emails and issue notification emails due to the BE being unable to reference the location of these template emails.

Closes FRM-2394.

## Solution
<!-- How did you solve the problem? -->

1. Update path to template file in `generatePaymentConfirmationHtml` and `generateIssueReportedNotificationHtml` to use `__dirname` (like other functions in `mail.service.ts`) instead of `process.cwd()`.
   - `process.cwd()` resolves to `/opt/formsg/src/app/views/templates/...`
   - `__dirname` resolves to `/opt/formsg/apps/backend/...`
2. Updated incorrect referencing on i18n variables for IssueNotificationModal

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
-  No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | --- | ---- |
| Issue Modal | <img width="605" height="406" alt="image" src="https://github.com/user-attachments/assets/ce86a8d1-59c0-4536-8607-8e0a0a3f9bc8" /> |  <img width="608" height="452" alt="image" src="https://github.com/user-attachments/assets/3e039fff-2659-4c11-9b42-76f80cd65672" /> |

## Tests
<!-- What tests should be run to confirm functionality? -->

 **TC1: Test report issue**
- [ ] On a public form (with yourself as an admin), attempt to report an issue
- [ ] Observe that the modal as the expected copy changes of issue reporting information and **Contact** label
- [ ] Successfully receive the issue notification email in your inbox

**TC2: Test payment confirmation email**
- [ ] On a payment form, attempt to make a submission
- [ ] Observe that you receive a payment confirmation email (NOT only the receipt)
