### PR TITLE
fix(table): show full dropdown label in disabled MRF cells

### DIFF
--- a/apps/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/apps/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -300,6 +300,7 @@ export const MultiSelectProvider = ({
     <SelectContext.Provider
       value={{
         fullWidth: false,
+        isDisabledScrollable: false,
         inputRef,
         isClearable: false,
         selectedItem: null,

--- a/apps/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/apps/frontend/src/components/Dropdown/SelectContext.tsx
@@ -29,6 +29,13 @@ export interface SharedSelectContextReturnProps<
 
   /** Renders without overflow limit */
   fullWidth?: boolean
+  /**
+   * When true and the select is disabled, the selected label allows
+   * horizontal scrolling and exposes the full label via a native `title`
+   * tooltip instead of ellipsis truncation. Opt-in to avoid regressing
+   * existing consumers' disabled rendering.
+   */
+  isDisabledScrollable?: boolean
 }
 
 interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>

--- a/apps/frontend/src/components/Dropdown/SingleSelect/SingleSelect.test.tsx
+++ b/apps/frontend/src/components/Dropdown/SingleSelect/SingleSelect.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+
+import { SingleSelect } from './SingleSelect'
+
+const LONG_LABEL =
+  'This is a very long dropdown option label that should not be truncated when disabled and scrollable'
+
+const ITEMS = [LONG_LABEL, 'Short option']
+
+describe('SingleSelect — disabled scrollable selected label', () => {
+  it('exposes the full selected label via title when isDisabled + isDisabledScrollable', () => {
+    render(
+      <SingleSelect
+        name="test-select"
+        value={LONG_LABEL}
+        onChange={() => undefined}
+        items={ITEMS}
+        isDisabled
+        isDisabledScrollable
+      />,
+    )
+
+    expect(screen.getByTitle(LONG_LABEL)).toBeInTheDocument()
+  })
+
+  it('does not set a title on the selected label when isDisabledScrollable is not enabled', () => {
+    render(
+      <SingleSelect
+        name="test-select"
+        value={LONG_LABEL}
+        onChange={() => undefined}
+        items={ITEMS}
+        isDisabled
+      />,
+    )
+
+    expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/apps/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -68,6 +68,7 @@ export const SingleSelectProvider = ({
   variant,
   fullWidth = false,
   isHighContrast = false,
+  isDisabledScrollable = false,
 }: SingleSelectProviderProps): JSX.Element => {
   const { items, getItemByValue } = useItems({ rawItems })
   const [isFocused, setIsFocused] = useState(false)
@@ -285,6 +286,7 @@ export const SingleSelectProvider = ({
         virtualListRef,
         virtualListHeight,
         fullWidth,
+        isDisabledScrollable,
         onBlur,
       }}
     >

--- a/apps/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/apps/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -36,6 +36,17 @@ const hideScrollbarStyles = {
   },
 } as const
 
+const disabledLabelColor = 'neutral.800'
+
+const truncatedLabelStyles = { noOfLines: 1 } as const
+
+const disabledTruncatedLabelStyles = {
+  ...truncatedLabelStyles,
+  ...hideScrollbarStyles,
+  color: disabledLabelColor,
+  pointerEvents: 'none',
+} as const
+
 export const SelectCombobox = forwardRef<HTMLInputElement>(
   (_props, ref): JSX.Element => {
     const {
@@ -103,27 +114,26 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
                 aria-disabled={isDisabled}
               />
             ) : null}
-            <Text
-              textStyle="body-1"
-              {...(isDisabled && isDisabledScrollable
-                ? {
-                    ...hideScrollbarStyles,
-                    color: 'neutral.800',
-                    title: selectedItemMeta.label,
-                  }
-                : {
-                    noOfLines: 1,
-                    ...(isDisabled
-                      ? {
-                          ...hideScrollbarStyles,
-                          color: 'neutral.800',
-                          pointerEvents: 'none',
-                        }
-                      : {}),
-                  })}
-            >
-              {selectedItemMeta.label}
-            </Text>
+            {(() => {
+              const disabledScrollableLabelStyles = {
+                ...hideScrollbarStyles,
+                color: disabledLabelColor,
+                title: selectedItemMeta.label,
+              }
+
+              const labelStyles =
+                isDisabled && isDisabledScrollable
+                  ? disabledScrollableLabelStyles
+                  : isDisabled
+                    ? disabledTruncatedLabelStyles
+                    : truncatedLabelStyles
+
+              return (
+                <Text textStyle="body-1" {...labelStyles}>
+                  {selectedItemMeta.label}
+                </Text>
+              )
+            })()}
           </Stack>
           <Input
             isReadOnly={!isSearchable || isReadOnly}

--- a/apps/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/apps/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -44,6 +44,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       getInputProps,
       styles,
       isDisabled,
+      isDisabledScrollable,
       isSearchable,
       isReadOnly,
       isInvalid,
@@ -104,14 +105,22 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
             ) : null}
             <Text
               textStyle="body-1"
-              noOfLines={1}
-              {...(isDisabled
+              {...(isDisabled && isDisabledScrollable
                 ? {
                     ...hideScrollbarStyles,
                     color: 'neutral.800',
-                    pointerEvents: 'none',
+                    title: selectedItemMeta.label,
                   }
-                : {})}
+                : {
+                    noOfLines: 1,
+                    ...(isDisabled
+                      ? {
+                          ...hideScrollbarStyles,
+                          color: 'neutral.800',
+                          pointerEvents: 'none',
+                        }
+                      : {}),
+                  })}
             >
               {selectedItemMeta.label}
             </Text>

--- a/apps/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/apps/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -130,7 +130,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
 
               return (
                 <Text textStyle="body-1" {...labelStyles}>
-                  {selectedItemMeta.label}
+                  <span>{selectedItemMeta.label}</span>
                 </Text>
               )
             })()}

--- a/apps/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/apps/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -144,6 +144,7 @@ const DropdownColumnCell = ({
       render={({ field }) => (
         <SingleSelect
           isDisabled={isDisabled}
+          isDisabledScrollable
           colorScheme={`theme-${colorTheme}`}
           // Possibility of fieldOptions being undefined during table field creation.
           items={fieldOptions ?? []}

--- a/apps/frontend/src/templates/Field/Table/TableField.stories.tsx
+++ b/apps/frontend/src/templates/Field/Table/TableField.stories.tsx
@@ -220,3 +220,32 @@ DisabledHighContrast.args = {
   isHighContrast: true,
   defaultValue: validValidationDefaultValues,
 }
+
+const LONG_DROPDOWN_OPTION =
+  'This is a very long dropdown option label that should not be truncated when disabled'
+
+const longDropdownSchema: TableFieldSchema = {
+  ...baseSchema,
+  columns: baseSchema.columns.map((c) =>
+    c.columnType === BasicField.Dropdown
+      ? { ...c, fieldOptions: [LONG_DROPDOWN_OPTION, 'Short'] }
+      : c,
+  ),
+}
+
+const longDropdownDefaultValues = longDropdownSchema.columns.reduce<
+  Record<string, string>
+>((acc, c) => {
+  if (c.columnType === BasicField.ShortText) {
+    acc[c._id] = 'Some short value'
+  } else if (c.columnType === BasicField.Dropdown) {
+    acc[c._id] = LONG_DROPDOWN_OPTION
+  }
+  return acc
+}, {})
+
+export const DisabledWithLongDropdownOption = Template.bind({})
+DisabledWithLongDropdownOption.args = {
+  schema: { ...longDropdownSchema, disabled: true },
+  defaultValue: longDropdownDefaultValues,
+}

--- a/apps/frontend/src/templates/Field/Table/TableField.test.tsx
+++ b/apps/frontend/src/templates/Field/Table/TableField.test.tsx
@@ -1,0 +1,19 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+
+import * as stories from './TableField.stories'
+
+const { DisabledWithLongDropdownOption } = composeStories(stories)
+
+const LONG_DROPDOWN_OPTION =
+  'This is a very long dropdown option label that should not be truncated when disabled'
+
+describe('TableField — disabled dropdown column cell', () => {
+  it('exposes the full selected dropdown label via a native title tooltip', () => {
+    render(<DisabledWithLongDropdownOption />)
+
+    // At least one row should expose the full label via title.
+    const titled = screen.getAllByTitle(LONG_DROPDOWN_OPTION)
+    expect(titled.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Problem

In a multi-respondent form, when a Table dropdown column cell is disabled for the current step's respondent (e.g. it was filled by an earlier step and not re-assigned), the selected option was rendered with an ellipsis (`...`) and no way to reveal the rest. Subsequent respondents could not see what was previously chosen. Closes #9498.

## Solution

Disabled dropdown column cells now drop the ellipsis: the selected label allows horizontal scrolling within the cell and exposes the full text via a native `title` tooltip on hover. The caret and clear button stay visible so the cell still reads as a dropdown, and row height is unchanged. The behaviour is gated behind a new opt-in `isDisabledScrollable` prop on `SingleSelect` so other call sites keep their current rendering; `DropdownColumnCell` is the only consumer.

**Alternatives considered**

We considered rendering the disabled cell as plain wrapped text instead of a select trigger, but that changes row height and makes the column look inconsistent with editable rows. We also considered mimicking the disabled text input exactly (no caret, no clear button), but we want the affordance that it is still a dropdown so a respondent recognises the kind of value at a glance.

**Screenshots**

Storybook: `TableField/DisabledWithLongDropdownOption`, selected value = `"This is a very long dropdown option label that should not be truncated when disabled"`.

| State | Screenshot |
| --- | --- |
| Before — ellipsis-truncated, no scroll, no tooltip | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/9498-table-dropdown-truncated/before-tablefield-disabled-dropdown.png) |
| After — same render at rest (row height + controls unchanged) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/9498-table-dropdown-truncated/after-tablefield-disabled-dropdown.png) |
| After — horizontally scrolled to reveal the rest of the label | ![after-scrolled](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/9498-table-dropdown-truncated/after-tablefield-scrolled.png) |
| After - with hover tooltip | <img width="1226" height="394" alt="image" src="https://github.com/user-attachments/assets/60fb4703-f12b-4001-91bc-599539abb2f5" /> | 

The native `title` tooltip on hover is not visible in headless capture.

**Breaking Changes**

No - backwards compatible. `isDisabledScrollable` defaults to `false` and is only opted into by `DropdownColumnCell`.

## Tests

**TC1: MRF subsequent step sees full previous-step dropdown selection**

- [ ] Open an MRF where step 1 fills a Table field with a Dropdown column containing a long option label.
- [ ] Submit step 1 and proceed to step 2 (where the Table field is not assigned).
- [ ] Hover the disabled dropdown cell — the native browser tooltip shows the full label.
- [ ] Drag horizontally inside the cell — the label scrolls to reveal the rest of the text.
- [ ] Confirm caret and clear button are visible but the dropdown cannot be opened or cleared.

**TC2: No regression on standalone disabled dropdown**

- [ ] Open Storybook `Templates/Field/DropdownField` (or any non-table disabled `SingleSelect`).
- [ ] Confirm the disabled rendering is unchanged from `develop`: ellipsis truncation, no `title` attribute, no horizontal scroll.

**TC3: No regression on editable Table dropdown cell**

- [ ] Open Storybook `TableField/Default` and select a long dropdown option in a row.
- [ ] Confirm the cell behaves exactly as before — clickable, truncated with ellipsis while editable.
