### PR TITLE
chore: revert hiding of number field stepper buttons

### DIFF
--- a/apps/frontend/src/templates/Field/Number/NumberField.test.tsx
+++ b/apps/frontend/src/templates/Field/Number/NumberField.test.tsx
@@ -13,16 +13,6 @@ import * as stories from './NumberField.stories'
 const { ValidationRequired, ValidationOptional } = composeStories(stories)
 
 describe('validation required', () => {
-  it('does not render stepper buttons', () => {
-    render(<ValidationRequired />)
-    expect(
-      screen.queryByRole('button', { name: /increment/i, hidden: true }),
-    ).toBeNull()
-    expect(
-      screen.queryByRole('button', { name: /decrement/i, hidden: true }),
-    ).toBeNull()
-  })
-
   it('renders error when field is not filled before submitting', async () => {
     // Arrange
     const user = userEvent.setup()

--- a/apps/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/apps/frontend/src/templates/Field/Number/NumberField.tsx
@@ -34,7 +34,6 @@ export const NumberField = ({
         defaultValue=""
         render={({ field: { value, onChange, ...rest } }) => (
           <NumberInput
-            showSteppers={false}
             min={0}
             inputMode="numeric"
             colorScheme={`theme-${colorTheme}`}


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

A previous change removed the stepper (increment/decrement) buttons from the Number field by setting `showSteppers={false}`. This change should be reverted — the stepper buttons provide useful UX for number inputs and should remain visible.

## Solution
<!-- How did you solve the problem? -->

Reverts the `showSteppers={false}` prop on the `NumberInput` component in `NumberField.tsx`, restoring the default stepper button behaviour. The corresponding test that asserted the buttons were hidden has also been removed.

**Breaking Changes**
- No — this PR is backwards compatible. It restores prior behaviour and has no impact on form data or submissions.

## Before & After Screenshots

| Item | **BEFORE** | **AFTER** |
| --- | ----- | ----- |
| Number field stepper buttons | <!-- add screenshot --> | <!-- add screenshot --> |

## Tests

TC1: Stepper buttons visible on Number field
- [ ] Open a form with a Number field in the form filler view
- [ ] Verify that the increment and decrement stepper buttons are rendered on the Number input
- [ ] Verify that clicking the stepper buttons increments/decrements the value correctly