### PR TITLE
feat(sdk): envelope-aware decryptWithAttachments and decryptWithAttachmentsVersioned (3/4) 

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -200,6 +200,8 @@ If you want the richer V4 structure (typed answers, question text, provenance), 
 > **Note:** <br>
 > MRF submissions made before the V4 switchover carry V3 content, which has no question text and cannot be converted to the `FormField[]` shape. `decrypt` returns `null` for these; decrypt them with `formsg.cryptoV3.decrypt` instead.
 
+`decryptWithAttachments` handles both envelopes transparently and returns the same adapted `FormField[]` content shape for V4 submissions; its sibling `formsg.crypto.decryptWithAttachmentsVersioned(formSecretKey, decryptParams)` returns the content in its submitted version (like `decryptVersioned`) alongside the decrypted attachments.
+
 _Warning:_ V4 attachments are encrypted with the per-submission keypair, not the form keypair. Manually decrypting downloaded files with your form secret key will not work for V4 submissions — use `decryptWithAttachments`, or `decryptVersioned` and decrypt the files with the returned `submissionSecretKey`.
 
 ### Processing Local address fields

--- a/packages/sdk/spec/crypto-attachments-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-attachments-versioned.spec.ts
@@ -105,4 +105,103 @@ describe('Crypto (envelope-aware attachment decryption)', () => {
       },
     })
   })
+
+  it('decryptWithAttachmentsVersioned returns native V4 content (not double-adapted) plus attachments', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const { enc, uploadedFile } = await encryptV4WithFile(
+      v4ResponsesWithAttachment,
+      publicKey,
+      testFileBuffer
+    )
+
+    const resultPromise = crypto.decryptWithAttachmentsVersioned(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+      version: MRF_TEST_VERSION,
+    })
+    mockAxios.mockResponse({ data: { encryptedFile: uploadedFile } })
+    const result = await resultPromise
+
+    expect(result).toEqual({
+      content: {
+        submissionSecretKey: enc.submissionSecretKey,
+        responses: v4ResponsesWithAttachment,
+      },
+      attachments: {
+        [ATTACHMENT_FIELD_ID]: {
+          filename: 'my-random-file.txt',
+          content: testFileBuffer,
+        },
+      },
+    })
+    // The attachment response keeps its structured V4 answer.
+    const responses = result!.content.responses as FieldResponsesV4
+    expect(responses[ATTACHMENT_FIELD_ID].answer).toEqual({
+      value: 'my-random-file.txt',
+      hasBeenScanned: false,
+    })
+  })
+
+  it('decryptWithAttachmentsVersioned returns the V1 arm plus attachments for a storage-mode payload', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const v1Plaintext = [
+      {
+        _id: ATTACHMENT_FIELD_ID,
+        question: 'Upload a file',
+        fieldType: 'attachment',
+        answer: 'my-random-file.txt',
+      },
+    ]
+    const encryptedContent = crypto.encrypt(v1Plaintext, publicKey)
+    // Storage-mode files are encrypted with the form keypair.
+    const encryptedFile = await crypto.encryptFile(testFileBuffer, publicKey)
+    const uploadedFile = {
+      submissionPublicKey: encryptedFile.submissionPublicKey,
+      nonce: encryptedFile.nonce,
+      binary: encodeBase64(encryptedFile.binary),
+    }
+
+    const resultPromise = crypto.decryptWithAttachmentsVersioned(secretKey, {
+      encryptedContent,
+      attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+      version: 1,
+    })
+    mockAxios.mockResponse({ data: { encryptedFile: uploadedFile } })
+    const result = await resultPromise
+
+    expect(result).toEqual({
+      content: { responses: v1Plaintext },
+      attachments: {
+        [ATTACHMENT_FIELD_ID]: {
+          filename: 'my-random-file.txt',
+          content: testFileBuffer,
+        },
+      },
+    })
+    expect(result!.content).not.toHaveProperty('submissionSecretKey')
+  })
+
+  it('returns null when a V4 attachment file was encrypted with the form key instead of the submission key', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const enc = cryptoV3.encrypt(v4ResponsesWithAttachment, publicKey)
+    // Wrongly encrypt the file to the form keypair; the submission secret key
+    // cannot open it.
+    const encryptedFile = await crypto.encryptFile(testFileBuffer, publicKey)
+    const uploadedFile = {
+      submissionPublicKey: encryptedFile.submissionPublicKey,
+      nonce: encryptedFile.nonce,
+      binary: encodeBase64(encryptedFile.binary),
+    }
+
+    const resultPromise = crypto.decryptWithAttachments(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+      version: MRF_TEST_VERSION,
+    })
+    mockAxios.mockResponse({ data: { encryptedFile: uploadedFile } })
+
+    expect(await resultPromise).toBeNull()
+  })
 })

