### PR TITLE
fix: signature canvas for v4 display

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/flattenV4ToFormFields.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/flattenV4ToFormFields.ts
@@ -171,7 +171,7 @@ export const flattenV4ToFormFields = ({
           _id: fieldId,
           question,
           fieldType,
-          answerArray: [JSON.stringify(answer.value)],
+          answerArray: [answer.type, JSON.stringify(answer.value)],
         })
         break
       }

--- a/apps/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/apps/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -213,7 +213,7 @@ const transformToSignatureOutput = (
   schema: SignatureFieldSchema,
   input?: SignatureFieldValues | SignatureFieldResponseV3,
 ): SignatureResponse => {
-  let answerArray: string[] = []
+  let answerArray: [string, string] = ['', '']
   if (input && input.value.length > 0) {
     answerArray = [input.type, convertToSignatureStringOutput(input.value)]
   }

--- a/packages/shared/types/response.ts
+++ b/packages/shared/types/response.ts
@@ -134,7 +134,7 @@ export type UenResponse = z.infer<typeof UenResponse>
 
 export const SignatureResponse = MultiAnswerResponse.extend({
   fieldType: z.literal(BasicField.Signature),
-  answerArray: z.array(z.string()) as unknown as z.Schema<string[]>,
+  answerArray: z.tuple([z.string(), z.string()]), // [signatureType, stringifiedSignatureValue]
 })
 
 export type SignatureResponse = z.infer<typeof SignatureResponse>


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When flattening v4 to v1 responses, signature canvas doesn't render due to a wrong transformation of signature `answerArray` value not including signature type.
- Signature canvas is not rendered on individual response page & PDF

## Solution
<!-- How did you solve the problem? -->

Add `answer.type` into answerArray when flattening v4 to v1 responses.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | ---- | ------ |
| Signature canvas | <img width="289" height="435" alt="image" src="https://github.com/user-attachments/assets/9773d2c0-3241-4081-b20e-f5b7ce0aab9a" /> | <img width="388" height="430" alt="image" src="https://github.com/user-attachments/assets/299e5313-2fae-4c28-b679-1c537361320b" /> |
| PDF | <img width="650" height="303" alt="image" src="https://github.com/user-attachments/assets/1ba05d08-05ae-4e9e-9737-d25b7ed17eeb" /> | <img width="734" height="355" alt="image" src="https://github.com/user-attachments/assets/3b289ef9-5d84-4180-82ab-f51e5c69032a" /> |

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: Signature canvas display
- [ ] Create an MRF form, add a signature field
- [ ] Make a submission 
- [ ] Verify that on response page & PDF, signature canvas is shown
- [ ] (regression) When download in CSV, verify that `Signature captured` is displayed as a column value
