### PR TITLE
fix(builder): allow text input spaces in builder page fields (#9552)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -231,15 +231,9 @@ const FieldRowContainer = ({
 
   const handleKeydown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
-
-      const target = e.target as HTMLElement;
-      const isEditable = target.tagName === 'INPUT' ||
-                         target.tagName === 'TEXTAREA' ||
-                         target.isContentEditable;
-
-      if(isEditable) {
+      if (e.currentTarget !== e.target) {
         return
-      };
+      }
 
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault()

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -231,6 +231,16 @@ const FieldRowContainer = ({
 
   const handleKeydown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
+
+      const target = e.target as HTMLElement;
+      const isEditable = target.tagName === 'INPUT' ||
+                         target.tagName === 'TEXTAREA' ||
+                         target.isContentEditable;
+
+      if(isEditable) {
+        return
+      };
+
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault()
         handleFieldClick()

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx
@@ -231,7 +231,13 @@ const FieldRowContainer = ({
 
   const handleKeydown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.currentTarget !== e.target) {
+      const target = e.target as HTMLElement
+      const isEditable =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+
+      if (isEditable) {
         return
       }
 


### PR DESCRIPTION
## Problem
The builder field row keyboard handler was intercepting `Space` / `Enter` events from nested editable elements, which blocked expected typing behavior in text inputs during preview.

## Solution
Reinstated the editable-only keydown guard in `FieldRowContainer`: the handler now returns early only when the event target is `INPUT`, `TEXTAREA`, or `contenteditable`, while preserving existing row keyboard activation behavior for non-editable targets (including buttons).

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- Details ...

**Improvements**:

- Keyboard handling logic in `FieldRowContainer` is now aligned with the intended editable-only exception behavior.
- Maintains existing activation behavior for non-editable controls inside the field row.

**Bug Fixes**:

- Restores expected `Space` behavior for text input scenarios in builder preview.
- Prevents `preventDefault()` from applying to editable targets (`INPUT`, `TEXTAREA`, `contenteditable`).

## Before & After Screenshots

**BEFORE**:


**AFTER**:


## Tests
- `pnpm --filter formsg-frontend exec prettier src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx -c`
- `pnpm --filter formsg-frontend exec eslint src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/FieldRow/FieldRowContainer.tsx`
- `pnpm --filter formsg-frontend test src/features/admin-form/create/builder-and-design/constants.test.ts --run`

## Deploy Notes
No special deploy considerations.

**New environment variables**:

- `env var` : env var details

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details