### PR TITLE
feat(sdk): decryptVersioned and V4-aware crypto.decrypt (MRF envelope support) (2/4)

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -179,6 +179,29 @@ Attachments are end-to-end encrypted in the same way as normal form submissions,
 
 _Warning:_ We do not have the ability to scan any attachments for malicious content (e.g. spyware or viruses), so careful handling is needed.
 
+### Decrypting Multirespondent (V4) Submissions
+
+Multirespondent form (MRF) webhooks deliver their content in the V4 format, encrypted with a unique keypair per submission. The webhook payload carries the per-submission secret key, itself encrypted with your form's public key, in the `encryptedSubmissionSecretKey` field. Pass the payload into `decrypt` as usual — when `decryptParams.encryptedSubmissionSecretKey` is present, the SDK opens the submission-key envelope for you:
+
+```javascript
+const submission = formsg.crypto.decrypt(formSecretKey, req.body.data)
+```
+
+`decrypt` returns the same `{ responses: FormField[] }` shape for V4 submissions as for storage-mode submissions, so existing processing code keeps working. Differences in V4-sourced output:
+
+| Aspect            | Storage mode (V1)                          | Multirespondent (V4)                                          |
+| ----------------- | ------------------------------------------ | ------------------------------------------------------------- |
+| Unanswered fields | Present with empty `answer`                | Omitted                                                       |
+| Section headers   | Present (`isHeader: true`)                 | Omitted                                                       |
+| Field order       | Form order                                 | Not guaranteed — key responses by `_id`, not array index      |
+
+If you want the richer V4 structure (typed answers, question text, provenance), use `formsg.crypto.decryptVersioned(formSecretKey, decryptParams)`, which returns the content in the version it was submitted in: `DecryptedContent | DecryptedContentV4 | null`. Discriminate the union with `Array.isArray(result.responses)` — `true` means V1 content, `false` means V4 content. The V4 arm additionally carries `submissionSecretKey`, the decrypted per-submission secret key, which you can use to decrypt that submission's attachments or other artifacts yourself.
+
+> **Note:** <br>
+> MRF submissions made before the V4 switchover carry V3 content, which has no question text and cannot be converted to the `FormField[]` shape. `decrypt` returns `null` for these; decrypt them with `formsg.cryptoV3.decrypt` instead.
+
+_Warning:_ V4 attachments are encrypted with the per-submission keypair, not the form keypair. Manually decrypting downloaded files with your form secret key will not work for V4 submissions — use `decryptWithAttachments`, or `decryptVersioned` and decrypt the files with the returned `submissionSecretKey`.
+
 ### Processing Local address fields
 
 Address Field is a compound field with 6 inputs in the answerArray. It will always follow the ordinance of [`blockNumber`, `streetName`, `buildingName`, `levelNumber`, `unitNumber`, `postalCode`]

--- a/packages/sdk/spec/crypto-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-versioned.spec.ts
@@ -1,0 +1,46 @@
+import Crypto from '../src/crypto'
+import CryptoV3 from '../src/crypto-v3'
+import { SIGNING_KEYS } from '../src/resource/signing-keys'
+import { DecryptedContentV4, FieldResponsesV4 } from '../src/types-v4'
+
+const signingPublicKey = SIGNING_KEYS.test.publicKey
+
+const MRF_TEST_VERSION = 3
+
+const v4Responses: FieldResponsesV4 = {
+  '650abc0000000000000000aa': {
+    fieldType: 'textfield',
+    question: 'What is your name?',
+    answer: { value: 'TAN AH KOW' },
+    provenance: { stepNumber: 1 },
+  },
+  '650abc0000000000000000ab': {
+    fieldType: 'radiobutton',
+    question: 'Favourite colour',
+    answer: { value: 'vermilion', isOthersInput: true },
+    provenance: { stepNumber: 2 },
+  },
+}
+
+describe('Crypto (versioned decryption)', () => {
+  const crypto = new Crypto({ signingPublicKey })
+  const cryptoV3 = new CryptoV3({ signingPublicKey })
+
+  it('decryptVersioned returns the V4 arm with the per-submission secret key for an MRF V4 payload', () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const enc = cryptoV3.encrypt(v4Responses, publicKey)
+
+    const result = crypto.decryptVersioned(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      version: MRF_TEST_VERSION,
+    })
+
+    expect(result).not.toBeNull()
+    expect(Array.isArray(result!.responses)).toBe(false)
+    expect(result!.responses).toEqual(v4Responses)
+    expect((result as DecryptedContentV4).submissionSecretKey).toEqual(
+      enc.submissionSecretKey
+    )
+  })
+})

--- a/packages/sdk/spec/crypto-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-versioned.spec.ts
@@ -1,3 +1,4 @@
+import { adaptV4ToV1 } from '../src/adapt-v4-to-v1'
 import Crypto from '../src/crypto'
 import CryptoV3 from '../src/crypto-v3'
 import { SIGNING_KEYS } from '../src/resource/signing-keys'
