### PR TITLE
feat(frontend): remove beta badge from save draft toggle

### DIFF
--- a/apps/frontend/src/features/admin-form/settings/components/FormSaveDraftToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormSaveDraftToggle.tsx
@@ -30,7 +30,6 @@ const FormSaveDraftToggle = () => {
     <Skeleton isLoaded={!isLoadingSettings && !!settings}>
       <Toggle
         label={t('features.adminForm.settings.general.saveDraft.label')}
-        betaBadge
         description={t(
           'features.adminForm.settings.general.saveDraft.description',
         )}


### PR DESCRIPTION
The save Draft feature is no longer in beta, so beta badge is removed.

## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [X] No - this PR is backwards compatible  