### PR TITLE
fix: keep calendar height constant across months

### DIFF
--- a/apps/frontend/src/components/Calendar/CalendarBase/CalendarPanel.tsx
+++ b/apps/frontend/src/components/Calendar/CalendarBase/CalendarPanel.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import {
   chakra,
   forwardRef,
@@ -5,7 +6,8 @@ import {
   Text,
   VisuallyHidden,
 } from '@chakra-ui/react'
-import { isSameDay } from 'date-fns'
+import { addDays, isSameDay, startOfWeek } from 'date-fns'
+import { DateObj } from 'dayzed'
 
 import { useCalendar } from './CalendarContext'
 import { CalendarHeader } from './CalendarHeader'
@@ -13,15 +15,23 @@ import { useCalendarStyles } from './CalendarStyleProvider'
 import { DayOfMonth } from './DayOfMonth'
 import { DAY_NAMES, generateClassNameForDate, MONTH_NAMES } from './utils'
 
+// Any month spans at most 6 week-rows; padding to this keeps the calendar height stable.
+const MAX_WEEKS_IN_MONTH = 6
+
 export const CalendarPanel = forwardRef<object, 'button'>(
   (_props, initialFocusRef): JSX.Element => {
     const styles = useCalendarStyles()
     const {
       classNameId,
       dateToFocus,
+      selectedDates,
       onMouseLeaveCalendar,
       renderProps: { calendars, getDateProps },
     } = useCalendar()
+
+    // Pinned to the first render so "today" doesn't shift if the picker is
+    // left open past midnight.
+    const today = useMemo(() => new Date(), [])
 
     return (
       <Stack
@@ -90,6 +100,52 @@ export const CalendarPanel = forwardRef<object, 'button'>(
                     </chakra.tr>
                   )
                 })}
+                {/* Skip for range picker — it already shows next month alongside. */}
+                {Array.from(
+                  {
+                    length:
+                      calendars.length === 1
+                        ? MAX_WEEKS_IN_MONTH - calendar.weeks.length
+                        : 0,
+                  },
+                  (_filler, windex) => (
+                    <chakra.tr key={`filler-${windex}`}>
+                      {DAY_NAMES.map((_dayName, index) => {
+                        const date = addDays(
+                          startOfWeek(
+                            new Date(calendar.year, calendar.month, 1),
+                          ),
+                          (calendar.weeks.length + windex) * 7 + index,
+                        )
+                        const dateObj: DateObj = {
+                          date,
+                          selectable: true,
+                          selected:
+                            selectedDates instanceof Date &&
+                            isSameDay(date, selectedDates),
+                          today: isSameDay(date, today),
+                          prevMonth: false,
+                          nextMonth: true,
+                        }
+                        return (
+                          <chakra.td
+                            key={`filler-${calendar.month}${calendar.year}${windex}${index}`}
+                          >
+                            <DayOfMonth
+                              {...getDateProps({ dateObj })}
+                              dateObj={dateObj}
+                              isOutsideCurrMonth
+                              className={generateClassNameForDate(
+                                classNameId,
+                                date,
+                              )}
+                            />
+                          </chakra.td>
+                        )
+                      })}
+                    </chakra.tr>
+                  ),
+                )}
               </chakra.tbody>
             </chakra.table>
             <VisuallyHidden aria-live="polite">


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #9351

The date picker navigation arrows (`‹ ›`) shift vertically when navigating between months. This happens because different months render 4–6 week-rows, changing the calendar height. When the popover opens above the input (bottom edge pinned), this height change pushes the header arrows up or down.
  
## Solution
Pad single-month calendar views to always render 6 week-rows. Trailing rows are filled with the following month's greyed-out days (consistent with Google Calendar behaviour). The range picker is unaffected (it already shows the next month alongside, so filler rows are skipped via a `calendars.length === 1` guard.)
  
**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- None

**Improvements**:

- Fixed date picker navigation arrows shifting vertically when navigating between months of different week-row counts.

**Bug Fixes**:

- None

## Before & After Screenshots

**BEFORE**:

<video src="https://github.com/user-attachments/assets/575c71fa-dcbf-47f4-b699-ba99d18d202e" width="352" height="720"></video>

**AFTER**:
<video src="https://github.com/user-attachments/assets/a0896563-b5fc-479c-8c1d-31c43c9e3f9b" width="352" height="720"></video>


## Tests
### Manual
- Open a date picker attached to an input near the bottom of the viewport so the popover opens above.
- Navigate forward and back through several months.
- Verify the arrows remain stable and do not shift vertically between months.
- Verify months with 4 and 5 week-rows render at the same height as a 6-row month.
- Verify filler dates are greyed out and clicking one navigates to that date.
- Open a date range picker and verify no change in behaviour.

## Deploy Notes

**New environment variables**:

- None

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None