@@ -292,6 +293,190 @@ describe('Crypto (versioned decryption)', () => {
           version: MRF_TEST_VERSION,
         })
       ).toBeNull()
+    })
+  })
+
+  describe('version param remains ignored', () => {
+    it.each([0, 4, 999, undefined])(
+      'produces identical results for version=%p on V1 and V4 payloads',
+      (junkVersion) => {
+        const { publicKey, secretKey } = crypto.generate()
+        const v1Encrypted = crypto.encrypt(plaintext, publicKey)
+        const v4Enc = cryptoV3.encrypt(v4Responses, publicKey)
+
+        const v1WithJunk = crypto.decryptVersioned(secretKey, {
+          encryptedContent: v1Encrypted,
+          version: junkVersion as unknown as number,
+        })
+        const v1WithCorrect = crypto.decryptVersioned(secretKey, {
+          encryptedContent: v1Encrypted,
+          version: 1,
+        })
+        expect(v1WithJunk).toEqual(v1WithCorrect)
+
+        const v4Params = {
+          encryptedContent: v4Enc.encryptedContent,
+          encryptedSubmissionSecretKey: v4Enc.encryptedSubmissionSecretKey,
+        }
+        const v4WithJunk = crypto.decryptVersioned(secretKey, {
+          ...v4Params,
+          version: junkVersion as unknown as number,
+        })
+        const v4WithCorrect = crypto.decryptVersioned(secretKey, {
+          ...v4Params,
+          version: MRF_TEST_VERSION,
+        })
+        expect(v4WithJunk).toEqual(v4WithCorrect)
+        expect(
+          crypto.decrypt(secretKey, {
+            ...v4Params,
+            version: junkVersion as unknown as number,
+          })
+        ).toEqual(
+          crypto.decrypt(secretKey, { ...v4Params, version: MRF_TEST_VERSION })
+        )
+      }
+    )
+  })
+
+  describe('key handling', () => {
+    it('never returns the form secret key as submissionSecretKey', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const enc = cryptoV3.encrypt(v4Responses, publicKey)
+
+      const result = crypto.decryptVersioned(secretKey, {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+        version: MRF_TEST_VERSION,
+      }) as DecryptedContentV4
+
+      expect(result.submissionSecretKey).toEqual(enc.submissionSecretKey)
+      expect(result.submissionSecretKey).not.toEqual(secretKey)
+    })
+
+    it('decrypt output has no submissionSecretKey property for either envelope', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const v4Enc = cryptoV3.encrypt(v4Responses, publicKey)
+
+      const fromV4 = crypto.decrypt(secretKey, {
+        encryptedContent: v4Enc.encryptedContent,
+        encryptedSubmissionSecretKey: v4Enc.encryptedSubmissionSecretKey,
+        version: MRF_TEST_VERSION,
+      })
+      const fromV1 = crypto.decrypt(secretKey, {
+        encryptedContent: crypto.encrypt(plaintext, publicKey),
+        version: 1,
+      })
+
+      expect(fromV4).not.toHaveProperty('submissionSecretKey')
+      expect(fromV1).not.toHaveProperty('submissionSecretKey')
+    })
+  })
+
+  describe('cross-implementation consistency', () => {
+    it('matches cryptoV3.decryptToV4 for the same MRF V4 payload', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const enc = cryptoV3.encrypt(v4Responses, publicKey)
+      const params = {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+        version: MRF_TEST_VERSION,
+      }
+
+      const versioned = crypto.decryptVersioned(
+        secretKey,
+        params
+      ) as DecryptedContentV4
+      const viaV3 = cryptoV3.decryptToV4(secretKey, params, {})
+
+      expect(versioned.responses).toEqual(viaV3!.responses)
+      expect(versioned.submissionSecretKey).toEqual(viaV3!.submissionSecretKey)
+    })
+
+    it('decrypt equals the V4 arm of decryptVersioned run through adaptV4ToV1', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const enc = cryptoV3.encrypt(v4Responses, publicKey)
+      const params = {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+        version: MRF_TEST_VERSION,
+      }
+
+      const adapted = crypto.decrypt(secretKey, params)
+      const versioned = crypto.decryptVersioned(
+        secretKey,
+        params
+      ) as DecryptedContentV4
+
+      expect(adapted).toEqual({ responses: adaptV4ToV1(versioned.responses) })
+    })
+  })
+
+  describe('verified content', () => {
+    const mockVerifiedContent = {
+      uinFin: 'S12345679Z',
+      somethingElse: 99,
+    }
+    const signingSecretKey = SIGNING_KEYS.test.secretKey
+
+    it('round-trips verified content in the V1 arm and stays absent when not given', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const encryptedContent = crypto.encrypt(plaintext, publicKey)
+      const verifiedContent = crypto.encrypt(
+        mockVerifiedContent,
+        publicKey,
+        signingSecretKey
+      )
+
+      const withVerified = crypto.decryptVersioned(secretKey, {
+        encryptedContent,
+        verifiedContent,
+        version: 1,
+      })
+      expect(withVerified).toEqual({
+        responses: plaintext,
+        verified: mockVerifiedContent,
+      })
+
+      const withoutVerified = crypto.decryptVersioned(secretKey, {
+        encryptedContent,
+        version: 1,
+      })
+      expect(withoutVerified).not.toHaveProperty('verified')
+    })
+
+    it('round-trips verified content in the V4 arm (and through decrypt) and stays absent when not given', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const enc = cryptoV3.encrypt(v4Responses, publicKey)
+      // MRF verified content is encrypted with the submission public key.
+      const verifiedContent = crypto.encrypt(
+        mockVerifiedContent,
+        enc.submissionPublicKey,
+        signingSecretKey
+      )
+      const params = {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+        version: MRF_TEST_VERSION,
+      }
+
+      const versioned = crypto.decryptVersioned(secretKey, {
+        ...params,
+        verifiedContent,
+      })
+      expect(versioned).toHaveProperty('verified', mockVerifiedContent)
+      expect(versioned!.responses).toEqual(v4Responses)
+
+      const adapted = crypto.decrypt(secretKey, {
+        ...params,
+        verifiedContent,
+      })
+      expect(adapted).toHaveProperty('verified', mockVerifiedContent)
+
+      expect(crypto.decryptVersioned(secretKey, params)).not.toHaveProperty(
+        'verified'
+      )
+      expect(crypto.decrypt(secretKey, params)).not.toHaveProperty('verified')
     })
   })
 })

