### PR TITLE
build: release v7.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [7.26.1](https://github.com/opengovsg/formsg/compare/v7.26.0...v7.26.1) (2026-06-09)
+
+
+### Bug Fixes
+
+* add replyTo and X-Formsg-Submission-ID headers to MRF outcome emails (#9570) ([#9570](https://github.com/opengovsg/formsg/commit/b7e9c320686c326dc9c6518da4b3a97875cdc980))
+
+
+### Miscellaneous
+
+* Merge pull request #9568 from opengovsg/chore/revert-number-field-buttons-removal ([#9568](https://github.com/opengovsg/formsg/commit/d1698445285a9b0be20d5ecf02d955cbb2500081))
+
 ## [7.26.0](https://github.com/opengovsg/formsg/compare/v7.25.0...v7.26.0) (2026-06-08)
 
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-backend",
-  "version": "7.26.0",
+  "version": "7.26.1",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -68,6 +68,7 @@ import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
 import { MultirespondentSubmissionContent } from './multirespondent-submission.types'
 import {
+  extractEmailAnswersFromResponses,
   extractRespondentCopyEmailDatas,
   formatSubmittedStepTimestamp,
   getEmailFromResponses,
@@ -524,13 +525,17 @@ const sendMrfOutcomeEmails = ({
         if (isApproval) {
           return MailService.sendMrfApprovalEmail({
             emails: destinationEmails,
-            formId: form._id,
+            formId: String(form._id),
             formTitle: form.title,
             responseId: submissionId,
+            submissionId,
             timestamp: latestSubmissionTimestamp,
             isRejected,
             formQuestionAnswers,
             attachments: emailAttachments,
+            replyTo:
+              extractEmailAnswersFromResponses(responses).join(', ') ||
+              undefined,
           }).orElse((error) => {
             logger.error({
               message: 'Failed to send approval email',
@@ -547,12 +552,15 @@ const sendMrfOutcomeEmails = ({
 
         return MailService.sendMrfWorkflowCompletionEmail({
           emails: destinationEmails,
-          formId: form._id,
+          formId: String(form._id),
           formTitle: form.title,
           responseId: submissionId,
+          submissionId,
           timestamp: latestSubmissionTimestamp,
           formQuestionAnswers,
           attachments: emailAttachments,
+          replyTo:
+            extractEmailAnswersFromResponses(responses).join(', ') || undefined,
         }).orElse((error) => {
           logger.error({
             message: 'Failed to send workflow completion email',

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -109,6 +109,23 @@ export const getEmailFromResponses = (
   return field.answer.value
 }
 
+export const extractEmailAnswersFromResponses = (
+  responses: FieldResponsesV3,
+): string[] => {
+  if (!responses) return []
+  return Object.values(responses)
+    .filter(
+      (
+        response,
+      ): response is Extract<
+        FieldResponseV3,
+        { fieldType: BasicField.Email }
+      > => response.fieldType === BasicField.Email,
+    )
+    .map((response) => response.answer.value)
+    .filter(Boolean)
+}
+
 const getConditionalFieldEmailRecipient = (
   form_fields: FormFieldSchema[] | FormFieldDto[],
   fieldId: string,

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -1186,17 +1186,21 @@ export class MailService {
     formId,
     formTitle,
     responseId,
+    submissionId,
     timestamp,
     formQuestionAnswers,
     attachments,
+    replyTo,
   }: {
     emails: string[]
     formId: string
     formTitle: string
     responseId: string
+    submissionId?: string
     timestamp: string
     formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
+    replyTo?: string
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
     const emailTemplateData: EmailData = {
       formTitle,
@@ -1213,6 +1217,8 @@ export class MailService {
       attachments,
       emailType: EmailType.WorkflowCompletion,
       actionName: 'sendMrfWorkflowCompletionEmail',
+      submissionId,
+      replyTo,
     })
   }
 
@@ -1221,19 +1227,23 @@ export class MailService {
     formId,
     formTitle,
     responseId,
+    submissionId,
     timestamp,
     isRejected,
     formQuestionAnswers,
     attachments,
+    replyTo,
   }: {
     emails: string[]
     formId: string
     formTitle: string
     responseId: string
+    submissionId?: string
     timestamp: string
     isRejected: boolean
     formQuestionAnswers: QuestionAnswer[]
     attachments?: Mail.Attachment[]
+    replyTo?: string
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
     const outcome = isRejected
       ? WorkflowOutcome.NOT_APPROVED
@@ -1255,6 +1265,8 @@ export class MailService {
       attachments,
       emailType: EmailType.WorkflowApproval,
       actionName: 'sendMrfApprovalEmail',
+      submissionId,
+      replyTo,
     })
   }
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-frontend",
-  "version": "7.26.0",
+  "version": "7.26.1",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/apps/frontend/src/templates/Field/Number/NumberField.test.tsx
+++ b/apps/frontend/src/templates/Field/Number/NumberField.test.tsx
@@ -13,16 +13,6 @@ import * as stories from './NumberField.stories'
 const { ValidationRequired, ValidationOptional } = composeStories(stories)
 
 describe('validation required', () => {
-  it('does not render stepper buttons', () => {
-    render(<ValidationRequired />)
-    expect(
-      screen.queryByRole('button', { name: /increment/i, hidden: true }),
-    ).toBeNull()
-    expect(
-      screen.queryByRole('button', { name: /decrement/i, hidden: true }),
-    ).toBeNull()
-  })
-
   it('renders error when field is not filled before submitting', async () => {
     // Arrange
     const user = userEvent.setup()

--- a/apps/frontend/src/templates/Field/Number/NumberField.tsx
+++ b/apps/frontend/src/templates/Field/Number/NumberField.tsx
@@ -34,7 +34,6 @@ export const NumberField = ({
         defaultValue=""
         render={({ field: { value, onChange, ...rest } }) => (
           <NumberInput
-            showSteppers={false}
             min={0}
             inputMode="numeric"
             colorScheme={`theme-${colorTheme}`}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-monorepo",
-  "version": "7.26.0",
+  "version": "7.26.1",
   "private": true,
   "description": "Form Manager for Government",
   "homepage": "https://form.gov.sg",

--- a/packages/react-email-preview/package.json
+++ b/packages/react-email-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-react-email-preview",
-  "version": "7.26.0",
+  "version": "7.26.1",
   "private": true,
   "scripts": {
     "build": "email build",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-shared",
-  "version": "7.26.0",
+  "version": "7.26.1",
   "private": true,
   "description": "",
   "scripts": {

--- a/services/form-payment-reconciliation/package.json
+++ b/services/form-payment-reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-payment-reconciliation",
-  "version": "7.26.0",
+  "version": "7.26.1",
   "private": true,
   "description": "Lambda function for payment reconciliation",
   "main": "index.js",

--- a/services/pdf-gen-sparticuz/package.json
+++ b/services/pdf-gen-sparticuz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-pdf-gen-sparticuz",
-  "version": "7.26.0",
+  "version": "7.26.1",
   "private": true,
   "description": "<!-- title: 'AWS NodeJS Example' description: 'This template demonstrates how to deploy a simple NodeJS function running on AWS Lambda using the Serverless Framework.' layout: Doc framework: v4 platform: AWS language: nodeJS priority: 1 authorLink: 'https://github.com/serverless' authorName: 'Serverless, Inc.' authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4' -->",
   "main": "dist/index.js",

--- a/services/virus-scanner-guardduty/package.json
+++ b/services/virus-scanner-guardduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-virus-scanner-guardduty",
-  "version": "7.26.0",
+  "version": "7.26.1",
   "private": true,
   "description": "",
   "scripts": {


### PR DESCRIPTION


### Bug Fixes

* add replyTo and X-Formsg-Submission-ID headers to MRF outcome emails (#9570) ([#9570](https://github.com/opengovsg/formsg/commit/b7e9c320686c326dc9c6518da4b3a97875cdc980))


### Miscellaneous

* Merge pull request #9568 from opengovsg/chore/revert-number-field-buttons-removal ([#9568](https://github.com/opengovsg/formsg/commit/d1698445285a9b0be20d5ecf02d955cbb2500081))


### Tests

### add replyTo and X-Formsg-Submission-ID headers to MRF outcome emails (#9570) ([#9570](https://github.com/opengovsg/formsg/commit/b7e9c320686c326dc9c6518da4b3a97875cdc980))

TC1: Workflow completion email includes correct headers
- [ ] Set up an MRF form with at least one email field across multiple steps and complete the full workflow
- [ ] Capture the outgoing completion email (e.g. via Mailtrap or email header inspection)
- [ ] Verify that the `Reply-To` header is present and contains all email field answers from all steps, comma-separated
- [ ] Verify that the `X-Formsg-Submission-ID` header is present and matches the submission ID

TC2: No email fields — headers degrade gracefully
- [ ] Set up an MRF form with no email fields and complete the workflow
- [ ] Verify that the completion/approval email is sent without a `Reply-To` header (no empty header)
- [ ] Verify that the `X-Formsg-Submission-ID` header is still present

### Merge pull request #9568 from opengovsg/chore/revert-number-field-buttons-removal ([#9568](https://github.com/opengovsg/formsg/commit/d1698445285a9b0be20d5ecf02d955cbb2500081))

TC1: Stepper buttons visible on Number field
- [ ] Open a form with a Number field in the form filler view
- [ ] Verify that the increment and decrement stepper buttons are rendered on the Number input
- [ ] Verify that clicking the stepper buttons increments/decrements the value correctly

