### PR TITLE
build: release v7.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [7.29.0](https://github.com/opengovsg/formsg/compare/v7.28.1...v7.29.0) (2026-06-15)
+
+
+### Features
+
+* **paper forms tracking:** form-origin model + backend persistence (part 1) (#9576) ([#9576](https://github.com/opengovsg/formsg/commit/0ae1a540624208dc86c77378b3b064dddddeacfe))
+
+
+### Bug Fixes
+
+* **copy:** align dashboard dropdown menu's copy with rest of platform (#9608) ([#9608](https://github.com/opengovsg/formsg/commit/5fe504743b8051d5e0b581363bfc765f3f8037b1))
+* add require for form (#9610) ([#9610](https://github.com/opengovsg/formsg/commit/3d51cebf9d74f38d839fa9b7bad3c9be5d6f380d))
+
 ## [7.28.1](https://github.com/opengovsg/formsg/compare/v7.28.0...v7.28.1) (2026-06-12)
 
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-backend",
-  "version": "7.28.1",
+  "version": "7.29.0",
   "private": true,
   "homepage": ".",
   "scripts": {

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -4076,7 +4076,7 @@ describe('admin-form.controller', () => {
     })
   })
 
-  describe('handleCopyTemplateForm', () => {
+  describe('copyTemplateForm', () => {
     const MOCK_USER_ID = new ObjectId().toHexString()
     const MOCK_FORM_ID = new ObjectId().toHexString()
     const MOCK_USER = {
@@ -4129,7 +4129,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
+      await AdminFormController.copyTemplateForm(
         mockReqWithParams,
         mockRes,
         jest.fn(),
@@ -4178,7 +4178,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
+      await AdminFormController.copyTemplateForm(
         mockReqWithParams,
         mockRes,
         jest.fn(),
@@ -4210,11 +4210,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
+      await AdminFormController.copyTemplateForm(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(403)
@@ -4249,7 +4245,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
+      await AdminFormController.copyTemplateForm(
         mockReqWithParams,
         mockRes,
         jest.fn(),
@@ -4283,11 +4279,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
+      await AdminFormController.copyTemplateForm(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(410)
@@ -4308,11 +4300,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
+      await AdminFormController.copyTemplateForm(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(422)
@@ -4333,11 +4321,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
+      await AdminFormController.copyTemplateForm(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)
@@ -4361,11 +4345,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
-        MOCK_REQ,
-        mockRes,
-        jest.fn(),
-      )
+      await AdminFormController.copyTemplateForm(MOCK_REQ, mockRes, jest.fn())
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)
@@ -4399,7 +4379,7 @@ describe('admin-form.controller', () => {
       )
 
       // Act
-      await AdminFormController.handleCopyTemplateForm(
+      await AdminFormController.copyTemplateForm(
         mockReqWithParams,
         mockRes,
         jest.fn(),

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -8,6 +8,7 @@ import {
   MAX_UPLOAD_FILE_SIZE,
   VALID_UPLOAD_FILE_TYPES,
 } from 'formsg-shared/constants/file'
+import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from 'formsg-shared/constants/form'
 import {
   AdminDashboardFormMetaDto,
   BasicField,
@@ -23,6 +24,7 @@ import {
   FormFeedbackMetaDto,
   FormFieldDto,
   FormLogoState,
+  FormOrigin,
   FormResponseMode,
   FormSettings,
   FormWebhookResponseModeSettings,
@@ -99,7 +101,21 @@ const Joi = BaseJoi.extend(JoiDate) as typeof BaseJoi
 
 const logger = createLoggerWithLabel(module)
 
-// Validators
+const clientMetadataValidator = Joi.object({
+  formOrigins: Joi.object({
+    value: Joi.array()
+      .items(
+        Joi.string().valid(
+          ...Object.values(FormOrigin),
+          CLIENT_CHECKBOX_OTHERS_INPUT_VALUE,
+        ),
+      )
+      .unique()
+      .required(),
+    othersInput: Joi.string().allow('').max(200),
+  }),
+})
+
 const createFormValidator = celebrate({
   [Segments.BODY]: {
     form: BaseJoi.object<CreateFormBodyDto>()
@@ -143,6 +159,7 @@ const createFormValidator = celebrate({
           otherwise: Joi.forbidden(),
         }),
         workspaceId: Joi.string(),
+        metadata: clientMetadataValidator,
       })
       .required()
       // Allow other form schema keys to be passed for form creation.
@@ -192,7 +209,14 @@ const duplicateFormValidator = celebrate({
       otherwise: Joi.forbidden(),
     }),
     workspaceId: Joi.string(),
+    metadata: clientMetadataValidator,
   }),
+})
+
+const copyTemplateFormValidator = celebrate({
+  [Segments.BODY]: BaseJoi.object<DuplicateFormBodyDto>({
+    metadata: clientMetadataValidator,
+  }).unknown(true),
 })
 
 const transferFormOwnershipValidator = celebrate({
@@ -939,7 +963,11 @@ export const duplicateAdminForm: ControllerHandler<
               originalForm,
               userId,
               overrideParams,
-              { workspaceId: workspaceId, overrideEmails },
+              {
+                workspaceId: workspaceId,
+                overrideEmails,
+                formOrigins: overrideParams.metadata?.formOrigins,
+              },
             ),
           )
           // Step 4: Retrieve dashboard view of duplicated form.
@@ -1040,7 +1068,7 @@ export const handleGetTemplateForm: ControllerHandler<
  * @returns 422 when user in session cannot be retrieved from the database
  * @returns 500 when database error occurs
  */
-export const handleCopyTemplateForm: ControllerHandler<
+export const copyTemplateForm: ControllerHandler<
   { formId: string },
   AdminDashboardFormMetaDto | ErrorDto,
   DuplicateFormBodyDto
@@ -1064,6 +1092,7 @@ export const handleCopyTemplateForm: ControllerHandler<
           AdminFormService.duplicateForm(originalForm, userId, overrideParams, {
             overrideEmails: [user.email],
             isFromTemplate: true,
+            formOrigins: overrideParams.metadata?.formOrigins,
           })
             // Step 4: Retrieve dashboard view of duplicated form.
             .map((duplicatedForm) => duplicatedForm.getDashboardView(user)),
@@ -1095,6 +1124,11 @@ export const handleCopyTemplateForm: ControllerHandler<
       })
   )
 }
+
+export const handleCopyTemplateForm = [
+  copyTemplateFormValidator,
+  copyTemplateForm,
+] as ControllerHandler[]
 
 /**
  * Handler for POST /admin/forms/all-transfer-owner.

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -663,6 +663,7 @@ type DuplicateFormOpts = {
   overrideEmails?: string[]
   // If duplicated from a use-template
   isFromTemplate?: boolean
+  formOrigins?: FormMetadata['formOrigins']
 }
 
 /**
@@ -683,7 +684,8 @@ export const duplicateForm = (
     overrideParams,
     newAdminId,
   )
-  const { workspaceId, overrideEmails, isFromTemplate } = opts ?? {}
+  const { workspaceId, overrideEmails, isFromTemplate, formOrigins } =
+    opts ?? {}
 
   // Set startPage.logo to default irregardless.
   overrideProps.startPage = {
@@ -722,11 +724,13 @@ export const duplicateForm = (
     })
   }
 
-  // if created from template, track original form id in metadata
-  if (isFromTemplate) {
-    duplicateParams.metadata = {
-      template_form_id: originalForm._id,
-    }
+  const metadata: FormMetadata = {
+    // if created from template, track original form id in metadata
+    ...(isFromTemplate && { template_form_id: originalForm._id }),
+    ...(formOrigins && { formOrigins }),
+  }
+  if (Object.keys(metadata).length > 0) {
+    duplicateParams.metadata = metadata
   }
 
   if (workspaceId)

--- a/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -8,11 +8,13 @@ import { buildCelebrateError } from '__tests__/unit/backend/helpers/celebrate'
 import { generateDefaultField } from '__tests__/unit/backend/helpers/generate-form-data'
 import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { jsonParseStringify } from '__tests__/unit/backend/helpers/serialize-data'
+import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from 'formsg-shared/constants/form'
 import {
   BasicField,
   FormColorTheme,
   FormEndPage,
   FormLogoState,
+  FormOrigin,
   FormResponseMode,
   FormStartPage,
   FormStatus,
@@ -260,6 +262,184 @@ describe('admin-form.form.routes', () => {
           form_logics: [],
         }),
       )
+    })
+
+    it('should persist form origins onto metadata when creating an MRF form', async () => {
+      // Arrange
+      const createMrfParams = {
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form with paper origin',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: {
+              value: [FormOrigin.Paper, FormOrigin.DigitalSpreadsheet],
+            },
+          },
+        },
+      }
+
+      // Act
+      const response = await request.post('/admin/forms').send(createMrfParams)
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          responseMode: FormResponseMode.Multirespondent,
+          metadata: expect.objectContaining({
+            formOrigins: {
+              value: [FormOrigin.Paper, FormOrigin.DigitalSpreadsheet],
+            },
+          }),
+        }),
+      )
+      // Persisted in a single create write (no follow-up update).
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.metadata?.formOrigins).toEqual({
+        value: [FormOrigin.Paper, FormOrigin.DigitalSpreadsheet],
+      })
+    })
+
+    it('should return 400 when an unrecognised form origin code is provided', async () => {
+      // Act
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form with bad origin',
+          publicKey: 'some random public key',
+          metadata: { formOrigins: { value: ['not-a-real-origin'] } },
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body.message).toEqual('Validation failed')
+    })
+
+    it('should return 400 when form origins contain duplicate values', async () => {
+      // Act
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form with duplicate origins',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: { value: [FormOrigin.Paper, FormOrigin.Paper] },
+          },
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body.message).toEqual('Validation failed')
+    })
+
+    it('should return 200 when no form origins are provided (legacy / flag-off)', async () => {
+      // Act
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form without origins',
+          publicKey: 'some random public key',
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(200)
+    })
+
+    it('should persist form origins on a non-MRF create (origins are best-effort, mode-agnostic)', async () => {
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: FormResponseMode.Encrypt,
+          title: 'storage form with origins',
+          publicKey: 'some random public key',
+          emails: [],
+          metadata: { formOrigins: { value: [FormOrigin.Paper] } },
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.metadata?.formOrigins).toEqual({
+        value: [FormOrigin.Paper],
+      })
+    })
+
+    it('should persist an "Other" origin with its free-text detail in othersInput', async () => {
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form with other origin',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: {
+              value: [FormOrigin.Paper, CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
+              othersInput: 'Carrier pigeon',
+            },
+          },
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.metadata?.formOrigins).toEqual({
+        value: [FormOrigin.Paper, CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
+        othersInput: 'Carrier pigeon',
+      })
+    })
+
+    it('should return 400 when metadata contains keys other than formOrigins', async () => {
+      // The rest of FormMetadata (e.g. internal counters) is server-managed.
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form with smuggled metadata',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: { value: [FormOrigin.Paper] },
+            mfb_text_prompt_count: 9000,
+          },
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body.message).toEqual('Validation failed')
+    })
+
+    it('should return 400 when formOrigins contains keys other than value/othersInput', async () => {
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form with bad formOrigins shape',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: { value: [FormOrigin.Paper], unexpected: true },
+          },
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body.message).toEqual('Validation failed')
+    })
+
+    it('should return 200 when form origins value is an empty array (best-effort)', async () => {
+      const response = await request.post('/admin/forms').send({
+        form: {
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form with empty origins',
+          publicKey: 'some random public key',
+          metadata: { formOrigins: { value: [] } },
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(200)
     })
 
     it('should return 400 when body.form.publicKey is missing', async () => {
@@ -1505,6 +1685,244 @@ describe('admin-form.form.routes', () => {
           },
         }),
       )
+    })
+
+    it('should return 400 when form origins contain duplicate values', async () => {
+      // Arrange
+      const formToDupe = await EncryptFormModel.create({
+        title: 'form to duplicate',
+        admin: defaultUser._id,
+        publicKey: 'some random key',
+        emails: [],
+      })
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${formToDupe._id}/duplicate`)
+        .send({
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'duplicated mrf form with duplicate origins',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: { value: [FormOrigin.Paper, FormOrigin.Paper] },
+          },
+        })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body.message).toEqual('Validation failed')
+    })
+  })
+
+  describe('POST /admin/forms/:formId/use-template', () => {
+    /** A public form usable as a template source for the tests below. */
+    const createPublicTemplateForm = () =>
+      EncryptFormModel.create({
+        title: 'public template form',
+        admin: defaultUser._id,
+        publicKey: 'some random key',
+        emails: [],
+        status: FormStatus.Public,
+      })
+
+    it('should persist form origins onto metadata when creating an MRF form from a template', async () => {
+      // Arrange
+      const templateForm = await createPublicTemplateForm()
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${templateForm._id}/use-template`)
+        .send({
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form from template with origins',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: {
+              value: [FormOrigin.Paper, FormOrigin.DigitalSpreadsheet],
+            },
+          },
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      // Persisted in the single create write, alongside the template tracking id.
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.metadata?.formOrigins).toEqual({
+        value: [FormOrigin.Paper, FormOrigin.DigitalSpreadsheet],
+      })
+      expect(String(saved?.metadata?.template_form_id)).toEqual(
+        String(templateForm._id),
+      )
+    })
+
+    it('should return 400 when an unrecognised form origin code is provided', async () => {
+      // Arrange
+      const templateForm = await createPublicTemplateForm()
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${templateForm._id}/use-template`)
+        .send({
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form from template with bad origin',
+          publicKey: 'some random public key',
+          metadata: { formOrigins: { value: ['not-a-real-origin'] } },
+        })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body.message).toEqual('Validation failed')
+    })
+
+    it('should return 400 when form origins contain duplicate values', async () => {
+      // Arrange
+      const templateForm = await createPublicTemplateForm()
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${templateForm._id}/use-template`)
+        .send({
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form from template with duplicate origins',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: { value: [FormOrigin.Paper, FormOrigin.Paper] },
+          },
+        })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body.message).toEqual('Validation failed')
+    })
+
+    it('should persist an "Other" origin with its free-text detail in othersInput', async () => {
+      // Arrange
+      const templateForm = await createPublicTemplateForm()
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${templateForm._id}/use-template`)
+        .send({
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form from template with other',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: {
+              value: [CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
+              othersInput: 'Carrier pigeon',
+            },
+          },
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.metadata?.formOrigins).toEqual({
+        value: [CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
+        othersInput: 'Carrier pigeon',
+      })
+    })
+
+    it('should persist form origins on a non-MRF use-template (mode-agnostic)', async () => {
+      const templateForm = await createPublicTemplateForm()
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${templateForm._id}/use-template`)
+        .send({
+          responseMode: FormResponseMode.Encrypt,
+          title: 'storage form from template with origins',
+          publicKey: 'some random public key',
+          emails: [],
+          metadata: { formOrigins: { value: [FormOrigin.Paper] } },
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.metadata?.formOrigins).toEqual({
+        value: [FormOrigin.Paper],
+      })
+    })
+
+    it('should not copy form origins over from the source form', async () => {
+      // The admin's answer describes their own process, never the template
+      // author's — when no answer is sent, the new form carries no origins.
+      const templateForm = await EncryptFormModel.create({
+        title: 'public template form with origins',
+        admin: defaultUser._id,
+        publicKey: 'some random key',
+        emails: [],
+        status: FormStatus.Public,
+        metadata: { formOrigins: { value: [FormOrigin.Paper] } },
+      })
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${templateForm._id}/use-template`)
+        .send({
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form from template without origins',
+          publicKey: 'some random public key',
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.metadata?.formOrigins).toBeUndefined()
+      expect(String(saved?.metadata?.template_form_id)).toEqual(
+        String(templateForm._id),
+      )
+    })
+
+    it('should return 400 when metadata contains keys other than formOrigins', async () => {
+      // The rest of FormMetadata (e.g. internal counters) is server-managed.
+      const templateForm = await createPublicTemplateForm()
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${templateForm._id}/use-template`)
+        .send({
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mrf form from template with smuggled metadata',
+          publicKey: 'some random public key',
+          metadata: {
+            formOrigins: { value: [FormOrigin.Paper] },
+            mfb_text_prompt_count: 9000,
+          },
+        })
+
+      // Assert
+      expect(response.status).toEqual(400)
+      expect(response.body.message).toEqual('Validation failed')
+    })
+
+    it('should persist form origins when duplicating a form', async () => {
+      // The duplicate-form modal re-asks the origin question, just like
+      // use-template. Origins are never copied from the source form.
+      const formToDupe = await EncryptFormModel.create({
+        title: 'form to duplicate',
+        admin: defaultUser._id,
+        publicKey: 'some random key',
+        emails: [],
+      })
+
+      // Act
+      const response = await request
+        .post(`/admin/forms/${formToDupe._id}/duplicate`)
+        .send({
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'duplicated mrf form with origins',
+          publicKey: 'some random public key',
+          metadata: { formOrigins: { value: [FormOrigin.Paper] } },
+        })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.metadata?.formOrigins).toEqual({
+        value: [FormOrigin.Paper],
+      })
     })
   })
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-frontend",
-  "version": "7.28.1",
+  "version": "7.29.0",
   "private": true,
   "homepage": ".",
   "type": "module",

--- a/apps/frontend/src/i18n/locales/features/workspace/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/en-sg.ts
@@ -33,8 +33,8 @@ export const enSG: Workspace = {
     preview: 'Preview',
     duplicate: 'Duplicate',
     share: 'Share form',
-    admins: 'Manage form admins',
-    move: 'Move to Folder',
+    admins: 'Manage collaborators',
+    move: 'Move to folder',
   },
   skeleton: {
     title: 'Loading title... Loading title...',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-monorepo",
-  "version": "7.28.1",
+  "version": "7.29.0",
   "private": true,
   "description": "Form Manager for Government",
   "homepage": "https://form.gov.sg",

--- a/packages/react-email-preview/package.json
+++ b/packages/react-email-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-react-email-preview",
-  "version": "7.28.1",
+  "version": "7.29.0",
   "private": true,
   "scripts": {
     "build": "email build",

--- a/packages/shared/constants/__tests__/form-origin.spec.ts
+++ b/packages/shared/constants/__tests__/form-origin.spec.ts
@@ -1,0 +1,10 @@
+import { FormOrigin } from '../../types/form/form'
+import { FORM_ORIGIN_OPTIONS } from '../form-origin'
+
+describe('FORM_ORIGIN_OPTIONS', () => {
+  it('lists every recognised origin code exactly once', () => {
+    expect([...FORM_ORIGIN_OPTIONS].sort()).toEqual(
+      [...Object.values(FormOrigin)].sort(),
+    )
+  })
+})

--- a/packages/shared/constants/form-origin.ts
+++ b/packages/shared/constants/form-origin.ts
@@ -1,0 +1,17 @@
+import { FormOrigin } from '../types/form/form'
+
+/**
+ * Form-origin options shown during form set-up for paper forms tracking.
+ * Ordered exactly as shown on the form set-up origin screen.
+ *
+ * Others option uses the CheckboxFieldResponsesV3.othersInput
+ * rather than as an origin code.
+ */
+export const FORM_ORIGIN_OPTIONS = [
+  FormOrigin.Paper,
+  FormOrigin.DigitalNew,
+  FormOrigin.DigitalEmail,
+  FormOrigin.DigitalDocument,
+  FormOrigin.DigitalSpreadsheet,
+  FormOrigin.DigitalFormBuilder,
+] as const

--- a/packages/shared/constants/index.ts
+++ b/packages/shared/constants/index.ts
@@ -1,5 +1,6 @@
 export * from './file'
 export * from './form'
+export * from './form-origin'
 export * from './links'
 export * from './feature-flags'
 export * from './errors'

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-shared",
-  "version": "7.28.1",
+  "version": "7.29.0",
   "private": true,
   "description": "",
   "scripts": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -75,6 +75,7 @@
       "default": "./constants/file.ts"
     },
     "./constants/form": {
+      "require": "./dist/constants/form.js",
       "default": "./constants/form.ts"
     },
     "./constants/routes": {

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -19,6 +19,7 @@ import {
   STORAGE_PUBLIC_FORM_FIELDS,
 } from '../../constants/form'
 import { DateString } from '../generic'
+import { CheckboxFieldResponsesV3 } from '../response-v3'
 import { FormLogic, LogicDto } from './form_logic'
 import { PaymentChannel, PaymentMethodType, PaymentType } from '../payment'
 import { Product } from './product'
@@ -111,12 +112,22 @@ export enum FormResponseMode {
   Multirespondent = 'multirespondent',
 }
 
+export enum FormOrigin {
+  Paper = 'paper',
+  DigitalNew = 'digital-new',
+  DigitalEmail = 'digital-email',
+  DigitalDocument = 'digital-document',
+  DigitalSpreadsheet = 'digital-spreadsheet',
+  DigitalFormBuilder = 'digital-formbuilder',
+}
+
 export interface FormMetadata {
   mfb_text_prompt_count?: number
   num_mrf_reminder_emails_sent?: number
   mfb_vision_prompt_count?: number
   template_form_id?: Schema.Types.ObjectId
   delimiter?: string
+  formOrigins?: CheckboxFieldResponsesV3
 }
 
 export type FormPaymentsChannel = {
@@ -431,6 +442,7 @@ export type DuplicateFormOverwriteDto = {
 
 export type DuplicateFormBodyDto = DuplicateFormOverwriteDto & {
   workspaceId?: string
+  metadata?: Pick<FormMetadata, 'formOrigins'>
 }
 
 export type CreateEmailFormBodyDto = Pick<
@@ -441,12 +453,16 @@ export type CreateEmailFormBodyDto = Pick<
 export type CreateStorageFormBodyDto = Pick<
   StorageFormDto,
   'publicKey' | 'responseMode' | 'title' | 'emails'
-> & { workspaceId?: string }
+> & { workspaceId?: string; metadata?: Pick<FormMetadata, 'formOrigins'> }
 
 export type CreateMultirespondentFormBodyDto = Pick<
   MultirespondentFormDto,
   'publicKey' | 'responseMode' | 'title'
-> & { workspaceId?: string; emails?: string[] }
+> & {
+  workspaceId?: string
+  emails?: string[]
+  metadata?: Pick<FormMetadata, 'formOrigins'>
+}
 
 export type CreateFormBodyDto =
   | CreateEmailFormBodyDto

--- a/services/form-payment-reconciliation/package.json
+++ b/services/form-payment-reconciliation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-payment-reconciliation",
-  "version": "7.28.1",
+  "version": "7.29.0",
   "private": true,
   "description": "Lambda function for payment reconciliation",
   "main": "index.js",

--- a/services/pdf-gen-sparticuz/package.json
+++ b/services/pdf-gen-sparticuz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-pdf-gen-sparticuz",
-  "version": "7.28.1",
+  "version": "7.29.0",
   "private": true,
   "description": "<!-- title: 'AWS NodeJS Example' description: 'This template demonstrates how to deploy a simple NodeJS function running on AWS Lambda using the Serverless Framework.' layout: Doc framework: v4 platform: AWS language: nodeJS priority: 1 authorLink: 'https://github.com/serverless' authorName: 'Serverless, Inc.' authorAvatar: 'https://avatars1.githubusercontent.com/u/13742415?s=200&v=4' -->",
   "main": "dist/index.js",

--- a/services/virus-scanner-guardduty/package.json
+++ b/services/virus-scanner-guardduty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "formsg-virus-scanner-guardduty",
-  "version": "7.28.1",
+  "version": "7.29.0",
   "private": true,
   "description": "",
   "scripts": {


### PR DESCRIPTION


### Features

* **paper forms tracking:** form-origin model + backend persistence (part 1) (#9576) ([#9576](https://github.com/opengovsg/formsg/commit/0ae1a540624208dc86c77378b3b064dddddeacfe))


### Bug Fixes

* **copy:** align dashboard dropdown menu's copy with rest of platform (#9608) ([#9608](https://github.com/opengovsg/formsg/commit/5fe504743b8051d5e0b581363bfc765f3f8037b1))
* add require for form (#9610) ([#9610](https://github.com/opengovsg/formsg/commit/3d51cebf9d74f38d839fa9b7bad3c9be5d6f380d))


### Tests

### **paper forms tracking:** form-origin model + backend persistence (part 1) (#9576) ([#9576](https://github.com/opengovsg/formsg/commit/0ae1a540624208dc86c77378b3b064dddddeacfe))

Covered in CI: unit tests for every validation rule
(`packages/shared/utils/__tests__/form-origin-validation.spec.ts`), an
enum/options sync check, and route tests for the create endpoint
(`admin-forms.form.routes.spec.ts`) — valid origins persist, each invalid case
400s, non-MRF creates reject the field, omitting it still works.

API-level smoke on a live/staging instance:

**TC1: Origins persist on an MRF create**

- [ ] Create a multirespondent form with `metadata.formOrigins: ["paper","digital-spreadsheet"]`
- [ ] Confirm the created form's `metadata.formOrigins` round-trips both codes

**TC2: "Others" round-trips with its embedded free text**

- [ ] Create an MRF form with `metadata: { formOrigins: ["paper", "digital-others: Carrier pigeon"] }`
- [ ] Confirm the embedded entry persists verbatim on the created form

**TC3: Origins forbidden on non-MRF creates**

- [ ] Create a storage/encrypt form with `metadata.formOrigins: ["paper"]`
- [ ] Confirm a 400 validation error (origin capture is MRF-only)

**TC4: Use-template persists the re-asked answer; duplicate rejects origins**

- [ ] POST use-template on a public form with `metadata.formOrigins: ["paper"]` — confirm the new form carries both `formOrigins` and `template_form_id`
- [ ] POST use-template without metadata on a source form that has origins — confirm the new form carries none
- [ ] POST duplicate with `metadata.formOrigins` — confirm a 400 validation error

### **copy:** align dashboard dropdown menu's copy with rest of platform (#9608) ([#9608](https://github.com/opengovsg/formsg/commit/5fe504743b8051d5e0b581363bfc765f3f8037b1))

**TC1: Dropdown copy**

- [ ] On the admin dashboard, click the dropdown arrow beside Edit on a form row
- [ ] Confirm the options read "Manage collaborators" and "Move to folder"
- [ ] Repeat on a mobile breakpoint (drawer variant) and confirm the same labels

