### PR TITLE
fix: signature field draggability interaction

### DIFF
--- a/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -272,18 +272,12 @@ const SignatureCanvas = ({
                   </Flex>
                 )}
                 <Box
-                  pointerEvents={schema.disabled ? 'none' : 'auto'} // disable canvas interaction
+                  // Set canvas as an interactive element so drag-and-drop libraries
+                  // treat it as interactive and skip drag initiation from the signature canvas to keep draw-ability.
+                  contentEditable={schema.disabled ? undefined : true}
+                  pointerEvents={schema.disabled ? 'none' : 'auto'}
                   width="100%"
                   height="100%"
-                  onPointerDown={(event) => {
-                    if (!schema.disabled) event.stopPropagation()
-                  }}
-                  onMouseDown={(event) => {
-                    if (!schema.disabled) event.stopPropagation()
-                  }}
-                  onTouchStart={(event) => {
-                    if (!schema.disabled) event.stopPropagation()
-                  }}
                   sx={{ cursor: 'default' }}
                 >
                   <canvas


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

After implementing a fully draggable form field, Signature field experiences a bug where the user is unable to draw on the field and experiences the drag action instead (only in the form builder).

`stopPropagation()` is not working as intended since it is a bubble-phase action, which doesn't block a capture-phase listener (`provided.dragHandleProps` spread onto `HighlightableFlex`) which is higher in the DOM tree and gets fired first and takes precedence.

## Solution
<!-- How did you solve the problem? -->

- Remove existing `stopPropagation()` code
- Set canvas element as an editable interactive elements, which then doesn't inherit draggable function (similar to other interactive elements e.g. TextFieldArea etc.)

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | ---- | ----- |
| Signature field | <img width="400" height="300" alt="s_wrong" src="https://github.com/user-attachments/assets/0703dc4e-6cc1-44df-9c20-97ec487d3b86" /> | <img width="400" height="300" alt="s_correct" src="https://github.com/user-attachments/assets/25bb5542-5807-4a07-a4ee-774e3c9d2887" /> |