### PR TITLE
fix: improve OTP rate limit messaging

### DIFF
--- a/apps/frontend/src/features/verifiable-fields/VerifiableFieldService.test.ts
+++ b/apps/frontend/src/features/verifiable-fields/VerifiableFieldService.test.ts
@@ -1,0 +1,100 @@
+import { StatusCodes } from 'http-status-codes'
+
+import { ApiService, HttpError } from '~services/ApiService'
+
+import {
+  OTP_RATE_LIMIT_ERROR_MESSAGE,
+  triggerSendOtp,
+  verifyOtp,
+} from './VerifiableFieldService'
+
+const MOCK_FORM_ID = '61540ece3d4a6e50ac0cc6ff'
+const MOCK_TRANSACTION_ID = '61540ece3d4a6e50ac0cc700'
+const MOCK_FIELD_ID = '61540ece3d4a6e50ac0cc701'
+
+describe('VerifiableFieldService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('triggerSendOtp', () => {
+    it('should show OTP-specific copy when the route rate limit is exceeded', async () => {
+      vi.spyOn(ApiService, 'post').mockRejectedValue(
+        new HttpError('Please try again later.', StatusCodes.TOO_MANY_REQUESTS),
+      )
+
+      await expect(
+        triggerSendOtp({
+          formId: MOCK_FORM_ID,
+          transactionId: MOCK_TRANSACTION_ID,
+          fieldId: MOCK_FIELD_ID,
+          answer: 'test@example.com',
+        }),
+      ).rejects.toMatchObject({
+        code: StatusCodes.TOO_MANY_REQUESTS,
+        message: OTP_RATE_LIMIT_ERROR_MESSAGE,
+      })
+    })
+
+    it('should preserve existing non-rate-limit OTP messages', async () => {
+      const resendCooldownMessage =
+        'Please wait for a while before requesting another OTP.'
+
+      vi.spyOn(ApiService, 'post').mockRejectedValue(
+        new HttpError(resendCooldownMessage, StatusCodes.UNPROCESSABLE_ENTITY),
+      )
+
+      await expect(
+        triggerSendOtp({
+          formId: MOCK_FORM_ID,
+          transactionId: MOCK_TRANSACTION_ID,
+          fieldId: MOCK_FIELD_ID,
+          answer: 'test@example.com',
+        }),
+      ).rejects.toMatchObject({
+        code: StatusCodes.UNPROCESSABLE_ENTITY,
+        message: resendCooldownMessage,
+      })
+    })
+  })
+
+  describe('verifyOtp', () => {
+    it('should show OTP-specific copy when the route rate limit is exceeded', async () => {
+      vi.spyOn(ApiService, 'post').mockRejectedValue(
+        new HttpError('Please try again later.', StatusCodes.TOO_MANY_REQUESTS),
+      )
+
+      await expect(
+        verifyOtp({
+          formId: MOCK_FORM_ID,
+          transactionId: MOCK_TRANSACTION_ID,
+          fieldId: MOCK_FIELD_ID,
+          otp: '123456',
+        }),
+      ).rejects.toMatchObject({
+        code: StatusCodes.TOO_MANY_REQUESTS,
+        message: OTP_RATE_LIMIT_ERROR_MESSAGE,
+      })
+    })
+
+    it('should preserve existing non-rate-limit OTP messages', async () => {
+      const wrongOtpMessage = 'OTP provided is not valid.'
+
+      vi.spyOn(ApiService, 'post').mockRejectedValue(
+        new HttpError(wrongOtpMessage, StatusCodes.UNPROCESSABLE_ENTITY),
+      )
+
+      await expect(
+        verifyOtp({
+          formId: MOCK_FORM_ID,
+          transactionId: MOCK_TRANSACTION_ID,
+          fieldId: MOCK_FIELD_ID,
+          otp: '123456',
+        }),
+      ).rejects.toMatchObject({
+        code: StatusCodes.UNPROCESSABLE_ENTITY,
+        message: wrongOtpMessage,
+      })
+    })
+  })
+})

--- a/apps/frontend/src/features/verifiable-fields/VerifiableFieldService.test.ts
+++ b/apps/frontend/src/features/verifiable-fields/VerifiableFieldService.test.ts
@@ -1,9 +1,11 @@
 import { StatusCodes } from 'http-status-codes'
 
+import i18n from '~/i18n/i18n'
+
 import { ApiService, HttpError } from '~services/ApiService'
 
 import {
-  OTP_RATE_LIMIT_ERROR_MESSAGE,
+  OTP_RATE_LIMIT_ERROR_MESSAGE_KEY,
   triggerSendOtp,
   verifyOtp,
 } from './VerifiableFieldService'
@@ -32,7 +34,7 @@ describe('VerifiableFieldService', () => {
         }),
       ).rejects.toMatchObject({
         code: StatusCodes.TOO_MANY_REQUESTS,
-        message: OTP_RATE_LIMIT_ERROR_MESSAGE,
+        message: i18n.t(OTP_RATE_LIMIT_ERROR_MESSAGE_KEY),
       })
     })
 
@@ -73,7 +75,7 @@ describe('VerifiableFieldService', () => {
         }),
       ).rejects.toMatchObject({
         code: StatusCodes.TOO_MANY_REQUESTS,
-        message: OTP_RATE_LIMIT_ERROR_MESSAGE,
+        message: i18n.t(OTP_RATE_LIMIT_ERROR_MESSAGE_KEY),
       })
     })
 