--- a/packages/sdk/spec/crypto-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-versioned.spec.ts
@@ -3,6 +3,8 @@ import CryptoV3 from '../src/crypto-v3'
 import { SIGNING_KEYS } from '../src/resource/signing-keys'
 import { DecryptedContentV4, FieldResponsesV4 } from '../src/types-v4'
 
+import { plaintext } from './resources/crypto-data-20200322'
+
 const signingPublicKey = SIGNING_KEYS.test.publicKey
 
 const MRF_TEST_VERSION = 3
@@ -42,5 +44,20 @@ describe('Crypto (versioned decryption)', () => {
     expect((result as DecryptedContentV4).submissionSecretKey).toEqual(
       enc.submissionSecretKey
     )
+  })
+
+  it('decryptVersioned returns the V1 arm for a storage-mode payload, with no submissionSecretKey property', () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const encryptedContent = crypto.encrypt(plaintext, publicKey)
+
+    const result = crypto.decryptVersioned(secretKey, {
+      encryptedContent,
+      version: 1,
+    })
+
+    expect(result).not.toBeNull()
+    expect(Array.isArray(result!.responses)).toBe(true)
+    expect(result!.responses).toEqual(plaintext)
+    expect(result).not.toHaveProperty('submissionSecretKey')
   })
 })

--- a/packages/sdk/spec/crypto-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-versioned.spec.ts
@@ -108,4 +108,97 @@ describe('Crypto (versioned decryption)', () => {
     const adapted = crypto.decrypt(secretKey, params)
     expect(adapted).toEqual({ responses: [] })
   })
