### PR TITLE
fix(feedback results): UI flicker bug

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.test.ts
+++ b/apps/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFeedbackPageView } from './FeedbackPage'
+
+describe('getFeedbackPageView', () => {
+  it('stays in the loading view until both the reviews and issues queries resolve', () => {
+    // The flicker bug: reviews resolved with no feedback, but issues still loading.
+    // The empty/content decision depends on both counts, so we must keep showing
+    // the skeleton rather than briefly rendering content (or empty) too early.
+    const view = getFeedbackPageView(
+      { count: 0, isGetLoading: false },
+      { count: undefined, isGetLoading: true },
+    )
+
+    expect(view).toBe('loading')
+  })
+
+  it('stays in the loading view when issues resolve before reviews', () => {
+    const view = getFeedbackPageView(
+      { count: undefined, isGetLoading: true },
+      { count: 0, isGetLoading: false },
+    )
+
+    expect(view).toBe('loading')
+  })
+
+  it('shows the loading view while both queries are still loading', () => {
+    const view = getFeedbackPageView(
+      { count: undefined, isGetLoading: true },
+      { count: undefined, isGetLoading: true },
+    )
+
+    expect(view).toBe('loading')
+  })
+
+  it('shows the empty view once both queries resolve with no feedback', () => {
+    const view = getFeedbackPageView(
+      { count: 0, isGetLoading: false },
+      { count: 0, isGetLoading: false },
+    )
+
+    expect(view).toBe('empty')
+  })
+
+  it('shows content when either reviews or issues have entries', () => {
+    expect(
+      getFeedbackPageView(
+        { count: 3, isGetLoading: false },
+        { count: 0, isGetLoading: false },
+      ),
+    ).toBe('content')
+
+    expect(
+      getFeedbackPageView(
+        { count: 0, isGetLoading: false },
+        { count: 5, isGetLoading: false },
+      ),
+    ).toBe('content')
+  })
+})

--- a/apps/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
+++ b/apps/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
@@ -17,6 +17,7 @@ import { ProcessedFeedbackMeta, ProcessedIssueMeta } from 'formsg-shared/types'
 import Pagination from '~/components/Pagination'
 
 import { BxsInfoCircle } from '~assets/icons'
+import { useDelayedFlag } from '~hooks/useDelayedFlag'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button, { ButtonProps } from '~components/Button'
 import Tooltip from '~components/Tooltip'
@@ -45,6 +46,10 @@ enum FeedbackType {
   Issues = 'issues',
   Reviews = 'reviews',
 }
