### PR TITLE
test(frontend): add disabled long-text table column story

### DIFF
--- a/apps/frontend/src/templates/Field/Table/TableField.stories.tsx
+++ b/apps/frontend/src/templates/Field/Table/TableField.stories.tsx
@@ -249,3 +249,23 @@ DisabledWithLongDropdownOption.args = {
   schema: { ...longDropdownSchema, disabled: true },
   defaultValue: longDropdownDefaultValues,
 }
+
+const LONG_SHORT_TEXT_VALUE =
+  'This is a very long text column value that should be available when disabled'
+
+const longShortTextDefaultValues = baseSchema.columns.reduce<
+  Record<string, string>
+>((acc, c) => {
+  if (c.columnType === BasicField.ShortText) {
+    acc[c._id] = LONG_SHORT_TEXT_VALUE
+  } else if (c.columnType === BasicField.Dropdown) {
+    acc[c._id] = STORYBOOK_DROPDOWN_OPTIONS[1]
+  }
+  return acc
+}, {})
+
+export const DisabledWithLongShortTextValue = Template.bind({})
+DisabledWithLongShortTextValue.args = {
+  schema: { ...baseSchema, disabled: true },
+  defaultValue: longShortTextDefaultValues,
+}


### PR DESCRIPTION
## Problem

Supplement to #9582 (which closes #9499). #9582 already ships the production fix (`title={isDisabled ? field.value : undefined}` on `ShortTextColumnCell`) and the disabled/editable unit tests, but does not include a Storybook story that visualises an overflowing disabled short-text value.

Per @LoneRifle's request on this PR, this is reworked into a story-only addition stacked on top of #9582's branch `fix/9499-table-text-cell-disabled-title`. When merged into that branch, the story lands alongside #9582's fix.

## Solution

Adds a single Storybook story, `DisabledWithLongShortTextValue`, to `TableField.stories.tsx`. It renders the base table schema disabled with a long short-text column value so the native hover tooltip is visible in Storybook and available as a regression fixture.

No production code or test changes — those are owned by #9582.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**: N/A
**Improvements**: N/A
**Bug Fixes**: N/A — story coverage for #9582.

## Before & After Screenshots

N/A - Storybook story only.

## Tests

Target: `apps/frontend` (Storybook story; no test assertions added).

- `pnpm --filter formsg-frontend exec prettier --check src/templates/Field/Table/TableField.stories.tsx`
- `pnpm --filter formsg-frontend exec eslint src/templates/Field/Table/TableField.stories.tsx --quiet`
- `pnpm --filter formsg-frontend exec tsc --noEmit --pretty false`
- `pnpm --filter formsg-frontend exec vitest run src/templates/Field/Table/TableField.test.tsx` (existing tests still pass with the new story exported)

## Deploy Notes

N/A