### PR TITLE
feat(mrf-cutover): foundation — beta flag, feature flag key, escape-hatch copy composer (1/6)

### DIFF
--- a/apps/backend/src/app/models/__tests__/user.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/user.server.model.spec.ts
@@ -146,6 +146,18 @@ describe('User Model', () => {
         'This email is not a valid agency email',
       )
     })
+
+    it('should persist createStorageModeForV1Webhook beta flag', async () => {
+      const saved = await User.create({
+        email: VALID_USER_EMAIL,
+        agency: agency._id,
+        contact: VALID_CONTACT,
+        betaFlags: { createStorageModeForV1Webhook: true },
+      })
+
+      const user = await User.findById(saved._id).lean()
+      expect(user?.betaFlags?.createStorageModeForV1Webhook).toBe(true)
+    })
   })
 
   describe('Methods', () => {

--- a/apps/backend/src/app/models/user.server.model.ts
+++ b/apps/backend/src/app/models/user.server.model.ts
@@ -84,6 +84,7 @@ const compileUserModel = (db: Mongoose) => {
         respondentCopy: Boolean,
         statusTracker: Boolean,
         signatureField: Boolean,
+        createStorageModeForV1Webhook: Boolean,
       },
       flags: {
         type: Schema.Types.Map, // of SeenFlags

--- a/apps/frontend/src/utils/__tests__/escapeHatchCopy.test.ts
+++ b/apps/frontend/src/utils/__tests__/escapeHatchCopy.test.ts
@@ -1,0 +1,41 @@
+import { composeEscapeHatchCopy } from '../escapeHatchCopy'
+
+describe('composeEscapeHatchCopy', () => {
+  it('returns payments-only copy when no extra flags are set', () => {
+    expect(composeEscapeHatchCopy()).toEqual({
+      prefix: 'Need payments? Use the ',
+      linkText: 'old version of FormSG',
+      suffix: '.',
+    })
+  })
+
+  it('mentions MyInfo children fields when children flag is set', () => {
+    expect(composeEscapeHatchCopy({ children: true }).prefix).toBe(
+      'Need payments or MyInfo children fields? Use the ',
+    )
+  })
+
+  it('mentions webhooks v1 when createStorageModeForV1Webhook flag is set', () => {
+    expect(
+      composeEscapeHatchCopy({ createStorageModeForV1Webhook: true }).prefix,
+    ).toBe('Need payments or webhooks v1? Use the ')
+  })
+
+  it('composes all reasons when both flags are set', () => {
+    expect(
+      composeEscapeHatchCopy({
+        children: true,
+        createStorageModeForV1Webhook: true,
+      }).prefix,
+    ).toBe('Need payments, MyInfo children fields, or webhooks v1? Use the ')
+  })
+
+  it('ignores unrelated falsy flags', () => {
+    expect(
+      composeEscapeHatchCopy({
+        children: false,
+        createStorageModeForV1Webhook: false,
+      }).prefix,
+    ).toBe('Need payments? Use the ')
+  })
+})

--- a/apps/frontend/src/utils/escapeHatchCopy.ts
+++ b/apps/frontend/src/utils/escapeHatchCopy.ts
@@ -1,0 +1,34 @@
+type EscapeHatchBetaFlags = {
+  children?: boolean
+  createStorageModeForV1Webhook?: boolean
+}
+
+export type EscapeHatchCopy = {
+  prefix: string
+  linkText: string
+  suffix: string
+}
+
+const LINK_TEXT = 'old version of FormSG'
+const SUFFIX = '.'
+
+export const composeEscapeHatchCopy = (
+  betaFlags?: EscapeHatchBetaFlags,
+): EscapeHatchCopy => {
+  const reasons: string[] = ['payments']
+  if (betaFlags?.children) reasons.push('MyInfo children fields')
+  if (betaFlags?.createStorageModeForV1Webhook) reasons.push('webhooks v1')
+
+  const reasonsString =
+    reasons.length === 1
+      ? reasons[0]
+      : reasons.length === 2
+        ? `${reasons[0]} or ${reasons[1]}`
+        : `${reasons.slice(0, -1).join(', ')}, or ${reasons[reasons.length - 1]}`
+
+  return {
+    prefix: `Need ${reasonsString}? Use the `,
+    linkText: LINK_TEXT,
+    suffix: SUFFIX,
+  }
+}

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -41,6 +41,7 @@ export const featureFlags = {
   ddSampleRatePublic: 'dd-sample-rate-public' as const,
   answerObjectDecryption: 'answer-object-decryption' as const,
   standardisedEmailTemplate: 'standardised-email-template' as const,
+  mrfCutover: 'mrf-cutover' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {

--- a/packages/shared/types/user.ts
+++ b/packages/shared/types/user.ts
@@ -31,6 +31,7 @@ export const UserBase = z.object({
       statusTracker: z.boolean().optional(),
       signatureField: z.boolean().optional(),
       singpassMrf: z.boolean().optional(),
+      createStorageModeForV1Webhook: z.boolean().optional(),
     })
     .optional(),
   flags: z.record(z.nativeEnum(SeenFlags), z.number()).optional(),


### PR DESCRIPTION
> Stacked PR 1/6 for MRF cutover (decomposition of #9457). Merge in order.

## Problem

Forms default to storage mode today, slowing org-wide migration to MRF and leaving admins on the legacy v1 webhook schema by default. Cutover work needs (a) a per-admin escape-hatch grant for v1 webhook users, (b) a feature flag to gate the cutover, and (c) a shared composer for the escape-hatch copy.

## Solution

Foundation-only changes used by branches 2–6. No user-visible behavior changes yet.

- New beta flag `createStorageModeForV1Webhook` on `UserBase.betaFlags` (zod) + mongoose user model. Granted manually via DB; flows through `UserDto` on next login.
- New feature flag key `mrf-cutover` registered in `packages/shared/constants/feature-flags.ts`.
- Pure `escapeHatchCopy` composer in `apps/frontend/src/utils/` — takes `betaFlags`, returns the composed line for modals (payments always, +children, +webhook v1). Tested.

**Breaking Changes**

No - backwards compatible. Backend `createForm` still accepts `Encrypt` without flag checks (see `docs/adr/0001-frontend-only-storage-form-gating.md`).

## Tests

**TC1: beta flag round-trips**

- [ ] Grant `createStorageModeForV1Webhook=true` to a test user in DB
- [ ] Log in; confirm `UserDto.betaFlags.createStorageModeForV1Webhook === true` in network response
