### PR TITLE
refactor(mrf-cutover): lift wizard navigation + pass source as prop (3/6)

### DIFF
--- a/apps/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/apps/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -20,6 +20,8 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 
+import { FormId } from 'formsg-shared/types/form/form'
+
 import { FORMSG_UAT } from '~constants/links'
 import { ADMINFORM_ROUTE, DASHBOARD_ROUTE } from '~constants/routes'
 import Button, { ButtonProps } from '~components/Button'
@@ -166,7 +168,11 @@ export const PreviewFormBanner = ({
             onClose={onModalClose}
           />
         ) : (
-          <DuplicateFormModal isOpen={isModalOpen} onClose={onModalClose} />
+          <DuplicateFormModal
+            isOpen={isModalOpen}
+            onClose={onModalClose}
+            formIdToDuplicate={formId as FormId}
+          />
         )}
         <Drawer
           placement="bottom"

--- a/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -32,8 +32,16 @@ export const useUseTemplateWizardContext = (
     (field) => field.fieldType === 'children',
   )
 
-  const { formMethods, currentStep, direction, keypair, setCurrentStep } =
-    useCommonFormWizardProvider()
+  const {
+    formMethods,
+    currentStep,
+    direction,
+    keypair,
+    setCurrentStep,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
+  } = useCommonFormWizardProvider()
 
   const { reset, getValues } = formMethods
 
@@ -168,6 +176,9 @@ export const useUseTemplateWizardContext = (
     hasMyInfoChildren,
     modalHeader: t('features.workspace.modals.forms.create.title.duplicate'),
     onClose,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
   }
 }
 

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -23,7 +23,6 @@ import Input from '~components/Input'
 
 import DataClassificationInfoBox from '~features/admin-form/settings/components/DataClassificationInfoBox'
 
