### PR TITLE
chore: email subject title update

### DIFF
--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -860,7 +860,7 @@ export class MailService {
       return this.#sendEmailWithTemplate({
         emails: adminEmails,
         formId: String(form._id),
-        subject: `Completed - ${formTitle} (${refNo})`,
+        subject: `Response received - ${formTitle} (${refNo})`,
         htmlData: emailData,
         attachments: attachmentsToInclude,
         replyTo: replyToEmails?.join(', '),
@@ -1211,7 +1211,7 @@ export class MailService {
     return this.#sendEmailWithTemplate({
       emails,
       formId,
-      subject: `Completed - ${formTitle} (${responseId})`,
+      subject: `Response received - ${formTitle} (${responseId})`,
       htmlData: emailTemplateData,
       attachments,
       emailType: EmailType.WorkflowCompletion,

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -849,7 +849,6 @@ export class MailService {
         }),
       )
       const emailData: EmailData = {
-        emailTitle: `${formTitle} has been completed by all respondents`,
         formTitle,
         responseId: refNo,
         timestamp: submissionTime,
@@ -1199,9 +1198,7 @@ export class MailService {
     formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
-    // Prepare data for EmailTemplate (2-column responsive)
     const emailTemplateData: EmailData = {
-      emailTitle: `${formTitle} has been completed by all respondents`,
       formTitle,
       responseId: responseId.toString(),
       timestamp,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Some concerns have risen from users after comms went out informing of FormSG's change in email subject title, and the confusion of the new email template.
- Email body title is confusing: `Completed by all respondents` does not make sense for forms with only one submission
- Email subject title `Completed - ` is not desired
     - Use case: Admins use FormSG form as an incident reporting form, where admins reply to the FormSG submission email that gets sent to the respondent - in many cases, responding to the submission does not necessarily mean that the incident has resolved, and this leads to respondents being confused with `Completed -`, as there may be subsequent back and forths

## Solution
<!-- How did you solve the problem? -->

Aligned with Prod and Design, implementation of:
1. Removing email body title for admin emails
2. Update `Completed - ` with `Responses received`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  
