### PR TITLE
fix: mrf v3 webhook retries, payload inconsistencies and incorrect submittedSteps values

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -66,6 +66,7 @@ describe('Submission Model', () => {
       responseHash: 'This is a hash',
       responseSalt: 'This is a salt',
       hasBounced: false,
+      webhookResponses: [],
     },
     MOCK_SUBMISSION_PARAMS,
   )
@@ -102,6 +103,7 @@ describe('Submission Model', () => {
       encryptedContent: MOCK_ENCRYPTED_CONTENT,
       version: 3,
       workflowStep: 0,
+      webhookResponses: [],
     },
     MOCK_SUBMISSION_PARAMS,
   )
@@ -1045,6 +1047,50 @@ describe('Submission Model', () => {
 
         // Assert
         expect(actualSubmission).toBeNull()
+      })
+
+      it('should push a webhook response onto a multirespondent submission', async () => {
+        // Arrange
+        const formId = new ObjectId()
+        const submission = await MultirespondentSubmission.create({
+          form: formId,
+          submissionType: SubmissionType.Multirespondent,
+          form_fields: [],
+          form_logics: [],
+          workflow: [],
+          submissionPublicKey: 'test public key',
+          encryptedSubmissionSecretKey: 'test secret key',
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
+          version: 1,
+          workflowStep: 0,
+          submittedSteps: [],
+        })
+
+        const webhookResponse: WebhookResponse = {
+          signature: 'mrf signature',
+          webhookUrl: 'https://form.gov.sg/mrf-endpoint',
+          response: {
+            data: '{"result":"mrf-ok"}',
+            status: 200,
+            headers: '{}',
+          },
+        }
+
+        // Act — call via the base Submission model to confirm the static
+        // resolves through the discriminator for MRF submissions.
+        const actualSubmission = await Submission.addWebhookResponse(
+          String(submission._id),
+          webhookResponse,
+        )
+        const webhookResponses = actualSubmission!.toObject().webhookResponses!
+
+        // Assert
+        expect(webhookResponses).toHaveLength(1)
+        expect(webhookResponses[0].signature).toEqual(webhookResponse.signature)
+        expect(webhookResponses[0].webhookUrl).toEqual(
+          webhookResponse.webhookUrl,
+        )
+        expect(webhookResponses[0].response).toEqual(webhookResponse.response)
       })
     })
   })

--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -4,6 +4,7 @@ import { promises as dns } from 'dns'
 import {
   BasicField,
   FormAuthType,
+  FormResponseMode,
   PaymentType,
   SubmissionType,
   WebhookResponse,
@@ -12,6 +13,7 @@ import {
 import { merge, omit, times } from 'lodash'
 import mongoose from 'mongoose'
 
+import { getMultirespondentFormModel } from 'src/app/models/form.server.model'
 import getSubmissionModel, {
   getEmailSubmissionModel,
   getEncryptSubmissionModel,
@@ -498,6 +500,61 @@ describe('Submission Model', () => {
               version: 0,
               created: submission.created,
               paymentContent: {},
+            },
+          },
+        })
+      })
+
+      it('should return the populated submission for a multirespondent submission', async () => {
+        const MultirespondentForm = getMultirespondentFormModel(mongoose)
+        const { user } = await dbHandler.insertFormCollectionReqs()
+        const form = await MultirespondentForm.create({
+          title: 'mrf webhook form',
+          admin: user._id,
+          responseMode: FormResponseMode.Multirespondent,
+          publicKey: 'mockPublicKey',
+          webhook: {
+            url: MOCK_WEBHOOK_URL,
+            isRetryEnabled: true,
+          },
+        })
+        const submission = await MultirespondentSubmission.create({
+          form: form._id,
+          submissionType: SubmissionType.Multirespondent,
+          form_fields: [],
+          form_logics: [],
+          workflow: [],
+          submissionPublicKey: 'test public key',
+          encryptedSubmissionSecretKey: 'test secret key',
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
+          version: 1,
+          workflowStep: 0,
+          submittedSteps: [],
+        })
+
+        const result = await Submission.retrieveWebhookInfoById(
+          String(submission._id),
+        )
+
+        expect(result).toEqual({
+          webhookUrl: MOCK_WEBHOOK_URL,
+          isRetryEnabled: true,
+          webhookView: {
+            data: {
+              attachmentDownloadUrls: {},
+              formId: String(form._id),
+              submissionId: String(submission._id),
+              encryptedContent: MOCK_ENCRYPTED_CONTENT,
+              encryptedSubmissionSecretKey: 'test secret key',
+              verifiedContent: undefined,
+              version: 1,
+              created: submission.created,
+              paymentContent: {},
+              workflowContent: {
+                workflow: submission.workflow,
+                workflowStep: 0,
+                submittedSteps: [],
+              },
             },
           },
         })

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -120,6 +120,23 @@ SubmissionSchema.statics.findFormsWithSubsAbove = function (
   ]).exec()
 }
 