--- a/packages/sdk/spec/crypto-attachments-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-attachments-versioned.spec.ts
@@ -1,0 +1,108 @@
+import mockAxios from 'jest-mock-axios'
+import { encodeBase64 } from 'tweetnacl-util'
+
+import Crypto from '../src/crypto'
+import CryptoV3 from '../src/crypto-v3'
+import { SIGNING_KEYS } from '../src/resource/signing-keys'
+import { FieldResponsesV4 } from '../src/types-v4'
+
+jest.mock('axios', () => mockAxios)
+
+const signingPublicKey = SIGNING_KEYS.test.publicKey
+
+const MRF_TEST_VERSION = 3
+const ATTACHMENT_FIELD_ID = '650abc0000000000000000fa'
+const TEXT_FIELD_ID = '650abc0000000000000000aa'
+const DOWNLOAD_URL = 'https://some.s3.url/some/encrypted/file'
+
+const testFileBuffer = new Uint8Array(Buffer.from('some file contents'))
+
+const v4ResponsesWithAttachment: FieldResponsesV4 = {
+  [TEXT_FIELD_ID]: {
+    fieldType: 'textfield',
+    question: 'What is your name?',
+    answer: { value: 'TAN AH KOW' },
+    provenance: { stepNumber: 1 },
+  },
+  [ATTACHMENT_FIELD_ID]: {
+    fieldType: 'attachment',
+    question: 'Upload a file',
+    answer: { value: 'my-random-file.txt', hasBeenScanned: false },
+    provenance: { stepNumber: 1 },
+  },
+}
+
+describe('Crypto (envelope-aware attachment decryption)', () => {
+  afterEach(() => mockAxios.reset())
+
+  const crypto = new Crypto({ signingPublicKey })
+  const cryptoV3 = new CryptoV3({ signingPublicKey })
+
+  // Encrypts a V4 submission and a file the way MRF does: both to the
+  // per-submission keypair.
+  const encryptV4WithFile = async (
+    responses: FieldResponsesV4,
+    formPublicKey: string,
+    fileBuffer: Uint8Array
+  ) => {
+    const enc = cryptoV3.encrypt(responses, formPublicKey)
+    const encryptedFile = await crypto.encryptFile(
+      fileBuffer,
+      enc.submissionPublicKey
+    )
+    return {
+      enc,
+      uploadedFile: {
+        submissionPublicKey: encryptedFile.submissionPublicKey,
+        nonce: encryptedFile.nonce,
+        binary: encodeBase64(encryptedFile.binary),
+      },
+    }
+  }
+
+  it('decryptWithAttachments returns decrypted files and adapted V1 content for an MRF V4 payload', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const { enc, uploadedFile } = await encryptV4WithFile(
+      v4ResponsesWithAttachment,
+      publicKey,
+      testFileBuffer
+    )
+
+    const resultPromise = crypto.decryptWithAttachments(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+      version: MRF_TEST_VERSION,
+    })
+    mockAxios.mockResponse({ data: { encryptedFile: uploadedFile } })
+    const result = await resultPromise
+
+    expect(mockAxios.get).toHaveBeenCalledWith(DOWNLOAD_URL, {
+      responseType: 'json',
+    })
+    expect(result).toEqual({
+      content: {
+        responses: [
+          {
+            _id: TEXT_FIELD_ID,
+            question: 'What is your name?',
+            fieldType: 'textfield',
+            answer: 'TAN AH KOW',
+          },
+          {
+            _id: ATTACHMENT_FIELD_ID,
+            question: 'Upload a file',
+            fieldType: 'attachment',
+            answer: 'my-random-file.txt',
+          },
+        ],
+      },
+      attachments: {
+        [ATTACHMENT_FIELD_ID]: {
+          filename: 'my-random-file.txt',
+          content: testFileBuffer,
+        },
+      },
+    })
+  })
+})

