### PR TITLE
feat(mrf-cutover): webhook v1 schema infobox + introduce mrf cutover and webhookV1StorageForm flags

### DIFF
--- a/apps/backend/src/app/models/__tests__/user.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/user.server.model.spec.ts
@@ -146,6 +146,18 @@ describe('User Model', () => {
         'This email is not a valid agency email',
       )
     })
+
+    it('should persist createStorageModeForV1Webhook beta flag', async () => {
+      const saved = await User.create({
+        email: VALID_USER_EMAIL,
+        agency: agency._id,
+        contact: VALID_CONTACT,
+        betaFlags: { createStorageModeForV1Webhook: true },
+      })
+
+      const user = await User.findById(saved._id).lean()
+      expect(user?.betaFlags?.createStorageModeForV1Webhook).toBe(true)
+    })
   })
 
   describe('Methods', () => {

--- a/apps/backend/src/app/models/user.server.model.ts
+++ b/apps/backend/src/app/models/user.server.model.ts
@@ -84,6 +84,7 @@ const compileUserModel = (db: Mongoose) => {
         respondentCopy: Boolean,
         statusTracker: Boolean,
         signatureField: Boolean,
+        createStorageModeForV1Webhook: Boolean,
       },
       flags: {
         type: Schema.Types.Map, // of SeenFlags

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
@@ -70,6 +70,19 @@ StorageModeRetryEnabled.parameters = {
 
 export const UnsupportedEmailMode = Template.bind({})
 
+export const UnsupportedMultirespondentMode = Template.bind({})
+UnsupportedMultirespondentMode.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Multirespondent,
+        },
+      }),
+    },
+  },
+}
+
 export const Loading = Template.bind({})
 Loading.parameters = {
   msw: { handlers: { default: buildMswRoutes({ delay: 'infinite' }) } },

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -10,6 +10,7 @@ import { useUser } from '~features/user/queries'
 import { CategoryHeader } from './components/CategoryHeader'
 import { WebhooksSection } from './components/WebhooksSection'
 import { WebhooksUnsupportedMsg } from './components/WebhooksSection/WebhooksUnsupportedMsg'
+import { WebhookV1SchemaInfobox } from './components/WebhooksSection/WebhookV1SchemaInfobox'
 import { useAdminFormSettings } from './queries'
 
 export const SettingsWebhooksPage = (): JSX.Element => {
@@ -40,9 +41,12 @@ export const SettingsWebhooksPage = (): JSX.Element => {
     )
   }
 
+  const isStorageMode = settings?.responseMode === FormResponseMode.Encrypt
+
   return (
     <Skeleton isLoaded={!isLoading}>
       <CategoryHeader>Webhooks</CategoryHeader>
+      {isStorageMode && <WebhookV1SchemaInfobox />}
       <WebhooksSection />
     </Skeleton>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookV1SchemaInfobox.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookV1SchemaInfobox.tsx
@@ -1,0 +1,10 @@
+import InlineMessage from '~components/InlineMessage'
+
+export const WebhookV1SchemaInfobox = (): JSX.Element => {
+  return (
+    <InlineMessage variant="info">
+      This form uses webhooks V1, which is outdated. Switch to the latest
+      version of FormSG unless your system requires v1.
+    </InlineMessage>
+  )
+}

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -41,6 +41,7 @@ export const featureFlags = {
   ddSampleRatePublic: 'dd-sample-rate-public' as const,
   answerObjectDecryption: 'answer-object-decryption' as const,
   standardisedEmailTemplate: 'standardised-email-template' as const,
+  mrfCutover: 'mrf-cutover' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {

--- a/packages/shared/types/user.ts
+++ b/packages/shared/types/user.ts
@@ -31,6 +31,7 @@ export const UserBase = z.object({
       statusTracker: z.boolean().optional(),
       signatureField: z.boolean().optional(),
       singpassMrf: z.boolean().optional(),
+      createStorageModeForV1Webhook: z.boolean().optional(),
     })
     .optional(),
   flags: z.record(z.nativeEnum(SeenFlags), z.number()).optional(),


### PR DESCRIPTION
## Problem

Part of the MRF cutover (see PRD): today's default to storage-mode forms quietly puts admins on the legacy v1 webhook schema. This PR ships three plumbing slices toward the cutover — no admin-visible flow changes to the create/dupe/template modals yet. Closes #9450, #9452, #9456.

## Solution

Three independent slices, each behind its own commit:

- **`mrf-cutover` feature flag key** — registers the kill-switch on `featureFlags`. No consumer wired in this PR; flag must also be created in GrowthBook.
- **`createStorageModeForV1Webhook` beta flag** — adds the optional boolean on `UserBase.betaFlags` (zod) and mirrors it on the mongoose user model so it can be granted per-user and read on the frontend via `UserDto`. Granted manually via DB. No new endpoint.
- **Webhook v1 schema infobox** — renders an `info`-variant `InlineMessage` on the webhook settings page when `responseMode === Encrypt`. MRF webhook settings are untouched; a new Storybook story locks the pre-cutover MRF "unavailable" baseline alongside the storage-mode infobox.

Gating remains frontend-only per [ADR-0001](docs/adr/0001-frontend-only-storage-form-gating.md): backend `createForm` still accepts `Encrypt` without flag checks.

**Screenshots**

| Page | Before | After |
| --- | --- | --- |
| Storage-mode webhook settings | ![before](https://github.com/user-attachments/assets/60348749-79b1-4963-a7b8-b02c04f62d17) | ![after](https://github.com/user-attachments/assets/f1aefb6c-2ee4-47c8-b910-6d5873617c06) |
| MRF webhook settings (story new on this branch) | _n/a_ | ![after](https://github.com/user-attachments/assets/175c2869-6dba-4f6f-9465-9147160493b0) |

**Breaking Changes**

No - backwards compatible. New fields are optional; no existing consumer reads them.

## Tests

**TC1: Storage-mode webhook settings show v1 infobox**

- [ ] Open the webhook settings page of a storage-mode (Encrypt) form
- [ ] Confirm the v1 schema infobox renders above the webhooks section
- [ ] Confirm copy matches Figma

**TC2: MRF webhook settings unchanged**

- [ ] Open the webhook settings page of a Multirespondent form
- [ ] Confirm the existing "unavailable" message renders, with no infobox above it

**TC3: Beta flag round-trips**

- [ ] In the DB, set `betaFlags.createStorageModeForV1Webhook = true` on a test user
- [ ] Log in as that user and confirm the flag is present on the `/user` payload
