### PR TITLE
feat: track form origin (paper-form question) in post-cutover Create flow

### DIFF
--- a/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
@@ -15,6 +15,7 @@ import {
   FormField,
   FormFieldDto,
   FormLogoState,
+  FormOrigin,
   FormPermission,
   FormResponseMode,
   FormStartPage,
@@ -113,6 +114,7 @@ const FORM_DEFAULTS = {
     isRetryEnabled: false,
   },
   status: 'PRIVATE',
+  formOrigin: FormOrigin.Unspecified,
   submissionLimit: null,
   goLinkSuffix: '',
   noSmsLimit: false,
@@ -188,6 +190,38 @@ describe('Form Model', () => {
         ])
         const expectedObject = merge({}, FORM_DEFAULTS, MOCK_FORM_PARAMS)
         expect(actualSavedObject).toEqual(expectedObject)
+      })
+
+      it('should persist a form with an explicit formOrigin', async () => {
+        // Arrange + Act
+        const savedForm = await new Form({
+          ...MOCK_FORM_PARAMS,
+          formOrigin: FormOrigin.Paper,
+        }).save()
+
+        // Assert
+        expect(savedForm.formOrigin).toEqual(FormOrigin.Paper)
+      })
+
+      it('should default formOrigin to unspecified when absent', async () => {
+        // Arrange + Act
+        const savedForm = await new Form(MOCK_FORM_PARAMS).save()
+
+        // Assert
+        expect(savedForm.formOrigin).toEqual(FormOrigin.Unspecified)
+      })
+
+      it('should reject an invalid formOrigin value', async () => {
+        // Arrange + Act
+        const invalidForm = new Form({
+          ...MOCK_FORM_PARAMS,
+          formOrigin: 'not-a-real-origin',
+        })
+
+        // Assert
+        await expect(invalidForm.save()).rejects.toThrow(
+          mongoose.Error.ValidationError,
+        )
       })
 
       it('should create and save successfully with valid esrvcId', async () => {

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -20,6 +20,7 @@ import {
   FormField,
   FormFieldDto,
   FormLogoState,
+  FormOrigin,
   FormPaymentsChannel,
   FormPaymentsField,
   FormPermission,
@@ -763,6 +764,15 @@ const compileFormModel = (db: Mongoose): IFormModel => {
         type: String,
         required: false,
         validate: [/^\S*$/i, 'e-service ID must not contain whitespace'],
+      },
+
+      // Where the form's content originated before FormSG (e.g. a paper form).
+      // Defaults to `unspecified` so forms created before origin tracking
+      // existed (no value in the DB) read back as `unspecified`.
+      formOrigin: {
+        type: String,
+        enum: Object.values(FormOrigin),
+        default: FormOrigin.Unspecified,
       },
 
       status: {

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -23,6 +23,7 @@ import {
   FormFeedbackMetaDto,
   FormFieldDto,
   FormLogoState,
+  FormOrigin,
   FormResponseMode,
   FormSettings,
   FormWebhookResponseModeSettings,
@@ -143,6 +144,9 @@ const createFormValidator = celebrate({
           otherwise: Joi.forbidden(),
         }),
         workspaceId: Joi.string(),
+        // Optional form origin metadata captured during creation. Absent
+        // values default to `unspecified` at the schema layer.
+        formOrigin: Joi.string().valid(...Object.values(FormOrigin)),
       })
       .required()
       // Allow other form schema keys to be passed for form creation.

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -22,6 +22,7 @@ import {
   FormFieldDto,
   FormLogoState,
   FormMetadata,
+  FormOrigin,
   FormPermission,
   FormResponseMode,
   FormSettings,
@@ -494,7 +495,7 @@ type MultirespondentFormToCreate = Merge<
  * @returns err(Database*Error) on database errors
  */
 export const createForm = (
-  formParams: Merge<IForm, { admin: string }>,
+  formParams: Merge<IForm, { admin: string; formOrigin?: FormOrigin }>,
   workspaceId?: string,
 ): ResultAsync<
   IFormDocument,
@@ -617,7 +618,7 @@ export const createForm = (
 // error handling will be done in parent createForm method.
 // Exported for testing
 export const createFormInWorkspaceTransaction = async (
-  formParams: Merge<IForm, { admin: string }>,
+  formParams: Merge<IForm, { admin: string; formOrigin?: FormOrigin }>,
   workspaceId: string,
 ): Promise<IFormDocument> => {
   let form: IFormDocument
@@ -635,7 +636,7 @@ export const createFormInWorkspaceTransaction = async (
 }
 
 export const processCreateFormInWorkspace = async (
-  formParams: Merge<IForm, { admin: string }>,
+  formParams: Merge<IForm, { admin: string; formOrigin?: FormOrigin }>,
   workspaceId: string,
   session?: ClientSession,
 ): Promise<IFormDocument> => {

--- a/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -13,6 +13,7 @@ import {
   FormColorTheme,
   FormEndPage,
   FormLogoState,
+  FormOrigin,
   FormResponseMode,
   FormStartPage,
   FormStatus,
@@ -260,6 +261,66 @@ describe('admin-form.form.routes', () => {
           form_logics: [],
         }),
       )
+    })
+
+    it('should persist formOrigin when creating an MRF form with formOrigin', async () => {
+      // Arrange
+      const createMrfParams = {
+        form: {
+          responseMode: 'multirespondent',
+          title: 'mrf paper form test',
+          publicKey: 'some random public key',
+          formOrigin: FormOrigin.Paper,
+        },
+      }
+
+      // Act
+      const response = await request.post('/admin/forms').send(createMrfParams)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          responseMode: FormResponseMode.Multirespondent,
+          title: createMrfParams.form.title,
+          formOrigin: FormOrigin.Paper,
+        }),
+      )
+    })
+
+    it('should default formOrigin to unspecified when omitted on create', async () => {
+      // Arrange
+      const createParams = {
+        form: {
+          responseMode: 'encrypt',
+          title: 'no origin form test',
+          publicKey: 'some random public key',
+          emails: [],
+        },
+      }
+
+      // Act
+      const response = await request.post('/admin/forms').send(createParams)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body.formOrigin).toEqual(FormOrigin.Unspecified)
+    })
+
+    it('should return 400 when formOrigin is not a valid origin', async () => {
+      // Act
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: 'encrypt',
+          title: 'invalid origin form test',
+          publicKey: 'some random public key',
+          emails: [],
+          formOrigin: 'not-a-real-origin',
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(400)
     })
 
     it('should return 400 when body.form.publicKey is missing', async () => {

--- a/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -41,6 +41,7 @@ export const useUseTemplateWizardContext = (
     isMrfCutoverEnabled,
     goToStorageModeDetails,
     goToMrfDetails,
+    goToPaperFormQuestion,
   } = useCommonFormWizardProvider()
 
   const { reset, getValues } = formMethods
@@ -180,6 +181,7 @@ export const useUseTemplateWizardContext = (
     isMrfCutoverEnabled,
     goToStorageModeDetails,
     goToMrfDetails,
+    goToPaperFormQuestion,
   }
 }
 

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModal.stories.tsx
@@ -30,6 +30,7 @@ import {
   EmailModeCreationScreen,
   EmailModeFeedbackScreen,
 } from './CreateFormModalContent/EmailModeFeedbackAndCreateScreen'
+import { PaperFormScreen } from './CreateFormModalContent/PaperFormScreen'
 import { SaveSecretKeyScreen } from './CreateFormModalContent/SaveSecretKeyScreen'
 import { CreateFormModal, CreateFormModalProps } from './CreateFormModal'
 import {
@@ -193,6 +194,27 @@ export const StorageModeAckScreen = () => {
           <CreateFormWizardProvider onClose={() => console.log('close modal')}>
             <ModalCloseButton />
             <SaveSecretKeyScreen useSaveSecretKeyHook={mockHook} />
+          </CreateFormWizardProvider>
+        </ModalContent>
+      </Modal>
+    </WorkspaceProvider>
+  )
+}
+
+export const PaperFormQuestion = () => {
+  return (
+    <WorkspaceProvider
+      currentWorkspace={MOCK_DEFAULT_WORKSPACE._id}
+      defaultWorkspace={MOCK_DEFAULT_WORKSPACE}
+      setCurrentWorkspace={() => {
+        return
+      }}
+    >
+      <Modal isOpen onClose={() => console.log('close modal')} size="full">
+        <ModalContent py={{ base: 'initial', md: '4.5rem' }}>
+          <CreateFormWizardProvider onClose={() => console.log('close modal')}>
+            <ModalCloseButton />
+            <PaperFormScreen />
           </CreateFormWizardProvider>
         </ModalContent>
       </Modal>

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormDetailsScreen.tsx
@@ -58,6 +58,7 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
     hasMyInfoChildren,
     isMrfCutoverEnabled,
     goToStorageModeDetails,
+    goToPaperFormQuestion,
   } = useCreateFormWizard()
   const {
     control,
@@ -156,14 +157,22 @@ export const CreateFormDetailsScreen = (): JSX.Element => {
             type="submit"
             isLoading={isLoading}
             isDisabled={isFetching}
-            onClick={handleCreateStorageModeOrMultirespondentForm}
+            // Post-cutover, the title screen leads into the paper-form question
+            // before the form is created; pre-cutover it creates directly.
+            onClick={
+              isMrfCutoverEnabled
+                ? goToPaperFormQuestion
+                : handleCreateStorageModeOrMultirespondentForm
+            }
             isFullWidth
             data-dd-action-name={getTrackingSubmissionActionName(
               responseModeValue,
             )}
           >
             <Text lineHeight="1.5rem">
-              {t('features.workspace.modals.forms.create.details.create')}
+              {isMrfCutoverEnabled
+                ? t('features.workspace.modals.forms.create.paperForm.nextStep')
+                : t('features.workspace.modals.forms.create.details.create')}
             </Text>
           </Button>
         </Container>

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
@@ -13,6 +13,7 @@ import {
   EmailModeCreationScreen,
   EmailModeFeedbackScreen,
 } from './EmailModeFeedbackAndCreateScreen'
+import { PaperFormScreen } from './PaperFormScreen'
 import { SaveSecretKeyScreen } from './SaveSecretKeyScreen'
 
 /**
@@ -28,6 +29,9 @@ export const CreateFormModalContent = () => {
       <XMotionBox keyProp={currentStep} custom={direction}>
         {currentStep === CreateFormFlowStates.Details && (
           <CreateFormDetailsScreen />
+        )}
+        {currentStep === CreateFormFlowStates.PaperFormQuestion && (
+          <PaperFormScreen />
         )}
         {currentStep === CreateFormFlowStates.StorageModeDetails && (
           <CreateFormStorageModeScreen />

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/PaperFormScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/PaperFormScreen.tsx
@@ -1,0 +1,130 @@
+import { Controller, useFormState } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { BiRightArrowAlt } from 'react-icons/bi'
+import {
+  Box,
+  Container,
+  FormControl,
+  ModalBody,
+  ModalHeader,
+  SimpleGrid,
+  Text,
+} from '@chakra-ui/react'
+
+import Button from '~components/Button'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+
+import { PaperFormAnswer } from '~features/workspace/utils/formMetadata'
+
+import { useCreateFormWizard } from '../CreateFormWizardContext'
+
+interface PaperFormOptionProps {
+  label: string
+  isSelected: boolean
+  onClick: () => void
+}
+
+const PaperFormOption = ({
+  label,
+  isSelected,
+  onClick,
+}: PaperFormOptionProps): JSX.Element => {
+  return (
+    <Box
+      as="button"
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      onClick={onClick}
+      textAlign="left"
+      px="1rem"
+      py="1.25rem"
+      borderRadius="0.25rem"
+      bg={isSelected ? 'primary.100' : 'white'}
+      border="1px solid"
+      borderColor={isSelected ? 'primary.500' : 'neutral.400'}
+      _hover={{ borderColor: isSelected ? 'primary.500' : 'neutral.500' }}
+      _focusVisible={{
+        boxShadow: '0 0 0 2px var(--chakra-colors-primary-500)',
+        outline: 'none',
+      }}
+    >
+      <Text textStyle="body-1" color="secondary.700">
+        {label}
+      </Text>
+    </Box>
+  )
+}
+
+export const PaperFormScreen = (): JSX.Element => {
+  const { t } = useTranslation()
+  const {
+    formMethods,
+    handleCreateStorageModeOrMultirespondentForm,
+    isLoading,
+  } = useCreateFormWizard()
+  const { control } = formMethods
+  // Subscribe to form state via the control so this screen re-renders when
+  // validation errors change — formMethods is shared through context, so
+  // reading formMethods.formState directly here would not be reactive.
+  const { errors } = useFormState({ control })
+
+  return (
+    <>
+      <ModalHeader color="secondary.700">
+        <Container maxW="45rem" p={0}>
+          {t('features.workspace.modals.forms.create.paperForm.title')}
+        </Container>
+      </ModalHeader>
+      <ModalBody whiteSpace="pre-wrap">
+        <Container maxW="45rem" p={0}>
+          <FormControl mt="2rem" isRequired isInvalid={!!errors.isPaperForm}>
+            <Controller
+              name="isPaperForm"
+              control={control}
+              rules={{
+                validate: (value) =>
+                  value === 'yes' ||
+                  value === 'no' ||
+                  t(
+                    'features.workspace.modals.forms.create.paperForm.required',
+                  ),
+              }}
+              render={({ field: { value, onChange } }) => (
+                <SimpleGrid columns={{ base: 1, md: 2 }} spacing="1rem">
+                  <PaperFormOption
+                    label={t(
+                      'features.workspace.modals.forms.create.paperForm.options.yes',
+                    )}
+                    isSelected={value === 'yes'}
+                    onClick={() => onChange('yes' satisfies PaperFormAnswer)}
+                  />
+                  <PaperFormOption
+                    label={t(
+                      'features.workspace.modals.forms.create.paperForm.options.no',
+                    )}
+                    isSelected={value === 'no'}
+                    onClick={() => onChange('no' satisfies PaperFormAnswer)}
+                  />
+                </SimpleGrid>
+              )}
+            />
+            <FormErrorMessage>{errors.isPaperForm?.message}</FormErrorMessage>
+          </FormControl>
+          <Button
+            mt="2.5rem"
+            rightIcon={<BiRightArrowAlt fontSize="1.5rem" />}
+            type="submit"
+            isLoading={isLoading}
+            onClick={handleCreateStorageModeOrMultirespondentForm}
+            isFullWidth
+          >
+            <Text lineHeight="1.5rem">
+              {t('features.workspace.modals.forms.create.paperForm.nextStep')}
+            </Text>
+          </Button>
+        </Container>
+      </ModalBody>
+    </>
+  )
+}

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -11,9 +11,12 @@ import {
 import formsgSdk from '~utils/formSdk'
 import { CheckboxFieldValues } from '~templates/Field'
 
+import { PaperFormAnswer } from '~features/workspace/utils/formMetadata'
+
 export enum CreateFormFlowStates {
   Landing = 'landing',
   Details = 'details',
+  PaperFormQuestion = 'paperFormQuestion',
   StorageModeDetails = 'storageModeDetails',
   EmailFeedback = 'emailFeedback',
   EmailModeCreation = 'emailModeCreation',
@@ -26,6 +29,8 @@ export interface CreateFormWizardInputProps {
   emails?: string[]
   // Storage form props
   storageAck?: boolean
+  // Form origin metadata: whether the form is currently a paper form.
+  isPaperForm?: PaperFormAnswer
 
   // TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented.
   reason?: CheckboxFieldValues // for kill email mode
@@ -52,6 +57,7 @@ export type CreateFormWizardContextReturn = {
   isMrfCutoverEnabled: boolean
   goToStorageModeDetails: () => void
   goToMrfDetails: () => void
+  goToPaperFormQuestion: () => void
 }
 
 export const CreateFormWizardContext = createContext<

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -14,6 +14,7 @@ import {
   useCreateFormMutations,
   useEmailModeFeedbackMutation,
 } from '~features/workspace/mutations'
+import { mapWizardAnswersToFormMetadata } from '~features/workspace/utils/formMetadata'
 import { useWorkspaceContext } from '~features/workspace/WorkspaceContext'
 
 import {
@@ -65,6 +66,12 @@ export const useCommonFormWizardProvider = ({
     setValue('responseMode', FormResponseMode.Multirespondent)
     setCurrentStep([CreateFormFlowStates.Details, -1])
   }
+  // Advance from the title screen to the paper-form question (post-cutover).
+  // handleSubmit gates the transition on title validation. Shared by the
+  // Create, Duplicate, and Use-Template wizards.
+  const goToPaperFormQuestion = formMethods.handleSubmit(() => {
+    setCurrentStep([CreateFormFlowStates.PaperFormQuestion, 1])
+  })
 
   return {
     formMethods,
@@ -75,6 +82,7 @@ export const useCommonFormWizardProvider = ({
     isMrfCutoverEnabled,
     goToStorageModeDetails,
     goToMrfDetails,
+    goToPaperFormQuestion,
   }
 }
 
@@ -91,6 +99,7 @@ const useCreateFormWizardContext = (
     isMrfCutoverEnabled,
     goToStorageModeDetails,
     goToMrfDetails,
+    goToPaperFormQuestion,
   } = useCommonFormWizardProvider({
     defaultValues: {
       responseMode: FormResponseMode.Encrypt,
@@ -117,7 +126,10 @@ const useCreateFormWizardContext = (
   const workspaceId = isDefaultWorkspace ? undefined : activeWorkspace._id
 
   const handleCreateStorageModeOrMultirespondentForm = handleSubmit(
-    ({ title, responseMode, emails }) => {
+    ({ title, responseMode, emails, isPaperForm }) => {
+      const { formOrigin } = mapWizardAnswersToFormMetadata({
+        isPaperForm: isPaperForm ?? 'no',
+      })
       switch (responseMode) {
         case FormResponseMode.Encrypt: {
           const defaultEmails = adminEmail ? [adminEmail] : []
@@ -128,6 +140,7 @@ const useCreateFormWizardContext = (
               publicKey: keypair.publicKey,
               workspaceId,
               emails: (emails ?? defaultEmails).filter(Boolean),
+              formOrigin,
             },
             {
               onSuccess: () => {
@@ -145,6 +158,7 @@ const useCreateFormWizardContext = (
               responseMode,
               publicKey: keypair.publicKey,
               workspaceId,
+              formOrigin,
             },
             {
               onSuccess: () => {
@@ -229,6 +243,7 @@ const useCreateFormWizardContext = (
     isMrfCutoverEnabled,
     goToStorageModeDetails,
     goToMrfDetails,
+    goToPaperFormQuestion,
   }
 }
 

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.test.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.test.tsx
@@ -56,6 +56,7 @@ describe('DupeFormWizardProvider', () => {
       isMrfCutoverEnabled: false,
       goToStorageModeDetails: vi.fn(),
       goToMrfDetails: vi.fn(),
+      goToPaperFormQuestion: vi.fn(),
     }))
 
     vi.mocked(usePreviewForm).mockReturnValue({

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -48,6 +48,7 @@ export const useDupeFormWizardContext = (
     isMrfCutoverEnabled,
     goToStorageModeDetails,
     goToMrfDetails,
+    goToPaperFormQuestion,
   } = useCommonFormWizardProvider()
 
   const { reset, getValues } = formMethods
@@ -215,6 +216,7 @@ export const useDupeFormWizardContext = (
     isMrfCutoverEnabled,
     goToStorageModeDetails,
     goToMrfDetails,
+    goToPaperFormQuestion,
   }
 }
 

--- a/apps/frontend/src/features/workspace/utils/formMetadata.test.ts
+++ b/apps/frontend/src/features/workspace/utils/formMetadata.test.ts
@@ -1,0 +1,17 @@
+import { FormOrigin } from 'formsg-shared/types'
+
+import { mapWizardAnswersToFormMetadata } from './formMetadata'
+
+describe('mapWizardAnswersToFormMetadata', () => {
+  it('maps a "yes" paper-form answer to a paper form origin', () => {
+    expect(mapWizardAnswersToFormMetadata({ isPaperForm: 'yes' })).toEqual({
+      formOrigin: FormOrigin.Paper,
+    })
+  })
+
+  it('maps a "no" paper-form answer to an unspecified origin', () => {
+    expect(mapWizardAnswersToFormMetadata({ isPaperForm: 'no' })).toEqual({
+      formOrigin: FormOrigin.Unspecified,
+    })
+  })
+})

--- a/apps/frontend/src/features/workspace/utils/formMetadata.ts
+++ b/apps/frontend/src/features/workspace/utils/formMetadata.ts
@@ -1,0 +1,24 @@
+import { FormOrigin } from 'formsg-shared/types'
+
+export type PaperFormAnswer = 'yes' | 'no'
+
+export interface FormWizardAnswers {
+  isPaperForm: PaperFormAnswer
+}
+
+export interface FormMetadataPayload {
+  formOrigin: FormOrigin
+}
+
+/**
+ * Single source of truth for turning form-creation wizard answers into the
+ * metadata persisted on the form record. Pure: no UI, no network.
+ */
+export const mapWizardAnswersToFormMetadata = ({
+  isPaperForm,
+}: FormWizardAnswers): FormMetadataPayload => {
+  return {
+    formOrigin:
+      isPaperForm === 'yes' ? FormOrigin.Paper : FormOrigin.Unspecified,
+  }
+}

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -59,6 +59,15 @@ export const enSG: CreateFormModal = {
     },
     create: 'Create form',
   },
+  paperForm: {
+    title: 'Is this currently a paper form?',
+    options: {
+      yes: 'Yes',
+      no: 'No',
+    },
+    nextStep: 'Next step',
+    required: 'Please select an option to continue',
+  },
   secretKey: {
     title: 'Your form has been created! Download your Secret Key to proceed.',
     message: {

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
@@ -50,6 +50,15 @@ export interface CreateFormModal {
     }
     create: string
   }
+  paperForm: {
+    title: string
+    options: {
+      yes: string
+      no: string
+    }
+    nextStep: string
+    required: string
+  }
   secretKey: {
     title: string
     message: {

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -111,6 +111,17 @@ export enum FormResponseMode {
   Multirespondent = 'multirespondent',
 }
 
+/**
+ * Where a form's content originated before it existed in FormSG (e.g. it was
+ * previously a paper form). Recorded on every form at creation. Modelled as an
+ * open/extensible enum so future values (e.g. `digital-pdf`, `digital-word`,
+ * `digital-email`) can be added without a schema redesign.
+ */
+export enum FormOrigin {
+  Paper = 'paper',
+  Unspecified = 'unspecified',
+}
+
 export interface FormMetadata {
   mfb_text_prompt_count?: number
   num_mrf_reminder_emails_sent?: number
@@ -215,6 +226,12 @@ export interface FormBase {
   metadata?: FormMetadata
   hasMultiLang?: boolean
   supportedLanguages?: Language[]
+
+  /**
+   * Where the form's content originated before FormSG. Absent on forms created
+   * before origin tracking existed; such forms read back as `unspecified`.
+   */
+  formOrigin: FormOrigin
 }
 
 export interface EmailFormBase extends FormBase {

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -452,17 +452,17 @@ export type DuplicateFormBodyDto = DuplicateFormOverwriteDto & {
 export type CreateEmailFormBodyDto = Pick<
   EmailFormDto,
   'emails' | 'responseMode' | 'title'
-> & { workspaceId?: string }
+> & { workspaceId?: string; formOrigin?: FormOrigin }
 
 export type CreateStorageFormBodyDto = Pick<
   StorageFormDto,
   'publicKey' | 'responseMode' | 'title' | 'emails'
-> & { workspaceId?: string }
+> & { workspaceId?: string; formOrigin?: FormOrigin }
 
 export type CreateMultirespondentFormBodyDto = Pick<
   MultirespondentFormDto,
   'publicKey' | 'responseMode' | 'title'
-> & { workspaceId?: string; emails?: string[] }
+> & { workspaceId?: string; emails?: string[]; formOrigin?: FormOrigin }
 
 export type CreateFormBodyDto =
   | CreateEmailFormBodyDto


### PR DESCRIPTION
## Problem

As FormSG moves through the MRF cutover, the team has no visibility into whether a new form is digitising an existing paper process. The creation modals collect nothing about a form's origin today, so the data simply doesn't exist. This is the foundational slice of the Form Origin & Storage Mode Reason PRD (issue #1): it establishes the reusable plumbing — the `formOrigin` field, the create-payload extension, the answer→metadata mapper, and the paper-form screen — that the Duplicate, Use-Template, and Storage-reasons slices build on.

## Solution

After the MRF cutover, the Create modal asks **"Is this currently a paper form?"** (Yes/No) as a step after the title screen and before the secret key. The answer is mapped to a `formOrigin` value (`paper` / `unspecified`) by a pure mapper and rides along in the create request, so a form is born with its origin in a single atomic write. `formOrigin` is added to the form record as an extensible enum and persisted by the backend create path. Forms created before this feature have no value and read back as `unspecified` (no backfill).

Scope is the **Create** modal, **MRF** flow, **post-cutover** only. `goToPaperFormQuestion` lives on the shared wizard provider so the Duplicate/Use-Template wizards still satisfy the context, but their flows are wired in later slices.

**Alternatives considered**

- We kept `formOrigin` **required** on the `FormBase`/`FormDto` type (every persisted form has exactly one origin, guaranteed by the schema default) and made it optional only on the create-input types — rather than making it optional everywhere, which would have pushed `?? unspecified` fallbacks onto every future reader.
- For the Yes/No options we built a small bespoke selector instead of reusing the `Tile` component (it requires an icon) or the design-system `Radio` (it renders a radio circle) — neither matches the iconless two-up cards in the design.
- The paper answer is gated with a `validate` rule read through `useFormState`, not a plain `required` rule. `required` didn't reliably block the custom control, and because `formMethods` is shared via React context the error message wasn't reactive without `useFormState`.

**Screenshots**

| Page | After |
| --- | --- |
| Create modal → paper-form question (post-cutover) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/form-origin-create-mrf/after-paper-form-question.png) |

_Net-new screen, so no "before". Layout verified against the design source in the visual gate._

**Breaking Changes**

No - backwards compatible. `formOrigin` is optional input and defaults to `unspecified`; existing forms read back as `unspecified`.

## Tests

**TC1: Paper form → paper origin (post-cutover MRF)**

- [ ] With `mrf-cutover` ON, create a form: enter a title, click Next.
- [ ] On "Is this currently a paper form?", choose **Yes**, click Next step.
- [ ] Form is created; its stored `formOrigin` is `paper`.

**TC2: Not a paper form → unspecified**

- [ ] Repeat TC1 but choose **No**; stored `formOrigin` is `unspecified`.

**TC3: Answer is required**

- [ ] On the paper-form screen, click Next step without choosing an option.
- [ ] The flow does not advance and an inline error is shown.

**TC4: Legacy form reads as unspecified**

- [ ] Open a form created before this change; its `formOrigin` reads as `unspecified` (no migration run).
