### PR TITLE
feat(mrf-cutover): webhook v1 schema infobox on storage-mode settings (3/6)

### DIFF
--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
@@ -1,5 +1,7 @@
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { Meta, StoryFn } from '@storybook/react'
 
+import { featureFlags } from 'formsg-shared/constants'
 import { FormResponseMode, FormSettings } from 'formsg-shared/types/form'
 
 import {
@@ -40,6 +42,30 @@ export default {
 const Template: StoryFn = () => <SettingsWebhooksPage />
 export const StorageModeEmpty = Template.bind({})
 StorageModeEmpty.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Encrypt,
+        },
+      }),
+    },
+  },
+}
+
+const mrfCutoverOnGrowthBook = new GrowthBook({
+  features: { [featureFlags.mrfCutover]: { defaultValue: true } },
+})
+
+export const StorageModeMrfCutoverOn = Template.bind({})
+StorageModeMrfCutoverOn.decorators = [
+  (Story) => (
+    <GrowthBookProvider growthbook={mrfCutoverOnGrowthBook}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+StorageModeMrfCutoverOn.parameters = {
   msw: {
     handlers: {
       default: buildMswRoutes({

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
@@ -70,6 +70,19 @@ StorageModeRetryEnabled.parameters = {
 
 export const UnsupportedEmailMode = Template.bind({})
 
+export const UnsupportedMultirespondentMode = Template.bind({})
+UnsupportedMultirespondentMode.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Multirespondent,
+        },
+      }),
+    },
+  },
+}
+
 export const Loading = Template.bind({})
 Loading.parameters = {
   msw: { handlers: { default: buildMswRoutes({ delay: 'infinite' }) } },

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
 import { Skeleton } from '@chakra-ui/react'
 import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from 'formsg-shared/constants'
 import { FormResponseMode } from 'formsg-shared/types/form'
+import { FormId } from 'formsg-shared/types/form/form'
 
 import { useUser } from '~features/user/queries'
 
@@ -26,7 +28,9 @@ export const SettingsWebhooksPage = (): JSX.Element => {
     })
   }, [userRes.user?.email, gb])
 
+  const { formId } = useParams()
   const enableMrfWebhooks = useFeatureIsOn(featureFlags.enableMrfWebhooks)
+  const isMrfCutoverEnabled = useFeatureIsOn(featureFlags.mrfCutover)
 
   const enableWebhooks =
     !isLoading &&
@@ -43,14 +47,19 @@ export const SettingsWebhooksPage = (): JSX.Element => {
     )
   }
 
-  const isStorageMode = settings?.responseMode === FormResponseMode.Encrypt
+  const showV1SchemaInfobox =
+    isMrfCutoverEnabled &&
+    settings?.responseMode === FormResponseMode.Encrypt &&
+    !!formId
 
   return (
     <Skeleton isLoaded={!isLoading}>
       <CategoryHeader>
         {t('features.adminForm.settings.webhooks.title')}
       </CategoryHeader>
-      {isStorageMode && <WebhookV1SchemaInfobox />}
+      {showV1SchemaInfobox && (
+        <WebhookV1SchemaInfobox formId={formId as FormId} />
+      )}
       <WebhooksSection />
     </Skeleton>
   )

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -11,6 +11,7 @@ import { useUser } from '~features/user/queries'
 import { CategoryHeader } from './components/CategoryHeader'
 import { WebhooksSection } from './components/WebhooksSection'
 import { WebhooksUnsupportedMsg } from './components/WebhooksSection/WebhooksUnsupportedMsg'
+import { WebhookV1SchemaInfobox } from './components/WebhooksSection/WebhookV1SchemaInfobox'
 import { useAdminFormSettings } from './queries'
 
 export const SettingsWebhooksPage = (): JSX.Element => {
@@ -42,11 +43,14 @@ export const SettingsWebhooksPage = (): JSX.Element => {
     )
   }
 
