### PR TITLE
chore: add v1 Claude Code agent skills configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (`opengovsg/FormSG`). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.
+
+### Review prep
+
+Commit style and breadcrumb convention for review-ready PRs. See `docs/agents/commit-style.md` and `docs/agents/decisions-breadcrumb.md`.

--- a/docs/agents/commit-style.md
+++ b/docs/agents/commit-style.md
@@ -1,0 +1,21 @@
+# Commit Style
+
+This project practices **review-by-commit**. A reviewer should be able to read the diff one commit at a time, in order, and follow a logical narrative — each commit a single defensible step.
+
+Implementation skills (`tdd` and any successor impl loops) follow this convention while they work. `prepare-for-review` trusts the commit history as-is when it assembles the PR's Review guide; if commits are wide or out of order, the Review guide will reflect that. There is no automated gate — commit discipline is enforced by convention here, not by tooling.
+
+## What a good commit looks like
+
+- **One logical change.** Refactor, new behavior, schema change, test addition — each its own commit. Don't bundle.
+- **Scoped to one concern.** If the commit description needs the word "and", it should probably be two commits.
+- **Tests live with the code they cover.** A new behavior + its tests = one commit. A pure test addition for existing behavior = a separate commit.
+- **Refactors are pure.** Renames, moves, extractions that change no behavior travel alone, so a reviewer can skim them and focus elsewhere.
+- **Commit message describes the *why*, not the *what*.** The diff already shows the what. A reader six months from now needs the motivation.
+
+## Message format
+
+This project mandates Conventional Commits. Subject line under ~70 characters, imperative mood, body wrapped at ~72. Reference an issue if one exists.
+
+## When commits go wide
+
+Sometimes a single change is genuinely large and cannot be sliced (a generated file, a sweeping rename, a vendor drop). Land it as one commit and put the reason in the message body — reviewers can then skim past it confidently. Don't synthesise fake boundaries.

--- a/docs/agents/decisions-breadcrumb.md
+++ b/docs/agents/decisions-breadcrumb.md
@@ -1,0 +1,60 @@
+# Breadcrumb Convention
+
+During implementation, the agent drops **breadcrumbs** — small structured decision notes — into `.scratch/<feature>/decisions.md` in this repo. `prepare-for-review` reads them at PR time and surfaces each one either in the PR body (as a bullet under "Alternatives considered") or as an inline review comment anchored to a specific line.
+
+Breadcrumbs exist so that rationale is captured at the moment of choice, not reconstructed after the fact. ADRs cover hard-to-reverse architectural decisions; breadcrumbs cover the smaller in-impl judgment calls where an ADR would be overkill but a reviewer would still benefit from knowing *why this and not that*.
+
+## File layout
+
+One file per feature: `.scratch/<feature>/decisions.md`. Append-only during the implementation loop. Each breadcrumb is a top-level `## decision:` section.
+
+If the file does not exist when the implementation starts, the implementation skill creates it (with a one-line header) before appending the first entry. If no non-obvious decision is made during the whole loop, the file may remain absent — `prepare-for-review` will simply omit the "Alternatives considered" sub-section.
+
+## Schema
+
+```md
+## decision: <kebab-case-slug>
+**kind**: pr-body | inline
+**file**: <path>             # required if kind=inline
+**line**: <line-number>      # required if kind=inline
+**why**: <one paragraph explaining the choice>
+**alternatives**:            # optional
+  - <option>: <why rejected>
+  - <option>: <why rejected>
+```
+
+Field semantics:
+
+- `kind: pr-body` — folded into the PR body's "Alternatives considered" sub-section under Solution. Use for design choices a reviewer can evaluate without staring at a specific line.
+- `kind: inline` — posted as an inline PR review comment on `file:line`. Use when the *exact code at that location* is the surprising bit and the reviewer will want context right there.
+- `why` — the load-bearing field. Be honest about the actual reason. If the reason was "this was the first thing that worked", say so.
+- `alternatives` — only what was actually weighed. Fabricating plausible alternatives defeats the entire purpose.
+
+## Example — kind: pr-body
+
+```md
+## decision: use-map-not-record-for-session-store
+**kind**: pr-body
+**why**: Session keys are constructed from untrusted user input, so `Map` is safer than a plain object — no risk of prototype pollution if a key happens to be `__proto__`. The slight readability cost is worth it for the security guarantee at a boundary.
+**alternatives**:
+  - Plain `Record<string, Session>`: rejected for the prototype-pollution reason above.
+  - A wrapped class with explicit get/set: rejected as over-engineered for two call sites.
+```
+
+## Example — kind: inline
+
+```md
+## decision: token-expiry-uses-inclusive-comparison
+**kind**: inline
+**file**: src/auth/token.ts
+**line**: 42
+**why**: RFC 7519 §4.1.4 defines `exp` as a time *on or after which* the token must be rejected — meaning the token is valid up to and including the exact expiry second. The `<=` here is intentional; a strict `<` would expire tokens one second too early.
+**alternatives**:
+  - Strict `<`: rejected — would expire tokens one second early, breaking parity with libraries that follow the spec.
+```
+
+## What does not belong here
+
+- Decisions that warrant an ADR (hard to reverse, architectural, surprising without context, real trade-off across genuine alternatives) — write the ADR, don't put it here.
+- Mechanical or obvious choices ("used the existing helper", "matched the surrounding style") — adding these turns the file into noise and the reviewer learns to ignore it.
+- Apologies or hedges ("I'm not sure if this is right but…") — if you're unsure, raise it as a question on the PR, not in a breadcrumb.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── ...
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (example decision) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "prettier": "^3.5.3",
-    "rimraf": "^5.0.5"
+    "rimraf": "^5.0.5",
+    "skills": "^1.5.7"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
+      skills:
+        specifier: ^1.5.7
+        version: 1.5.7
 
   apps/backend:
     dependencies:
