### PR TITLE
fix(backend): separate OTP prefix from digits in verification SMS

### DIFF
--- a/apps/backend/src/app/services/postman-sms/postman-sms.util.ts
+++ b/apps/backend/src/app/services/postman-sms/postman-sms.util.ts
@@ -15,6 +15,6 @@ export const renderBouncedSubmissionSms = (formTitle: string): string => dedent`
 export const renderVerificationSms = (
   otp: string,
   otpPrefix: string,
-): string => dedent`Use the OTP ${otpPrefix}-${otp} to submit on FormSG.
+): string => dedent`Use the OTP ${otp} to submit on FormSG. Verification reference: ${otpPrefix}.
 
   Never share your OTP with anyone else. If you did not request this OTP, you can safely ignore this SMS.`


### PR DESCRIPTION
## Problem
- iOS Security Code AutoFill on iPhone 15 / iOS 26.3.1 / Mobile Chrome was including the three-letter prefix when pasting the SMS OTP (e.g. pasting `ABC123456` instead of `123456`), because the prefix was adjacent to the digits via a dash.

## Solution
- Move the prefix into its own sentence (`Use the OTP 123456 to submit on FormSG. Verification reference: ABC.`) so iOS's heuristic only captures the six-digit code.
- The prefix is still shown for visual verification — it is rendered as a separate input addon in the verification box and is never typed by the user.

Fixes [FRM-2399](https://linear.app/ogp/issue/FRM-2399/pasting-sms-otp-includes-first-three-letters).

## Outcome

<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/2976b082-b569-42fc-9b5f-202d056086da" />

## Test plan
- [x] Trigger a verification SMS on a form with a phone field on iPhone 15 / iOS 26.3.1 / Mobile Chrome, and confirm the keyboard paste suggestion contains only the 6 digits.
- [x] Trigger a verification SMS on iOS Safari and confirm `one-time-code` autofill still works.
- [x] Confirm the SMS body still surfaces the verification reference so the user can visually match it to the prefix shown on the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)