### PR TITLE
fix: call toObject() on submissionData before spreading to preserve submittedAt timestamps

### DIFF
--- a/apps/backend/src/app/modules/status-tracker/status-tracker.controller.ts
+++ b/apps/backend/src/app/modules/status-tracker/status-tracker.controller.ts
@@ -38,8 +38,7 @@ const getStatusTrackerSubmissionData: ControllerHandler<
     .andThen((submissionId) => getMultirespondentSubmission(submissionId))
     .map((submissionData) => {
       // strip emails from submitted steps and workflow
-      // toObject() is required: spreading a Mongoose subdocument copies internals (_doc, $__parent)
-      // rather than the document fields, so submittedAt etc. would be lost.
+      // drop mongoose internals to extract documentFields (e.g. submittedAt, etc.)
       const strippedSubmittedSteps = submissionData
         .toObject()
         .submittedSteps?.map(

--- a/apps/backend/src/app/modules/status-tracker/status-tracker.controller.ts
+++ b/apps/backend/src/app/modules/status-tracker/status-tracker.controller.ts
@@ -1,5 +1,9 @@
 import { celebrate, Joi, Segments } from 'celebrate'
-import { StatusTrackerData, StrippedFormWorkflowDto } from 'formsg-shared/types'
+import {
+  StatusTrackerData,
+  StrippedFormWorkflowDto,
+  SubmittedStep,
+} from 'formsg-shared/types'
 import { stripWorkflowEmails } from 'formsg-shared/utils/strip-workflow-emails'
 import { StatusCodes } from 'http-status-codes'
 import { okAsync } from 'neverthrow'
@@ -34,10 +38,14 @@ const getStatusTrackerSubmissionData: ControllerHandler<
     .andThen((submissionId) => getMultirespondentSubmission(submissionId))
     .map((submissionData) => {
       // strip emails from submitted steps and workflow
-      const strippedSubmittedSteps = submissionData.submittedSteps?.map(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        ({ nextStepRecipientEmails, ...rest }) => rest,
-      )
+      // toObject() is required: spreading a Mongoose subdocument copies internals (_doc, $__parent)
+      // rather than the document fields, so submittedAt etc. would be lost.
+      const strippedSubmittedSteps = submissionData
+        .toObject()
+        .submittedSteps?.map(
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          ({ nextStepRecipientEmails, ...rest }: SubmittedStep) => rest,
+        )
 
       const strippedWorkflow: StrippedFormWorkflowDto = stripWorkflowEmails(
         submissionData.workflow,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When the status tracker API strips `nextStepRecipientEmails` from `submittedSteps`, it was spreading directly from a Mongoose subdocument. Spreading a Mongoose subdocument copies internal Mongoose metadata (`_doc`, `$__parent`, etc.) rather than the actual document fields. As a result, `submittedAt` timestamps and other step fields were lost from the API response.

## Solution
<!-- How did you solve the problem? -->

Call `.toObject()` on the Mongoose document before mapping over `submittedSteps`. This converts the subdocument to a plain JavaScript object so spreading correctly enumerates the actual document fields rather than Mongoose internals.

Also imports the `SubmittedStep` type from `formsg-shared/types` to properly type the map callback after the conversion.

**Breaking Changes**
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No — this PR is backwards compatible. The fix restores data that was already expected to be present in the response.

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: Status tracker reflects correct `submittedAt` timestamps
- [ ] Create a multirespondent form with at least two workflow steps
- [ ] Submit step 1 as respondent 1
- [ ] Submit step 2 as respondent 2
- [ ] Open the status tracker URL for the submission
- [ ] Verify that each completed step shows its `submittedAt` timestamp correctly (not undefined/null)