--- a/packages/sdk/spec/crypto-attachments-versioned.spec.ts
+++ b/packages/sdk/spec/crypto-attachments-versioned.spec.ts
@@ -204,4 +204,229 @@ describe('Crypto (envelope-aware attachment decryption)', () => {
 
     expect(await resultPromise).toBeNull()
   })
+
+  it('preserves binary integrity for non-UTF-8 file contents', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const binaryFixture = new Uint8Array([0, 255, 1, 254, 0x80, 0xc3, 0x28, 7])
+    const { enc, uploadedFile } = await encryptV4WithFile(
+      v4ResponsesWithAttachment,
+      publicKey,
+      binaryFixture
+    )
+
+    const resultPromise = crypto.decryptWithAttachments(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+      version: MRF_TEST_VERSION,
+    })
+    mockAxios.mockResponse({ data: { encryptedFile: uploadedFile } })
+    const result = await resultPromise
+
+    expect(result!.attachments[ATTACHMENT_FIELD_ID].content).toEqual(
+      binaryFixture
+    )
+  })
+
+  it('decrypts multiple attachments mixed with non-attachment fields, keyed by field _id', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const secondAttachmentId = '650abc0000000000000000fb'
+    const responses: FieldResponsesV4 = {
+      ...v4ResponsesWithAttachment,
+      [secondAttachmentId]: {
+        fieldType: 'attachment',
+        question: 'Upload another file',
+        answer: { value: 'second-file.bin', hasBeenScanned: true },
+        provenance: { stepNumber: 2 },
+      },
+    }
+    const firstBuffer = new Uint8Array(Buffer.from('first file'))
+    const secondBuffer = new Uint8Array(Buffer.from('second file'))
+    const enc = cryptoV3.encrypt(responses, publicKey)
+    const uploads = await Promise.all(
+      [firstBuffer, secondBuffer].map(async (buffer) => {
+        const encryptedFile = await crypto.encryptFile(
+          buffer,
+          enc.submissionPublicKey
+        )
+        return {
+          submissionPublicKey: encryptedFile.submissionPublicKey,
+          nonce: encryptedFile.nonce,
+          binary: encodeBase64(encryptedFile.binary),
+        }
+      })
+    )
+    const secondUrl = 'https://some.s3.url/another/encrypted/file'
+
+    const resultPromise = crypto.decryptWithAttachments(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      attachmentDownloadUrls: {
+        [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL,
+        [secondAttachmentId]: secondUrl,
+      },
+      version: MRF_TEST_VERSION,
+    })
+    // Respond per requested URL so files land on the right field ids.
+    const requested = mockAxios.queue().map((req: any) => req.url)
+    requested.forEach((url: string) => {
+      mockAxios.mockResponseFor(
+        { url },
+        { data: { encryptedFile: uploads[url === DOWNLOAD_URL ? 0 : 1] } }
+      )
+    })
+    const result = await resultPromise
+
+    expect(result!.attachments).toEqual({
+      [ATTACHMENT_FIELD_ID]: {
+        filename: 'my-random-file.txt',
+        content: firstBuffer,
+      },
+      [secondAttachmentId]: {
+        filename: 'second-file.bin',
+        content: secondBuffer,
+      },
+    })
+    expect(
+      result!.content.responses.map((r) => r._id).sort()
+    ).toEqual(
+      [TEXT_FIELD_ID, ATTACHMENT_FIELD_ID, secondAttachmentId].sort()
+    )
+  })
+
+  it('succeeds with empty attachments for a V4 payload with zero attachments', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const responses: FieldResponsesV4 = {
+      [TEXT_FIELD_ID]: v4ResponsesWithAttachment[TEXT_FIELD_ID],
+    }
+    const enc = cryptoV3.encrypt(responses, publicKey)
+
+    const result = await crypto.decryptWithAttachments(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      version: MRF_TEST_VERSION,
+    })
+
+    expect(result!.attachments).toEqual({})
+    expect(result!.content.responses).toHaveLength(1)
+  })
+
+  it('returns null when a download URL targets a field _id not present in the responses', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const enc = cryptoV3.encrypt(v4ResponsesWithAttachment, publicKey)
+
+    const result = await crypto.decryptWithAttachments(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      attachmentDownloadUrls: { '000000000000000000000000': DOWNLOAD_URL },
+      version: MRF_TEST_VERSION,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('skips downloading an attachment response that has no corresponding download URL', async () => {
+    const { publicKey, secretKey } = crypto.generate()
+    const enc = cryptoV3.encrypt(v4ResponsesWithAttachment, publicKey)
+
+    const result = await crypto.decryptWithAttachments(secretKey, {
+      encryptedContent: enc.encryptedContent,
+      encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+      version: MRF_TEST_VERSION,
+    })
+
+    expect(mockAxios.get).not.toHaveBeenCalled()
+    expect(result!.attachments).toEqual({})
+    // The attachment response itself still appears in the content.
+    expect(
+      result!.content.responses.find((r) => r._id === ATTACHMENT_FIELD_ID)
+    ).toMatchObject({ answer: 'my-random-file.txt' })
+  })
+
+  describe('failure semantics on the V4 path', () => {
+    it('returns null on HTTP download failure', async () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const { enc } = await encryptV4WithFile(
+        v4ResponsesWithAttachment,
+        publicKey,
+        testFileBuffer
+      )
+
+      const resultPromise = crypto.decryptWithAttachments(secretKey, {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+        attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+        version: MRF_TEST_VERSION,
+      })
+      mockAxios.mockError(new Error('Network Error'))
+
+      expect(await resultPromise).toBeNull()
+    })
+
+    it('returns null on a non-2xx download response', async () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const { enc } = await encryptV4WithFile(
+        v4ResponsesWithAttachment,
+        publicKey,
+        testFileBuffer
+      )
+
+      const resultPromise = crypto.decryptWithAttachments(secretKey, {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+        attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+        version: MRF_TEST_VERSION,
+      })
+      mockAxios.mockResponse({
+        data: {},
+        status: 404,
+        statusText: 'Not Found',
+      })
+
+      expect(await resultPromise).toBeNull()
+    })
+
+    it('returns null on corrupt attachment ciphertext', async () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const { enc, uploadedFile } = await encryptV4WithFile(
+        v4ResponsesWithAttachment,
+        publicKey,
+        testFileBuffer
+      )
+
+      const resultPromise = crypto.decryptWithAttachments(secretKey, {
+        encryptedContent: enc.encryptedContent,
+        encryptedSubmissionSecretKey: enc.encryptedSubmissionSecretKey,
+        attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+        version: MRF_TEST_VERSION,
+      })
+      mockAxios.mockResponse({
+        data: {
+          encryptedFile: {
+            ...uploadedFile,
+            binary: 'YmFkZW5jcnlwdGVkY29udGVudHM=',
+          },
+        },
+      })
+
+      expect(await resultPromise).toBeNull()
+    })
+
+    it('returns null for the V4 attachment path without encryptedSubmissionSecretKey', async () => {
+      const { publicKey, secretKey } = crypto.generate()
+      const { enc } = await encryptV4WithFile(
+        v4ResponsesWithAttachment,
+        publicKey,
+        testFileBuffer
+      )
+
+      const result = await crypto.decryptWithAttachments(secretKey, {
+        encryptedContent: enc.encryptedContent,
+        attachmentDownloadUrls: { [ATTACHMENT_FIELD_ID]: DOWNLOAD_URL },
+        version: MRF_TEST_VERSION,
+      })
+
+      expect(result).toBeNull()
+    })
+  })
 })

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -29,7 +29,12 @@ import {
   EncryptedContent,
   FormField,
 } from './types'
