### PR TITLE
refactor(backend): add i18n message keys to backend error responses

### DIFF
--- a/apps/backend/src/app/modules/core/core.types.ts
+++ b/apps/backend/src/app/modules/core/core.types.ts
@@ -1,9 +1,12 @@
 import { RequestHandler } from 'express'
+import { I18nMessageParams } from 'formsg-shared/types'
 import { StatusCodes } from 'http-status-codes'
 
 export type ErrorResponseData = {
   statusCode: StatusCodes
   errorMessage: string
+  errorMessageKey?: string
+  errorMessageParams?: I18nMessageParams
 }
 
 export type ControllerHandler<

--- a/apps/backend/src/app/modules/submission/__tests__/submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submission.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   WorkflowType,
 } from 'formsg-shared/types'
 import { readFileSync } from 'fs'
+import { StatusCodes } from 'http-status-codes'
 import { cloneDeep, merge } from 'lodash'
 import path from 'path'
 
@@ -14,12 +15,26 @@ import {
   IMultirespondentSubmissionSchema,
   SingleAnswerFieldResponse,
 } from '../../../../types'
+import { VerifyJwtError } from '../../spcp/spcp.errors'
+import {
+  AttachmentSizeLimitExceededError,
+  AttachmentUploadError,
+  DownloadCleanFileFailedError,
+  ExpectedResponseNotFoundError,
+  GuardDutyDownloadCleanFileFailedError,
+  GuardDutyVirusScanFailedError,
+  InvalidWorkflowTypeError,
+  MissingSubmitterIdError,
+  VirusScanFailedError,
+} from '../submission.errors'
 import {
   areAttachmentsMoreThanLimit,
   buildMrfMetadata,
   getInvalidFileExtensions,
   getResponseModeFilter,
   mapAttachmentsFromResponses,
+  mapRouteError,
+  sendRouteError,
 } from '../submission.utils'
 
 const RESOURCES = path.join(
@@ -80,6 +95,108 @@ const getResponse = (_id: string, answer: string): SingleAnswerFieldResponse =>
   }) as unknown as SingleAnswerFieldResponse
 
 describe('submission.utils', () => {
+  describe('mapRouteError', () => {
+    it.each([
+      [
+        new VerifyJwtError(),
+        StatusCodes.UNAUTHORIZED,
+        'Something went wrong with your login. Please try logging in and submitting again.',
+        'loginFailed',
+      ],
+      [
+        new AttachmentUploadError(),
+        StatusCodes.BAD_REQUEST,
+        'Could not upload attachments for submission. For assistance, please contact the person who asked you to fill in this form.',
+        'files.uploadFailed',
+      ],
+      [
+        new AttachmentSizeLimitExceededError(),
+        StatusCodes.BAD_REQUEST,
+        'Total attachment size exceeds maximum file size limit. Please reduce your total attachment size and try again.',
+        'files.totalSizeExceeded',
+      ],
+      [
+        new VirusScanFailedError(),
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        'Virus scan failed. Please try again.',
+        'files.virusScanFailed',
+      ],
+      [
+        new GuardDutyVirusScanFailedError(),
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        'Virus scan failed. Please try again.',
+        'files.virusScanFailed',
+      ],
+      [
+        new DownloadCleanFileFailedError(),
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        'Attempt to download clean file failed. Please try again.',
+        'files.cleanFileDownloadFailed',
+      ],
+      [
+        new GuardDutyDownloadCleanFileFailedError(),
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        'Attempt to download clean file failed. Please try again.',
+        'files.cleanFileDownloadFailed',
+      ],
+      [
+        new MissingSubmitterIdError(),
+        StatusCodes.INTERNAL_SERVER_ERROR,
+        'Failed to retrieve submitter ID. Please try again.',
+        'mrf.missingSubmitterId',
+      ],
+      [
+        new InvalidWorkflowTypeError(),
+        StatusCodes.BAD_REQUEST,
+        'Invalid workflow type encountered. Please contact the form admin and try again later.',
+        'mrf.invalidWorkflowType',
+      ],
+      [
+        new ExpectedResponseNotFoundError(),
+        StatusCodes.BAD_REQUEST,
+        'Response for the Yes/No field for this approval step is not found',
+        'mrf.expectedResponseNotFound',
+      ],
+    ])(
+      'should include message key for migrated submission error %#',
+      (error, statusCode, errorMessage, key) => {
+        expect(mapRouteError(error)).toEqual({
+          statusCode,
+          errorMessage,
+          errorMessageKey: `features.publicForm.backendErrors.submission.${key}`,
+        })
+      },
+    )
+  })
+
+  describe('sendRouteError', () => {
+    it('should serialize legacy message, i18n metadata, and extra response body fields', () => {
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn().mockReturnThis(),
+      }
+
+      sendRouteError(
+        mockRes as never,
+        {
+          statusCode: StatusCodes.BAD_REQUEST,
+          errorMessage: 'Fallback message',
+          errorMessageKey: 'features.publicForm.backendErrors.submission.test',
+          errorMessageParams: { count: 1 },
+        },
+        { spcpSubmissionFailure: true },
+      )
+
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: 'Fallback message',
+        messageKey: 'features.publicForm.backendErrors.submission.test',
+        messageParams: { count: 1 },
+        spcpSubmissionFailure: true,
+      })
+    })
+  })
+
   describe('buildMrfMetadata', () => {
     const YES_NO_FIELD = {
       _id: 'yes_no_field_id',

--- a/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -10,6 +10,8 @@ import {
   ErrorCode,
   FormAuthType,
   MyInfoAttribute,
+  PaymentChannel,
+  PaymentType,
 } from 'formsg-shared/types'
 import { merge } from 'lodash'
 import mongoose from 'mongoose'
@@ -1375,6 +1377,59 @@ describe('encrypt-submission.controller', () => {
         performEncryptPostSubmissionActionsSpy.mock.calls[0][0]
           .respondentEmails,
       ).toEqual(mockRespondentEmails)
+    })
+  })
+
+  describe('payment submissions', () => {
+    it('should return message key when payment settings are invalid', async () => {
+      const mockReq = merge(
+        expressHandler.mockRequest({
+          params: { formId: new ObjectId().toHexString() },
+          body: { responses: [] },
+        }),
+        {
+          formsg: {
+            filteredResponses: [],
+            respondentEmails: [],
+            responseMetadata: {},
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+              payments: {},
+              paymentReceiptEmail: 'test@example.com',
+            },
+            formDef: {
+              _id: new ObjectId(),
+            },
+            encryptedFormDef: {
+              _id: new ObjectId(),
+              authType: FormAuthType.NIL,
+              isSubmitterIdCollectionEnabled: false,
+              getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+              payments_field: {
+                enabled: true,
+                payment_type: PaymentType.Fixed,
+                gst_enabled: false,
+              },
+              payments_channel: {
+                channel: PaymentChannel.Stripe,
+                target_account_id: 'acct_mock',
+              },
+            },
+          } as unknown as FormCompleteDto,
+        },
+      ) as unknown as SubmitEncryptModeFormHandlerRequest
+      const mockRes = expressHandler.mockResponse()
+
+      await submitEncryptModeFormForTest(mockReq, mockRes)
+
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message:
+          "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+        messageKey:
+          'features.publicForm.backendErrors.submission.payment.invalidSettings',
+      })
     })
   })
 })

--- a/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.middleware.spec.ts
@@ -1,0 +1,40 @@
+import expressHandler from '__tests__/unit/backend/helpers/jest-express'
+
+import { validatePaymentSubmission } from '../encrypt-submission.middleware'
+
+jest.mock('src/app/modules/datadog/datadog.utils')
+
+describe('encrypt-submission.middleware', () => {
+  describe('validatePaymentSubmission', () => {
+    it('should return message key when payment settings have been updated', async () => {
+      const mockReq = expressHandler.mockRequest({
+        body: {
+          paymentProducts: [{ data: { id: 'mock-product-id', quantity: 1 } }],
+        },
+      })
+      mockReq.formsg = {
+        formDef: {
+          _id: 'mockFormId',
+          toObject: () => ({
+            _id: 'mockFormId',
+            payments_field: {},
+          }),
+        },
+      } as never
+
+      const mockRes = expressHandler.mockResponse()
+      const mockNext = jest.fn()
+
+      await validatePaymentSubmission(mockReq as never, mockRes, mockNext)
+
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(400)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message:
+          'The payment settings in this form have been updated. Please refresh and try again.',
+        messageKey:
+          'features.publicForm.backendErrors.submission.payment.settingsUpdated',
+      })
+    })
+  })
+})

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -92,6 +92,13 @@ const logger = createLoggerWithLabel(module)
 const EncryptSubmission = getEncryptSubmissionModel(mongoose)
 const EncryptPendingSubmission = getEncryptPendingSubmissionModel(mongoose)
 const Payment = getPaymentModel(mongoose)
+const paymentInvalidSettingsRouteError = {
+  statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+  errorMessage:
+    "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+  errorMessageKey:
+    'features.publicForm.backendErrors.submission.payment.invalidSettings',
+}
 
 // NOTE: Refer to this for documentation: https://github.com/sideway/joi-date/blob/master/API.md
 const Joi = BaseJoi.extend(JoiDate)
