### PR TITLE
build: release v7.20.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [7.20.7](https://github.com/opengovsg/formsg/compare/v7.20.6...v7.20.7) (2026-05-26)
+
+
+### Bug Fixes
+
+* **frontend:** close 0-byte upload bypass paths in attachment field (#9482) ([#9482](https://github.com/opengovsg/formsg/commit/5a92062b753b95026bb0b99e2ab6eb8e9c38f469))
+* signature canvas for v4 display (#9485) ([#9485](https://github.com/opengovsg/formsg/commit/f0e7c03cc1f93c91e97761c5a65f16a2e7c0d533))
+
 ## [7.20.6](https://github.com/opengovsg/formsg/compare/v7.20.5...v7.20.6) (2026-05-25)
 
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-backend",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-frontend",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/apps/frontend/src/components/Field/Attachment/Attachment.tsx
+++ b/apps/frontend/src/components/Field/Attachment/Attachment.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { DropzoneProps, useDropzone } from 'react-dropzone'
 import { useTranslation } from 'react-i18next'
 import {
@@ -10,6 +10,7 @@ import {
   useMergeRefs,
   useMultiStyleConfig,
 } from '@chakra-ui/react'
+import { datadogLogs } from '@datadog/browser-logs'
 import imageCompression from 'browser-image-compression'
 import omit from 'lodash/omit'
 
@@ -17,6 +18,8 @@ import { MB } from 'formsg-shared/constants/file'
 
 import { ATTACHMENT_THEME_KEY } from '~theme/components/Field/Attachment'
 import { ThemeColorScheme } from '~theme/foundations/colours'
+
+import { PublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { downloadFile } from './utils/downloadFile'
 import { AttachmentStylesProvider } from './AttachmentContext'
@@ -141,6 +144,7 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
     ref,
   ) => {
     const { t } = useTranslation()
+    const publicFormId = useContext(PublicFormContext)?.formId
     // Merge given props with any form control props, if they exist.
     const inputProps = useFormControl(props)
     // id to set on the rendered max size FormFieldMessage component.
@@ -221,21 +225,43 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
             initialQuality: 0.8,
             useWebWorker: false,
             preserveExif: true,
-          }).then((blob) =>
-            onChange(
+          }).then((blob) => {
+            if (blob.size === 0) {
+              datadogLogs.logger.warn('attachment empty after compression', {
+                formId: publicFormId,
+                fileName: acceptedFile.name,
+                originalSize: acceptedFile.size,
+                originalType: acceptedFile.type,
+                reason: 'imageCompressionEmpty',
+              })
+              return onError?.(
+                t(
+                  'features.publicForm.components.fields.attachment.error.imageProcessingError',
+                ),
+              )
+            }
+            return onChange(
               new File([blob], acceptedFile.name, {
                 type: blob.type,
               }),
-            ),
-          )
+            )
+          })
         }
         onChange(acceptedFile)
       },
