### PR TITLE
fix: enable line breaks in thank you page message

### DIFF
--- a/apps/frontend/src/components/FormEndPage/EndPageBlock.tsx
+++ b/apps/frontend/src/components/FormEndPage/EndPageBlock.tsx
@@ -112,7 +112,7 @@ export const EndPageBlock = ({
         </Text>
         {paragraph ? (
           <Box mt="0.75rem">
-            <MarkdownText components={mdComponents}>{paragraph}</MarkdownText>
+            <MarkdownText multilineBreaks components={mdComponents}>{paragraph}</MarkdownText>
           </Box>
         ) : null}
       </Box>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Line breaks don't work in thank you page message. Users adding newlines in the thank you page message see them stripped instead of rendered as actual line breaks.
Closes #9348

## Solution
<!-- How did you solve the problem? -->
The `MarkdownText` component has a `multilineBreaks` prop that enables sequential newlines to generate line breaks. This prop was not being passed when rendering the thank you page message in `EndPageBlock.tsx`, causing newlines to be stripped.
Added the `multilineBreaks` prop to the `MarkdownText` component in `EndPageBlock.tsx:115` - same approach used by other components like `ParagraphField` that handle multiline text.

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  
**Features**:
- None
**Improvements**:
- None
**Bug Fixes**:
- Enable line breaks in thank you page message by passing `multilineBreaks` prop to `MarkdownText` component
## Before & After Screenshots
**BEFORE**:
<img width="1464" height="718" alt="Screenshot 2026-05-17 at 4 30 48 PM" src="https://github.com/user-attachments/assets/6b51c6d5-709c-4a98-9402-c971396be537" />

**AFTER**:
<img width="1454" height="731" alt="Screenshot 2026-05-17 at 4 31 17 PM" src="https://github.com/user-attachments/assets/13f18dc3-569a-40d2-ac4e-b2f9b5dc4a89" />

## Tests
<!-- What tests should be run to confirm functionality? -->
- `pnpm test:frontend` - 199 tests passed
- Visual verification via Storybook at `Pages/PublicFormPage/FormEndPage > Default`
## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
**New environment variables**:
- None
**New scripts**:
- None
**New dependencies**:
- None
**New dev dependencies**:
- None