### PR TITLE
fix: allow links in public form messages

### DIFF
--- a/apps/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/PublicFormSubmitButton.tsx
@@ -211,7 +211,7 @@ export const PublicFormSubmitButton = ({
         </Button>
       </Flex>
       {preventSubmissionLogic ? (
-        <InlineMessage variant="warning">
+        <InlineMessage variant="warning" useMarkdown>
           {preventSubmissionMessage}
         </InlineMessage>
       ) : null}

--- a/apps/frontend/src/features/public-form/components/FormNotFound/FormNotFound.test.tsx
+++ b/apps/frontend/src/features/public-form/components/FormNotFound/FormNotFound.test.tsx
@@ -1,0 +1,25 @@
+import { screen } from '@testing-library/react'
+
+import { render } from '~/test-utils'
+
+import { FormNotFound } from './FormNotFound'
+
+vi.mock('../FormFooter', () => ({
+  FormFooter: () => <div>Footer</div>,
+}))
+
+describe('FormNotFound', () => {
+  it('renders markdown links in the message', () => {
+    render(
+      <FormNotFound
+        header="This form is closed."
+        message="Please visit our [help page](https://example.com/help)."
+      />,
+    )
+
+    expect(screen.getByRole('link', { name: /help page/i })).toHaveAttribute(
+      'href',
+      'https://example.com/help',
+    )
+  })
+})

--- a/apps/frontend/src/features/public-form/components/FormNotFound/FormNotFound.tsx
+++ b/apps/frontend/src/features/public-form/components/FormNotFound/FormNotFound.tsx
@@ -1,4 +1,7 @@
-import { Flex, Stack, Text } from '@chakra-ui/react'
+import { Box, Flex, Stack, Text } from '@chakra-ui/react'
+
+import { useMdComponents } from '~hooks/useMdComponents'
+import { MarkdownText } from '~components/MarkdownText'
 
 import { FormFooter } from '../FormFooter'
 
@@ -13,6 +16,14 @@ export const FormNotFound = ({
   header = 'This form is not available.',
   message,
 }: FormNotFoundProps): JSX.Element => {
+  const mdComponents = useMdComponents({
+    styles: {
+      text: {
+        textStyle: 'body-1',
+      },
+    },
+  })
+
   return (
     <Flex flex={1} flexDir="column" h="100%">
       <Flex
@@ -41,7 +52,11 @@ export const FormNotFound = ({
           <Text as="h2" textStyle="h2">
             {header}
           </Text>
-          <Text textStyle="body-1">{message}</Text>
+          {message ? (
+            <Box>
+              <MarkdownText components={mdComponents}>{message}</MarkdownText>
+            </Box>
+          ) : null}
         </Stack>
       </Flex>
       <Flex


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #9344

Closed form messages and prevent-submit logic messages did not render markdown links as clickable anchors. 
As a result, respondents had to manually copy/paste URLs from these messages instead of being able to follow the intended link directly.

## Solution
<!-- How did you solve the problem? -->

Enabled markdown link rendering for two public-form message surfaces:
- Closed form message shown on the public form unavailable page
- Prevent-submit logic warning shown when form logic blocks submission

Also added focused frontend test coverage for the closed-form message rendering path.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- None

**Improvements**:

- Respondents can now directly open follow-up links from closed form messages.
- Respondents can now directly open follow-up links from prevent-submit logic messages.

**Bug Fixes**:

- Fixed closed form messages so markdown links render as clickable anchors.
- Fixed prevent-submit logic messages so markdown links render as clickable anchors.
- Added focused automated coverage for the closed-form message rendering path.

## Before & After Screenshots

### Closed form message

**BEFORE**:
<img width="2484" height="1516" alt="image" src="https://github.com/user-attachments/assets/6db6598c-8837-4125-91c1-c95c13220691" />

**AFTER**:
<img width="1114" height="706" alt="image" src="https://github.com/user-attachments/assets/f7f8b98c-fad8-4037-8aba-0719fdbbb9b9" />

### Prevent-submit logic message

**BEFORE**:
<img width="1030" height="731" alt="image" src="https://github.com/user-attachments/assets/91bf6d07-68d4-4b6d-9505-1adf5b57689e" />

**AFTER**:
<img width="1009" height="673" alt="image" src="https://github.com/user-attachments/assets/8e560732-3169-4560-8f42-ce8194030189" />

## Tests
<!-- What tests should be run to confirm functionality? -->

### Automated
- `cd apps/frontend && ./node_modules/.bin/vitest run src/features/public-form/components/FormNotFound/FormNotFound.test.tsx`

### Manual
- Added a markdown link in the closed form message and verified it renders as a clickable link on the public closed-form state.
- Added a markdown link in a prevent-submit logic message and verified it renders as a clickable link when the logic condition is triggered.

### Notes
- I added a focused frontend test for the closed-form message rendering path.
- I did not add a separate automated prevent-submit test because that path reuses the existing `InlineMessage` markdown rendering path, and testing it directly would require a heavier component harness for a smaller incremental assertion. Happy to add parity coverage if maintainers would prefer it.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- None

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
