### PR TITLE
fix: use POSIX compliant syntax in husky hook scripts for shell interoperability

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,7 @@
+#!/usr/bin/env sh
+
 # Section for git-secrets
-if ! command -v git-secrets &> /dev/null
+if ! command -v git-secrets > /dev/null 2>&1
 then
     echo "git-secrets is not installed. Please run 'brew install git-secrets' or visit https://github.com/awslabs/git-secrets#installing-git-secrets"
     exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
+#!/usr/bin/env sh
+
 # Section for git-secrets
-if ! command -v git-secrets &> /dev/null
+if ! command -v git-secrets > /dev/null 2>&1
 then
     echo "git-secrets is not installed. Please run 'brew install git-secrets' or visit https://github.com/awslabs/git-secrets#installing-git-secrets"
     exit 1

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,5 +1,7 @@
+#!/usr/bin/env sh
+
 # Section for git-secrets
-if ! command -v git-secrets &> /dev/null
+if ! command -v git-secrets > /dev/null 2>&1
 then
     echo "git-secrets is not installed. Please run 'brew install git-secrets' or visit https://github.com/awslabs/git-secrets#installing-git-secrets"
     exit 1
@@ -11,4 +13,3 @@ git-secrets --register-aws > /dev/null
 echo "Running git-secrets prepare_commit_msg_hook"
 # Determines if merging in a commit will introduce tainted history.
 git-secrets --prepare_commit_msg_hook -- "$@"
-


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Our current pre-commit hooks only work on bash which is the current login shell on MacOS. 
However, husky uses sh which requires POSIX compliant syntax on linux machines. 
This causes issues running the hooks on other machines such as isolated sandboxes eg, codespaces.  

## Solution
<!-- How did you solve the problem? -->
Specify `sh` usage with shebang. Update to use POSIX compliant syntax in husky hook scripts whilst maintaining the same script behavior. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: 
- [x] Can still commit on local macOS with bash 

TC2: 
- [x] Can also commit on linux machines eg, Github codespaces 