### PR TITLE
fix(frontend): show "(optional)" beside Description for input fields

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDecimal/EditDecimal.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDecimal/EditDecimal.tsx
@@ -107,11 +107,7 @@ export const EditDecimal = ({ field }: EditDecimalProps): JSX.Element => {
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={isLoading}
-        isInvalid={!!errors.description}
-      >
+      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
         <FormLabel>
           {t(
             'features.adminForm.sidebar.fields.commonFieldComponents.description',

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -159,11 +159,7 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={isLoading}
-        isInvalid={!!errors.description}
-      >
+      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
         <FormLabel>
           {t(
             'features.adminForm.sidebar.fields.commonFieldComponents.description',

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHomeno/EditHomeno.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditHomeno/EditHomeno.tsx
@@ -63,11 +63,7 @@ export const EditHomeno = ({ field }: EditHomenoProps): JSX.Element => {
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={isLoading}
-        isInvalid={!!errors.description}
-      >
+      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
         <FormLabel>
           {t(
             'features.adminForm.sidebar.fields.commonFieldComponents.description',

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -145,11 +145,7 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={isLoading}
-        isInvalid={!!errors.description}
-      >
+      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
         <FormLabel>
           {t(
             'features.adminForm.sidebar.fields.commonFieldComponents.description',

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMobile/EditMobile.tsx
@@ -81,11 +81,7 @@ export const EditMobile = ({ field }: EditMobileProps): JSX.Element => {
           <Input autoFocus {...register('title', requiredValidationRule)} />
           <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
         </FormControl>
-        <FormControl
-          isRequired
-          isReadOnly={isLoading}
-          isInvalid={!!errors.description}
-        >
+        <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
           <FormLabel>
             {t(
               'features.adminForm.sidebar.fields.commonFieldComponents.description',

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditNumber/EditNumber.tsx
@@ -304,11 +304,7 @@ export const EditNumber = ({ field }: EditNumberProps): JSX.Element => {
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={isLoading}
-        isInvalid={!!errors.description}
-      >
+      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
         <FormLabel>
           {t(
             'features.adminForm.sidebar.fields.commonFieldComponents.description',

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -189,11 +189,7 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
-      <FormControl
-        isRequired
-        isReadOnly={isLoading}
-        isInvalid={!!errors.description}
-      >
+      <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
         <FormLabel>
           {t(
             'features.adminForm.sidebar.fields.commonFieldComponents.description',


### PR DESCRIPTION
Closes #9345

## Problem

The "(optional)" indicator was missing beside the **Description** label in the admin field editor (EditFieldDrawer) for 7 field types: 

- Short answer
- Long answer
- Number
- Decimal
- Email
- Mobile number
- Local number 

## Cause

In these 7 fields, the description `FormControl` was marked `isRequired`. The shared `FormLabel.OptionalIndicator` only renders "(optional)" when the control is **not** required (`FormLabel.tsx`), so the flag suppressed it. It also set a stray `aria-required` on the textarea.

The flag was purely a mislabel: `description` is registered with `register('description')` and carries **no validation rule**, so nothing actually required it. Every other field type already omits `isRequired` on this control.

## Fix

Remove `isRequired` from the description `FormControl` in the 7 affected fields, aligning them with the ~13 other field types. The two editors where the description *is* genuinely required content — `EditParagraph` and `EditImage` (both use `requiredValidationRule`) — were intentionally left untouched.

No validation logic changes; the field's separate `required` toggle (for respondents) is unaffected.

## Before and after

Issue:

<img width="540" height="424" alt="Image" src="https://github.com/user-attachments/assets/04acd5df-9b53-49f3-9430-5e42bcacea96" />

Correct behavior: 

<img width="540" height="424" alt="Image" src="https://github.com/user-attachments/assets/95b97b9e-8729-48ed-9f93-ca842ca06675" />