### PR TITLE
chore: remove corepack

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,7 +6,7 @@
 FROM node:22.22.2-alpine3.22 AS build-base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
+RUN npm install -g pnpm@10.30.3
 
 # Install build dependencies (same as Dockerfile.production build stage)
 RUN apk upgrade --no-cache && \
@@ -32,7 +32,7 @@ RUN pnpm install --frozen-lockfile --filter "!services/*" --filter "!packages/re
 FROM node:22.22.2-alpine3.22 AS runtime-base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
+RUN npm install -g pnpm@10.30.3
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -12,7 +12,7 @@ ENV NODE_ENV=development
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
+RUN npm install -g pnpm@10.30.3
 # Build dependencies for node_modules
 RUN apk add --virtual native-deps \
     # Python version must be specified starting in alpine3.12

--- a/services/virus-scanner-guardduty/Dockerfile
+++ b/services/virus-scanner-guardduty/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
   python3
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
+RUN npm install -g pnpm@10.30.3
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
During deployment, corepack throws an error `[EACCES] EACCES: permission denied.`, which blocks our deployments.

Thanks to @scottheng96's analysis, turns out it was due to corepack using a later version of pnpm than what we pinned as allowable for pnpm. 

We need to resolve this error from corepack to unblock our deployments. 

## Solution
<!-- How did you solve the problem? -->
Remove corepack (which is not needed) and use npm to install pnpm@<pinned at 10.3.30> instead. 
This uses npm which is pre-included in the base image.

## Explanation 
For context, from corepack docs, this is what corepack does:
`In practical terms, Corepack lets you use Yarn, npm, and pnpm without having to install them.`
The reason why we added corepack was likely since it was an AI autosuggestion to get pnpm installed. We did not look into detail about what it did. Hence, this could be an opportunity to remove corepack. 

Side note, above the corepack command in our dockerfile, there is the comment:
```
# Install pnpm
RUN corepack enable && corepack prepare pnpm@10.30.3 --activate
```
Comparing with corepack's docs, this comment signals that it was probably not our intention to use corepack in the first place, since we are only using `pnpm` and it is acceptable to install `pnpm` at the pinned version in our docker image.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  