### PR TITLE
refactor(multirespondent): make MRF Singpass/MyInfo validation step-aware

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -10,6 +10,7 @@ import {
   ChildBirthRecordsResponseV3,
   EmailResponseV3,
   FieldResponsesV3,
+  FormAuthType,
   FormFieldDto,
   FormWorkflowStepConditional,
   FormWorkflowStepDto,
@@ -49,6 +50,7 @@ import {
   createPublicMultirespondentSubmissionDto,
   extractRespondentCopyEmailDatas,
   getQuestionAnswerPairsForMultipleFields,
+  isSingpassEnforcedOnStep,
   retrieveWorkflowStepEmailAddresses,
   validateMrfFieldResponses,
 } from '../multirespondent-submission.utils'
@@ -1051,5 +1053,38 @@ describe('multirespondent-submission.utils', () => {
       responses: null as unknown as FieldResponsesV3,
     })
     expect(nullResult).toEqual([])
+  })
+
+  describe('isSingpassEnforcedOnStep', () => {
+    it.each([
+      FormAuthType.SP,
+      FormAuthType.CP,
+      FormAuthType.MyInfo,
+      FormAuthType.SGID,
+      FormAuthType.SGID_MyInfo,
+    ])('should return true on step 1 when authType is %s', (authType) => {
+      expect(isSingpassEnforcedOnStep({ authType }, 1)).toBe(true)
+    })
+
+    it('should return false on step 1 when authType is NIL', () => {
+      expect(isSingpassEnforcedOnStep({ authType: FormAuthType.NIL }, 1)).toBe(
+        false,
+      )
+    })
+
+    it('should return false on step 0', () => {
+      expect(isSingpassEnforcedOnStep({ authType: FormAuthType.SP }, 0)).toBe(
+        false,
+      )
+    })
+
+    it.each([2, 3, 10])(
+      'should return false on step %i even with a Singpass authType',
+      (stepNumber) => {
+        expect(
+          isSingpassEnforcedOnStep({ authType: FormAuthType.SP }, stepNumber),
+        ).toBe(false)
+      },
+    )
   })
 })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -75,7 +75,10 @@ import {
   ProcessedMultirespondentSubmissionHandlerType,
   StrippedAttachmentResponseV3,
 } from './multirespondent-submission.types'
-import { validateMrfFieldResponses } from './multirespondent-submission.utils'
+import {
+  isSingpassEnforcedOnStep,
+  validateMrfFieldResponses,
+} from './multirespondent-submission.utils'
 
 const logger = createLoggerWithLabel(module)
 
