### PR TITLE
fix: add shouldWrapChildren to button component to fix translation engine issues

### DIFF
--- a/apps/frontend/src/components/Button/Button.tsx
+++ b/apps/frontend/src/components/Button/Button.tsx
@@ -62,7 +62,10 @@ export const Button = forwardRef<ButtonProps, 'button'>(
         {...(isFullWidth ? { minH: '3.5rem' } : {})}
         {...(isHighContrast ? { variant: 'highContrast' } : {})}
       >
-        {children}
+        {/* Span wrapper prevents Chrome's translation engine from directly
+            modifying button text nodes, which breaks React reconciliation
+            when the button switches to its loading state. */}
+        <span>{children}</span>
       </ChakraButton>
     )
   },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Error boundary error when trying to submit a FormSG form, when using google translate.

[FRM-2404](https://linear.app/ogp/issue/FRM-2404/browser-translation-breaks-loading-state-on-public-forms)

Closes [FRM-2404](https://linear.app/ogp/issue/FRM-2404/browser-translation-breaks-loading-state-on-public-forms)

## Solution
<!-- How did you solve the problem? -->

1. Add `shouldWrapChildren` as button property (as per [previous fix in ActiveSG](https://github.com/opengovsg/activesg/pull/2339/changes#diff-9d8d946492a6d3d985d594e799a51e85693f9c3fd39d23426e20955d47b2abe7R8))
2. Wrap button children in a `<span>`
- chrome's translation engine wraps button text nodes in <font> tags
- when the button switches to loading state, React cannot reconcile against the modified DOM - throws error
- wrapping children in a <span> gives React a stable node to swap out, chrome's modifications stay contained inside the span - doesn't throw error

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
