### PR TITLE
fix: verified content in response page

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/apps/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -154,20 +154,22 @@ export const getDecryptedSubmissionById = async ({
           formFieldsMeta,
         )
 
-        if (decryptedV4) {
-          const v4Responses = decryptedV4.verified
-            ? {
-                ...decryptedV4.responses,
-                ...convertVerifiedToV4(decryptedV4.verified),
-              }
-            : decryptedV4.responses
-          processedContentV4 = v4Responses
-          responsesV4 = augmentDecryptedResponsesV4(
-            encryptedSubmission.form_fields,
-            processedContentV4,
-            encryptedSubmission.attachmentMetadata,
+        if (!decryptedV4)
+          throw new Error(
+            'Could not decrypt the multirespondent form response in v4',
           )
-        }
+
+        const processedContentV4 = decryptedV4.verified
+          ? {
+              ...decryptedV4.responses,
+              ...convertVerifiedToV4(decryptedV4.verified),
+            }
+          : decryptedV4.responses
+        responsesV4 = augmentDecryptedResponsesV4(
+          encryptedSubmission.form_fields,
+          processedContentV4,
+          encryptedSubmission.attachmentMetadata,
+        )
       }
       submissionSecretKey = decryptedContent.submissionSecretKey
       mrfVersion = encryptedSubmission.mrfVersion

--- a/apps/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
+++ b/apps/frontend/src/features/admin-form/responses/AdminSubmissionsService.ts
@@ -1,3 +1,5 @@
+import { datadogLogs } from '@datadog/browser-logs'
+
 import { DateString } from 'formsg-shared/types'
 import {
   FormSubmissionMetadataQueryDto,
@@ -154,10 +156,21 @@ export const getDecryptedSubmissionById = async ({
           formFieldsMeta,
         )
 
-        if (!decryptedV4)
+        if (!decryptedV4) {
+          datadogLogs.logger.error(
+            'Could not decrypt the multirespondent form response in v4',
+            {
+              meta: {
+                action: 'getDecryptedSubmissionById',
+                formId,
+                submissionId,
+              },
+            },
+          )
           throw new Error(
             'Could not decrypt the multirespondent form response in v4',
           )
+        }
 
         const processedContentV4 = decryptedV4.verified
           ? {

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
@@ -65,11 +65,20 @@ export const augmentDecryptedResponsesV4 = (
   responsesV4: FieldResponsesV4,
   attachmentMetadata: EncryptedAttachmentRecords,
 ): AugmentedDecryptedResponseV4[] => {
+  // Build ordered field IDs: form fields first, then any remaining (e.g. verified content)
+  const formFieldIds = new Set(formFields.map((f) => f._id))
+  const remainingFieldIds = Object.keys(responsesV4).filter(
+    (id) => !formFieldIds.has(id),
+  )
+  const orderedFieldIds = [
+    ...formFields.map((f) => f._id),
+    ...remainingFieldIds,
+  ]
+
   let nonResponseFieldsCount = 0
   const results: AugmentedDecryptedResponseV4[] = []
 
-  formFields.forEach((formField, index) => {
-    const fieldId = formField._id
+  orderedFieldIds.forEach((fieldId, index) => {
     const field = responsesV4[fieldId]
     if (!field) return
 

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processDecryptedContent.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/processDecryptedContent.ts
@@ -198,23 +198,3 @@ export const convertVerifiedToV4 = (
   }
   return v4Verified
 }
-
-/**
- * Processes V3 (MRF) decrypted content into V4 format.
- */
-export const processDecryptedContentV3ToV4 = (
-  form_fields: FormFieldDto[],
-  decrypted: DecryptedContentV3,
-): FieldResponsesV4 => {
-  const { responses, verified } = decrypted
-  const formFields = buildFormFieldMetaMap(form_fields)
-
-  const v4Responses = adaptV3ToV4(responses, { formFields })
-
-  if (verified) {
-    const v4Verified = convertVerifiedToV4(verified)
-    return { ...v4Responses, ...v4Verified }
-  }
-
-  return v4Responses
-}

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/worker/decryption.worker.ts
@@ -160,7 +160,10 @@ async function decryptSubmissionData(
           formFieldsMeta,
         )
         if (!decryptedV4) {
-          console.error('Invalid decryption for multirespondent response')
+          console.error(
+            'Invalid decryption for multirespondent response in v4',
+            { submissionId: submissionData._id },
+          )
           return {
             isSubmissionDecryptionSuccessful: false,
           }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Verified Content responses (Singpass Validated NRIC) don't get displayed on the Individual Response Page. This is because:
- during augmentation of questions and answers in v4, the form_fields are used to create the question/response pairs
- since verified content is not part of form_fields, it gets omitted

Note: This has been verified not to affect downloading of csv responses (NRIC already included) since they use different flows for decryption + preparation of respsonses, and it is already being handled in decrypt workers.

## Solution
<!-- How did you solve the problem? -->

1. Instead of relying solely on formFields, build an ordered map of form fields and append the remaining verified content fields at the end

Unrelated: Improved logging for observability as we plan to toggle on usage of v4 decryption

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Singpass-collected NRIC form**
- [ ] Create an MFR Singpass form, toggle on Collect NRICs
- [ ] Make a submission
- [ ] Verify that feature flag `answer-object-decryption` is on in testing env
- [ ] Visit results page and the individual submission page, verify that Singpass Validated NRIC is shown
- [ ] (regression) Download a CSV of responses, verify that Singpass Validated NRIC is column with data