### PR TITLE
chore: add formId attr to standardised template feature flag

### DIFF
--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -289,6 +289,11 @@ export const performEncryptPostSubmissionActions = ({
       ).andThen(() => okAsync(form))
     })
     .andThen((form) => {
+      // Add formId to growthbook attributes to allow for targeting in growthbook feature flags
+      void growthbook?.setAttributes({
+        ...growthbook?.getAttributes(),
+        formId: form._id.toString(),
+      })
       const respondentCopyEmailData: AutoReplyMailData[] = respondentEmails
         ? respondentEmails?.map((val) => {
             return {
@@ -330,7 +335,7 @@ export const performEncryptPostSubmissionActions = ({
         growthbook,
       }).orElse(() => okAsync(undefined))
 
-      //TODO (email-standardisation): remove when email standardisation is GA
+      /* TODO: (email-standardisation): remove when email standardisation is GA */
       const useStandardisedEmailTemplate: boolean =
         growthbook?.getFeatureValue(
           featureFlags.standardisedEmailTemplate,

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -335,7 +335,7 @@ export const performEncryptPostSubmissionActions = ({
         growthbook,
       }).orElse(() => okAsync(undefined))
 
-      /* TODO: (email-standardisation): remove when email standardisation is GA */
+      // TODO (email-standardisation): remove when email standardisation is GA
       const useStandardisedEmailTemplate: boolean =
         growthbook?.getFeatureValue(
           featureFlags.standardisedEmailTemplate,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

`use-standardised-template` feature flag requires a whitelist feature to force values based on `formId` to handle straggling users who do not wish to use the new template when we cut over.

## Solution
<!-- How did you solve the problem? -->

Add formId as part of `use-standardised-template` growthbook attributes, to allow for overriding rules to be set base on formId.

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: Force rule = Off for specific forms
- [x] Create/use an existing storage mode form, copy the `formId`
- [x] Verify that growthbook flag for `use-standardised-template` is ON (for your testing env)

<img width="1454" height="518" alt="image" src="https://github.com/user-attachments/assets/8b0e4c39-bb5d-48b1-aa64-6ed320ec0487" />

- [x] Add a rule to force the growthbook value to OFF for the that specific formId
- [x] Make a submission, observe that the admin copy email uses old template (might need to wait awhile for BE to take changes to gb attributes)
- [x] (regression) make another submission for another storage mode form, observe that the new template is used
