### PR TITLE
fix(login): show toast for non-401 errors on sgID profile

### DIFF
--- a/apps/frontend/src/features/login/LoginPage.tsx
+++ b/apps/frontend/src/features/login/LoginPage.tsx
@@ -114,8 +114,13 @@ export const LoginPage = (): JSX.Element => {
         return t('features.login.LoginPage.forbidden')
       case StatusCodes.UNAUTHORIZED.toString():
         return t('features.login.LoginPage.expiredSession')
-      default:
+      default: {
+        const code = parseInt(statusCode ?? '')
+        if (code >= 500 && code < 600) {
+          return t('features.common.errors.serverError')
+        }
         return t('features.common.errors.generic')
+      }
     }
   }, [statusCode])
 

--- a/apps/frontend/src/features/login/SelectProfilePage.tsx
+++ b/apps/frontend/src/features/login/SelectProfilePage.tsx
@@ -29,7 +29,7 @@ import { DASHBOARD_ROUTE, LOGIN_ROUTE } from '~constants/routes'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import { useToast } from '~hooks/useToast'
-import { ApiService } from '~services/ApiService'
+import { ApiService, HttpError } from '~services/ApiService'
 import Button from '~components/Button'
 import { ModalCloseButton } from '~components/Modal'
 
@@ -132,7 +132,23 @@ export const SelectProfilePage = (): JSX.Element => {
   // If redirected back here but already authed, redirect to dashboard.
   if (user) window.location.replace(DASHBOARD_ROUTE)
   // User doesn't have any profiles, should reattempt to login
-  if (profilesResponse.error) window.location.replace(LOGIN_ROUTE)
+
+  if (profilesResponse.error) {
+    if (
+      (profilesResponse.error as HttpError).code === StatusCodes.UNAUTHORIZED
+    ) {
+      // 401 — session invalid, redirect quietly
+      window.location.replace(LOGIN_ROUTE)
+    } else {
+      // all other errors (5xx, network failure, etc.) — redirect with status
+      // so LoginPage can surface the generic error toast on arrival.
+      // Fall back to 500 for network failures where no status code is present.
+      const statusCode =
+        (profilesResponse.error as HttpError).code ??
+        StatusCodes.INTERNAL_SERVER_ERROR
+      window.location.replace(`${LOGIN_ROUTE}?status=${statusCode}`)
+    }
+  }
 
   useEffect(() => {
     if (profilesResponse.data?.profiles.length === 0) {

--- a/apps/frontend/src/features/login/SelectProfilePage.tsx
+++ b/apps/frontend/src/features/login/SelectProfilePage.tsx
@@ -134,19 +134,17 @@ export const SelectProfilePage = (): JSX.Element => {
   // User doesn't have any profiles, should reattempt to login
 
   if (profilesResponse.error) {
-    if (
-      (profilesResponse.error as HttpError).code === StatusCodes.UNAUTHORIZED
-    ) {
+    const err = profilesResponse.error
+    const statusCode = err instanceof HttpError ? err.code : undefined
+
+    if (statusCode === StatusCodes.UNAUTHORIZED) {
       // 401 — session invalid, redirect quietly
       window.location.replace(LOGIN_ROUTE)
     } else {
-      // all other errors (5xx, network failure, etc.) — redirect with status
-      // so LoginPage can surface the generic error toast on arrival.
-      // Fall back to 500 for network failures where no status code is present.
-      const statusCode =
-        (profilesResponse.error as HttpError).code ??
-        StatusCodes.INTERNAL_SERVER_ERROR
-      window.location.replace(`${LOGIN_ROUTE}?status=${statusCode}`)
+      // all other HTTP errors — redirect with status so LoginPage can surface the appropriate toast.
+      // For non-HTTP errors (e.g. network failures), use a non-5xx sentinel so we fall back to the generic toast.
+      const statusParam = statusCode ?? 0
+      window.location.replace(`${LOGIN_ROUTE}?status=${statusParam}`)
     }
   }
 

--- a/apps/frontend/src/i18n/locales/features/common/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/common/en-sg.ts
@@ -62,6 +62,7 @@ export const enSG: Common = {
     },
     pageNotFound: 'This page could not be found.',
     generic: 'Something went wrong. Please try again later.',
+    serverError: 'A server error occurred. Please try again later.',
   },
   tooltip: {
     deleteField: 'Delete field',

--- a/apps/frontend/src/i18n/locales/features/common/index.ts
+++ b/apps/frontend/src/i18n/locales/features/common/index.ts
@@ -62,6 +62,7 @@ export interface Common {
     }
     pageNotFound: string
     generic: string
+    serverError: string
   }
   tooltip: {
     deleteField: string


### PR DESCRIPTION
## Problem

`SelectProfilePage` unconditionally redirects all errors from `useSgidProfiles` to the login page with no user feedback. Only a 401 (unauthenticated) is a valid reason to redirect silently — all other errors (5xx, other 4xx, network failures) left users stuck in a silent redirect loop with no indication that the service was at fault.

Closes #9540

## Solution

Gate the redirect on the error status code. Previously all errors redirected silently to `/login` with no feedback. Now all errors redirect to `/login?status=<code>`, leveraging the existing `LoginPage` status-based toast mechanism to surface a user-facing message appropriate to the error type:

- **401** → "Your session has expired, please log in again"
- **403** → "You are not authorised to access this page"  
- **5xx** → "A server error occurred. Please try again later."
- **other** → generic error message: "Something went wrong. Please try again later."

5xx range handling and the `errors.serverError` translation key were added to support the new explicit server error message.

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `SelectProfilePage`: all errors now redirect to `/login?status=<code>` instead of silently redirecting to `/login` with no feedback, allowing `LoginPage` to surface the appropriate error toast per status code
- `LoginPage`: added 5xx range handling in the status-based toast switch — codes 500–599 now show `'A server error occurred. Please try again later.'` instead of the generic fallback
- `i18n`: added `errors.serverError` translation key to `features/common` to support the explicit server error message

## Before & After Screenshots

**BEFORE**:
User hits a 5xx on the sgID profiles endpoint → silently redirected to `/login` → re-attempts → infinite loop, no error shown

**AFTER**:
User hits a 500 → redirected to `/login?status=500` → toast appears: `'A server error occurred. Please try again later.'`

<img width="1705" height="581" alt="image" src="https://github.com/user-attachments/assets/d84cb6d5-e874-431a-8c3f-3e8a8bfa934d" />

## Tests

1. Override `useSgidProfiles` in `queries.ts` to throw `Object.assign(new Error('Simulated 503'), { code: 503 })`
2. Go through the sgID login flow
3. Confirm redirect lands on `/login?status=503` with a server error toast visible
4. Change to `{ code: 401 }` — confirm redirect lands on `/login?status=401` with an expired session toast
5. Change to a plain `new Error('network error')` (no `.code`) — confirm redirect lands on `/login?status=500` with a generic error toast
6. Revert `queries.ts` and confirm normal sgID login flow is unaffected