### PR TITLE
fix: add require for form

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -75,6 +75,7 @@
       "default": "./constants/file.ts"
     },
     "./constants/form": {
+      "require": "./dist/constants/form.js",
       "default": "./constants/form.ts"
     },
     "./constants/routes": {


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Require was missing for the formsg-shared exports, causing the backend to not be able to resolve the required file.  

## Solution
<!-- How did you solve the problem? -->
This fix adds require in package json so nodejs can resolve the formsg-shared import.

Alternative is to switch the import to formsg-shared/constants instead, but i think this should be a change delegated to the restructuring of the shared package exports as a whole

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  