+SubmissionSchema.statics.retrieveWebhookInfoById = async function (
+  this: ISubmissionModel,
+  submissionId: string,
+): Promise<SubmissionWebhookInfo | null> {
+  const populatedSubmission = (await this.findById(submissionId).populate([
+    { path: 'form', select: 'webhook' },
+    { path: 'paymentId' },
+  ])) as IPopulatedWebhookSubmission | null
+  if (!populatedSubmission) return null
+  const webhookView = await populatedSubmission.getWebhookView()
+  return {
+    webhookUrl: populatedSubmission.form.webhook?.url ?? '',
+    isRetryEnabled: !!populatedSubmission.form.webhook?.isRetryEnabled,
+    webhookView,
+  }
+}
+
 /**
  * Creates a new email submission only if provided submitterId is unique.
  * This method ensures that isSingleSubmission is enforced.
@@ -302,28 +319,6 @@ EncryptSubmissionSchema.statics.addWebhookResponse = function (
     { $push: { webhookResponses: webhookResponse } },
     { new: true, setDefaultsOnInsert: true, runValidators: true },
   ).exec()
-}
-
-EncryptSubmissionSchema.statics.retrieveWebhookInfoById = function (
-  this: IEncryptSubmissionModel,
-  submissionId: string,
-): Promise<SubmissionWebhookInfo | null> {
-  return this.findById(submissionId)
-    .populate([{ path: 'form', select: 'webhook' }, { path: 'paymentId' }])
-    .then((populatedSubmission: IPopulatedWebhookSubmission | null) => {
-      if (!populatedSubmission) return null
-      const webhookView = populatedSubmission.getWebhookView()
-      return Promise.all([populatedSubmission, webhookView])
-    })
-    .then((arr) => {
-      if (!arr) return null
-      const [populatedSubmission, webhookView] = arr
-      return {
-        webhookUrl: populatedSubmission.form.webhook?.url ?? '',
-        isRetryEnabled: !!populatedSubmission.form.webhook?.isRetryEnabled,
-        webhookView,
-      }
-    })
 }
 
 EncryptSubmissionSchema.statics.findSingleMetadata = function (

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -44,6 +44,33 @@ import { PAYMENT_SCHEMA_ID } from './payment.server.model'
 
 export const SUBMISSION_SCHEMA_ID = 'Submission'
 
+const webhookResponseSchema = new Schema<IWebhookResponseSchema>(
+  {
+    webhookUrl: {
+      type: String,
+      required: true,
+    },
+    signature: {
+      type: String,
+      required: true,
+    },
+    response: {
+      status: {
+        type: Number,
+        required: true,
+      },
+      headers: String,
+      data: String,
+    },
+  },
+  {
+    timestamps: {
+      createdAt: 'created',
+      updatedAt: false,
+    },
+  },
+)
+
 // Exported for use in pending submissions model
 export const SubmissionSchema = new Schema<ISubmissionSchema, ISubmissionModel>(
   {
@@ -82,6 +109,7 @@ export const SubmissionSchema = new Schema<ISubmissionSchema, ISubmissionModel>(
         type: Number,
       },
     },
+    webhookResponses: [webhookResponseSchema],
   },
   {
     timestamps: {
@@ -118,6 +146,18 @@ SubmissionSchema.statics.findFormsWithSubsAbove = function (
       },
     },
   ]).exec()
+}
+
+SubmissionSchema.statics.addWebhookResponse = function (
+  this: ISubmissionModel,
+  submissionId: string,
+  webhookResponse: WebhookResponse,
+): Promise<ISubmissionSchema | null> {
+  return this.findByIdAndUpdate(
+    submissionId,
+    { $push: { webhookResponses: webhookResponse } },
+    { new: true, setDefaultsOnInsert: true, runValidators: true },
+  ).exec()
 }
 
 SubmissionSchema.statics.retrieveWebhookInfoById = async function (
@@ -216,33 +256,6 @@ EmailSubmissionSchema.methods.getWebhookView = function (): Promise<null> {
   return Promise.resolve(null)
 }
 
-const webhookResponseSchema = new Schema<IWebhookResponseSchema>(
-  {
-    webhookUrl: {
-      type: String,
-      required: true,
-    },
-    signature: {
-      type: String,
-      required: true,
-    },
-    response: {
-      status: {
-        type: Number,
-        required: true,
-      },
-      headers: String,
-      data: String,
-    },
-  },
-  {
-    timestamps: {
-      createdAt: 'created',
-      updatedAt: false,
-    },
-  },
-)
-
 // Exported for use in pending submissions model
 export const EncryptSubmissionSchema = new Schema<
   IEncryptedSubmissionSchema,
@@ -270,7 +283,6 @@ export const EncryptSubmissionSchema = new Schema<
     // Defer loading of the ref due to circular dependency on schema IDs.
     ref: () => PAYMENT_SCHEMA_ID,
   },
-  webhookResponses: [webhookResponseSchema],
 })
 
 /**
@@ -308,17 +320,6 @@ EncryptSubmissionSchema.methods.getWebhookView = async function (
   return {
     data: webhookData,
   }
-}
-
-EncryptSubmissionSchema.statics.addWebhookResponse = function (
-  submissionId: string,
-  webhookResponse: WebhookResponse,
-): Promise<IEncryptedSubmissionSchema | null> {
-  return this.findByIdAndUpdate(
-    submissionId,
-    { $push: { webhookResponses: webhookResponse } },
-    { new: true, setDefaultsOnInsert: true, runValidators: true },
-  ).exec()
 }
 
 EncryptSubmissionSchema.statics.findSingleMetadata = function (

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -4,6 +4,7 @@ import {
   SubmissionMetadata,
   SubmissionType,
   WebhookResponse,
+  WorkflowStatus,
 } from 'formsg-shared/types'
 import moment from 'moment-timezone'
 import mongoose, {
@@ -520,6 +521,30 @@ EncryptSubmissionSchema.statics.findEncryptedSubmissionById = function (
     .exec()
 }
 
+const submittedStepSchema = new Schema(
+  {
+    isApproval: {
+      type: Boolean,
+      required: true,
+    },
+    submittedAt: {
+      type: String,
+      required: true,
+    },
+    nextStepRecipientEmails: {
+      type: [String],
+    },
+    submitterId: {
+      type: String,
+    },
+    status: {
+      type: String,
+      enum: [WorkflowStatus.APPROVED, WorkflowStatus.REJECTED],
+    },
+  },
+  { _id: false },
+)
+
 export const MultirespondentSubmissionSchema = new Schema<
   IMultirespondentSubmissionSchema,
   IMultirespondentSubmissionModel
@@ -564,7 +589,7 @@ export const MultirespondentSubmissionSchema = new Schema<
     type: Number,
   },
   submittedSteps: {
-    type: Array,
+    type: [submittedStepSchema],
     default: [],
   },
 })

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -271,7 +271,7 @@ EncryptSubmissionSchema.methods.getWebhookView = async function (
   )
 
   if (this.paymentId) {
-    await (this as IPopulatedWebhookSubmission).populate('paymentId')
+    await (this as IEncryptedSubmissionSchema).populate('paymentId')
   }
   const paymentContent = this.populated('paymentId')
     ? getPaymentWebhookEventObject(this.paymentId)

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -96,6 +96,13 @@ export const checkFormIsMultirespondent = (
       )
 }
 
+const checkIsStepApproval = (
+  form: Pick<IPopulatedMultirespondentForm, 'workflow'>,
+  zeroIndexedStepNumber: number,
+): boolean => {
+  return form.workflow && !!form.workflow[zeroIndexedStepNumber]?.approval_field
+}
+
 const checkIsFormApproval = (
   form: Pick<IPopulatedMultirespondentForm, 'workflow'>,
 ): boolean => {
@@ -1222,7 +1229,6 @@ export const updateMultiRespondentFormSubmission = ({
         ? nextStepRecipientEmailsResult.unwrapOr(undefined)
         : undefined
 
-      const isApprovalForm = checkIsFormApproval(snapshottedFormDef)
       const isStepRejectedResult = checkIsStepRejected({
         zeroIndexedStepNumber: workflowStep,
         form: snapshottedFormDef,
@@ -1244,7 +1250,10 @@ export const updateMultiRespondentFormSubmission = ({
         submittedAt: new Date().toISOString(),
         nextStepRecipientEmails,
       }
-      const submittedStepMeta = isApprovalForm
+      const submittedStepMeta = checkIsStepApproval(
+        snapshottedFormDef,
+        workflowStep,
+      )
         ? ({
             ...submittedStepMetaCommons,
             status: isStepRejected

--- a/apps/backend/src/app/modules/webhook/__tests__/webhook.consumer.spec.ts
+++ b/apps/backend/src/app/modules/webhook/__tests__/webhook.consumer.spec.ts
@@ -6,7 +6,7 @@ import { WebhookResponse } from 'formsg-shared/types'
 import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 
-import { getEncryptSubmissionModel } from 'src/app/models/submission.server.model'
+import getSubmissionModel from 'src/app/models/submission.server.model'
 import { SubmissionWebhookInfo } from 'src/types'
 
 import { createWebhookQueueHandler } from '../webhook.consumer'
@@ -18,7 +18,7 @@ import { WebhookQueueMessageObject } from '../webhook.types'
 jest.mock('../webhook.service')
 const MockWebhookService = jest.mocked(WebhookService)
 
-const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
+const SubmissionModel = getSubmissionModel(mongoose)
 
 const MOCK_WEBHOOK_SUCCESS_RESPONSE: WebhookResponse = {
   signature: 'mockSignature',
@@ -132,7 +132,7 @@ describe('webhook.consumer', () => {
 
     it('should reject when submission ID cannot be found', async () => {
       jest
-        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
         .mockResolvedValueOnce(null)
 
       await expect(
@@ -145,7 +145,7 @@ describe('webhook.consumer', () => {
 
     it('should reject when database error occurs', async () => {
       jest
-        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
         .mockRejectedValueOnce(new Error(''))
 
       await expect(
@@ -158,7 +158,7 @@ describe('webhook.consumer', () => {
 
     it('should resolve when form has no webhook URL', async () => {
       jest
-        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
         .mockResolvedValueOnce({
           ...MOCK_WEBHOOK_INFO,
           webhookUrl: '',
@@ -174,7 +174,7 @@ describe('webhook.consumer', () => {
 
     it('should resolve when form does not have retries enabled', async () => {
       jest
-        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
         .mockResolvedValueOnce({
           ...MOCK_WEBHOOK_INFO,
           isRetryEnabled: false,
@@ -190,7 +190,7 @@ describe('webhook.consumer', () => {
 
     it('should resolve without requeuing when webhook succeeds', async () => {
       jest
-        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
         .mockResolvedValueOnce(MOCK_WEBHOOK_INFO)
       MockWebhookService.sendWebhook.mockReturnValueOnce(
         okAsync(MOCK_WEBHOOK_SUCCESS_RESPONSE),
@@ -212,7 +212,7 @@ describe('webhook.consumer', () => {
 
     it('should requeue webhook when retry fails and there are retries remaining', async () => {
       jest
-        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
         .mockResolvedValueOnce(MOCK_WEBHOOK_INFO)
       MockWebhookService.sendWebhook.mockReturnValueOnce(
         // note failure response instead of success
@@ -235,7 +235,7 @@ describe('webhook.consumer', () => {
 
     it('should resolve without requeuing when retry fails and there are no retries remaining', async () => {
       jest
-        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
         .mockResolvedValueOnce(MOCK_WEBHOOK_INFO)
       MockWebhookService.sendWebhook.mockReturnValueOnce(
         okAsync(MOCK_WEBHOOK_SUCCESS_RESPONSE),
@@ -264,7 +264,7 @@ describe('webhook.consumer', () => {
 
     it('should reject when retry fails and subsequently fails to be requeued', async () => {
       jest
-        .spyOn(EncryptSubmissionModel, 'retrieveWebhookInfoById')
+        .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
         .mockResolvedValueOnce(MOCK_WEBHOOK_INFO)
       MockWebhookService.sendWebhook.mockReturnValueOnce(
         okAsync(MOCK_WEBHOOK_FAILURE_RESPONSE),

--- a/apps/backend/src/app/modules/webhook/__tests__/webhook.service.spec.ts
+++ b/apps/backend/src/app/modules/webhook/__tests__/webhook.service.spec.ts
@@ -6,7 +6,9 @@ import mongoose from 'mongoose'
 import { ok, okAsync } from 'neverthrow'
 
 import formsgSdk from 'src/app/config/formsg-sdk'
-import { getEncryptSubmissionModel } from 'src/app/models/submission.server.model'
+import getSubmissionModel, {
+  getEncryptSubmissionModel,
+} from 'src/app/models/submission.server.model'
 import { WebhookValidationError } from 'src/app/modules/webhook/webhook.errors'
 import * as WebhookValidationModule from 'src/app/modules/webhook/webhook.validation'
 import { transformMongoError } from 'src/app/utils/handle-mongo-error'
@@ -32,6 +34,7 @@ jest.mock('../webhook.message.ts')
 const MockWebhookQueueMessage = jest.mocked(WebhookQueueMessage)
 
 const EncryptSubmissionModel = getEncryptSubmissionModel(mongoose)
+const SubmissionModel = getSubmissionModel(mongoose)
 
 // define test constants
 
@@ -142,7 +145,7 @@ describe('webhook.service', () => {
       const mockDBError = new Error(DEFAULT_ERROR_MSG)
 
       const addWebhookResponseSpy = jest
-        .spyOn(EncryptSubmissionModel, 'addWebhookResponse')
+        .spyOn(SubmissionModel, 'addWebhookResponse')
         .mockRejectedValueOnce(mockDBError)
 
       // Act
@@ -199,7 +202,7 @@ describe('webhook.service', () => {
       expectedSubmission.webhookResponses = [mockWebhookResponse]
 
       const addWebhookResponseSpy = jest
-        .spyOn(EncryptSubmissionModel, 'addWebhookResponse')
+        .spyOn(SubmissionModel, 'addWebhookResponse')
         .mockResolvedValue(expectedSubmission)
 
       // Act
@@ -415,7 +418,7 @@ describe('webhook.service', () => {
         _id: MOCK_SUBMISSION_ID,
       })
       jest
-        .spyOn(EncryptSubmissionModel, 'addWebhookResponse')
+        .spyOn(SubmissionModel, 'addWebhookResponse')
         .mockResolvedValue(testSubmission)
       MockWebhookValidationModule.validateWebhookUrl.mockResolvedValue()
     })

--- a/apps/backend/src/app/modules/webhook/webhook.consumer.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.consumer.ts
@@ -6,7 +6,7 @@ import { Consumer } from 'sqs-consumer'
 import { SubmissionWebhookInfo } from '../../../types'
 import config from '../../config/config'
 import { createLoggerWithLabel, CustomLoggerParams } from '../../config/logger'
-import { getEncryptSubmissionModel } from '../../models/submission.server.model'
+import getSubmissionModel from '../../models/submission.server.model'
 import { transformMongoError } from '../../utils/handle-mongo-error'
 import { PossibleDatabaseError } from '../core/core.errors'
 import { SubmissionNotFoundError } from '../submission/submission.errors'
@@ -21,7 +21,7 @@ import * as WebhookService from './webhook.service'
 import { isSuccessfulResponse } from './webhook.utils'
 
 const logger = createLoggerWithLabel(module)
-const EncryptSubmission = getEncryptSubmissionModel(mongoose)
+const Submission = getSubmissionModel(mongoose)
 
 /**
  * Starts polling a queue for webhook messages.
@@ -215,7 +215,7 @@ const retrieveWebhookInfo = (
   SubmissionNotFoundError | PossibleDatabaseError
 > => {
   return ResultAsync.fromPromise(
-    EncryptSubmission.retrieveWebhookInfoById(submissionId),
+    Submission.retrieveWebhookInfoById(submissionId),
     (error) => {
       logger.error({
         message: 'Error while retrieving webhook info for submission',

--- a/apps/backend/src/app/modules/webhook/webhook.service.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.service.ts
@@ -14,7 +14,7 @@ import {
 import { aws as AwsConfig } from '../../config/config'
 import formsgSdk from '../../config/formsg-sdk'
 import { createLoggerWithLabel } from '../../config/logger'
-import { getEncryptSubmissionModel } from '../../models/submission.server.model'
+import getSubmissionModel from '../../models/submission.server.model'
 import { transformMongoError } from '../../utils/handle-mongo-error'
 import { DatabaseError, PossibleDatabaseError } from '../core/core.errors'
 import { SubmissionNotFoundError } from '../submission/submission.errors'
@@ -34,7 +34,7 @@ import { formatWebhookResponse, isSuccessfulResponse } from './webhook.utils'
 import { validateWebhookUrl } from './webhook.validation'
 
 const logger = createLoggerWithLabel(module)
-const EncryptSubmission = getEncryptSubmissionModel(mongoose)
+const Submission = getSubmissionModel(mongoose)
 
 /**
  * Updates the submission in the database with the webhook response
@@ -54,7 +54,7 @@ export const saveWebhookRecord = (
   PossibleDatabaseError | SubmissionNotFoundError
 > => {
   return ResultAsync.fromPromise(
-    EncryptSubmission.addWebhookResponse(submissionId, record),
+    Submission.addWebhookResponse(submissionId, record),
     (error) => {
       logger.error({
         message: 'Database update for webhook status failed',

--- a/apps/backend/src/app/modules/webhook/webhook.service.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.service.ts
@@ -50,7 +50,7 @@ export const saveWebhookRecord = (
   submissionId: ISubmissionSchema['_id'],
   record: WebhookResponse,
 ): ResultAsync<
-  IEncryptedSubmissionSchema,
+  ISubmissionSchema,
   PossibleDatabaseError | SubmissionNotFoundError
 > => {
   return ResultAsync.fromPromise(

--- a/apps/backend/src/types/submission.ts
+++ b/apps/backend/src/types/submission.ts
@@ -123,6 +123,18 @@ export interface ISubmissionModel extends Model<ISubmissionSchema> {
   retrieveWebhookInfoById(
     submissionId: string,
   ): Promise<SubmissionWebhookInfo | null>
+
+  /**
+   * Adds a record of a webhook response to a submission. Resolves via
+   * the discriminator, so Encrypt and Multirespondent submissions are
+   * both supported.
+   * @param submissionId ID of submission to update
+   * @param webhookResponse Response data to push
+   */
+  addWebhookResponse(
+    submissionId: string,
+    webhookResponse: WebhookResponse,
+  ): Promise<ISubmissionSchema | null>
 }
 
 export interface IEmailSubmissionSchema
