### PR TITLE
fix(frontend): close 0-byte upload bypass paths in attachment field

### DIFF
--- a/apps/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/apps/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -236,6 +236,16 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
 
     const fileValidator = useCallback<NonNullable<DropzoneProps['validator']>>(
       (file) => {
+        // 0-byte check runs for all file types — images included — so that
+        // empty files cannot bypass the validator via the compression branch.
+        if (file.size === 0) {
+          return {
+            code: 'file-empty',
+            message: t(
+              'features.publicForm.components.fields.attachment.error.zipParsing',
+            ),
+          }
+        }
         if (!IMAGE_UPLOAD_TYPES_TO_COMPRESS.includes(file.type)) {
           if (maxSize && file.size > maxSize) {
             return {
@@ -243,14 +253,6 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
               message: t(
                 'features.publicForm.components.fields.attachment.error.fileTooLarge',
                 { readableMaxSize },
-              ),
-            }
-          }
-          if (file.size === 0) {
-            return {
-              code: 'file-empty',
-              message: t(
-                'features.publicForm.components.fields.attachment.error.zipParsing',
               ),
             }
           }

--- a/apps/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/apps/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { DropzoneProps, useDropzone } from 'react-dropzone'
 import { useTranslation } from 'react-i18next'
 import {
@@ -18,6 +18,8 @@ import { MB } from 'formsg-shared/constants/file'
 
 import { ATTACHMENT_THEME_KEY } from '~theme/components/Field/Attachment'
 import { ThemeColorScheme } from '~theme/foundations/colours'
+
+import { PublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { downloadFile } from './utils/downloadFile'
 import { AttachmentStylesProvider } from './AttachmentContext'
@@ -114,13 +116,6 @@ export interface AttachmentProps extends UseFormControlProps<HTMLElement> {
    * Callback function that is invoked when replace button is clicked. 'Show Replace' must be present for function to work.
    */
   handleReplaceFileOverride?: () => void
-
-  /**
-   * Public form id. When present, attached to Datadog warn logs emitted by
-   * defensive empty-file short-circuits so the originating form can be
-   * identified during quarantine-bucket triage.
-   */
-  formId?: string
 }
 
 export const Attachment = forwardRef<AttachmentProps, 'div'>(
@@ -144,12 +139,16 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
       handleDownloadFileOverride,
       handleRemoveFileOverride,
       handleReplaceFileOverride,
-      formId,
       ...props
     },
     ref,
   ) => {
     const { t } = useTranslation()
+    // Read PublicFormContext non-throwingly so admin-side usages (form builder,
+    // storybook) that mount Attachment outside the public form provider
+    // continue to render. formId is used only for telemetry on the defensive
+    // empty-file short-circuit and may legitimately be undefined.
+    const formId = useContext(PublicFormContext)?.formId
     // Merge given props with any form control props, if they exist.
     const inputProps = useFormControl(props)
     // id to set on the rendered max size FormFieldMessage component.
@@ -268,7 +267,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
           return {
             code: 'file-empty',
             message: t(
-              'features.publicForm.components.fields.attachment.error.zipParsing',
+              'features.publicForm.components.fields.attachment.error.fileEmpty',
             ),
           }
         }

--- a/apps/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/apps/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -144,11 +144,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
     ref,
   ) => {
     const { t } = useTranslation()
-    // Read PublicFormContext non-throwingly so admin-side usages (form builder,
-    // storybook) that mount Attachment outside the public form provider
-    // continue to render. formId is used only for telemetry on the defensive
-    // empty-file short-circuit and may legitimately be undefined.
-    const formId = useContext(PublicFormContext)?.formId
+    const publicFormId = useContext(PublicFormContext)?.formId
     // Merge given props with any form control props, if they exist.
     const inputProps = useFormControl(props)
     // id to set on the rendered max size FormFieldMessage component.
@@ -230,12 +226,9 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
             useWebWorker: false,
             preserveExif: true,
           }).then((blob) => {
-            // Defensive: if compression resolves to a 0-byte blob, do not
-            // hand it downstream — it would land in the GuardDuty quarantine
-            // bucket and break the virus-scanner lambda.
             if (blob.size === 0) {
               datadogLogs.logger.warn('attachment empty after compression', {
-                formId,
+                formId: publicFormId,
                 fileName: acceptedFile.name,
                 originalSize: acceptedFile.size,
                 originalType: acceptedFile.type,
@@ -256,13 +249,11 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
         }
         onChange(acceptedFile)
       },
-      [accept, formId, maxSize, onChange, onError, t],
+      [accept, publicFormId, maxSize, onChange, onError, t],
     )
 
     const fileValidator = useCallback<NonNullable<DropzoneProps['validator']>>(
       (file) => {
-        // 0-byte check runs for all file types — images included — so that
-        // empty files cannot bypass the validator via the compression branch.
         if (file.size === 0) {
           return {
             code: 'file-empty',

--- a/apps/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/apps/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -10,6 +10,7 @@ import {
   useMergeRefs,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
+import { datadogLogs } from '@datadog/browser-logs'
 import imageCompression from 'browser-image-compression'
 import omit from 'lodash/omit'
 
@@ -113,6 +114,13 @@ export interface AttachmentProps extends UseFormControlProps<HTMLElement> {
    * Callback function that is invoked when replace button is clicked. 'Show Replace' must be present for function to work.
    */
   handleReplaceFileOverride?: () => void
+
+  /**
+   * Public form id. When present, attached to Datadog warn logs emitted by
+   * defensive empty-file short-circuits so the originating form can be
+   * identified during quarantine-bucket triage.
+   */
+  formId?: string
 }
 
 export const Attachment = forwardRef<AttachmentProps, 'div'>(
@@ -136,6 +144,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
       handleDownloadFileOverride,
       handleRemoveFileOverride,
       handleReplaceFileOverride,
+      formId,
       ...props
     },
     ref,
@@ -221,17 +230,34 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
             initialQuality: 0.8,
             useWebWorker: false,
             preserveExif: true,
-          }).then((blob) =>
-            onChange(
+          }).then((blob) => {
+            // Defensive: if compression resolves to a 0-byte blob, do not
+            // hand it downstream — it would land in the GuardDuty quarantine
+            // bucket and break the virus-scanner lambda.
+            if (blob.size === 0) {
+              datadogLogs.logger.warn('attachment empty after compression', {
+                formId,
+                fileName: acceptedFile.name,
+                originalSize: acceptedFile.size,
+                originalType: acceptedFile.type,
+                reason: 'imageCompressionEmpty',
+              })
+              return onError?.(
+                t(
+                  'features.publicForm.components.fields.attachment.error.imageProcessingError',
+                ),
+              )
+            }
+            return onChange(
               new File([blob], acceptedFile.name, {
                 type: blob.type,
               }),
-            ),
-          )
+            )
+          })
         }
         onChange(acceptedFile)
       },
-      [accept, maxSize, onChange, onError, t],
+      [accept, formId, maxSize, onChange, onError, t],
     )
 
     const fileValidator = useCallback<NonNullable<DropzoneProps['validator']>>(

--- a/apps/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
@@ -34,6 +34,8 @@ export const enSG: Fields = {
       zipParsing: 'An error has occurred whilst parsing your zip file',
       imageProcessingError:
         'There was an issue processing your image. Please try again or upload a different file.',
+      fileReadError:
+        'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
     },
   },
   email: {

--- a/apps/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
@@ -32,6 +32,8 @@ export const enSG: Fields = {
       zipFileInvalidType:
         'The following file extensions in your zip file are not valid: {stringOfInvalidExtensions}',
       zipParsing: 'An error has occurred whilst parsing your zip file',
+      imageProcessingError:
+        'There was an issue processing your image. Please try again or upload a different file.',
     },
   },
   email: {

--- a/apps/frontend/src/i18n/locales/features/public-form/fields/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/fields/index.ts
@@ -32,6 +32,7 @@ export interface Fields {
       tooManyFiles: string
       zipFileInvalidType: string
       zipParsing: string
+      imageProcessingError: string
     }
   }
   verification: {

--- a/apps/frontend/src/i18n/locales/features/public-form/fields/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/fields/index.ts
@@ -33,6 +33,7 @@ export interface Fields {
       zipFileInvalidType: string
       zipParsing: string
       imageProcessingError: string
+      fileReadError: string
     }
   }
   verification: {

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
@@ -170,6 +170,28 @@ describe('attachment validation', () => {
     expect(error).not.toBeNull()
   })
 
+  it('rejects 0-byte image file at the dropzone validator', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const schema = ValidationOptional.args?.schema
+    render(<ValidationOptional />)
+    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+
+    // Act — 0-byte PNG (image type goes through the compression branch
+    // and previously bypassed the size===0 validator check).
+    const emptyImage = new File([], 'empty.png', { type: 'image/png' })
+    Object.defineProperty(emptyImage, 'size', { value: 0 })
+    await user.upload(input, emptyImage)
+
+    // Assert
+    await waitFor(() => {
+      const error = screen.queryByText(
+        /An error has occurred whilst parsing your zip file/i,
+      )
+      expect(error).not.toBeNull()
+    })
+  })
+
   it('renders error when zip file contains invalid extensions', async () => {
     // Arrange
     const user = userEvent.setup()

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
@@ -13,6 +13,11 @@ import { VALID_EXTENSIONS } from 'formsg-shared/utils/file-validation'
 import { REQUIRED_ERROR } from '~constants/validation'
 import fileArrayBuffer from '~utils/fileArrayBuffer'
 
+import {
+  PublicFormContext,
+  PublicFormContextProps,
+} from '~features/public-form/PublicFormContext'
+
 import { AttachmentFieldSchema } from '../types'
 
 import * as stories from './AttachmentField.stories'
@@ -312,6 +317,85 @@ describe('attachment validation', () => {
     expect(Object.keys(payload as object).sort()).toEqual(
       ['cloneSize', 'fileName', 'formId', 'originalSize', 'reason'].sort(),
     )
+  })
+
+  it('logs the public-form formId in empty-clone warn payload when wrapped in PublicFormContext', async () => {
+    // Arrange — when the field is rendered inside a public-form flow, the
+    // datadog warn payload must carry the form's id so quarantine-bucket
+    // triage can link the event back to the originating form.
+    const user = userEvent.setup()
+    const schema = ValidationOptional.args?.schema
+    const PUBLIC_FORM_ID = 'public-form-id-clone'
+    const providerValue = {
+      formId: PUBLIC_FORM_ID,
+    } as unknown as PublicFormContextProps
+
+    render(
+      <PublicFormContext.Provider value={providerValue}>
+        <ValidationOptional />
+      </PublicFormContext.Provider>,
+    )
+    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+
+    vi.mocked(fileArrayBuffer).mockResolvedValueOnce(new ArrayBuffer(0))
+
+    const sourceFile = new File(['real content'], 'doc.pdf', {
+      type: 'application/pdf',
+    })
+
+    // Act
+    await user.upload(input, sourceFile)
+
+    // Assert
+    await waitFor(() => {
+      expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
+    expect(payload).toMatchObject({
+      reason: 'fileCloneEmpty',
+      formId: PUBLIC_FORM_ID,
+    })
+  })
+
+  it('logs the public-form formId in empty-compression warn payload when wrapped in PublicFormContext', async () => {
+    // Arrange — public-form flow + image-compression returns an empty blob.
+    const user = userEvent.setup()
+    const schema: AttachmentFieldSchema = merge(
+      {},
+      ValidationOptional.args?.schema,
+      { attachmentSize: AttachmentSize.OneMb },
+    )
+    const PUBLIC_FORM_ID = 'public-form-id-compress'
+    const providerValue = {
+      formId: PUBLIC_FORM_ID,
+    } as unknown as PublicFormContextProps
+
+    render(
+      <PublicFormContext.Provider value={providerValue}>
+        <ValidationOptional schema={schema} />
+      </PublicFormContext.Provider>,
+    )
+    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+
+    vi.mocked(imageCompression).mockResolvedValueOnce(
+      new Blob([], { type: 'image/jpeg' }) as unknown as File,
+    )
+
+    const largeImage = new File(['x'], 'photo.png', { type: 'image/png' })
+    Object.defineProperty(largeImage, 'size', { value: 2 * MB })
+
+    // Act
+    await user.upload(input, largeImage)
+
+    // Assert
+    await waitFor(() => {
+      expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
+    expect(payload).toMatchObject({
+      reason: 'imageCompressionEmpty',
+      formId: PUBLIC_FORM_ID,
+    })
   })
 
   it('renders error when zip file contains invalid extensions', async () => {

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
@@ -147,6 +147,11 @@ describe('validation optional', () => {
 })
 
 describe('attachment validation', () => {
+  const PUBLIC_FORM_ID = 'public-form-id'
+  const providerValue = {
+    formId: PUBLIC_FORM_ID,
+  } as unknown as PublicFormContextProps
+
   it('renders error when file with invalid extension is uploaded', async () => {
     // Arrange
     const user = userEvent.setup({ applyAccept: false })
@@ -213,54 +218,58 @@ describe('attachment validation', () => {
     render(<ValidationOptional />)
     const input = screen.getByTestId(schema!._id) as HTMLInputElement
 
-    // Act — 0-byte PNG (image type goes through the compression branch
-    // and previously bypassed the size===0 validator check).
-    const emptyImage = new File([], 'empty.png', { type: 'image/png' })
-    Object.defineProperty(emptyImage, 'size', { value: 0 })
-    await user.upload(input, emptyImage)
+    // Act
+    // RATIONALE: image types previously bypassed the size===0 check via the
+    // compression branch — this is the regression we guard against.
+    const zeroByteImage = new File([], 'empty.png', { type: 'image/png' })
+    Object.defineProperty(zeroByteImage, 'size', { value: 0 })
+    await user.upload(input, zeroByteImage)
 
-    // Assert — fileEmpty validator error surfaces (not the compression path).
+    // Assert
     await waitFor(() => {
-      const error = screen.queryByText(/you have uploaded an empty file/i)
-      expect(error).not.toBeNull()
+      const fileEmptyError = screen.queryByText(
+        /you have uploaded an empty file/i,
+      )
+      expect(fileEmptyError).not.toBeNull()
     })
   })
 
   it('rejects empty image-compression blob, surfaces processing error, and logs warn', async () => {
-    // Arrange — schema is 1MB so a 2MB image triggers the compression branch.
+    // Arrange
     const user = userEvent.setup()
-    const schema: AttachmentFieldSchema = merge(
+    const oneMbLimitSchema: AttachmentFieldSchema = merge(
       {},
       ValidationOptional.args?.schema,
       { attachmentSize: AttachmentSize.OneMb },
     )
-    render(<ValidationOptional schema={schema} />)
-    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+    render(<ValidationOptional schema={oneMbLimitSchema} />)
+    const input = screen.getByTestId(oneMbLimitSchema._id) as HTMLInputElement
 
-    // imageCompression resolves to an empty blob (the regression scenario).
-    vi.mocked(imageCompression).mockResolvedValueOnce(
-      new Blob([], { type: 'image/jpeg' }) as unknown as File,
-    )
+    const emptyCompressedBlob = new Blob([], {
+      type: 'image/jpeg',
+    }) as unknown as File
+    vi.mocked(imageCompression).mockResolvedValueOnce(emptyCompressedBlob)
 
-    const largeImage = new File(['x'], 'photo.png', { type: 'image/png' })
-    Object.defineProperty(largeImage, 'size', { value: 2 * MB })
+    const overSizeLimitImage = new File(['x'], 'photo.png', {
+      type: 'image/png',
+    })
+    Object.defineProperty(overSizeLimitImage, 'size', { value: 2 * MB })
 
     // Act
-    await user.upload(input, largeImage)
+    await user.upload(input, overSizeLimitImage)
 
-    // Assert — user sees the new processing-error message.
+    // Assert
     await waitFor(() => {
-      const error = screen.queryByText(
+      const processingError = screen.queryByText(
         /there was an issue processing your image/i,
       )
-      expect(error).not.toBeNull()
+      expect(processingError).not.toBeNull()
     })
 
-    // Assert — onChange was NOT called: no file info / no "you have submitted" success.
-    // The dropzone should still be present (no AttachmentFileInfo rendered).
-    expect(screen.queryByLabelText(/click to remove file/i)).toBeNull()
+    const removeFileAffordance =
+      screen.queryByLabelText(/click to remove file/i)
+    expect(removeFileAffordance).toBeNull()
 
-    // Assert — datadog warn emitted once with the documented payload shape.
     expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
     const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
     expect(payload).toMatchObject({
@@ -269,64 +278,59 @@ describe('attachment validation', () => {
       originalSize: 2 * MB,
       originalType: 'image/png',
     })
-    // Privacy: payload must only carry metadata, never file contents.
+    // RATIONALE: payload must only carry metadata, never file contents (privacy).
     expect(Object.keys(payload as object).sort()).toEqual(
       ['fileName', 'formId', 'originalSize', 'originalType', 'reason'].sort(),
     )
   })
 
   it('rejects empty file clone, shows reading error, and logs warn', async () => {
-    // Arrange — fileArrayBuffer returns an empty buffer, so the clone is 0 bytes
-    // even though the source file is not. The clone is what flows to S3, so this
-    // is the path that previously slipped past the dropzone validator.
+    // Arrange
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
     render(<ValidationOptional />)
     const input = screen.getByTestId(schema!._id) as HTMLInputElement
 
+    // RATIONALE: the cloned file, not the source file, is what flows to S3, so a
+    // 0-byte clone from a non-empty source is the path that previously
+    // slipped past the dropzone validator.
     vi.mocked(fileArrayBuffer).mockResolvedValueOnce(new ArrayBuffer(0))
 
-    const sourceFile = new File(['real content'], 'doc.pdf', {
+    const nonEmptySourceFile = new File(['real content'], 'doc.pdf', {
       type: 'application/pdf',
     })
 
     // Act
-    await user.upload(input, sourceFile)
+    await user.upload(input, nonEmptySourceFile)
 
-    // Assert — existing reading-error message surfaces.
+    // Assert
     await waitFor(() => {
-      const error = screen.queryByText(/error reading your file/i)
-      expect(error).not.toBeNull()
+      const readingError = screen.queryByText(/error reading your file/i)
+      expect(readingError).not.toBeNull()
     })
 
-    // Assert — no file ends up attached (no remove-file affordance rendered).
-    expect(screen.queryByLabelText(/click to remove file/i)).toBeNull()
+    const removeFileAffordance =
+      screen.queryByLabelText(/click to remove file/i)
+    expect(removeFileAffordance).toBeNull()
 
-    // Assert — exactly one warn with fileCloneEmpty reason and both sizes.
     expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
     const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
     expect(payload).toMatchObject({
       reason: 'fileCloneEmpty',
       fileName: 'doc.pdf',
-      originalSize: sourceFile.size,
+      originalSize: nonEmptySourceFile.size,
       cloneSize: 0,
     })
-    // Privacy: payload must only carry metadata, never file contents.
+    // RATIONALE: payload must only carry metadata, never file contents (privacy).
     expect(Object.keys(payload as object).sort()).toEqual(
       ['cloneSize', 'fileName', 'formId', 'originalSize', 'reason'].sort(),
     )
   })
 
   it('logs the public-form formId in empty-clone warn payload when wrapped in PublicFormContext', async () => {
-    // Arrange — when the field is rendered inside a public-form flow, the
-    // datadog warn payload must carry the form's id so quarantine-bucket
-    // triage can link the event back to the originating form.
+    // Arrange
     const user = userEvent.setup()
     const schema = ValidationOptional.args?.schema
-    const PUBLIC_FORM_ID = 'public-form-id-clone'
-    const providerValue = {
-      formId: PUBLIC_FORM_ID,
-    } as unknown as PublicFormContextProps
 
     render(
       <PublicFormContext.Provider value={providerValue}>
@@ -337,12 +341,12 @@ describe('attachment validation', () => {
 
     vi.mocked(fileArrayBuffer).mockResolvedValueOnce(new ArrayBuffer(0))
 
-    const sourceFile = new File(['real content'], 'doc.pdf', {
+    const nonEmptySourceFile = new File(['real content'], 'doc.pdf', {
       type: 'application/pdf',
     })
 
     // Act
-    await user.upload(input, sourceFile)
+    await user.upload(input, nonEmptySourceFile)
 
     // Assert
     await waitFor(() => {
@@ -356,9 +360,9 @@ describe('attachment validation', () => {
   })
 
   it('logs the public-form formId in empty-compression warn payload when wrapped in PublicFormContext', async () => {
-    // Arrange — public-form flow + image-compression returns an empty blob.
+    // Arrange
     const user = userEvent.setup()
-    const schema: AttachmentFieldSchema = merge(
+    const oneMbLimitSchema: AttachmentFieldSchema = merge(
       {},
       ValidationOptional.args?.schema,
       { attachmentSize: AttachmentSize.OneMb },
@@ -370,20 +374,23 @@ describe('attachment validation', () => {
 
     render(
       <PublicFormContext.Provider value={providerValue}>
-        <ValidationOptional schema={schema} />
+        <ValidationOptional schema={oneMbLimitSchema} />
       </PublicFormContext.Provider>,
     )
-    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+    const input = screen.getByTestId(oneMbLimitSchema._id) as HTMLInputElement
 
-    vi.mocked(imageCompression).mockResolvedValueOnce(
-      new Blob([], { type: 'image/jpeg' }) as unknown as File,
-    )
+    const emptyCompressedBlob = new Blob([], {
+      type: 'image/jpeg',
+    }) as unknown as File
+    vi.mocked(imageCompression).mockResolvedValueOnce(emptyCompressedBlob)
 
-    const largeImage = new File(['x'], 'photo.png', { type: 'image/png' })
-    Object.defineProperty(largeImage, 'size', { value: 2 * MB })
+    const overSizeLimitImage = new File(['x'], 'photo.png', {
+      type: 'image/png',
+    })
+    Object.defineProperty(overSizeLimitImage, 'size', { value: 2 * MB })
 
     // Act
-    await user.upload(input, largeImage)
+    await user.upload(input, overSizeLimitImage)
 
     // Assert
     await waitFor(() => {

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
@@ -219,11 +219,9 @@ describe('attachment validation', () => {
     Object.defineProperty(emptyImage, 'size', { value: 0 })
     await user.upload(input, emptyImage)
 
-    // Assert
+    // Assert — fileEmpty validator error surfaces (not the compression path).
     await waitFor(() => {
-      const error = screen.queryByText(
-        /An error has occurred whilst parsing your zip file/i,
-      )
+      const error = screen.queryByText(/you have uploaded an empty file/i)
       expect(error).not.toBeNull()
     })
   })

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
@@ -11,6 +11,7 @@ import { AttachmentSize } from 'formsg-shared/types/field'
 import { VALID_EXTENSIONS } from 'formsg-shared/utils/file-validation'
 
 import { REQUIRED_ERROR } from '~constants/validation'
+import fileArrayBuffer from '~utils/fileArrayBuffer'
 
 import { AttachmentFieldSchema } from '../types'
 
@@ -30,7 +31,21 @@ vi.mock('@datadog/browser-logs', () => ({
   },
 }))
 
+vi.mock('~utils/fileArrayBuffer', async () => {
+  const actual = await vi.importActual<typeof import('~utils/fileArrayBuffer')>(
+    '~utils/fileArrayBuffer',
+  )
+  return {
+    __esModule: true,
+    default: vi.fn(actual.default),
+  }
+})
+
 const { ValidationRequired, ValidationOptional } = composeStories(stories)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('validation required', () => {
   it('renders error when field is not filled before submitting', async () => {
@@ -251,6 +266,52 @@ describe('attachment validation', () => {
       originalSize: 2 * MB,
       originalType: 'image/png',
     })
+    // Privacy: payload must only carry metadata, never file contents.
+    expect(Object.keys(payload as object).sort()).toEqual(
+      ['fileName', 'formId', 'originalSize', 'originalType', 'reason'].sort(),
+    )
+  })
+
+  it('rejects empty file clone, shows reading error, and logs warn', async () => {
+    // Arrange — fileArrayBuffer returns an empty buffer, so the clone is 0 bytes
+    // even though the source file is not. The clone is what flows to S3, so this
+    // is the path that previously slipped past the dropzone validator.
+    const user = userEvent.setup()
+    const schema = ValidationOptional.args?.schema
+    render(<ValidationOptional />)
+    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+
+    vi.mocked(fileArrayBuffer).mockResolvedValueOnce(new ArrayBuffer(0))
+
+    const sourceFile = new File(['real content'], 'doc.pdf', {
+      type: 'application/pdf',
+    })
+
+    // Act
+    await user.upload(input, sourceFile)
+
+    // Assert — existing reading-error message surfaces.
+    await waitFor(() => {
+      const error = screen.queryByText(/error reading your file/i)
+      expect(error).not.toBeNull()
+    })
+
+    // Assert — no file ends up attached (no remove-file affordance rendered).
+    expect(screen.queryByLabelText(/click to remove file/i)).toBeNull()
+
+    // Assert — exactly one warn with fileCloneEmpty reason and both sizes.
+    expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
+    const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
+    expect(payload).toMatchObject({
+      reason: 'fileCloneEmpty',
+      fileName: 'doc.pdf',
+      originalSize: sourceFile.size,
+      cloneSize: 0,
+    })
+    // Privacy: payload must only carry metadata, never file contents.
+    expect(Object.keys(payload as object).sort()).toEqual(
+      ['cloneSize', 'fileName', 'formId', 'originalSize', 'reason'].sort(),
+    )
   })
 
   it('renders error when zip file contains invalid extensions', async () => {

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
@@ -1,6 +1,8 @@
+import { datadogLogs } from '@datadog/browser-logs'
 import { composeStories } from '@storybook/react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import imageCompression from 'browser-image-compression'
 import JSZip from 'jszip'
 import { merge } from 'lodash'
 
@@ -13,6 +15,20 @@ import { REQUIRED_ERROR } from '~constants/validation'
 import { AttachmentFieldSchema } from '../types'
 
 import * as stories from './AttachmentField.stories'
+
+vi.mock('browser-image-compression', () => ({
+  __esModule: true,
+  default: vi.fn(),
+}))
+
+vi.mock('@datadog/browser-logs', () => ({
+  datadogLogs: {
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}))
 
 const { ValidationRequired, ValidationOptional } = composeStories(stories)
 
@@ -189,6 +205,51 @@ describe('attachment validation', () => {
         /An error has occurred whilst parsing your zip file/i,
       )
       expect(error).not.toBeNull()
+    })
+  })
+
+  it('rejects empty image-compression blob, surfaces processing error, and logs warn', async () => {
+    // Arrange — schema is 1MB so a 2MB image triggers the compression branch.
+    const user = userEvent.setup()
+    const schema: AttachmentFieldSchema = merge(
+      {},
+      ValidationOptional.args?.schema,
+      { attachmentSize: AttachmentSize.OneMb },
+    )
+    render(<ValidationOptional schema={schema} />)
+    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+
+    // imageCompression resolves to an empty blob (the regression scenario).
+    vi.mocked(imageCompression).mockResolvedValueOnce(
+      new Blob([], { type: 'image/jpeg' }) as unknown as File,
+    )
+
+    const largeImage = new File(['x'], 'photo.png', { type: 'image/png' })
+    Object.defineProperty(largeImage, 'size', { value: 2 * MB })
+
+    // Act
+    await user.upload(input, largeImage)
+
+    // Assert — user sees the new processing-error message.
+    await waitFor(() => {
+      const error = screen.queryByText(
+        /there was an issue processing your image/i,
+      )
+      expect(error).not.toBeNull()
+    })
+
+    // Assert — onChange was NOT called: no file info / no "you have submitted" success.
+    // The dropzone should still be present (no AttachmentFileInfo rendered).
+    expect(screen.queryByLabelText(/click to remove file/i)).toBeNull()
+
+    // Assert — datadog warn emitted once with the documented payload shape.
+    expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
+    const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
+    expect(payload).toMatchObject({
+      reason: 'imageCompressionEmpty',
+      fileName: 'photo.png',
+      originalSize: 2 * MB,
+      originalType: 'image/png',
     })
   })
 

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -4,6 +4,7 @@ import {
   ControllerRenderProps,
   useFormContext,
 } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { datadogLogs } from '@datadog/browser-logs'
 
 import { MB } from 'formsg-shared/constants/file'
@@ -35,6 +36,7 @@ export const AttachmentField = ({
   colorTheme = FormColorTheme.Blue,
   isHighContrast,
 }: AttachmentFieldProps): JSX.Element => {
+  const { t } = useTranslation()
   const fieldName = schema._id
   // Read PublicFormContext non-throwingly so admin-side usages (form builder,
   // storybook) that mount AttachmentField outside the public form provider
@@ -92,7 +94,9 @@ export const AttachmentField = ({
           // the source file has content. Reject before it reaches S3.
           if (clone.size === 0) {
             setErrorMessage(
-              'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+              t(
+                'features.publicForm.components.fields.attachment.error.fileReadError',
+              ),
             )
             datadogLogs.logger.warn('attachment file clone is empty', {
               formId,
@@ -115,7 +119,9 @@ export const AttachmentField = ({
           return onChange(clone)
         } catch (error) {
           setErrorMessage(
-            'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+            t(
+              'features.publicForm.components.fields.attachment.error.fileReadError',
+            ),
           )
 
           // For RUM error tracking
@@ -126,7 +132,7 @@ export const AttachmentField = ({
           return onChange(undefined) // Clear attachment and return
         }
       },
-    [clearErrors, fieldName, formId, setErrorMessage, schema.disabled],
+    [clearErrors, fieldName, formId, setErrorMessage, schema.disabled, t],
   )
 
   return (

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -151,7 +151,6 @@ export const AttachmentField = ({
             title={`${schema.questionNumber}. ${schema.title}`}
             showDownload={showDownload}
             showRemove={!schema.disabled}
-            formId={formId}
           />
         )}
         name={fieldName}

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -87,6 +87,23 @@ export const AttachmentField = ({
           const buffer = await fileArrayBuffer(file)
           const clone = new File([buffer], file.name, { type: file.type })
 
+          // Defensive: some browsers / file pickers (e.g. Android + Google
+          // Drive) can produce a clone that resolves to 0 bytes even when
+          // the source file has content. Reject before it reaches S3.
+          if (clone.size === 0) {
+            setErrorMessage(
+              'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+            )
+            datadogLogs.logger.warn('attachment file clone is empty', {
+              formId,
+              fileName: file.name,
+              originalSize: file.size,
+              cloneSize: clone.size,
+              reason: 'fileCloneEmpty',
+            })
+            return onChange(undefined)
+          }
+
           /**
            * Set a custom field to force attachment field to remain dirty.
            * React Hook Form is unable to evaluate dirtiness file when comparing File objects https://react-hook-form.com/docs/useformstate#return
@@ -109,7 +126,7 @@ export const AttachmentField = ({
           return onChange(undefined) // Clear attachment and return
         }
       },
-    [clearErrors, fieldName, setErrorMessage, schema.disabled],
+    [clearErrors, fieldName, formId, setErrorMessage, schema.disabled],
   )
 
   return (

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import {
   Controller,
   ControllerRenderProps,
@@ -13,6 +13,8 @@ import { VALID_EXTENSIONS } from 'formsg-shared/utils/file-validation'
 import { useAttachmentValidationRules } from '~utils/fieldValidation'
 import fileArrayBuffer from '~utils/fileArrayBuffer'
 import Attachment from '~components/Field/Attachment'
+
+import { PublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
 import { AttachmentFieldInput, AttachmentFieldSchema } from '../types'
@@ -34,6 +36,11 @@ export const AttachmentField = ({
   isHighContrast,
 }: AttachmentFieldProps): JSX.Element => {
   const fieldName = schema._id
+  // Read PublicFormContext non-throwingly so admin-side usages (form builder,
+  // storybook) that mount AttachmentField outside the public form provider
+  // continue to render.
+  const publicFormContext = useContext(PublicFormContext)
+  const formId = publicFormContext?.formId
   const validationRules = useAttachmentValidationRules(
     schema,
     disableRequiredValidation,
@@ -121,6 +128,7 @@ export const AttachmentField = ({
             title={`${schema.questionNumber}. ${schema.title}`}
             showDownload={showDownload}
             showRemove={!schema.disabled}
+            formId={formId}
           />
         )}
         name={fieldName}

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -38,11 +38,7 @@ export const AttachmentField = ({
 }: AttachmentFieldProps): JSX.Element => {
   const { t } = useTranslation()
   const fieldName = schema._id
-  // Read PublicFormContext non-throwingly so admin-side usages (form builder,
-  // storybook) that mount AttachmentField outside the public form provider
-  // continue to render.
-  const publicFormContext = useContext(PublicFormContext)
-  const formId = publicFormContext?.formId
+  const publicFormId = useContext(PublicFormContext)?.formId
   const validationRules = useAttachmentValidationRules(
     schema,
     disableRequiredValidation,
@@ -89,9 +85,6 @@ export const AttachmentField = ({
           const buffer = await fileArrayBuffer(file)
           const clone = new File([buffer], file.name, { type: file.type })
 
-          // Defensive: some browsers / file pickers (e.g. Android + Google
-          // Drive) can produce a clone that resolves to 0 bytes even when
-          // the source file has content. Reject before it reaches S3.
           if (clone.size === 0) {
             setErrorMessage(
               t(
@@ -99,7 +92,7 @@ export const AttachmentField = ({
               ),
             )
             datadogLogs.logger.warn('attachment file clone is empty', {
-              formId,
+              formId: publicFormId,
               fileName: file.name,
               originalSize: file.size,
               cloneSize: clone.size,
@@ -132,7 +125,7 @@ export const AttachmentField = ({
           return onChange(undefined) // Clear attachment and return
         }
       },
-    [clearErrors, fieldName, formId, setErrorMessage, schema.disabled, t],
+    [clearErrors, fieldName, publicFormId, setErrorMessage, schema.disabled, t],
   )
 
   return (


### PR DESCRIPTION
## Problem

A 0-byte attachment can reach S3 through three independent frontend paths,
landing in the GuardDuty quarantine bucket and breaking the virus-scanner
lambda (it retries on `HeadObject.ContentLength === 0` and logs a
misleading "Body is empty"). This PR closes all three paths in the
Attachment field components.

Closes #9479.

## Solution

Three short-circuits in the attachment flow, all returning the user to the
empty dropzone without invoking `onChange`:

### Path 1 — dropzone validator

The `file.size === 0` check sat inside the non-image branch, so empty PNG/JPEG
files slipped through to the compression branch. Moved the check above the
image-type guard so it runs for every file type.

### Path 2 — empty compression blob

When `browser-image-compression` resolves to a 0-byte blob, surface the new
`attachment.error.imageProcessingError` message and emit a Datadog warn with
`{ formId, fileName, originalSize, originalType, reason: 'imageCompressionEmpty' }`.

### Path 3 — empty file clone

The `new File([await fileArrayBuffer(file)], …)` clone can resolve to 0 bytes
on Android + Google Drive even when the source has content. After cloning we
now compare sizes; if the clone is empty we surface the existing reading-error
message and warn `{ formId, fileName, originalSize, cloneSize, reason: 'fileCloneEmpty' }`.

**Alternatives considered**

- Path 2's log lives in `Attachment.tsx`, which has no form context (the component
  is reused by admin-side form builder / whitelist / workflow code, so
  `usePublicFormContext` would throw there). We considered routing the log up
  to `AttachmentField` via a new `onCompressionEmpty` callback, but that adds
  surface area for the same outcome. Instead `Attachment` accepts an optional
  `formId?: string` prop and `AttachmentField` reads `PublicFormContext` with
  raw `useContext` (non-throwing) and threads it down. Admin usages pass
  nothing and the Datadog payload just carries `formId: undefined`.

**Breaking Changes**

No - backwards compatible. `formId` on `Attachment` is optional.

## Tests

**TC1: 0-byte image of any type is rejected at the dropzone**

- [ ] Open a public form with an attachment field
- [ ] Create a 0-byte file with `.png` extension (e.g. `: > empty.png`) and drag it in
- [ ] Confirm the empty-file error appears and no file is attached
- [ ] Repeat with a 0-byte `.pdf` (non-image path still works)

**TC2: Image-compression producing an empty blob is handled**

- [ ] On a field with a small `attachmentSize` (e.g. 1MB), upload an image that
      forces compression
- [ ] If compression produces an empty result, confirm the new
      "There was an issue processing your image…" message appears and no file
      is attached
- [ ] Confirm one Datadog warn fires with `reason: 'imageCompressionEmpty'`,
      `formId`, and file metadata only (no contents)

**TC3: Empty file clone is rejected**

- [ ] From an Android device, pick an attachment via the Google Drive picker
- [ ] If the clone resolves to 0 bytes, confirm the existing reading-error
      message appears
- [ ] Confirm one Datadog warn fires with `reason: 'fileCloneEmpty'`,
      `formId`, both sizes, and no file contents

> Screenshots omitted — change is functional (validation paths) and the only
> visible UI delta is the new `imageProcessingError` toast string.
