### PR TITLE
chore: remove deprecated auth types from form settings UI

### DIFF
--- a/apps/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/AdminFormSettingsPage.stories.tsx
@@ -82,7 +82,7 @@ PreventActivation.parameters = {
         getAdminFormSettings({
           overrides: {
             status: FormStatus.Private,
-            authType: FormAuthType.SP,
+            authType: FormAuthType.MyInfo,
             esrvcId: '',
           },
         }),

--- a/apps/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsAuthPage.stories.tsx
@@ -128,7 +128,7 @@ PublicEmailSingpassForm.parameters = {
     handlers: {
       default: buildEmailModeMswRoutes({
         status: FormStatus.Public,
-        authType: FormAuthType.SP,
+        authType: FormAuthType.MyInfo,
         esrvcId: 'STORYBOOK-TEST',
         responseMode: FormResponseMode.Email,
       }),
@@ -188,19 +188,6 @@ PublicEmailMyInfoForm.parameters = {
   },
 }
 
-export const PrivateEmailSingpassFormSubmitterIdCollectionEnabled =
-  Template.bind({})
-PrivateEmailSingpassFormSubmitterIdCollectionEnabled.parameters = {
-  msw: {
-    handlers: {
-      default: buildEmailModeMswRoutes({
-        status: FormStatus.Private,
-        authType: FormAuthType.SGID,
-        isSubmitterIdCollectionEnabled: true,
-      }),
-    },
-  },
-}
 export const PrivateEmailMyInfoFormSubmitterIdCollectionEnabled = Template.bind(
   {},
 )
@@ -228,7 +215,7 @@ PrivateEmailSingpassFormSingleSubmissionEnabled.parameters = {
     handlers: {
       default: buildEmailModeMswRoutes({
         status: FormStatus.Private,
-        authType: FormAuthType.SGID,
+        authType: FormAuthType.MyInfo,
         isSingleSubmission: true,
       }),
     },
@@ -242,7 +229,7 @@ PrivateStorageSingpassFormAllTogglesEnabled.parameters = {
     handlers: {
       default: buildEncryptModeMswRoutes({
         status: FormStatus.Private,
-        authType: FormAuthType.SGID,
+        authType: FormAuthType.MyInfo,
         isSingleSubmission: true,
         isSubmitterIdCollectionEnabled: true,
       }),
@@ -304,31 +291,15 @@ PublicStorageMyInfoPaymentEnabledForm.parameters = {
   },
 }
 
-export const PrivateStorageSgidPaymentEnabledForm = Template.bind({})
-PrivateStorageSgidPaymentEnabledForm.parameters = {
-  msw: {
-    handlers: {
-      default: [
-        ...buildEncryptModeMswRoutes({
-          status: FormStatus.Private,
-          authType: FormAuthType.SGID,
-          responseMode: FormResponseMode.Encrypt,
-          payments_channel: DUMMY_STRIPE_PAYMENT_CHANNEL_VALUE,
-        }),
-      ],
-    },
-  },
-}
-
 // stories for whitelist setting
-export const PrivateStorageSgidWhitelistEnabledForm = Template.bind({})
-PrivateStorageSgidWhitelistEnabledForm.parameters = {
+export const PrivateStorageMyInfoWhitelistEnabledForm = Template.bind({})
+PrivateStorageMyInfoWhitelistEnabledForm.parameters = {
   msw: {
     handlers: {
       default: [
         ...buildEncryptModeMswRoutes({
           status: FormStatus.Private,
-          authType: FormAuthType.SGID,
+          authType: FormAuthType.MyInfo,
           responseMode: FormResponseMode.Encrypt,
           whitelistedSubmitterIds: {
             isWhitelistEnabled: true,

--- a/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcHelperText.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/EsrvcHelperText.tsx
@@ -13,7 +13,6 @@ export const EsrvcHelperText = ({
   authType,
 }: EsrvcHelperTextProps): JSX.Element => {
   switch (authType) {
-    case FormAuthType.SP:
     case FormAuthType.CP:
     case FormAuthType.MyInfo:
       return (

--- a/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/SingpassAuthOptionsRadio.tsx
@@ -3,11 +3,9 @@ import {
   KeyboardEventHandler,
   MouseEventHandler,
   useCallback,
-  useMemo,
   useState,
 } from 'react'
 import { Box, Flex, Spacer } from '@chakra-ui/react'
-import { pickBy } from 'lodash'
 
 import { FormAuthType, FormSettings, FormStatus } from 'formsg-shared/types'
 
@@ -27,14 +25,8 @@ export interface SingpassAuthOptionsRadioProps {
 
 type RadioOptionsType = [FormAuthType, string][]
 
-const COLLAPSED_FORM_SINGPASS_AUTHTYPES = pickBy(
-  FORM_SINGPASS_AUTHTYPES,
-  (_, key) =>
-    [FormAuthType.MyInfo, FormAuthType.CP].includes(key as FormAuthType),
-)
-
 const baseRadioOptions: RadioOptionsType = Object.entries(
-  COLLAPSED_FORM_SINGPASS_AUTHTYPES,
+  FORM_SINGPASS_AUTHTYPES,
 ) as [FormAuthType, string][]
 
 export const SingpassAuthOptionsRadio = ({
@@ -51,21 +43,6 @@ export const SingpassAuthOptionsRadio = ({
   const checkIsDisabled = useCallback(() => {
     return isDisabled || mutateFormAuthType.isLoading
   }, [isDisabled, mutateFormAuthType.isLoading])
-
-  const radioOptionsWithInitialChoice: RadioOptionsType = useMemo(() => {
-    if (baseRadioOptions.some(([key, _]) => key === settings.authType)) {
-      return baseRadioOptions
-    }
-    if (settings.authType === FormAuthType.NIL) {
-      return baseRadioOptions
-    }
-
-    // reinsert the initial choice so that admins can see it in the list
-    return [
-      [settings.authType, FORM_SINGPASS_AUTHTYPES[settings.authType]],
-      ...baseRadioOptions,
-    ]
-  }, [settings.authType])
 
   const handleEnterKeyDown: KeyboardEventHandler = useCallback(
     (e) => {
@@ -108,17 +85,13 @@ export const SingpassAuthOptionsRadio = ({
       onKeyDown={handleEnterKeyDown}
       onChange={(e: FormAuthType) => setFocusedValue(e)}
     >
-      {radioOptionsWithInitialChoice.map(([authType, text]) => (
+      {baseRadioOptions.map(([authType, text]) => (
         <Fragment key={authType}>
           <Box onClick={handleOptionClick(authType)}>
             <Radio value={authType} isDisabled={checkIsDisabled()}>
               <Flex>
                 {text}
-                {[
-                  FormAuthType.SGID,
-                  FormAuthType.SGID_MyInfo,
-                  FormAuthType.MyInfo,
-                ].includes(authType) ? (
+                {authType === FormAuthType.MyInfo ? (
                   <>
                     <Spacer w="16px" />
                     <Tag size="sm" variant="subtle">

--- a/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
+++ b/apps/frontend/src/features/admin-form/settings/components/AuthSettingsSection/constants.ts
@@ -2,10 +2,9 @@ import { FormAuthType } from 'formsg-shared/types/form'
 
 type FormSingpassAuthType = Exclude<FormAuthType, FormAuthType.NIL>
 
-export const FORM_SINGPASS_AUTHTYPES: Record<FormSingpassAuthType, string> = {
-  [FormAuthType.SGID]: 'Singpass App-only Login',
-  [FormAuthType.SGID_MyInfo]: 'Singpass App-only with Myinfo',
-  [FormAuthType.SP]: 'Singpass',
+export const FORM_SINGPASS_AUTHTYPES: Partial<
+  Record<FormSingpassAuthType, string>
+> = {
   [FormAuthType.MyInfo]: 'Singpass',
   [FormAuthType.CP]: 'Corppass',
 }

--- a/apps/frontend/src/features/admin-form/settings/components/utils.ts
+++ b/apps/frontend/src/features/admin-form/settings/components/utils.ts
@@ -9,7 +9,6 @@ import { FormAuthType } from 'formsg-shared/types'
 
 export const isEsrvcidRequired = (authType: FormAuthType) => {
   switch (authType) {
-    case FormAuthType.SP:
     case FormAuthType.CP:
       return true
     default:


### PR DESCRIPTION
## Problem

`FormAuthType.SP`, `FormAuthType.SGID`, and `FormAuthType.SGID_MyInfo` are deprecated. After MyInfo became free of charge, every production form previously using these auth types was manually migrated to `MyInfo`, but the codebase still references the deprecated values across admin UI, public-form rendering, backend modules (`sgid`, `spcp`), and the shared `FormAuthType` enum.

This is **PR 1 of 3** in a layered cleanup:

1. **This PR — Frontend form-settings strip.** Remove the deprecated values from the admin auth-settings surface (radio, dropdown labels, helper text, related Storybook fixtures).
2. **PR 2 — Backend strip.** Wholesale-delete the `sgid` module, surgically strip `SP` paths from the joint `spcp` module (CP preserved), and clean up remaining frontend rendering references (`FormAuth.tsx`, `FormAuthMessage.tsx`, `FormBanner`, billing labels, MSW handlers).
3. **PR 3 — Type & schema lock-in.** Shrink the `FormAuthType` enum in `packages/shared`; tighten the Mongoose `enum` validators on `Form` and `Submission` schemas; update the Zod `nativeEnum`.

Closes [insert issue #]

## Solution

The actual selection of these auth types in the admin form-settings UI was already filtered to `MyInfo` and `CP` only (`SingpassAuthOptionsRadio.tsx` used `pickBy` to collapse the option set). The deprecated values only surfaced through a "reinsert the initial choice" fallback (for forms whose `authType` was already `SP`/`SGID`/`SGID_MyInfo` — none exist anymore) and a few static label/helper-text references. This PR strips that residue:

- `constants.ts` — drop the `SP`, `SGID`, `SGID_MyInfo` entries from `FORM_SINGPASS_AUTHTYPES`. The map type changes to `Partial<Record<…>>` because the surviving entries (`MyInfo`, `CP`) no longer cover the full domain.
- `SingpassAuthOptionsRadio.tsx` — remove the `pickBy` collapse (no longer needed once the source map is already trimmed), the `radioOptionsWithInitialChoice` useMemo (the only branch that used it was the now-dead "reinsert" path), and reduce the "Free" tag check to `MyInfo` only.
- `EsrvcHelperText.tsx` — drop the `SP` case from the e-Service ID helper switch (safe — has a `default` fallback).
- `utils.ts` — drop `SP` from `isEsrvcidRequired` (safe — has a `default`).
- Storybook fixtures (`SettingsAuthPage.stories.tsx`, `AdminFormSettingsPage.stories.tsx`) — stories that named `SGID` specifically as the test fixture are converted to `MyInfo` (preserving each story's underlying scenario: single submission, whitelist, payment-enabled, all-toggles); two duplicates of existing `MyInfo` stories are removed.

**Breaking Changes**
- [x] No - this PR is backwards compatible

The `FormAuthType` enum is unchanged. Mongoose and Zod validators still accept all six values, so historical submission documents with `authType: 'SP' | 'SGID' | 'SGID_MyInfo'` continue to read normally. The only user-visible effect is in the admin form-settings page, which no longer surfaces the deprecated options (already filtered before this PR — this just removes the residual references).

## Before & After Screenshots

## Tests

TC1: Admin auth-settings UI still works for surviving auth types
- [ ] Open an existing form in the admin panel → Settings → Singpass authentication
- [ ] Toggle Singpass auth on; verify the radio offers exactly two options: **Singpass** (MyInfo) and **Corppass** (CP), each with the **Free** tag where appropriate
- [ ] Select `Singpass` (MyInfo); verify the e-Service ID input box appears
- [ ] Select `Corppass` (CP); verify the e-Service ID input box appears and the e-Service ID helper text still renders
- [ ] Save and reload; verify the chosen `authType` persists