+
+  describe('envelope/content mismatches', () => {
+    it('returns null for an MRF payload when encryptedSubmissionSecretKey is not given', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const enc = cryptoV3.encrypt(v4Responses, publicKey)
+      const params = {
+        encryptedContent: enc.encryptedContent,
+        version: MRF_TEST_VERSION,
+      }
+
+      expect(crypto.decryptVersioned(secretKey, params)).toBeNull()
+      expect(crypto.decrypt(secretKey, params)).toBeNull()
+    })
+
+    it('returns null for a storage-mode payload carrying a spurious encryptedSubmissionSecretKey', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const encryptedContent = crypto.encrypt(plaintext, publicKey)
+      // A validly-enveloped submission key that did not encrypt this content.
+      const spuriousEnvelope = cryptoV3.encrypt({}, publicKey)
+      const params = {
+        encryptedContent,
+        encryptedSubmissionSecretKey:
+          spuriousEnvelope.encryptedSubmissionSecretKey,
+        version: 1,
+      }
+
+      expect(crypto.decryptVersioned(secretKey, params)).toBeNull()
+      expect(crypto.decrypt(secretKey, params)).toBeNull()
+    })
+
+    it('returns null when encryptedSubmissionSecretKey is corrupt or encrypted for another key', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const otherKeypair = crypto.generate()
+      const enc = cryptoV3.encrypt(v4Responses, publicKey)
+      const wrongKeyEnvelope = cryptoV3.encrypt(v4Responses, otherKeypair.publicKey)
+
+      const corrupt = {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: 'utterly;corrupt:envelope',
+        version: MRF_TEST_VERSION,
+      }
+      const wrongKey = {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: wrongKeyEnvelope.encryptedSubmissionSecretKey,
+        version: MRF_TEST_VERSION,
+      }
+
+      expect(crypto.decryptVersioned(secretKey, corrupt)).toBeNull()
+      expect(crypto.decrypt(secretKey, corrupt)).toBeNull()
+      expect(crypto.decryptVersioned(secretKey, wrongKey)).toBeNull()
+      expect(crypto.decrypt(secretKey, wrongKey)).toBeNull()
+    })
+
+    it('returns null for tampered ciphertext and wrong form secret key in both arms', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const otherKeypair = crypto.generate()
+
+      const v1Encrypted = crypto.encrypt(plaintext, publicKey)
+      const v4Enc = cryptoV3.encrypt(v4Responses, publicKey)
+
+      const tamper = (content: string) => {
+        const flipped = content.slice(0, -4) + (content.endsWith('AAAA') ? 'BBBB' : 'AAAA')
+        return flipped
+      }
+
+      expect(
+        crypto.decryptVersioned(secretKey, {
+          encryptedContent: tamper(v1Encrypted),
+          version: 1,
+        })
+      ).toBeNull()
+      expect(
+        crypto.decryptVersioned(secretKey, {
+          encryptedContent: tamper(v4Enc.encryptedContent),
+          encryptedSubmissionSecretKey: v4Enc.encryptedSubmissionSecretKey,
+          version: MRF_TEST_VERSION,
+        })
+      ).toBeNull()
+      expect(
+        crypto.decryptVersioned(otherKeypair.secretKey, {
+          encryptedContent: v1Encrypted,
+          version: 1,
+        })
+      ).toBeNull()
+      expect(
+        crypto.decryptVersioned(otherKeypair.secretKey, {
+          encryptedContent: v4Enc.encryptedContent,
+          encryptedSubmissionSecretKey: v4Enc.encryptedSubmissionSecretKey,
+          version: MRF_TEST_VERSION,
+        })
+      ).toBeNull()
+    })
+  })
 })

--- a/packages/sdk/spec/crypto-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-versioned.spec.ts
@@ -3,6 +3,10 @@ import CryptoV3 from '../src/crypto-v3'
 import { SIGNING_KEYS } from '../src/resource/signing-keys'
 import { DecryptedContentV4, FieldResponsesV4 } from '../src/types-v4'
 
+import { decodeUTF8 } from 'tweetnacl-util'
+
+import { encryptMessage } from '../src/util/crypto'
+
 import { plaintext } from './resources/crypto-data-20200322'
 
 const signingPublicKey = SIGNING_KEYS.test.publicKey
@@ -196,6 +200,95 @@ describe('Crypto (versioned decryption)', () => {
         crypto.decryptVersioned(otherKeypair.secretKey, {
           encryptedContent: v4Enc.encryptedContent,
           encryptedSubmissionSecretKey: v4Enc.encryptedSubmissionSecretKey,
+          version: MRF_TEST_VERSION,
+        })
+      ).toBeNull()
+    })
+  })
+
+  describe('plaintext-shape dispatch', () => {
+    // Encrypts arbitrary plaintext (even invalid JSON) inside an MRF envelope.
+    const encryptRawInEnvelope = (raw: string, formPublicKey: string) => {
+      const envelope = cryptoV3.encrypt({}, formPublicKey)
+      return {
+        // Encrypt to the submission keypair like the MRF envelope does.
+        encryptedContent: encryptMessage(
+          decodeUTF8(raw),
+          envelope.submissionPublicKey
+        ),
+        encryptedSubmissionSecretKey: envelope.encryptedSubmissionSecretKey,
+        version: MRF_TEST_VERSION,
+      }
+    }
+
+    it('returns null for a V3-shaped record (no provenance)', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const v3Responses = {
+        '650abc0000000000000000aa': {
+          fieldType: 'textfield',
+          answer: 'TAN AH KOW',
+        },
+      }
+      const enc = cryptoV3.encrypt(v3Responses, publicKey)
+      const params = {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+        version: MRF_TEST_VERSION,
+      }
+
+      expect(crypto.decryptVersioned(secretKey, params)).toBeNull()
+      expect(crypto.decrypt(secretKey, params)).toBeNull()
+    })
+
+    it('returns null for non-JSON plaintext', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const params = encryptRawInEnvelope('this is not json {', publicKey)
+
+      expect(crypto.decryptVersioned(secretKey, params)).toBeNull()
+      expect(crypto.decrypt(secretKey, params)).toBeNull()
+    })
+
+    it.each([
+      ['string literal', '"just a string"'],
+      ['number literal', '42'],
+      ['boolean literal', 'true'],
+      ['null literal', 'null'],
+    ])('returns null for JSON that is a %s', (_label, raw) => {
+      const { publicKey, secretKey } = crypto.generate()
+      const params = encryptRawInEnvelope(raw, publicKey)
+
+      expect(crypto.decryptVersioned(secretKey, params)).toBeNull()
+      expect(crypto.decrypt(secretKey, params)).toBeNull()
+    })
+
+    it('returns null for an array that fails the V1 field validator', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const invalidV1 = [{ notAFormField: true }]
+      const encryptedContent = crypto.encrypt(invalidV1, publicKey)
+      const params = { encryptedContent, version: 1 }
+
+      expect(crypto.decryptVersioned(secretKey, params)).toBeNull()
+      expect(crypto.decrypt(secretKey, params)).toBeNull()
+    })
+
+    it('decrypt returns null, not partial output, when a later V4 entry is malformed', () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const responses = {
+        ...v4Responses,
+        '650abc0000000000000000ac': {
+          fieldType: 'checkbox',
+          question: 'Broken checkbox',
+          // checkbox answers must carry an array value
+          answer: { value: 'not-an-array' },
+          provenance: { stepNumber: 1 },
+        },
+      }
+      const enc = cryptoV3.encrypt(responses, publicKey)
+
+      expect(
+        crypto.decrypt(secretKey, {
+          encryptedContent: enc.encryptedContent,
+          encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
           version: MRF_TEST_VERSION,
         })
       ).toBeNull()

--- a/packages/sdk/spec/crypto-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-versioned.spec.ts
@@ -89,4 +89,23 @@ describe('Crypto (versioned decryption)', () => {
     })
     expect(result).not.toHaveProperty('submissionSecretKey')
   })
