### PR TITLE
fix(backend): update sso integration behavior

### DIFF
--- a/apps/backend/src/app/config/features/sso.config.ts
+++ b/apps/backend/src/app/config/features/sso.config.ts
@@ -11,8 +11,7 @@ convict.addFormat(url)
 
 export const optionalValuesFromSsm: Path<ISsoVarsSchema>[] = [] //['hostname']
 
-// Placeholder defaults used when SSO env vars are not provided. Referenced by
-// both the schema below and isSsoConfigured() so the two cannot drift apart.
+// RATIONALE: shared between the schema and isSsoConfigured() so they can't drift.
 const SSO_PLACEHOLDER_CLIENT_ID = 'client-id'
 const SSO_PLACEHOLDER_CLIENT_SECRET = 'test'
 
@@ -38,22 +37,16 @@ export const ssoVarsSchema: Schema<ISsoVarsSchema> = {
   },
 }
 
-// Load SSO configuration. All vars have schema defaults, so missing env vars
-// do not throw at startup; isSsoConfigured() reports at runtime whether the
-// loaded values are usable.
+// RATIONALE: every var has a default so missing env doesn't throw at startup;
+// isSsoConfigured() decides at runtime whether values are usable.
 const ssoConfig = convict(ssoVarsSchema)
 resetToApplicationDefaultForUndefinedSsmValues(ssoConfig, optionalValuesFromSsm)
 
 export const sso = ssoConfig.validate({ allowed: 'strict' }).getProperties()
 
