### PR TITLE
build: release v7.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [7.22.0](https://github.com/opengovsg/formsg/compare/v7.21.2...v7.22.0) (2026-06-03)
+
+
+### Features
+
+* **mrf-cutover:** foundation — beta flag, feature flag key, escape-hatch copy composer (1/6) (#9462) ([#9462](https://github.com/opengovsg/formsg/commit/7c498f72bcf9f23c5e1a0da4c4832cb31b87232d))
+* **mrf-cutover:** webhook v1 schema infobox on storage-mode settings (3/6) (#9463) ([#9463](https://github.com/opengovsg/formsg/commit/e885b98a44c897071132b28e9f4fa3b7d08c8c63))
+
+
+### Bug Fixes
+
+* add mt to webhook section (#9530) ([#9530](https://github.com/opengovsg/formsg/commit/3b192a38fb3ba0d367fd3ae2c909a397ddcd8012))
+
+
+### Miscellaneous
+
+* Merge pull request #9468 from opengovsg/refactor/modal-cutover-prep ([#9468](https://github.com/opengovsg/formsg/commit/b4b89a78a081e5a7148c65bb1f123a0d4224ec86))
+
+
+### Builds
+
+* merge 7.21.2 back to develop (#9521) ([#9521](https://github.com/opengovsg/formsg/commit/2d7a69174f7efd125450e0e851bc2ecb96fe6482))
+
 ## [7.21.2](https://github.com/opengovsg/formsg/compare/v7.21.1...v7.21.2) (2026-06-02)
 
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-backend",
-  "version": "7.21.2",
+  "version": "7.22.0",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/apps/backend/src/app/models/__tests__/user.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/user.server.model.spec.ts
@@ -146,6 +146,18 @@ describe('User Model', () => {
         'This email is not a valid agency email',
       )
     })
+
+    it('should persist createStorageModeForV1Webhook beta flag', async () => {
+      const saved = await User.create({
+        email: VALID_USER_EMAIL,
+        agency: agency._id,
+        contact: VALID_CONTACT,
+        betaFlags: { createStorageModeForV1Webhook: true },
+      })
+
+      const user = await User.findById(saved._id).lean()
+      expect(user?.betaFlags?.createStorageModeForV1Webhook).toBe(true)
+    })
   })
 
   describe('Methods', () => {

--- a/apps/backend/src/app/models/user.server.model.ts
+++ b/apps/backend/src/app/models/user.server.model.ts
@@ -84,6 +84,7 @@ const compileUserModel = (db: Mongoose) => {
         respondentCopy: Boolean,
         statusTracker: Boolean,
         signatureField: Boolean,
+        createStorageModeForV1Webhook: Boolean,
       },
       flags: {
         type: Schema.Types.Map, // of SeenFlags

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-frontend",
-  "version": "7.21.2",
+  "version": "7.22.0",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/apps/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/apps/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -20,6 +20,8 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 
+import { FormId } from 'formsg-shared/types/form/form'
+
 import { FORMSG_UAT } from '~constants/links'
 import { ADMINFORM_ROUTE, DASHBOARD_ROUTE } from '~constants/routes'
 import Button, { ButtonProps } from '~components/Button'
@@ -166,7 +168,11 @@ export const PreviewFormBanner = ({
             onClose={onModalClose}
           />
         ) : (
-          <DuplicateFormModal isOpen={isModalOpen} onClose={onModalClose} />
+          <DuplicateFormModal
+            isOpen={isModalOpen}
+            onClose={onModalClose}
+            formIdToDuplicate={formId as FormId}
+          />
         )}
         <Drawer
           placement="bottom"

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
@@ -1,5 +1,7 @@
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { Meta, StoryFn } from '@storybook/react'
 
+import { featureFlags } from 'formsg-shared/constants'
 import { FormResponseMode, FormSettings } from 'formsg-shared/types/form'
 
 import {
@@ -51,6 +53,30 @@ StorageModeEmpty.parameters = {
   },
 }
 
+const mrfCutoverOnGrowthBook = new GrowthBook({
+  features: { [featureFlags.mrfCutover]: { defaultValue: true } },
+})
+
+export const StorageModeMrfCutoverOn = Template.bind({})
+StorageModeMrfCutoverOn.decorators = [
+  (Story) => (
+    <GrowthBookProvider growthbook={mrfCutoverOnGrowthBook}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+StorageModeMrfCutoverOn.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Encrypt,
+        },
+      }),
+    },
+  },
+}
+
 export const StorageModeRetryEnabled = Template.bind({})
 StorageModeRetryEnabled.parameters = {
   msw: {
@@ -69,6 +95,19 @@ StorageModeRetryEnabled.parameters = {
 }
 
 export const UnsupportedEmailMode = Template.bind({})
+
+export const UnsupportedMultirespondentMode = Template.bind({})
+UnsupportedMultirespondentMode.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Multirespondent,
+        },
+      }),
+    },
+  },
+}
 
 export const Loading = Template.bind({})
 Loading.parameters = {

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -1,16 +1,19 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
 import { Skeleton } from '@chakra-ui/react'
 import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 
 import { featureFlags } from 'formsg-shared/constants'
 import { FormResponseMode } from 'formsg-shared/types/form'
+import { FormId } from 'formsg-shared/types/form/form'
 
 import { useUser } from '~features/user/queries'
 
 import { CategoryHeader } from './components/CategoryHeader'
 import { WebhooksSection } from './components/WebhooksSection'
 import { WebhooksUnsupportedMsg } from './components/WebhooksSection/WebhooksUnsupportedMsg'
+import { WebhookV1SchemaInfobox } from './components/WebhooksSection/WebhookV1SchemaInfobox'
 import { useAdminFormSettings } from './queries'
 
 export const SettingsWebhooksPage = (): JSX.Element => {
@@ -25,7 +28,9 @@ export const SettingsWebhooksPage = (): JSX.Element => {
     })
   }, [userRes.user?.email, gb])
 