+
+  it('treats an MRF payload with an empty record as a valid empty V4 submission', () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const enc = cryptoV3.encrypt({}, publicKey)
+    const params = {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      version: MRF_TEST_VERSION,
+    }
+
+    const versioned = crypto.decryptVersioned(secretKey, params)
+    expect(versioned).toEqual({
+      submissionSecretKey: enc.submissionSecretKey,
+      responses: {},
+    })
+
+    const adapted = crypto.decrypt(secretKey, params)
+    expect(adapted).toEqual({ responses: [] })
+  })
 })

--- a/packages/sdk/spec/crypto-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-versioned.spec.ts
@@ -60,4 +60,33 @@ describe('Crypto (versioned decryption)', () => {
     expect(result!.responses).toEqual(plaintext)
     expect(result).not.toHaveProperty('submissionSecretKey')
   })
+
+  it('decrypt adapts an MRF V4 payload to V1 DecryptedContent without key material', () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const enc = cryptoV3.encrypt(v4Responses, publicKey)
+
+    const result = crypto.decrypt(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      version: MRF_TEST_VERSION,
+    })
+
+    expect(result).toEqual({
+      responses: [
+        {
+          _id: '650abc0000000000000000aa',
+          question: 'What is your name?',
+          fieldType: 'textfield',
+          answer: 'TAN AH KOW',
+        },
+        {
+          _id: '650abc0000000000000000ab',
+          question: 'Favourite colour',
+          fieldType: 'radiobutton',
+          answer: 'Others: vermilion',
+        },
+      ],
+    })
+    expect(result).not.toHaveProperty('submissionSecretKey')
+  })
 })

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -15,6 +15,7 @@ import {
   verifySignedMessage,
 } from './util/crypto'
 import { determineIsFormFields } from './util/validate'
+import { adaptV4ToV1 } from './adapt-v4-to-v1'
 import CryptoBase from './crypto-base'
 import { isFieldResponsesV4 } from './crypto-v3'
 import { AttachmentDecryptionError, MissingPublicKeyError } from './errors'
