### PR TITLE
fix(copy): align dashboard dropdown menu's copy with rest of platform

### DIFF
--- a/apps/frontend/src/i18n/locales/features/workspace/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/en-sg.ts
@@ -33,8 +33,8 @@ export const enSG: Workspace = {
     preview: 'Preview',
     duplicate: 'Duplicate',
     share: 'Share form',
-    admins: 'Manage form admins',
-    move: 'Move to Folder',
+    admins: 'Manage collaborators',
+    move: 'Move to folder',
   },
   skeleton: {
     title: 'Loading title... Loading title...',


### PR DESCRIPTION
## Problem

The form-row dropdown menu on the admin dashboard labels two actions
inconsistently with the rest of FormSG: "Manage form admins" (called
"Manage collaborators" everywhere else) and "Move to Folder" (title case
where sentence case is the norm).

## Solution

Rename the two i18n strings in the workspace locale so the dropdown
matches the established copy: "Manage collaborators" and "Move to folder".
Both keys are consumed by the desktop dropdown and the mobile drawer, so
the single locale edit covers both surfaces.

Before:
<img width="1485" height="791" alt="image" src="https://github.com/user-attachments/assets/daec4dd4-f25f-4c1a-9245-3ef98e989507" />


After: 
<img width="1485" height="791" alt="image" src="https://github.com/user-attachments/assets/a53aba51-e58b-4104-ad20-c6d76803f16f" />


**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: Dropdown copy**

- [ ] On the admin dashboard, click the dropdown arrow beside Edit on a form row
- [ ] Confirm the options read "Manage collaborators" and "Move to folder"
- [ ] Repeat on a mobile breakpoint (drawer variant) and confirm the same labels
