### PR TITLE
fix: preserve line breaks in standardised email template responses

### DIFF
--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -844,7 +844,7 @@ export class MailService {
       const formQuestionAnswers: QuestionAnswer[] = formData.map(
         ({ question, answerTemplate, fieldType }) => ({
           question,
-          answer: String(answerTemplate),
+          answer: answerTemplate.join('\n'),
           fieldType,
         }),
       )

--- a/apps/backend/src/app/views/templates/EmailTemplate.tsx
+++ b/apps/backend/src/app/views/templates/EmailTemplate.tsx
@@ -96,7 +96,12 @@ export const EmailTemplate = ({
         </Text>
       )}
       <Text style={{ ...secondaryTextStyle, ...answerMargin }}>
-        {qa.answer}
+        {qa.answer.split(/\r?\n/).map((line, i, arr) => (
+          <React.Fragment key={i}>
+            {line}
+            {i < arr.length - 1 && <br />}
+          </React.Fragment>
+        ))}
       </Text>
     </>
   )


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

When form responses are displayed in the standardised email template, multi-line answers (e.g. from long text fields) lose their line breaks. Two bugs compound each other:

1. `String(answerTemplate)` converts a `string[]` to a comma-separated string — e.g. `["line 1", "line 2"]` becomes `"line 1,line 2"` instead of `"line 1\nline 2"`.
2. Even with a corrected answer string, the `EmailTemplate` renders `qa.answer` as plain text without splitting on `\n` and inserting `<br />` tags.

## Solution
<!-- How did you solve the problem? -->

1. Replace `String(answerTemplate)` with `answerTemplate.join('\n')` to reconstructs the original string exactly
2. Apply the same `split(/\r?\n/).map(...)` pattern already used for `emailBody` to render `qa.answer` — splitting on `\r?\n` and inserting `<br />` between lines

## Before and After Screenshots
| Item | **BEFORE** | **AFTER** |
| --- | ----- | ----- |
| long text output in email | <img width="704" height="481" alt="image" src="https://github.com/user-attachments/assets/d22901a5-d92a-4d61-99d5-37a496b63797" /> | <img width="580" height="406" alt="image" src="https://github.com/user-attachments/assets/6b8bdaa4-4119-4899-854c-47d015ab5ac6" /> |

**Breaking Changes**
- No — this is a bug fix. The rendered output for single-line answers and empty answers is unchanged; only multi-line answers are affected.

## Tests

TC1: Multi-line answer in admin MRF notification email
- [ ] Create a form with a long text field
- [ ] Submit the form with an answer containing multiple lines (e.g. `Line 1\nLine 2\nLine 3`)
- [ ] Verify that the admin notification email renders each line on its own line (not comma-separated)