@@ -1329,7 +1332,7 @@ importers:
         version: 5.5.5(eslint-config-prettier@10.1.5(eslint@8.57.1))(eslint@8.57.1)(prettier@3.8.1)
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3))
       mongoose:
         specifier: ~7.8.9
         version: 7.8.9
@@ -12543,6 +12546,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  skills@1.5.7:
+    resolution: {integrity: sha512-Df/2bXm/5Glp7o6n2Ft5v5EmowaD0x8lbvDwionoIhS1sxnWTy5KwMsMPlu3fqhfIZj95m7CC4p+jNVkXNQGYQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -14691,8 +14699,8 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.577.0
-      '@aws-sdk/client-sts': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
+      '@aws-sdk/client-sso-oidc': 3.577.0(@aws-sdk/client-sts@3.577.0)
+      '@aws-sdk/client-sts': 3.577.0
       '@aws-sdk/core': 3.576.0
       '@aws-sdk/credential-provider-node': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -14825,11 +14833,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.577.0':
+  '@aws-sdk/client-sso-oidc@3.577.0(@aws-sdk/client-sts@3.577.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
+      '@aws-sdk/client-sts': 3.577.0
       '@aws-sdk/core': 3.576.0
       '@aws-sdk/credential-provider-node': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -14868,6 +14876,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
+      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.693.0)':
@@ -15044,11 +15053,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.577.0(@aws-sdk/client-sso-oidc@3.577.0)':
+  '@aws-sdk/client-sts@3.577.0':
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sso-oidc': 3.577.0
+      '@aws-sdk/client-sso-oidc': 3.577.0(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/core': 3.576.0
       '@aws-sdk/credential-provider-node': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/middleware-host-header': 3.577.0
@@ -15087,7 +15096,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/client-sts@3.693.0':
@@ -15316,7 +15324,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.577.0(@aws-sdk/client-sso-oidc@3.577.0)(@aws-sdk/client-sts@3.577.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
+      '@aws-sdk/client-sts': 3.577.0
       '@aws-sdk/credential-provider-env': 3.577.0
       '@aws-sdk/credential-provider-process': 3.577.0
       '@aws-sdk/credential-provider-sso': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
@@ -15633,7 +15641,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.577.0(@aws-sdk/client-sts@3.577.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.577.0(@aws-sdk/client-sso-oidc@3.577.0)
+      '@aws-sdk/client-sts': 3.577.0
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/types': 3.7.2
@@ -16147,7 +16155,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.577.0(@aws-sdk/client-sso-oidc@3.577.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.577.0
+      '@aws-sdk/client-sso-oidc': 3.577.0(@aws-sdk/client-sts@3.577.0)
       '@aws-sdk/types': 3.577.0
       '@smithy/property-provider': 3.1.11
       '@smithy/shared-ini-file-loader': 3.1.12
@@ -25572,25 +25580,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3))
@@ -26328,18 +26317,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -29893,6 +29870,10 @@ snapshots:
   simplur@3.0.1: {}
 
   sisteransi@1.0.5: {}
+
+  skills@1.5.7:
+    dependencies:
+      yaml: 2.8.4
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
Note: this PR is generated using `prepare-for-review` skill for dogfooding. 

## Problem

The repo had no configuration for Claude Code's engineering skills (`triage`, `tdd`, `to-issues`, `prepare-for-review`, `improve-codebase-architecture`, etc.), so each skill had to guess where issues live, what label vocabulary to use, and where to look for domain docs.

## Solution

Adds `CLAUDE.md` at the repo root (the file Claude Code reads on every session) and five supporting files under `docs/agents/`:

- **`issue-tracker.md`** — GitHub Issues via the `gh` CLI
- **`triage-labels.md`** — canonical label defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`)
- **`domain.md`** — single-context layout (`CONTEXT.md` + `docs/adr/` at root)
- **`commit-style.md`** — review-by-commit convention (Conventional Commits, one logical change per commit)
- **`decisions-breadcrumb.md`** — `.scratch/<feature>/decisions.md` schema for capturing in-impl rationale

**Breaking Changes**

No — backwards compatible. These are new files; nothing existing is modified.

## Tests

**TC1: Skills read config correctly**
- [ ] Install `pnpm exec skills add kevin9foong/skills`. See source: https://github.com/kevin9foong/skills (which is a FormSG team/OGP specific extension of matt pocock's skills which is MIT licensed). This contains engineering skills our team can use (eg, `/tdd`, `/prepare-for-review`). Install desired skills (recommend all engineering skills), install into your claude code.  
- [ ] Run `/to-issues` — verify it creates a GitHub issue in `opengovsg/FormSG`