### PR TITLE
chore(sdk): sync package.json version to 7.2.0

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/formsg-sdk",
-  "version": "7.1.4",
+  "version": "7.2.0",
   "main": "./cjs-entry.cjs",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
## Problem

The `sdk-v7.2.0` git tag was created during a previous release, but the version-bump commit (`chore(sdk): bump version to 7.2.0`) was never merged back into `develop`. This left `packages/sdk/package.json` at `7.1.4` while the tag already exists at `7.2.0`.

As a result, running `release_prep.sh` fails with:

```
fatal: tag 'sdk-v7.2.0' already exists
```

because `commit-and-tag-version` reads `7.1.4` from `package.json`, sees the new `feat:` commit since `sdk-v7.2.0`, and tries to bump to `7.2.0` — which is already taken.

## Solution

Manually sync `packages/sdk/package.json` to `7.2.0` to match the existing tag. With `7.2.0` as the base, the next `commit-and-tag-version` run will correctly bump to `7.3.0` for the new feat commit.

**Breaking Changes**
- No — this is a version field correction only; no code changes.

## Tests

TC1: Release script runs cleanly after merge
- [ ] Merge this PR into `develop`
- [ ] Run `./scripts/release_prep.sh`
- [ ] Verify the SDK version bumps to `7.3.0` and the `sdk-v7.3.0` tag is created without error