### PR TITLE
fix: signature hover state to match form theme color

### DIFF
--- a/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -5,10 +5,10 @@ import {
   useFormContext,
   useFormState,
 } from 'react-hook-form'
-import { Box, Flex, FormControl, Stack, Text, useToken } from '@chakra-ui/react'
+import { Box, Flex, FormControl, Stack, Text } from '@chakra-ui/react'
 import getStroke from 'perfect-freehand'
 
-import { FormColorTheme, SignatureVectorArray } from 'formsg-shared/types' //
+import { FormColorTheme, SignatureVectorArray } from 'formsg-shared/types'
 import {
   SIGNATURE_STROKE_SIZE,
   SIGNATURE_STROKE_SMOOTHING,
@@ -46,7 +46,7 @@ export interface SignatureCanvasProps {
 
 const SignatureCanvas = ({
   schema,
-  colorTheme = FormColorTheme.Blue, // defaults to blue
+  colorTheme = FormColorTheme.Blue,
   isHighContrast,
   isSubmitting,
   isValid,
@@ -58,8 +58,6 @@ const SignatureCanvas = ({
     () => `theme-${colorTheme}` as const,
     [colorTheme],
   )
-
-  const [primaryColor] = useToken('colors', [`${fieldColorScheme}.500`])
 
   const signatureErrors = errors?.[schema._id]
   const [showSignaturePlaceholder, setShowSignaturePlaceholder] = useState(true)
@@ -255,7 +253,7 @@ const SignatureCanvas = ({
                   signatureErrors
                     ? 'red.600'
                     : isDrawing
-                      ? primaryColor
+                      ? `${fieldColorScheme}.500`
                       : 'neutral.400'
                 }
                 position="relative"
@@ -264,7 +262,10 @@ const SignatureCanvas = ({
                   background: schema.disabled
                     ? 'neutral.200'
                     : `${fieldColorScheme}.100`,
-                  outline: isDrawing ? `2px solid ${primaryColor}` : 'none',
+                  outline: isDrawing ? `2px solid` : 'none',
+                  outlineColor: isDrawing
+                    ? `${fieldColorScheme}.500`
+                    : undefined,
                 }}
               >
                 {showSignaturePlaceholder && (

--- a/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
+++ b/apps/frontend/src/templates/Field/Signature/SignatureField.tsx
@@ -5,10 +5,10 @@ import {
   useFormContext,
   useFormState,
 } from 'react-hook-form'
-import { Box, Flex, FormControl, Stack, Text } from '@chakra-ui/react'
+import { Box, Flex, FormControl, Stack, Text, useToken } from '@chakra-ui/react'
 import getStroke from 'perfect-freehand'
 
-import { SignatureVectorArray } from 'formsg-shared/types'
+import { FormColorTheme, SignatureVectorArray } from 'formsg-shared/types' //
 import {
   SIGNATURE_STROKE_SIZE,
   SIGNATURE_STROKE_SMOOTHING,
@@ -35,6 +35,7 @@ export interface SignatureFieldProps extends BaseFieldProps {
 
 export interface SignatureCanvasProps {
   schema: SignatureFieldSchema
+  colorTheme?: FormColorTheme
   isHighContrast?: boolean
   isSubmitting: boolean
   isValid: boolean
@@ -45,6 +46,7 @@ export interface SignatureCanvasProps {
 
 const SignatureCanvas = ({
   schema,
+  colorTheme = FormColorTheme.Blue, // defaults to blue
   isHighContrast,
   isSubmitting,
   isValid,
@@ -52,6 +54,13 @@ const SignatureCanvas = ({
   value,
   onChange,
 }: SignatureCanvasProps) => {
+  const fieldColorScheme = useMemo(
+    () => `theme-${colorTheme}` as const,
+    [colorTheme],
+  )
+
+  const [primaryColor] = useToken('colors', [`${fieldColorScheme}.500`])
+
   const signatureErrors = errors?.[schema._id]
   const [showSignaturePlaceholder, setShowSignaturePlaceholder] = useState(true)
 
@@ -246,14 +255,16 @@ const SignatureCanvas = ({
                   signatureErrors
                     ? 'red.600'
                     : isDrawing
-                      ? '#445fcd'
+                      ? primaryColor
                       : 'neutral.400'
                 }
                 position="relative"
                 overflow="hidden"
                 _hover={{
-                  background: schema.disabled ? 'neutral.200' : 'primary.100',
-                  outline: isDrawing ? '2px solid #445fcd' : 'none',
+                  background: schema.disabled
+                    ? 'neutral.200'
+                    : `${fieldColorScheme}.100`,
+                  outline: isDrawing ? `2px solid ${primaryColor}` : 'none',
                 }}
               >
                 {showSignaturePlaceholder && (
@@ -325,6 +336,7 @@ export const SignatureField = ({
   schema,
   disableRequiredValidation,
   isHighContrast,
+  colorTheme,
 }: SignatureFieldProps): JSX.Element => {
   const { control } = useFormContext<SignatureFieldInput>()
   const { isSubmitting, isValid, errors } = useFormState<SignatureFieldInput>()
@@ -342,6 +354,7 @@ export const SignatureField = ({
       render={({ field }) => (
         <SignatureCanvas
           schema={schema}
+          colorTheme={colorTheme}
           isHighContrast={isHighContrast}
           isSubmitting={isSubmitting}
           isValid={isValid}


### PR DESCRIPTION
## Problem
The signature field's hover uses a hardcoded blue (#445fcd) instead of following the form's theme color like other fields

Closes #9347

## Solution
I added colorTheme to SignatureCanvas so it uses the form's theme color. Swapped the hardcoded color for semantic tokens matching what other fields use

## Tests
Verified in Storybook that the field renders with theme colors