+  const isStorageMode = settings?.responseMode === FormResponseMode.Encrypt
+
   return (
     <Skeleton isLoaded={!isLoading}>
       <CategoryHeader>
         {t('features.adminForm.settings.webhooks.title')}
       </CategoryHeader>
+      {isStorageMode && <WebhookV1SchemaInfobox />}
       <WebhooksSection />
     </Skeleton>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookV1SchemaInfobox.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookV1SchemaInfobox.tsx
@@ -1,0 +1,10 @@
+import InlineMessage from '~components/InlineMessage'
+
+export const WebhookV1SchemaInfobox = (): JSX.Element => {
+  return (
+    <InlineMessage variant="info">
+      This form uses webhooks V1, which is outdated. Switch to the latest
+      version of FormSG unless your system requires v1.
+    </InlineMessage>
+  )
+}

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookV1SchemaInfobox.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookV1SchemaInfobox.tsx
@@ -1,10 +1,37 @@
-import InlineMessage from '~components/InlineMessage'
+import { Text, useDisclosure } from '@chakra-ui/react'
 
-export const WebhookV1SchemaInfobox = (): JSX.Element => {
+import { FormId } from 'formsg-shared/types/form/form'
+
+import InlineMessage from '~components/InlineMessage'
+import Link from '~components/Link'
+
+import { DuplicateFormModal } from '~features/workspace/components/DuplicateFormModal'
+
+interface WebhookV1SchemaInfoboxProps {
+  formId: FormId
+}
+
+export const WebhookV1SchemaInfobox = ({
+  formId,
+}: WebhookV1SchemaInfoboxProps): JSX.Element => {
+  const dupeModal = useDisclosure()
+
   return (
-    <InlineMessage variant="info">
-      This form uses webhooks V1, which is outdated. Switch to the latest
-      version of FormSG unless your system requires v1.
-    </InlineMessage>
+    <>
+      <InlineMessage variant="info">
+        <Text>
+          This form uses webhooks V1, which is outdated. Switch to the{' '}
+          <Link cursor="pointer" onClick={dupeModal.onOpen}>
+            latest version of FormSG
+          </Link>{' '}
+          unless your system requires v1.
+        </Text>
+      </InlineMessage>
+      <DuplicateFormModal
+        isOpen={dupeModal.isOpen}
+        onClose={dupeModal.onClose}
+        formIdToDuplicate={formId}
+      />
+    </>
   )
 }


### PR DESCRIPTION
> Stacked PR 3/6 for MRF cutover. Base: `refactor/modal-cutover-prep`.

## Problem

Storage-mode forms emit the legacy v1 webhook schema, but the webhook settings page does not surface this — admins discover it only by inspecting payloads. MRF webhook support is not shipped yet.

Closes #9452.

## Solution

- New `WebhookV1SchemaInfobox` rendered on the webhook settings page when `responseMode === Encrypt`. Copy from Figma.
- Settings page gated on `mrf-cutover` feature flag, with migration CTA opening the Duplicate Form modal prefilled with the current form (uses the `formIdToDuplicate` prop introduced in PR 2/6).
- Storybook story for the MRF "unavailable" state (untouched behaviour, snapshot pinned).

MRF webhook settings are intentionally left as-is — a v4 schema infobox will land when MRF webhooks ship.

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: storage-mode webhook page shows v1 infobox**

- [ ] Open webhook settings on a storage-mode form with `mrf-cutover` flag enabled
- [ ] Confirm v1 schema infobox renders with migration CTA

**TC2: migration CTA opens duplicate flow**

- [ ] Click the "latest version of FormSG" link in the infobox
- [ ] Confirm the Duplicate Form modal opens prefilled with the current form

**TC3: MRF webhook page unchanged**

- [ ] Open webhook settings on an MRF
- [ ] Confirm existing "unavailable" message renders; no v1 infobox