@@ -284,16 +296,6 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
       formId: string,
       submissionId: string,
     ): Promise<StorageModeSubmissionData | null>
-
-    /**
-     * Adds a record of a webhook response to a submission
-     * @param submissionId ID of submission to update
-     * @param webhookResponse Response data to push
-     */
-    addWebhookResponse(
-      submissionId: string,
-      webhookResponse: WebhookResponse,
-    ): Promise<IEncryptedSubmissionSchema | null>
   }
 
 export type IMultirespondentSubmissionModel =

--- a/apps/backend/src/types/submission.ts
+++ b/apps/backend/src/types/submission.ts
@@ -112,6 +112,17 @@ export interface ISubmissionModel extends Model<ISubmissionSchema> {
    * @returns created submission if successful, null otherwise
    */
   saveIfSubmitterIdIsUnique: SaveIfSubmitterIdIsUniqueType
+
+  /**
+   * Retrieves webhook-related info for a given submission. Resolves via
+   * the discriminator, so Encrypt and Multirespondent submissions are
+   * both supported.
+   * @param submissionId
+   * @returns Object containing webhook destination and data
+   */
+  retrieveWebhookInfoById(
+    submissionId: string,
+  ): Promise<SubmissionWebhookInfo | null>
 }
 
 export interface IEmailSubmissionSchema