@@ -472,10 +479,7 @@ const _createPaymentSubmission = async ({
       message: 'Error when creating payment: amount is missing',
       meta: logMeta,
     })
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message:
-        "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
-    })
+    return sendRouteError(res, paymentInvalidSettingsRouteError)
   }
 
   const paymentMinAmount =
@@ -490,10 +494,7 @@ const _createPaymentSubmission = async ({
       message: 'Error when creating payment: amount is not within bounds',
       meta: logMeta,
     })
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message:
-        "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
-    })
+    return sendRouteError(res, paymentInvalidSettingsRouteError)
   }
   const paymentReceiptEmail =
     encryptedPayload.paymentReceiptEmail?.toLowerCase()
@@ -503,9 +504,9 @@ const _createPaymentSubmission = async ({
         'Error when creating payment: payment receipt email not provided.',
       meta: logMeta,
     })
-    return res.status(StatusCodes.BAD_REQUEST).json({
-      message:
-        "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+    return sendRouteError(res, {
+      ...paymentInvalidSettingsRouteError,
+      statusCode: StatusCodes.BAD_REQUEST,
     })
   }
 
@@ -542,9 +543,12 @@ const _createPaymentSubmission = async ({
       error: err,
     })
     // Block the submission so that user can try to resubmit
-    return res.status(StatusCodes.BAD_REQUEST).json({
-      message:
+    return sendRouteError(res, {
+      statusCode: StatusCodes.BAD_REQUEST,
+      errorMessage:
         'Could not save pending submission. For assistance, please contact the person who asked you to fill in this form.',
+      errorMessageKey:
+        'features.publicForm.backendErrors.submission.payment.pendingSubmissionSaveFailed',
     })
   }
 
@@ -595,9 +599,12 @@ const _createPaymentSubmission = async ({
       error: err,
     })
     // Return a 502 error here since the issue was with Stripe.
-    return res.status(StatusCodes.BAD_GATEWAY).json({
-      message:
+    return sendRouteError(res, {
+      statusCode: StatusCodes.BAD_GATEWAY,
+      errorMessage:
         'There was a problem creating the payment intent. Please try again.',
+      errorMessageKey:
+        'features.publicForm.backendErrors.submission.payment.intentCreateFailed',
     })
   }
 
@@ -645,9 +652,12 @@ const _createPaymentSubmission = async ({
     }
     // Regardless of whether the cancellation succeeded or failed, block the
     // submission so that user can try to resubmit
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message:
+    return sendRouteError(res, {
+      statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+      errorMessage:
         'There was a problem updating the payment document. Please try again.',
+      errorMessageKey:
+        'features.publicForm.backendErrors.submission.payment.documentUpdateFailed',
     })
   }
 

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -62,6 +62,7 @@ import {
   generateHashedSubmitterId,
   getCookieNameByAuthType,
   mapRouteError,
+  sendRouteError,
 } from '../submission.utils'
 import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
@@ -127,10 +128,7 @@ const submitEncryptModeForm = async (
 
   if (!hasEnsuredAll) {
     if (!res.headersSent) {
-      const { errorMessage, statusCode } = mapRouteError(
-        new SubmissionFailedError(),
-      )
-      return res.status(statusCode).json({ message: errorMessage })
+      return sendRouteError(res, mapRouteError(new SubmissionFailedError()))
     }
     return // required to stop submission processing
   }
@@ -156,16 +154,12 @@ const submitEncryptModeForm = async (
         .extractJwt(req.cookies)
         .asyncAndThen((jwt) => oidcService.extractJwtPayload(jwt))
       if (jwtPayloadResult.isErr()) {
-        const { statusCode, errorMessage } = mapRouteError(
-          jwtPayloadResult.error,
-        )
         logger.error({
           message: 'Failed to verify Singpass JWT with auth client',
           meta: logMeta,
           error: jwtPayloadResult.error,
         })
-        return res.status(statusCode).json({
-          message: errorMessage,
+        return sendRouteError(res, mapRouteError(jwtPayloadResult.error), {
           spcpSubmissionFailure: true,
         })
       }
@@ -178,16 +172,12 @@ const submitEncryptModeForm = async (
         .extractJwt(req.cookies)
         .asyncAndThen((jwt) => oidcService.extractJwtPayload(jwt))
       if (jwtPayloadResult.isErr()) {
-        const { statusCode, errorMessage } = mapRouteError(
-          jwtPayloadResult.error,
-        )
         logger.error({
           message: 'Failed to verify Corppass JWT with auth client',
           meta: logMeta,
           error: jwtPayloadResult.error,
         })
-        return res.status(statusCode).json({
-          message: errorMessage,
+        return sendRouteError(res, mapRouteError(jwtPayloadResult.error), {
           spcpSubmissionFailure: true,
         })
       }
@@ -216,9 +206,6 @@ const submitEncryptModeForm = async (
           return error
         })
       if (jwtPayloadResult.isErr()) {
-        const { statusCode, errorMessage } = mapRouteError(
-          jwtPayloadResult.error,
-        )
         logger.error({
           message: `Failed to verify ${
             authType === FormAuthType.SGID_MyInfo ? 'SGID' : 'Singpass'
@@ -226,8 +213,7 @@ const submitEncryptModeForm = async (
           meta: logMeta,
           error: jwtPayloadResult.error,
         })
-        return res.status(statusCode).json({
-          message: errorMessage,
+        return sendRouteError(res, mapRouteError(jwtPayloadResult.error), {
           spcpSubmissionFailure: true,
         })
       }
@@ -239,16 +225,12 @@ const submitEncryptModeForm = async (
         req.cookies.jwtSgid,
       )
       if (jwtPayloadResult.isErr()) {
-        const { statusCode, errorMessage } = mapRouteError(
-          jwtPayloadResult.error,
-        )
         logger.error({
           message: 'Failed to verify sgID JWT with auth client',
           meta: logMeta,
           error: jwtPayloadResult.error,
         })
-        return res.status(statusCode).json({
-          message: errorMessage,
+        return sendRouteError(res, mapRouteError(jwtPayloadResult.error), {
           spcpSubmissionFailure: true,
         })
       }
@@ -364,9 +346,12 @@ const submitEncryptModeForm = async (
           error,
         })
 
-        return res
-          .status(StatusCodes.BAD_REQUEST)
-          .json({ message: 'Invalid data was found. Please submit again.' })
+        return sendRouteError(res, {
+          statusCode: StatusCodes.BAD_REQUEST,
+          errorMessage: 'Invalid data was found. Please submit again.',
+          errorMessageKey:
+            'features.publicForm.backendErrors.submission.validation.invalidData',
+        })
       } else {
         // No errors, set local variable to the encrypted string.
         verified = encryptVerifiedContentResult.value
@@ -384,12 +369,7 @@ const submitEncryptModeForm = async (
     )
 
     if (attachmentUploadResult.isErr()) {
-      const { statusCode, errorMessage } = mapRouteError(
-        attachmentUploadResult.error,
-      )
-      return res.status(statusCode).json({
-        message: errorMessage,
-      })
+      return sendRouteError(res, mapRouteError(attachmentUploadResult.error))
     } else {
       attachmentMetadata = attachmentUploadResult.value
     }
@@ -872,11 +852,7 @@ const _getAllEncryptedResponse: ControllerHandler<
           meta: logMeta,
           error,
         })
-
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({
-          message: errorMessage,
-        })
+        return sendRouteError(res, mapRouteError(error))
       })
   )
 }

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.ensures.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.ensures.ts
@@ -37,9 +37,11 @@ export const ensureFormWithinSubmissionLimits: Middleware<
       error: formSubmissionLimitResult.error,
     })
     const routeError = mapRouteError(formSubmissionLimitResult.error)
-    return sendRouteError(res, routeError, {
-      message: form.inactiveMessage,
-    })
+    return sendRouteError(
+      res,
+      { ...routeError, errorMessageKey: undefined, errorMessageParams: undefined },
+      { message: form.inactiveMessage },
+    )
   }
   return next()
 }

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.ensures.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.ensures.ts
@@ -10,7 +10,7 @@ import * as TurnstileService from '../../../services/turnstile/turnstile.service
 import { Middleware } from '../../../utils/pipeline-middleware'
 import { getRequestIp } from '../../../utils/request'
 import * as FormService from '../../form/form.service'
-import { mapRouteError } from '../submission.utils'
+import { mapRouteError, sendRouteError } from '../submission.utils'
 
 const logger = createLoggerWithLabel(module)
 
@@ -36,8 +36,8 @@ export const ensureFormWithinSubmissionLimits: Middleware<
       meta: logMeta,
       error: formSubmissionLimitResult.error,
     })
-    const { statusCode } = mapRouteError(formSubmissionLimitResult.error)
-    return res.status(statusCode).json({
+    const routeError = mapRouteError(formSubmissionLimitResult.error)
+    return sendRouteError(res, routeError, {
       message: form.inactiveMessage,
     })
   }
@@ -70,10 +70,7 @@ export const ensureValidCaptcha: Middleware<
             meta: logMeta,
             error: turnstileResult.error,
           })
-          const { errorMessage, statusCode } = mapRouteError(
-            turnstileResult.error,
-          )
-          return res.status(statusCode).json({ message: errorMessage })
+          return sendRouteError(res, mapRouteError(turnstileResult.error))
         }
         break
       }
@@ -89,10 +86,7 @@ export const ensureValidCaptcha: Middleware<
             meta: logMeta,
             error: captchaResult.error,
           })
-          const { errorMessage, statusCode } = mapRouteError(
-            captchaResult.error,
-          )
-          return res.status(statusCode).json({ message: errorMessage })
+          return sendRouteError(res, mapRouteError(captchaResult.error))
         }
         break
       }
@@ -113,10 +107,7 @@ export const ensurePublicForm: Middleware<FormSubmissionPipelineContext> = (
       meta: logMeta,
       error: formPublicResult.error,
     })
-    const { statusCode, errorMessage } = mapRouteError(formPublicResult.error)
-    return res.status(statusCode).json({
-      message: errorMessage,
-    })
+    return sendRouteError(res, mapRouteError(formPublicResult.error))
   }
   return next()
 }

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -312,9 +312,12 @@ export const validatePaymentSubmission = async (
         meta: logMeta,
       })
 
-      return res.status(StatusCodes.BAD_REQUEST).json({
-        message:
+      return sendRouteError(res, {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage:
           'The payment settings in this form have been updated. Please refresh and try again.',
+        errorMessageKey:
+          'features.publicForm.backendErrors.submission.payment.settingsUpdated',
       })
     }
     return PaymentsService.validatePaymentProducts(

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -37,6 +37,7 @@ import {
   isAttachmentResponse,
   isQuarantinedAttachmentResponse,
   mapRouteError,
+  sendRouteError,
 } from '../submission.utils'
 
 import {
@@ -625,8 +626,7 @@ export const createFormsgAndRetrieveForm = async (
       meta: logMeta,
       error: formResult.error,
     })
-    const { errorMessage, statusCode } = mapRouteError(formResult.error)
-    return res.status(statusCode).json({ message: errorMessage })
+    return sendRouteError(res, mapRouteError(formResult.error))
   }
 
   // Step 3b: Set formsg.formDef in req.body

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -96,6 +96,18 @@ const mockSubmissionId = new ObjectId().toHexString()
 const mockMrfSubmission = {
   _id: mockSubmissionId,
 } as IMultirespondentSubmissionSchema & { _id: Types.ObjectId }
+const SUBMISSION_BACKEND_ERROR_KEY_PREFIX =
+  'features.publicForm.backendErrors.submission'
+
+const expectedSubmissionError = (
+  key: string,
+  message: string,
+  extraBody: Record<string, unknown> = {},
+) => ({
+  message,
+  messageKey: `${SUBMISSION_BACKEND_ERROR_KEY_PREFIX}.${key}`,
+  ...extraBody,
+})
 
 describe('multirespondent-submision.controller', () => {
   beforeEach(() => {
@@ -346,10 +358,12 @@ describe('multirespondent-submision.controller', () => {
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(400)
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message:
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expectedSubmissionError(
+          'files.uploadFailed',
           'Could not upload attachments for submission. For assistance, please contact the person who asked you to fill in this form.',
-      })
+        ),
+      )
     })
 
     it('returns 404 not found when form has reached submission limit', async () => {
@@ -402,6 +416,7 @@ describe('multirespondent-submision.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: inactiveMessage,
+        messageKey: 'features.publicForm.errors.private',
       })
       expect(mockRes.json).toHaveBeenCalledTimes(1)
     })
@@ -443,9 +458,9 @@ describe('multirespondent-submision.controller', () => {
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message: submissionSaveError.message,
-      })
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expectedSubmissionError('saveFailed', submissionSaveError.message),
+      )
     })
 
     it('returns 200 ok when step has invalid workflow type', async () => {
@@ -704,10 +719,12 @@ describe('multirespondent-submision.controller', () => {
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(400)
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message:
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expectedSubmissionError(
+          'files.uploadFailed',
           'Could not upload attachments for submission. For assistance, please contact the person who asked you to fill in this form.',
-      })
+        ),
+      )
     })
 
     it('returns 404 not found when form has reached submission limit', async () => {
@@ -775,6 +792,7 @@ describe('multirespondent-submision.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: inactiveMessage,
+        messageKey: 'features.publicForm.errors.private',
       })
       expect(mockRes.json).toHaveBeenCalledTimes(1)
     })
@@ -830,10 +848,11 @@ describe('multirespondent-submision.controller', () => {
 
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(500)
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message: submissionSaveError.message,
-        submissionId: mockSubmissionId,
-      })
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expectedSubmissionError('saveFailed', submissionSaveError.message, {
+          submissionId: mockSubmissionId,
+        }),
+      )
     })
 
     it('returns 404 not found when submission id not found', async () => {
@@ -1191,6 +1210,7 @@ describe('multirespondent-submision.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(404)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: formNotFoundError.message,
+        messageKey: 'features.publicForm.errors.notFound',
       })
     })
 
@@ -1443,6 +1463,7 @@ describe('multirespondent-submision.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: mailSendError.message,
+        messageKey: `${SUBMISSION_BACKEND_ERROR_KEY_PREFIX}.generic`,
       })
     })
   })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -625,6 +625,8 @@ describe('Multirespondent Submission Middleware', () => {
         expect(mockRes.status).toHaveBeenCalledWith(500)
         expect(mockRes.json).toHaveBeenCalledWith({
           message: 'Failed to retrieve submitter ID. Please try again.',
+          messageKey:
+            'features.publicForm.backendErrors.submission.mrf.missingSubmitterId',
         })
       })
     })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -42,7 +42,7 @@ import {
   getEncryptedSubmissionData,
   transformAttachmentMetasToSignedUrls,
 } from '../submission.service'
-import { mapRouteError } from '../submission.utils'
+import { mapRouteError, sendRouteError } from '../submission.utils'
 
 import { ensureSubmitterIdIsWhitelisted } from './multirespondent-submission.ensures'
 import * as MultirespondentSubmissionMiddleware from './multirespondent-submission.middleware'
@@ -114,10 +114,7 @@ const submitMultirespondentForm = async (
 
   if (!hasEnsuredAll) {
     if (!res.headersSent) {
-      const { errorMessage, statusCode } = mapRouteError(
-        new SubmissionFailedError(),
-      )
-      return res.status(statusCode).json({ message: errorMessage })
+      return sendRouteError(res, mapRouteError(new SubmissionFailedError()))
     }
     return // required to stop submission processing
   }
@@ -134,8 +131,7 @@ const submitMultirespondentForm = async (
   if (createMultiRespondentFormSubmissionResult.isErr()) {
     const error = createMultiRespondentFormSubmissionResult.error
 
-    const { errorMessage, statusCode } = mapRouteError(error)
-    return res.status(statusCode).json({ message: errorMessage })
+    return sendRouteError(res, mapRouteError(error))
   }
 
   const submission = createMultiRespondentFormSubmissionResult.value
@@ -176,10 +172,7 @@ const updateMultirespondentSubmission = async (
   const { formDef: currentForm, snapshottedFormDef } = req.formsg
 
   if (!snapshottedFormDef) {
-    const { errorMessage, statusCode } = mapRouteError(
-      new SubmissionFailedError(),
-    )
-    return res.status(statusCode).json({ message: errorMessage })
+    return sendRouteError(res, mapRouteError(new SubmissionFailedError()))
   }
 
   setFormTags(currentForm)
@@ -204,10 +197,7 @@ const updateMultirespondentSubmission = async (
 
   if (!hasEnsuredAll) {
     if (!res.headersSent) {
-      const { errorMessage, statusCode } = mapRouteError(
-        new SubmissionFailedError(),
-      )
-      return res.status(statusCode).json({ message: errorMessage })
+      return sendRouteError(res, mapRouteError(new SubmissionFailedError()))
     }
     return // required to stop submission processing
   }
@@ -226,14 +216,19 @@ const updateMultirespondentSubmission = async (
     const error = updateMultiRespondentFormSubmissionResult.error
 
     if (error instanceof SubmissionSaveError) {
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: error.message,
-        submissionId,
-      })
+      return sendRouteError(
+        res,
+        {
+          statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+          errorMessage: error.message,
+          errorMessageKey:
+            'features.publicForm.backendErrors.submission.saveFailed',
+        },
+        { submissionId },
+      )
     }
 
-    const { errorMessage, statusCode } = mapRouteError(error)
-    return res.status(statusCode).json({ message: errorMessage })
+    return sendRouteError(res, mapRouteError(error))
   }
 
   const submission = updateMultiRespondentFormSubmissionResult.value
@@ -378,10 +373,7 @@ export const handleGetMultirespondentSubmissionForRespondent: ControllerHandler<
           error,
         })
 
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({
-          message: errorMessage,
-        })
+        return sendRouteError(res, mapRouteError(error))
       })
   )
 }
@@ -471,10 +463,7 @@ const sendPendingMrfSubmissionReminder: ControllerHandler<
       return
     })
     .mapErr((err) => {
-      const { errorMessage, statusCode } = mapRouteError(err)
-      return res.status(statusCode).json({
-        message: errorMessage,
-      })
+      return sendRouteError(res, mapRouteError(err))
     })
 }
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.ensures.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.ensures.ts
@@ -6,7 +6,7 @@ import {
 import { Middleware } from '../../../utils/pipeline-middleware'
 import { FormRespondentNotWhitelistedError } from '../../form/form.errors'
 import * as FormService from '../../form/form.service'
-import { mapRouteError } from '../submission.utils'
+import { mapRouteError, sendRouteError } from '../submission.utils'
 
 import {
   ProcessedMultirespondentSubmissionHandlerType,
@@ -38,8 +38,7 @@ export const ensureSubmitterIdIsWhitelisted: Middleware<
       error,
     })
 
-    const { statusCode, errorMessage } = mapRouteError(error)
-    res.status(statusCode).json({ message: errorMessage })
+    return sendRouteError(res, mapRouteError(error))
     return
   }
 
@@ -55,10 +54,7 @@ export const ensureSubmitterIdIsWhitelisted: Middleware<
       error: formRespondentNotWhitelistedError,
     })
 
-    const { statusCode, errorMessage } = mapRouteError(
-      formRespondentNotWhitelistedError,
-    )
-    res.status(statusCode).json({ message: errorMessage })
+    return sendRouteError(res, mapRouteError(formRespondentNotWhitelistedError))
     return
   }
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.ensures.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.ensures.ts
@@ -39,7 +39,6 @@ export const ensureSubmitterIdIsWhitelisted: Middleware<
     })
 
     return sendRouteError(res, mapRouteError(error))
-    return
   }
 
   const isRespondentNotWhitelisted =
@@ -55,7 +54,6 @@ export const ensureSubmitterIdIsWhitelisted: Middleware<
     })
 
     return sendRouteError(res, mapRouteError(formRespondentNotWhitelistedError))
-    return
   }
 
   return next()

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -61,6 +61,7 @@ import {
   getEncryptedAttachmentsMapFromAttachmentsMap,
   isAttachmentResponseV3,
   mapRouteError,
+  sendRouteError,
 } from '../submission.utils'
 
 import {
@@ -186,8 +187,7 @@ export const createFormsgAndRetrieveForm = (
             meta: logMeta,
             error,
           })
-          const { statusCode, errorMessage } = mapRouteError(error)
-          return res.status(statusCode).json({ message: errorMessage })
+          return sendRouteError(res, mapRouteError(error))
         })
         .map((mrfSubmission) => {
           formsg.mrfSubmission = mrfSubmission
@@ -202,8 +202,7 @@ export const createFormsgAndRetrieveForm = (
                 meta: logMeta,
                 error,
               })
-              const { errorMessage, statusCode } = mapRouteError(error)
-              return res.status(statusCode).json({ message: errorMessage })
+              return sendRouteError(res, mapRouteError(error))
             })
             .andThen((latestFormDef) => {
               // Step 4a: Check form is multirespondent form
@@ -215,10 +214,7 @@ export const createFormsgAndRetrieveForm = (
                     meta: logMeta,
                     error,
                   })
-                  const { statusCode, errorMessage } = mapRouteError(error)
-                  return res.status(statusCode).json({
-                    message: errorMessage,
-                  })
+                  return sendRouteError(res, mapRouteError(error))
                 },
               )
             })
@@ -374,12 +370,7 @@ export const scanAndRetrieveAttachments = async (
       error: scanAndRetrieveFilesResult.error,
     })
 
-    const { statusCode, errorMessage } = mapRouteError(
-      scanAndRetrieveFilesResult.error,
-    )
-    return res.status(statusCode).json({
-      message: errorMessage,
-    })
+    return sendRouteError(res, mapRouteError(scanAndRetrieveFilesResult.error))
   }
 
   logger.info({
@@ -655,10 +646,7 @@ export const validateMultirespondentSubmission = async (
           error,
         })
 
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({
-          message: errorMessage,
-        })
+        return sendRouteError(res, mapRouteError(error))
       })
   )
 }
@@ -719,10 +707,7 @@ export const setCurrentWorkflowStep = async (
           error,
         })
 
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({
-          message: errorMessage,
-        })
+        return sendRouteError(res, mapRouteError(error))
       })
   )
 }
@@ -882,14 +867,12 @@ export const handleNdiResponses = async (
     }
 
     if (jwtPayloadResult?.isErr()) {
-      const { statusCode, errorMessage } = mapRouteError(jwtPayloadResult.error)
       logger.error({
         message: `Failed to verify ${authType} JWT with auth client`,
         meta: logMeta,
         error: jwtPayloadResult.error,
       })
-      return res.status(statusCode).json({
-        message: errorMessage,
+      return sendRouteError(res, mapRouteError(jwtPayloadResult.error), {
         spcpSubmissionFailure: true,
       })
     } else {
@@ -910,18 +893,18 @@ export const handleNdiResponses = async (
           error,
         })
 
-        return res
-          .status(StatusCodes.BAD_REQUEST)
-          .json({ message: 'Invalid data was found. Please submit again.' })
+        return sendRouteError(res, {
+          statusCode: StatusCodes.BAD_REQUEST,
+          errorMessage: 'Invalid data was found. Please submit again.',
+          errorMessageKey:
+            'features.publicForm.backendErrors.submission.validation.invalidData',
+        })
       }
 
       const submitterId = userName?.toUpperCase()
       if (!submitterId) {
         const missingSubmitterIdError = new MissingSubmitterIdError()
-        const { statusCode, errorMessage } = mapRouteError(
-          missingSubmitterIdError,
-        )
-        return res.status(statusCode).json({ message: errorMessage })
+        return sendRouteError(res, mapRouteError(missingSubmitterIdError))
       }
       const hashedSubmitterId = generateHashedSubmitterId(submitterId, formId)
       req.formsg.encryptedPayload.hashedSubmitterId = hashedSubmitterId
@@ -959,9 +942,12 @@ export const handleNdiResponses = async (
         meta: logMeta,
       })
 
-      return res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid data was found. Please submit again.' })
+      return sendRouteError(res, {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: 'Invalid data was found. Please submit again.',
+        errorMessageKey:
+          'features.publicForm.backendErrors.submission.validation.invalidData',
+      })
     }
   }
 
@@ -986,9 +972,12 @@ export const handleNdiResponses = async (
         error,
       })
 
-      return res
-        .status(StatusCodes.BAD_REQUEST)
-        .json({ message: 'Invalid data was found. Please submit again.' })
+      return sendRouteError(res, {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: 'Invalid data was found. Please submit again.',
+        errorMessageKey:
+          'features.publicForm.backendErrors.submission.validation.invalidData',
+      })
     } else {
       req.formsg.encryptedPayload.verifiedContent =
         encryptVerifiedContentResult.value

--- a/apps/backend/src/app/modules/submission/receiver/receiver.middleware.ts
+++ b/apps/backend/src/app/modules/submission/receiver/receiver.middleware.ts
@@ -10,6 +10,7 @@ import { Result } from 'neverthrow'
 import { createLoggerWithLabel } from '../../../config/logger'
 import { createReqMeta } from '../../../utils/request'
 import { ControllerHandler } from '../../core/core.types'
+import { sendRouteError } from '../submission.utils'
 
 import { InitialiseMultipartReceiverError } from './receiver.errors'
 import * as SubmissionReceiver from './receiver.service'
@@ -127,7 +128,6 @@ const receiveSubmission = async (
         meta: logMeta,
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return sendRouteError(res, mapRouteError(error))
     })
 }

--- a/apps/backend/src/app/modules/submission/submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/submission.utils.ts
@@ -1,6 +1,7 @@
 import { GrowthBook } from '@growthbook/growthbook'
 import { encode as encodeBase64 } from '@stablelib/base64'
 import crypto from 'crypto'
+import { Response } from 'express'
 import {
   AdminEmailPdfFeatureValue,
   featureFlags,
@@ -84,6 +85,7 @@ import {
   EmptyErrorFieldError,
   MalformedParametersError,
 } from '../core/core.errors'
+import { ErrorResponseData } from '../core/core.types'
 import {
   ForbiddenFormError,
   FormDeletedError,
@@ -137,6 +139,7 @@ import {
   DownloadCleanFileFailedError,
   ExpectedResponseNotFoundError,
   FeatureDisabledError,
+  GuardDutyDownloadCleanFileFailedError,
   GuardDutyInvalidFileKeyError,
   GuardDutyParseVirusScannerLambdaPayloadError,
   GuardDutyVirusScanFailedError,
@@ -144,6 +147,7 @@ import {
   InvalidFieldIdError,
   InvalidFileExtensionError,
   InvalidFileKeyError,
+  InvalidWorkflowTypeError,
   MaliciousFileDetectedError,
   MissingSubmitterIdError,
   MrfReminderInvalidWorkflowStepError,
@@ -174,6 +178,32 @@ type ResponseModeFilterParam = {
 }
 
 const MB_MULTIPLIER = 1000000
+const PUBLIC_FORM_BACKEND_ERROR_KEY_PREFIX =
+  'features.publicForm.backendErrors.submission'
+
+const submissionErrorKey = (suffix: string) =>
+  `${PUBLIC_FORM_BACKEND_ERROR_KEY_PREFIX}.${suffix}`
+
+const buildErrorDto = ({
+  errorMessage,
+  errorMessageKey,
+  errorMessageParams,
+}: ErrorResponseData) => ({
+  message: errorMessage,
+  ...(errorMessageKey ? { messageKey: errorMessageKey } : {}),
+  ...(errorMessageParams ? { messageParams: errorMessageParams } : {}),
+})
+
+export const sendRouteError = (
+  res: Response,
+  routeError: ErrorResponseData,
+  extraBody: Record<string, unknown> = {},
+) => {
+  return res.status(routeError.statusCode).json({
+    ...buildErrorDto(routeError),
+    ...extraBody,
+  })
+}
 
 /**
  * Handler to map ApplicationErrors to their correct status code and error
@@ -190,16 +220,19 @@ const errorMapper: MapRouteError = (
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'Could not upload attachments for submission. For assistance, please contact the person who asked you to fill in this form.',
+        errorMessageKey: submissionErrorKey('files.uploadFailed'),
       }
     case SubmissionSaveError:
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: error.message,
+        errorMessageKey: submissionErrorKey('saveFailed'),
       }
     case CreateRedirectUrlError:
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: coreErrorMessage,
+        errorMessageKey: submissionErrorKey('loginFailed'),
       }
     case FormRespondentNotWhitelistedError:
       return {
@@ -225,23 +258,27 @@ const errorMapper: MapRouteError = (
         statusCode: StatusCodes.UNAUTHORIZED,
         errorMessage:
           'Something went wrong with your login. Please try logging in and submitting again.',
+        errorMessageKey: submissionErrorKey('loginFailed'),
       }
     case MyInfoMissingHashError:
       return {
         statusCode: StatusCodes.GONE,
         errorMessage:
           'MyInfo verification expired, please refresh and try again.',
+        errorMessageKey: submissionErrorKey('myInfo.expired'),
       }
     case MyInfoHashDidNotMatchError:
       return {
         statusCode: StatusCodes.UNAUTHORIZED,
         errorMessage: 'MyInfo verification failed.',
+        errorMessageKey: submissionErrorKey('myInfo.failed'),
       }
     case MyInfoHashingError:
       return {
         statusCode: StatusCodes.SERVICE_UNAVAILABLE,
         errorMessage:
           'MyInfo verification unavailable, please try again later.',
+        errorMessageKey: submissionErrorKey('myInfo.unavailable'),
       }
     case MissingUserError:
       return {
@@ -252,6 +289,7 @@ const errorMapper: MapRouteError = (
       return {
         statusCode: StatusCodes.NOT_FOUND,
         errorMessage: error.message,
+        errorMessageKey: 'features.publicForm.errors.notFound',
       }
     case ResponseModeError:
     case InvalidPaymentProductsError:
@@ -269,46 +307,54 @@ const errorMapper: MapRouteError = (
       return {
         statusCode: StatusCodes.GONE,
         errorMessage: error.message,
+        errorMessageKey: 'features.publicForm.errors.deleted',
       }
     case PrivateFormError:
       return {
         statusCode: StatusCodes.NOT_FOUND,
         errorMessage:
           'This form has been taken down. For assistance, please contact the person who asked you to fill in this form.',
+        errorMessageKey: 'features.publicForm.errors.private',
       }
     case CaptchaConnectionError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'Could not verify captcha. Please submit again in a few minutes.',
+        errorMessageKey: submissionErrorKey('captcha.connection'),
       }
     case VerifyCaptchaError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: 'Captcha was incorrect. Please submit again.',
+        errorMessageKey: submissionErrorKey('captcha.incorrect'),
       }
     case MissingCaptchaError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: 'Captcha was missing. Please refresh and submit again.',
+        errorMessageKey: submissionErrorKey('captcha.missing'),
       }
     case TurnstileConnectionError:
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage:
           'Error connecting to Turnstile server . Please submit again in a few minutes.',
+        errorMessageKey: submissionErrorKey('turnstile.connection'),
       }
     case VerifyTurnstileError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'Incorrect Turnstile parameters. Please refresh and submit again.',
+        errorMessageKey: submissionErrorKey('turnstile.incorrectParameters'),
       }
     case MissingTurnstileError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'Missing Turnstile challenge. Please refresh and submit again.',
+        errorMessageKey: submissionErrorKey('turnstile.missingChallenge'),
       }
     case MalformedParametersError:
       return {
@@ -330,12 +376,14 @@ const errorMapper: MapRouteError = (
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'Invalid data was found. Please check your responses and submit again.',
+        errorMessageKey: submissionErrorKey('validation.invalidData'),
       }
     case DatabasePayloadSizeError:
       return {
         statusCode: StatusCodes.REQUEST_TOO_LONG,
         errorMessage:
           'Submission too large to be saved. Please reduce the size of your submission and try again.',
+        errorMessageKey: submissionErrorKey('validation.submissionTooLarge'),
       }
     case ValidateFieldError:
     case ValidateFieldErrorV3:
@@ -347,6 +395,7 @@ const errorMapper: MapRouteError = (
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page.',
+        errorMessageKey: submissionErrorKey('validation.invalidSubmission'),
       }
     case DatabaseConflictError:
     case ConflictError:
@@ -354,16 +403,33 @@ const errorMapper: MapRouteError = (
         statusCode: StatusCodes.CONFLICT,
         errorMessage:
           'The form has been updated. Please refresh and submit again.',
+        errorMessageKey: submissionErrorKey('validation.formUpdated'),
+      }
+    case MissingSubmitterIdError:
+      return {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        errorMessage: error.message,
+        errorMessageKey: submissionErrorKey('mrf.missingSubmitterId'),
+      }
+    case VirusScanFailedError:
+    case GuardDutyVirusScanFailedError:
+      return {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        errorMessage: error.message,
+        errorMessageKey: submissionErrorKey('files.virusScanFailed'),
+      }
+    case DownloadCleanFileFailedError:
+    case GuardDutyDownloadCleanFileFailedError:
+      return {
+        statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
+        errorMessage: error.message,
+        errorMessageKey: submissionErrorKey('files.cleanFileDownloadFailed'),
       }
     case FormWhitelistSettingNotFoundError:
-    case MissingSubmitterIdError:
     case PaymentNotFoundError:
     case CreatePresignedPostError:
     case DatabaseError:
     case EmptyErrorFieldError:
-    case VirusScanFailedError:
-    case GuardDutyVirusScanFailedError:
-    case DownloadCleanFileFailedError:
     case ParseVirusScannerLambdaPayloadError:
     case GuardDutyParseVirusScannerLambdaPayloadError:
       return {
@@ -372,14 +438,30 @@ const errorMapper: MapRouteError = (
       }
     case SubmissionFailedError:
     case InvalidFieldIdError:
-    case AttachmentSizeLimitExceededError:
     case InvalidFileKeyError:
     case GuardDutyInvalidFileKeyError:
     case MaliciousFileDetectedError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+      }
+    case AttachmentSizeLimitExceededError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+        errorMessageKey: submissionErrorKey('files.totalSizeExceeded'),
+      }
     case ExpectedResponseNotFoundError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,
+        errorMessageKey: submissionErrorKey('mrf.expectedResponseNotFound'),
+      }
+    case InvalidWorkflowTypeError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+        errorMessageKey: submissionErrorKey('mrf.invalidWorkflowType'),
       }
     case MrfReminderInvalidWorkflowStepError:
     case MrfReminderRecipientEmailsEmptyError:
@@ -392,11 +474,13 @@ const errorMapper: MapRouteError = (
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage:
           'The link you used is no longer valid. Please contact the form admin that gave you this link.',
+        errorMessageKey: submissionErrorKey('mrf.invalidLink'),
       }
     case MailSendError:
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: error.message,
+        errorMessageKey: submissionErrorKey('generic'),
       }
     default:
       logger.error({
@@ -410,6 +494,7 @@ const errorMapper: MapRouteError = (
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage: 'Something went wrong. Please try again.',
+        errorMessageKey: submissionErrorKey('generic'),
       }
   }
 }

--- a/apps/backend/src/app/modules/submission/submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/submission.utils.ts
@@ -1,7 +1,7 @@
 import { GrowthBook } from '@growthbook/growthbook'
 import { encode as encodeBase64 } from '@stablelib/base64'
 import crypto from 'crypto'
-import { Response } from 'express'
+import type { Response } from 'express'
 import {
   AdminEmailPdfFeatureValue,
   featureFlags,

--- a/apps/backend/src/app/modules/submission/submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/submission.utils.ts
@@ -339,7 +339,7 @@ const errorMapper: MapRouteError = (
       return {
         statusCode: StatusCodes.INTERNAL_SERVER_ERROR,
         errorMessage:
-          'Error connecting to Turnstile server . Please submit again in a few minutes.',
+          'Error connecting to Turnstile server. Please submit again in a few minutes.',
         errorMessageKey: submissionErrorKey('turnstile.connection'),
       }
     case VerifyTurnstileError:

--- a/apps/backend/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/apps/backend/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -107,6 +107,17 @@ const mockCpOidcServiceClass = jest.mocked(
 )
 
 describe('Verification controller', () => {
+  const VERIFICATION_BACKEND_ERROR_KEY_PREFIX =
+    'features.publicForm.backendErrors.verification'
+  const expectedVerificationError = (
+    key: string,
+    message: string,
+    messageParams?: Record<string, string | number>,
+  ) => ({
+    message,
+    messageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.${key}`,
+    ...(messageParams ? { messageParams } : {}),
+  })
   const MOCK_FORM_ID = new ObjectId().toHexString()
   const MOCK_TRANSACTION_ID = new ObjectId().toHexString()
   const MOCK_FIELD_ID = new ObjectId().toHexString()
@@ -538,9 +549,10 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new TransactionExpiredError("don't eat expired food")),
       )
-      const expectedResponse = {
-        message: 'Your session has expired, please refresh and try again.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'sessionExpired',
+        'Your session has expired, please refresh and try again.',
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -594,10 +606,10 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new MailSendError()),
       )
-      const expectedResponse = {
-        message:
-          'Sorry, we were unable to send the email out at this time. Please ensure that the email entered is correct. If this problem persists, please refresh and try again later.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'mailSend',
+        'Sorry, we were unable to send the email out at this time. Please ensure that the email entered is correct. If this problem persists, please refresh and try again later.',
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -623,10 +635,10 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new InvalidNumberError()),
       )
-      const expectedResponse = {
-        message:
-          'This phone number does not seem to be valid. Please try again with a valid phone number.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'invalidNumber',
+        'This phone number does not seem to be valid. Please try again with a valid phone number.',
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -652,10 +664,10 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new SmsLimitExceededError()),
       )
-      const expected = {
-        message:
-          'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',
-      }
+      const expected = expectedVerificationError(
+        'outdatedForm',
+        'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -1082,9 +1094,11 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new WaitForOtpError()),
       )
-      const expectedResponse = {
-        message: `You must wait for ${WAIT_FOR_OTP_SECONDS} seconds between each OTP request.`,
-      }
+      const expectedResponse = expectedVerificationError(
+        'waitForOtp',
+        `You must wait for ${WAIT_FOR_OTP_SECONDS} seconds between each OTP request.`,
+        { waitForOtpSeconds: WAIT_FOR_OTP_SECONDS },
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -1399,9 +1413,10 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new TransactionExpiredError("don't eat expired food")),
       )
-      const expectedResponse = {
-        message: 'Your session has expired, please refresh and try again.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'sessionExpired',
+        'Your session has expired, please refresh and try again.',
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -1455,10 +1470,10 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new MailSendError()),
       )
-      const expectedResponse = {
-        message:
-          'Sorry, we were unable to send the email out at this time. Please ensure that the email entered is correct. If this problem persists, please refresh and try again later.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'mailSend',
+        'Sorry, we were unable to send the email out at this time. Please ensure that the email entered is correct. If this problem persists, please refresh and try again later.',
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -1484,10 +1499,10 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new InvalidNumberError()),
       )
-      const expectedResponse = {
-        message:
-          'This phone number does not seem to be valid. Please try again with a valid phone number.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'invalidNumber',
+        'This phone number does not seem to be valid. Please try again with a valid phone number.',
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -1513,10 +1528,10 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new SmsLimitExceededError()),
       )
