### PR TITLE
build: release v7.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [7.28.0](https://github.com/opengovsg/formsg/compare/v7.27.0...v7.28.0) (2026-06-11)
+
+
+### Features
+
+* add headers to questionAnswerPairs; affecting mrf nextstep, workflow completion, respondent copy emails ([08b9e25](https://github.com/opengovsg/formsg/commit/08b9e252cfae5d3fcce02a4c91c0ff64d7b87e29))
+* add JSON to MRF emails ([18c613a](https://github.com/opengovsg/formsg/commit/18c613a4ddb097b5bcca1b77551fb0d233d0bc93))
+* add verified prefix to questionAnswer ([6c89002](https://github.com/opengovsg/formsg/commit/6c890028d3cac88137c89031fae16538f7c00f26))
+* implement standardised email template for payment form, feature-flagged ([1a0ddf6](https://github.com/opengovsg/formsg/commit/1a0ddf66265ef314d28e4d2343bf18ee62fb793f))
+* include 'Others :' in checkbox & radio others field ([4f23b42](https://github.com/opengovsg/formsg/commit/4f23b42510e40f4cf09416ba42db4f1cd0b4e994))
+* make MRF JSON table delimiters ;, implement foothole to use formSetting to determine delimiter used for the future ([59c474b](https://github.com/opengovsg/formsg/commit/59c474b796c20727c459daf9e43345a348653561))
+* show headers with different styles in email template ([d0c4075](https://github.com/opengovsg/formsg/commit/d0c40758baf1a7f768a718774a7278dfb402ec1a))
+
+
+### Bug Fixes
+
+* add fieldType to storage mode respondent copy so headers take header css property in email template ([7eebf73](https://github.com/opengovsg/formsg/commit/7eebf734f723c2e5f09537b8157c1dbb4c912457))
+* preserve line breaks in standardised email template responses (#9592) ([#9592](https://github.com/opengovsg/formsg/commit/1c1bb6c1ab215eb161eb59bce1c7a3a7b8aed4a5))
+* rename [MyInfo] with [Myinfo] ([c29de94](https://github.com/opengovsg/formsg/commit/c29de94b08ca83d82603fe49b4273126b177294c))
+* tests & linting ([0c5a4f6](https://github.com/opengovsg/formsg/commit/0c5a4f6c4cca0fcf1e80a038d113cae25f72e017))
+
+
+### Chores
+
+* move non_response_field_set to shared file to be used by FE and BE ([cecbef1](https://github.com/opengovsg/formsg/commit/cecbef130cbe625e215d8b69c515aa4c24502a42))
+
+
+### Miscellaneous
+
+* Merge pull request #9505 from opengovsg/feat/email-standardisation-phase-3 ([#9505](https://github.com/opengovsg/formsg/commit/ced5773d208035d2ea58c862d06898093a3fc194))
+* resolve JSON DOM tree status in email template ([6621269](https://github.com/opengovsg/formsg/commit/6621269b2e5d62325c11139bbe794d1edcd5e576))
+
 ## [7.27.0](https://github.com/opengovsg/formsg/compare/v7.26.1...v7.27.0) (2026-06-10)
 
 

--- a/__tests__/e2e/utils/response.ts
+++ b/__tests__/e2e/utils/response.ts
@@ -57,7 +57,7 @@ export const getResponseTitle = (
     responseView.mode === FormResponseMode.Encrypt && responseView.csv
   // MyInfo fields
   if (isMyInfoableFieldType(field) && field.myInfo) {
-    if (field.myInfo.verified) return `[MyInfo] ${field.title}`
+    if (field.myInfo.verified) return `[Myinfo] ${field.title}`
     return field.title
   }
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-backend",
-  "version": "7.27.0",
+  "version": "7.28.0",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/apps/backend/src/app/modules/submission/email-submission/email-submission.constants.ts
+++ b/apps/backend/src/app/modules/submission/email-submission/email-submission.constants.ts
@@ -1,5 +1,5 @@
 // Prefixes in response emails, a space is included after the [field] for formatting
-export const MYINFO_PREFIX = '[MyInfo] '
+export const MYINFO_PREFIX = '[Myinfo] '
 export const VERIFIED_PREFIX = '[verified] '
 export const TABLE_PREFIX = '[table] '
 export const ATTACHMENT_PREFIX = '[attachment] '

--- a/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.service.spec.ts
@@ -650,7 +650,7 @@ describe('encrypt-submission.service', () => {
           const mockResponses: ProcessedFieldResponse[] = [
             {
               _id: new ObjectId().toHexString(),
-              question: '[MyInfo] Test Question',
+              question: '[Myinfo] Test Question',
               answer: 'Test Answer',
               fieldType: BasicField.ShortText,
             },
@@ -694,12 +694,12 @@ describe('encrypt-submission.service', () => {
           )
         })
 
-        it('should strip [MyInfo] prefix from expected dataCollationData to sendSubmissionToAdmin', async () => {
+        it('should strip [Myinfo] prefix from expected dataCollationData to sendSubmissionToAdmin', async () => {
           // Arrange
           const mockResponses: ProcessedFieldResponse[] = [
             {
               _id: new ObjectId().toHexString(),
-              question: '[MyInfo] Name',
+              question: '[Myinfo] Name',
               answer: 'Test Answer',
               fieldType: BasicField.ShortText,
               isVisible: true,

--- a/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.utils.spec.ts
@@ -171,7 +171,7 @@ describe('encrypt-submission.utils', () => {
       expect(actual).toEqual(parsedResponses)
     })
 
-    it('should prefix MyInfo fields in responses when hashed fields are provided', () => {
+    it('should prefix Myinfo fields in responses when hashed fields are provided', () => {
       // Arrange
       const parsedResponses: any[] = [
         {
@@ -210,7 +210,7 @@ describe('encrypt-submission.utils', () => {
       expect(actual).toEqual([
         {
           _id: 'field1',
-          question: '[MyInfo] Question 1',
+          question: '[Myinfo] Question 1',
           myInfo: { attr: 'NAME' },
           answer: 'John Doe',
           fieldType: 'textfield',
@@ -223,7 +223,7 @@ describe('encrypt-submission.utils', () => {
         },
         {
           _id: 'childrenbirthrecords.692411846d1da146b503aada.childname.0',
-          question: '[MyInfo] Question Child',
+          question: '[Myinfo] Question Child',
           myInfo: { attr: 'childname' },
           answer: 'Child Name',
           fieldType: 'children',

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -45,6 +45,7 @@ import {
 import * as fieldValidation from '../../../../utils/field-validation'
 import { ValidateFieldErrorV3 } from '../../submission.errors'
 import {
+  buildMrfResponseJson,
   createMultirespondentSubmissionDto,
   createPublicMultirespondentSubmissionDto,
   extractRespondentCopyEmailDatas,
@@ -1051,5 +1052,199 @@ describe('multirespondent-submission.utils', () => {
       responses: null as unknown as FieldResponsesV3,
     })
     expect(nullResult).toEqual([])
+  })
+
+  describe('buildMrfResponseJson', () => {
+    const BASE_ARGS = { responseId: 'abc123', timestamp: '1 Jan 2025' }
+
+    it('should prepend Response ID and Timestamp as first two entries', () => {
+      const result = JSON.parse(
+        buildMrfResponseJson({ ...BASE_ARGS, formFields: [], responses: {} }),
+      )
+      expect(result[0]).toEqual({ question: 'Response ID', answer: 'abc123' })
+      expect(result[1]).toEqual({ question: 'Timestamp', answer: '1 Jan 2025' })
+    })
+
+    it('should include question and answer for a basic field', () => {
+      const fieldId = '1'
+      const result = JSON.parse(
+        buildMrfResponseJson({
+          ...BASE_ARGS,
+          formFields: [
+            {
+              _id: fieldId,
+              title: 'Name',
+              fieldType: BasicField.ShortText,
+            } as IShortTextFieldSchema,
+          ],
+          responses: {
+            [fieldId]: {
+              fieldType: BasicField.ShortText,
+              answer: 'Alice',
+            } as ShortTextResponseV3,
+          },
+        }),
+      )
+      expect(result[2]).toEqual({ question: 'Name', answer: 'Alice' })
+    })
+
+    it('should output address sub-fields as separate flat entries', () => {
+      const fieldId = '1'
+      const result = JSON.parse(
+        buildMrfResponseJson({
+          ...BASE_ARGS,
+          formFields: [
+            {
+              _id: fieldId,
+              title: 'Home Address',
+              fieldType: BasicField.Address,
+            } as IAddressCompoundFieldSchema,
+          ],
+          responses: {
+            [fieldId]: {
+              fieldType: BasicField.Address,
+              answer: {
+                addressSubFields: {
+                  blockNumber: '161',
+                  streetName: 'BUKIT BATOK STREET 11',
+                  buildingName: '',
+                  levelNumber: '01',
+                  unitNumber: '02',
+                  postalCode: '650161',
+                } as AddressAttributes,
+              },
+            } as AddressResponseV3,
+          },
+        }),
+      )
+      expect(result[2]).toEqual({
+        question: 'Home Address - blockNumber',
+        answer: '161',
+      })
+      expect(result[3]).toEqual({
+        question: 'Home Address - streetName',
+        answer: 'BUKIT BATOK STREET 11',
+      })
+      expect(result[4]).toEqual({
+        question: 'Home Address - buildingName',
+        answer: '',
+      })
+      expect(result[5]).toEqual({
+        question: 'Home Address - levelNumber',
+        answer: '01',
+      })
+      expect(result[6]).toEqual({
+        question: 'Home Address - unitNumber',
+        answer: '02',
+      })
+      expect(result[7]).toEqual({
+        question: 'Home Address - postalCode',
+        answer: '650161',
+      })
+    })
+
+    it('should not add [Verified] prefix to email field questions', () => {
+      const fieldId = '1'
+      const result = JSON.parse(
+        buildMrfResponseJson({
+          ...BASE_ARGS,
+          formFields: [
+            {
+              _id: fieldId,
+              title: 'Email',
+              fieldType: BasicField.Email,
+            } as IEmailFieldSchema,
+          ],
+          responses: {
+            [fieldId]: {
+              fieldType: BasicField.Email,
+              answer: { value: 'alice@example.com', signature: 'sig' },
+            } as EmailResponseV3,
+          },
+        }),
+      )
+      expect(result[2]).toEqual({
+        question: 'Email',
+        answer: 'alice@example.com',
+      })
+    })
+
+    it('should output empty string for fields with no response', () => {
+      const result = JSON.parse(
+        buildMrfResponseJson({
+          ...BASE_ARGS,
+          formFields: [
+            {
+              _id: '1',
+              title: 'Unanswered',
+              fieldType: BasicField.ShortText,
+            } as IShortTextFieldSchema,
+          ],
+          responses: {},
+        }),
+      )
+      expect(result[2]).toEqual({ question: 'Unanswered', answer: '' })
+    })
+
+    it('should exclude non-response fields (Section, Statement, Image)', () => {
+      const result = JSON.parse(
+        buildMrfResponseJson({
+          ...BASE_ARGS,
+          formFields: [
+            {
+              _id: '1',
+              title: 'Section Header',
+              fieldType: BasicField.Section,
+            } as FormFieldSchema,
+            {
+              _id: '2',
+              title: 'Statement',
+              fieldType: BasicField.Statement,
+            } as FormFieldSchema,
+            {
+              _id: '3',
+              title: 'Image',
+              fieldType: BasicField.Image,
+            } as FormFieldSchema,
+            {
+              _id: '4',
+              title: 'Name',
+              fieldType: BasicField.ShortText,
+            } as IShortTextFieldSchema,
+          ],
+          responses: {
+            '4': {
+              fieldType: BasicField.ShortText,
+              answer: 'Alice',
+            } as ShortTextResponseV3,
+          },
+        }),
+      )
+      expect(result).toHaveLength(3) // Response ID + Timestamp + Name
+      expect(result[2]).toEqual({ question: 'Name', answer: 'Alice' })
+    })
+
+    it('should not include fieldType in output entries', () => {
+      const fieldId = '1'
+      const result = JSON.parse(
+        buildMrfResponseJson({
+          ...BASE_ARGS,
+          formFields: [
+            {
+              _id: fieldId,
+              title: 'Name',
+              fieldType: BasicField.ShortText,
+            } as IShortTextFieldSchema,
+          ],
+          responses: {
+            [fieldId]: {
+              fieldType: BasicField.ShortText,
+              answer: 'Alice',
+            } as ShortTextResponseV3,
+          },
+        }),
+      )
+      expect(result[2]).not.toHaveProperty('fieldType')
+    })
   })
 })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -663,7 +663,7 @@ describe('multirespondent-submission.utils', () => {
       expect(result).toEqual([
         {
           question: 'Checkbox',
-          answer: 'Option 1,Option 2,Custom Option',
+          answer: 'Option 1, Option 2, Others: Custom Option',
           fieldType: BasicField.Checkbox,
         },
       ])
@@ -742,7 +742,7 @@ describe('multirespondent-submission.utils', () => {
 
       expect(result).toEqual([
         {
-          question: '[signature] Signature',
+          question: '[Signature] Signature',
           answer: 'Signature captured',
           fieldType: BasicField.Signature,
           signatureDataPngDataUri: expectedSignatureDataPngDataUri,
@@ -776,7 +776,7 @@ describe('multirespondent-submission.utils', () => {
 
       expect(result).toEqual([
         {
-          question: '[signature] Signature',
+          question: '[Signature] Signature',
           answer: 'Signature captured',
           fieldType: BasicField.Signature,
           signatureDataPngDataUri: undefined,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -68,10 +68,12 @@ import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
 import { MultirespondentSubmissionContent } from './multirespondent-submission.types'
 import {
+  buildMrfResponseJson,
   extractEmailAnswersFromResponses,
   extractRespondentCopyEmailDatas,
   formatSubmittedStepTimestamp,
   getEmailFromResponses,
+  getFormDelimiter,
   getQuestionAnswerPairsForMultipleFields,
   getResponsesDataFromMrfResponses,
   retrieveWorkflowStepEmailAddresses,
@@ -447,6 +449,7 @@ const sendMrfOutcomeEmails = ({
     | '_id'
     | 'title'
     | 'emails'
+    | 'metadata'
     | 'stepOneEmailNotificationFieldId'
     | 'stepsToNotify'
     | 'workflow'
@@ -521,6 +524,7 @@ const sendMrfOutcomeEmails = ({
           responses,
           responseId: submissionId,
           timestamp: latestSubmissionTimestamp,
+          delimiter: getFormDelimiter(form.metadata),
         })
 
         const emailAttachments = []

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -516,6 +516,13 @@ const sendMrfOutcomeEmails = ({
           responses,
         })
 
+        const responseJson = buildMrfResponseJson({
+          formFields: form.form_fields,
+          responses,
+          responseId: submissionId,
+          timestamp: latestSubmissionTimestamp,
+        })
+
         const emailAttachments = []
         emailAttachments.push(...(attachments ?? []))
         if (responsePdf) {
@@ -532,6 +539,7 @@ const sendMrfOutcomeEmails = ({
             timestamp: latestSubmissionTimestamp,
             isRejected,
             formQuestionAnswers,
+            responseJson,
             attachments: emailAttachments,
             replyTo:
               extractEmailAnswersFromResponses(responses).join(', ') ||
@@ -558,6 +566,7 @@ const sendMrfOutcomeEmails = ({
           submissionId,
           timestamp: latestSubmissionTimestamp,
           formQuestionAnswers,
+          responseJson,
           attachments: emailAttachments,
           replyTo:
             extractEmailAnswersFromResponses(responses).join(', ') || undefined,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -370,6 +370,9 @@ const getQuestionAnswerPairsForOneField = ({
     }
     case BasicField.Email:
     case BasicField.Mobile:
+      if (response.answer.signature)
+        questionTitle = `[Verified] ${questionTitle}`
+
       answer = response.answer.value
       break
     case BasicField.Table:

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -331,6 +331,16 @@ const getQuestionAnswerPairsForOneField = ({
   let answerArray: string[] = []
   const questionAnswerPairs: QuestionAnswerPair[] = []
 
+  // edge case handling for headers
+  if (formField.fieldType === BasicField.Section) {
+    questionAnswerPairs.push({
+      question: questionTitle,
+      answer,
+      fieldType: formField.fieldType,
+    })
+    return questionAnswerPairs
+  }
+
   switch (response.fieldType) {
     case BasicField.Attachment:
       questionTitle = `[Attachment] ${questionTitle}`
@@ -477,7 +487,12 @@ export const getQuestionAnswerPairsForMultipleFields = ({
     const questionTitle = currentFormField.title
     const response = responses[currentFormField._id]
 
-    if (!response || !questionTitle) continue
+    if (
+      (!response && currentFormField.fieldType !== BasicField.Section) || //Allow headers to be included
+      !questionTitle
+    )
+      continue
+
     const questionAnswerPairsForCurrentFormField =
       getQuestionAnswerPairsForOneField({
         formField: currentFormField,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -4,6 +4,7 @@ import {
   FieldResponsesV3,
   FieldResponseV3,
   FormFieldDto,
+  FormMetadata,
   FormWorkflowStepDto,
   MultirespondentSubmissionDto,
   NdiResponseV3,
@@ -103,6 +104,9 @@ export const createPublicMultirespondentSubmissionDto = (
     workflow: stripWorkflowEmails(submissionData.workflow),
   }
 }
+
+export const getFormDelimiter = (metadata?: FormMetadata): string =>
+  metadata?.delimiter ?? ', '
 
 export const getEmailFromResponses = (
   fieldId: string,
@@ -325,10 +329,12 @@ const getQuestionAnswerPairsForOneField = ({
   formField,
   response,
   includeSignatureDataPngDataUri,
+  delimiter = '; ',
 }: {
   formField: FormFieldSchema | FormFieldDto
   response: FieldResponseV3
   includeSignatureDataPngDataUri: boolean
+  delimiter?: string
 }): QuestionAnswerPair[] => {
   let questionTitle = formField.title
   let answer = ''
@@ -400,11 +406,11 @@ const getQuestionAnswerPairsForOneField = ({
             const colTitle = idToColTitleMap[colId]
             return `${colTitle}`
           })
-          .join('; ')
+          .join(delimiter)
 
         const delimitedColumnAnswers = validColumns
           .map(([, colAns]) => colAns ?? '')
-          .join('; ')
+          .join(delimiter)
 
         const question = `[Table] ${formField.title} (${delimitedColumnTitles})`
         const answer = delimitedColumnAnswers
@@ -569,11 +575,13 @@ export const buildMrfResponseJson = ({
   responses,
   responseId,
   timestamp,
+  delimiter = ', ',
 }: {
   formFields: FormFieldSchema[] | FormFieldDto[]
   responses: FieldResponsesV3
   responseId: string
   timestamp: string
+  delimiter?: string
 }): string => {
   const entries: Array<{ question: string; answer: string }> = [
     { question: 'Response ID', answer: responseId },
@@ -613,6 +621,7 @@ export const buildMrfResponseJson = ({
           formField: field,
           response,
           includeSignatureDataPngDataUri: false,
+          delimiter,
         })
         for (const pair of pairs) {
           entries.push({ question: pair.question, answer: pair.answer })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -11,7 +11,10 @@ import {
   SubmissionType,
   WorkflowType,
 } from 'formsg-shared/types'
-import { handleAddressResponseDisplay } from 'formsg-shared/utils/address'
+import {
+  answerKey,
+  handleAddressResponseDisplay,
+} from 'formsg-shared/utils/address'
 import { NON_RESPONSE_FIELD_SET } from 'formsg-shared/utils/field'
 import { SIGNATURE_CAPTURED_STRING } from 'formsg-shared/utils/signature'
 import { stripDropdownFieldOptionsToRecipientsMap } from 'formsg-shared/utils/strip-dropdown-field-optionsToRecipientsMap'
@@ -557,8 +560,8 @@ export const getResponsesDataFromMrfResponses = ({
 
 /**
  * Serialises MRF submission responses into a JSON string for email attachment.
- * Built directly from raw form fields and responses so that specific field
- * types (e.g. Address) can be handled in custom ways than the generic question-answer pair extraction
+ * Built directly from raw form fields and responses so that specific field types
+ * (e.g. Address) can be handled in custom ways than the generic question-answer pair extraction
  * fields are handled consistently with the email body.
  */
 export const buildMrfResponseJson = ({
@@ -577,6 +580,8 @@ export const buildMrfResponseJson = ({
     { question: 'Timestamp', answer: timestamp },
   ]
 
+  if (!formFields || !responses) return JSON.stringify(entries)
+
   for (const field of formFields) {
     // Skip non-response fields and fields without titles
     if (NON_RESPONSE_FIELD_SET.has(field.fieldType as BasicField)) continue
@@ -590,10 +595,12 @@ export const buildMrfResponseJson = ({
 
     switch (response.fieldType) {
       case BasicField.Address: {
-        for (const [key, value] of Object.entries(
-          response.answer.addressSubFields,
-        )) {
-          entries.push({ question: `${field.title} - ${key}`, answer: value })
+        const subFields = response.answer.addressSubFields
+        for (const key of answerKey) {
+          entries.push({
+            question: `${field.title} - ${key}`,
+            answer: subFields[key as keyof typeof subFields],
+          })
         }
         break
       }

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -12,6 +12,7 @@ import {
   WorkflowType,
 } from 'formsg-shared/types'
 import { handleAddressResponseDisplay } from 'formsg-shared/utils/address'
+import { NON_RESPONSE_FIELD_SET } from 'formsg-shared/utils/field'
 import { SIGNATURE_CAPTURED_STRING } from 'formsg-shared/utils/signature'
 import { stripDropdownFieldOptionsToRecipientsMap } from 'formsg-shared/utils/strip-dropdown-field-optionsToRecipientsMap'
 import { stripWorkflowEmails } from 'formsg-shared/utils/strip-workflow-emails'
@@ -435,7 +436,7 @@ const getQuestionAnswerPairsForOneField = ({
     }
     case BasicField.Signature: {
       const signatureQuestionAnswer = {
-        question: `[signature] ${questionTitle}`,
+        question: `[Signature] ${questionTitle}`,
         answer: SIGNATURE_CAPTURED_STRING,
         signatureDataPngDataUri: includeSignatureDataPngDataUri
           ? convertToSignaturePngDataUri(response.answer.value)
@@ -552,6 +553,75 @@ export const getResponsesDataFromMrfResponses = ({
       fieldType: questionAnswerPair.fieldType,
     }
   })
+}
+
+/**
+ * Serialises MRF submission responses into a JSON string for email attachment.
+ * Built directly from raw form fields and responses so that specific field
+ * types (e.g. Address) can be handled in custom ways than the generic question-answer pair extraction
+ * fields are handled consistently with the email body.
+ */
+export const buildMrfResponseJson = ({
+  formFields,
+  responses,
+  responseId,
+  timestamp,
+}: {
+  formFields: FormFieldSchema[] | FormFieldDto[]
+  responses: FieldResponsesV3
+  responseId: string
+  timestamp: string
+}): string => {
+  const entries: Array<{ question: string; answer: string }> = [
+    { question: 'Response ID', answer: responseId },
+    { question: 'Timestamp', answer: timestamp },
+  ]
+
+  for (const field of formFields) {
+    // Skip non-response fields and fields without titles
+    if (NON_RESPONSE_FIELD_SET.has(field.fieldType as BasicField)) continue
+    if (!field.title) continue
+
+    const response = responses[field._id]
+    if (!response) {
+      entries.push({ question: field.title, answer: '' })
+      continue
+    }
+
+    switch (response.fieldType) {
+      case BasicField.Address: {
+        for (const [key, value] of Object.entries(
+          response.answer.addressSubFields,
+        )) {
+          entries.push({ question: `${field.title} - ${key}`, answer: value })
+        }
+        break
+      }
+      case BasicField.Email:
+      case BasicField.Mobile:
+        entries.push({ question: field.title, answer: response.answer.value })
+        break
+      default: {
+        const pairs = getQuestionAnswerPairsForOneField({
+          formField: field,
+          response,
+          includeSignatureDataPngDataUri: false,
+        })
+        for (const pair of pairs) {
+          entries.push({ question: pair.question, answer: pair.answer })
+        }
+      }
+    }
+  }
+
+  for (const key in responses) {
+    if (startsWithSPCPFieldTitle(key)) {
+      const { answer } = responses[key] as NdiResponseV3
+      entries.push({ question: key, answer })
+    }
+  }
+
+  return JSON.stringify(entries)
 }
 
 /**

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -417,19 +417,22 @@ const getQuestionAnswerPairsForOneField = ({
         'value' in response.answer
           ? response.answer.value
           : 'othersInput' in response.answer
-            ? response.answer.othersInput
+            ? 'Others: ' + response.answer.othersInput
             : ''
       break
-    case BasicField.Checkbox:
-      // eslint-disable-next-line no-case-declarations
-      const selectedAnswers =
-        (response.answer.othersInput
-          ? [...response.answer.value, response.answer.othersInput]
-          : [...response.answer.value]
-        ).filter((val) => val !== CLIENT_CHECKBOX_OTHERS_INPUT_VALUE) ?? []
-
-      answer = selectedAnswers.toString()
+    case BasicField.Checkbox: {
+      answer = response.answer.value
+        .map((val) =>
+          val === CLIENT_CHECKBOX_OTHERS_INPUT_VALUE
+            ? response.answer.othersInput
+              ? 'Others: ' + response.answer.othersInput
+              : null
+            : val,
+        )
+        .filter(Boolean)
+        .join(', ')
       break
+    }
     case BasicField.Signature: {
       const signatureQuestionAnswer = {
         question: `[signature] ${questionTitle}`,

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -1027,6 +1027,7 @@ export class MailService {
     formId,
     paymentId,
     paymentAmount,
+    useStandardisedEmailTemplate,
   }: {
     email: string
     formTitle: string

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -978,9 +978,10 @@ export class MailService {
         //TODO (email-standardisation): remove when email standardisation is GA
         if (useStandardisedEmailTemplate) {
           const formQuestionAnswers: QuestionAnswer[] = responsesData.map(
-            ({ question, answerTemplate }) => ({
+            ({ question, answerTemplate, fieldType }) => ({
               question,
               answer: String(answerTemplate), // fallback to answerTemplate if answer is empty to still show the question in the email
+              fieldType,
             }),
           )
 

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -844,7 +844,7 @@ export class MailService {
       const formQuestionAnswers: QuestionAnswer[] = formData.map(
         ({ question, answerTemplate, fieldType }) => ({
           question,
-          answer: String(answerTemplate),
+          answer: answerTemplate.join('\n'),
           fieldType,
         }),
       )

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -1028,7 +1028,6 @@ export class MailService {
     formId,
     paymentId,
     paymentAmount,
-    useStandardisedEmailTemplate,
   }: {
     email: string
     formTitle: string
@@ -1191,6 +1190,7 @@ export class MailService {
     submissionId,
     timestamp,
     formQuestionAnswers,
+    responseJson,
     attachments,
     replyTo,
   }: {
@@ -1201,6 +1201,7 @@ export class MailService {
     submissionId?: string
     timestamp: string
     formQuestionAnswers: QuestionAnswer[]
+    responseJson: string
     attachments?: Mail.Attachment[]
     replyTo?: string
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
@@ -1209,6 +1210,7 @@ export class MailService {
       responseId: responseId.toString(),
       timestamp,
       formQuestionAnswers,
+      responseJson,
     }
 
     return this.#sendEmailWithTemplate({
@@ -1233,6 +1235,7 @@ export class MailService {
     timestamp,
     isRejected,
     formQuestionAnswers,
+    responseJson,
     attachments,
     replyTo,
   }: {
@@ -1244,6 +1247,7 @@ export class MailService {
     timestamp: string
     isRejected: boolean
     formQuestionAnswers: QuestionAnswer[]
+    responseJson: string
     attachments?: Mail.Attachment[]
     replyTo?: string
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
@@ -1257,6 +1261,7 @@ export class MailService {
       timestamp,
       outcome,
       formQuestionAnswers,
+      responseJson,
     }
 
     return this.#sendEmailWithTemplate({

--- a/apps/backend/src/app/views/templates/EmailTemplate.tsx
+++ b/apps/backend/src/app/views/templates/EmailTemplate.tsx
@@ -24,6 +24,7 @@ import {
 } from '@react-email/components'
 import { BasicField } from 'formsg-shared/types'
 import React from 'react'
+import { BasicField } from 'formsg-shared/types'
 
 import { FORMSG_LOGO_URL } from '../../constants/formsg-logo'
 

--- a/apps/backend/src/app/views/templates/EmailTemplate.tsx
+++ b/apps/backend/src/app/views/templates/EmailTemplate.tsx
@@ -22,9 +22,9 @@ import {
   Section,
   Text,
 } from '@react-email/components'
+
 import { BasicField } from 'formsg-shared/types'
 import React from 'react'
-import { BasicField } from 'formsg-shared/types'
 
 import { FORMSG_LOGO_URL } from '../../constants/formsg-logo'
 

--- a/apps/backend/src/app/views/templates/EmailTemplate.tsx
+++ b/apps/backend/src/app/views/templates/EmailTemplate.tsx
@@ -22,7 +22,6 @@ import {
   Section,
   Text,
 } from '@react-email/components'
-
 import { BasicField } from 'formsg-shared/types'
 import React from 'react'
 

--- a/apps/backend/src/app/views/templates/EmailTemplate.tsx
+++ b/apps/backend/src/app/views/templates/EmailTemplate.tsx
@@ -96,7 +96,12 @@ export const EmailTemplate = ({
         </Text>
       )}
       <Text style={{ ...secondaryTextStyle, ...answerMargin }}>
-        {qa.answer}
+        {qa.answer.split(/\r?\n/).map((line, i, arr) => (
+          <React.Fragment key={i}>
+            {line}
+            {i < arr.length - 1 && <br />}
+          </React.Fragment>
+        ))}
       </Text>
     </>
   )

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-frontend",
-  "version": "7.27.0",
+  "version": "7.28.0",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/apps/frontend/src/features/form/constants.ts
+++ b/apps/frontend/src/features/form/constants.ts
@@ -1,9 +1,3 @@
-import { BasicField } from 'formsg-shared/types'
-
-export const NON_RESPONSE_FIELD_SET = new Set([
-  BasicField.Section,
-  BasicField.Statement,
-  BasicField.Image,
-])
+export { NON_RESPONSE_FIELD_SET } from 'formsg-shared/utils/field'
 
 export const SAVE_DRAFT_INDEXEDDB_STORE_NAME = 'savedDrafts'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-monorepo",
-  "version": "7.27.0",
+  "version": "7.28.0",
   "private": true,
   "description": "Form Manager for Government",
   "homepage": "https://form.gov.sg",

--- a/packages/react-email-preview/package.json
+++ b/packages/react-email-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-react-email-preview",
-  "version": "7.27.0",
+  "version": "7.28.0",
   "private": true,
   "scripts": {
     "build": "email build",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-shared",
-  "version": "7.27.0",
+  "version": "7.28.0",
   "private": true,
   "description": "",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -89,6 +89,10 @@
       "require": "./dist/constants/field/myinfo/index.js",
       "default": "./constants/field/myinfo/index.ts"
     },
+    "./utils/field": {
+      "require": "./dist/utils/field.js",
+      "default": "./utils/field.ts"
+    },
     "./utils/address-validation": {
       "require": "./dist/utils/address-validation.js",
       "default": "./utils/address-validation.ts"

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -116,6 +116,7 @@ export interface FormMetadata {
   num_mrf_reminder_emails_sent?: number
   mfb_vision_prompt_count?: number
   template_form_id?: Schema.Types.ObjectId
+  delimiter?: string
 }
 
 export type FormPaymentsChannel = {

--- a/packages/shared/utils/field.ts
+++ b/packages/shared/utils/field.ts
@@ -1,0 +1,7 @@
+import { BasicField } from '../types'
+
+export const NON_RESPONSE_FIELD_SET = new Set([
+  BasicField.Section,
+  BasicField.Statement,
+  BasicField.Image,
+])

--- a/services/form-payment-reconciliation/package.json
+++ b/services/form-payment-reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-payment-reconciliation",
-  "version": "7.27.0",
+  "version": "7.28.0",
   "private": true,
   "description": "Lambda function for payment reconciliation",
   "main": "index.js",

--- a/services/pdf-gen-sparticuz/package.json
+++ b/services/pdf-gen-sparticuz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-pdf-gen-sparticuz",
-  "version": "7.27.0",
+  "version": "7.28.0",
   "private": true,
   "description": "<!-- title: 'AWS NodeJS Example' description: 'This template demonstrates how to deploy a simple NodeJS function running on AWS Lambda using the Serverless Framework.' layout: Doc framework: v4 platform: AWS language: nodeJS priority: 1 authorLink: 'https://github.com/serverless' authorName: 'Serverless, Inc.' authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4' -->",
   "main": "dist/index.js",

--- a/services/virus-scanner-guardduty/package.json
+++ b/services/virus-scanner-guardduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-virus-scanner-guardduty",
-  "version": "7.27.0",
+  "version": "7.28.0",
   "private": true,
   "description": "",
   "scripts": {


### PR DESCRIPTION


### Features

* add headers to questionAnswerPairs; affecting mrf nextstep, workflow completion, respondent copy emails ([08b9e25](https://github.com/opengovsg/formsg/commit/08b9e252cfae5d3fcce02a4c91c0ff64d7b87e29))
* add JSON to MRF emails ([18c613a](https://github.com/opengovsg/formsg/commit/18c613a4ddb097b5bcca1b77551fb0d233d0bc93))
* add verified prefix to questionAnswer ([6c89002](https://github.com/opengovsg/formsg/commit/6c890028d3cac88137c89031fae16538f7c00f26))
* implement standardised email template for payment form, feature-flagged ([1a0ddf6](https://github.com/opengovsg/formsg/commit/1a0ddf66265ef314d28e4d2343bf18ee62fb793f))
* include 'Others :' in checkbox & radio others field ([4f23b42](https://github.com/opengovsg/formsg/commit/4f23b42510e40f4cf09416ba42db4f1cd0b4e994))
* make MRF JSON table delimiters ;, implement foothole to use formSetting to determine delimiter used for the future ([59c474b](https://github.com/opengovsg/formsg/commit/59c474b796c20727c459daf9e43345a348653561))
* show headers with different styles in email template ([d0c4075](https://github.com/opengovsg/formsg/commit/d0c40758baf1a7f768a718774a7278dfb402ec1a))


### Bug Fixes

* add fieldType to storage mode respondent copy so headers take header css property in email template ([7eebf73](https://github.com/opengovsg/formsg/commit/7eebf734f723c2e5f09537b8157c1dbb4c912457))
* rename [MyInfo] with [Myinfo] ([c29de94](https://github.com/opengovsg/formsg/commit/c29de94b08ca83d82603fe49b4273126b177294c))
* tests & linting ([0c5a4f6](https://github.com/opengovsg/formsg/commit/0c5a4f6c4cca0fcf1e80a038d113cae25f72e017))


### Chores

* move non_response_field_set to shared file to be used by FE and BE ([cecbef1](https://github.com/opengovsg/formsg/commit/cecbef130cbe625e215d8b69c515aa4c24502a42))


### Miscellaneous

* Merge pull request #9505 from opengovsg/feat/email-standardisation-phase-3 ([#9505](https://github.com/opengovsg/formsg/commit/ced5773d208035d2ea58c862d06898093a3fc194))
* resolve JSON DOM tree status in email template ([6621269](https://github.com/opengovsg/formsg/commit/6621269b2e5d62325c11139bbe794d1edcd5e576))


### Tests

TC1: Multi-line answer in admin MRF notification email

- [x] Create a form with a long text field
- [x]  Submit the form with an answer containing multiple lines (e.g. Line 1\nLine 2\nLine 3)
- [ ]  Verify that the admin notification email renders each line on its own line (not comma-separated)
 
TC1: JSON in MRF emails
- [x] Create an MRF form, add a email field (turn on OTP verification), addres field & an optional text field and a header field
- [x] Attempt a successful submission
- [x] Verify on JSON
    - [x] six entries for the address field (e.g. `"Home Address - blockNumber"`, `"Home Address - buildingName"` with `""`, etc.)
    - [x] No `[Verified]` prefix for verified email field
    - [x] Have text-field key-value pair with empty string value
    - [x] Have header field
    - [x] Table delimiter is ', '
- [ ] Verify on email body responses
   - [x] address field email body still shows the address as a single-line string
   - [x] Have `[Verified]` prefix for verified email field
   - [x] Lack of text-field key-value pair with empty string value
   - [x] Lack of header field
 

