### PR TITLE
fix: standardize ; delimiters across email body and response page fields

### DIFF
--- a/apps/backend/src/app/modules/myinfo/myinfo.format.ts
+++ b/apps/backend/src/app/modules/myinfo/myinfo.format.ts
@@ -60,7 +60,7 @@ export const formatAddress = (addr: MyInfoAddress | undefined): string => {
       result += line1.value
     }
     if (line2.value) {
-      result += ', ' + line2.value
+      result += '; ' + line2.value
     }
     return result
   }
@@ -178,7 +178,7 @@ export const formatVehicleNumbers = (
       vehicleNumbers.push(vehicle.vehicleno.value)
     }
   })
-  return vehicleNumbers.join(', ')
+  return vehicleNumbers.join('; ')
 }
 
 /**

--- a/apps/backend/src/app/modules/sgid/sgid.format.ts
+++ b/apps/backend/src/app/modules/sgid/sgid.format.ts
@@ -27,7 +27,7 @@ export const formatVehicles = (vehicles: string): string => {
       const vehiclesObject = JSON.parse(vehicles)
       const vehicleNos = vehiclesObject
         .map((vehicle: { vehicle_number: string }) => vehicle['vehicle_number'])
-        .join(', ')
+          .join('; ')
       return vehicleNos
     } catch (error) {
       logger.error({

--- a/apps/backend/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
+++ b/apps/backend/src/app/modules/submission/email-submission/__tests__/email-submission.util.spec.ts
@@ -228,7 +228,7 @@ describe('email-submission.util', () => {
       )
 
       const { question, answerArray, fieldType } = response
-      const answer = answerArray.join(', ')
+      const answer = answerArray.join('; ')
 
       const expectedDataCollationData = [{ question, answer }]
       const expectedFormData = [
@@ -342,7 +342,7 @@ describe('email-submission.util', () => {
       )
 
       const { question, fieldType } = response
-      const answer = answerArray.join(', ')
+      const answer = answerArray.join('; ')
 
       const expectedDataCollationData = [{ question, answer }]
       const expectedFormData = [

--- a/apps/backend/src/app/modules/submission/email-submission/email-submission.util.ts
+++ b/apps/backend/src/app/modules/submission/email-submission/email-submission.util.ts
@@ -200,7 +200,7 @@ export const getAnswerForCheckbox = (
     myInfo: response.myInfo,
     isVisible: response.isVisible,
     isUserVerified: response.isUserVerified,
-    answer: response.answerArray.join(', '),
+    answer: response.answerArray.join('; '),
   }
 }
 
@@ -217,7 +217,7 @@ export const getAnswerForAddress = (
     myInfo: response.myInfo,
     isVisible: response.isVisible,
     isUserVerified: response.isUserVerified,
-    answer: handleAddressResponseDisplay(response.answerArray).join(', '),
+    answer: handleAddressResponseDisplay(response.answerArray).join('; '),
   }
 }
 

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/DecryptedRow.tsx
@@ -116,7 +116,7 @@ const DecryptedAttachmentRow = ({
 const DecryptedAddressRow = ({ row }: DecryptedRowBaseProps): JSX.Element => {
   const transformedAddress = handleAddressResponseDisplay(
     row.answerArray as string[],
-  ).join(', ')
+  ).join('; ')
   return (
     <Stack>
       <DecryptedQuestionLabel row={row} />
@@ -158,7 +158,7 @@ export const DecryptedRow = memo(
             <DecryptedQuestionLabel row={row} />
             {row.answer && <Text textStyle="body-1">{row.answer}</Text>}
             {row.answerArray && (
-              <Text textStyle="body-1">{row.answerArray.join(', ')}</Text>
+              <Text textStyle="body-1">{row.answerArray.join('; ')}</Text>
             )}
           </Stack>
         )

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -88,7 +88,7 @@ const PrintableDecryptedRow = ({
     case BasicField.Address: {
       const transformedAddress = handleAddressResponseDisplay(
         row.answerArray as string[],
-      ).join(', ')
+      ).join('; ')
       return (
         <StandardPrintableRow
           question={row.question}
@@ -131,7 +131,7 @@ const PrintableDecryptedRow = ({
       return (
         <StandardPrintableRow
           question={row.question}
-          answer={row.answer || row.answerArray?.join(', ') || ''}
+          answer={row.answer || row.answerArray?.join('; ') || ''}
         />
       )
   }


### PR DESCRIPTION
Fixes #9575

Standardizes `; ` as the delimiter for checkbox answers, MyInfo children, 
and vehicle fields across email body and response page views.

Table field JSON intentionally retains `, ` per issue spec to reduce 
migration friction and match storage mode emails.

Files changed:
- email-submission.util.ts — checkbox + address answers
- myinfo.format.ts — address line2 + vehicles
- sgid.format.ts — sgID vehicles
- DecryptedRow.tsx — response page address + default answerArray
- PrintableResponse.tsx — printable response address + default answerArray
- email-submission.util.spec.ts — updated test expectations