+  const { formId } = useParams()
   const enableMrfWebhooks = useFeatureIsOn(featureFlags.enableMrfWebhooks)
+  const isMrfCutoverEnabled = useFeatureIsOn(featureFlags.mrfCutover)
 
   const enableWebhooks =
     !isLoading &&
@@ -42,11 +47,19 @@ export const SettingsWebhooksPage = (): JSX.Element => {
     )
   }
 
+  const showV1SchemaInfobox =
+    isMrfCutoverEnabled &&
+    settings?.responseMode === FormResponseMode.Encrypt &&
+    !!formId
+
   return (
     <Skeleton isLoaded={!isLoading}>
       <CategoryHeader>
         {t('features.adminForm.settings.webhooks.title')}
       </CategoryHeader>
+      {showV1SchemaInfobox && (
+        <WebhookV1SchemaInfobox formId={formId as FormId} />
+      )}
       <WebhooksSection />
     </Skeleton>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookV1SchemaInfobox.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookV1SchemaInfobox.tsx
@@ -1,0 +1,37 @@
+import { Text, useDisclosure } from '@chakra-ui/react'
+
+import { FormId } from 'formsg-shared/types/form/form'
+
+import InlineMessage from '~components/InlineMessage'
+import Link from '~components/Link'
+
+import { DuplicateFormModal } from '~features/workspace/components/DuplicateFormModal'
+
+interface WebhookV1SchemaInfoboxProps {
+  formId: FormId
+}
+
+export const WebhookV1SchemaInfobox = ({
+  formId,
+}: WebhookV1SchemaInfoboxProps): JSX.Element => {
+  const dupeModal = useDisclosure()
+
+  return (
+    <>
+      <InlineMessage variant="info">
+        <Text>
+          This form uses webhooks V1, which is outdated. Switch to the{' '}
+          <Link cursor="pointer" onClick={dupeModal.onOpen}>
+            latest version of FormSG
+          </Link>{' '}
+          unless your system requires v1.
+        </Text>
+      </InlineMessage>
+      <DuplicateFormModal
+        isOpen={dupeModal.isOpen}
+        onClose={dupeModal.onClose}
+        formIdToDuplicate={formId}
+      />
+    </>
+  )
+}

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksSection.tsx
@@ -5,7 +5,7 @@ import { WebhookUrlInput } from './WebhookUrlInput'
 
 export const WebhooksSection = (): JSX.Element => {
   return (
-    <Stack spacing="2.5rem">
+    <Stack mt="2.5rem" spacing="2.5rem">
       <WebhookUrlInput />
       <RetryToggle />
     </Stack>

--- a/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -32,8 +32,16 @@ export const useUseTemplateWizardContext = (
     (field) => field.fieldType === 'children',
   )
 
-  const { formMethods, currentStep, direction, keypair, setCurrentStep } =
-    useCommonFormWizardProvider()
+  const {
+    formMethods,
+    currentStep,
+    direction,
+    keypair,
+    setCurrentStep,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
+  } = useCommonFormWizardProvider()
 
   const { reset, getValues } = formMethods
 
@@ -168,6 +176,9 @@ export const useUseTemplateWizardContext = (
     hasMyInfoChildren,
     modalHeader: t('features.workspace.modals.forms.create.title.duplicate'),
     onClose,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
   }
 }
 

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -23,7 +23,6 @@ import Input from '~components/Input'
 
 import DataClassificationInfoBox from '~features/admin-form/settings/components/DataClassificationInfoBox'
 
-import { WorkspaceRowsProvider } from '../../WorkspaceFormRow/WorkspaceRowsContext'
 import {
   CreateFormWizardInputProps,
   useCreateFormWizard,
@@ -127,13 +126,11 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
                 name="responseMode"
                 control={control}
                 render={({ field }) => (
-                  <WorkspaceRowsProvider>
-                    <FormResponseOptions
-                      {...field}
-                      hasMyInfoChildren={hasMyInfoChildren}
-                      handleEmailButtonPress={handleEmailButtonPress}
-                    />
-                  </WorkspaceRowsProvider>
+                  <FormResponseOptions
+                    {...field}
+                    hasMyInfoChildren={hasMyInfoChildren}
+                    handleEmailButtonPress={handleEmailButtonPress}
+                  />
                 )}
                 rules={{
                   required: t(

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -14,6 +14,7 @@ import { CheckboxFieldValues } from '~templates/Field'
 export enum CreateFormFlowStates {
   Landing = 'landing',
   Details = 'details',
+  StorageModeDetails = 'storageModeDetails',
   EmailFeedback = 'emailFeedback',
   EmailModeCreation = 'emailModeCreation',
 }
@@ -48,6 +49,9 @@ export type CreateFormWizardContextReturn = {
   isSingpass: boolean
   hasMyInfoChildren: boolean
   onClose: () => void
+  isMrfCutoverEnabled: boolean
+  goToStorageModeDetails: () => void
+  goToMrfDetails: () => void
 }
 
 export const CreateFormWizardContext = createContext<

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -2,7 +2,9 @@
 import { useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
 
+import { featureFlags } from 'formsg-shared/constants'
 import { FormResponseMode, PublicFormViewDto } from 'formsg-shared/types'
 
 import formsgSdk from '~utils/formSdk'
@@ -33,6 +35,7 @@ interface UseCommonFormWizardProviderProps {
 export const useCommonFormWizardProvider = ({
   defaultValues,
 }: UseCommonFormWizardProviderProps = {}) => {
+  const isMrfCutoverEnabled = useFeatureIsOn(featureFlags.mrfCutover)
   const [[currentStep, direction], setCurrentStep] =
     useState(INITIAL_STEP_STATE)
 
@@ -43,8 +46,24 @@ export const useCommonFormWizardProvider = ({
   const keypair = useMemo(() => formsgSdk.crypto.generate(), [])
 
   const formMethods = useForm<CreateFormWizardInputProps>({
-    defaultValues,
+    defaultValues: {
+      ...defaultValues,
+      ...(isMrfCutoverEnabled
+        ? { responseMode: FormResponseMode.Multirespondent }
+        : {}),
+    },
   })
+
+  const { setValue } = formMethods
+
+  const goToStorageModeDetails = () => {
+    setValue('responseMode', FormResponseMode.Encrypt)
+    setCurrentStep([CreateFormFlowStates.StorageModeDetails, 1])
+  }
+  const goToMrfDetails = () => {
+    setValue('responseMode', FormResponseMode.Multirespondent)
+    setCurrentStep([CreateFormFlowStates.Details, -1])
+  }
 
   return {
     formMethods,
@@ -52,6 +71,9 @@ export const useCommonFormWizardProvider = ({
     currentStep,
     direction,
     setCurrentStep,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
   }
 }
 
@@ -59,12 +81,20 @@ const useCreateFormWizardContext = (
   onClose: () => void,
 ): CreateFormWizardContextReturn => {
   const { t } = useTranslation()
-  const { formMethods, currentStep, direction, keypair, setCurrentStep } =
-    useCommonFormWizardProvider({
-      defaultValues: {
-        responseMode: FormResponseMode.Encrypt,
-      },
-    })
+  const {
+    formMethods,
+    currentStep,
+    direction,
+    keypair,
+    setCurrentStep,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
+  } = useCommonFormWizardProvider({
+    defaultValues: {
+      responseMode: FormResponseMode.Encrypt,
+    },
+  })
 
   const { handleSubmit, setValue } = formMethods
 
@@ -193,6 +223,9 @@ const useCreateFormWizardContext = (
     hasMyInfoChildren: false,
     modalHeader: t('features.workspace.modals.forms.create.title.setup'),
     onClose,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
   }
 }
 

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.test.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.test.tsx
@@ -2,13 +2,11 @@ import { act, renderHook } from '@testing-library/react'
 
 import { usePreviewForm } from '~features/admin-form/common/queries'
 import { useUser } from '~features/user/queries'
-import { useWorkspaceRowsContext } from '~features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext'
 import {
   useDuplicateFormMutations,
   useEmailModeFeedbackMutation,
 } from '~features/workspace/mutations'
 import { useDashboard } from '~features/workspace/queries'
-import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import { CreateFormFlowStates } from '../CreateFormModal/CreateFormWizardContext'
 import { useCommonFormWizardProvider } from '../CreateFormModal/CreateFormWizardProvider'
@@ -22,8 +20,6 @@ vi.mock('~features/workspace/queries')
 vi.mock('~features/admin-form/common/queries')
 vi.mock('~features/workspace/mutations')
 vi.mock('~features/user/queries')
-vi.mock('~features/workspace/WorkspaceContext')
-vi.mock('~features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext')
 vi.mock('../CreateFormModal/CreateFormWizardProvider')
 
 const MOCK_FORM_TITLE = 'My Test Form'
@@ -57,11 +53,10 @@ describe('DupeFormWizardProvider', () => {
       direction: 1 as const,
       keypair: { publicKey: 'pk', secretKey: 'sk' } as any,
       setCurrentStep: vi.fn(),
+      isMrfCutoverEnabled: false,
+      goToStorageModeDetails: vi.fn(),
+      goToMrfDetails: vi.fn(),
     }))
-
-    vi.mocked(useWorkspaceRowsContext).mockReturnValue({
-      activeFormMeta: { _id: MOCK_FORM_ID } as any,
-    } as any)
 
     vi.mocked(usePreviewForm).mockReturnValue({
       data: makeMockPreviewFormData() as any,
@@ -71,11 +66,6 @@ describe('DupeFormWizardProvider', () => {
     vi.mocked(useDashboard).mockReturnValue({
       data: makeMockDashboardForms(),
       isLoading: false,
-    } as any)
-
-    vi.mocked(useWorkspaceContext).mockReturnValue({
-      activeWorkspace: { _id: 'ws1' } as any,
-      isDefaultWorkspace: true,
     } as any)
 
     vi.mocked(useUser).mockReturnValue({
@@ -94,7 +84,11 @@ describe('DupeFormWizardProvider', () => {
   })
 
   it('should call reset() with a generated title on the Details step', () => {
-    renderHook(() => useDupeFormWizardContext(vi.fn()))
+    renderHook(() =>
+      useDupeFormWizardContext(vi.fn(), {
+        formIdToDuplicate: MOCK_FORM_ID as any,
+      }),
+    )
 
     expect(mockReset).toHaveBeenCalledTimes(1)
     expect(mockReset).toHaveBeenCalledWith(
@@ -105,7 +99,11 @@ describe('DupeFormWizardProvider', () => {
   it('should not call reset() when dashboardForms changes after moving past the Details step', () => {
     // Bug scenario: dashboard refetches after form is created, triggering useEffect
     // which previously overwrote the title used for the secret key filename.
-    const { rerender } = renderHook(() => useDupeFormWizardContext(vi.fn()))
+    const { rerender } = renderHook(() =>
+      useDupeFormWizardContext(vi.fn(), {
+        formIdToDuplicate: MOCK_FORM_ID as any,
+      }),
+    )
 
     expect(mockReset).toHaveBeenCalledTimes(1)
     mockReset.mockClear()
@@ -129,7 +127,11 @@ describe('DupeFormWizardProvider', () => {
   it('should call reset() again when dashboardForms changes while still on the Details step', () => {
     // Confirm that the guard does not break legitimate re-computation of the title
     // while the user is still on the Details step (e.g. slow initial load).
-    const { rerender } = renderHook(() => useDupeFormWizardContext(vi.fn()))
+    const { rerender } = renderHook(() =>
+      useDupeFormWizardContext(vi.fn(), {
+        formIdToDuplicate: MOCK_FORM_ID as any,
+      }),
+    )
 
     expect(mockReset).toHaveBeenCalledWith(
       expect.objectContaining({ title: `${MOCK_FORM_TITLE}_1` }),

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { FormResponseMode, PublicFormViewDto } from 'formsg-shared/types'
+import { FormId } from 'formsg-shared/types/form/form'
 
 import { usePreviewForm } from '~features/admin-form/common/queries'
 import { useUser } from '~features/user/queries'
@@ -11,7 +12,6 @@ import {
 } from '~features/workspace/mutations'
 import { useDashboard } from '~features/workspace/queries'
 import { makeDuplicateFormTitle } from '~features/workspace/utils/createDuplicateFormTitle'
-import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import {
   CreateFormFlowStates,
@@ -19,23 +19,36 @@ import {
   CreateFormWizardContextReturn,
 } from '../CreateFormModal/CreateFormWizardContext'
 import { useCommonFormWizardProvider } from '../CreateFormModal/CreateFormWizardProvider'
-import { useWorkspaceRowsContext } from '../WorkspaceFormRow/WorkspaceRowsContext'
+
+interface DupeFormWizardSource {
+  formIdToDuplicate: FormId | undefined
+  workspaceId?: string
+}
 
 export const useDupeFormWizardContext = (
   onClose: () => void,
+  source: DupeFormWizardSource,
 ): CreateFormWizardContextReturn => {
   const { t } = useTranslation()
   const { data: dashboardForms, isLoading: isWorkspaceLoading } = useDashboard()
-  const { activeFormMeta } = useWorkspaceRowsContext()
+  const sourceFormId = source.formIdToDuplicate
   const { data: previewFormData, isLoading: isPreviewFormLoading } =
     usePreviewForm(
-      activeFormMeta?._id ?? '',
+      sourceFormId ?? '',
       // Stop querying once submissionData is present.
-      /* enabled= */ !!activeFormMeta,
+      /* enabled= */ !!sourceFormId,
     )
 
-  const { formMethods, currentStep, direction, keypair, setCurrentStep } =
-    useCommonFormWizardProvider()
+  const {
+    formMethods,
+    currentStep,
+    direction,
+    keypair,
+    setCurrentStep,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
+  } = useCommonFormWizardProvider()
 
   const { reset, getValues } = formMethods
 
@@ -83,15 +96,11 @@ export const useDupeFormWizardContext = (
 
   const { emailModeFeedbackMutation } = useEmailModeFeedbackMutation()
 
-  const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
-
-  // do not mutate with workspaceId if it is 'All Forms' (default workspace)
-  // as the default workspace contains an empty string as workspaceId
-  const workspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
+  const workspaceId = source.workspaceId
 
   const handleCreateStorageModeOrMultirespondentForm = handleSubmit(
     ({ title, responseMode, emails }) => {
-      if (!activeFormMeta?._id) {
+      if (!sourceFormId) {
         return
       }
 
@@ -99,7 +108,7 @@ export const useDupeFormWizardContext = (
         case FormResponseMode.Encrypt:
           return dupeStorageModeFormMutation.mutate(
             {
-              formIdToDuplicate: activeFormMeta._id,
+              formIdToDuplicate: sourceFormId,
               title,
               responseMode,
               publicKey: keypair.publicKey,
@@ -117,7 +126,7 @@ export const useDupeFormWizardContext = (
         case FormResponseMode.Multirespondent:
           return dupeMultirespondentModeFormMutation.mutate(
             {
-              formIdToDuplicate: activeFormMeta._id,
+              formIdToDuplicate: sourceFormId,
               title,
               responseMode,
               publicKey: keypair.publicKey,
@@ -172,10 +181,10 @@ export const useDupeFormWizardContext = (
   // TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented.
   const handleCreateEmailModeForm = () =>
     handleSubmit((inputs) => {
-      if (!activeFormMeta?._id) return
+      if (!sourceFormId) return
 
       return dupeEmailModeFormMutation.mutate({
-        formIdToDuplicate: activeFormMeta._id,
+        formIdToDuplicate: sourceFormId,
         emails: inputs.emails.filter(Boolean),
         title: inputs.title,
         responseMode: FormResponseMode.Email,
@@ -201,17 +210,27 @@ export const useDupeFormWizardContext = (
     hasMyInfoChildren,
     modalHeader: t('features.workspace.modals.forms.create.title.duplicate'),
     onClose,
+    isMrfCutoverEnabled,
+    goToStorageModeDetails,
+    goToMrfDetails,
   }
 }
 
 export const DupeFormWizardProvider = ({
   children,
   onClose,
+  formIdToDuplicate,
+  workspaceId,
 }: {
   children: React.ReactNode
   onClose: () => void
+  formIdToDuplicate: FormId | undefined
+  workspaceId?: string
 }): JSX.Element => {
-  const values = useDupeFormWizardContext(onClose)
+  const values = useDupeFormWizardContext(onClose, {
+    formIdToDuplicate,
+    workspaceId,
+  })
   return (
     <CreateFormWizardContext.Provider value={values}>
       {children}

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DuplicateFormModal.tsx
@@ -6,6 +6,8 @@ import {
   UseDisclosureReturn,
 } from '@chakra-ui/react'
 
+import { FormId } from 'formsg-shared/types/form/form'
+
 import { CreateFormModalContent } from '../CreateFormModal/CreateFormModalContent'
 
 import { DupeFormWizardProvider } from './DupeFormWizardProvider'
@@ -13,11 +15,16 @@ import { DupeFormWizardProvider } from './DupeFormWizardProvider'
 export type DuplicateFormModalProps = Pick<
   UseDisclosureReturn,
   'onClose' | 'isOpen'
->
+> & {
+  formIdToDuplicate: FormId | undefined
+  workspaceId?: string
+}
 
 export const DuplicateFormModal = ({
   isOpen,
   onClose,
+  formIdToDuplicate,
+  workspaceId,
 }: DuplicateFormModalProps) => {
   const modalSize = useBreakpointValue({
     base: 'mobile',
@@ -27,12 +34,16 @@ export const DuplicateFormModal = ({
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
-      {/* HACK: Chakra isn't able to cleanly handle nested scroll locks https://github.com/chakra-ui/chakra-ui/issues/7723 
-          We'll override chakra's <RemoveScroll /> manually as react-remove-scroll give priority to the latest mounted instance 
+      {/* HACK: Chakra isn't able to cleanly handle nested scroll locks https://github.com/chakra-ui/chakra-ui/issues/7723
+          We'll override chakra's <RemoveScroll /> manually as react-remove-scroll give priority to the latest mounted instance
       */}
       <RemoveScroll>
         <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
-          <DupeFormWizardProvider onClose={onClose}>
+          <DupeFormWizardProvider
+            onClose={onClose}
+            formIdToDuplicate={formIdToDuplicate}
+            workspaceId={workspaceId}
+          >
             <CreateFormModalContent />
           </DupeFormWizardProvider>
         </ModalContent>

--- a/apps/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
+++ b/apps/frontend/src/features/workspace/components/WorkspaceFormRow/WorkspaceRowsContext.tsx
@@ -8,6 +8,7 @@ import { AdminDashboardFormMetaDto, FormStatus } from 'formsg-shared/types'
 
 import CollaboratorModal from '~features/admin-form/common/components/CollaboratorModal'
 import { ShareFormModal } from '~features/admin-form/share'
+import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import { DeleteFormModal } from '../DeleteFormModal/DeleteFormModal'
 import { DuplicateFormModal } from '../DuplicateFormModal'
@@ -36,6 +37,9 @@ export const WorkspaceRowsProvider = ({
   const shareFormModalDisclosure = useDisclosure()
   const collabModalDisclosure = useDisclosure()
   const deleteFormModalDisclosure = useDisclosure()
+
+  const { activeWorkspace, isDefaultWorkspace } = useWorkspaceContext()
+  const dupeWorkspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
 
   const onOpenDupeFormModal = (meta?: AdminDashboardFormMetaDto) => {
     setActiveFormMeta(meta)
@@ -78,6 +82,8 @@ export const WorkspaceRowsProvider = ({
       <DuplicateFormModal
         isOpen={dupeFormModalDisclosure.isOpen}
         onClose={dupeFormModalDisclosure.onClose}
+        formIdToDuplicate={activeFormMeta?._id}
+        workspaceId={dupeWorkspaceId}
       />
       <ShareFormModal
         isOpen={shareFormModalDisclosure.isOpen}

--- a/apps/frontend/src/utils/__tests__/escapeHatchCopy.test.ts
+++ b/apps/frontend/src/utils/__tests__/escapeHatchCopy.test.ts
@@ -1,0 +1,41 @@
+import { composeEscapeHatchCopy } from '../escapeHatchCopy'
+
+describe('composeEscapeHatchCopy', () => {
+  it('returns payments-only copy when no extra flags are set', () => {
+    expect(composeEscapeHatchCopy()).toEqual({
+      prefix: 'Need payments? Use the ',
+      linkText: 'old version of FormSG',
+      suffix: '.',
+    })
+  })
+
+  it('mentions MyInfo children fields when children flag is set', () => {
+    expect(composeEscapeHatchCopy({ children: true }).prefix).toBe(
+      'Need payments or MyInfo children fields? Use the ',
+    )
+  })
+
+  it('mentions webhooks v1 when createStorageModeForV1Webhook flag is set', () => {
+    expect(
+      composeEscapeHatchCopy({ createStorageModeForV1Webhook: true }).prefix,
+    ).toBe('Need payments or webhooks v1? Use the ')
+  })
+
+  it('composes all reasons when both flags are set', () => {
+    expect(
+      composeEscapeHatchCopy({
+        children: true,
+        createStorageModeForV1Webhook: true,
+      }).prefix,
+    ).toBe('Need payments, MyInfo children fields, or webhooks v1? Use the ')
+  })
+
+  it('ignores unrelated falsy flags', () => {
+    expect(
+      composeEscapeHatchCopy({
+        children: false,
+        createStorageModeForV1Webhook: false,
+      }).prefix,
+    ).toBe('Need payments? Use the ')
+  })
+})

--- a/apps/frontend/src/utils/escapeHatchCopy.ts
+++ b/apps/frontend/src/utils/escapeHatchCopy.ts
@@ -1,0 +1,34 @@
+type EscapeHatchBetaFlags = {
+  children?: boolean
+  createStorageModeForV1Webhook?: boolean
+}
+
+export type EscapeHatchCopy = {
+  prefix: string
+  linkText: string
+  suffix: string
+}
+
+const LINK_TEXT = 'old version of FormSG'
+const SUFFIX = '.'
+
+export const composeEscapeHatchCopy = (
+  betaFlags?: EscapeHatchBetaFlags,
+): EscapeHatchCopy => {
+  const reasons: string[] = ['payments']
+  if (betaFlags?.children) reasons.push('MyInfo children fields')
+  if (betaFlags?.createStorageModeForV1Webhook) reasons.push('webhooks v1')
+
+  const reasonsString =
+    reasons.length === 1
+      ? reasons[0]
+      : reasons.length === 2
+        ? `${reasons[0]} or ${reasons[1]}`
+        : `${reasons.slice(0, -1).join(', ')}, or ${reasons[reasons.length - 1]}`
+
+  return {
+    prefix: `Need ${reasonsString}? Use the `,
+    linkText: LINK_TEXT,
+    suffix: SUFFIX,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-monorepo",
-  "version": "7.21.2",
+  "version": "7.22.0",
   "private": true,
   "description": "Form Manager for Government",
   "homepage": "https://form.gov.sg",

--- a/packages/react-email-preview/package.json
+++ b/packages/react-email-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-react-email-preview",
-  "version": "7.21.2",
+  "version": "7.22.0",
   "private": true,
   "scripts": {
     "build": "email build",

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -41,6 +41,7 @@ export const featureFlags = {
   ddSampleRatePublic: 'dd-sample-rate-public' as const,
   answerObjectDecryption: 'answer-object-decryption' as const,
   standardisedEmailTemplate: 'standardised-email-template' as const,
+  mrfCutover: 'mrf-cutover' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-shared",
-  "version": "7.21.2",
+  "version": "7.22.0",
   "private": true,
   "description": "",
   "scripts": {

--- a/packages/shared/types/user.ts
+++ b/packages/shared/types/user.ts
@@ -31,6 +31,7 @@ export const UserBase = z.object({
       statusTracker: z.boolean().optional(),
       signatureField: z.boolean().optional(),
       singpassMrf: z.boolean().optional(),
+      createStorageModeForV1Webhook: z.boolean().optional(),
     })
     .optional(),
   flags: z.record(z.nativeEnum(SeenFlags), z.number()).optional(),

--- a/services/form-payment-reconciliation/package.json
+++ b/services/form-payment-reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-payment-reconciliation",
-  "version": "7.21.2",
+  "version": "7.22.0",
   "private": true,
   "description": "Lambda function for payment reconciliation",
   "main": "index.js",

--- a/services/pdf-gen-sparticuz/package.json
+++ b/services/pdf-gen-sparticuz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-pdf-gen-sparticuz",
-  "version": "7.21.2",
+  "version": "7.22.0",
   "private": true,
   "description": "<!-- title: 'AWS NodeJS Example' description: 'This template demonstrates how to deploy a simple NodeJS function running on AWS Lambda using the Serverless Framework.' layout: Doc framework: v4 platform: AWS language: nodeJS priority: 1 authorLink: 'https://github.com/serverless' authorName: 'Serverless, Inc.' authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4' -->",
   "main": "dist/index.js",

--- a/services/virus-scanner-guardduty/package.json
+++ b/services/virus-scanner-guardduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-virus-scanner-guardduty",
-  "version": "7.21.2",
+  "version": "7.22.0",
   "private": true,
   "description": "",
   "scripts": {


### PR DESCRIPTION


### Features

* **mrf-cutover:** foundation — beta flag, feature flag key, escape-hatch copy composer (1/6) (#9462) ([#9462](https://github.com/opengovsg/formsg/commit/7c498f72bcf9f23c5e1a0da4c4832cb31b87232d))
* **mrf-cutover:** webhook v1 schema infobox on storage-mode settings (3/6) (#9463) ([#9463](https://github.com/opengovsg/formsg/commit/e885b98a44c897071132b28e9f4fa3b7d08c8c63))


### Bug Fixes

* add mt to webhook section (#9530) ([#9530](https://github.com/opengovsg/formsg/commit/3b192a38fb3ba0d367fd3ae2c909a397ddcd8012))


### Miscellaneous

* Merge pull request #9468 from opengovsg/refactor/modal-cutover-prep ([#9468](https://github.com/opengovsg/formsg/commit/b4b89a78a081e5a7148c65bb1f123a0d4224ec86))


### Builds

* merge 7.21.2 back to develop (#9521) ([#9521](https://github.com/opengovsg/formsg/commit/2d7a69174f7efd125450e0e851bc2ecb96fe6482))


### Tests

### **mrf-cutover:** foundation — beta flag, feature flag key, escape-hatch copy composer (1/6) (#9462) ([#9462](https://github.com/opengovsg/formsg/commit/7c498f72bcf9f23c5e1a0da4c4832cb31b87232d))

**TC1: beta flag round-trips**

- [x] Grant `createStorageModeForV1Webhook=true` to a test user in DB
- [x] Log in; confirm `UserDto.betaFlags.createStorageModeForV1Webhook === true` in network response

### **mrf-cutover:** webhook v1 schema infobox on storage-mode settings (3/6) (#9463) ([#9463](https://github.com/opengovsg/formsg/commit/e885b98a44c897071132b28e9f4fa3b7d08c8c63))

**TC1: storage-mode webhook page shows v1 infobox**

- [x] Open webhook settings on a storage-mode form with `mrf-cutover` flag enabled
- [x] Confirm v1 schema infobox renders with migration CTA

**TC2: migration CTA opens duplicate flow**

- [x] Click the "latest version of FormSG" link in the infobox
- [x] Confirm the Duplicate Form modal opens prefilled with the current form

**TC3: MRF webhook page unchanged**

- [x] Open webhook settings on an MRF
- [x] Confirm existing "unavailable" message renders; no v1 infobox

### Merge pull request #9468 from opengovsg/refactor/modal-cutover-prep ([#9468](https://github.com/opengovsg/formsg/commit/b4b89a78a081e5a7148c65bb1f123a0d4224ec86))

**TC1: existing modal flows unchanged**

- [x] Open Create Form, Duplicate Form, Use Template modals (flag off)
- [x] Confirm wizard steps + navigation work exactly as before