@@ -73,59 +74,21 @@ export default class Crypto extends CryptoBase {
     formSecretKey: string,
     decryptParams: DecryptParams
   ): DecryptedContent | null => {
+    const decrypted = this.decryptVersioned(formSecretKey, decryptParams)
+    if (decrypted === null) return null
+    if (Array.isArray(decrypted.responses)) {
+      return decrypted as DecryptedContent
+    }
     try {
-      const { encryptedContent, verifiedContent } = decryptParams
-
-      // Do not return the transformed object in `_decrypt` function as a signed
-      // object is not encoded in UTF8 and is encoded in Base-64 instead.
-      const decryptedContent = decryptContent(formSecretKey, encryptedContent)
-      if (!decryptedContent) {
-        throw new Error('Failed to decrypt content')
+      return {
+        responses: adaptV4ToV1(decrypted.responses),
+        ...(decrypted.verified !== undefined && {
+          verified: decrypted.verified,
+        }),
       }
-      const decryptedObject: Record<string, unknown> = JSON.parse(
-        encodeUTF8(decryptedContent)
-      )
-      if (!determineIsFormFields(decryptedObject)) {
-        throw new Error('Decrypted object does not fit expected shape')
-      }
-
-      const returnedObject: DecryptedContent = {
-        responses: decryptedObject,
-      }
-
-      if (verifiedContent) {
-        if (!this.signingPublicKey) {
-          throw new MissingPublicKeyError(
-            'Public signing key must be provided when instantiating the Crypto class in order to verify verified content'
-          )
-        }
-        // Only care if it is the correct shape if verifiedContent exists, since
-        // we need to append it to the end.
-        // Decrypted message must be able to be authenticated by the public key.
-        const decryptedVerifiedContent = decryptContent(
-          formSecretKey,
-          verifiedContent
-        )
-        if (!decryptedVerifiedContent) {
-          // Returns null if decrypting verified content failed.
-          throw new Error('Failed to decrypt verified content')
-        }
-        const decryptedVerifiedObject = verifySignedMessage(
-          decryptedVerifiedContent,
-          this.signingPublicKey
-        )
-
-        returnedObject.verified = decryptedVerifiedObject
-      }
-
-      return returnedObject
-    } catch (err) {
-      // Should only throw if MissingPublicKeyError.
-      // This library should be able to be used to encrypt and decrypt content
-      // if the content does not contain verified fields.
-      if (err instanceof MissingPublicKeyError) {
-        throw err
-      }
+    } catch {
+      // Malformed V4 answer shapes abort the whole submission rather than
+      // produce partial output.
       return null
     }
   }
@@ -141,12 +104,39 @@ export default class Crypto extends CryptoBase {
    * @returns The decrypted content if successful. Else, null will be returned.
    * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
    */
+  /**
+   * Decrypts and verifies signed verified content with the same key that
+   * encrypted the submission content.
+   * @throws {MissingPublicKeyError} if no signing public key was provided at instantiation.
+   * @throws {Error} if decryption or signature verification fails.
+   */
+  private decryptVerifiedContent = (
+    contentSecretKey: string,
+    verifiedContent: EncryptedContent
+  ): Record<string, any> => {
+    if (!this.signingPublicKey) {
+      throw new MissingPublicKeyError(
+        'Public signing key must be provided when instantiating the Crypto class in order to verify verified content'
+      )
+    }
+    // Decrypted message must be able to be authenticated by the public key.
+    const decryptedVerifiedContent = decryptContent(
+      contentSecretKey,
+      verifiedContent
+    )
+    if (!decryptedVerifiedContent) {
+      throw new Error('Failed to decrypt verified content')
+    }
+    return verifySignedMessage(decryptedVerifiedContent, this.signingPublicKey)
+  }
+
   decryptVersioned = (
     formSecretKey: string,
     decryptParams: DecryptParams
   ): DecryptedContent | DecryptedContentV4 | null => {
     try {
-      const { encryptedContent, encryptedSubmissionSecretKey } = decryptParams
+      const { encryptedContent, verifiedContent, encryptedSubmissionSecretKey } =
+        decryptParams
 
       let contentSecretKey = formSecretKey
       let submissionSecretKey: string | null = null
@@ -167,9 +157,16 @@ export default class Crypto extends CryptoBase {
       if (!decryptedContent) return null
       const decryptedObject: unknown = JSON.parse(encodeUTF8(decryptedContent))
 
+      const verified = verifiedContent
+        ? this.decryptVerifiedContent(contentSecretKey, verifiedContent)
+        : undefined
+
       if (Array.isArray(decryptedObject)) {
         if (!determineIsFormFields(decryptedObject)) return null
-        return { responses: decryptedObject }
+        return {
+          responses: decryptedObject,
+          ...(verified !== undefined && { verified }),
+        }
       }
 
       if (
@@ -184,6 +181,7 @@ export default class Crypto extends CryptoBase {
       return {
         submissionSecretKey,
         responses: decryptedObject as FieldResponsesV4,
+        ...(verified !== undefined && { verified }),
       }
     } catch (err) {
       if (err instanceof MissingPublicKeyError) {

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -169,12 +169,17 @@ export default class Crypto extends CryptoBase {
         }
       }
 
-      if (
-        typeof decryptedObject !== 'object' ||
-        decryptedObject === null ||
-        !isFieldResponsesV4(decryptedObject as Record<string, unknown>) ||
-        submissionSecretKey === null
-      ) {
+      if (typeof decryptedObject !== 'object' || decryptedObject === null) {
+        return null
+      }
+      // An empty record is a valid V4 submission with no answered fields;
+      // `isFieldResponsesV4` alone cannot claim it since it checks the first entry.
+      const isV4Record =
+        Object.keys(decryptedObject).length === 0 ||
+        isFieldResponsesV4(decryptedObject as Record<string, unknown>)
+      // V4 content only arrives inside an MRF envelope; without one there is
+      // no per-submission secret key to honestly return.
+      if (!isV4Record || submissionSecretKey === null) {
         return null
       }
 

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -167,10 +167,14 @@ export default class Crypto extends CryptoBase {
       if (!decryptedContent) return null
       const decryptedObject: unknown = JSON.parse(encodeUTF8(decryptedContent))
 
+      if (Array.isArray(decryptedObject)) {
+        if (!determineIsFormFields(decryptedObject)) return null
+        return { responses: decryptedObject }
+      }
+
       if (
         typeof decryptedObject !== 'object' ||
         decryptedObject === null ||
-        Array.isArray(decryptedObject) ||
         !isFieldResponsesV4(decryptedObject as Record<string, unknown>) ||
         submissionSecretKey === null
       ) {

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -94,17 +94,6 @@ export default class Crypto extends CryptoBase {
   }
 
   /**
-   * Decrypts an encrypted submission and returns its content in the version it
-   * was submitted in: V1 content (storage-mode envelope) as `DecryptedContent`,
-   * V4 content (MRF envelope) as `DecryptedContentV4` including the decrypted
-   * per-submission secret key. Consumers discriminate the union with
-   * `Array.isArray(result.responses)`.
-   * @param formSecretKey The base-64 secret key of the form to decrypt with.
-   * @param decryptParams The params containing encrypted content and information.
-   * @returns The decrypted content if successful. Else, null will be returned.
-   * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
-   */
-  /**
    * Decrypts and verifies signed verified content with the same key that
    * encrypted the submission content.
    * @throws {MissingPublicKeyError} if no signing public key was provided at instantiation.
@@ -130,6 +119,17 @@ export default class Crypto extends CryptoBase {
     return verifySignedMessage(decryptedVerifiedContent, this.signingPublicKey)
   }
 
+  /**
+   * Decrypts an encrypted submission and returns its content in the version it
+   * was submitted in: V1 content (storage-mode envelope) as `DecryptedContent`,
+   * V4 content (MRF envelope) as `DecryptedContentV4` including the decrypted
+   * per-submission secret key. Consumers discriminate the union with
+   * `Array.isArray(result.responses)`.
+   * @param formSecretKey The base-64 secret key of the form to decrypt with.
+   * @param decryptParams The params containing encrypted content and information.
+   * @returns The decrypted content if successful. Else, null will be returned.
+   * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
+   */
   decryptVersioned = (
     formSecretKey: string,
     decryptParams: DecryptParams
@@ -157,12 +157,11 @@ export default class Crypto extends CryptoBase {
       if (!decryptedContent) return null
       const decryptedObject: unknown = JSON.parse(encodeUTF8(decryptedContent))
 
-      const verified = verifiedContent
-        ? this.decryptVerifiedContent(contentSecretKey, verifiedContent)
-        : undefined
-
       if (Array.isArray(decryptedObject)) {
         if (!determineIsFormFields(decryptedObject)) return null
+        const verified = verifiedContent
+          ? this.decryptVerifiedContent(contentSecretKey, verifiedContent)
+          : undefined
         return {
           responses: decryptedObject,
           ...(verified !== undefined && { verified }),
@@ -183,6 +182,9 @@ export default class Crypto extends CryptoBase {
         return null
       }
 
+      const verified = verifiedContent
+        ? this.decryptVerifiedContent(contentSecretKey, verifiedContent)
+        : undefined
       return {
         submissionSecretKey,
         responses: decryptedObject as FieldResponsesV4,

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -1,6 +1,11 @@
 import axios from 'axios'
 import nacl from 'tweetnacl'
-import { decodeBase64, decodeUTF8, encodeUTF8 } from 'tweetnacl-util'
+import {
+  decodeBase64,
+  decodeUTF8,
+  encodeBase64,
+  encodeUTF8,
+} from 'tweetnacl-util'
 
 import {
   areAttachmentFieldIdsValid,
@@ -11,6 +16,7 @@ import {
 } from './util/crypto'
 import { determineIsFormFields } from './util/validate'
 import CryptoBase from './crypto-base'
+import { isFieldResponsesV4 } from './crypto-v3'
 import { AttachmentDecryptionError, MissingPublicKeyError } from './errors'
 import {
   DecryptedAttachments,
@@ -22,6 +28,7 @@ import {
   EncryptedContent,
   FormField,
 } from './types'
+import { DecryptedContentV4, FieldResponsesV4 } from './types-v4'
 
 export default class Crypto extends CryptoBase {
   signingPublicKey?: string
@@ -116,6 +123,65 @@ export default class Crypto extends CryptoBase {
       // Should only throw if MissingPublicKeyError.
       // This library should be able to be used to encrypt and decrypt content
       // if the content does not contain verified fields.
+      if (err instanceof MissingPublicKeyError) {
+        throw err
+      }
+      return null
+    }
+  }
+
+  /**
+   * Decrypts an encrypted submission and returns its content in the version it
+   * was submitted in: V1 content (storage-mode envelope) as `DecryptedContent`,
+   * V4 content (MRF envelope) as `DecryptedContentV4` including the decrypted
+   * per-submission secret key. Consumers discriminate the union with
+   * `Array.isArray(result.responses)`.
+   * @param formSecretKey The base-64 secret key of the form to decrypt with.
+   * @param decryptParams The params containing encrypted content and information.
+   * @returns The decrypted content if successful. Else, null will be returned.
+   * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
+   */
+  decryptVersioned = (
+    formSecretKey: string,
+    decryptParams: DecryptParams
+  ): DecryptedContent | DecryptedContentV4 | null => {
+    try {
+      const { encryptedContent, encryptedSubmissionSecretKey } = decryptParams
+
+      let contentSecretKey = formSecretKey
+      let submissionSecretKey: string | null = null
+      if (encryptedSubmissionSecretKey) {
+        const decryptedSubmissionSecretKey = decryptContent(
+          formSecretKey,
+          encryptedSubmissionSecretKey
+        )
+        if (decryptedSubmissionSecretKey === null) return null
+        submissionSecretKey = encodeBase64(decryptedSubmissionSecretKey)
+        contentSecretKey = submissionSecretKey
+      }
+
+      const decryptedContent = decryptContent(
+        contentSecretKey,
+        encryptedContent
+      )
+      if (!decryptedContent) return null
+      const decryptedObject: unknown = JSON.parse(encodeUTF8(decryptedContent))
+
+      if (
+        typeof decryptedObject !== 'object' ||
+        decryptedObject === null ||
+        Array.isArray(decryptedObject) ||
+        !isFieldResponsesV4(decryptedObject as Record<string, unknown>) ||
+        submissionSecretKey === null
+      ) {
+        return null
+      }
+
+      return {
+        submissionSecretKey,
+        responses: decryptedObject as FieldResponsesV4,
+      }
+    } catch (err) {
       if (err instanceof MissingPublicKeyError) {
         throw err
       }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -77,6 +77,14 @@ export interface DecryptParams {
   version: number
   verifiedContent?: EncryptedContent
   attachmentDownloadUrls?: EncryptedAttachmentRecords
+  /**
+   * Present on multirespondent (MRF) webhook payloads. When given, decryption
+   * opens the MRF envelope: the submission secret key is decrypted with the
+   * form secret key, then the content with the submission secret key. When
+   * absent, content decrypts directly with the form secret key (storage-mode
+   * envelope).
+   */
+  encryptedSubmissionSecretKey?: EncryptedContent
 }
 
 export interface DecryptParamsV3 {


### PR DESCRIPTION
## Problem

Agencies consume FormSG webhooks through the SDK's `crypto.decrypt`, which only understands V1 content from storage-mode forms. Multirespondent (MRF) webhooks now deliver V4 content wrapped in the MRF envelope (`encryptedSubmissionSecretKey` on the payload), and the SDK returns `null` for them, leaving webhook integrators unable to decrypt MRF responses. Closes #9586.

## Solution

`DecryptParams` gains an optional `encryptedSubmissionSecretKey`. When present, decryption opens the MRF envelope (submission secret key decrypted with the form key, content with the submission key); when absent, content decrypts directly with the form key. The new `crypto.decryptVersioned` returns the content in its submitted version — `DecryptedContent | DecryptedContentV4 | null`, discriminated by `Array.isArray(result.responses)` — with the V4 arm carrying the honestly-populated per-submission secret key. `crypto.decrypt` keeps its exact signature: it now delegates to `decryptVersioned` and adapts the V4 arm through `adaptV4ToV1`, dropping the key. Content version is detected by plaintext shape (array → V1, provenance-carrying record → V4, empty record → empty V4, anything else → `null`); the `version` param stays ignored as it always has been. Design is per ADR 0001; the README gains the consumer-contract section "Decrypting Multirespondent (V4) Submissions".

**Alternatives considered**

- We considered letting V4-shaped content decrypted without an MRF envelope return a result with `submissionSecretKey` set to the form secret key, but that hands consumers a key with form-wide blast radius disguised as a per-submission key, so it returns `null` instead. Making `submissionSecretKey` optional on the V4 arm was also skipped — it would widen the published `DecryptedContentV4` type that `cryptoV3.decryptToV4` already returns with the key required.
- We considered honouring the `version` field instead of shape detection, but there is no submission-version constant for V4 content (MRF submissions are version 3 whether their plaintext is V3 or V4), and making a long-ignored parameter load-bearing would break integrators who pass junk versions today (per ADR 0001).
- Verified content is decrypted only after shape validation, matching the legacy `decrypt` ordering — otherwise a malformed payload with verified content and no signing key would start throwing `MissingPublicKeyError` where it previously returned `null`.

**Breaking Changes**

No - backwards compatible. `decrypt`'s signature and V1 behaviour are unchanged; the pre-existing crypto suite passes unmodified.

## Tests

**TC1: MRF webhook round-trip**

- [ ] Point an MRF form's webhook at a consumer using this SDK build
- [ ] Submit a multirespondent response and pass the payload (including `encryptedSubmissionSecretKey`) to `crypto.decrypt` — responses arrive as `FormField[]`
- [ ] Pass the same payload to `crypto.decryptVersioned` — V4 structure with `submissionSecretKey` matching the envelope

**TC2: storage-mode regression**

- [ ] Submit to a storage-mode form webhook and confirm `crypto.decrypt` output is unchanged from the previous SDK version