@@ -841,11 +844,13 @@ export const handleNdiResponses = async (
   const isSingpassAuthType =
     authType === FormAuthType.CP || authType === FormAuthType.MyInfo
 
-  // 1. Handle Ndi data for current step
-  if (
-    isSingpassAuthType &&
-    stepNumber === 1 // TODO: update to handle when subsequent steps are Singpass-enabled
-  ) {
+  // 1. Handle Ndi data for current step.
+  // isSingpassEnforcedOnStep answers only the shared step rule (true on the
+  // first step today); the CP/MyInfo authType gate above stays here. When
+  // per-step Singpass config is added (issue #9513 follow-up), changing the
+  // helper extends this step gate, but see the helper's note: the controller's
+  // step-2+ path must be wired separately.
+  if (isSingpassAuthType && isSingpassEnforcedOnStep(formDef, stepNumber)) {
     let userName
     let userInfo
     let jwtPayloadResult

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -3,6 +3,7 @@ import {
   BasicField,
   FieldResponsesV3,
   FieldResponseV3,
+  FormAuthType,
   FormFieldDto,
   FormWorkflowStepDto,
   MultirespondentSubmissionDto,
@@ -559,3 +560,30 @@ export const formatSubmittedStepTimestamp = ({
     .tz('Asia/Singapore')
     .format('ddd, DD MMM YYYY hh:mm:ss A')
 }
+
+/**
+ * Whether the form's Singpass/MyInfo (SPCP) authentication must be
+ * (re-)verified on the given MRF workflow step.
+ *
+ * Today SPCP is only enforced on the first step; later steps rely on the MRF
+ * JWT issued after the previous step. This centralises only the STEP rule (the
+ * `stepNumber === 1` part) that was duplicated across the OTP controller and
+ * the NDI submission middleware. It does NOT centralise the per-authType
+ * policy: each call site keeps its own authType handling, which differs by
+ * design (the controller verifies SP/CP/SGID/MyInfo/SGID_MyInfo; the middleware
+ * only builds NDI content for CP/MyInfo).
+ *
+ * The `form` parameter is taken so the body can later derive the answer from
+ * per-step form configuration (issue #9513 follow-up). Note: enabling Singpass
+ * on step 2+ is NOT just a change to this helper: the OTP controller's step-2+
+ * branch (the `previousSubmissionId` path) skips SPCP without calling this
+ * helper, so that branch must be wired up too (deriving the real step from the
+ * validated MRF JWT) or step-2+ enforcement will fail open.
+ *
+ * NOT behaviour-changing today: with no per-step config in the schema, it
+ * returns true only for step 1 of an auth-enabled form.
+ */
+export const isSingpassEnforcedOnStep = (
+  form: { authType: FormAuthType },
+  stepNumber: number,
+): boolean => form.authType !== FormAuthType.NIL && stepNumber === 1

--- a/apps/backend/src/app/modules/verification/verification.controller.ts
+++ b/apps/backend/src/app/modules/verification/verification.controller.ts
@@ -23,7 +23,10 @@ import { SGID_COOKIE_NAME } from '../sgid/sgid.constants'
 import { SgidService } from '../sgid/sgid.service'
 import { getOidcService } from '../spcp/spcp.oidc.service'
 import { MrfJwtPayload } from '../submission/multirespondent-submission/multirespondent-submission.types'
-import { getMrfCookieName } from '../submission/multirespondent-submission/multirespondent-submission.utils'
+import {
+  getMrfCookieName,
+  isSingpassEnforcedOnStep,
+} from '../submission/multirespondent-submission/multirespondent-submission.utils'
 import * as SubmissionService from '../submission/submission.service'
 
 import { MrfJwtValidationError } from './verification.errors'
@@ -114,9 +117,12 @@ export const _handleGenerateOtp: ControllerHandler<
     FormService.retrieveFullFormById(formId)
       // Step 2: Verify SPCP/MyInfo, if form requires it
       .andThen((form) => {
-        // If previousSubmissionId exists, this means it is coming from a 2+ step MRF workflow
-        // verify MRF JWT and skip SPCP/MyInfo since Singpass is currently only enabled for MRF first step
-        // TODO: revisit this logic when Singpass is enabled for all MRF steps (fix is to run validation check if step is Singpass-enabled)
+        // A previousSubmissionId means this is an MRF step 2+ request: verify the
+        // MRF JWT issued after the previous step. SPCP/MyInfo is not re-verified
+        // here because isSingpassEnforcedOnStep currently returns false for steps
+        // beyond the first. When per-step Singpass config is added (issue #9513
+        // follow-up), gate an SPCP check on isSingpassEnforcedOnStep(form, step)
+        // in this branch too.
         if (previousSubmissionId) {
           const mrfCookie =
             req.cookies[getMrfCookieName({ formId, previousSubmissionId })]
@@ -189,8 +195,13 @@ export const _handleGenerateOtp: ControllerHandler<
             })
         }
 
-        // No previousSubmissionId, proceed with SPCP/MyInfo verification
+        // No previousSubmissionId => MRF first step. Re-verify SPCP/MyInfo only on
+        // steps where the form enforces it; isSingpassEnforcedOnStep is the shared
+        // step rule (this path keeps its own authType switch below).
         setFormTags(form)
+        if (!isSingpassEnforcedOnStep(form, 1)) {
+          return okAsync(form)
+        }
         const { authType } = form
         switch (authType) {
           case FormAuthType.CP: {


### PR DESCRIPTION
## Problem

The MRF Singpass/MyInfo (SPCP) re-verification decision is hardcoded as a `step === 1` assumption in two independent backend locations:

- `verification.controller.ts`: `_handleGenerateOtp` treats the presence of `previousSubmissionId` (any step 2+ request) as a signal to skip SPCP/MyInfo.
- `multirespondent-submission.middleware.ts`: `handleNdiResponses` gates verified-content generation behind `stepNumber === 1`.

Both carried `// TODO` comments pointing at the same future fix. The behaviour is correct for how MRF forms are configured today; the issue is maintainability. The same rule lives in two hand-synced places rather than one named location.

Closes #9513

## Solution

Extract the duplicated step rule into a single shared, tested helper `isSingpassEnforcedOnStep(form, stepNumber)` and have both call sites consume it. This is a behaviour-preserving refactor: for every form configuration that exists today, the validation outcome is unchanged.

Scope is intentionally limited to centralising the step rule. There is no per-step Singpass config in the form schema today, so the helper reads `authType` and the step number only (`authType !== NIL && stepNumber === 1`); it does not unify the per-authType policy, which legitimately differs between the two call sites. Enabling Singpass on step 2+ (schema plus enforcement) is left as a follow-up rather than widening this PR, per the issue's Non-goals. The helper's JSDoc documents what that follow-up must wire (including the controller's step-2+ path) so it does not silently fail open.

**Breaking Changes**
- [x] No - this PR is backwards compatible

**Improvements**:

- Add `isSingpassEnforcedOnStep(form, stepNumber)` helper in `multirespondent-submission.utils.ts` as the single source of truth for the step rule, with unit tests.
- `_handleGenerateOtp` and `handleNdiResponses` now call the helper instead of inlining `step === 1` / `previousSubmissionId` assumptions.
- Remove the two stale `// TODO` comments; replace with a documented extension point for the per-step-config follow-up.

## Tests

- `pnpm --filter formsg-backend test -- multirespondent-submission.utils.spec`: new unit tests for the helper (every `authType` on step 1 is enforced, `NIL` is not, steps 0/2/3/10 are not).
- `pnpm --filter formsg-backend test -- verification.controller.spec`: existing `_handleGenerateOtp` suite stays green (no behaviour change for SPCP-on-step-1 and no-SPCP forms).
- `pnpm --filter formsg-backend test -- multirespondent-submission.middleware.spec`: existing `handleNdiResponses` suite stays green (step-1 enforce, step-2+ skip, NIL no-op).
- All three suites: 132 passed.

## Deploy Notes

No new environment variables, scripts, or dependencies.
