### PR TITLE
fix(frontend): react translate compatibility

### DIFF
--- a/apps/frontend/src/components/Button/Button.tsx
+++ b/apps/frontend/src/components/Button/Button.tsx
@@ -32,7 +32,14 @@ export interface ButtonProps extends ChakraButtonProps {
 
 export const Button = forwardRef<ButtonProps, 'button'>(
   (
-    { children, spinnerFontSize, isFullWidth, isHighContrast, ...props },
+    {
+      children,
+      spinnerFontSize,
+      isFullWidth,
+      isHighContrast,
+      loadingText,
+      ...props
+    },
     ref,
   ) => {
     const gb = useGrowthBook()
@@ -53,10 +60,17 @@ export const Button = forwardRef<ButtonProps, 'button'>(
       <Spinner fontSize={spinnerFontSize ?? '1.5rem'} />
     )
 
+    // Chakra renders loadingText as a raw text node sibling to the spinner
+    // when isLoading is true. Wrap in a span for the same reason as
+    // children below.
+    const wrappedLoadingText =
+      loadingText !== undefined ? <span>{loadingText}</span> : undefined
+
     return (
       <ChakraButton
         ref={ref}
         spinner={spinner}
+        loadingText={wrappedLoadingText}
         width={isFullWidth ? '100%' : undefined}
         {...props}
         {...(isFullWidth ? { minH: '3.5rem' } : {})}

--- a/apps/frontend/src/components/Calendar/CalendarBase/DayOfMonth.tsx
+++ b/apps/frontend/src/components/Calendar/CalendarBase/DayOfMonth.tsx
@@ -158,7 +158,7 @@ export const DayOfMonth = forwardRef<DayOfMonthProps, 'button'>(
           ref={ref}
           {...props}
         >
-          {date.getDate()}
+          <span>{date.getDate()}</span>
         </chakra.button>
       </Flex>
     )

--- a/apps/frontend/src/components/Dropdown/components/DropdownItem/DropdownItemTextHighlighter.tsx
+++ b/apps/frontend/src/components/Dropdown/components/DropdownItem/DropdownItemTextHighlighter.tsx
@@ -31,13 +31,23 @@ export const DropdownItemTextHighlighter = ({
   const markedComponents = useMemo(() => {
     const result = fuzzysort.single(inputValue, textToHighlight)
     // Return the original text if no match is found.
-    if (!result) return textToHighlight
+    if (!result) return [textToHighlight]
     return result.highlight((m, i) => (
-      <HighlightMark showHoverBg={showHoverBg} key={i}>
+      <HighlightMark showHoverBg={showHoverBg} key={`m-${i}`}>
         {m}
       </HighlightMark>
     ))
   }, [inputValue, showHoverBg, textToHighlight])
 
-  return <chakra.span>{markedComponents}</chakra.span>
+  // Wrap unmatched string fragments in <span> so every child of the outer
+  // span is a stable element. Browser translation engines can wrap text
+  // nodes in <font>, which breaks React reconciliation if it later tries to
+  // remove or replace those text nodes directly.
+  return (
+    <chakra.span>
+      {markedComponents.map((node, i) =>
+        typeof node === 'string' ? <span key={`u-${i}`}>{node}</span> : node,
+      )}
+    </chakra.span>
+  )
 }

--- a/apps/frontend/src/components/Footer/FullFooter.tsx
+++ b/apps/frontend/src/components/Footer/FullFooter.tsx
@@ -108,7 +108,7 @@ export const FullFooter = ({
             ))}
           </Stack>
           <Text textStyle="legal" color={`${textColorScheme}.500`}>
-            ©{currentYear} Open Government Products
+            {`©${currentYear} Open Government Products`}
           </Text>
         </Box>
       </FullFooter.Section>

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/NewStepBlock/NewStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/NewStepBlock/NewStepBlock.tsx
@@ -1,9 +1,10 @@
 import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BiPlus } from 'react-icons/bi'
-import { Button } from '@chakra-ui/react'
 
 import { FormWorkflowStep } from 'formsg-shared/types'
+
+import Button from '~components/Button'
 
 import {
   isCreatingStateSelector,

--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TranslationSection.tsx
@@ -1,11 +1,12 @@
 import { FormProvider, useForm } from 'react-hook-form'
 import { BiChevronLeft } from 'react-icons/bi'
-import { Button, Flex, Skeleton } from '@chakra-ui/react'
+import { Flex, Skeleton } from '@chakra-ui/react'
 
 import { Language } from 'formsg-shared/types'
 
 import { useToast } from '~hooks/useToast'
 import { convertUnicodeLocaleToLanguage } from '~utils/multiLanguage'
+import Button from '~components/Button'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 

--- a/apps/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
+++ b/apps/frontend/src/features/public-form/components/SectionSidebar/SidebarLink.tsx
@@ -101,7 +101,7 @@ export const SidebarLink = ({
       <VisuallyHidden>
         {t('features.publicForm.components.sidebarLink.navigateToSection')}
       </VisuallyHidden>
-      {title}
+      <span>{title}</span>
     </chakra.button>
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Browser translation engines substitute text nodes with font nodes, which can cause application crashes.

Closes FRM-2417.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Wrap other text nodes in spans for browser translation compatibility.