-import { DecryptedContentV4, FieldResponsesV4 } from './types-v4'
+import {
+  AttachmentAnswerV4,
+  DecryptedContentV4,
+  DecryptedVersionedContentAndAttachments,
+  FieldResponsesV4,
+} from './types-v4'
 
 export default class Crypto extends CryptoBase {
   signingPublicKey?: string
@@ -229,20 +234,75 @@ export default class Crypto extends CryptoBase {
     formSecretKey: string,
     decryptParams: DecryptParams
   ): Promise<DecryptedContentAndAttachments | null> => {
+    const decrypted = await this.decryptWithAttachmentsVersioned(
+      formSecretKey,
+      decryptParams
+    )
+    if (decrypted === null) return null
+    if (Array.isArray(decrypted.content.responses)) {
+      return decrypted as DecryptedContentAndAttachments
+    }
+    try {
+      return {
+        content: {
+          responses: adaptV4ToV1(decrypted.content.responses),
+          ...(decrypted.content.verified !== undefined && {
+            verified: decrypted.content.verified,
+          }),
+        },
+        attachments: decrypted.attachments,
+      }
+    } catch {
+      // Malformed V4 answer shapes abort the whole submission rather than
+      // produce partial output.
+      return null
+    }
+  }
+
+  /**
+   * Decrypts an encrypted submission in its submitted content version, and
+   * also downloads and decrypts any attachments alongside it. Attachment files
+   * are decrypted with the per-submission secret key for MRF (V4) submissions
+   * and the form secret key for storage-mode (V1) submissions.
+   * @param formSecretKey Secret key as a base-64 string
+   * @param decryptParams The params containing encrypted content and information.
+   * @returns A promise of the versioned decrypted content and attachments (if any). Or else returns null if a decryption error decrypting any part of the submission.
+   * @throws {MissingPublicKeyError} if a public key is not provided when instantiating this class and is needed for verifying signed content.
+   */
+  decryptWithAttachmentsVersioned = async (
+    formSecretKey: string,
+    decryptParams: DecryptParams
+  ): Promise<DecryptedVersionedContentAndAttachments | null> => {
     const decryptedRecords: DecryptedAttachments = {}
     const filenames: Record<string, string> = {}
 
     const attachmentRecords: EncryptedAttachmentRecords =
       decryptParams.attachmentDownloadUrls ?? {}
-    const decryptedContent = this.decrypt(formSecretKey, decryptParams)
+    const decryptedContent = this.decryptVersioned(formSecretKey, decryptParams)
     if (decryptedContent === null) return null
 
     // Retrieve all original filenames for attachments for easy lookup
-    decryptedContent.responses.forEach((response) => {
-      if (response.fieldType === 'attachment' && response.answer) {
-        filenames[response._id] = response.answer
-      }
-    })
+    let fileSecretKey = formSecretKey
+    if (Array.isArray(decryptedContent.responses)) {
+      decryptedContent.responses.forEach((response) => {
+        if (response.fieldType === 'attachment' && response.answer) {
+          filenames[response._id] = response.answer
+        }
+      })
+    } else {
+      // V4 attachment files are encrypted with the per-submission keypair.
+      const v4Content = decryptedContent as DecryptedContentV4
+      fileSecretKey = v4Content.submissionSecretKey
+      Object.entries(v4Content.responses).forEach(
+        ([fieldId, response]) => {
+          if (response.fieldType !== 'attachment') return
+          const { value } = response.answer as AttachmentAnswerV4
+          if (typeof value === 'string' && value) {
+            filenames[fieldId] = value
+          }
+        }
+      )
+    }
 
     const fieldIds = Object.keys(attachmentRecords)
     // Check if all fieldIds are within filenames
@@ -261,7 +321,7 @@ export default class Crypto extends CryptoBase {
           .then(({ data: downloadResponse }) => {
             const encryptedFile =
               convertEncryptedAttachmentToFileContent(downloadResponse)
-            return this.decryptFile(formSecretKey, encryptedFile)
+            return this.decryptFile(fileSecretKey, encryptedFile)
           })
           .then((decryptedFile) => {
             // Check if the file exists and set the filename accordingly; otherwise, throw an error

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -39,6 +39,7 @@ export type {
   CheckboxAnswerV4,
   ChildrenAnswerV4,
   DecryptedContentV4,
+  DecryptedVersionedContentAndAttachments,
   FieldResponsesV4,
   FieldResponseV4,
   FormFieldMeta,

--- a/packages/sdk/src/types-v4.ts
+++ b/packages/sdk/src/types-v4.ts
@@ -1,4 +1,8 @@
-import { FieldType } from './types'
+import {
+  DecryptedAttachments,
+  DecryptedContent,
+  FieldType,
+} from './types'
 
 // TODO: provenance shape may be updated when it is implemented
 export type ResponseProvenance = {
@@ -177,4 +181,9 @@ export type DecryptedContentV4 = {
   responses: FieldResponsesV4
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   verified?: Record<string, any>
+}
+
+export type DecryptedVersionedContentAndAttachments = {
+  content: DecryptedContent | DecryptedContentV4
+  attachments: DecryptedAttachments
 }


### PR DESCRIPTION
## Problem

`crypto.decryptWithAttachments` decrypts downloaded files with the form secret key, but V4 (multirespondent) attachments are encrypted with the per-submission keypair, so MRF submissions with attachments cannot be processed. Closes #9587.

## Solution

`decryptWithAttachments` is now envelope-aware: it decrypts content through `decryptVersioned`, selects the per-submission secret key (V4) or the form secret key (V1) for file decryption, and returns the same adapted V1 shape as before. Its new union-returning sibling `decryptWithAttachmentsVersioned` returns the content in its submitted version alongside the decrypted attachments; the V4 arm collects attachment filenames from the native structure (`answer.value`) without adapting twice. Existing failure semantics are preserved — filename mismatch, download failure, corrupt ciphertext, and wrong keys still return `null`. The README documents the sibling in the V4 section.

**Alternatives considered**

- We considered adapting V4 content to V1 internally and reusing the existing filename walk, but the adapter throws on malformed entries the versioned path is not supposed to care about, and the adapted array would be thrown away — so filenames are collected from whichever native shape was decrypted.
- An attachment response with no corresponding download URL is simply absent from `attachments` while staying in `content` — identical to the long-standing V1 behaviour (downloads are driven by `attachmentDownloadUrls` keys); we pinned this with a test rather than changing it.

**Breaking Changes**

No - backwards compatible. V1/storage-mode attachment behaviour is unchanged; all pre-existing attachment tests pass unmodified.

## Tests

**TC1: MRF attachment round-trip**

- [ ] Submit an MRF response with an attachment and pass the webhook payload to `decryptWithAttachments` — the file decrypts and bytes match the upload
- [ ] Pass the same payload to `decryptWithAttachmentsVersioned` — native V4 content plus the same decrypted file

**TC2: storage-mode attachment regression**

- [ ] Submit a storage-mode response with an attachment and confirm `decryptWithAttachments` output is unchanged from the previous SDK version
