### PR TITLE
feat(backend): wildcard email domains

### DIFF
--- a/apps/backend/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
+++ b/apps/backend/src/app/utils/field-validation/validators/__tests__/email-validation.spec.ts
@@ -209,6 +209,64 @@ describe('Email field validation', () => {
     expect(validateResult._unsafeUnwrap()).toEqual(true)
   })
 
+  it('should allow email addresses matching a wildcard domain pattern', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: true,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: ['@*.moe.gov.sg'],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'user@mail.moe.gov.sg',
+      signature: 'some signature',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should not allow the base domain itself against a wildcard pattern', () => {
+    const formField = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      globalId: 'random',
+      title: 'random',
+      required: true,
+      isVerifiable: true,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: ['@*.moe.gov.sg'],
+    } as OmitUnusedValidatorProps<IEmailFieldSchema>
+    const response = {
+      _id: 'abc123',
+      fieldType: BasicField.Email,
+      question: 'random',
+      isVisible: true,
+      answer: 'user@moe.gov.sg',
+      signature: 'some signature',
+    } as SingleAnswerFieldResponse
+    const validateResult = validateField(
+      'formId',
+      formField,
+      response as ProcessedFieldResponse,
+    )
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
+  })
+
   it('should not allow email addresses whose email domain does not belong to allowedEmailDomains when isVerifiable is true, hasAllowedEmailDomains is true and allowedEmailDomains is not empty', () => {
     const formField = {
       _id: 'abc123',
@@ -754,6 +812,54 @@ describe('Email field validation V3', () => {
     })
     expect(validateResult.isOk()).toBe(true)
     expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should allow email addresses matching a wildcard domain pattern (V3)', () => {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
+      isVerifiable: true,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: ['@*.moe.gov.sg'],
+    })
+    const response = generateVerifiableAnswerResponseV3({
+      fieldType: BasicField.Email,
+      answer: {
+        value: 'user@mail.moe.gov.sg',
+        signature: 'some signature',
+      },
+    })
+    const validateResult = validateFieldV3({
+      formId: 'formId',
+      formField,
+      response,
+      isVisible: true,
+    })
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should not allow the base domain itself against a wildcard pattern (V3)', () => {
+    const formField = generateDefaultFieldV3(BasicField.Email, {
+      isVerifiable: true,
+      hasAllowedEmailDomains: true,
+      allowedEmailDomains: ['@*.moe.gov.sg'],
+    })
+    const response = generateVerifiableAnswerResponseV3({
+      fieldType: BasicField.Email,
+      answer: {
+        value: 'user@moe.gov.sg',
+        signature: 'some signature',
+      },
+    })
+    const validateResult = validateFieldV3({
+      formId: 'formId',
+      formField,
+      response,
+      isVisible: true,
+    })
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldError('Invalid answer submitted'),
+    )
   })
 
   it('should not allow email addresses whose email domain does not belong to allowedEmailDomains when isVerifiable is true, hasAllowedEmailDomains is true and allowedEmailDomains is not empty', () => {

--- a/apps/backend/src/app/utils/field-validation/validators/emailValidator.ts
+++ b/apps/backend/src/app/utils/field-validation/validators/emailValidator.ts
@@ -1,4 +1,5 @@
 import { BasicField, EmailResponseV3 } from 'formsg-shared/types'
+import { emailDomainMatchesAllowed } from 'formsg-shared/utils/email-domain-validation'
 import { chain, left, right } from 'fp-ts/lib/Either'
 import { flow } from 'fp-ts/lib/function'
 import isEmail from 'validator/lib/isEmail'
@@ -47,10 +48,10 @@ const makeEmailDomainValidator: EmailValidatorConstructor =
     const emailAddress = String(answer).trim()
     if (!(hasAllowedEmailDomains && allowedEmailDomains.length))
       return right(response)
-    const emailDomain = ('@' + emailAddress.split('@').pop()).toLowerCase()
+    const emailDomain = '@' + emailAddress.split('@').pop()
 
-    return allowedEmailDomains.some(
-      (domain) => domain.toLowerCase() === emailDomain,
+    return allowedEmailDomains.some((domain) =>
+      emailDomainMatchesAllowed(emailDomain, domain),
     )
       ? right(response)
       : left(`EmailValidator:\t answer is not a valid email domain`)
@@ -104,10 +105,10 @@ const makeEmailDomainValidatorV3: ResponseValidatorConstructor<
   const emailAddress = String(value).trim()
   if (!(hasAllowedEmailDomains && allowedEmailDomains.length))
     return right(response)
-  const emailDomain = ('@' + emailAddress.split('@').pop()).toLowerCase()
+  const emailDomain = '@' + emailAddress.split('@').pop()
 
-  return allowedEmailDomains.some(
-    (domain) => domain.toLowerCase() === emailDomain,
+  return allowedEmailDomains.some((domain) =>
+    emailDomainMatchesAllowed(emailDomain, domain),
   )
     ? right(response)
     : left(`EmailValidatorV3:\t answer value is not a valid email domain`)

--- a/apps/frontend/src/utils/fieldValidation.ts
+++ b/apps/frontend/src/utils/fieldValidation.ts
@@ -49,6 +49,7 @@ import {
   validatePostalCode,
 } from 'formsg-shared/utils/address-validation'
 import { isDateAnInvalidDay } from 'formsg-shared/utils/date-validation'
+import { emailDomainMatchesAllowed } from 'formsg-shared/utils/email-domain-validation'
 import {
   isMFinSeriesValid,
   isNricValid,
@@ -910,11 +911,15 @@ export const baseEmailValidationFn =
     if (!validator.isEmail(trimmedInputValue))
       return t ? t('invalidEmail') : INVALID_EMAIL_ERROR
 
-    // Valid domain check
-    const allowedDomains = new Set(schema.allowedEmailDomains)
-    if (allowedDomains.size !== 0) {
-      const domainInValue = trimmedInputValue.split('@')[1].toLowerCase()
-      if (domainInValue && !allowedDomains.has(`@${domainInValue}`)) {
+    // Valid domain check (supports exact and wildcard patterns like @*.agency.gov.sg)
+    const { allowedEmailDomains } = schema
+    if (allowedEmailDomains.length !== 0) {
+      const domainInValue = '@' + trimmedInputValue.split('@')[1]
+      if (
+        !allowedEmailDomains.some((allowed) =>
+          emailDomainMatchesAllowed(domainInValue, allowed),
+        )
+      ) {
         return validationErrorMessages.domainDisallowed
       }
     }

--- a/packages/shared/utils/__tests__/email-domain-validation.spec.ts
+++ b/packages/shared/utils/__tests__/email-domain-validation.spec.ts
@@ -1,0 +1,102 @@
+import {
+  emailDomainMatchesAllowed,
+  validateEmailDomains,
+} from '../email-domain-validation'
+
+describe('validateEmailDomains', () => {
+  it('should return true for empty array', () => {
+    expect(validateEmailDomains([])).toBe(true)
+  })
+
+  it('should return true for valid exact domains', () => {
+    expect(validateEmailDomains(['@test.gov.sg'])).toBe(true)
+    expect(validateEmailDomains(['@example.com', '@test.gov.sg'])).toBe(true)
+  })
+
+  it('should return false for domains without @', () => {
+    expect(validateEmailDomains(['test.gov.sg'])).toBe(false)
+  })
+
+  it('should return false for duplicate domains', () => {
+    expect(validateEmailDomains(['@test.gov.sg', '@test.gov.sg'])).toBe(false)
+  })
+
+  it('should return true for valid wildcard domains', () => {
+    expect(validateEmailDomains(['@*.gov.sg'])).toBe(true)
+    expect(validateEmailDomains(['@*.moe.gov.sg'])).toBe(true)
+  })
+
+  it('should return false for invalid wildcard domains', () => {
+    expect(validateEmailDomains(['@*.'])).toBe(false)
+    expect(validateEmailDomains(['@*'])).toBe(false)
+  })
+
+  it('should accept a mix of exact and wildcard domains', () => {
+    expect(
+      validateEmailDomains(['@test.gov.sg', '@*.moe.gov.sg']),
+    ).toBe(true)
+  })
+})
+
+describe('emailDomainMatchesAllowed', () => {
+  describe('exact matching', () => {
+    it('should match identical domains', () => {
+      expect(emailDomainMatchesAllowed('@test.gov.sg', '@test.gov.sg')).toBe(
+        true,
+      )
+    })
+
+    it('should match case-insensitively', () => {
+      expect(emailDomainMatchesAllowed('@TeSt.GoV.Sg', '@test.gov.sg')).toBe(
+        true,
+      )
+    })
+
+    it('should not match different domains', () => {
+      expect(
+        emailDomainMatchesAllowed('@other.gov.sg', '@test.gov.sg'),
+      ).toBe(false)
+    })
+
+    it('should not match subdomains against an exact domain', () => {
+      expect(
+        emailDomainMatchesAllowed('@mail.test.gov.sg', '@test.gov.sg'),
+      ).toBe(false)
+    })
+  })
+
+  describe('wildcard matching', () => {
+    it('should match a single subdomain level', () => {
+      expect(
+        emailDomainMatchesAllowed('@mail.moe.gov.sg', '@*.moe.gov.sg'),
+      ).toBe(true)
+    })
+
+    it('should match multiple subdomain levels', () => {
+      expect(
+        emailDomainMatchesAllowed(
+          '@dept.mail.moe.gov.sg',
+          '@*.moe.gov.sg',
+        ),
+      ).toBe(true)
+    })
+
+    it('should not match the base domain itself', () => {
+      expect(
+        emailDomainMatchesAllowed('@moe.gov.sg', '@*.moe.gov.sg'),
+      ).toBe(false)
+    })
+
+    it('should match case-insensitively', () => {
+      expect(
+        emailDomainMatchesAllowed('@Mail.MOE.Gov.Sg', '@*.moe.gov.sg'),
+      ).toBe(true)
+    })
+
+    it('should not match unrelated domains with same suffix', () => {
+      expect(
+        emailDomainMatchesAllowed('@notmoe.gov.sg', '@*.moe.gov.sg'),
+      ).toBe(false)
+    })
+  })
+})

--- a/packages/shared/utils/__tests__/email-domain-validation.spec.ts
+++ b/packages/shared/utils/__tests__/email-domain-validation.spec.ts
@@ -32,9 +32,7 @@ describe('validateEmailDomains', () => {
   })
 
   it('should accept a mix of exact and wildcard domains', () => {
-    expect(
-      validateEmailDomains(['@test.gov.sg', '@*.moe.gov.sg']),
-    ).toBe(true)
+    expect(validateEmailDomains(['@test.gov.sg', '@*.moe.gov.sg'])).toBe(true)
   })
 })
 
@@ -53,9 +51,9 @@ describe('emailDomainMatchesAllowed', () => {
     })
 
     it('should not match different domains', () => {
-      expect(
-        emailDomainMatchesAllowed('@other.gov.sg', '@test.gov.sg'),
-      ).toBe(false)
+      expect(emailDomainMatchesAllowed('@other.gov.sg', '@test.gov.sg')).toBe(
+        false,
+      )
     })
 
     it('should not match subdomains against an exact domain', () => {
@@ -74,17 +72,14 @@ describe('emailDomainMatchesAllowed', () => {
 
     it('should match multiple subdomain levels', () => {
       expect(
-        emailDomainMatchesAllowed(
-          '@dept.mail.moe.gov.sg',
-          '@*.moe.gov.sg',
-        ),
+        emailDomainMatchesAllowed('@dept.mail.moe.gov.sg', '@*.moe.gov.sg'),
       ).toBe(true)
     })
 
     it('should not match the base domain itself', () => {
-      expect(
-        emailDomainMatchesAllowed('@moe.gov.sg', '@*.moe.gov.sg'),
-      ).toBe(false)
+      expect(emailDomainMatchesAllowed('@moe.gov.sg', '@*.moe.gov.sg')).toBe(
+        false,
+      )
     })
 
     it('should match case-insensitively', () => {
@@ -94,9 +89,9 @@ describe('emailDomainMatchesAllowed', () => {
     })
 
     it('should not match unrelated domains with same suffix', () => {
-      expect(
-        emailDomainMatchesAllowed('@notmoe.gov.sg', '@*.moe.gov.sg'),
-      ).toBe(false)
+      expect(emailDomainMatchesAllowed('@notmoe.gov.sg', '@*.moe.gov.sg')).toBe(
+        false,
+      )
     })
   })
 })

--- a/packages/shared/utils/email-domain-validation.ts
+++ b/packages/shared/utils/email-domain-validation.ts
@@ -1,15 +1,57 @@
 import isEmpty from 'lodash/isEmpty'
 import validator from 'validator'
 
+/**
+ * Checks whether a single allowed-domain entry is syntactically valid.
+ * Accepts exact domains (`@example.gov.sg`) and wildcard domains
+ * (`@*.example.gov.sg`).
+ */
+const isValidDomainEntry = (emailDomain: string): boolean => {
+  if (!emailDomain.startsWith('@')) return false
+
+  // Wildcard pattern: @*.something.tld
+  if (emailDomain.startsWith('@*.')) {
+    const baseDomain = emailDomain.slice(2) // ".something.tld"
+    // Validate by forming a synthetic email with the base domain.
+    return validator.isEmail('bob@sub' + baseDomain)
+  }
+
+  // Exact domain – existing behaviour.
+  return validator.isEmail('bob' + emailDomain)
+}
+
 export const validateEmailDomains = (emailDomains: string[]): boolean => {
   return (
     isEmpty(emailDomains) ||
     (new Set(emailDomains).size === emailDomains.length &&
-      emailDomains.every(
-        (emailDomain) =>
-          // We need to prepend "bob" to the email domain so that it can form an
-          // email address and can be validated by validator.isEmail.
-          emailDomain.startsWith('@') && validator.isEmail('bob' + emailDomain),
-      ))
+      emailDomains.every(isValidDomainEntry))
+  )
+}
+
+/**
+ * Returns true when `emailDomain` (e.g. `@mail.moe.gov.sg`) matches the
+ * given `allowedDomain` pattern.
+ *
+ * - Exact pattern  `@moe.gov.sg`      → matches only `@moe.gov.sg`.
+ * - Wildcard       `@*.moe.gov.sg`    → matches any `@<sub>.moe.gov.sg`
+ *   (one or more subdomain levels).
+ *
+ * Both sides are compared lower-cased.
+ */
+export const emailDomainMatchesAllowed = (
+  emailDomain: string,
+  allowedDomain: string,
+): boolean => {
+  const lowerEmail = emailDomain.toLowerCase()
+  const lowerAllowed = allowedDomain.toLowerCase()
+
+  if (!lowerAllowed.startsWith('@*.')) {
+    return lowerEmail === lowerAllowed
+  }
+
+  // +1 accounts for the leading '@' that is NOT part of baseSuffix.
+  const baseSuffix = lowerAllowed.slice(2) // ".base.tld"
+  return (
+    lowerEmail.endsWith(baseSuffix) && lowerEmail.length > baseSuffix.length + 1
   )
 }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

It's effortful and laborious to whitelist multiple agency subdomains in an email field.

Closes FRM-2370.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Features**:

- Support wildcard domains in email field allowlists

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

**AFTER**:
<!-- [insert screenshot here] -->

## Tests
<!-- What tests should be run to confirm functionality? -->

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->
