### PR TITLE
chore: add agent context and scratch to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,12 @@ coverage/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# AI Configurations
+# =======
+.claude
+.agents
+
+# Scratch files (usually used for AI state/context handoff)
+# =======
+.scratch 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Agent context files and local scratch files (used to save agent context) should not be committed to version control. 

## Solution
<!-- How did you solve the problem? -->
Explicitly ignore in .gitignore. This prevents accidental commits and removes bloat when selecting files to stage for commit.  

We could also add to dockerignore, but let's keep it minimal for now and only add as necessary. (if it noticeably causes issues to eg, local docker runs) 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  