-/**
- * Validates if the SSO configuration is properly set up.
- * Checks if the discovery URL is valid and environment variables are not default/placeholder values.
- */
 export const isSsoConfigured = (config: ISsoVarsSchema): boolean => {
   const { discoveryUrl, clientId, clientSecret } = config
 
-  // Check if environment variables are blank or default values
   if (
     !discoveryUrl ||
     !clientId ||
@@ -76,7 +69,6 @@ export const isSsoConfigured = (config: ISsoVarsSchema): boolean => {
     return false
   }
 
-  // Validate that discoveryUrl is a valid URL
   try {
     new URL(discoveryUrl)
   } catch (error) {

--- a/apps/backend/src/app/config/features/sso.config.ts
+++ b/apps/backend/src/app/config/features/sso.config.ts
@@ -2,7 +2,10 @@ import convict, { Path, Schema } from 'convict'
 import { url } from 'convict-format-with-validator'
 
 import { ISsoVarsSchema } from '../../../types'
+import { createLoggerWithLabel } from '../logger'
 import { resetToApplicationDefaultForUndefinedSsmValues } from '../schema'
+
+const logger = createLoggerWithLabel(module)
 
 convict.addFormat(url)
 
@@ -36,3 +39,53 @@ const ssoConfig = convict(ssoVarsSchema)
 resetToApplicationDefaultForUndefinedSsmValues(ssoConfig, optionalValuesFromSsm)
 
 export const sso = ssoConfig.validate({ allowed: 'strict' }).getProperties()
+
+/**
+ * Validates if the SSO configuration is properly set up.
+ * Checks if the discovery URL is valid and environment variables are not default/placeholder values.
+ */
+export const isSsoConfigured = (): boolean => {
+  const { discoveryUrl, clientId, clientSecret } = sso
+
+  // Check if environment variables are blank or default values
+  if (
+    !discoveryUrl ||
+    !clientId ||
+    !clientSecret ||
+    clientId === 'client-id' ||
+    clientSecret === 'test'
+  ) {
+    logger.warn({
+      message:
+        'SSO configuration is incomplete. SSO login will be disabled. Using default Email OTP authentication.',
+      meta: {
+        action: 'isSsoConfigured',
+        hasDiscoveryUrl: !!discoveryUrl,
+        hasClientId: !!clientId,
+        hasClientSecret: !!clientSecret,
+        isDefaultClientId: clientId === 'client-id',
+        isDefaultClientSecret: clientSecret === 'test',
+      },
+    })
+    return false
+  }
+
+  // Validate that discoveryUrl is a valid URL
+  try {
+    new URL(discoveryUrl)
+  } catch (error) {
+    logger.error({
+      message:
+        'SSO_DISCOVERY_URL is not a valid URL. SSO login will be disabled. Using default Email OTP authentication.',
+      meta: {
+        action: 'isSsoConfigured',
+        discoveryUrl,
+        error,
+      },
+      error,
+    })
+    return false
+  }
+
+  return true
+}

--- a/apps/backend/src/app/config/features/sso.config.ts
+++ b/apps/backend/src/app/config/features/sso.config.ts
@@ -11,6 +11,11 @@ convict.addFormat(url)
 
 export const optionalValuesFromSsm: Path<ISsoVarsSchema>[] = [] //['hostname']
 
+// Placeholder defaults used when SSO env vars are not provided. Referenced by
+// both the schema below and isSsoConfigured() so the two cannot drift apart.
+const SSO_PLACEHOLDER_CLIENT_ID = 'client-id'
+const SSO_PLACEHOLDER_CLIENT_SECRET = 'test'
+
 export const ssoVarsSchema: Schema<ISsoVarsSchema> = {
   discoveryUrl: {
     doc: 'The discovery URL for the SSO service',
@@ -22,19 +27,20 @@ export const ssoVarsSchema: Schema<ISsoVarsSchema> = {
   clientId: {
     doc: 'The client id registered with SSO',
     format: String,
-    default: 'client-id',
+    default: SSO_PLACEHOLDER_CLIENT_ID,
     env: 'SSO_CLIENT_ID',
   },
   clientSecret: {
     doc: 'The client secret for the SSO service',
     format: String,
-    default: 'test',
+    default: SSO_PLACEHOLDER_CLIENT_SECRET,
     env: 'SSO_CLIENT_SECRET',
   },
 }
 
-// Load and validate sgid configuration values
-// If environment variables are not present, an error will be thrown
+// Load SSO configuration. All vars have schema defaults, so missing env vars
+// do not throw at startup; isSsoConfigured() reports at runtime whether the
+// loaded values are usable.
 const ssoConfig = convict(ssoVarsSchema)
 resetToApplicationDefaultForUndefinedSsmValues(ssoConfig, optionalValuesFromSsm)
 
@@ -44,16 +50,16 @@ export const sso = ssoConfig.validate({ allowed: 'strict' }).getProperties()
  * Validates if the SSO configuration is properly set up.
  * Checks if the discovery URL is valid and environment variables are not default/placeholder values.
  */
-export const isSsoConfigured = (): boolean => {
-  const { discoveryUrl, clientId, clientSecret } = sso
+export const isSsoConfigured = (config: ISsoVarsSchema): boolean => {
+  const { discoveryUrl, clientId, clientSecret } = config
 
   // Check if environment variables are blank or default values
   if (
     !discoveryUrl ||
     !clientId ||
     !clientSecret ||
-    clientId === 'client-id' ||
-    clientSecret === 'test'
+    clientId === SSO_PLACEHOLDER_CLIENT_ID ||
+    clientSecret === SSO_PLACEHOLDER_CLIENT_SECRET
   ) {
     logger.warn({
       message:
@@ -63,8 +69,8 @@ export const isSsoConfigured = (): boolean => {
         hasDiscoveryUrl: !!discoveryUrl,
         hasClientId: !!clientId,
         hasClientSecret: !!clientSecret,
-        isDefaultClientId: clientId === 'client-id',
-        isDefaultClientSecret: clientSecret === 'test',
+        isDefaultClientId: clientId === SSO_PLACEHOLDER_CLIENT_ID,
+        isDefaultClientSecret: clientSecret === SSO_PLACEHOLDER_CLIENT_SECRET,
       },
     })
     return false

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.spec.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.spec.ts
@@ -1,0 +1,98 @@
+import * as oidcClient from 'openid-client'
+
+import { ISsoVarsSchema } from 'src/types'
+
+import { SsoCreateRedirectUrlError } from './auth-sso.errors'
+import { AuthSsoServiceClass } from './auth-sso.service'
+
+// Silence logger output during tests
+jest.mock('src/app/config/logger', () => ({
+  createLoggerWithLabel: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}))
+
+const mockDiscovery = jest.mocked(oidcClient.discovery)
+
+const VALID_CONFIG: ISsoVarsSchema = {
+  discoveryUrl: 'https://sso.example.com/.well-known/openid-configuration',
+  clientId: 'real-client-id',
+  clientSecret: 'real-secret',
+}
+
+// Mirrors the placeholder defaults in sso.config.ts. Kept inline so a future
+// drift between schema defaults and the placeholder check is caught here.
+const PLACEHOLDER_CONFIG: ISsoVarsSchema = {
+  discoveryUrl: 'https://sso.example.com/.well-known/openid-configuration',
+  clientId: 'client-id',
+  clientSecret: 'test',
+}
+
+describe('AuthSsoServiceClass', () => {
+  beforeEach(() => {
+    mockDiscovery.mockReset()
+  })
+
+  describe('getClientConfigResult — misconfigured SSO', () => {
+    it('short-circuits to errAsync without calling discovery', async () => {
+      const svc = new AuthSsoServiceClass(PLACEHOLDER_CONFIG)
+
+      const result = await svc.getClientConfigResult()
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        SsoCreateRedirectUrlError,
+      )
+      expect(mockDiscovery).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getClientConfigResult — discovery retry cooldown', () => {
+    // Stub Date.now so we can advance time without touching real timers.
+    let fakeNow: number
+    let nowSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      fakeNow = 1_700_000_000_000
+      nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => fakeNow)
+    })
+
+    afterEach(() => {
+      nowSpy.mockRestore()
+    })
+
+    it('reuses the cached rejected promise within the cooldown window', async () => {
+      mockDiscovery.mockRejectedValue(new Error('discovery boom'))
+      const svc = new AuthSsoServiceClass(VALID_CONFIG)
+
+      const r1 = await svc.getClientConfigResult()
+      expect(r1.isErr()).toBe(true)
+      expect(mockDiscovery).toHaveBeenCalledTimes(1)
+
+      // Within cooldown (60s default): cached rejection should be reused.
+      fakeNow += 30_000
+
+      const r2 = await svc.getClientConfigResult()
+      expect(r2.isErr()).toBe(true)
+      expect(mockDiscovery).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries discovery after the cooldown elapses', async () => {
+      mockDiscovery.mockRejectedValue(new Error('discovery boom'))
+      const svc = new AuthSsoServiceClass(VALID_CONFIG)
+
+      const r1 = await svc.getClientConfigResult()
+      expect(r1.isErr()).toBe(true)
+      expect(mockDiscovery).toHaveBeenCalledTimes(1)
+
+      // Past cooldown (60s default): a fresh discovery attempt should be made.
+      fakeNow += 61_000
+
+      const r2 = await svc.getClientConfigResult()
+      expect(r2.isErr()).toBe(true)
+      expect(mockDiscovery).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -67,7 +67,7 @@ export class AuthSsoServiceClass {
               'Error while discovering SSO client configuration from upstream service. SSO login is unavailable.',
             error,
           })
-          // Return a rejected promise to avoid throwing in catch handler
+          // Return rejected promise to satisfy typesafe/no-throw-sync-func linter rule
           return Promise.reject(
             new SsoCreateRedirectUrlError(
               'SSO service discovery failed. Please try again later.',
@@ -118,7 +118,15 @@ export class AuthSsoServiceClass {
     // Initialize the client config if not already done
     this.initializeClientConfig()
 
-    if (!this.clientConfigPromise) {
+    // TypeScript doesn't know that initializeClientConfig always sets clientConfigPromise,
+    // so we need to check for it explicitly
+    const configPromise = this.clientConfigPromise
+    if (!configPromise) {
+      // This should never happen, but handle it gracefully
+      logger.error({
+        message: 'SSO client configuration promise was not initialized',
+        meta: logMeta,
+      })
       return errAsync(
         new SsoCreateRedirectUrlError(
           'SSO service initialization failed. Please try again later.',
@@ -126,7 +134,7 @@ export class AuthSsoServiceClass {
       )
     }
 
-    return ResultAsync.fromPromise(this.clientConfigPromise, (error) => {
+    return ResultAsync.fromPromise(configPromise, (error) => {
       logger.error({
         message:
           'Error while retrieving SSO client configuration. SSO service may be unavailable.',

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -15,9 +15,8 @@ const logger = createLoggerWithLabel(module)
 export const SSO_LOGIN_OAUTH_STATE = 'ssoLogin'
 
 export class AuthSsoServiceClass {
-  // Cooldown between discovery retries after a failure, so a transient
-  // upstream outage doesn't permanently disable SSO until process restart
-  // but we also don't hammer the discovery endpoint on every request.
+  // RATIONALE: bound retries so a transient outage doesn't disable SSO until
+  // restart, without hammering the discovery endpoint on every request.
   private static readonly DISCOVERY_RETRY_INTERVAL_MS = 60_000
 
   private clientConfigPromise: Promise<oidcClient.Configuration> | null = null
@@ -31,10 +30,8 @@ export class AuthSsoServiceClass {
   }
 
   /**
-   * Initializes the OIDC client configuration by performing discovery.
-   * This is done lazily to prevent startup crashes if the discovery URL is unreachable.
-   * On failure, the cached rejected promise is reused for DISCOVERY_RETRY_INTERVAL_MS
-   * and then discarded so the next request re-attempts discovery.
+   * RATIONALE: discover lazily so an unreachable URL doesn't crash startup;
+   * cache failures for DISCOVERY_RETRY_INTERVAL_MS before retrying.
    */
   private initializeClientConfig(): void {
     if (this.clientConfigPromise) {
@@ -45,7 +42,6 @@ export class AuthSsoServiceClass {
       if (this.discoveryFailedAt === null || recentlyFailed) {
         return
       }
-      // Cooldown elapsed: discard the stale rejected promise and try again.
       this.clientConfigPromise = null
       this.discoveryFailedAt = null
     }
@@ -85,9 +81,8 @@ export class AuthSsoServiceClass {
             error,
           })
           this.discoveryFailedAt = Date.now()
-          // Return rejected promise to satisfy typesafe/no-throw-sync-func linter rule.
-          // This rejected promise is safe - it's stored in clientConfigPromise and only
-          // accessed via ResultAsync.fromPromise() which properly handles rejections.
+          // RATIONALE: reject (not throw) to satisfy typesafe/no-throw-sync-func;
+          // consumed via ResultAsync.fromPromise().
           return Promise.reject(
             new SsoCreateRedirectUrlError(
               'SSO service discovery failed. Please try again later.',
@@ -105,7 +100,6 @@ export class AuthSsoServiceClass {
         error,
       })
       this.discoveryFailedAt = Date.now()
-      // Create a rejected promise
       this.clientConfigPromise = Promise.reject(
         new SsoCreateRedirectUrlError(
           'SSO service configuration is invalid. Please try again later.',
@@ -122,7 +116,6 @@ export class AuthSsoServiceClass {
       action: 'getClientConfigResult',
     }
 
-    // Check if SSO is configured before attempting to use it
     if (!this.isConfigured) {
       logger.warn({
         message:
@@ -136,14 +129,11 @@ export class AuthSsoServiceClass {
       )
     }
 
-    // Initialize the client config if not already done
     this.initializeClientConfig()
 
-    // TypeScript doesn't know that initializeClientConfig always sets clientConfigPromise,
-    // so we need to check for it explicitly
+    // RATIONALE: initializeClientConfig always sets this, but TS can't prove it.
     const configPromise = this.clientConfigPromise
     if (!configPromise) {
-      // This should never happen, but handle it gracefully
       logger.error({
         message: 'SSO client configuration promise was not initialized',
         meta: logMeta,

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -27,7 +27,7 @@ export class AuthSsoServiceClass {
 
   constructor(config: ISsoVarsSchema) {
     this.config = config
-    this.isConfigured = isSsoConfigured()
+    this.isConfigured = isSsoConfigured(config)
   }
 
   /**

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -15,7 +15,13 @@ const logger = createLoggerWithLabel(module)
 export const SSO_LOGIN_OAUTH_STATE = 'ssoLogin'
 
 export class AuthSsoServiceClass {
+  // Cooldown between discovery retries after a failure, so a transient
+  // upstream outage doesn't permanently disable SSO until process restart
+  // but we also don't hammer the discovery endpoint on every request.
+  private static readonly DISCOVERY_RETRY_INTERVAL_MS = 60_000
+
   private clientConfigPromise: Promise<oidcClient.Configuration> | null = null
+  private discoveryFailedAt: number | null = null
   private readonly config: ISsoVarsSchema
   private readonly isConfigured: boolean
 
@@ -27,10 +33,21 @@ export class AuthSsoServiceClass {
   /**
    * Initializes the OIDC client configuration by performing discovery.
    * This is done lazily to prevent startup crashes if the discovery URL is unreachable.
+   * On failure, the cached rejected promise is reused for DISCOVERY_RETRY_INTERVAL_MS
+   * and then discarded so the next request re-attempts discovery.
    */
   private initializeClientConfig(): void {
     if (this.clientConfigPromise) {
-      return
+      const recentlyFailed =
+        this.discoveryFailedAt !== null &&
+        Date.now() - this.discoveryFailedAt <
+          AuthSsoServiceClass.DISCOVERY_RETRY_INTERVAL_MS
+      if (this.discoveryFailedAt === null || recentlyFailed) {
+        return
+      }
+      // Cooldown elapsed: discard the stale rejected promise and try again.
+      this.clientConfigPromise = null
+      this.discoveryFailedAt = null
     }
 
     const { discoveryUrl, clientId, clientSecret } = this.config
@@ -67,6 +84,7 @@ export class AuthSsoServiceClass {
               'Error while discovering SSO client configuration from upstream service. SSO login is unavailable.',
             error,
           })
+          this.discoveryFailedAt = Date.now()
           // Return rejected promise to satisfy typesafe/no-throw-sync-func linter rule.
           // This rejected promise is safe - it's stored in clientConfigPromise and only
           // accessed via ResultAsync.fromPromise() which properly handles rejections.
@@ -86,6 +104,7 @@ export class AuthSsoServiceClass {
           'Error while parsing SSO discovery URL. SSO login is unavailable.',
         error,
       })
+      this.discoveryFailedAt = Date.now()
       // Create a rejected promise
       this.clientConfigPromise = Promise.reject(
         new SsoCreateRedirectUrlError(

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -173,7 +173,9 @@ export class AuthSsoServiceClass {
           meta: logMeta,
           error,
         })
-        return new SsoCreateRedirectUrlError()
+        return new SsoCreateRedirectUrlError(
+          'Failed to calculate PKCE code challenge for SSO authentication',
+        )
       },
     )
     return ResultAsync.combine([
@@ -234,7 +236,9 @@ export class AuthSsoServiceClass {
             meta: { ...logMeta, error },
             error,
           })
-          return new SsoCreateRedirectUrlError()
+          return new SsoCreateRedirectUrlError(
+            'Failed to retrieve access token from SSO service',
+          )
         },
       )
     })
@@ -265,7 +269,9 @@ export class AuthSsoServiceClass {
             meta: logMeta,
             error,
           })
-          return new SsoCreateRedirectUrlError()
+          return new SsoCreateRedirectUrlError(
+            'Failed to retrieve user information from SSO service',
+          )
         },
       ).map((userInfo) => {
         logger.info({

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -1,11 +1,11 @@
-import { okAsync, ResultAsync } from 'neverthrow'
+import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { getValidatedIdTokenClaims } from 'oauth4webapi'
 import * as oidcClient from 'openid-client'
 
 import { ISsoVarsSchema } from 'src/types'
 
 import { isDev } from '../../../config/config'
-import { sso } from '../../../config/features/sso.config'
+import { isSsoConfigured, sso } from '../../../config/features/sso.config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { resolveAppUrl } from '../../../utils/urls'
 
@@ -15,13 +15,26 @@ const logger = createLoggerWithLabel(module)
 export const SSO_LOGIN_OAUTH_STATE = 'ssoLogin'
 
 export class AuthSsoServiceClass {
-  private clientConfigPromise: Promise<oidcClient.Configuration>
+  private clientConfigPromise: Promise<oidcClient.Configuration> | null = null
+  private readonly config: ISsoVarsSchema
+  private readonly isConfigured: boolean
 
-  constructor({
-    discoveryUrl: _discoveryUrl,
-    clientId,
-    clientSecret,
-  }: ISsoVarsSchema) {
+  constructor(config: ISsoVarsSchema) {
+    this.config = config
+    this.isConfigured = isSsoConfigured()
+  }
+
+  /**
+   * Initializes the OIDC client configuration by performing discovery.
+   * This is done lazily to prevent startup crashes if the discovery URL is unreachable.
+   */
+  private initializeClientConfig(): void {
+    if (this.clientConfigPromise) {
+      return
+    }
+
+    const { discoveryUrl, clientId, clientSecret } = this.config
+
     const clientAuth: oidcClient.ClientAuth | undefined = clientSecret
       ? oidcClient.ClientSecretPost(clientSecret)
       : undefined
@@ -34,26 +47,46 @@ export class AuthSsoServiceClass {
       clientDiscoveryRequestOptions.execute = [oidcClient.allowInsecureRequests]
     }
 
-    const oidcServer = new URL(_discoveryUrl)
-    this.clientConfigPromise = oidcClient
-      .discovery(
-        oidcServer,
-        clientId,
-        undefined, // clientMetadata,
-        clientAuth,
-        clientDiscoveryRequestOptions,
-      )
-      .catch((error) => {
-        logger.error({
-          meta: {
-            action: 'AuthSsoServiceClass.constructor',
+    try {
+      const oidcServer = new URL(discoveryUrl)
+      this.clientConfigPromise = oidcClient
+        .discovery(
+          oidcServer,
+          clientId,
+          undefined, // clientMetadata,
+          clientAuth,
+          clientDiscoveryRequestOptions,
+        )
+        .catch((error) => {
+          logger.error({
+            meta: {
+              action: 'AuthSsoServiceClass.initializeClientConfig',
+              error,
+            },
+            message:
+              'Error while discovering SSO client configuration from upstream service. SSO login is unavailable.',
             error,
-          },
-          message: 'Error while discovering SSO client configuration',
-          error,
+          })
+          throw new SsoCreateRedirectUrlError(
+            'SSO service discovery failed. Please try again later.',
+          )
         })
-        throw new SsoCreateRedirectUrlError()
+    } catch (error) {
+      logger.error({
+        meta: {
+          action: 'AuthSsoServiceClass.initializeClientConfig',
+          error,
+        },
+        message: 'Error while parsing SSO discovery URL. SSO login is unavailable.',
+        error,
       })
+      // Create a rejected promise
+      this.clientConfigPromise = Promise.reject(
+        new SsoCreateRedirectUrlError(
+          'SSO service configuration is invalid. Please try again later.',
+        ),
+      )
+    }
   }
 
   getClientConfigResult(): ResultAsync<
@@ -63,13 +96,42 @@ export class AuthSsoServiceClass {
     const logMeta = {
       action: 'getClientConfigResult',
     }
+
+    // Check if SSO is configured before attempting to use it
+    if (!this.isConfigured) {
+      logger.warn({
+        message:
+          'SSO is not properly configured. Cannot retrieve client configuration.',
+        meta: logMeta,
+      })
+      return errAsync(
+        new SsoCreateRedirectUrlError(
+          'SSO service is not configured. Please use Email OTP login.',
+        ),
+      )
+    }
+
+    // Initialize the client config if not already done
+    this.initializeClientConfig()
+
+    if (!this.clientConfigPromise) {
+      return errAsync(
+        new SsoCreateRedirectUrlError(
+          'SSO service initialization failed. Please try again later.',
+        ),
+      )
+    }
+
     return ResultAsync.fromPromise(this.clientConfigPromise, (error) => {
       logger.error({
-        message: 'Error while retrieving SSO client configuration',
+        message:
+          'Error while retrieving SSO client configuration. SSO service may be unavailable.',
         meta: logMeta,
         error,
       })
-      return new SsoCreateRedirectUrlError()
+      return new SsoCreateRedirectUrlError(
+        'SSO service is currently unavailable. Please try again later or use Email OTP login.',
+      )
     })
   }
   /**

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -67,8 +67,11 @@ export class AuthSsoServiceClass {
               'Error while discovering SSO client configuration from upstream service. SSO login is unavailable.',
             error,
           })
-          throw new SsoCreateRedirectUrlError(
-            'SSO service discovery failed. Please try again later.',
+          // Return a rejected promise to avoid throwing in catch handler
+          return Promise.reject(
+            new SsoCreateRedirectUrlError(
+              'SSO service discovery failed. Please try again later.',
+            ),
           )
         })
     } catch (error) {
@@ -77,7 +80,8 @@ export class AuthSsoServiceClass {
           action: 'AuthSsoServiceClass.initializeClientConfig',
           error,
         },
-        message: 'Error while parsing SSO discovery URL. SSO login is unavailable.',
+        message:
+          'Error while parsing SSO discovery URL. SSO login is unavailable.',
         error,
       })
       // Create a rejected promise

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -67,7 +67,9 @@ export class AuthSsoServiceClass {
               'Error while discovering SSO client configuration from upstream service. SSO login is unavailable.',
             error,
           })
-          // Return rejected promise to satisfy typesafe/no-throw-sync-func linter rule
+          // Return rejected promise to satisfy typesafe/no-throw-sync-func linter rule.
+          // This rejected promise is safe - it's stored in clientConfigPromise and only
+          // accessed via ResultAsync.fromPromise() which properly handles rejections.
           return Promise.reject(
             new SsoCreateRedirectUrlError(
               'SSO service discovery failed. Please try again later.',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When the SSO discovery URL is not available at container start, the FormSG application may error out.

Previously related to #9029.
Closes FRM-2259.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Improvements**:

- Retry discovery so that SSO can recover without a container restart

**Bug Fixes**:

- Handle the error when SSO_DISCOVERY_URL cannot be loaded
