### PR TITLE
feat(mrf-cutover): default CreateFormModal to MRF with storage-mode escape hatch (4/6)

### DIFF
--- a/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -75,13 +75,14 @@ export const useUseTemplateWizardContext = (
       if (!formId) return
       switch (responseMode) {
         case FormResponseMode.Encrypt: {
+          const defaultEmails = adminEmail ? [adminEmail] : []
           return useStorageModeFormTemplateMutation.mutate(
             {
               formIdToDuplicate: formId,
               title,
               responseMode,
               publicKey: keypair.publicKey,
-              emails: emails.filter(Boolean),
+              emails: (emails ?? defaultEmails).filter(Boolean),
             },
             {
               onSuccess: () => {
@@ -152,7 +153,7 @@ export const useUseTemplateWizardContext = (
     handleSubmit((inputs) => {
       return useEmailModeFormTemplateMutation.mutate({
         formIdToDuplicate: formId,
-        emails: inputs.emails.filter(Boolean),
+        emails: (inputs.emails ?? []).filter(Boolean),
         title: inputs.title,
         responseMode: FormResponseMode.Email,
       })

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -133,6 +133,29 @@ MrfCutoverOnWebhookV1Beta.parameters = {
   ],
 }
 
+export const MrfCutoverOnAllExceptions = Template.bind({})
+MrfCutoverOnAllExceptions.decorators = [
+  (Story) => (
+    <GrowthBookProvider growthbook={mrfCutoverOn}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+MrfCutoverOnAllExceptions.parameters = {
+  msw: [
+    getUser({
+      delay: 0,
+      mockUser: {
+        ...MOCK_USER,
+        betaFlags: {
+          children: true,
+          createStorageModeForV1Webhook: true,
+        },
+      },
+    }),
+  ],
+}
+
 export const StorageModeAckScreen = () => {
   const secretKey = 'mock-secret-key'
 

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -9,13 +9,15 @@ import {
   useClipboard,
   useDisclosure,
 } from '@chakra-ui/react'
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { Meta, StoryFn } from '@storybook/react'
 
+import { featureFlags } from 'formsg-shared/constants'
 import { UserId } from 'formsg-shared/types'
 import { PublicFormViewDto } from 'formsg-shared/types/form'
 import { Workspace, WorkspaceId } from 'formsg-shared/types/workspace'
 
-import { userHandlers } from '~/mocks/msw/handlers/user'
+import { getUser, MOCK_USER, userHandlers } from '~/mocks/msw/handlers/user'
 
 import { ApiError } from '~typings/core'
 
@@ -80,6 +82,56 @@ const Template: StoryFn<CreateFormModalProps> = (args) => {
   )
 }
 export const Default = Template.bind({})
+
+const mrfCutoverOn = new GrowthBook({
+  features: { [featureFlags.mrfCutover]: { defaultValue: true } },
+})
+
+export const MrfCutoverOn = Template.bind({})
+MrfCutoverOn.decorators = [
+  (Story) => (
+    <GrowthBookProvider growthbook={mrfCutoverOn}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+
+export const MrfCutoverOnChildrenBeta = Template.bind({})
+MrfCutoverOnChildrenBeta.decorators = [
+  (Story) => (
+    <GrowthBookProvider growthbook={mrfCutoverOn}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+MrfCutoverOnChildrenBeta.parameters = {
+  msw: [
+    getUser({
+      delay: 0,
+      mockUser: { ...MOCK_USER, betaFlags: { children: true } },
+    }),
+  ],
+}
+
+export const MrfCutoverOnWebhookV1Beta = Template.bind({})
+MrfCutoverOnWebhookV1Beta.decorators = [
+  (Story) => (
+    <GrowthBookProvider growthbook={mrfCutoverOn}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+MrfCutoverOnWebhookV1Beta.parameters = {
+  msw: [
+    getUser({
+      delay: 0,
+      mockUser: {
+        ...MOCK_USER,
+        betaFlags: { createStorageModeForV1Webhook: true },
+      },
+    }),
+  ],
+}
 
 export const StorageModeAckScreen = () => {
   const secretKey = 'mock-secret-key'

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -2,6 +2,7 @@ import { Controller, RegisterOptions } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { BiRightArrowAlt } from 'react-icons/bi'
 import {
+  Box,
   Container,
   FormControl,
   ModalBody,
@@ -62,7 +63,6 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     isLoading,
     isFetching,
     modalHeader,
-    isSingpass,
     hasMyInfoChildren,
     isMrfCutoverEnabled,
     goToStorageModeDetails,
@@ -117,7 +117,9 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             ) : null}
           </FormControl>
           {isMrfCutoverEnabled ? (
-            <EscapeHatchLink onClick={goToStorageModeDetails} />
+            <Box my="2.5rem">
+              <EscapeHatchLink onClick={goToStorageModeDetails} />
+            </Box>
           ) : (
             <FormControl
               isRequired
@@ -184,7 +186,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
                 <EmailFormRecipientsInput />
               </FormControl>
             )}
-          <DataClassificationInfoBox />
+          {!isMrfCutoverEnabled && <DataClassificationInfoBox />}
           <Button
             rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}
             type="submit"

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -1,4 +1,4 @@
-import { Controller, RegisterOptions } from 'react-hook-form'
+import { Controller } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { BiRightArrowAlt } from 'react-icons/bi'
 import {
@@ -14,27 +14,19 @@ import {
 import { FormResponseMode } from 'formsg-shared/types/form/form'
 
 import { GUIDE_PREVENT_EMAIL_BOUNCE } from '~constants/links'
-import { useFormTitleValidationRules } from '~utils/formValidation'
 import Button from '~components/Button'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
-import FormFieldMessage from '~components/FormControl/FormFieldMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import InlineMessage from '~components/InlineMessage'
-import Input from '~components/Input'
 
 import DataClassificationInfoBox from '~features/admin-form/settings/components/DataClassificationInfoBox'
 
-import {
-  CreateFormWizardInputProps,
-  useCreateFormWizard,
-} from '../CreateFormWizardContext'
+import { useCreateFormWizard } from '../CreateFormWizardContext'
 
 import { EmailFormRecipientsInput } from './EmailFormRecipientsInput'
 import { EscapeHatchLink } from './EscapeHatchLink'
 import { FormResponseOptions } from './FormResponseOptions'
-
-/** The length of form title to start showing warning text */
-const FORM_TITLE_LENGTH_WARNING = 65
+import { FormTitleInput } from './FormTitleInput'
 
 const getTrackingSubmissionActionName = (
   responseModeValue: FormResponseMode,
@@ -68,19 +60,15 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     goToStorageModeDetails,
   } = useCreateFormWizard()
   const {
-    register,
     control,
     formState: { errors },
     watch,
   } = formMethods
 
-  const titleInputValue = watch('title')
   const responseModeValue = watch('responseMode')
   const handleEmailButtonPress = () => {
     handleEmailFeedbackSubmit()
   }
-
-  const formTitleValidationRules = useFormTitleValidationRules()
 
   return (
     <>
@@ -91,31 +79,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
       </ModalHeader>
       <ModalBody whiteSpace="pre-wrap">
         <Container maxW="45rem" p={0}>
-          <FormControl isRequired isInvalid={!!errors.title} mb="2.25rem">
-            <FormLabel useMarkdownForDescription>
-              {t('features.workspace.modals.forms.create.details.name.label')}
-            </FormLabel>
-            <Skeleton isLoaded={!isFetching}>
-              <Input
-                autoFocus
-                {...register(
-                  'title',
-                  formTitleValidationRules as RegisterOptions<
-                    CreateFormWizardInputProps,
-                    'title'
-                  >,
-                )}
-              />
-            </Skeleton>
-            <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
-            {titleInputValue?.length > FORM_TITLE_LENGTH_WARNING ? (
-              <FormFieldMessage>
-                {t(
-                  'features.workspace.modals.forms.create.details.name.message',
-                )}
-              </FormFieldMessage>
-            ) : null}
-          </FormControl>
+          <FormTitleInput />
           {isMrfCutoverEnabled ? (
             <Box my="2.5rem">
               <EscapeHatchLink onClick={goToStorageModeDetails} />

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -29,6 +29,7 @@ import {
 } from '../CreateFormWizardContext'
 
 import { EmailFormRecipientsInput } from './EmailFormRecipientsInput'
+import { EscapeHatchLink } from './EscapeHatchLink'
 import { FormResponseOptions } from './FormResponseOptions'
 
 /** The length of form title to start showing warning text */
@@ -63,6 +64,8 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     modalHeader,
     isSingpass,
     hasMyInfoChildren,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
   } = useCreateFormWizard()
   const {
     register,
@@ -113,63 +116,74 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
               </FormFieldMessage>
             ) : null}
           </FormControl>
-          <FormControl isRequired isInvalid={!!errors.responseMode} mb="2.5rem">
-            <FormLabel
-              description={t(
-                'features.workspace.modals.forms.create.details.type.description',
-              )}
-            >
-              {t('features.workspace.modals.forms.create.details.type.label')}
-            </FormLabel>
-            <Skeleton isLoaded={!isFetching}>
-              <Controller
-                name="responseMode"
-                control={control}
-                render={({ field }) => (
-                  <FormResponseOptions
-                    {...field}
-                    hasMyInfoChildren={hasMyInfoChildren}
-                    handleEmailButtonPress={handleEmailButtonPress}
-                  />
-                )}
-                rules={{
-                  required: t(
-                    'features.workspace.modals.forms.create.errors.responseMode.required',
-                  ),
-                }}
-              />
-            </Skeleton>
-            <FormErrorMessage>{errors.responseMode?.message}</FormErrorMessage>
-            {hasMyInfoChildren && (
-              <InlineMessage mt="2rem">
-                {t(
-                  'features.workspace.modals.forms.create.errors.noMyInfoChildrenInMrf',
-                )}
-              </InlineMessage>
-            )}
-          </FormControl>
-          {(responseModeValue === FormResponseMode.Encrypt ||
-            responseModeValue === FormResponseMode.Email) && (
+          {isMrfCutoverEnabled ? (
+            <EscapeHatchLink onClick={goToStorageModeDetails} />
+          ) : (
             <FormControl
-              isRequired={responseModeValue === FormResponseMode.Email}
-              isInvalid={!!errors.emails}
-              mb="2.25rem"
+              isRequired
+              isInvalid={!!errors.responseMode}
+              mb="2.5rem"
             >
               <FormLabel
-                isRequired={responseModeValue === FormResponseMode.Email}
-                useMarkdownForDescription
                 description={t(
-                  'features.workspace.modals.forms.create.details.notifications.description',
-                  { GUIDE_PREVENT_EMAIL_BOUNCE },
+                  'features.workspace.modals.forms.create.details.type.description',
                 )}
               >
-                {t(
-                  'features.workspace.modals.forms.create.details.notifications.label',
-                )}
+                {t('features.workspace.modals.forms.create.details.type.label')}
               </FormLabel>
-              <EmailFormRecipientsInput />
+              <Skeleton isLoaded={!isFetching}>
+                <Controller
+                  name="responseMode"
+                  control={control}
+                  render={({ field }) => (
+                    <FormResponseOptions
+                      {...field}
+                      hasMyInfoChildren={hasMyInfoChildren}
+                      handleEmailButtonPress={handleEmailButtonPress}
+                    />
+                  )}
+                  rules={{
+                    required: t(
+                      'features.workspace.modals.forms.create.errors.responseMode.required',
+                    ),
+                  }}
+                />
+              </Skeleton>
+              <FormErrorMessage>
+                {errors.responseMode?.message}
+              </FormErrorMessage>
+              {hasMyInfoChildren && (
+                <InlineMessage mt="2rem">
+                  {t(
+                    'features.workspace.modals.forms.create.errors.noMyInfoChildrenInMrf',
+                  )}
+                </InlineMessage>
+              )}
             </FormControl>
           )}
+          {!isMrfCutoverEnabled &&
+            (responseModeValue === FormResponseMode.Encrypt ||
+              responseModeValue === FormResponseMode.Email) && (
+              <FormControl
+                isRequired={responseModeValue === FormResponseMode.Email}
+                isInvalid={!!errors.emails}
+                mb="2.25rem"
+              >
+                <FormLabel
+                  isRequired={responseModeValue === FormResponseMode.Email}
+                  useMarkdownForDescription
+                  description={t(
+                    'features.workspace.modals.forms.create.details.notifications.description',
+                    { GUIDE_PREVENT_EMAIL_BOUNCE },
+                  )}
+                >
+                  {t(
+                    'features.workspace.modals.forms.create.details.notifications.label',
+                  )}
+                </FormLabel>
+                <EmailFormRecipientsInput />
+              </FormControl>
+            )}
           <DataClassificationInfoBox />
           <Button
             rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
@@ -8,6 +8,7 @@ import {
 } from '../CreateFormWizardContext'
 
 import { CreateFormDetailsScreen } from './CreateFormDetailsScreen'
+import { CreateFormStorageModeScreen } from './CreateFormStorageModeScreen'
 import {
   EmailModeCreationScreen,
   EmailModeFeedbackScreen,
@@ -27,6 +28,9 @@ export const CreateFormModalContent = () => {
       <XMotionBox keyProp={currentStep} custom={direction}>
         {currentStep === CreateFormFlowStates.Details && (
           <CreateFormDetailsScreen />
+        )}
+        {currentStep === CreateFormFlowStates.StorageModeDetails && (
+          <CreateFormStorageModeScreen />
         )}
         {currentStep === CreateFormFlowStates.Landing && (
           <SaveSecretKeyScreen />

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormStorageModeScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormStorageModeScreen.tsx
@@ -1,48 +1,22 @@
-import { RegisterOptions } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { BiArrowBack, BiRightArrowAlt } from 'react-icons/bi'
-import {
-  Container,
-  Flex,
-  FormControl,
-  ModalBody,
-  ModalHeader,
-  Skeleton,
-  Text,
-} from '@chakra-ui/react'
+import { Container, Flex, ModalBody, ModalHeader, Text } from '@chakra-ui/react'
 
-import { useFormTitleValidationRules } from '~utils/formValidation'
 import Button from '~components/Button'
-import FormErrorMessage from '~components/FormControl/FormErrorMessage'
-import FormFieldMessage from '~components/FormControl/FormFieldMessage'
-import FormLabel from '~components/FormControl/FormLabel'
 import IconButton from '~components/IconButton'
-import Input from '~components/Input'
 
-import {
-  CreateFormWizardInputProps,
-  useCreateFormWizard,
-} from '../CreateFormWizardContext'
+import { useCreateFormWizard } from '../CreateFormWizardContext'
 
-const FORM_TITLE_LENGTH_WARNING = 65
+import { FormTitleInput } from './FormTitleInput'
 
 export const CreateFormStorageModeScreen = (): JSX.Element => {
   const { t } = useTranslation()
   const {
-    formMethods,
     handleCreateStorageModeOrMultirespondentForm,
     isLoading,
     isFetching,
     goToMrfDetails,
   } = useCreateFormWizard()
-  const {
-    register,
-    formState: { errors },
-    watch,
-  } = formMethods
-
-  const titleInputValue = watch('title')
-  const formTitleValidationRules = useFormTitleValidationRules()
 
   return (
     <>
@@ -67,31 +41,7 @@ export const CreateFormStorageModeScreen = (): JSX.Element => {
             use this if you need a feature not yet available in the current
             version.
           </Text>
-          <FormControl isRequired isInvalid={!!errors.title} mb="2.5rem">
-            <FormLabel useMarkdownForDescription>
-              {t('features.workspace.modals.forms.create.details.name.label')}
-            </FormLabel>
-            <Skeleton isLoaded={!isFetching}>
-              <Input
-                autoFocus
-                {...register(
-                  'title',
-                  formTitleValidationRules as RegisterOptions<
-                    CreateFormWizardInputProps,
-                    'title'
-                  >,
-                )}
-              />
-            </Skeleton>
-            <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
-            {titleInputValue?.length > FORM_TITLE_LENGTH_WARNING ? (
-              <FormFieldMessage>
-                {t(
-                  'features.workspace.modals.forms.create.details.name.message',
-                )}
-              </FormFieldMessage>
-            ) : null}
-          </FormControl>
+          <FormTitleInput mb="2.5rem" />
           <Button
             rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}
             type="submit"

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormStorageModeScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormStorageModeScreen.tsx
@@ -56,12 +56,17 @@ export const CreateFormStorageModeScreen = (): JSX.Element => {
               onClick={goToMrfDetails}
               mr="0.5rem"
             />
-            {t('features.workspace.modals.forms.create.title.setup')}
+            Set up a Storage mode form
           </Flex>
         </Container>
       </ModalHeader>
       <ModalBody whiteSpace="pre-wrap">
         <Container maxW="45rem" p={0}>
+          <Text textStyle="body-2" color="secondary.500" mb="2rem">
+            Storage mode is outdated and no longer receives new features. Only
+            use this if you need a feature not yet available in the current
+            version.
+          </Text>
           <FormControl isRequired isInvalid={!!errors.title} mb="2.25rem">
             <FormLabel useMarkdownForDescription>
               {t('features.workspace.modals.forms.create.details.name.label')}

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormStorageModeScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormStorageModeScreen.tsx
@@ -67,7 +67,7 @@ export const CreateFormStorageModeScreen = (): JSX.Element => {
             use this if you need a feature not yet available in the current
             version.
           </Text>
-          <FormControl isRequired isInvalid={!!errors.title} mb="2.25rem">
+          <FormControl isRequired isInvalid={!!errors.title} mb="2.5rem">
             <FormLabel useMarkdownForDescription>
               {t('features.workspace.modals.forms.create.details.name.label')}
             </FormLabel>

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormStorageModeScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormStorageModeScreen.tsx
@@ -1,0 +1,107 @@
+import { RegisterOptions } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { BiArrowBack, BiRightArrowAlt } from 'react-icons/bi'
+import {
+  Container,
+  Flex,
+  FormControl,
+  ModalBody,
+  ModalHeader,
+  Skeleton,
+  Text,
+} from '@chakra-ui/react'
+
+import { useFormTitleValidationRules } from '~utils/formValidation'
+import Button from '~components/Button'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormFieldMessage from '~components/FormControl/FormFieldMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import IconButton from '~components/IconButton'
+import Input from '~components/Input'
+
+import {
+  CreateFormWizardInputProps,
+  useCreateFormWizard,
+} from '../CreateFormWizardContext'
+
+const FORM_TITLE_LENGTH_WARNING = 65
+
+export const CreateFormStorageModeScreen = (): JSX.Element => {
+  const { t } = useTranslation()
+  const {
+    formMethods,
+    handleCreateStorageModeOrMultirespondentForm,
+    isLoading,
+    isFetching,
+    goToMrfDetails,
+  } = useCreateFormWizard()
+  const {
+    register,
+    formState: { errors },
+    watch,
+  } = formMethods
+
+  const titleInputValue = watch('title')
+  const formTitleValidationRules = useFormTitleValidationRules()
+
+  return (
+    <>
+      <ModalHeader color="secondary.700">
+        <Container maxW="45rem" p={0}>
+          <Flex align="center">
+            <IconButton
+              variant="clear"
+              aria-label="Back"
+              icon={<BiArrowBack />}
+              onClick={goToMrfDetails}
+              mr="0.5rem"
+            />
+            {t('features.workspace.modals.forms.create.title.setup')}
+          </Flex>
+        </Container>
+      </ModalHeader>
+      <ModalBody whiteSpace="pre-wrap">
+        <Container maxW="45rem" p={0}>
+          <FormControl isRequired isInvalid={!!errors.title} mb="2.25rem">
+            <FormLabel useMarkdownForDescription>
+              {t('features.workspace.modals.forms.create.details.name.label')}
+            </FormLabel>
+            <Skeleton isLoaded={!isFetching}>
+              <Input
+                autoFocus
+                {...register(
+                  'title',
+                  formTitleValidationRules as RegisterOptions<
+                    CreateFormWizardInputProps,
+                    'title'
+                  >,
+                )}
+              />
+            </Skeleton>
+            <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+            {titleInputValue?.length > FORM_TITLE_LENGTH_WARNING ? (
+              <FormFieldMessage>
+                {t(
+                  'features.workspace.modals.forms.create.details.name.message',
+                )}
+              </FormFieldMessage>
+            ) : null}
+          </FormControl>
+          <Button
+            rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}
+            type="submit"
+            isLoading={isLoading}
+            isDisabled={isFetching}
+            onClick={handleCreateStorageModeOrMultirespondentForm}
+            isFullWidth
+            data-dd-action-name="dashboard.create.create_encrypt"
+          >
+            <Text lineHeight="1.5rem">
+              {t('features.workspace.modals.forms.create.details.create')}
+            </Text>
+          </Button>
+        </Container>
+      </ModalBody>
+    </>
+  )
+}

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EscapeHatchLink.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EscapeHatchLink.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@chakra-ui/react'
 
 import { composeEscapeHatchCopy } from '~utils/escapeHatchCopy'
+import InlineMessage from '~components/InlineMessage'
 import Link from '~components/Link'
 
 import { useUser } from '~features/user/queries'
@@ -15,12 +16,14 @@ export const EscapeHatchLink = ({
   const { user } = useUser()
   const { prefix, linkText, suffix } = composeEscapeHatchCopy(user?.betaFlags)
   return (
-    <Text textStyle="body-2" color="secondary.500">
-      {prefix}
-      <Link cursor="pointer" onClick={onClick}>
-        {linkText}
-      </Link>
-      {suffix}
-    </Text>
+    <InlineMessage variant="info">
+      <Text>
+        {prefix}
+        <Link cursor="pointer" onClick={onClick}>
+          {linkText}
+        </Link>
+        {suffix}
+      </Text>
+    </InlineMessage>
   )
 }

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EscapeHatchLink.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/EscapeHatchLink.tsx
@@ -1,0 +1,26 @@
+import { Text } from '@chakra-ui/react'
+
+import { composeEscapeHatchCopy } from '~utils/escapeHatchCopy'
+import Link from '~components/Link'
+
+import { useUser } from '~features/user/queries'
+
+interface EscapeHatchLinkProps {
+  onClick: () => void
+}
+
+export const EscapeHatchLink = ({
+  onClick,
+}: EscapeHatchLinkProps): JSX.Element => {
+  const { user } = useUser()
+  const { prefix, linkText, suffix } = composeEscapeHatchCopy(user?.betaFlags)
+  return (
+    <Text textStyle="body-2" color="secondary.500">
+      {prefix}
+      <Link cursor="pointer" onClick={onClick}>
+        {linkText}
+      </Link>
+      {suffix}
+    </Text>
+  )
+}

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormTitleInput.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/FormTitleInput.tsx
@@ -1,0 +1,62 @@
+import { RegisterOptions } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { FormControl, FormControlProps, Skeleton } from '@chakra-ui/react'
+
+import { useFormTitleValidationRules } from '~utils/formValidation'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormFieldMessage from '~components/FormControl/FormFieldMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+
+import {
+  CreateFormWizardInputProps,
+  useCreateFormWizard,
+} from '../CreateFormWizardContext'
+
+/** The length of form title to start showing warning text */
+export const FORM_TITLE_LENGTH_WARNING = 65
+
+interface FormTitleInputProps {
+  mb?: FormControlProps['mb']
+}
+
+export const FormTitleInput = ({
+  mb = '2.25rem',
+}: FormTitleInputProps): JSX.Element => {
+  const { t } = useTranslation()
+  const { formMethods, isFetching } = useCreateFormWizard()
+  const {
+    register,
+    formState: { errors },
+    watch,
+  } = formMethods
+
+  const titleInputValue = watch('title')
+  const formTitleValidationRules = useFormTitleValidationRules()
+
+  return (
+    <FormControl isRequired isInvalid={!!errors.title} mb={mb}>
+      <FormLabel useMarkdownForDescription>
+        {t('features.workspace.modals.forms.create.details.name.label')}
+      </FormLabel>
+      <Skeleton isLoaded={!isFetching}>
+        <Input
+          autoFocus
+          {...register(
+            'title',
+            formTitleValidationRules as RegisterOptions<
+              CreateFormWizardInputProps,
+              'title'
+            >,
+          )}
+        />
+      </Skeleton>
+      <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+      {titleInputValue?.length > FORM_TITLE_LENGTH_WARNING ? (
+        <FormFieldMessage>
+          {t('features.workspace.modals.forms.create.details.name.message')}
+        </FormFieldMessage>
+      ) : null}
+    </FormControl>
+  )
+}

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -23,7 +23,7 @@ export interface CreateFormWizardInputProps {
   title: string
   responseMode: FormResponseMode
   // Email form props
-  emails: string[]
+  emails?: string[]
   // Storage form props
   storageAck?: boolean
 

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -119,16 +119,15 @@ const useCreateFormWizardContext = (
   const handleCreateStorageModeOrMultirespondentForm = handleSubmit(
     ({ title, responseMode, emails }) => {
       switch (responseMode) {
-        case FormResponseMode.Encrypt:
+        case FormResponseMode.Encrypt: {
+          const cutoverDefaultEmails = user?.email ? [user.email] : []
           return createStorageModeFormMutation.mutate(
             {
               title,
               responseMode,
               publicKey: keypair.publicKey,
               workspaceId,
-              // NOTE (MRF-CUTOVER): During the cutover modal flow, there is no emails input.
-              emails:
-                emails.filter(Boolean) || (user?.email ? [user.email] : []),
+              emails: emails ? emails.filter(Boolean) : cutoverDefaultEmails,
             },
             {
               onSuccess: () => {
@@ -136,6 +135,7 @@ const useCreateFormWizardContext = (
               },
             },
           )
+        }
         case FormResponseMode.Email:
           return
         case FormResponseMode.Multirespondent:

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -56,9 +56,10 @@ export const useCommonFormWizardProvider = ({
 
   const { setValue } = formMethods
 
+  // TODO [MRF-CUTOVER]: Remove after cutover. -1 is used temporarily as there is an existing animation bug with +1.
   const goToStorageModeDetails = () => {
     setValue('responseMode', FormResponseMode.Encrypt)
-    setCurrentStep([CreateFormFlowStates.StorageModeDetails, 1])
+    setCurrentStep([CreateFormFlowStates.StorageModeDetails, -1])
   }
   const goToMrfDetails = () => {
     setValue('responseMode', FormResponseMode.Multirespondent)
@@ -125,7 +126,9 @@ const useCreateFormWizardContext = (
               responseMode,
               publicKey: keypair.publicKey,
               workspaceId,
-              emails: emails.filter(Boolean),
+              // NOTE (MRF-CUTOVER): During the cutover modal flow, there is no emails input.
+              emails:
+                emails.filter(Boolean) || (user?.email ? [user.email] : []),
             },
             {
               onSuccess: () => {

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -120,14 +120,14 @@ const useCreateFormWizardContext = (
     ({ title, responseMode, emails }) => {
       switch (responseMode) {
         case FormResponseMode.Encrypt: {
-          const cutoverDefaultEmails = user?.email ? [user.email] : []
+          const defaultEmails = adminEmail ? [adminEmail] : []
           return createStorageModeFormMutation.mutate(
             {
               title,
               responseMode,
               publicKey: keypair.publicKey,
               workspaceId,
-              emails: emails ? emails.filter(Boolean) : cutoverDefaultEmails,
+              emails: (emails ?? defaultEmails).filter(Boolean),
             },
             {
               onSuccess: () => {
@@ -200,7 +200,7 @@ const useCreateFormWizardContext = (
   const handleCreateEmailModeForm = () => {
     return handleSubmit((inputs) => {
       createEmailModeFormMutation.mutate({
-        emails: inputs.emails.filter(Boolean),
+        emails: (inputs.emails ?? []).filter(Boolean),
         title: inputs.title,
         responseMode: FormResponseMode.Email,
         workspaceId,

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -105,7 +105,8 @@ export const useDupeFormWizardContext = (
       }
 
       switch (responseMode) {
-        case FormResponseMode.Encrypt:
+        case FormResponseMode.Encrypt: {
+          const defaultEmails = adminEmail ? [adminEmail] : []
           return dupeStorageModeFormMutation.mutate(
             {
               formIdToDuplicate: sourceFormId,
@@ -113,7 +114,7 @@ export const useDupeFormWizardContext = (
               responseMode,
               publicKey: keypair.publicKey,
               workspaceId,
-              emails: emails.filter(Boolean),
+              emails: (emails ?? defaultEmails).filter(Boolean),
             },
             {
               onSuccess: () => {
@@ -121,6 +122,7 @@ export const useDupeFormWizardContext = (
               },
             },
           )
+        }
         case FormResponseMode.Email:
           return
         case FormResponseMode.Multirespondent:
@@ -185,7 +187,7 @@ export const useDupeFormWizardContext = (
 
       return dupeEmailModeFormMutation.mutate({
         formIdToDuplicate: sourceFormId,
-        emails: inputs.emails.filter(Boolean),
+        emails: (inputs.emails ?? []).filter(Boolean),
         title: inputs.title,
         responseMode: FormResponseMode.Email,
         workspaceId,


### PR DESCRIPTION
> Stacked PR 4/6 for MRF cutover. Base: `refactor/modal-cutover-prep`.

## Problem

Per the PRD (issue #9454): the Create Form modal currently defaults to storage mode and offers it side-by-side with MRF, which slows org-wide MRF migration and leaves admins on the legacy v1 webhook schema by default. Closes #9453.

## Solution

Under the `mrf-cutover` flag:

- Default `CreateFormModal` to **Multirespondent** — no mode toggle on the first screen.
- New `CreateFormStorageModeScreen` reachable via the escape-hatch link ("old version of FormSG"), composed from the `escapeHatchCopy` foundation in PR 1. Title input + create button, with a "back" affordance to return to the MRF default screen.
- Match Figma fidelity: hide the data-classification infobox in the cutover flow, use 2.5rem spacing.
- Fix sliding-animation bug + `undefined` email crash that surfaced during escape-hatch navigation.
- Storybook stories for the three escape-hatch copy variants (payments-only, +children, +webhook v1).

When the flag is off, the original modal renders unchanged.

**Breaking Changes**

No - gated behind `mrf-cutover` feature flag. Backend `createForm` still accepts `Encrypt` without flag checks (see `docs/adr/0001-frontend-only-storage-form-gating.md`).

## Tests

**TC1: flag on, default MRF flow**

- [ ] Enable `mrf-cutover` flag; open Create Form
- [ ] Confirm MRF default screen renders (no mode toggle, no data-classification infobox)
- [ ] Submit a title → confirm an MRF is created

**TC2: escape hatch → storage mode**

- [ ] On the MRF default screen, click "old version of FormSG"
- [ ] Confirm `CreateFormStorageModeScreen` renders with title input + create button
- [ ] Submit → confirm a storage-mode form is created
- [ ] From the storage screen, click "back" → confirm return to MRF screen without state loss

**TC3: escape-hatch copy by beta flag**

- [ ] User with no extra flags → copy mentions payments only
- [ ] User with `betaFlags.children` → copy mentions payments + children fields
- [ ] User with `betaFlags.createStorageModeForV1Webhook` → copy mentions payments + webhooks v1

**TC4: flag off**

- [ ] Disable `mrf-cutover` flag; open Create Form
- [ ] Confirm original modal renders unchanged
