### PR TITLE
feat: short answer prefill progressive disclosure

### DIFF
--- a/apps/backend/src/app/models/__tests__/form_fields.schema.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form_fields.schema.spec.ts
@@ -233,25 +233,18 @@ describe('Form Field Schema', () => {
         expect(fieldObj).toHaveProperty('lockPrefill', true)
       })
 
-      it('should not allow creation of short text field with allowPrefill = false and lockPrefill = true settings', async () => {
+      it('should remember lockPrefill = true even when allowPrefill = false (lock persists independently of prefill)', async () => {
         // Arrange
-        const createField = async () => {
-          const field = await createAndReturnFormField({
-            fieldType: BasicField.ShortText,
-            allowPrefill: false,
-            lockPrefill: true,
-          })
-
-          return field
-        }
-
-        // Act
-        const createFieldPromise = createField()
+        const field = await createAndReturnFormField({
+          fieldType: BasicField.ShortText,
+          allowPrefill: false,
+          lockPrefill: true,
+        })
 
         // Assert
-        await expect(createFieldPromise).rejects.toThrow(
-          'Cannot lock prefill if prefill is not enabled',
-        )
+        const fieldObj = field.toObject()
+        expect(fieldObj).toHaveProperty('allowPrefill', false)
+        expect(fieldObj).toHaveProperty('lockPrefill', true)
       })
     })
   })

--- a/apps/backend/src/app/models/field/shortTextField.ts
+++ b/apps/backend/src/app/models/field/shortTextField.ts
@@ -22,20 +22,9 @@ const createShortTextFieldSchema = () => {
       default: false,
     },
     lockPrefill: {
-      // locks prefill if it is enabled
       type: Boolean,
       default: false,
       required: false,
-      // Only allow lock prefill if prefill is enabled
-      validate: {
-        validator: function (this: IShortTextFieldSchema) {
-          if (!this.allowPrefill && this.lockPrefill) {
-            return false
-          }
-          return true
-        },
-        message: 'Cannot lock prefill if prefill is not enabled',
-      },
     },
   })
 

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.stories.tsx
@@ -75,3 +75,12 @@ PrefillWithFieldId.args = {
     _id: 'mock-field-id-allow-copy',
   },
 }
+
+export const PrefillLocked = Template.bind({})
+PrefillLocked.args = {
+  field: {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    ...PrefillWithFieldId.args.field!,
+    lockPrefill: true,
+  },
+}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Controller, RegisterOptions } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import {
@@ -6,7 +6,6 @@ import {
   InputGroup,
   InputRightElement,
   SimpleGrid,
-  useMergeRefs,
 } from '@chakra-ui/react'
 import { extend, isEmpty, pick } from 'lodash'
 
@@ -120,26 +119,7 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
     'ValidationOptions.selectedValidation',
   )
 
-  const hasLockPrefillRef = useRef<HTMLInputElement>(null)
-
-  const lockPrefillRegister = useMemo(() => register('lockPrefill'), [register])
-
-  const mergedLockPrefillRef = useMergeRefs(
-    hasLockPrefillRef,
-    lockPrefillRegister.ref,
-  )
-
   const watchAllowPrefill = watch('allowPrefill')
-  const watchLockPrefill = watch('lockPrefill')
-
-  useEffect(() => {
-    // Prefill must be enabled for lockPrefill
-    // We cannot simply use setValue as it does not update
-    // the UI
-    if (!watchAllowPrefill && watchLockPrefill) {
-      hasLockPrefillRef.current?.click()
-    }
-  }, [watchAllowPrefill, watchLockPrefill])
 
   const customValValidationOptions: RegisterOptions<
     EditShortTextInputs,
@@ -272,15 +252,23 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
           </>
         ) : null}
       </FormControl>
-      <FormControl isReadOnly={isLoading}>
-        <Toggle
-          {...lockPrefillRegister}
-          ref={mergedLockPrefillRef}
-          label="Prevent pre-fill editing"
-          description="This prevents respondents from clicking the field to edit it. However, field content can still be modified via the URL."
-          isDisabled={!watchAllowPrefill}
-        />
-      </FormControl>
+      {watchAllowPrefill ? (
+        <FormControl isReadOnly={isLoading}>
+          <Controller
+            name="lockPrefill"
+            control={control}
+            render={({ field: { value, onChange, ...rest } }) => (
+              <Toggle
+                {...rest}
+                isChecked={!!value}
+                onChange={onChange}
+                label="Prevent pre-fill editing"
+                description="This prevents respondents from clicking the field to edit it. However, field content can still be modified via the URL."
+              />
+            )}
+          />
+        </FormControl>
+      ) : null}
       <FormFieldDrawerActions
         isLoading={isLoading}
         buttonText={buttonText}


### PR DESCRIPTION
## Problem

Closes #9356.

On the **Short Answer** field editor, both pre-fill controls — "Enable pre-fill" and "Prevent pre-fill editing" — are always shown ("Prevent pre-fill editing" merely greyed out when pre-fill is off). Pre-fill is an advanced feature used by a minority of admins on a very common field, so the always-visible controls clutter the editor and push the "Create field" button out of view.

## Solution

Progressive disclosure: **"Prevent pre-fill editing" is hidden until "Enable pre-fill" is on**. The lock value is **remembered** while pre-fill is off (not reset), so re-enabling pre-fill restores the prior choice.

<img width="1484" height="751" alt="image" src="https://github.com/user-attachments/assets/0dc120f3-155f-4743-9985-c01b05c75548" />

<img width="1484" height="751" alt="image" src="https://github.com/user-attachments/assets/0303448b-6da9-403e-86be-f20a7922b617" />

## Test cases

**TC1: Lock toggle is hidden until pre-fill is enabled**
- [ ] Add a new Short Answer field and open its editor
- [ ] Confirm "Prevent pre-fill editing" is **not** shown while "Enable pre-fill" is OFF
- [ ] Turn "Enable pre-fill" ON, and confirm the lock toggle appears, OFF and fully usable (not greyed out)

**TC2: Lock choice is remembered when pre-fill is toggled off and on**
- [ ] Enable pre-fill, turn the lock ON, then turn "Enable pre-fill" OFF
- [ ] Confirm the lock toggle (and Field ID box) disappear
- [ ] Turn "Enable pre-fill" ON again, and confirm the lock reappears still ON

**TC3: Saved field reopens correctly, and disabling pre-fill hides the lock** *(regression)*
- [ ] Enable pre-fill + lock ON, Save, then reopen the field
- [ ] Confirm pre-fill is ON and the lock toggle is visible and ON
- [ ] Turn "Enable pre-fill" OFF, and confirm both the lock toggle and Field ID box hide

**TC4: Field saves with pre-fill OFF but lock ON (no validation error)**
- [ ] Enable pre-fill, turn the lock ON, turn pre-fill OFF, then Save
- [ ] Confirm it saves with no "Cannot lock prefill if prefill is not enabled" error
- [ ] Reopen, enable pre-fill, and confirm the lock comes back ON

**TC5: Respondent — lock only takes effect when a pre-fill value is present**
- [ ] On a field with pre-fill ON + lock ON, open the live form with a pre-fill value in the URL → confirm the field is pre-filled and not editable
- [ ] Open it without a pre-fill value (and also test a field saved as pre-fill OFF + lock ON) → confirm the field is a normal editable field
