### PR TITLE
fix: add default options for dropdown columns in table field

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTableDropdown.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTableDropdown.tsx
@@ -30,7 +30,7 @@ export const EditTableDropdown = ({
         name={inputName}
         control={control}
         // Required so value exists (and does not crash the app) when column is swapped to Dropdown type.
-        defaultValue={[]}
+        defaultValue={['Option 1', 'Option 2']}
         rules={{
           required: REQUIRED_ERROR,
           validate: (value) => {


### PR DESCRIPTION
## Problem

Table field dropdown columns start with empty options when created or when a column type is switched from "Short answer" to "Dropdown". This is inconsistent with standalone Dropdown, Radio, and Checkbox fields, which all default to "Option 1" and "Option 2" to guide the admin.

Closes #9346

## Solution

In `EditTableDropdown.tsx`, the `Controller` component's `defaultValue` was set to `[]` (empty array). Changed it to `['Option 1', 'Option 2']` to match the default behavior of standalone dropdown fields defined in `fieldCreation.ts`.

```diff
- defaultValue={[]}
+ defaultValue={['Option 1', 'Option 2']}
```

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Table field dropdown columns now pre-populate with "Option 1" and "Option 2" as default options, consistent with standalone Dropdown, Radio, and Checkbox fields


## Tests

- Verified via Storybook (`EditTable` story) that dropdown columns show "Option 1" and "Option 2" by default
- Switching a column from "Short answer" to "Dropdown" also shows the default options
- Existing dropdown columns with custom options are unaffected (the `defaultValue` only applies when no value exists)

## Deploy Notes

No new dependencies, environment variables, or scripts required. This is a one-line frontend-only change.
