### PR TITLE
chore: pin pnpm@10.30.3 as packagemanager in package.json

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,7 +6,7 @@
 FROM node:22.22.2-alpine3.22 AS build-base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
+RUN npm install -g pnpm@10.30.3
 
 # Install build dependencies (same as Dockerfile.production build stage)
 RUN apk upgrade --no-cache && \
@@ -32,7 +32,7 @@ RUN pnpm install --frozen-lockfile --filter "!services/*" --filter "!packages/re
 FROM node:22.22.2-alpine3.22 AS runtime-base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
+RUN npm install -g pnpm@10.30.3
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -12,7 +12,7 @@ ENV NODE_ENV=development
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
+RUN npm install -g pnpm@10.30.3
 # Build dependencies for node_modules
 RUN apk add --virtual native-deps \
     # Python version must be specified starting in alpine3.12

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "node": ">=22.22",
     "pnpm": ">=10.30.3"
   },
+  "packageManager": "pnpm@10.30.3",
   "scriptComments": {
     "clean": "remove all current build artifacts"
   },

--- a/services/virus-scanner-guardduty/Dockerfile
+++ b/services/virus-scanner-guardduty/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
   python3
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
+RUN npm install -g pnpm@10.30.3
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Corepack tries to download pnpm@11.0.9 which doesn't align with our usage of pnpm@10.30.3. Leading to 
```
[EACCES] EACCES: permission denied, open '/opt/formsg/_tmp_19_7d9943cbe54aed2bf741cdf728280f22'
```

Container installation hangs and times out after 1 hour

## Solution
<!-- How did you solve the problem? -->

Pin package manager to use pnpm@10.30.3

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
