### PR TITLE
refactor: rename billing to singpass transactions

### DIFF
--- a/apps/frontend/src/features/user/billing/BillCharges/BillCharges.tsx
+++ b/apps/frontend/src/features/user/billing/BillCharges/BillCharges.tsx
@@ -85,7 +85,7 @@ export const BillCharges = ({
   )
 
   const prettifiedLoginCount = useMemo(
-    () => simplur` ${[loginCount]}login[|s] for FormSG-MOE`,
+    () => simplur` ${[loginCount]}login[|s] for `,
     [loginCount],
   )
 

--- a/apps/frontend/src/features/user/billing/BillCharges/BillCharges.tsx
+++ b/apps/frontend/src/features/user/billing/BillCharges/BillCharges.tsx
@@ -85,7 +85,7 @@ export const BillCharges = ({
   )
 
   const prettifiedLoginCount = useMemo(
-    () => simplur` ${[loginCount]}login[|s] for `,
+    () => simplur` ${[loginCount]}login[|s] for FormSG-MOE`,
     [loginCount],
   )
 
@@ -127,9 +127,9 @@ export const BillCharges = ({
       <Stack spacing="2rem">
         <Stack spacing="0.5rem">
           <Text as="h2" textStyle="h2" whiteSpace="pre-wrap">
-            Bill charges
+            Singpass transactions
           </Text>
-          <Text>Export monthly bill charges</Text>
+          <Text>Export monthly transactions</Text>
         </Stack>
         <Flex flexDir="column" h="100%">
           <Grid

--- a/apps/frontend/src/features/user/billing/BillingForm/BillingForm.tsx
+++ b/apps/frontend/src/features/user/billing/BillingForm/BillingForm.tsx
@@ -43,7 +43,7 @@ export const BillingForm = ({
         <BillingSvg />
         <Skeleton isLoaded={true} w="fit-content">
           <Text as="h2" textStyle="h2" whiteSpace="pre-wrap">
-            Bill charges
+            Singpass transactions
           </Text>
         </Skeleton>
         <form onSubmit={handleSubmit(onSubmitForm)}>
@@ -52,7 +52,7 @@ export const BillingForm = ({
             isReadOnly={formState.isSubmitting}
             mb="2.5rem"
           >
-            <FormLabel isRequired>e-service ID</FormLabel>
+            <FormLabel isRequired>Enter e-service or form ID</FormLabel>
             <Input
               autoComplete="email"
               autoFocus

--- a/apps/frontend/src/i18n/locales/features/app/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/app/en-sg.ts
@@ -18,7 +18,7 @@ export const enSG: App = {
       formGuide: 'Help',
     },
     avatarMenuItem: {
-      billing: 'Billing',
+      billing: 'Singpass transactions',
       emergencyContact: 'Emergency contact',
       transferAllForms: 'Transfer all forms',
     },


### PR DESCRIPTION
## Problem
The current menu item “Billing” and the corresponding page title “Bill charges” do not reflect the updated product naming. This change renames them to “Singpass transactions” to align with the latest design and copy requirements.

Closes #9342

## Solution
- Renamed the menu label from “Billing” to “Singpass transactions” in the i18n locale file (`en-sg.ts`).
- Changed the page heading from “Bill charges” to “Singpass transactions” in `BillCharges.tsx`.
- Updated the supporting description text (“Export monthly bill charges” → “Export monthly Singpass transactions”).
- (Optional) Updated the search bar placeholder and helper text if required by the new design.

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:
- None

**Improvements**:
- Improved copy consistency by replacing “Billing” / “Bill charges” with “Singpass transactions” across the billing page and user menu.

**Bug Fixes**:
- None

## Before & After Screenshots

## Tests
- Navigate to the app and open the avatar menu → verify the menu item shows “Singpass transactions”.
- Click the menu item → verify the page title is “Singpass transactions” (and any subtext is updated).
- Verify that the e-service ID search, date filter, and download functionality still work as before.
- Check that the change appears in all supported languages (if other locale files exist, update them similarly).

## Deploy Notes
No new environment variables, scripts, or dependencies introduced.