### PR TITLE
fix(NumberField): remove +/- stepper buttons

### DIFF
--- a/apps/frontend/src/templates/Field/Number/NumberField.test.tsx
+++ b/apps/frontend/src/templates/Field/Number/NumberField.test.tsx
@@ -13,6 +13,16 @@ import * as stories from './NumberField.stories'
 const { ValidationRequired, ValidationOptional } = composeStories(stories)
 
 describe('validation required', () => {
+  it('does not render stepper buttons', () => {
+    render(<ValidationRequired />)
+    expect(
+      screen.queryByRole('button', { name: /increment/i, hidden: true }),
+    ).toBeNull()
+    expect(
+      screen.queryByRole('button', { name: /decrement/i, hidden: true }),
+    ).toBeNull()
+  })
+
   it('renders error when field is not filled before submitting', async () => {
     // Arrange
     const user = userEvent.setup()

--- a/apps/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/apps/frontend/src/templates/Field/Number/NumberField.tsx
@@ -34,6 +34,7 @@ export const NumberField = ({
         defaultValue=""
         render={({ field: { value, onChange, ...rest } }) => (
           <NumberInput
+            showSteppers={false}
             min={0}
             inputMode="numeric"
             colorScheme={`theme-${colorTheme}`}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
This fixes usability and accessibility issues in NumberField. Scrolling while the input is focused could accidentally change values, causing incorrect responses, and screen readers announced the +/- buttons as extra controls, creating a confusing experience for assistive-technology users.
Closes [#9048 ]

## Solution
<!-- How did you solve the problem? -->
Pass showSteppers={false} to the NumberInput component inside NumberField. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] No - this PR is backwards compatible  

**Bug Fixes**:

- Removed +/- stepper buttons from NumberField to prevent accidental value    
  changes when scrolling  

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
<img width="1463" height="738" alt="Screenshot 2026-05-19 at 12 13 49 PM" src="https://github.com/user-attachments/assets/9f928bc5-37ea-43a0-a6d8-afc7fe1670cf" />



**AFTER**:
<!-- [insert screenshot here] -->
<img width="1463" height="738" alt="Screenshot 2026-05-19 at 12 13 13 PM" src="https://github.com/user-attachments/assets/eb2b64b0-5f95-4ef6-ad5b-a71ecc929135" />

## Tests
<!-- What tests should be run to confirm functionality? -->
Run pnpm test:frontend to confirm all tests pass. A regression test has been added to NumberField.test.tsx that asserts the stepper buttons are not rendered in the NumberField component.    

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

 No new environment variables, scripts, or dependencies introduced.