-import { WorkspaceRowsProvider } from '../../WorkspaceFormRow/WorkspaceRowsContext'
 import {
   CreateFormWizardInputProps,
   useCreateFormWizard,
@@ -127,13 +126,11 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
                 name="responseMode"
                 control={control}
                 render={({ field }) => (
-                  <WorkspaceRowsProvider>
-                    <FormResponseOptions
-                      {...field}
-                      hasMyInfoChildren={hasMyInfoChildren}
-                      handleEmailButtonPress={handleEmailButtonPress}
-                    />
-                  </WorkspaceRowsProvider>
+                  <FormResponseOptions
+                    {...field}
+                    hasMyInfoChildren={hasMyInfoChildren}
+                    handleEmailButtonPress={handleEmailButtonPress}
+                  />
                 )}
                 rules={{
                   required: t(

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -14,6 +14,7 @@ import { CheckboxFieldValues } from '~templates/Field'
 export enum CreateFormFlowStates {
   Landing = 'landing',
   Details = 'details',
+  StorageModeDetails = 'storageModeDetails',
   EmailFeedback = 'emailFeedback',
   EmailModeCreation = 'emailModeCreation',
 }
@@ -48,6 +49,9 @@ export type CreateFormWizardContextReturn = {
   isSingpass: boolean
   hasMyInfoChildren: boolean
   onClose: () => void
+  isMrfCutoverEnabled: boolean
+  goToStorageModeDetails: () => void
+  goToMrfDetails: () => void
 }
 
 export const CreateFormWizardContext = createContext<

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -2,7 +2,9 @@
 import { useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
 
+import { featureFlags } from 'formsg-shared/constants'
 import { FormResponseMode, PublicFormViewDto } from 'formsg-shared/types'
 
 import formsgSdk from '~utils/formSdk'
@@ -33,6 +35,7 @@ interface UseCommonFormWizardProviderProps {
 export const useCommonFormWizardProvider = ({
   defaultValues,
 }: UseCommonFormWizardProviderProps = {}) => {
+  const isMrfCutoverEnabled = useFeatureIsOn(featureFlags.mrfCutover)
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)
 
@@ -43,8 +46,24 @@ export const useCommonFormWizardProvider = ({
   const keypair = useMemo(() => formsgSdk.crypto.generate(), [])
 
   const formMethods = useForm<CreateFormWizardInputProps>({
-    defaultValues,
+    defaultValues: {
+      ...defaultValues,
+      ...(isMrfCutoverEnabled
+        ? { responseMode: FormResponseMode.Multirespondent }
+        : {}),
+    },
   })
+
+  const { setValue } = formMethods
+
+  const goToStorageModeDetails = () => {
+    setValue('responseMode', FormResponseMode.Encrypt)
+    setCurrentStep([CreateFormFlowStates.StorageModeDetails, 1])
+  }
+  const goToMrfDetails = () => {
+    setValue('responseMode', FormResponseMode.Multirespondent)
+    setCurrentStep([CreateFormFlowStates.Details, -1])
+  }
 
   return {
     formMethods,
@@ -52,6 +71,9 @@ export const useCommonFormWizardProvider = ({
     currentStep,
     direction,
     setCurrentStep,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
   }
 }
 
@@ -59,12 +81,20 @@ const useCreateFormWizardContext = (
   onClose: () => void,
 ): CreateFormWizardContextReturn => {
   const { t } = useTranslation()
-  const { formMethods, currentStep, direction, keypair, setCurrentStep } =
-    useCommonFormWizardProvider({
-      defaultValues: {
-        responseMode: FormResponseMode.Encrypt,
-      },
-    })
+  const {
+    formMethods,
+    currentStep,
+    direction,
+    keypair,
+    setCurrentStep,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
+  } = useCommonFormWizardProvider({
+    defaultValues: {
+      responseMode: FormResponseMode.Encrypt,
+    },
+  })
 
   const { handleSubmit, setValue } = formMethods
 
@@ -193,6 +223,9 @@ const useCreateFormWizardContext = (
     hasMyInfoChildren: false,
     modalHeader: t('features.workspace.modals.forms.create.title.setup'),
     onClose,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
   }
 }
 

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.test.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.test.tsx
@@ -2,13 +2,11 @@ import { act, renderHook } from '@testing-library/react'
 
 import { usePreviewForm } from '~features/admin-form/common/queries'
 import { useUser } from '~features/user/queries'
-import { useWorkspaceRowsContext } from '~features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext'
 import {
   useDuplicateFormMutations,
   useEmailModeFeedbackMutation,
 } from '~features/workspace/mutations'
 import { useDashboard } from '~features/workspace/queries'
-import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import { CreateFormFlowStates } from '../CreateFormModal/CreateFormWizardContext'
 import { useCommonFormWizardProvider } from '../CreateFormModal/CreateFormWizardProvider'
@@ -22,8 +20,6 @@ vi.mock('~features/workspace/queries')
 vi.mock('~features/admin-form/common/queries')
 vi.mock('~features/workspace/mutations')
 vi.mock('~features/user/queries')
-vi.mock('~features/workspace/WorkspaceContext')
-vi.mock('~features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext')
 vi.mock('../CreateFormModal/CreateFormWizardProvider')
 
 const MOCK_FORM_TITLE = 'My Test Form'
@@ -59,10 +55,6 @@ describe('DupeFormWizardProvider', () => {
       setCurrentStep: vi.fn(),
     }))
 
-    vi.mocked(useWorkspaceRowsContext).mockReturnValue({
-      activeFormMeta: { _id: MOCK_FORM_ID } as any,
-    } as any)
-
     vi.mocked(usePreviewForm).mockReturnValue({
       data: makeMockPreviewFormData() as any,
       isLoading: false,
@@ -71,11 +63,6 @@ describe('DupeFormWizardProvider', () => {
     vi.mocked(useDashboard).mockReturnValue({
       data: makeMockDashboardForms(),
       isLoading: false,
-    } as any)
-
-    vi.mocked(useWorkspaceContext).mockReturnValue({
-      activeWorkspace: { _id: 'ws1' } as any,
-      isDefaultWorkspace: true,
     } as any)
 
     vi.mocked(useUser).mockReturnValue({
@@ -94,7 +81,11 @@ describe('DupeFormWizardProvider', () => {
   })
 
   it('should call reset() with a generated title on the Details step', () => {
-    renderHook(() => useDupeFormWizardContext(vi.fn()))
+    renderHook(() =>
+      useDupeFormWizardContext(vi.fn(), {
+        formIdToDuplicate: MOCK_FORM_ID as any,
+      }),
+    )
 
     expect(mockReset).toHaveBeenCalledTimes(1)
     expect(mockReset).toHaveBeenCalledWith(
@@ -105,7 +96,11 @@ describe('DupeFormWizardProvider', () => {
   it('should not call reset() when dashboardForms changes after moving past the Details step', () => {
     // Bug scenario: dashboard refetches after form is created, triggering useEffect
     // which previously overwrote the title used for the secret key filename.
-    const { rerender } = renderHook(() => useDupeFormWizardContext(vi.fn()))
+    const { rerender } = renderHook(() =>
+      useDupeFormWizardContext(vi.fn(), {
+        formIdToDuplicate: MOCK_FORM_ID as any,
+      }),
+    )
 
     expect(mockReset).toHaveBeenCalledTimes(1)
     mockReset.mockClear()
@@ -129,7 +124,11 @@ describe('DupeFormWizardProvider', () => {
   it('should call reset() again when dashboardForms changes while still on the Details step', () => {
     // Confirm that the guard does not break legitimate re-computation of the title
     // while the user is still on the Details step (e.g. slow initial load).
-    const { rerender } = renderHook(() => useDupeFormWizardContext(vi.fn()))
+    const { rerender } = renderHook(() =>
+      useDupeFormWizardContext(vi.fn(), {
+        formIdToDuplicate: MOCK_FORM_ID as any,
+      }),
+    )
 
     expect(mockReset).toHaveBeenCalledWith(
       expect.objectContaining({ title: `${MOCK_FORM_TITLE}_1` }),

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.test.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.test.tsx
@@ -53,6 +53,9 @@ describe('DupeFormWizardProvider', () => {
       direction: 1 as const,
       keypair: { publicKey: 'pk', secretKey: 'sk' } as any,
       setCurrentStep: vi.fn(),
+      isMrfCutoverEnabled: false,
+      goToStorageModeDetails: vi.fn(),
+      goToMrfDetails: vi.fn(),
     }))
 
     vi.mocked(usePreviewForm).mockReturnValue({

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -39,8 +39,16 @@ export const useDupeFormWizardContext = (
       /* enabled= */ !!sourceFormId,
     )
 
-  const { formMethods, currentStep, direction, keypair, setCurrentStep } =
-    useCommonFormWizardProvider()
+  const {
+    formMethods,
+    currentStep,
+    direction,
+    keypair,
+    setCurrentStep,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
+  } = useCommonFormWizardProvider()
 
   const { reset, getValues } = formMethods
 
@@ -202,6 +210,9 @@ export const useDupeFormWizardContext = (
     hasMyInfoChildren,
     modalHeader: t('features.workspace.modals.forms.create.title.duplicate'),
     onClose,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
   }
 }
 

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FormResponseMode, PublicFormViewDto } from 'formsg-shared/types'
+import { FormId } from 'formsg-shared/types/form/form'
 
 import { usePreviewForm } from '~features/admin-form/common/queries'
 import { useUser } from '~features/user/queries'
@@ -11,7 +12,6 @@ import {
 } from '~features/workspace/mutations'
 import { useDashboard } from '~features/workspace/queries'
 import { makeDuplicateFormTitle } from '~features/workspace/utils/createDuplicateFormTitle'
-import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import {
   CreateFormFlowStates,
@@ -19,19 +19,24 @@ import {
   CreateFormWizardContextReturn,
 } from '../CreateFormModal/CreateFormWizardContext'
 import { useCommonFormWizardProvider } from '../CreateFormModal/CreateFormWizardProvider'
-import { useWorkspaceRowsContext } from '../WorkspaceFormRow/WorkspaceRowsContext'
+
+interface DupeFormWizardSource {
+  formIdToDuplicate: FormId | undefined
+  workspaceId?: string
+}
 
 export const useDupeFormWizardContext = (
   onClose: () => void,
+  source: DupeFormWizardSource,
 ): CreateFormWizardContextReturn => {
   const { t } = useTranslation()
   const { data: dashboardForms, isLoading: isWorkspaceLoading } = useDashboard()
-  const { activeFormMeta } = useWorkspaceRowsContext()
+  const sourceFormId = source.formIdToDuplicate
   const { data: previewFormData, isLoading: isPreviewFormLoading } =
     usePreviewForm(
-      activeFormMeta?._id ?? '',
+      sourceFormId ?? '',
       // Stop querying once submissionData is present.
-      /* enabled= */ !!activeFormMeta,
+      /* enabled= */ !!sourceFormId,
     )
 
   const { formMethods, currentStep, direction, keypair, setCurrentStep } =
@@ -83,15 +88,11 @@ export const useDupeFormWizardContext = (
 
   const { emailModeFeedbackMutation } = useEmailModeFeedbackMutation()
 
-  const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
-
-  // do not mutate with workspaceId if it is 'All Forms' (default workspace)
-  // as the default workspace contains an empty string as workspaceId
-  const workspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
+  const workspaceId = source.workspaceId
 
   const handleCreateStorageModeOrMultirespondentForm = handleSubmit(
     ({ title, responseMode, emails }) => {
-      if (!activeFormMeta?._id) {
+      if (!sourceFormId) {
         return
       }
 
@@ -99,7 +100,7 @@ export const useDupeFormWizardContext = (
         case FormResponseMode.Encrypt:
           return dupeStorageModeFormMutation.mutate(
             {
-              formIdToDuplicate: activeFormMeta._id,
+              formIdToDuplicate: sourceFormId,
               title,
               responseMode,
               publicKey: keypair.publicKey,
@@ -117,7 +118,7 @@ export const useDupeFormWizardContext = (
         case FormResponseMode.Multirespondent:
           return dupeMultirespondentModeFormMutation.mutate(
             {
-              formIdToDuplicate: activeFormMeta._id,
+              formIdToDuplicate: sourceFormId,
               title,
               responseMode,
               publicKey: keypair.publicKey,
@@ -172,10 +173,10 @@ export const useDupeFormWizardContext = (
   // TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented.
   const handleCreateEmailModeForm = () =>
     handleSubmit((inputs) => {
-      if (!activeFormMeta?._id) return
+      if (!sourceFormId) return
 
       return dupeEmailModeFormMutation.mutate({
-        formIdToDuplicate: activeFormMeta._id,
+        formIdToDuplicate: sourceFormId,
         emails: inputs.emails.filter(Boolean),
         title: inputs.title,
         responseMode: FormResponseMode.Email,
@@ -207,11 +208,18 @@ export const useDupeFormWizardContext = (
 export const DupeFormWizardProvider = ({
   children,
   onClose,
+  formIdToDuplicate,
+  workspaceId,
 }: {
   children: React.ReactNode
   onClose: () => void
+  formIdToDuplicate: FormId | undefined
+  workspaceId?: string
 }): JSX.Element => {
-  const values = useDupeFormWizardContext(onClose)
+  const values = useDupeFormWizardContext(onClose, {
+    formIdToDuplicate,
+    workspaceId,
+  })
   return (
     <CreateFormWizardContext.Provider value={values}>
       {children}

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -6,6 +6,8 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
+import { FormId } from 'formsg-shared/types/form/form'
+
 import { CreateFormModalContent } from '../CreateFormModal/CreateFormModalContent'
 
 import { DupeFormWizardProvider } from './DupeFormWizardProvider'
@@ -13,11 +15,16 @@ import { DupeFormWizardProvider } from './DupeFormWizardProvider'
 export type DuplicateFormModalProps = Pick<
   UseDisclosureReturn,
   'onClose' | 'isOpen'
->
+> & {
+  formIdToDuplicate: FormId | undefined
+  workspaceId?: string
+}
 
 export const DuplicateFormModal = ({
   isOpen,
   onClose,
+  formIdToDuplicate,
+  workspaceId,
 }: DuplicateFormModalProps) => {
   const modalSize = useBreakpointValue({
     base: 'mobile',
@@ -27,12 +34,16 @@ export const DuplicateFormModal = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
-      {/* HACK: Chakra isn't able to cleanly handle nested scroll locks https://github.com/chakra-ui/chakra-ui/issues/7723 
-          We'll override chakra's <RemoveScroll /> manually as react-remove-scroll give priority to the latest mounted instance 
+      {/* HACK: Chakra isn't able to cleanly handle nested scroll locks https://github.com/chakra-ui/chakra-ui/issues/7723
+          We'll override chakra's <RemoveScroll /> manually as react-remove-scroll give priority to the latest mounted instance
       */}
       <RemoveScroll>
         <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-          <DupeFormWizardProvider onClose={onClose}>
+          <DupeFormWizardProvider
+            onClose={onClose}
+            formIdToDuplicate={formIdToDuplicate}
+            workspaceId={workspaceId}
+          >
             <CreateFormModalContent />
           </DupeFormWizardProvider>
         </ModalContent>

--- a/apps/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/apps/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -8,6 +8,7 @@ import { AdminDashboardFormMetaDto, FormStatus } from 'formsg-shared/types'
 
 import CollaboratorModal from '~features/admin-form/common/components/CollaboratorModal'
 import { ShareFormModal } from '~features/admin-form/share'
+import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import { DeleteFormModal } from '../DeleteFormModal/DeleteFormModal'
 import { DuplicateFormModal } from '../DuplicateFormModal'
@@ -36,6 +37,9 @@ export const WorkspaceRowsProvider = ({
   const shareFormModalDisclosure = useDisclosure()
   const collabModalDisclosure = useDisclosure()
   const deleteFormModalDisclosure = useDisclosure()
+
+  const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
+  const dupeWorkspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
 
   const onOpenDupeFormModal = (meta?: AdminDashboardFormMetaDto) => {
     setActiveFormMeta(meta)
@@ -78,6 +82,8 @@ export const WorkspaceRowsProvider = ({
       <DuplicateFormModal
         isOpen={dupeFormModalDisclosure.isOpen}
         onClose={dupeFormModalDisclosure.onClose}
+        formIdToDuplicate={activeFormMeta?._id}
+        workspaceId={dupeWorkspaceId}
       />
       <ShareFormModal
         isOpen={shareFormModalDisclosure.isOpen}


### PR DESCRIPTION
> Stacked PR 2/6 for MRF cutover. Base: `feat/mrf-cutover-foundations`.

## Problem

Preparing the create / duplicate / use-template modals for the cutover requires shared wizard scaffolding. Each modal currently owns its own navigation handling, and the duplicate modal pulls its "source" form from React context, making the upcoming MRF-default + escape-hatch wiring duplicative and hard to test. The duplicate modal also needs to be mountable outside the workspace tree so the webhook-v1 infobox (PR 3/6) can open it from settings.

## Solution

Pure refactor — no user-visible behavior change.

- Lift `mrf-cutover` navigation (switching between MRF default screen and storage-mode escape-hatch screen) into the common wizard provider used by all three modals.
- Pass `source` (form id + workspace id) as explicit props to `DuplicateFormModal` instead of reading from `WorkspaceRowsContext` / `WorkspaceContext`. Lets callers outside the workspace tree mount the modal.
- Remove the now-unused `WorkspaceRowsProvider` wrapping around `CreateFormDetailsScreen`.

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: existing modal flows unchanged**

- [ ] Open Create Form, Duplicate Form, Use Template modals (flag off)
- [ ] Confirm wizard steps + navigation work exactly as before
