### PR TITLE
fix(backend): reject 0-byte uploads at presigned POST policy

### DIFF
--- a/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -2545,7 +2545,7 @@ describe('submission.service', () => {
             ...expectedCalledWithSubset,
             Bucket: aws.guarddutyQuarantineS3Bucket,
             Fields: { key: uuid1 },
-            Conditions: [['content-length-range', 0, 1]],
+            Conditions: [['content-length-range', 1, 1]],
           },
           expect.any(Function), // anonymous error handling function
         ],
@@ -2554,7 +2554,7 @@ describe('submission.service', () => {
             ...expectedCalledWithSubset,
             Bucket: aws.guarddutyQuarantineS3Bucket,
             Fields: { key: uuid2 },
-            Conditions: [['content-length-range', 0, 2]],
+            Conditions: [['content-length-range', 1, 2]],
           },
           expect.any(Function), // anonymous error handling function
         ],
@@ -2598,7 +2598,7 @@ describe('submission.service', () => {
           Bucket: aws.guarddutyQuarantineS3Bucket,
           Fields: { key: expect.stringMatching(REGEX_UUID) },
           Expires: 1 * 60, // expires in 1 minutes
-          Conditions: [['content-length-range', 0, 1]],
+          Conditions: [['content-length-range', 1, 1]],
         },
         expect.any(Function), // anonymous error handling function
       )

--- a/apps/backend/src/app/modules/submission/submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/submission.controller.ts
@@ -448,12 +448,14 @@ export const handleStreamEncryptedResponses = [
  * Exported for testing
  */
 export const getS3PresignedPostData: ControllerHandler<
-  unknown,
+  { formId: string },
   AttachmentPresignedPostDataMapType[] | ErrorDto,
   AttachmentSizeMapType[]
 > = async (req, res) => {
+  const { formId } = req.params
   const logMeta = {
     action: 'getS3PresignedPostData',
+    formId,
     ...createReqMeta(req),
   }
 

--- a/apps/backend/src/app/utils/aws-s3.ts
+++ b/apps/backend/src/app/utils/aws-s3.ts
@@ -36,8 +36,10 @@ export const createPresignedPostDataPromise = (
           Bucket: params.bucketName,
           Expires: params.expiresSeconds,
           Conditions: [
-            // Content length restrictions: 0 to MAX_UPLOAD_FILE_SIZE.
-            ['content-length-range', 0, params.size],
+            // Content length restrictions: 1 byte to MAX_UPLOAD_FILE_SIZE.
+            // Minimum is 1 (not 0) so S3 rejects empty uploads at the edge
+            // with EntityTooSmall, keeping 0-byte objects out of quarantine.
+            ['content-length-range', 1, params.size],
           ],
           Fields: {
             key: params.key ?? crypto.randomUUID(),


### PR DESCRIPTION
## Problem

The presigned POST policy allowed `content-length-range` down to 0, so 0-byte uploads succeeded at the S3 edge and landed in the GuardDuty quarantine bucket. The virus-scan lambda then failed with `Body is empty`. No legitimate workflow relies on empty attachment uploads.

We previously introduced FE gating to prevent 0B file uploads, noting that there are no detected compression or cloning failures. This means that 0B files are not likely originating from the FE. 

Instead of allowing 0B file uploads to quarantine bucket and rejecting it at the virus scanner step, we should not accept 0B file uploads to the quarantine bucket in the first place. 

Closes #9480.

## Solution

Bump the policy minimum from `0` to `1` in `createPresignedPostDataPromise`. S3 now returns `EntityTooSmall` for 0-byte PUTs against a valid presigned URL. This is a defense-in-depth backstop for the frontend short-circuits shipped in #9479 — the frontend should never produce a 0-byte upload, but if it does (new entry path, regression), S3 refuses it instead of quarantine.

**Breaking Changes**

No - backwards compatible. No legitimate flow uploads 0-byte files.

## Tests

**TC1: 0-byte upload is rejected at S3**

- [ ] Request a presigned POST URL from staging.
- [ ] `curl` a 0-byte body to that URL with the returned fields.
- [ ] Confirm response is HTTP 400 with `EntityTooSmall`.

**TC2: Normal uploads still work**

- [ ] Submit a storage-mode form on staging with a small (>0B) attachment.
- [ ] Confirm the attachment lands in the clean bucket and decrypts on the responses page.