-      const expected = {
-        message:
-          'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',
-      }
+      const expected = expectedVerificationError(
+        'outdatedForm',
+        'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -1943,9 +1958,11 @@ describe('Verification controller', () => {
       MockVerificationService.sendNewOtp.mockReturnValueOnce(
         errAsync(new WaitForOtpError()),
       )
-      const expectedResponse = {
-        message: `You must wait for ${WAIT_FOR_OTP_SECONDS} seconds between each OTP request.`,
-      }
+      const expectedResponse = expectedVerificationError(
+        'waitForOtp',
+        `You must wait for ${WAIT_FOR_OTP_SECONDS} seconds between each OTP request.`,
+        { waitForOtpSeconds: WAIT_FOR_OTP_SECONDS },
+      )
 
       // Act
       await VerificationController._handleGenerateOtp(
@@ -2408,9 +2425,12 @@ describe('Verification controller', () => {
         MockVerificationService.resetFieldForTransaction,
       ).toHaveBeenCalledWith(resetFieldForTransactionToHaveBeenCalledWith)
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message: expect.any(String),
-      })
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expectedVerificationError(
+          'sessionExpired',
+          'Your session has expired, please refresh and try again.',
+        ),
+      )
     })
 
     it('should return 404 when form is not found', async () => {
@@ -2587,9 +2607,10 @@ describe('Verification controller', () => {
       MockVerificationService.verifyOtp.mockReturnValueOnce(
         errAsync(new TransactionExpiredError()),
       )
-      const expectedResponse = {
-        message: 'Your session has expired, please refresh and try again.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'sessionExpired',
+        'Your session has expired, please refresh and try again.',
+      )
 
       // Act
       await VerificationController._handleOtpVerification(
@@ -2720,9 +2741,10 @@ describe('Verification controller', () => {
       MockVerificationService.verifyOtp.mockReturnValueOnce(
         errAsync(new OtpExpiredError()),
       )
-      const expectedResponse = {
-        message: 'Your OTP has expired, please request for a new one.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'otpExpired',
+        'Your OTP has expired, please request for a new one.',
+      )
 
       // Act
       await VerificationController._handleOtpVerification(
@@ -2749,10 +2771,10 @@ describe('Verification controller', () => {
       MockVerificationService.verifyOtp.mockReturnValueOnce(
         errAsync(new OtpRetryExceededError()),
       )
-      const expectedResponse = {
-        message:
-          'You have entered too many invalid OTPs. Please request for a new OTP and try again.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'otpRetryExceeded',
+        'You have entered too many invalid OTPs. Please request for a new OTP and try again.',
+      )
 
       // Act
       await VerificationController._handleOtpVerification(
@@ -2779,9 +2801,10 @@ describe('Verification controller', () => {
       MockVerificationService.verifyOtp.mockReturnValueOnce(
         errAsync(new WrongOtpError()),
       )
-      const expectedResponse = {
-        message: 'Wrong OTP.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'wrongOtp',
+        'Wrong OTP.',
+      )
 
       // Act
       await VerificationController._handleOtpVerification(
@@ -2890,9 +2913,10 @@ describe('Verification controller', () => {
       MockVerificationService.verifyOtp.mockReturnValueOnce(
         errAsync(new TransactionExpiredError()),
       )
-      const expectedResponse = {
-        message: 'Your session has expired, please refresh and try again.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'sessionExpired',
+        'Your session has expired, please refresh and try again.',
+      )
 
       // Act
       await VerificationController._handleOtpVerification(
@@ -3023,9 +3047,10 @@ describe('Verification controller', () => {
       MockVerificationService.verifyOtp.mockReturnValueOnce(
         errAsync(new OtpExpiredError()),
       )
-      const expectedResponse = {
-        message: 'Your OTP has expired, please request for a new one.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'otpExpired',
+        'Your OTP has expired, please request for a new one.',
+      )
 
       // Act
       await VerificationController._handleOtpVerification(
@@ -3052,10 +3077,10 @@ describe('Verification controller', () => {
       MockVerificationService.verifyOtp.mockReturnValueOnce(
         errAsync(new OtpRetryExceededError()),
       )
-      const expectedResponse = {
-        message:
-          'You have entered too many invalid OTPs. Please request for a new OTP and try again.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'otpRetryExceeded',
+        'You have entered too many invalid OTPs. Please request for a new OTP and try again.',
+      )
 
       // Act
       await VerificationController._handleOtpVerification(
@@ -3082,9 +3107,10 @@ describe('Verification controller', () => {
       MockVerificationService.verifyOtp.mockReturnValueOnce(
         errAsync(new WrongOtpError()),
       )
-      const expectedResponse = {
-        message: 'Wrong OTP.',
-      }
+      const expectedResponse = expectedVerificationError(
+        'wrongOtp',
+        'Wrong OTP.',
+      )
 
       // Act
       await VerificationController._handleOtpVerification(

--- a/apps/backend/src/app/modules/verification/verification.controller.ts
+++ b/apps/backend/src/app/modules/verification/verification.controller.ts
@@ -14,7 +14,7 @@ import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
 import { generateOtpWithHash } from '../../utils/otp'
 import { createReqMeta, getRequestIp } from '../../utils/request'
-import { ControllerHandler } from '../core/core.types'
+import { ControllerHandler, ErrorResponseData } from '../core/core.types'
 import { setFormTags } from '../datadog/datadog.utils'
 import * as FormService from '../form/form.service'
 import { MyInfoService } from '../myinfo/myinfo.service'
@@ -32,6 +32,16 @@ import { Transaction } from './verification.types'
 import { mapRouteError } from './verification.util'
 
 const logger = createLoggerWithLabel(module)
+
+const buildErrorDto = ({
+  errorMessage,
+  errorMessageKey,
+  errorMessageParams,
+}: ErrorResponseData): ErrorDto => ({
+  message: errorMessage,
+  ...(errorMessageKey ? { messageKey: errorMessageKey } : {}),
+  ...(errorMessageParams ? { messageParams: errorMessageParams } : {}),
+})
 
 /**
  * Handler for POST /forms/:formId/fieldverifications
@@ -67,8 +77,10 @@ export const handleCreateVerificationTransaction: ControllerHandler<
         meta: logMeta,
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      const errorResponse = mapRouteError(error)
+      return res
+        .status(errorResponse.statusCode)
+        .json(buildErrorDto(errorResponse))
     })
 }
 
@@ -287,8 +299,10 @@ export const _handleGenerateOtp: ControllerHandler<
           meta: logMeta,
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        const errorResponse = mapRouteError(error)
+        return res
+          .status(errorResponse.statusCode)
+          .json(buildErrorDto(errorResponse))
       })
   )
 }
@@ -357,8 +371,10 @@ export const _handleOtpVerification: ControllerHandler<
           meta: logMeta,
           error,
         })
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        const errorResponse = mapRouteError(error)
+        return res
+          .status(errorResponse.statusCode)
+          .json(buildErrorDto(errorResponse))
       })
   )
 }
@@ -419,7 +435,9 @@ export const handleResetFieldVerification: ControllerHandler<
         meta: logMeta,
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      const errorResponse = mapRouteError(error)
+      return res
+        .status(errorResponse.statusCode)
+        .json(buildErrorDto(errorResponse))
     })
 }

--- a/apps/backend/src/app/modules/verification/verification.util.ts
+++ b/apps/backend/src/app/modules/verification/verification.util.ts
@@ -62,6 +62,8 @@ import {
 } from './verification.errors'
 
 const logger = createLoggerWithLabel(module)
+const VERIFICATION_BACKEND_ERROR_KEY_PREFIX =
+  'features.publicForm.backendErrors.verification'
 
 /**
  * Evaluates whether a field is verifiable
@@ -162,38 +164,48 @@ export const mapRouteError: MapRouteError = (
     case TransactionExpiredError:
       return {
         errorMessage: 'Your session has expired, please refresh and try again.',
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.sessionExpired`,
         statusCode: StatusCodes.BAD_REQUEST,
       }
     case OtpExpiredError:
       return {
         errorMessage: 'Your OTP has expired, please request for a new one.',
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.otpExpired`,
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
       }
     case OtpRetryExceededError:
       return {
         errorMessage:
           'You have entered too many invalid OTPs. Please request for a new OTP and try again.',
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.otpRetryExceeded`,
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
       }
     case WrongOtpError:
       return {
         errorMessage: 'Wrong OTP.',
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.wrongOtp`,
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
       }
     case WaitForOtpError:
       return {
         errorMessage: `You must wait for ${WAIT_FOR_OTP_SECONDS} seconds between each OTP request.`,
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.waitForOtp`,
+        errorMessageParams: {
+          waitForOtpSeconds: WAIT_FOR_OTP_SECONDS,
+        },
         statusCode: StatusCodes.UNPROCESSABLE_ENTITY,
       }
     case OtpRequestCountExceededError:
       return {
         errorMessage: `You have requested too many OTPs. Please refresh and try again.`,
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.otpRequestCountExceeded`,
         statusCode: StatusCodes.BAD_REQUEST,
       }
     case InvalidNumberError:
       return {
         errorMessage:
           'This phone number does not seem to be valid. Please try again with a valid phone number.',
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.invalidNumber`,
         statusCode: StatusCodes.BAD_REQUEST,
       }
     case MalformedParametersError:
@@ -223,6 +235,7 @@ export const mapRouteError: MapRouteError = (
       return {
         errorMessage:
           'Sorry, we were unable to send the email out at this time. Please ensure that the email entered is correct. If this problem persists, please refresh and try again later.',
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.mailSend`,
         statusCode: StatusCodes.BAD_REQUEST,
       }
     case DatabasePayloadSizeError:
@@ -249,6 +262,7 @@ export const mapRouteError: MapRouteError = (
       return {
         errorMessage:
           'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',
+        errorMessageKey: `${VERIFICATION_BACKEND_ERROR_KEY_PREFIX}.outdatedForm`,
         statusCode: StatusCodes.BAD_REQUEST,
       }
     case HashingError:

--- a/apps/backend/src/types/routing.ts
+++ b/apps/backend/src/types/routing.ts
@@ -1,3 +1,4 @@
+import { I18nMessageParams } from 'formsg-shared/types'
 import { StatusCodes } from 'http-status-codes'
 
 import { ApplicationError } from '../app/modules/core/core.errors'
@@ -5,6 +6,8 @@ import { ApplicationError } from '../app/modules/core/core.errors'
 type ErrorResponseData = {
   statusCode: StatusCodes
   errorMessage: string
+  errorMessageKey?: string
+  errorMessageParams?: I18nMessageParams
 }
 
 export interface MapRouteError {

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -4,6 +4,25 @@ import { enSG as table } from './table'
 import { PublicForm } from '.'
 
 export const enSG: PublicForm = {
+  backendErrors: {
+    verification: {
+      sessionExpired: 'Your session has expired, please refresh and try again.',
+      otpExpired: 'Your OTP has expired, please request for a new one.',
+      otpRetryExceeded:
+        'You have entered too many invalid OTPs. Please request for a new OTP and try again.',
+      wrongOtp: 'Wrong OTP.',
+      waitForOtp:
+        'You must wait for {waitForOtpSeconds} seconds between each OTP request.',
+      otpRequestCountExceeded:
+        'You have requested too many OTPs. Please refresh and try again.',
+      invalidNumber:
+        'This phone number does not seem to be valid. Please try again with a valid phone number.',
+      mailSend:
+        'Sorry, we were unable to send the email out at this time. Please ensure that the email entered is correct. If this problem persists, please refresh and try again later.',
+      outdatedForm:
+        'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',
+    },
+  },
   errors: {
     notAvailable: 'This form is not available.',
     notFound: 'Form not found',

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -74,6 +74,18 @@ export const enSG: PublicForm = {
         expectedResponseNotFound:
           'Response for the Yes/No field for this approval step is not found',
       },
+      payment: {
+        invalidSettings:
+          "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+        pendingSubmissionSaveFailed:
+          'Could not save pending submission. For assistance, please contact the person who asked you to fill in this form.',
+        intentCreateFailed:
+          'There was a problem creating the payment intent. Please try again.',
+        documentUpdateFailed:
+          'There was a problem updating the payment document. Please try again.',
+        settingsUpdated:
+          'The payment settings in this form have been updated. Please refresh and try again.',
+      },
       generic: 'Something went wrong. Please try again.',
     },
   },

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -22,6 +22,60 @@ export const enSG: PublicForm = {
       outdatedForm:
         'Sorry, this form is outdated. Please refresh your browser to get the latest version of the form',
     },
+    submission: {
+      saveFailed: 'Failed to save submission. Please try again later.',
+      loginFailed:
+        'Something went wrong with your login. Please try logging in and submitting again.',
+      myInfo: {
+        expired: 'MyInfo verification expired, please refresh and try again.',
+        failed: 'MyInfo verification failed.',
+        unavailable: 'MyInfo verification unavailable, please try again later.',
+      },
+      captcha: {
+        connection:
+          'Could not verify captcha. Please submit again in a few minutes.',
+        incorrect: 'Captcha was incorrect. Please submit again.',
+        missing: 'Captcha was missing. Please refresh and submit again.',
+      },
+      turnstile: {
+        connection:
+          'Error connecting to Turnstile server . Please submit again in a few minutes.',
+        incorrectParameters:
+          'Incorrect Turnstile parameters. Please refresh and submit again.',
+        missingChallenge:
+          'Missing Turnstile challenge. Please refresh and submit again.',
+      },
+      validation: {
+        invalidData:
+          'Invalid data was found. Please check your responses and submit again.',
+        submissionTooLarge:
+          'Submission too large to be saved. Please reduce the size of your submission and try again.',
+        invalidSubmission:
+          'There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page.',
+        formUpdated:
+          'The form has been updated. Please refresh and submit again.',
+      },
+      files: {
+        uploadFailed:
+          'Could not upload attachments for submission. For assistance, please contact the person who asked you to fill in this form.',
+        totalSizeExceeded:
+          'Total attachment size exceeds maximum file size limit. Please reduce your total attachment size and try again.',
+        virusScanFailed: 'Virus scan failed. Please try again.',
+        cleanFileDownloadFailed:
+          'Attempt to download clean file failed. Please try again.',
+      },
+      mrf: {
+        missingSubmitterId:
+          'Failed to retrieve submitter ID. Please try again.',
+        invalidLink:
+          'The link you used is no longer valid. Please contact the form admin that gave you this link.',
+        invalidWorkflowType:
+          'Invalid workflow type encountered. Please contact the form admin and try again later.',
+        expectedResponseNotFound:
+          'Response for the Yes/No field for this approval step is not found',
+      },
+      generic: 'Something went wrong. Please try again.',
+    },
   },
   errors: {
     notAvailable: 'This form is not available.',

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -39,7 +39,7 @@ export const enSG: PublicForm = {
       },
       turnstile: {
         connection:
-          'Error connecting to Turnstile server . Please submit again in a few minutes.',
+          'Error connecting to Turnstile server. Please submit again in a few minutes.',
         incorrectParameters:
           'Incorrect Turnstile parameters. Please refresh and submit again.',
         missingChallenge:

--- a/apps/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/index.ts
@@ -53,6 +53,13 @@ export interface PublicForm {
         invalidWorkflowType: string
         expectedResponseNotFound: string
       }
+      payment: {
+        invalidSettings: string
+        pendingSubmissionSaveFailed: string
+        intentCreateFailed: string
+        documentUpdateFailed: string
+        settingsUpdated: string
+      }
       generic: string
     }
   }

--- a/apps/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/index.ts
@@ -5,6 +5,19 @@ import { Table } from './table'
 export * from './en-sg'
 
 export interface PublicForm {
+  backendErrors: {
+    verification: {
+      sessionExpired: string
+      otpExpired: string
+      otpRetryExceeded: string
+      wrongOtp: string
+      waitForOtp: string
+      otpRequestCountExceeded: string
+      invalidNumber: string
+      mailSend: string
+      outdatedForm: string
+    }
+  }
   errors: {
     notAvailable: string
     notFound: string

--- a/apps/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/index.ts
@@ -17,6 +17,44 @@ export interface PublicForm {
       mailSend: string
       outdatedForm: string
     }
+    submission: {
+      saveFailed: string
+      loginFailed: string
+      myInfo: {
+        expired: string
+        failed: string
+        unavailable: string
+      }
+      captcha: {
+        connection: string
+        incorrect: string
+        missing: string
+      }
+      turnstile: {
+        connection: string
+        incorrectParameters: string
+        missingChallenge: string
+      }
+      validation: {
+        invalidData: string
+        submissionTooLarge: string
+        invalidSubmission: string
+        formUpdated: string
+      }
+      files: {
+        uploadFailed: string
+        totalSizeExceeded: string
+        virusScanFailed: string
+        cleanFileDownloadFailed: string
+      }
+      mrf: {
+        missingSubmitterId: string
+        invalidLink: string
+        invalidWorkflowType: string
+        expectedResponseNotFound: string
+      }
+      generic: string
+    }
   }
   errors: {
     notAvailable: string

--- a/apps/frontend/src/services/ApiService.ts
+++ b/apps/frontend/src/services/ApiService.ts
@@ -2,9 +2,11 @@ import { datadogLogs } from '@datadog/browser-logs'
 import axios, { AxiosError } from 'axios'
 import { StatusCodes } from 'http-status-codes'
 
+import { ErrorDto } from 'formsg-shared/types'
 import { ErrorCode } from 'formsg-shared/types/errorCodes'
 
 import { env } from '~/env'
+import i18n from '~/i18n/i18n'
 
 import { ApiError } from '~typings/core'
 
@@ -27,6 +29,32 @@ export class HttpError extends Error {
 export class SingleSubmissionValidationError extends HttpError {
   constructor() {
     super('Single submission validation failed', StatusCodes.BAD_REQUEST)
+  }
+}
+
+const isErrorDto = (data: unknown): data is ErrorDto => {
+  return typeof data === 'object' && data !== null
+}
+
+const getTranslatedBackendMessage = (data: unknown): string | undefined => {
+  if (!isErrorDto(data)) return undefined
+
+  const { message, messageKey, messageParams } = data
+  if (typeof messageKey === 'string') {
+    const translatedMessage = i18n.t(messageKey, messageParams)
+    return translatedMessage === messageKey ? message : translatedMessage
+  }
+
+  return typeof message === 'string' ? message : undefined
+}
+
+const parseJsonSafely = (text: string): unknown => {
+  if (!text) return null
+
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
   }
 }
 
@@ -60,8 +88,9 @@ export const transformAxiosError = (error: Error): ApiError => {
           statusCode,
         )
       }
-      if (error.response.data?.message) {
-        return new HttpError(error.response.data.message, statusCode)
+      const backendMessage = getTranslatedBackendMessage(error.response.data)
+      if (backendMessage) {
+        return new HttpError(backendMessage, statusCode)
       }
       if (error.response.statusText) {
         return new HttpError(error.response.statusText, statusCode)
@@ -121,14 +150,22 @@ ApiService.interceptors.response.use(
 )
 
 export const processFetchResponse = async (response: Response) => {
+  let responseBody = ''
   try {
     // throw if response status not 2XX
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`Non-2XX response: ${response.status}`)
-    } else {
-      const data = await response.json()
-      return data
+      responseBody = await response.text()
+      const parsedErrorBody = parseJsonSafely(responseBody)
+      throw new HttpError(
+        getTranslatedBackendMessage(parsedErrorBody) ??
+          (typeof parsedErrorBody === 'string' ? parsedErrorBody : undefined) ??
+          (response.statusText || `Error: ${response.status}`),
+        response.status,
+      )
     }
+
+    const data = await response.json()
+    return data
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     // No guarantee that error is an Error object
@@ -139,7 +176,7 @@ export const processFetchResponse = async (response: Response) => {
           status: response.status,
           statusText: response.statusText,
           headers: [...(response.headers?.entries() || [])],
-          body: await response.text(),
+          body: responseBody,
         },
         error: {
           name: error.name,

--- a/packages/shared/types/core.ts
+++ b/packages/shared/types/core.ts
@@ -12,8 +12,12 @@ export type FrontendRuntimeEnv = {
   ddSampleRatePublic?: number
 }
 
+export type I18nMessageParams = Record<string, string | number>
+
 export interface ErrorDto {
   message: string
+  messageKey?: string
+  messageParams?: I18nMessageParams
 }
 
 export interface SuccessMessageDto {


### PR DESCRIPTION
## Problem
Relates to [#9213](https://github.com/opengovsg/FormSG/issues/9213)

Backend error responses only returned a hardcoded English `message` string, with no structured way for the frontend to look up the correct localised string for a given error. This PR addresses the backend portion of #9213 specifically, augmenting error response DTOs with `messageKey` and `messageParams`, centralising response serialisation via `sendRouteError()`, and wiring up the frontend `ApiService` to resolve translations. Locale files for other languages and frontend UI integration remain outstanding.

## Solution

Added optional `messageKey` and `messageParams` fields to all backend error responses, and wired up the frontend to resolve translations via `i18n.t()` before falling back to the legacy `message` string.

**Breaking Changes**
- [ ] No — this PR is backwards compatible. The legacy `message` field is preserved in all responses; `messageKey` and `messageParams` are additive optional fields.

**Improvements**:
- Added `messageKey` and `messageParams` to `ErrorDto` (shared types) and `ErrorResponseData` (backend core types)
- Introduced `sendRouteError()` helper in `submission.utils.ts` to centralise response serialisation, replacing scattered `res.status(x).json({ message })` patterns
- All submission and verification error responses now include a structured `messageKey` (e.g. `features.publicForm.backendErrors.submission.files.uploadFailed`)
- Frontend `ApiService` now resolves translated messages via `i18n.t(messageKey, messageParams)` before falling back to the raw `message`
- Added full `backendErrors` namespace to the `en-sg` frontend locale file covering `verification` and `submission` error categories (files, MRF, payment, validation, captcha, Turnstile, MyInfo, login)
- `WaitForOtpError` now passes `waitForOtpSeconds` as a typed param for correct string interpolation

## Before & After Screenshots
N/A — no UI visual change

## Tests

**TC1: Submission errors include message key**
- Trigger an attachment upload failure on a public form submission
- Confirm response JSON contains both `message` and `messageKey: "features.publicForm.backendErrors.submission.files.uploadFailed"`

**TC2: Frontend resolves translated message**
- With a valid translation in `en-sg.ts`, trigger any mapped backend error (e.g. wrong OTP)
- Confirm the error toast displays the translated string, not the raw fallback

**TC3: WaitForOtp interpolation**
- Trigger OTP too-soon error
- Confirm `messageParams.waitForOtpSeconds` is present in the response and the frontend interpolates it correctly into the translated string

**TC4: Legacy message fallback still works**
- For any error without a `messageKey`, confirm the frontend still displays the raw `message` string as before

**TC5: Payment errors include message key**
- Trigger invalid payment settings on a form submission
- Confirm response includes `messageKey: "features.publicForm.backendErrors.submission.payment.invalidSettings"`

## Deploy Notes

**New environment variables**: None

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None

---

**Team**: FormSG Team 1 (YouthTechSG)

> Contributors: [@beefwhale](https://github.com/beefwhale) [@weisintai](https://github.com/weisintai) [@jerememememe](https://github.com/jerememememe) 