### PR TITLE
fix: add replyTo and X-Formsg-Submission-ID headers to MRF outcome emails

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -68,6 +68,7 @@ import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
 import { MultirespondentSubmissionContent } from './multirespondent-submission.types'
 import {
+  extractEmailAnswersFromResponses,
   extractRespondentCopyEmailDatas,
   formatSubmittedStepTimestamp,
   getEmailFromResponses,
@@ -550,9 +551,12 @@ const sendMrfOutcomeEmails = ({
           formId: form._id,
           formTitle: form.title,
           responseId: submissionId,
+          submissionId,
           timestamp: latestSubmissionTimestamp,
           formQuestionAnswers,
           attachments: emailAttachments,
+          replyTo:
+            extractEmailAnswersFromResponses(responses).join(', ') || undefined,
         }).orElse((error) => {
           logger.error({
             message: 'Failed to send workflow completion email',

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -528,10 +528,14 @@ const sendMrfOutcomeEmails = ({
             formId: form._id,
             formTitle: form.title,
             responseId: submissionId,
+            submissionId,
             timestamp: latestSubmissionTimestamp,
             isRejected,
             formQuestionAnswers,
             attachments: emailAttachments,
+            replyTo:
+              extractEmailAnswersFromResponses(responses).join(', ') ||
+              undefined,
           }).orElse((error) => {
             logger.error({
               message: 'Failed to send approval email',

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -525,7 +525,7 @@ const sendMrfOutcomeEmails = ({
         if (isApproval) {
           return MailService.sendMrfApprovalEmail({
             emails: destinationEmails,
-            formId: form._id,
+            formId: String(form._id),
             formTitle: form.title,
             responseId: submissionId,
             submissionId,
@@ -552,7 +552,7 @@ const sendMrfOutcomeEmails = ({
 
         return MailService.sendMrfWorkflowCompletionEmail({
           emails: destinationEmails,
-          formId: form._id,
+          formId: String(form._id),
           formTitle: form.title,
           responseId: submissionId,
           submissionId,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -112,6 +112,7 @@ export const getEmailFromResponses = (
 export const extractEmailAnswersFromResponses = (
   responses: FieldResponsesV3,
 ): string[] => {
+  if (!responses) return []
   return Object.values(responses)
     .filter(
       (

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -109,6 +109,22 @@ export const getEmailFromResponses = (
   return field.answer.value
 }
 
+export const extractEmailAnswersFromResponses = (
+  responses: FieldResponsesV3,
+): string[] => {
+  return Object.values(responses)
+    .filter(
+      (
+        response,
+      ): response is Extract<
+        FieldResponseV3,
+        { fieldType: BasicField.Email }
+      > => response.fieldType === BasicField.Email,
+    )
+    .map((response) => response.answer.value)
+    .filter(Boolean)
+}
+
 const getConditionalFieldEmailRecipient = (
   form_fields: FormFieldSchema[] | FormFieldDto[],
   fieldId: string,

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -1227,19 +1227,23 @@ export class MailService {
     formId,
     formTitle,
     responseId,
+    submissionId,
     timestamp,
     isRejected,
     formQuestionAnswers,
     attachments,
+    replyTo,
   }: {
     emails: string[]
     formId: string
     formTitle: string
     responseId: string
+    submissionId?: string
     timestamp: string
     isRejected: boolean
     formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
+    replyTo?: string
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
     const outcome = isRejected
       ? WorkflowOutcome.NOT_APPROVED
@@ -1261,6 +1265,8 @@ export class MailService {
       attachments,
       emailType: EmailType.WorkflowApproval,
       actionName: 'sendMrfApprovalEmail',
+      submissionId,
+      replyTo,
     })
   }
 

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -1186,17 +1186,21 @@ export class MailService {
     formId,
     formTitle,
     responseId,
+    submissionId,
     timestamp,
     formQuestionAnswers,
     attachments,
+    replyTo,
   }: {
     emails: string[]
     formId: string
     formTitle: string
     responseId: string
+    submissionId?: string
     timestamp: string
     formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
+    replyTo?: string
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
     const emailTemplateData: EmailData = {
       formTitle,
@@ -1213,6 +1217,8 @@ export class MailService {
       attachments,
       emailType: EmailType.WorkflowCompletion,
       actionName: 'sendMrfWorkflowCompletionEmail',
+      submissionId,
+      replyTo,
     })
   }
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

MRF workflow completion and approval emails were missing two email headers that storage mode admin emails include:

1. **`Reply-To`** — without this, Zendesk automation cannot automatically assign the respondent's email as the ticket requester, requiring manual triage.
2. **`X-Formsg-Submission-ID`** — without this, email-based integrations (e.g. Zendesk, filtering rules) cannot correlate incoming emails back to a specific FormSG submission.

## Solution
<!-- How did you solve the problem? -->

Added a `extractEmailAnswersFromResponses` utility to `multirespondent-submission.utils.ts` that collects all email field answers from a `FieldResponsesV3` response map (mirroring `extractEmailAnswers` used for storage mode). This is then joined and passed as `replyTo` to both `sendMrfWorkflowCompletionEmail` and `sendMrfApprovalEmail`.

Both mail service functions now also accept and forward a `submissionId` parameter, which `#sendEmailWithTemplate` uses to conditionally set the `X-Formsg-Submission-ID` header (the conditional was already in place — it just wasn't being passed).

**Breaking Changes**
- No — this PR is backwards compatible. The new parameters are optional; existing callers not passing them will see no change in behaviour.

## Tests

TC1: Workflow completion email includes correct headers
- [ ] Set up an MRF form with at least one email field across multiple steps and complete the full workflow
- [ ] Capture the outgoing completion email (e.g. via Mailtrap or email header inspection)
- [ ] Verify that the `Reply-To` header is present and contains all email field answers from all steps, comma-separated
- [ ] Verify that the `X-Formsg-Submission-ID` header is present and matches the submission ID

TC2: No email fields — headers degrade gracefully
- [ ] Set up an MRF form with no email fields and complete the workflow
- [ ] Verify that the completion/approval email is sent without a `Reply-To` header (no empty header)
- [ ] Verify that the `X-Formsg-Submission-ID` header is still present