### PR TITLE
fix: add title to disabled table text cells

### DIFF
--- a/apps/frontend/src/templates/Field/Table/ColumnCell.tsx
+++ b/apps/frontend/src/templates/Field/Table/ColumnCell.tsx
@@ -80,6 +80,7 @@ const ShortTextColumnCell = ({
           colorScheme={`theme-${colorTheme}`}
           aria-labelledby={schema._id}
           isHighContrast={isHighContrast}
+          title={isDisabled ? field.value : undefined}
           {...field}
         />
       )}

--- a/apps/frontend/src/templates/Field/Table/TableField.test.tsx
+++ b/apps/frontend/src/templates/Field/Table/TableField.test.tsx
@@ -1,12 +1,17 @@
 import { composeStories } from '@storybook/react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 
 import * as stories from './TableField.stories'
 
-const { DisabledWithLongDropdownOption } = composeStories(stories)
+const {
+  DisabledHighContrast,
+  DisabledWithLongDropdownOption,
+  ValidationValid,
+} = composeStories(stories)
 
 const LONG_DROPDOWN_OPTION =
   'This is a very long dropdown option label that should not be truncated when disabled'
+const SHORT_TEXT_VALUE = 'This is a valid value'
 
 describe('TableField — disabled dropdown column cell', () => {
   it('exposes the full selected dropdown label via a native title tooltip', () => {
@@ -15,5 +20,29 @@ describe('TableField — disabled dropdown column cell', () => {
     // At least one row should expose the full label via title.
     const titled = screen.getAllByTitle(LONG_DROPDOWN_OPTION)
     expect(titled.length).toBeGreaterThan(0)
+  })
+})
+
+describe('TableField — short text column cell', () => {
+  it('exposes the cell value via a native title tooltip when disabled', () => {
+    render(<DisabledHighContrast />)
+
+    const table = screen.getByRole('table')
+    const jobTitleInput = within(table).getAllByRole('textbox', {
+      name: 'Job title',
+    })[0]
+
+    expect(jobTitleInput).toHaveAttribute('title', SHORT_TEXT_VALUE)
+  })
+
+  it('does not expose a native title tooltip when editable', () => {
+    render(<ValidationValid />)
+
+    const table = screen.getByRole('table')
+    const jobTitleInput = within(table).getAllByRole('textbox', {
+      name: 'Job title',
+    })[0]
+
+    expect(jobTitleInput).not.toHaveAttribute('title')
   })
 })


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Disabled ShortText column cells in Table fields did not expose their full cell value via the native browser tooltip, unlike disabled Dropdown column cells.

Closes #9499

## Solution
<!-- How did you solve the problem? -->
Added a title attribute to ShortText table column inputs only when the cell is disabled, using the current cell value. Editable ShortText cells continue to render without a title attribute.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- NA

**Improvements**:

- Disabled ShortText table column cells now expose their full value via the native browser tooltip

**Bug Fixes**:

- Prevents disabled ShortText table column cells from missing the title attribute needed to view the full cell value on hover.

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

 N/A: this change affects the input `title` attribute and does not produce a visible layout change.

**AFTER**:
<!-- [insert screenshot here] -->

[FormSG #9499 - Google Docs.pdf](https://github.com/user-attachments/files/28683967/FormSG.9499.-.Google.Docs.pdf)
— verified via Storybook DOM inspection:
- Disabled ShortText table cells render `title="This is a valid value"`.
- Editable ShortText table cells do not render a `title` attribute.

## Tests
<!-- What tests should be run to confirm functionality? -->

pnpm --filter formsg-frontend test src/templates/Field/Table/TableField.test.tsx
pnpm -r --filter formsg-frontend... build
[FormSG #9499 - Google Docs.pdf](https://github.com/user-attachments/files/28683967/FormSG.9499.-.Google.Docs.pdf)

Verified in Storybook that disabled ShortText table cells render title="This is a valid value".
Verified in Storybook that editable ShortText table cells do not render a title attribute.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- N/A

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
[FormSG #9499 - Google Docs.pdf](https://github.com/user-attachments/files/28683967/FormSG.9499.-.Google.Docs.pdf)
