### PR TITLE
fix: update augmented responses v4 to include unaswered questions & headers

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRowV4.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRowV4.tsx
@@ -209,10 +209,23 @@ export const DecryptedRowV4 = memo(
     questionNumber,
     downloadUrl,
     attachmentDecryptionKey,
+    unanswered,
   }: DecryptedRowV4Props): JSX.Element => {
-    switch (field.fieldType) {
-      case BasicField.Section:
+    if (unanswered) {
+      if (field.fieldType === BasicField.Section) {
         return <DecryptedHeaderRowV4 field={field} />
+      }
+      return (
+        <Stack>
+          <DecryptedQuestionLabelV4
+            field={field}
+            questionNumber={questionNumber}
+          />
+        </Stack>
+      )
+    }
+
+    switch (field.fieldType) {
       case BasicField.Attachment:
         return (
           <DecryptedAttachmentRowV4

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -321,6 +321,7 @@ export const IndividualResponsePage = (): JSX.Element => {
                       questionNumber={row.questionNumber}
                       downloadUrl={row.downloadUrl}
                       attachmentDecryptionKey={attachmentDecryptionKey}
+                      unanswered={row.unanswered}
                     />
                   ))
                 : data?.responses.map((r, idx) => (

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
@@ -105,17 +105,18 @@ export const augmentDecryptedResponsesV4 = (
   const results: AugmentedDecryptedResponseV4[] = []
 
   orderedFieldIds.forEach((fieldId, index) => {
-    const field = responsesV4[fieldId]
+    const fieldFromResponse = responsesV4[fieldId]
     const formField = formFieldMap.get(fieldId)
 
-    const fieldType = field?.fieldType ?? (formField?.fieldType as BasicField)
-    if (!fieldType || !formField || !isBasicField(fieldType)) return
+    const fieldType =
+      fieldFromResponse?.fieldType ?? (formField?.fieldType as BasicField)
+    if (!isBasicField(fieldType)) return
 
     const isNonResponse = NON_RESPONSE_FIELD_SET.has(fieldType)
     if (isNonResponse) {
       nonResponseFieldsCount++
       // Only Section headers are rendered; other non-response fields (e.g. Statement) are skipped
-      if (fieldType === BasicField.Section) {
+      if (fieldType === BasicField.Section && formField) {
         results.push({
           fieldId,
           field: buildSyntheticField(formField),
@@ -127,10 +128,12 @@ export const augmentDecryptedResponsesV4 = (
 
     results.push({
       fieldId,
-      field: field ?? buildSyntheticField(formField),
+      field:
+        fieldFromResponse ??
+        (formField ? buildSyntheticField(formField) : undefined),
       questionNumber: index + 1 - nonResponseFieldsCount,
       downloadUrl: attachmentMetadata[fieldId],
-      unanswered: !field,
+      unanswered: !fieldFromResponse,
     })
   })
 

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponses.ts
@@ -1,4 +1,8 @@
-import { FieldResponsesV4, FieldResponseV4 } from '@opengovsg/formsg-sdk'
+import {
+  AnswerV4,
+  FieldResponsesV4,
+  FieldResponseV4,
+} from '@opengovsg/formsg-sdk'
 import type {
   EncryptedAttachmentRecords,
   FormField,
@@ -58,17 +62,39 @@ export type AugmentedDecryptedResponseV4 = {
   field: FieldResponseV4
   questionNumber?: number
   downloadUrl?: string
+  unanswered?: boolean
 }
 
+/**
+ * Builds a synthetic FieldResponseV4 from a form field definition.
+ * Used for non-response fields (e.g. Section headers) and unanswered optional fields,
+ * so they can be rendered with question text but no answer body.
+ * Safe to use only when paired with unanswered: true, which bypasses answer rendering.
+ */
+const buildSyntheticField = (formField: FormFieldDto): FieldResponseV4 => ({
+  fieldType: formField.fieldType as FieldResponseV4['fieldType'],
+  question: formField.title,
+  answer: {} as AnswerV4,
+  provenance: {},
+})
+
+/**
+ * Augments decrypted responses with question no., and download url for attachments.
+ * Handles inclusion of unanswered fields + header fields
+ * @param formFields Ordered snapshot of form field definitions for the submission
+ * @param responsesV4 Decrypted responses in V4 format, keyed by field ID
+ * @param attachmentMetadata Map of field ID to attachment download URL
+ * @returns Ordered list of augmented responses ready for display
+ */
 export const augmentDecryptedResponsesV4 = (
   formFields: FormFieldDto[],
   responsesV4: FieldResponsesV4,
   attachmentMetadata: EncryptedAttachmentRecords,
 ): AugmentedDecryptedResponseV4[] => {
   // Build ordered field IDs: form fields first, then any remaining (e.g. verified content)
-  const formFieldIds = new Set(formFields.map((f) => f._id))
+  const formFieldMap = new Map(formFields.map((f) => [f._id, f]))
   const remainingFieldIds = Object.keys(responsesV4).filter(
-    (id) => !formFieldIds.has(id),
+    (id) => !formFieldMap.has(id),
   )
   const orderedFieldIds = [
     ...formFields.map((f) => f._id),
@@ -80,24 +106,31 @@ export const augmentDecryptedResponsesV4 = (
 
   orderedFieldIds.forEach((fieldId, index) => {
     const field = responsesV4[fieldId]
-    if (!field) return
+    const formField = formFieldMap.get(fieldId)
 
-    if (!isBasicField(field.fieldType)) return
+    const fieldType = field?.fieldType ?? (formField?.fieldType as BasicField)
+    if (!fieldType || !formField || !isBasicField(fieldType)) return
 
-    const isNonResponse = NON_RESPONSE_FIELD_SET.has(
-      field.fieldType as BasicField,
-    )
+    const isNonResponse = NON_RESPONSE_FIELD_SET.has(fieldType)
     if (isNonResponse) {
       nonResponseFieldsCount++
+      // Only Section headers are rendered; other non-response fields (e.g. Statement) are skipped
+      if (fieldType === BasicField.Section) {
+        results.push({
+          fieldId,
+          field: buildSyntheticField(formField),
+          unanswered: true,
+        })
+      }
+      return
     }
 
     results.push({
       fieldId,
-      field,
-      questionNumber: isNonResponse
-        ? undefined
-        : index + 1 - nonResponseFieldsCount,
+      field: field ?? buildSyntheticField(formField),
+      questionNumber: index + 1 - nonResponseFieldsCount,
       downloadUrl: attachmentMetadata[fieldId],
+      unanswered: !field,
     })
   })
 

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponsesV4.test.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/augmentDecryptedResponsesV4.test.ts
@@ -1,0 +1,211 @@
+import { FieldResponsesV4 } from '@opengovsg/formsg-sdk'
+
+import type { FormFieldDto } from 'formsg-shared/types'
+import { BasicField } from 'formsg-shared/types'
+
+import { augmentDecryptedResponsesV4 } from './augmentDecryptedResponses'
+
+const makeFormField = (
+  id: string,
+  fieldType: BasicField,
+  title = `Question ${id}`,
+): FormFieldDto =>
+  ({
+    _id: id,
+    fieldType,
+    title,
+  }) as unknown as FormFieldDto
+
+const makeResponse = (
+  fieldType: string,
+  question: string,
+  answerValue = 'some answer',
+): FieldResponsesV4[string] => ({
+  fieldType: fieldType as never,
+  question,
+  answer: { value: answerValue } as never,
+  provenance: {},
+})
+
+describe('augmentDecryptedResponsesV4', () => {
+  describe('Section (header) fields', () => {
+    it('includes a Section field with unanswered=true and no questionNumber', () => {
+      const formFields = [
+        makeFormField('sec-1', BasicField.Section, 'About You'),
+      ]
+      const responses: FieldResponsesV4 = {}
+
+      const result = augmentDecryptedResponsesV4(formFields, responses, {})
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        fieldId: 'sec-1',
+        unanswered: true,
+      })
+      expect(result[0].field.question).toBe('About You')
+      expect(result[0].field.fieldType).toBe(BasicField.Section)
+    })
+
+    it('assigns a synthetic field using the form field title for a Section', () => {
+      const formFields = [
+        makeFormField('sec-2', BasicField.Section, 'Work History'),
+      ]
+      const result = augmentDecryptedResponsesV4(formFields, {}, {})
+
+      expect(result[0].field.question).toBe('Work History')
+    })
+  })
+
+  describe('Non-response fields excluded from output', () => {
+    it('excludes Statement fields', () => {
+      const formFields = [makeFormField('stmt-1', BasicField.Statement)]
+      const result = augmentDecryptedResponsesV4(formFields, {}, {})
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('excludes Image fields', () => {
+      const formFields = [makeFormField('img-1', BasicField.Image)]
+      const result = augmentDecryptedResponsesV4(formFields, {}, {})
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('Question numbering', () => {
+    it('assigns correct questionNumber to response fields, skipping non-response fields', () => {
+      const formFields = [
+        makeFormField('sec-1', BasicField.Section),
+        makeFormField('q-1', BasicField.ShortText),
+        makeFormField('stmt-1', BasicField.Statement),
+        makeFormField('q-2', BasicField.Email),
+      ]
+      const responses: FieldResponsesV4 = {
+        'q-1': makeResponse('textfield', 'Name'),
+        'q-2': makeResponse('email', 'Email'),
+      }
+
+      const result = augmentDecryptedResponsesV4(formFields, responses, {})
+
+      const answeredFields = result.filter((r) => !r.unanswered)
+      expect(answeredFields[0].questionNumber).toBe(1) // index 1, minus 1 non-response before it
+      expect(answeredFields[1].questionNumber).toBe(2) // index 3, minus 1 section + 1 statement = 2 non-response fields → but statement is excluded so only section counts
+    })
+
+    it('numbers multiple response fields consecutively after a section header', () => {
+      const formFields = [
+        makeFormField('sec-1', BasicField.Section),
+        makeFormField('q-1', BasicField.ShortText),
+        makeFormField('q-2', BasicField.ShortText),
+      ]
+      const responses: FieldResponsesV4 = {
+        'q-1': makeResponse('textfield', 'First name'),
+        'q-2': makeResponse('textfield', 'Last name'),
+      }
+
+      const result = augmentDecryptedResponsesV4(formFields, responses, {})
+
+      const answered = result.filter((r) => !r.unanswered)
+      expect(answered[0].questionNumber).toBe(1)
+      expect(answered[1].questionNumber).toBe(2)
+    })
+  })
+
+  describe('Unanswered optional fields', () => {
+    it('marks fields missing from responses as unanswered=true', () => {
+      const formFields = [
+        makeFormField('q-1', BasicField.ShortText, 'Nickname'),
+      ]
+      const result = augmentDecryptedResponsesV4(formFields, {}, {})
+
+      expect(result).toHaveLength(1)
+      expect(result[0].unanswered).toBe(true)
+      expect(result[0].questionNumber).toBe(1)
+    })
+
+    it('uses form field title as question text for unanswered fields', () => {
+      const formFields = [makeFormField('q-2', BasicField.Email, 'Your email')]
+      const result = augmentDecryptedResponsesV4(formFields, {}, {})
+
+      expect(result[0].field.question).toBe('Your email')
+    })
+
+    it('marks answered fields as unanswered=false', () => {
+      const formFields = [makeFormField('q-3', BasicField.ShortText, 'City')]
+      const responses: FieldResponsesV4 = {
+        'q-3': makeResponse('textfield', 'City', 'Singapore'),
+      }
+
+      const result = augmentDecryptedResponsesV4(formFields, responses, {})
+
+      expect(result[0].unanswered).toBe(false)
+    })
+  })
+
+  describe('Attachment download URLs', () => {
+    it('sets downloadUrl for attachment fields when metadata is present', () => {
+      const formFields = [
+        makeFormField('att-1', BasicField.Attachment, 'Upload file'),
+      ]
+      const responses: FieldResponsesV4 = {
+        'att-1': makeResponse('attachment', 'Upload file', 'file.pdf'),
+      }
+      const attachmentMetadata = { 'att-1': 'https://example.com/file.pdf' }
+
+      const result = augmentDecryptedResponsesV4(
+        formFields,
+        responses,
+        attachmentMetadata,
+      )
+
+      expect(result[0].downloadUrl).toBe('https://example.com/file.pdf')
+    })
+
+    it('leaves downloadUrl undefined when no attachment metadata exists', () => {
+      const formFields = [makeFormField('q-1', BasicField.ShortText, 'Name')]
+      const responses: FieldResponsesV4 = {
+        'q-1': makeResponse('textfield', 'Name', 'Alice'),
+      }
+
+      const result = augmentDecryptedResponsesV4(formFields, responses, {})
+
+      expect(result[0].downloadUrl).toBeUndefined()
+    })
+  })
+
+  describe('Mixed form with sections, unanswered, and answered fields', () => {
+    it('produces the correct ordered list of augmented responses', () => {
+      const formFields = [
+        makeFormField('sec-1', BasicField.Section, 'Section A'),
+        makeFormField('q-1', BasicField.ShortText, 'Name'),
+        makeFormField('q-2', BasicField.Email, 'Email'),
+        makeFormField('stmt-1', BasicField.Statement, 'Please note'),
+        makeFormField('sec-2', BasicField.Section, 'Section B'),
+        makeFormField('q-3', BasicField.ShortText, 'City'),
+      ]
+      const responses: FieldResponsesV4 = {
+        'q-1': makeResponse('textfield', 'Name', 'Alice'),
+        // q-2 not answered (unanswered)
+        'q-3': makeResponse('textfield', 'City', 'Singapore'),
+      }
+
+      const result = augmentDecryptedResponsesV4(formFields, responses, {})
+
+      // Statement is excluded; Sections are included as unanswered
+      // Expected output: [sec-1, q-1, q-2, sec-2, q-3]
+      expect(result.map((r) => r.fieldId)).toEqual([
+        'sec-1',
+        'q-1',
+        'q-2',
+        'sec-2',
+        'q-3',
+      ])
+
+      expect(result[0]).toMatchObject({ unanswered: true }) // sec-1
+      expect(result[1]).toMatchObject({ unanswered: false, questionNumber: 1 }) // q-1 (index 1, 1 non-response before)
+      expect(result[2]).toMatchObject({ unanswered: true, questionNumber: 2 }) // q-2 unanswered
+      expect(result[3]).toMatchObject({ unanswered: true }) // sec-2
+      expect(result[4]).toMatchObject({ unanswered: false, questionNumber: 3 }) // q-3 (index 3, 2 non-response: sec-1 + stmt-1 + sec-2 = 3, but stmt-1 increments count without being in results)
+    })
+  })
+})


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Found bugs with v4 decryption onto response pages:
1. Numberings don't align with response-only questions; non-response fields increment the question number, but aren't shown on the page, leading to mismatch between form and response question numbers
2. unanswered fields don't get displayed on the response page
3. Header's aren't shown in individual response page (regression from v3)

## Solution
<!-- How did you solve the problem? -->

When augmenting v4 responses,
1.  stop question number incrementing based on formField, not response (since responses will never contain non-response fields)
2. Determine if formField exists but not yet responded to - if so create a synthetic responseV4 with empty value
3. Include headers in augmented response v4

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots
| Item | **BEFORE** | **AFTER** |
| --- | ----- | ----- |
| Headers, unaswered questions 
<img width="707" height="787" alt="image" src="https://github.com/user-attachments/assets/1a6d5ba3-9ff7-46e7-89c8-b001feb08af5" /> | <img width="572" height="441" alt="image" src="https://github.com/user-attachments/assets/d5623b5e-f6ba-4b5a-9b48-069b107120cc" /> | <img width="971" height="709" alt="image" src="https://github.com/user-attachments/assets/035722d8-9434-4cf2-a3ef-a9bdd341bb5d" /> |

## Tests

TC1: Verify unanswered and headers behaviour on IndividualResponsePage
- [ ] Create an MRF form with 2 basic text fields (make 1 optional), 1 header field, 1 section/image field
- [ ] Make a submissions of the form, leave optional field blank
- [ ] Visit the IndividualResponsePage and observe that
   - [ ] Responses are numbered matching the questions on the form
   - [ ] Unanswered text field shows a question without an answer
   - [ ] Headers are included, but not numbered

TC2: Verify download csv responses (regression)
-  [ ] Download responses into CSV with PDF attachment
-  [ ] Verify that CSV columns correspond with all response-related fields, and optional field is not answered
-  [ ] Verify that PDF shows optional field unanswered & presence of headers
