### PR TITLE
fix: render signature question with empty answer when signature is not captured in PDF

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -127,7 +127,6 @@ const PrintableDecryptedRow = ({
       }
       return <StandardPrintableRow question={row.question} answer="" />
     }
-    // falls through to default
     default:
       return (
         <StandardPrintableRow

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -109,7 +109,7 @@ const PrintableDecryptedRow = ({
         </>
       )
     case BasicField.Signature: {
-      if (row.answerArray && row.answerArray.length > 1) {
+      if (row.answerArray && row.answerArray[1]) {
         const signatureVectorArray = JSON.parse(row.answerArray[1] as string)
         const signatureSvg = convertToSignatureSvgString(signatureVectorArray)
         return (
@@ -125,8 +125,9 @@ const PrintableDecryptedRow = ({
           </TableRow>
         )
       }
-      return <></>
+      return <StandardPrintableRow question={row.question} answer="" />
     }
+    // falls through to default
     default:
       return (
         <StandardPrintableRow


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When downloading responses as PDF, if a form contains an optional Signature field that was left unanswered, the PDF generation crashes with `SyntaxError: Unexpected end of JSON input`. This happens because unanswered fields are reconstructed at decryption time (not stored in the encrypted payload) — `processDecryptedContentV3/V4` fills in an empty `answerArray: ['', '']` for unanswered Signature fields. The previous guard only checked `answerArray.length > 1`, which is true for `['', '']`, so `JSON.parse('')` was called and threw.

## Solution
<!-- How did you solve the problem? -->

Changed the guard condition in `PrintableDecryptedRow` from `row.answerArray.length > 1` to `row.answerArray[1]` (truthiness check). An empty string `''` (V3 unanswered path) and `undefined` (V4 path where `JSON.stringify(undefined)` returns `undefined`) are both falsy, so `JSON.parse` is no longer called for these cases.

When the signature value is absent, the field now falls through to render a `StandardPrintableRow` with the question label and an empty answer, consistent with how other unanswered fields appear in the PDF.

**Breaking Changes**
- No — this PR is backwards compatible.

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | ----- | ----- |
| PDF download with unanswered Signature field | Crashes with `SyntaxError: Unexpected end of JSON input` <img width="1688" height="522" alt="image" src="https://github.com/user-attachments/assets/fab01494-448b-4db8-b0f1-b9893f4ea8b5" /> | Question shown with blank answer cell |

## Tests
<!-- What tests should be run to confirm functionality? -->

TC1: PDF download with unanswered optional Signature field
- [ ] Create a Storage/MRF form with an optional Signature field
- [ ] Submit the form without filling in the Signature field
- [ ] As admin, open the Responses page, enter the secret key, and download responses as PDF
- [ ] Verify that the PDF generates successfully without errors
- [ ] Verify that the Signature field appears in the PDF with the question label and a blank answer

TC2: PDF download with answered Signature field
- [ ] Create a Storage/MRF form with a Signature field
- [ ] Submit the form and capture a signature
- [ ] As admin, download responses as PDF
- [ ] Verify that the PDF renders the signature image correctly

TC3: Regression — individual response view
- [ ] Open any individual response containing a Signature field via the Responses page
- [ ] Verify that answered signatures render correctly in the response view
- [ ] Verify that unanswered optional signatures do not crash the page