### PR TITLE
fix: normalize markdown bullet styling in descriptions

### DIFF
--- a/apps/frontend/src/components/FormControl/FormLabel/FormLabel.stories.tsx
+++ b/apps/frontend/src/components/FormControl/FormLabel/FormLabel.stories.tsx
@@ -39,7 +39,7 @@ export const WithMarkdownDescription = Template.bind({})
 WithMarkdownDescription.args = {
   children: 'This is a label',
   description:
-    'Description _can_ **have** [Markdown](https://guides.github.com/features/mastering-markdown/)',
+    'Description _can_ **have** [Markdown](https://guides.github.com/features/mastering-markdown/)\n\n- First bullet point\n- Second bullet with **bold text**\n- Third bullet with a [link](https://example.com)',
   useMarkdownForDescription: true,
 }
 

--- a/apps/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
+++ b/apps/frontend/src/components/FormControl/FormLabel/FormLabel.tsx
@@ -162,6 +162,7 @@ const FormLabelDescription = ({
 
   const mdComponentsStyles = {
     text: styleProps,
+    list: styleProps,
     link: { display: 'initial' },
   }
   const mdComponents = useMdComponents({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #9349

Bullet lists in markdown-enabled field descriptions are rendered with unintended bold styling. This happens because description lists inherit the stronger `FormLabel` typography instead of consistently using the intended description text styling.

## Solution
<!-- How did you solve the problem? -->

Ensure markdown lists rendered within `FormLabel` descriptions use the same typography as the rest of the description text.

Also updated the existing `WithMarkdownDescription` Storybook example to include a list case, so this markdown shape is easier to verify visually.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- None

**Improvements**:

- Markdown bullet lists in field descriptions now render with consistent description typography.
- Expanded the existing Storybook markdown description example to cover bullet list rendering, inline bold text, and inline links.

**Bug Fixes**:

- Fixed unintended bold styling for bullet points in markdown-enabled field descriptions.

## Before & After Screenshots

**BEFORE**:
<img width="869" height="712" alt="image" src="https://github.com/user-attachments/assets/c2a11aae-c006-431d-a988-b044fa20b60e" />

**AFTER**:
<img width="867" height="703" alt="image" src="https://github.com/user-attachments/assets/aebe1d08-3311-4d66-809d-0862c2e19154" />

## Tests
<!-- What tests should be run to confirm functionality? -->

### Manual
- Open a form field with markdown-enabled description rendering.
- Set the description to:

```md
Description _can_ **have** [Markdown](https://guides.github.com/features/mastering-markdown/)

- First bullet point
- Second bullet with **bold text**
- Third bullet with a [link](https://example.com)
```
- Verify the bullet points render with normal description styling and are not unintentionally bolded.
- Verify inline bold text inside a bullet still renders as bold.
- Verify inline links inside a bullet still render correctly.

### Storybook
- Run Storybook and open Components/FormControl/FormLabel.
- Verify WithMarkdownDescription renders both inline markdown and bullet list markdown correctly.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- None

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