+
+// Hold off rendering the skeleton until loading outlasts this threshold, so
+// fast loads don't flash it. ~300ms is below the point a blank gap is noticed.
+const SKELETON_DELAY_MS = 300
 
 interface Feedback {
   count: number | undefined
@@ -182,7 +187,15 @@ export const FeedbackPage = (): JSX.Element => {
   // Empty vs content depends on both queries' counts, so wait for both to
   // resolve — otherwise the faster query resolving empty flickers the wrong view.
   const pageView = getFeedbackPageView(reviewProps, issueProps)
+
+  // Only show the skeleton once loading outlasts the threshold. Fast loads
+  // resolve before then and render nothing instead, avoiding a skeleton flash.
+  const showSkeleton = useDelayedFlag(pageView === 'loading', SKELETON_DELAY_MS)
+
   if (pageView === 'loading') {
+    if (!showSkeleton) {
+      return <></>
+    }
     return isMobile ? <FeedbackPageSkeletonMobile /> : <FeedbackPageSkeleton />
   }
   if (pageView === 'empty') {

--- a/apps/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
+++ b/apps/frontend/src/features/admin-form/responses/FeedbackPage/FeedbackPage.tsx
@@ -179,13 +179,13 @@ export const FeedbackPage = (): JSX.Element => {
     form?.title,
   ])
 
-  // Handle page loading state
-  if (isPageLoading(currentFeedbackType, issueProps, reviewProps)) {
+  // Empty vs content depends on both queries' counts, so wait for both to
+  // resolve — otherwise the faster query resolving empty flickers the wrong view.
+  const pageView = getFeedbackPageView(reviewProps, issueProps)
+  if (pageView === 'loading') {
     return isMobile ? <FeedbackPageSkeletonMobile /> : <FeedbackPageSkeleton />
   }
-
-  // Handle page empty state
-  if (issueProps.count === 0 && reviewProps.count === 0) {
+  if (pageView === 'empty') {
     return <EmptyFeedback />
   }
 
@@ -377,7 +377,11 @@ const getFeedBackDownloadButtonProps = (
   isDisabled: boolean
   isLoading: boolean
 } => {
-  const isLoading = isPageLoading(currentFeedbackType, issueProps, reviewProps)
+  const isLoading = isCurrentTabLoading(
+    currentFeedbackType,
+    issueProps,
+    reviewProps,
+  )
   if (currentFeedbackType === FeedbackType.Issues) {
     return {
       isDisabled:
@@ -392,7 +396,7 @@ const getFeedBackDownloadButtonProps = (
   }
 }
 
-const isPageLoading = (
+const isCurrentTabLoading = (
   currentFeedbackType: FeedbackType,
   issueProps: Issue,
   reviewProps: Review,
@@ -402,12 +406,27 @@ const isPageLoading = (
     : reviewProps.isGetLoading
 }
 
+type FeedbackPageView = 'loading' | 'empty' | 'content'
+
+export const getFeedbackPageView = (
+  review: Feedback,
+  issue: Feedback,
+): FeedbackPageView => {
+  if (review.isGetLoading || issue.isGetLoading) {
+    return 'loading'
+  }
+  if (review.count === 0 && issue.count === 0) {
+    return 'empty'
+  }
+  return 'content'
+}
+
 const getDisplayTableProp = (
   currentFeedbackType: FeedbackType,
   issueProps: Issue,
   reviewProps: Review,
 ): string => {
-  return isPageLoading(currentFeedbackType, issueProps, reviewProps) ||
+  return isCurrentTabLoading(currentFeedbackType, issueProps, reviewProps) ||
     currentFeedbackType === FeedbackType.Issues
     ? issueProps.count === 0
       ? 'none'

--- a/apps/frontend/src/hooks/useDelayedFlag.test.ts
+++ b/apps/frontend/src/hooks/useDelayedFlag.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useDelayedFlag } from './useDelayedFlag'
+
+describe('useDelayedFlag', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('stays false while active, until the delay elapses', () => {
+    const { result } = renderHook(() => useDelayedFlag(true, 300))
+
+    expect(result.current).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(299)
+    })
+    expect(result.current).toBe(false)
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(result.current).toBe(true)
+  })
+
+  it('never flips to true if active clears before the delay (the flicker case)', () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useDelayedFlag(active, 300),
+      { initialProps: { active: true } },
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    expect(result.current).toBe(false)
+
+    // Loading finished before the threshold — the skeleton must never show.
+    rerender({ active: false })
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(result.current).toBe(false)
+  })
+
+  it('resets to false when active clears after having elapsed', () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useDelayedFlag(active, 300),
+      { initialProps: { active: true } },
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current).toBe(true)
+
+    rerender({ active: false })
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/frontend/src/hooks/useDelayedFlag.ts
+++ b/apps/frontend/src/hooks/useDelayedFlag.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns `true` only once `active` has stayed `true` continuously for at least
+ * `delayMs`. Resets to `false` the moment `active` becomes `false`.
+ *
+ * Useful for avoiding a flash-of-loading-state: gate a skeleton/spinner behind
+ * this so fast operations (that finish before `delayMs`) never render it, while
+ * genuinely slow ones still do.
+ */
+export const useDelayedFlag = (active: boolean, delayMs: number): boolean => {
+  const [isElapsed, setIsElapsed] = useState(false)
+
+  useEffect(() => {
+    if (!active) {
+      setIsElapsed(false)
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => setIsElapsed(true), delayMs)
+    return () => window.clearTimeout(timeoutId)
+  }, [active, delayMs])
+
+  return active && isElapsed
+}


### PR DESCRIPTION
## Problem

Navigating to a form's Results → Feedback briefly flashes the full feedback
view (empty table) before settling on the "You don't have any feedback yet"
empty state.

https://github.com/user-attachments/assets/8cafdc1a-8cb8-4c1b-b3c0-ac04a30fd8a6


Closes #9594

## Solution

The page defaults to the Reviews tab and gated its loading skeleton on only the
*current* tab's query. When the reviews query resolved empty while the issues
query was still in flight, the empty-state check — which needs *both* counts —
failed, so the full view rendered for a moment. Extracted a pure
`getFeedbackPageView(review, issue)` that stays in the loading state until both
queries resolve, so the empty-vs-content decision is only made once both counts
are known. Renamed the old per-tab predicate to `isCurrentTabLoading` (still
used by the download button and table display) so the two loading concepts read
distinctly.

**Alternatives considered**

We considered just changing the gate to an inline `reviewLoading ||
issueLoading` one-liner, but pulling the three-way decision into a named,
testable function matches this directory's pattern of unit-testing pure helpers
and let us lock the exact ordering regression with tests.

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: Feedback page with no feedback**

- [ ] Open a form with zero reviews and zero issues → Results → Feedback
- [ ] Confirm the skeleton shows, then "You don't have any feedback yet", with no flash of the empty table/headers in between

**TC2: Feedback page with data**

- [ ] Open a form that has reviews and/or issues → Results → Feedback
- [ ] Confirm the table and counts render once, with no flicker