--- a/apps/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
+++ b/apps/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
@@ -3,6 +3,8 @@ import { Opaque } from 'type-fest'
 
 import { SendFormOtpResponseDto } from 'formsg-shared/types/form'
 
+import i18n from '~/i18n/i18n'
+
 import { transformAllIsoStringsToDate } from '~utils/date'
 import { ApiService, HttpError } from '~services/ApiService'
 
@@ -18,8 +20,8 @@ type VerifiedFieldSignature = Opaque<string, 'VerifiedFieldSignature'>
 
 const FORM_API_PREFIX = '/forms'
 const VERIFICATION_ENDPOINT = 'fieldverifications'
-export const OTP_RATE_LIMIT_ERROR_MESSAGE =
-  'Too many OTP attempts. Please wait a few minutes before trying again.'
+export const OTP_RATE_LIMIT_ERROR_MESSAGE_KEY =
+  'features.publicForm.components.fields.verification.error.rateLimit'
 
 const mapOtpRateLimitError = (error: unknown): never => {
   if (
@@ -27,7 +29,7 @@ const mapOtpRateLimitError = (error: unknown): never => {
     error.code === StatusCodes.TOO_MANY_REQUESTS
   ) {
     throw new HttpError(
-      OTP_RATE_LIMIT_ERROR_MESSAGE,
+      i18n.t(OTP_RATE_LIMIT_ERROR_MESSAGE_KEY),
       StatusCodes.TOO_MANY_REQUESTS,
     )
   }

--- a/apps/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
+++ b/apps/frontend/src/features/verifiable-fields/VerifiableFieldService.ts
@@ -1,9 +1,10 @@
+import { StatusCodes } from 'http-status-codes'
 import { Opaque } from 'type-fest'
 
 import { SendFormOtpResponseDto } from 'formsg-shared/types/form'
 
 import { transformAllIsoStringsToDate } from '~utils/date'
-import { ApiService } from '~services/ApiService'
+import { ApiService, HttpError } from '~services/ApiService'
 
 /**
  * Response when retrieving new transaction. Can be an empty object if the
@@ -17,6 +18,22 @@ type VerifiedFieldSignature = Opaque<string, 'VerifiedFieldSignature'>
 
 const FORM_API_PREFIX = '/forms'
 const VERIFICATION_ENDPOINT = 'fieldverifications'
+export const OTP_RATE_LIMIT_ERROR_MESSAGE =
+  'Too many OTP attempts. Please wait a few minutes before trying again.'
+
+const mapOtpRateLimitError = (error: unknown): never => {
+  if (
+    error instanceof HttpError &&
+    error.code === StatusCodes.TOO_MANY_REQUESTS
+  ) {
+    throw new HttpError(
+      OTP_RATE_LIMIT_ERROR_MESSAGE,
+      StatusCodes.TOO_MANY_REQUESTS,
+    )
+  }
+
+  throw error
+}
 
 /**
  * Create a transaction for given form.
@@ -66,7 +83,9 @@ export const triggerSendOtp = async ({
       answer,
       previousSubmissionId,
     },
-  ).then(({ data }) => data)
+  )
+    .then(({ data }) => data)
+    .catch(mapOtpRateLimitError)
 }
 
 /**
@@ -93,7 +112,9 @@ export const verifyOtp = async ({
     {
       otp,
     },
-  ).then(({ data }) => data)
+  )
+    .then(({ data }) => data)
+    .catch(mapOtpRateLimitError)
 }
 
 /**

--- a/apps/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/fields/en-sg.ts
@@ -53,6 +53,10 @@ export const enSG: Fields = {
         verified: 'Verified',
       },
     },
+    error: {
+      rateLimit:
+        'Too many OTP attempts. Please wait a few minutes before trying again.',
+    },
     modal: {
       email: {
         title: 'Verify your email',

--- a/apps/frontend/src/i18n/locales/features/public-form/fields/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/fields/index.ts
@@ -43,6 +43,9 @@ export interface Fields {
         verified: string
       }
     }
+    error: {
+      rateLimit: string
+    }
     modal: {
       email: {
         title: string


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #9541

Verifiable email/mobile OTP generate and verify flows showed the generic `Please try again later.` message when the backend returned HTTP 429 route-level rate limits. Respondents could not tell that they had made too many OTP attempts and needed to wait before retrying.

## Solution
<!-- How did you solve the problem? -->

Mapped HTTP 429 errors from verifiable-field OTP generate and verify calls to OTP-specific copy:

`Too many OTP attempts. Please wait a few minutes before trying again.`

Existing non-429 OTP messages are preserved.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- N/A

**Improvements**:

- Respondents now get clearer guidance when they hit OTP rate limits for verifiable email/mobile fields.

**Bug Fixes**:

- HTTP 429 responses from verifiable-field OTP generate and verify flows now show OTP-specific rate-limit messaging instead of the generic frontend fallback.

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->

N/A - copy-only error handling change. Previous message was `Please try again later.`

**AFTER**:
<!-- [insert screenshot here] -->

N/A - copy-only error handling change. New message is `Too many OTP attempts. Please wait a few minutes before trying again.`

## Tests
<!-- What tests should be run to confirm functionality? -->

- `pnpm --filter formsg-frontend exec eslint src/features/verifiable-fields/VerifiableFieldService.ts src/features/verifiable-fields/VerifiableFieldService.test.ts`
- `pnpm --filter formsg-frontend test src/features/verifiable-fields/VerifiableFieldService.test.ts --run`

Both pass locally.

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- N/A

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
