### PR TITLE
build: release v7.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [7.21.1](https://github.com/opengovsg/formsg/compare/v7.21.0...v7.21.1) (2026-05-28)
+
+
+### Bug Fixes
+
+* **backend:** reject 0-byte uploads at presigned POST policy (#9483) ([#9483](https://github.com/opengovsg/formsg/commit/bc83515e5f79fb937e9300d8ffb91444991f4284))
+* **backend:** update sso integration behavior (#9459) ([#9459](https://github.com/opengovsg/formsg/commit/b6434431efe9e2be0a4e2d395b308c5d37bd930d))
+* **table:** show full dropdown label in disabled MRF cells (#9501) ([#9501](https://github.com/opengovsg/formsg/commit/d9bdd5b4d63816b028714752ec9b7727fc011295))
+
 ## [7.21.0](https://github.com/opengovsg/formsg/compare/v7.20.7...v7.21.0) (2026-05-26)
 
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-backend",
-  "version": "7.21.0",
+  "version": "7.21.1",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/apps/backend/src/app/config/features/sso.config.ts
+++ b/apps/backend/src/app/config/features/sso.config.ts
@@ -2,11 +2,18 @@ import convict, { Path, Schema } from 'convict'
 import { url } from 'convict-format-with-validator'
 
 import { ISsoVarsSchema } from '../../../types'
+import { createLoggerWithLabel } from '../logger'
 import { resetToApplicationDefaultForUndefinedSsmValues } from '../schema'
+
+const logger = createLoggerWithLabel(module)
 
 convict.addFormat(url)
 
 export const optionalValuesFromSsm: Path<ISsoVarsSchema>[] = [] //['hostname']
+
+// RATIONALE: shared between the schema and isSsoConfigured() so they can't drift.
+const SSO_PLACEHOLDER_CLIENT_ID = 'client-id'
+const SSO_PLACEHOLDER_CLIENT_SECRET = 'test'
 
 export const ssoVarsSchema: Schema<ISsoVarsSchema> = {
   discoveryUrl: {
@@ -19,20 +26,64 @@ export const ssoVarsSchema: Schema<ISsoVarsSchema> = {
   clientId: {
     doc: 'The client id registered with SSO',
     format: String,
-    default: 'client-id',
+    default: SSO_PLACEHOLDER_CLIENT_ID,
     env: 'SSO_CLIENT_ID',
   },
   clientSecret: {
     doc: 'The client secret for the SSO service',
     format: String,
-    default: 'test',
+    default: SSO_PLACEHOLDER_CLIENT_SECRET,
     env: 'SSO_CLIENT_SECRET',
   },
 }
 
-// Load and validate sgid configuration values
-// If environment variables are not present, an error will be thrown
+// RATIONALE: every var has a default so missing env doesn't throw at startup;
+// isSsoConfigured() decides at runtime whether values are usable.
 const ssoConfig = convict(ssoVarsSchema)
 resetToApplicationDefaultForUndefinedSsmValues(ssoConfig, optionalValuesFromSsm)
 
 export const sso = ssoConfig.validate({ allowed: 'strict' }).getProperties()
+
+export const isSsoConfigured = (config: ISsoVarsSchema): boolean => {
+  const { discoveryUrl, clientId, clientSecret } = config
+
+  if (
+    !discoveryUrl ||
+    !clientId ||
+    !clientSecret ||
+    clientId === SSO_PLACEHOLDER_CLIENT_ID ||
+    clientSecret === SSO_PLACEHOLDER_CLIENT_SECRET
+  ) {
+    logger.warn({
+      message:
+        'SSO configuration is incomplete. SSO login will be disabled. Using default Email OTP authentication.',
+      meta: {
+        action: 'isSsoConfigured',
+        hasDiscoveryUrl: !!discoveryUrl,
+        hasClientId: !!clientId,
+        hasClientSecret: !!clientSecret,
+        isDefaultClientId: clientId === SSO_PLACEHOLDER_CLIENT_ID,
+        isDefaultClientSecret: clientSecret === SSO_PLACEHOLDER_CLIENT_SECRET,
+      },
+    })
+    return false
+  }
+
+  try {
+    new URL(discoveryUrl)
+  } catch (error) {
+    logger.error({
+      message:
+        'SSO_DISCOVERY_URL is not a valid URL. SSO login will be disabled. Using default Email OTP authentication.',
+      meta: {
+        action: 'isSsoConfigured',
+        discoveryUrl,
+        error,
+      },
+      error,
+    })
+    return false
+  }
+
+  return true
+}

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.spec.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.spec.ts
@@ -1,0 +1,98 @@
+import * as oidcClient from 'openid-client'
+
+import { ISsoVarsSchema } from 'src/types'
+
+import { SsoCreateRedirectUrlError } from './auth-sso.errors'
+import { AuthSsoServiceClass } from './auth-sso.service'
+
+// Silence logger output during tests
+jest.mock('src/app/config/logger', () => ({
+  createLoggerWithLabel: () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}))
+
+const mockDiscovery = jest.mocked(oidcClient.discovery)
+
+const VALID_CONFIG: ISsoVarsSchema = {
+  discoveryUrl: 'https://sso.example.com/.well-known/openid-configuration',
+  clientId: 'real-client-id',
+  clientSecret: 'real-secret',
+}
+
+// Mirrors the placeholder defaults in sso.config.ts. Kept inline so a future
+// drift between schema defaults and the placeholder check is caught here.
+const PLACEHOLDER_CONFIG: ISsoVarsSchema = {
+  discoveryUrl: 'https://sso.example.com/.well-known/openid-configuration',
+  clientId: 'client-id',
+  clientSecret: 'test',
+}
+
+describe('AuthSsoServiceClass', () => {
+  beforeEach(() => {
+    mockDiscovery.mockReset()
+  })
+
+  describe('getClientConfigResult — misconfigured SSO', () => {
+    it('short-circuits to errAsync without calling discovery', async () => {
+      const svc = new AuthSsoServiceClass(PLACEHOLDER_CONFIG)
+
+      const result = await svc.getClientConfigResult()
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        SsoCreateRedirectUrlError,
+      )
+      expect(mockDiscovery).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getClientConfigResult — discovery retry cooldown', () => {
+    // Stub Date.now so we can advance time without touching real timers.
+    let fakeNow: number
+    let nowSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      fakeNow = 1_700_000_000_000
+      nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => fakeNow)
+    })
+
+    afterEach(() => {
+      nowSpy.mockRestore()
+    })
+
+    it('reuses the cached rejected promise within the cooldown window', async () => {
+      mockDiscovery.mockRejectedValue(new Error('discovery boom'))
+      const svc = new AuthSsoServiceClass(VALID_CONFIG)
+
+      const r1 = await svc.getClientConfigResult()
+      expect(r1.isErr()).toBe(true)
+      expect(mockDiscovery).toHaveBeenCalledTimes(1)
+
+      // Within cooldown (60s default): cached rejection should be reused.
+      fakeNow += 30_000
+
+      const r2 = await svc.getClientConfigResult()
+      expect(r2.isErr()).toBe(true)
+      expect(mockDiscovery).toHaveBeenCalledTimes(1)
+    })
+
+    it('retries discovery after the cooldown elapses', async () => {
+      mockDiscovery.mockRejectedValue(new Error('discovery boom'))
+      const svc = new AuthSsoServiceClass(VALID_CONFIG)
+
+      const r1 = await svc.getClientConfigResult()
+      expect(r1.isErr()).toBe(true)
+      expect(mockDiscovery).toHaveBeenCalledTimes(1)
+
+      // Past cooldown (60s default): a fresh discovery attempt should be made.
+      fakeNow += 61_000
+
+      const r2 = await svc.getClientConfigResult()
+      expect(r2.isErr()).toBe(true)
+      expect(mockDiscovery).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
+++ b/apps/backend/src/app/modules/auth/sso/auth-sso.service.ts
@@ -1,11 +1,11 @@
-import { okAsync, ResultAsync } from 'neverthrow'
+import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { getValidatedIdTokenClaims } from 'oauth4webapi'
 import * as oidcClient from 'openid-client'
 
 import { ISsoVarsSchema } from 'src/types'
 
 import { isDev } from '../../../config/config'
-import { sso } from '../../../config/features/sso.config'
+import { isSsoConfigured, sso } from '../../../config/features/sso.config'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { resolveAppUrl } from '../../../utils/urls'
 
@@ -15,13 +15,39 @@ const logger = createLoggerWithLabel(module)
 export const SSO_LOGIN_OAUTH_STATE = 'ssoLogin'
 
 export class AuthSsoServiceClass {
-  private clientConfigPromise: Promise<oidcClient.Configuration>
+  // RATIONALE: bound retries so a transient outage doesn't disable SSO until
+  // restart, without hammering the discovery endpoint on every request.
+  private static readonly DISCOVERY_RETRY_INTERVAL_MS = 60_000
 
-  constructor({
-    discoveryUrl: _discoveryUrl,
-    clientId,
-    clientSecret,
-  }: ISsoVarsSchema) {
+  private clientConfigPromise: Promise<oidcClient.Configuration> | null = null
+  private discoveryFailedAt: number | null = null
+  private readonly config: ISsoVarsSchema
+  private readonly isConfigured: boolean
+
+  constructor(config: ISsoVarsSchema) {
+    this.config = config
+    this.isConfigured = isSsoConfigured(config)
+  }
+
+  /**
+   * RATIONALE: discover lazily so an unreachable URL doesn't crash startup;
+   * cache failures for DISCOVERY_RETRY_INTERVAL_MS before retrying.
+   */
+  private initializeClientConfig(): void {
+    if (this.clientConfigPromise) {
+      const recentlyFailed =
+        this.discoveryFailedAt !== null &&
+        Date.now() - this.discoveryFailedAt <
+          AuthSsoServiceClass.DISCOVERY_RETRY_INTERVAL_MS
+      if (this.discoveryFailedAt === null || recentlyFailed) {
+        return
+      }
+      this.clientConfigPromise = null
+      this.discoveryFailedAt = null
+    }
+
+    const { discoveryUrl, clientId, clientSecret } = this.config
+
     const clientAuth: oidcClient.ClientAuth | undefined = clientSecret
       ? oidcClient.ClientSecretPost(clientSecret)
       : undefined
@@ -34,26 +60,52 @@ export class AuthSsoServiceClass {
       clientDiscoveryRequestOptions.execute = [oidcClient.allowInsecureRequests]
     }
 
-    const oidcServer = new URL(_discoveryUrl)
-    this.clientConfigPromise = oidcClient
-      .discovery(
-        oidcServer,
-        clientId,
-        undefined, // clientMetadata,
-        clientAuth,
-        clientDiscoveryRequestOptions,
-      )
-      .catch((error) => {
-        logger.error({
-          meta: {
-            action: 'AuthSsoServiceClass.constructor',
+    try {
+      const oidcServer = new URL(discoveryUrl)
+      this.clientConfigPromise = oidcClient
+        .discovery(
+          oidcServer,
+          clientId,
+          undefined, // clientMetadata,
+          clientAuth,
+          clientDiscoveryRequestOptions,
+        )
+        .catch((error) => {
+          logger.error({
+            meta: {
+              action: 'AuthSsoServiceClass.initializeClientConfig',
+              error,
+            },
+            message:
+              'Error while discovering SSO client configuration from upstream service. SSO login is unavailable.',
             error,
-          },
-          message: 'Error while discovering SSO client configuration',
-          error,
+          })
+          this.discoveryFailedAt = Date.now()
+          // RATIONALE: reject (not throw) to satisfy typesafe/no-throw-sync-func;
+          // consumed via ResultAsync.fromPromise().
+          return Promise.reject(
+            new SsoCreateRedirectUrlError(
+              'SSO service discovery failed. Please try again later.',
+            ),
+          )
         })
-        throw new SsoCreateRedirectUrlError()
+    } catch (error) {
+      logger.error({
+        meta: {
+          action: 'AuthSsoServiceClass.initializeClientConfig',
+          error,
+        },
+        message:
+          'Error while parsing SSO discovery URL. SSO login is unavailable.',
+        error,
       })
+      this.discoveryFailedAt = Date.now()
+      this.clientConfigPromise = Promise.reject(
+        new SsoCreateRedirectUrlError(
+          'SSO service configuration is invalid. Please try again later.',
+        ),
+      )
+    }
   }
 
   getClientConfigResult(): ResultAsync<
@@ -63,13 +115,46 @@ export class AuthSsoServiceClass {
     const logMeta = {
       action: 'getClientConfigResult',
     }
-    return ResultAsync.fromPromise(this.clientConfigPromise, (error) => {
+
+    if (!this.isConfigured) {
+      logger.warn({
+        message:
+          'SSO is not properly configured. Cannot retrieve client configuration.',
+        meta: logMeta,
+      })
+      return errAsync(
+        new SsoCreateRedirectUrlError(
+          'SSO service is not configured. Please use Email OTP login.',
+        ),
+      )
+    }
+
+    this.initializeClientConfig()
+
+    // RATIONALE: initializeClientConfig always sets this, but TS can't prove it.
+    const configPromise = this.clientConfigPromise
+    if (!configPromise) {
       logger.error({
-        message: 'Error while retrieving SSO client configuration',
+        message: 'SSO client configuration promise was not initialized',
+        meta: logMeta,
+      })
+      return errAsync(
+        new SsoCreateRedirectUrlError(
+          'SSO service initialization failed. Please try again later.',
+        ),
+      )
+    }
+
+    return ResultAsync.fromPromise(configPromise, (error) => {
+      logger.error({
+        message:
+          'Error while retrieving SSO client configuration. SSO service may be unavailable.',
         meta: logMeta,
         error,
       })
-      return new SsoCreateRedirectUrlError()
+      return new SsoCreateRedirectUrlError(
+        'SSO service is currently unavailable. Please try again later or use Email OTP login.',
+      )
     })
   }
   /**
@@ -99,7 +184,9 @@ export class AuthSsoServiceClass {
           meta: logMeta,
           error,
         })
-        return new SsoCreateRedirectUrlError()
+        return new SsoCreateRedirectUrlError(
+          'Failed to calculate PKCE code challenge for SSO authentication',
+        )
       },
     )
     return ResultAsync.combine([
@@ -160,7 +247,9 @@ export class AuthSsoServiceClass {
             meta: { ...logMeta, error },
             error,
           })
-          return new SsoCreateRedirectUrlError()
+          return new SsoCreateRedirectUrlError(
+            'Failed to retrieve access token from SSO service',
+          )
         },
       )
     })
@@ -191,7 +280,9 @@ export class AuthSsoServiceClass {
             meta: logMeta,
             error,
           })
-          return new SsoCreateRedirectUrlError()
+          return new SsoCreateRedirectUrlError(
+            'Failed to retrieve user information from SSO service',
+          )
         },
       ).map((userInfo) => {
         logger.info({

--- a/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -2545,7 +2545,7 @@ describe('submission.service', () => {
             ...expectedCalledWithSubset,
             Bucket: aws.guarddutyQuarantineS3Bucket,
             Fields: { key: uuid1 },
-            Conditions: [['content-length-range', 0, 1]],
+            Conditions: [['content-length-range', 1, 1]],
           },
           expect.any(Function), // anonymous error handling function
         ],
@@ -2554,7 +2554,7 @@ describe('submission.service', () => {
             ...expectedCalledWithSubset,
             Bucket: aws.guarddutyQuarantineS3Bucket,
             Fields: { key: uuid2 },
-            Conditions: [['content-length-range', 0, 2]],
+            Conditions: [['content-length-range', 1, 2]],
           },
           expect.any(Function), // anonymous error handling function
         ],
@@ -2598,7 +2598,7 @@ describe('submission.service', () => {
           Bucket: aws.guarddutyQuarantineS3Bucket,
           Fields: { key: expect.stringMatching(REGEX_UUID) },
           Expires: 1 * 60, // expires in 1 minutes
-          Conditions: [['content-length-range', 0, 1]],
+          Conditions: [['content-length-range', 1, 1]],
         },
         expect.any(Function), // anonymous error handling function
       )

--- a/apps/backend/src/app/modules/submission/submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/submission.controller.ts
@@ -448,12 +448,14 @@ export const handleStreamEncryptedResponses = [
  * Exported for testing
  */
 export const getS3PresignedPostData: ControllerHandler<
-  unknown,
+  { formId: string },
   AttachmentPresignedPostDataMapType[] | ErrorDto,
   AttachmentSizeMapType[]
 > = async (req, res) => {
+  const { formId } = req.params
   const logMeta = {
     action: 'getS3PresignedPostData',
+    formId,
     ...createReqMeta(req),
   }
 

--- a/apps/backend/src/app/utils/aws-s3.ts
+++ b/apps/backend/src/app/utils/aws-s3.ts
@@ -36,8 +36,10 @@ export const createPresignedPostDataPromise = (
           Bucket: params.bucketName,
           Expires: params.expiresSeconds,
           Conditions: [
-            // Content length restrictions: 0 to MAX_UPLOAD_FILE_SIZE.
-            ['content-length-range', 0, params.size],
+            // Content length restrictions: 1 byte to MAX_UPLOAD_FILE_SIZE.
+            // Minimum is 1 (not 0) so S3 rejects empty uploads at the edge
+            // with EntityTooSmall, keeping 0-byte objects out of quarantine.
+            ['content-length-range', 1, params.size],
           ],
           Fields: {
             key: params.key ?? crypto.randomUUID(),

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-frontend",
-  "version": "7.21.0",
+  "version": "7.21.1",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/apps/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
+++ b/apps/frontend/src/components/Dropdown/MultiSelect/MultiSelectProvider.tsx
@@ -300,6 +300,7 @@ export const MultiSelectProvider = ({
     <SelectContext.Provider
       value={{
         fullWidth: false,
+        isDisabledScrollable: false,
         inputRef,
         isClearable: false,
         selectedItem: null,

--- a/apps/frontend/src/components/Dropdown/SelectContext.tsx
+++ b/apps/frontend/src/components/Dropdown/SelectContext.tsx
@@ -29,6 +29,13 @@ export interface SharedSelectContextReturnProps<
 
   /** Renders without overflow limit */
   fullWidth?: boolean
+  /**
+   * When true and the select is disabled, the selected label allows
+   * horizontal scrolling and exposes the full label via a native `title`
+   * tooltip instead of ellipsis truncation. Opt-in to avoid regressing
+   * existing consumers' disabled rendering.
+   */
+  isDisabledScrollable?: boolean
 }
 
 interface SelectContextReturn<Item extends ComboboxItem = ComboboxItem>

--- a/apps/frontend/src/components/Dropdown/SingleSelect/SingleSelect.test.tsx
+++ b/apps/frontend/src/components/Dropdown/SingleSelect/SingleSelect.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+
+import { SingleSelect } from './SingleSelect'
+
+const LONG_LABEL =
+  'This is a very long dropdown option label that should not be truncated when disabled and scrollable'
+
+const ITEMS = [LONG_LABEL, 'Short option']
+
+describe('SingleSelect — disabled scrollable selected label', () => {
+  it('exposes the full selected label via title when isDisabled + isDisabledScrollable', () => {
+    render(
+      <SingleSelect
+        name="test-select"
+        value={LONG_LABEL}
+        onChange={() => undefined}
+        items={ITEMS}
+        isDisabled
+        isDisabledScrollable
+      />,
+    )
+
+    expect(screen.getByTitle(LONG_LABEL)).toBeInTheDocument()
+  })
+
+  it('does not set a title on the selected label when isDisabledScrollable is not enabled', () => {
+    render(
+      <SingleSelect
+        name="test-select"
+        value={LONG_LABEL}
+        onChange={() => undefined}
+        items={ITEMS}
+        isDisabled
+      />,
+    )
+
+    expect(screen.queryByTitle(LONG_LABEL)).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
+++ b/apps/frontend/src/components/Dropdown/SingleSelect/SingleSelectProvider.tsx
@@ -68,6 +68,7 @@ export const SingleSelectProvider = ({
   variant,
   fullWidth = false,
   isHighContrast = false,
+  isDisabledScrollable = false,
 }: SingleSelectProviderProps): JSX.Element => {
   const { items, getItemByValue } = useItems({ rawItems })
   const [isFocused, setIsFocused] = useState(false)
@@ -285,6 +286,7 @@ export const SingleSelectProvider = ({
         virtualListRef,
         virtualListHeight,
         fullWidth,
+        isDisabledScrollable,
         onBlur,
       }}
     >

--- a/apps/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
+++ b/apps/frontend/src/components/Dropdown/components/SelectCombobox/SelectCombobox.tsx
@@ -36,6 +36,17 @@ const hideScrollbarStyles = {
   },
 } as const
 
+const disabledLabelColor = 'neutral.800'
+
+const truncatedLabelStyles = { noOfLines: 1 } as const
+
+const disabledTruncatedLabelStyles = {
+  ...truncatedLabelStyles,
+  ...hideScrollbarStyles,
+  color: disabledLabelColor,
+  pointerEvents: 'none',
+} as const
+
 export const SelectCombobox = forwardRef<HTMLInputElement>(
   (_props, ref): JSX.Element => {
     const {
@@ -44,6 +55,7 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
       getInputProps,
       styles,
       isDisabled,
+      isDisabledScrollable,
       isSearchable,
       isReadOnly,
       isInvalid,
@@ -102,19 +114,26 @@ export const SelectCombobox = forwardRef<HTMLInputElement>(
                 aria-disabled={isDisabled}
               />
             ) : null}
-            <Text
-              textStyle="body-1"
-              noOfLines={1}
-              {...(isDisabled
-                ? {
-                    ...hideScrollbarStyles,
-                    color: 'neutral.800',
-                    pointerEvents: 'none',
-                  }
-                : {})}
-            >
-              {selectedItemMeta.label}
-            </Text>
+            {(() => {
+              const disabledScrollableLabelStyles = {
+                ...hideScrollbarStyles,
+                color: disabledLabelColor,
+                title: selectedItemMeta.label,
+              }
+
+              const labelStyles =
+                isDisabled && isDisabledScrollable
+                  ? disabledScrollableLabelStyles
+                  : isDisabled
+                    ? disabledTruncatedLabelStyles
+                    : truncatedLabelStyles
+
+              return (
+                <Text textStyle="body-1" {...labelStyles}>
+                  <span>{selectedItemMeta.label}</span>
+                </Text>
+              )
+            })()}
           </Stack>
           <Input
             isReadOnly={!isSearchable || isReadOnly}

--- a/apps/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/apps/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -144,6 +144,7 @@ const DropdownColumnCell = ({
       render={({ field }) => (
         <SingleSelect
           isDisabled={isDisabled}
+          isDisabledScrollable
           colorScheme={`theme-${colorTheme}`}
           // Possibility of fieldOptions being undefined during table field creation.
           items={fieldOptions ?? []}

--- a/apps/frontend/src/templates/Field/Table/TableField.stories.tsx
+++ b/apps/frontend/src/templates/Field/Table/TableField.stories.tsx
@@ -220,3 +220,32 @@ DisabledHighContrast.args = {
   isHighContrast: true,
   defaultValue: validValidationDefaultValues,
 }
+
+const LONG_DROPDOWN_OPTION =
+  'This is a very long dropdown option label that should not be truncated when disabled'
+
+const longDropdownSchema: TableFieldSchema = {
+  ...baseSchema,
+  columns: baseSchema.columns.map((c) =>
+    c.columnType === BasicField.Dropdown
+      ? { ...c, fieldOptions: [LONG_DROPDOWN_OPTION, 'Short'] }
+      : c,
+  ),
+}
+
+const longDropdownDefaultValues = longDropdownSchema.columns.reduce<
+  Record<string, string>
+>((acc, c) => {
+  if (c.columnType === BasicField.ShortText) {
+    acc[c._id] = 'Some short value'
+  } else if (c.columnType === BasicField.Dropdown) {
+    acc[c._id] = LONG_DROPDOWN_OPTION
+  }
+  return acc
+}, {})
+
+export const DisabledWithLongDropdownOption = Template.bind({})
+DisabledWithLongDropdownOption.args = {
+  schema: { ...longDropdownSchema, disabled: true },
+  defaultValue: longDropdownDefaultValues,
+}

--- a/apps/frontend/src/templates/Field/Table/TableField.test.tsx
+++ b/apps/frontend/src/templates/Field/Table/TableField.test.tsx
@@ -1,0 +1,19 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+
+import * as stories from './TableField.stories'
+
+const { DisabledWithLongDropdownOption } = composeStories(stories)
+
+const LONG_DROPDOWN_OPTION =
+  'This is a very long dropdown option label that should not be truncated when disabled'
+
+describe('TableField — disabled dropdown column cell', () => {
+  it('exposes the full selected dropdown label via a native title tooltip', () => {
+    render(<DisabledWithLongDropdownOption />)
+
+    // At least one row should expose the full label via title.
+    const titled = screen.getAllByTitle(LONG_DROPDOWN_OPTION)
+    expect(titled.length).toBeGreaterThan(0)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-monorepo",
-  "version": "7.21.0",
+  "version": "7.21.1",
   "private": true,
   "description": "Form Manager for Government",
   "homepage": "https://form.gov.sg",

--- a/packages/react-email-preview/package.json
+++ b/packages/react-email-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-react-email-preview",
-  "version": "7.21.0",
+  "version": "7.21.1",
   "private": true,
   "scripts": {
     "build": "email build",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-shared",
-  "version": "7.21.0",
+  "version": "7.21.1",
   "private": true,
   "description": "",
   "scripts": {

--- a/services/form-payment-reconciliation/package.json
+++ b/services/form-payment-reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-payment-reconciliation",
-  "version": "7.21.0",
+  "version": "7.21.1",
   "private": true,
   "description": "Lambda function for payment reconciliation",
   "main": "index.js",

--- a/services/pdf-gen-sparticuz/package.json
+++ b/services/pdf-gen-sparticuz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-pdf-gen-sparticuz",
-  "version": "7.21.0",
+  "version": "7.21.1",
   "private": true,
   "description": "<!-- title: 'AWS NodeJS Example' description: 'This template demonstrates how to deploy a simple NodeJS function running on AWS Lambda using the Serverless Framework.' layout: Doc framework: v4 platform: AWS language: nodeJS priority: 1 authorLink: 'https://github.com/serverless' authorName: 'Serverless, Inc.' authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4' -->",
   "main": "dist/index.js",

--- a/services/virus-scanner-guardduty/package.json
+++ b/services/virus-scanner-guardduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-virus-scanner-guardduty",
-  "version": "7.21.0",
+  "version": "7.21.1",
   "private": true,
   "description": "",
   "scripts": {


### PR DESCRIPTION


### Bug Fixes

* **backend:** reject 0-byte uploads at presigned POST policy (#9483) ([#9483](https://github.com/opengovsg/formsg/commit/bc83515e5f79fb937e9300d8ffb91444991f4284))
* **backend:** update sso integration behavior (#9459) ([#9459](https://github.com/opengovsg/formsg/commit/b6434431efe9e2be0a4e2d395b308c5d37bd930d))
* **table:** show full dropdown label in disabled MRF cells (#9501) ([#9501](https://github.com/opengovsg/formsg/commit/d9bdd5b4d63816b028714752ec9b7727fc011295))


### Tests

### **backend:** reject 0-byte uploads at presigned POST policy (#9483) ([#9483](https://github.com/opengovsg/formsg/commit/bc83515e5f79fb937e9300d8ffb91444991f4284))

**TC1: 0-byte upload is rejected at S3**

- [ ] Request a presigned POST URL from staging.
- [ ] `curl` a 0-byte body to that URL with the returned fields.
- [ ] Confirm response is HTTP 400 with `EntityTooSmall`.

**TC2: Normal uploads still work**

- [x] Submit a storage-mode form on staging with a small (>0B) attachment.
- [x] Confirm the attachment lands in the clean bucket and decrypts on the responses page.

### **table:** show full dropdown label in disabled MRF cells (#9501) ([#9501](https://github.com/opengovsg/formsg/commit/d9bdd5b4d63816b028714752ec9b7727fc011295))

**TC1: MRF subsequent step sees full previous-step dropdown selection**

- [x] Open an MRF where step 1 fills a Table field with a Dropdown column containing a long option label.
- [x] Submit step 1 and proceed to step 2 (where the Table field is not assigned).
- [x] Hover the disabled dropdown cell — the native browser tooltip shows the full label.
- [x] Drag horizontally inside the cell — the label scrolls to reveal the rest of the text.
- [x] Confirm caret and clear button are visible but the dropdown cannot be opened or cleared.

**TC2: No regression on standalone disabled dropdown**

- [x] Open Storybook `Templates/Field/DropdownField` (or any non-table disabled `SingleSelect`).
- [x] Confirm the disabled rendering is unchanged from `develop`: ellipsis truncation, no `title` attribute, no horizontal scroll.

**TC3: No regression on editable Table dropdown cell**

- [x] Open Storybook `TableField/Default` and select a long dropdown option in a row.
- [x] Confirm the cell behaves exactly as before — clickable, truncated with ellipsis while editable.

