### PR TITLE
fix(admin-form): show error state when webhook settings fetch fails

### DIFF
--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryFn } from '@storybook/react'
+import { http, HttpResponse } from 'msw'
 
 import { FormResponseMode, FormSettings } from 'formsg-shared/types/form'
 
@@ -73,6 +74,22 @@ export const UnsupportedEmailMode = Template.bind({})
 export const Loading = Template.bind({})
 Loading.parameters = {
   msw: { handlers: { default: buildMswRoutes({ delay: 'infinite' }) } },
+}
+
+export const Error = Template.bind({})
+Error.parameters = {
+  msw: {
+    handlers: {
+      default: [
+        http.get('/api/v3/admin/forms/:formId/settings', () =>
+          HttpResponse.json(
+            { message: 'Internal Server Error' },
+            { status: 500 },
+          ),
+        ),
+      ],
+    },
+  },
 }
 
 export const Mobile = Template.bind({})

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.test.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.test.tsx
@@ -1,0 +1,32 @@
+import { composeStories } from '@storybook/react'
+import { act, render, screen } from '@testing-library/react'
+
+import * as stories from './SettingsWebhooksPage.stories'
+
+const { Error: ErrorStory, UnsupportedEmailMode } = composeStories(stories)
+
+const UNSUPPORTED_MSG = /webhooks are only available in storage mode/i
+const ERROR_MSG = /couldn't load webhook settings/i
+
+describe('SettingsWebhooksPage', () => {
+  it('shows an error state, not the unsupported-mode message, when the settings fetch fails', async () => {
+    await act(async () => {
+      render(<ErrorStory />)
+    })
+
+    await screen.findByText(ERROR_MSG)
+    expect(
+      screen.getByRole('button', { name: /try again/i }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(UNSUPPORTED_MSG)).not.toBeInTheDocument()
+  })
+
+  it('still shows the unsupported-mode message for a form whose mode genuinely lacks webhook support', async () => {
+    await act(async () => {
+      render(<UnsupportedEmailMode />)
+    })
+
+    await screen.findByText(UNSUPPORTED_MSG)
+    expect(screen.queryByText(ERROR_MSG)).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.test.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.test.tsx
@@ -15,6 +15,8 @@ describe('SettingsWebhooksPage', () => {
     })
 
     await screen.findByText(ERROR_MSG)
+    // The error is announced to assistive tech (it appears after an async failure).
+    expect(screen.getByRole('alert')).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /try again/i }),
     ).toBeInTheDocument()

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -10,13 +10,20 @@ import { useUser } from '~features/user/queries'
 
 import { CategoryHeader } from './components/CategoryHeader'
 import { WebhooksSection } from './components/WebhooksSection'
+import { WebhooksErrorMsg } from './components/WebhooksSection/WebhooksErrorMsg'
 import { WebhooksUnsupportedMsg } from './components/WebhooksSection/WebhooksUnsupportedMsg'
 import { useAdminFormSettings } from './queries'
 
 export const SettingsWebhooksPage = (): JSX.Element => {
   const { t } = useTranslation()
   const gb = useGrowthBook()
-  const { data: settings, isLoading } = useAdminFormSettings()
+  const {
+    data: settings,
+    isLoading,
+    isError,
+    isFetching,
+    refetch,
+  } = useAdminFormSettings()
   const userRes = useUser()
 
   useEffect(() => {
@@ -26,6 +33,12 @@ export const SettingsWebhooksPage = (): JSX.Element => {
   }, [userRes.user?.email, gb])
 
   const enableMrfWebhooks = useFeatureIsOn(featureFlags.enableMrfWebhooks)
+
+  // The settings fetch failed. Show an explicit error/retry state instead of
+  // misreporting the form's response mode as unsupported.
+  if (isError) {
+    return <WebhooksErrorMsg onRetry={refetch} isRetrying={isFetching} />
+  }
 
   const enableWebhooks =
     !isLoading &&

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -21,7 +21,7 @@ export const SettingsWebhooksPage = (): JSX.Element => {
     data: settings,
     isLoading,
     isError,
-    isFetching,
+    isRefetching,
     refetch,
   } = useAdminFormSettings()
   const userRes = useUser()
@@ -37,7 +37,7 @@ export const SettingsWebhooksPage = (): JSX.Element => {
   // The settings fetch failed. Show an explicit error/retry state instead of
   // misreporting the form's response mode as unsupported.
   if (isError) {
-    return <WebhooksErrorMsg onRetry={refetch} isRetrying={isFetching} />
+    return <WebhooksErrorMsg onRetry={refetch} isRetrying={isRefetching} />
   }
 
   const enableWebhooks =

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -42,7 +42,7 @@ export const SettingsWebhooksPage = (): JSX.Element => {
 
   const enableWebhooks =
     !isLoading &&
-    (settings?.responseMode == FormResponseMode.Encrypt ||
+    (settings?.responseMode === FormResponseMode.Encrypt ||
       (settings?.responseMode === FormResponseMode.Multirespondent &&
         enableMrfWebhooks))
 

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksErrorMsg.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksErrorMsg.tsx
@@ -1,0 +1,34 @@
+import { Flex, Text } from '@chakra-ui/react'
+
+import Button from '~components/Button'
+
+export interface WebhooksErrorMsgProps {
+  onRetry: () => void
+  isRetrying?: boolean
+}
+
+export const WebhooksErrorMsg = ({
+  onRetry,
+  isRetrying = false,
+}: WebhooksErrorMsgProps): JSX.Element => {
+  return (
+    <Flex justify="center" flexDir="column" textAlign="center">
+      <Text textStyle="h2" as="h2" color="primary.500" mb="1rem">
+        Couldn't load webhook settings
+      </Text>
+      <Text textStyle="body-1" color="secondary.500" mb="2.5rem">
+        Something went wrong while loading this form's settings. This does not
+        affect your form or its responses. Please try again.
+      </Text>
+      <Flex justify="center">
+        <Button
+          isLoading={isRetrying}
+          loadingText="Trying again…"
+          onClick={onRetry}
+        >
+          Try again
+        </Button>
+      </Flex>
+    </Flex>
+  )
+}

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksErrorMsg.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksErrorMsg.tsx
@@ -12,7 +12,7 @@ export const WebhooksErrorMsg = ({
   isRetrying = false,
 }: WebhooksErrorMsgProps): JSX.Element => {
   return (
-    <Flex justify="center" flexDir="column" textAlign="center">
+    <Flex justify="center" flexDir="column" textAlign="center" role="alert">
       <Text textStyle="h2" as="h2" color="primary.500" mb="1rem">
         Couldn't load webhook settings
       </Text>


### PR DESCRIPTION
## Problem

On a storage-mode form, if the admin-form settings request fails or hangs, `SettingsWebhooksPage` renders the "Webhooks are only available in storage mode" message instead of an error state. The page reads only `data`/`isLoading` from `useAdminFormSettings()` and ignores `isError`; on failure `settings` is `undefined`, so `enableWebhooks` collapses to `false` and the unsupported-mode branch renders. Admins on a form that *does* support webhooks are told the opposite, with no indication that anything failed.

Closes #9512

## Solution

Check the query's error state before evaluating the response mode:

- Read `isError`, `isFetching`, and `refetch` from `useAdminFormSettings()`.
- Return an explicit error/retry state (`WebhooksErrorMsg`) when `isError` is true, *before* computing `enableWebhooks`. The unsupported-mode message now only renders for a successfully-loaded form whose mode genuinely lacks webhook support. Loading-skeleton behaviour is unchanged (during loading `isError` is false).
- Add `WebhooksErrorMsg`, a presentational error component with a retry button wired to `refetch` (`isFetching` drives the button's loading state). It mirrors the layout/conventions of the sibling `WebhooksUnsupportedMsg`, including its hardcoded copy — i18n is intentionally not introduced here to stay consistent with the existing component and keep this change scoped.

Scope is intentionally limited to `SettingsWebhooksPage`. Other `Settings*Page` components may share the same destructuring pattern; auditing them is left as a follow-up rather than widening this PR.

**Breaking Changes**
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- A failed/transient settings fetch no longer misreports a storage-mode form's response mode as unsupported; admins get a clear "couldn't load, try again" state with a working retry instead.

## Before & After Screenshots

**BEFORE**:
<!-- settings fetch blocked: shows "Webhooks are only available in storage mode" -->

<img width="1481" height="694" alt="Screenshot 2026-05-26 222429" src="https://github.com/user-attachments/assets/f5647b98-559f-42d4-ba6c-f38ffb4e3b4c" />

**AFTER**:
<!-- same failure: shows "Couldn't load webhook settings" + "Try again" -->

<img width="537" height="518" alt="Screenshot 2026-06-02 145623" src="https://github.com/user-attachments/assets/a68f97ea-6492-4d9f-a69a-870be3be7c62" />

## Tests

- `pnpm test:frontend
` — all tests pass.
- Added `SettingsWebhooksPage.test.tsx` (via `composeStories`): (1) on a failed settings fetch, the error state and retry button render and the unsupported-mode message does **not**; (2) on a genuine email-mode form, the unsupported-mode message still renders and the error state does not (guards the legitimate case).
- Added an `Error` story backed by a 500 MSW handler for the settings endpoint (dev/test only; not shipped to users).
- Verified the test is a real regression guard: removing the `isError` branch makes test (1) fail; restoring it passes.

## Deploy Notes

No new environment variables, scripts, or dependencies.