@@ -283,15 +294,6 @@ export type IEncryptSubmissionModel = Model<IEncryptedSubmissionSchema> &
       submissionId: string,
       webhookResponse: WebhookResponse,
     ): Promise<IEncryptedSubmissionSchema | null>
-
-    /**
-     * Retrieves webhook-related info for a given submission.
-     * @param submissionId
-     * @returns Object containing webhook destination and data
-     */
-    retrieveWebhookInfoById(
-      submissionId: string,
-    ): Promise<SubmissionWebhookInfo | null>
   }
 
 export type IMultirespondentSubmissionModel =

--- a/apps/backend/src/types/submission.ts
+++ b/apps/backend/src/types/submission.ts
@@ -53,7 +53,10 @@ export type FindFormsWithSubsAboveResult = {
   count: number
 }
 
-export interface IPopulatedWebhookSubmission extends IEncryptedSubmissionSchema {
+export type IPopulatedWebhookSubmission = (
+  | IEncryptedSubmissionSchema
+  | IMultirespondentSubmissionSchema
+) & {
   form: {
     _id: IFormSchema['_id']
     webhook: IFormSchema['webhook']

--- a/packages/shared/types/submission.ts
+++ b/packages/shared/types/submission.ts
@@ -30,6 +30,18 @@ export const ResponseMetadata = z.object({
 
 export type ResponseMetadata = z.infer<typeof ResponseMetadata>
 
+export const WebhookResponse = z.object({
+  webhookUrl: z.string(),
+  signature: z.string(),
+  response: z.object({
+    status: z.number(),
+    headers: z.string(),
+    data: z.string(),
+  }),
+})
+
+export type WebhookResponse = z.infer<typeof WebhookResponse>
+
 export const SubmissionBase = z.object({
   form: z.string(),
   authType: z.nativeEnum(FormAuthType),
@@ -37,6 +49,7 @@ export const SubmissionBase = z.object({
   myInfoFields: z.array(z.nativeEnum(MyInfoAttribute)).optional(),
   submissionType: z.nativeEnum(SubmissionType),
   responseMetadata: ResponseMetadata.optional(),
+  webhookResponses: z.array(WebhookResponse).optional(),
 })
 export type SubmissionBase = z.infer<typeof SubmissionBase>
 
@@ -51,18 +64,6 @@ export interface EmailModeSubmissionBase extends SubmissionBase {
   hasBounced: boolean
 }
 
-export const WebhookResponse = z.object({
-  webhookUrl: z.string(),
-  signature: z.string(),
-  response: z.object({
-    status: z.number(),
-    headers: z.string(),
-    data: z.string(),
-  }),
-})
-
-export type WebhookResponse = z.infer<typeof WebhookResponse>
-
 /**
  * Storage mode submission typings as stored in the database.
  */
@@ -73,7 +74,6 @@ export const StorageModeSubmissionBase = SubmissionBase.extend({
   verifiedContent: z.string().optional(),
   attachmentMetadata: z.map(z.string(), z.string()).optional(),
   version: z.number(),
-  webhookResponses: z.array(WebhookResponse).optional(),
   paymentId: z.string().optional(),
 })
 


### PR DESCRIPTION
## Problem

There are a several bugs related to MRF webhooks: 

<img width="2112" height="1136" alt="image" src="https://github.com/user-attachments/assets/758f4ff4-7833-4642-ac10-530379cb4037" />

1. Webhook retries for Multirespondent (MRF) form submissions are broken. This has 2 causes: 
- after sending the initial webhook, the mrf post submission code tries to update the sent webhook status in the MR submission document in the DB via `EncryptSubmission.addWebhookResponse`. However, it fails to find the submission id and throws an error before adding the webhook retry message into the queue. 

This is fixed in commits: 444f296f8ac19895e404760717d35ffa5160add6^..746479084d477097ef48e16e5a5d2a7d4fdd1072

- Secondly, after the MR webhook retry message is added to the queue. The retry consumer fetches submission info via `EncryptSubmission.retrieveWebhookInfoById(...)` which is defined only on the Encrypt discriminator model. Hence, the webhook info fails to retrieve and the webhook retry fails. 

This is fixed in commits: 26f93c121b6a54628e3be88ff6078991139c1f48^..31a5d6d31e89b5b77ef44d2310e0d340ae7ee1ea

| Initial webhook | Retry webhook | 
| --- | --- | 
| <img width="740" height="182" alt="image" src="https://github.com/user-attachments/assets/dbfbe283-d8f0-477f-bf22-d77c6ceeb0fa" /> | <img width="473" height="133" alt="image" src="https://github.com/user-attachments/assets/96030abd-9f2d-420b-afcc-e9568f1300c6" /> | 
2. Webhook initial payload and retry payload are inconsistent. Specifically, in second step onwards, the `submittedStep` object has different `nextStepEmails` values. The initial webhook payload is `undefined`, while subsequent payloads are `null`.  

This is due to differences in in-memory object and rehydrated object, the saving and rehydration causes the retry webhook payloads to be populated with `null`. This is addressed by specifying the type of `submittedSteps` key, which ensures both are set to a consistent `[]` if empty. 

This is fixed in commit: 038910a247aa2523d4e1df9dd0a0edd1aedd6c62

3. For >=2 steps, despite the step not being an approval step, as long as the form has an approval step, all >=2 steps in `submittedSteps` are marked as `isApproval = true`. This is a bug. 
This is caused by the check for `isApproval = true` relying on the wrong boolean `isFormApproval` instead of `isStepApproval`. 
This is fixed in commit: 235ab19c3cdff88c713e73dead21e0009d5c6e70

Closes FRM-2402

## Solution

This change is expected to apply to v4 webhooks for unified mode as well. 

Define `retrieveWebhookInfoById` onto the base `SubmissionSchema` so the lookup resolves through Mongoose's submission type discriminator, enabling finding the relevant webhook info based on the submission type. 

**Breaking Changes**
No — backwards compatible. Encrypt-mode webhook retries continue to work identically; MRF retries now work too.

## Before & After Screenshots

N/A — backend-only refactor; no user-facing UI change.

## Tests
Note: to accelerate testing and reduce the retry duration, i have pushed a commit to reduce the retry delay to stg-alt3 (see: https://github.com/opengovsg/FormSG/commit/f10ed7e5cdd1400566a608b28bf44177f2d2ec74) This commit is not included as part of this change. You should receive 3 retries at 10s intervals. 

TC1: Webhook retries work for storage mode 
- [ ] Create a webhook endpoint on eg, webhook.site. edit the response value to 500 to emulate failure. 
- [ ] Create storage mode form with webhooks, use the created webhook endpoint. 
- [ ] Submit the form. 
- [ ] Assert that a webhook is sent and received immediately (ie, initial webhook is sent) 
- [ ] Wait 5 mins. Assert that the retry is sent and identical as the first initial webhook. (check the submission id to verify this) 

TC2: Webhook retries work for MRF step 1 
- [x] Create a webhook endpoint on eg, webhook.site. edit the response value to 500 to emulate failure. 
- [x] Create multi respondent mode form with webhooks and 3 steps (2nd should be non-approval, 3rd should be approval), use the created webhook endpoint. 
- [x] Submit the form. 
- [x] Assert that a webhook is sent and received immediately (ie, initial webhook is sent) 
- [ ] Wait 5 mins. Assert that the retry is sent and identical as the first initial webhook. Assert the MRF related keys are included in the retry webhook payload. (check the submission id to verify this) 

TC3: Webhook retries work for MRF step >=2 
- [ ] Continue from TC2. 
- [ ] Submit the form's step 2. 
- [ ] Assert that a webhook is sent and received immediately (ie, initial webhook is sent) 
- [ ] Wait 5 mins. Assert that the retry is sent and identical as the first initial webhook. Assert the MRF related keys are included in the retry webhook payload. (check the submission id to verify this) 
- [x] Assert that the isApproval = false in the submittedSteps key of the webhook payload. 

TC4: Webhook retries work for MRF step >=2 approval step. 
- [ ] Continue from TC3. 
- [ ] Submit the form's step 3. 
- [x] Assert that a webhook is sent and received immediately (ie, initial webhook is sent) 
- [x] Wait 5 mins. Assert that the retry is sent and identical as the first initial webhook. Assert the MRF related keys are included in the retry webhook payload. (check the submission id to verify this) 
- [ ] Assert that the isApproval = false in the submittedSteps key of the webhook payload and the status is reflected correctly. 