### PR TITLE
fix(builder): allow text input spaces in builder page fields

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -231,6 +231,16 @@ const FieldRowContainer = ({
 
   const handleKeydown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
+
+      const target = e.target as HTMLElement;
+      const isEditable = target.tagName === 'INPUT' ||
+                         target.tagName === 'TEXTAREA' ||
+                         target.isContentEditable;
+
+      if(isEditable) {
+        return
+      };
+
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault()
         handleFieldClick()


### PR DESCRIPTION
## Problem
When testing forms on the builder page, input fields (such as Short Answer, Long Answer, and search bars) do not allow empty spaces. This affects form testing, as admins are uncertain what the fields can do until they actually preview the form or make a test submission.

Closes #9343

## Solution
- Added an event target filter within the `handleKeydown` callback of the field container.
- If the space key event originates from an `INPUT`, `TEXTAREA`, or any `contenteditable` element, the function returns early.
- This prevents `e.preventDefault()` from being called inappropriately, thereby preserving the native input behavior of inner fields while maintaining accessibility for the outer container.

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- None

**Improvements**:

- Spacebar now works as expected inside all text input fields during builder preview/testing, matching the behaviour respondents experience on the live form.

**Bug Fixes**:

- Fixed a bug where `e.preventDefault()` on the outer field container intercepted and swallowed spacebar inputs inside inner form text elements (INPUT/TEXTAREA).

## Before & After Screenshots

**BEFORE**:
<img width="591" height="602" alt="BeforeTheIssue-ezgif com-resize" src="https://github.com/user-attachments/assets/2fdc4473-863f-43cb-96e0-32f60113a4bf" />


**AFTER**:
<img width="589" height="604" alt="AfterFixedTheIssue-ezgif com-resize" src="https://github.com/user-attachments/assets/e9582a33-4153-44ef-b90a-4a559982fbfd" />


## Tests
1. Open the form builder page and focus on a field container (e.g., Short Answer).
2. Click inside the text input field and type a string containing spaces (e.g., `"James Bond"`). Verify that spaces are rendered correctly.
3. Use the `Tab` key to focus on the outer field container itself. Press `Space` or `Enter` and verify that the field still activates/opens the builder drawer as expected.
4. Test with other affected fields (e.g., Long Answer, searching dropdowns) to ensure consistent behavior across the builder.

## Deploy Notes
No deployment risks or environmental changes introduced.

**New environment variables**:

- None

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None