-      [accept, maxSize, onChange, onError, t],
+      [accept, publicFormId, maxSize, onChange, onError, t],
     )
 
     const fileValidator = useCallback<NonNullable<DropzoneProps['validator']>>(
       (file) => {
+        if (file.size === 0) {
+          return {
+            code: 'file-empty',
+            message: t(
+              'features.publicForm.components.fields.attachment.error.fileEmpty',
+            ),
+          }
+        }
         if (!IMAGE_UPLOAD_TYPES_TO_COMPRESS.includes(file.type)) {
           if (maxSize && file.size > maxSize) {
             return {
@@ -243,14 +269,6 @@ export const Attachment = forwardRef<AttachmentProps, 'div'>(
               message: t(
                 'features.publicForm.components.fields.attachment.error.fileTooLarge',
                 { readableMaxSize },
-              ),
-            }
-          }
-          if (file.size === 0) {
-            return {
-              code: 'file-empty',
-              message: t(
-                'features.publicForm.components.fields.attachment.error.zipParsing',
               ),
             }
           }

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/flattenV4ToFormFields.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/flattenV4ToFormFields.ts
@@ -171,7 +171,7 @@ export const flattenV4ToFormFields = ({
           _id: fieldId,
           question,
           fieldType,
-          answerArray: [JSON.stringify(answer.value)],
+          answerArray: [answer.type, JSON.stringify(answer.value)],
         })
         break
       }

--- a/apps/frontend/src/features/public-form/utils/inputTransformation.ts
+++ b/apps/frontend/src/features/public-form/utils/inputTransformation.ts
@@ -213,7 +213,7 @@ const transformToSignatureOutput = (
   schema: SignatureFieldSchema,
   input?: SignatureFieldValues | SignatureFieldResponseV3,
 ): SignatureResponse => {
-  let answerArray: string[] = []
+  let answerArray: [string, string] = ['', '']
   if (input && input.value.length > 0) {
     answerArray = [input.type, convertToSignatureStringOutput(input.value)]
   }

--- a/apps/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
@@ -32,6 +32,10 @@ export const enSG: Fields = {
       zipFileInvalidType:
         'The following file extensions in your zip file are not valid: {stringOfInvalidExtensions}',
       zipParsing: 'An error has occurred whilst parsing your zip file',
+      imageProcessingError:
+        'There was an issue processing your image. Please try again or upload a different file.',
+      fileReadError:
+        'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
     },
   },
   email: {

--- a/apps/frontend/src/i18n/locales/features/public-form/fields/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/fields/index.ts
@@ -32,6 +32,8 @@ export interface Fields {
       tooManyFiles: string
       zipFileInvalidType: string
       zipParsing: string
+      imageProcessingError: string
+      fileReadError: string
     }
   }
   verification: {

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.test.tsx
@@ -1,6 +1,8 @@
+import { datadogLogs } from '@datadog/browser-logs'
 import { composeStories } from '@storybook/react'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import imageCompression from 'browser-image-compression'
 import JSZip from 'jszip'
 import { merge } from 'lodash'
 
@@ -9,12 +11,46 @@ import { AttachmentSize } from 'formsg-shared/types/field'
 import { VALID_EXTENSIONS } from 'formsg-shared/utils/file-validation'
 
 import { REQUIRED_ERROR } from '~constants/validation'
+import fileArrayBuffer from '~utils/fileArrayBuffer'
+
+import {
+  PublicFormContext,
+  PublicFormContextProps,
+} from '~features/public-form/PublicFormContext'
 
 import { AttachmentFieldSchema } from '../types'
 
 import * as stories from './AttachmentField.stories'
 
+vi.mock('browser-image-compression', () => ({
+  __esModule: true,
+  default: vi.fn(),
+}))
+
+vi.mock('@datadog/browser-logs', () => ({
+  datadogLogs: {
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('~utils/fileArrayBuffer', async () => {
+  const actual = await vi.importActual<typeof import('~utils/fileArrayBuffer')>(
+    '~utils/fileArrayBuffer',
+  )
+  return {
+    __esModule: true,
+    default: vi.fn(actual.default),
+  }
+})
+
 const { ValidationRequired, ValidationOptional } = composeStories(stories)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('validation required', () => {
   it('renders error when field is not filled before submitting', async () => {
@@ -111,6 +147,11 @@ describe('validation optional', () => {
 })
 
 describe('attachment validation', () => {
+  const PUBLIC_FORM_ID = 'public-form-id'
+  const providerValue = {
+    formId: PUBLIC_FORM_ID,
+  } as unknown as PublicFormContextProps
+
   it('renders error when file with invalid extension is uploaded', async () => {
     // Arrange
     const user = userEvent.setup({ applyAccept: false })
@@ -168,6 +209,198 @@ describe('attachment validation', () => {
       /You have exceeded the file size limit, please upload a file below 1 MB/i,
     )
     expect(error).not.toBeNull()
+  })
+
+  it('rejects 0-byte image file at the dropzone validator', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const schema = ValidationOptional.args?.schema
+    render(<ValidationOptional />)
+    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+
+    // Act
+    // RATIONALE: image types previously bypassed the size===0 check via the
+    // compression branch — this is the regression we guard against.
+    const zeroByteImage = new File([], 'empty.png', { type: 'image/png' })
+    Object.defineProperty(zeroByteImage, 'size', { value: 0 })
+    await user.upload(input, zeroByteImage)
+
+    // Assert
+    await waitFor(() => {
+      const fileEmptyError = screen.queryByText(
+        /you have uploaded an empty file/i,
+      )
+      expect(fileEmptyError).not.toBeNull()
+    })
+  })
+
+  it('rejects empty image-compression blob, surfaces processing error, and logs warn', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const oneMbLimitSchema: AttachmentFieldSchema = merge(
+      {},
+      ValidationOptional.args?.schema,
+      { attachmentSize: AttachmentSize.OneMb },
+    )
+    render(<ValidationOptional schema={oneMbLimitSchema} />)
+    const input = screen.getByTestId(oneMbLimitSchema._id) as HTMLInputElement
+
+    const emptyCompressedBlob = new Blob([], {
+      type: 'image/jpeg',
+    }) as unknown as File
+    vi.mocked(imageCompression).mockResolvedValueOnce(emptyCompressedBlob)
+
+    const overSizeLimitImage = new File(['x'], 'photo.png', {
+      type: 'image/png',
+    })
+    Object.defineProperty(overSizeLimitImage, 'size', { value: 2 * MB })
+
+    // Act
+    await user.upload(input, overSizeLimitImage)
+
+    // Assert
+    await waitFor(() => {
+      const processingError = screen.queryByText(
+        /there was an issue processing your image/i,
+      )
+      expect(processingError).not.toBeNull()
+    })
+
+    const removeFileAffordance =
+      screen.queryByLabelText(/click to remove file/i)
+    expect(removeFileAffordance).toBeNull()
+
+    expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
+    const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
+    expect(payload).toMatchObject({
+      reason: 'imageCompressionEmpty',
+      fileName: 'photo.png',
+      originalSize: 2 * MB,
+      originalType: 'image/png',
+    })
+    // RATIONALE: payload must only carry metadata, never file contents (privacy).
+    expect(Object.keys(payload as object).sort()).toEqual(
+      ['fileName', 'formId', 'originalSize', 'originalType', 'reason'].sort(),
+    )
+  })
+
+  it('rejects empty file clone, shows reading error, and logs warn', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const schema = ValidationOptional.args?.schema
+    render(<ValidationOptional />)
+    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+
+    // RATIONALE: the cloned file, not the source file, is what flows to S3, so a
+    // 0-byte clone from a non-empty source is the path that previously
+    // slipped past the dropzone validator.
+    vi.mocked(fileArrayBuffer).mockResolvedValueOnce(new ArrayBuffer(0))
+
+    const nonEmptySourceFile = new File(['real content'], 'doc.pdf', {
+      type: 'application/pdf',
+    })
+
+    // Act
+    await user.upload(input, nonEmptySourceFile)
+
+    // Assert
+    await waitFor(() => {
+      const readingError = screen.queryByText(/error reading your file/i)
+      expect(readingError).not.toBeNull()
+    })
+
+    const removeFileAffordance =
+      screen.queryByLabelText(/click to remove file/i)
+    expect(removeFileAffordance).toBeNull()
+
+    expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
+    const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
+    expect(payload).toMatchObject({
+      reason: 'fileCloneEmpty',
+      fileName: 'doc.pdf',
+      originalSize: nonEmptySourceFile.size,
+      cloneSize: 0,
+    })
+    // RATIONALE: payload must only carry metadata, never file contents (privacy).
+    expect(Object.keys(payload as object).sort()).toEqual(
+      ['cloneSize', 'fileName', 'formId', 'originalSize', 'reason'].sort(),
+    )
+  })
+
+  it('logs the public-form formId in empty-clone warn payload when wrapped in PublicFormContext', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const schema = ValidationOptional.args?.schema
+
+    render(
+      <PublicFormContext.Provider value={providerValue}>
+        <ValidationOptional />
+      </PublicFormContext.Provider>,
+    )
+    const input = screen.getByTestId(schema!._id) as HTMLInputElement
+
+    vi.mocked(fileArrayBuffer).mockResolvedValueOnce(new ArrayBuffer(0))
+
+    const nonEmptySourceFile = new File(['real content'], 'doc.pdf', {
+      type: 'application/pdf',
+    })
+
+    // Act
+    await user.upload(input, nonEmptySourceFile)
+
+    // Assert
+    await waitFor(() => {
+      expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
+    expect(payload).toMatchObject({
+      reason: 'fileCloneEmpty',
+      formId: PUBLIC_FORM_ID,
+    })
+  })
+
+  it('logs the public-form formId in empty-compression warn payload when wrapped in PublicFormContext', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const oneMbLimitSchema: AttachmentFieldSchema = merge(
+      {},
+      ValidationOptional.args?.schema,
+      { attachmentSize: AttachmentSize.OneMb },
+    )
+    const PUBLIC_FORM_ID = 'public-form-id-compress'
+    const providerValue = {
+      formId: PUBLIC_FORM_ID,
+    } as unknown as PublicFormContextProps
+
+    render(
+      <PublicFormContext.Provider value={providerValue}>
+        <ValidationOptional schema={oneMbLimitSchema} />
+      </PublicFormContext.Provider>,
+    )
+    const input = screen.getByTestId(oneMbLimitSchema._id) as HTMLInputElement
+
+    const emptyCompressedBlob = new Blob([], {
+      type: 'image/jpeg',
+    }) as unknown as File
+    vi.mocked(imageCompression).mockResolvedValueOnce(emptyCompressedBlob)
+
+    const overSizeLimitImage = new File(['x'], 'photo.png', {
+      type: 'image/png',
+    })
+    Object.defineProperty(overSizeLimitImage, 'size', { value: 2 * MB })
+
+    // Act
+    await user.upload(input, overSizeLimitImage)
+
+    // Assert
+    await waitFor(() => {
+      expect(datadogLogs.logger.warn).toHaveBeenCalledTimes(1)
+    })
+    const [, payload] = vi.mocked(datadogLogs.logger.warn).mock.calls[0]
+    expect(payload).toMatchObject({
+      reason: 'imageCompressionEmpty',
+      formId: PUBLIC_FORM_ID,
+    })
   })
 
   it('renders error when zip file contains invalid extensions', async () => {

--- a/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
+++ b/apps/frontend/src/templates/Field/Attachment/AttachmentField.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import {
   Controller,
   ControllerRenderProps,
   useFormContext,
 } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { datadogLogs } from '@datadog/browser-logs'
 
 import { MB } from 'formsg-shared/constants/file'
@@ -13,6 +14,8 @@ import { VALID_EXTENSIONS } from 'formsg-shared/utils/file-validation'
 import { useAttachmentValidationRules } from '~utils/fieldValidation'
 import fileArrayBuffer from '~utils/fileArrayBuffer'
 import Attachment from '~components/Field/Attachment'
+
+import { PublicFormContext } from '~features/public-form/PublicFormContext'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
 import { AttachmentFieldInput, AttachmentFieldSchema } from '../types'
@@ -33,7 +36,9 @@ export const AttachmentField = ({
   colorTheme = FormColorTheme.Blue,
   isHighContrast,
 }: AttachmentFieldProps): JSX.Element => {
+  const { t } = useTranslation()
   const fieldName = schema._id
+  const publicFormId = useContext(PublicFormContext)?.formId
   const validationRules = useAttachmentValidationRules(
     schema,
     disableRequiredValidation,
@@ -80,6 +85,22 @@ export const AttachmentField = ({
           const buffer = await fileArrayBuffer(file)
           const clone = new File([buffer], file.name, { type: file.type })
 
+          if (clone.size === 0) {
+            setErrorMessage(
+              t(
+                'features.publicForm.components.fields.attachment.error.fileReadError',
+              ),
+            )
+            datadogLogs.logger.warn('attachment file clone is empty', {
+              formId: publicFormId,
+              fileName: file.name,
+              originalSize: file.size,
+              cloneSize: clone.size,
+              reason: 'fileCloneEmpty',
+            })
+            return onChange(undefined)
+          }
+
           /**
            * Set a custom field to force attachment field to remain dirty.
            * React Hook Form is unable to evaluate dirtiness file when comparing File objects https://react-hook-form.com/docs/useformstate#return
@@ -91,7 +112,9 @@ export const AttachmentField = ({
           return onChange(clone)
         } catch (error) {
           setErrorMessage(
-            'There was an error reading your file. If you are uploading a file and using online storage such as Google Drive, download your file before attaching the downloaded version. Otherwise, please refresh and try again.',
+            t(
+              'features.publicForm.components.fields.attachment.error.fileReadError',
+            ),
           )
 
           // For RUM error tracking
@@ -102,7 +125,7 @@ export const AttachmentField = ({
           return onChange(undefined) // Clear attachment and return
         }
       },
-    [clearErrors, fieldName, setErrorMessage, schema.disabled],
+    [clearErrors, fieldName, publicFormId, setErrorMessage, schema.disabled, t],
   )
 
   return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-monorepo",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "private": true,
   "description": "Form Manager for Government",
   "homepage": "https://form.gov.sg",

--- a/packages/react-email-preview/package.json
+++ b/packages/react-email-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-react-email-preview",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "private": true,
   "scripts": {
     "build": "email build",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-shared",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "private": true,
   "description": "",
   "scripts": {

--- a/packages/shared/types/response.ts
+++ b/packages/shared/types/response.ts
@@ -134,7 +134,7 @@ export type UenResponse = z.infer<typeof UenResponse>
 
 export const SignatureResponse = MultiAnswerResponse.extend({
   fieldType: z.literal(BasicField.Signature),
-  answerArray: z.array(z.string()) as unknown as z.Schema<string[]>,
+  answerArray: z.tuple([z.string(), z.string()]), // [signatureType, stringifiedSignatureValue]
 })
 
 export type SignatureResponse = z.infer<typeof SignatureResponse>

--- a/services/form-payment-reconciliation/package.json
+++ b/services/form-payment-reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-payment-reconciliation",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "private": true,
   "description": "Lambda function for payment reconciliation",
   "main": "index.js",

--- a/services/pdf-gen-sparticuz/package.json
+++ b/services/pdf-gen-sparticuz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-pdf-gen-sparticuz",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "private": true,
   "description": "<!-- title: 'AWS NodeJS Example' description: 'This template demonstrates how to deploy a simple NodeJS function running on AWS Lambda using the Serverless Framework.' layout: Doc framework: v4 platform: AWS language: nodeJS priority: 1 authorLink: 'https://github.com/serverless' authorName: 'Serverless, Inc.' authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4' -->",
   "main": "dist/index.js",

--- a/services/virus-scanner-guardduty/package.json
+++ b/services/virus-scanner-guardduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-virus-scanner-guardduty",
-  "version": "7.20.6",
+  "version": "7.20.7",
   "private": true,
   "description": "",
   "scripts": {


### PR DESCRIPTION


### Bug Fixes

* **frontend:** close 0-byte upload bypass paths in attachment field (#9482) ([#9482](https://github.com/opengovsg/formsg/commit/5a92062b753b95026bb0b99e2ab6eb8e9c38f469))
* signature canvas for v4 display (#9485) ([#9485](https://github.com/opengovsg/formsg/commit/f0e7c03cc1f93c91e97761c5a65f16a2e7c0d533))


### Tests

### **frontend:** close 0-byte upload bypass paths in attachment field (#9482) ([#9482](https://github.com/opengovsg/formsg/commit/5a92062b753b95026bb0b99e2ab6eb8e9c38f469))

**TC1: 0-byte image of any type is rejected at the dropzone**

- [x] Open a public form with an attachment field
- [x] Create a 0-byte file with `.png` extension (e.g. `: > empty.png`) and drag it in
- [x] Confirm the empty-file error appears and no file is attached
- [x] Repeat with a 0-byte `.pdf` (non-image path still works)

**TC2: Image-compression producing an empty blob is handled**

- [ ] On a field with a small `attachmentSize` (e.g. 1MB), upload an image that
      forces compression
- [ ] If compression produces an empty result, confirm the new
      "There was an issue processing your image…" message appears and no file
      is attached
- [ ] Confirm one Datadog warn fires with `reason: 'imageCompressionEmpty'`,
      `formId`, and file metadata only (no contents)

**TC3: Empty file clone is rejected**

- [ ] From an Android device, pick an attachment via the Google Drive picker
- [ ] If the clone resolves to 0 bytes, confirm the existing reading-error
      message appears
- [ ] Confirm one Datadog warn fires with `reason: 'fileCloneEmpty'`,
      `formId`, both sizes, and no file contents

> Screenshots omitted — change is functional (validation paths) and the only
> visible UI delta is the new `imageProcessingError` toast string.

### signature canvas for v4 display (#9485) ([#9485](https://github.com/opengovsg/formsg/commit/f0e7c03cc1f93c91e97761c5a65f16a2e7c0d533))
<!-- What tests should be run to confirm functionality? -->

TC1: Signature canvas display
- [x] Create an MRF form, add a signature field
- [x] Make a submission 
- [x] Verify that on response page & PDF, signature canvas is shown
- [x] (regression) When download in CSV, verify that `Signature captured` is displayed as a column value

