### PR TITLE
feat(i18n): extract text from MultiLanguageSection components

### DIFF
--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormFieldTranslationContainer.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormFieldTranslationContainer.tsx
@@ -1,4 +1,5 @@
 import { FormState } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Divider, Flex, Text } from '@chakra-ui/react'
 
 import { FormField, Language } from 'formsg-shared/types'
@@ -22,6 +23,8 @@ export const FormFieldTranslationContainer = ({
   unicodeLocale,
   formState,
 }: FormFieldTranslationContainerProps) => {
+  const { t } = useTranslation()
+
   if (!formFieldData) return null
 
   const hasDescription =
@@ -50,7 +53,7 @@ export const FormFieldTranslationContainer = ({
           fontWeight="600"
           mb="1rem"
         >
-          Question
+          {t('features.adminForm.settings.multiLanguage.sections.question')}
         </Text>
         <TranslationContainer
           language={capitalisedLanguage}
@@ -69,7 +72,9 @@ export const FormFieldTranslationContainer = ({
               fontWeight="600"
               mb="1rem"
             >
-              Description
+              {t(
+                'features.adminForm.settings.multiLanguage.sections.description',
+              )}
             </Text>
             <TranslationContainer
               language={capitalisedLanguage}

--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormLogicTranslationContainer.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormLogicTranslationContainer.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Divider, Flex, FormControl, Text } from '@chakra-ui/react'
 
 import { Language, PreventSubmitLogicDto } from 'formsg-shared/types'
@@ -18,6 +19,7 @@ export const FormLogicTranslationContainer = ({
   unicodeLocale,
   formLogics,
 }: TableTranslationContainerProps) => {
+  const { t } = useTranslation()
   const { register } = useFormContext<TranslationInput>()
 
   return (
@@ -44,7 +46,9 @@ export const FormLogicTranslationContainer = ({
               fontWeight="600"
               mb="1rem"
             >
-              Disable Submission
+              {t(
+                'features.adminForm.settings.multiLanguage.sections.disableSubmission',
+              )}
             </Text>
             <Flex direction="column" width="100%">
               <Flex alignItems="flex-start" mb="2rem">
@@ -54,7 +58,7 @@ export const FormLogicTranslationContainer = ({
                   mr="7.5rem"
                   width="6.25rem"
                 >
-                  Default
+                  {t('features.common.default')}
                 </Text>
                 <Textarea
                   placeholder={defaultPreventSubmitMessage}

--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormMultiLanguageToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/FormMultiLanguageToggle.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiEditAlt } from 'react-icons/bi'
 import { GoEye, GoEyeClosed } from 'react-icons/go'
 import { useParams, useSearchParams } from 'react-router-dom'
@@ -41,6 +42,7 @@ const LanguageTranslationRow = ({
   isDefaultLanguage,
   isLast,
 }: LanguageTranslationRowProps): JSX.Element => {
+  const { t } = useTranslation()
   const { formId } = useParams()
   const { data: settings } = useAdminFormSettings()
   const [, setSearchParams] = useSearchParams()
@@ -93,13 +95,17 @@ const LanguageTranslationRow = ({
           <Text mr="0.75rem">{languageToDisplay}</Text>
           {isDefaultLanguage && (
             <Badge variant="solid" colorScheme="success" color="secondary.700">
-              Default
+              {t('features.common.default')}
             </Badge>
           )}
         </Flex>
         {!isDefaultLanguage && (
           <HStack spacing="0.75rem">
-            <Tooltip label="Hide/show language on form">
+            <Tooltip
+              label={t(
+                'features.adminForm.settings.multiLanguage.languageRow.hideShowTooltip',
+              )}
+            >
               <IconButton
                 variant="clear"
                 icon={
@@ -110,16 +116,26 @@ const LanguageTranslationRow = ({
                   )
                 }
                 colorScheme="secondary"
-                aria-label={`Select ${unicodeLocale} as the form's default language`}
+                aria-label={t(
+                  'features.adminForm.settings.multiLanguage.languageRow.selectDefaultAriaLabel',
+                  { language: unicodeLocale },
+                )}
                 onClick={() => handleToggleSupportedLanguage(unicodeLocale)}
               />
             </Tooltip>
-            <Tooltip label="Edit translation">
+            <Tooltip
+              label={t(
+                'features.adminForm.settings.multiLanguage.languageRow.editTooltip',
+              )}
+            >
               <IconButton
                 variant="clear"
                 icon={<BiEditAlt width="44px" />}
                 colorScheme="secondary"
-                aria-label={`Add ${unicodeLocale} translations`}
+                aria-label={t(
+                  'features.adminForm.settings.multiLanguage.languageRow.addTranslationsAriaLabel',
+                  { language: unicodeLocale },
+                )}
                 onClick={() =>
                   handleLanguageTranslationEditClick(unicodeLocale)
                 }
@@ -160,6 +176,7 @@ const LanguageTranslationSection = ({
 }
 
 export const FormMultiLanguageToggle = (): JSX.Element => {
+  const { t } = useTranslation()
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -196,8 +213,10 @@ export const FormMultiLanguageToggle = (): JSX.Element => {
       <Toggle
         onChange={handleToggleMultiLang}
         isChecked={hasMultiLang}
-        label="Enable multi-language"
-        description="This will allow respondents to select a language they prefer to view your form in. Translations are not automated."
+        label={t('features.adminForm.settings.multiLanguage.toggle.label')}
+        description={t(
+          'features.adminForm.settings.multiLanguage.toggle.description',
+        )}
       />
       {settings && hasMultiLang ? (
         <Skeleton isLoaded={true}>

--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/MultiLanguageSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/MultiLanguageSection.tsx
@@ -1,11 +1,17 @@
+import { useTranslation } from 'react-i18next'
+
 import { CategoryHeader } from '../CategoryHeader'
 
 import { FormMultiLanguageToggle } from './FormMultiLanguageToggle'
 
 export const MultiLanguageSection = (): JSX.Element => {
+  const { t } = useTranslation()
+
   return (
     <>
-      <CategoryHeader>Multi-language</CategoryHeader>
+      <CategoryHeader>
+        {t('features.adminForm.settings.multiLanguage.title')}
+      </CategoryHeader>
       <FormMultiLanguageToggle />
     </>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/OptionsTranslationContainer.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/OptionsTranslationContainer.tsx
@@ -1,4 +1,5 @@
 import { FieldError, useFormContext } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Flex, FormControl, Text } from '@chakra-ui/react'
 
 import {
@@ -26,6 +27,7 @@ export const OptionsTranslationContainer = ({
   formFieldData,
   errors,
 }: OptionsTranslationContainerProps) => {
+  const { t } = useTranslation()
   const { register } = useFormContext<TranslationInput>()
 
   const fieldOptions = formFieldData.fieldOptions || []
@@ -46,7 +48,7 @@ export const OptionsTranslationContainer = ({
           mr="7.5rem"
           width="6.25rem"
         >
-          Default
+          {t('features.common.default')}
         </Text>
         <Textarea
           placeholder={defaultFieldOptions}

--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/StartPageTranslationContainer.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/StartPageTranslationContainer.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Flex, Text } from '@chakra-ui/react'
 
 import { FormStartPage, Language } from 'formsg-shared/types'
@@ -16,6 +17,8 @@ export const StartPageTranslationContainer = ({
   capitalisedLanguage,
   unicodeLocale,
 }: StartPageTranslationContainerProps) => {
+  const { t } = useTranslation()
+
   if (!startPage) return null
 
   const currentTranslations = startPage.paragraphTranslations ?? []
@@ -27,7 +30,7 @@ export const StartPageTranslationContainer = ({
   return (
     <Flex justifyContent="flex-start" mb="2.5rem" direction="column">
       <Text color="secondary.500" fontSize="1.25rem" fontWeight="600" mb="1rem">
-        Question
+        {t('features.adminForm.settings.multiLanguage.sections.question')}
       </Text>
       <TranslationContainer
         language={capitalisedLanguage}

--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/TableTranslationContainer.tsx
@@ -1,4 +1,5 @@
 import { FieldError, useFormContext } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Divider, Flex, FormControl, Text } from '@chakra-ui/react'
 
 import { Language } from 'formsg-shared/types'
@@ -30,6 +31,7 @@ export const TableTranslationContainer = ({
   unicodeLocale,
   errors,
 }: TableTranslationContainerProps) => {
+  const { t } = useTranslation()
   const { register } = useFormContext<TranslationInput>()
 
   return (
@@ -65,7 +67,7 @@ export const TableTranslationContainer = ({
               fontWeight="600"
               mb="1rem"
             >
-              Column
+              {t('features.adminForm.settings.multiLanguage.sections.column')}
             </Text>
             <Flex direction="column" width="100%">
               <Flex alignItems="flex-start" mb="2rem">
@@ -75,7 +77,7 @@ export const TableTranslationContainer = ({
                   mr="7.5rem"
                   width="6.25rem"
                 >
-                  Default
+                  {t('features.common.default')}
                 </Text>
                 <Textarea
                   placeholder={column.title}
@@ -106,7 +108,9 @@ export const TableTranslationContainer = ({
                   mb="1rem"
                   mt="2rem"
                 >
-                  Options
+                  {t(
+                    'features.adminForm.settings.multiLanguage.sections.options',
+                  )}
                 </Text>
                 <Flex alignItems="flex-start" mb="2rem">
                   <Text
@@ -115,7 +119,7 @@ export const TableTranslationContainer = ({
                     mr="7.5rem"
                     width="6.25rem"
                   >
-                    Default
+                    {t('features.common.default')}
                   </Text>
                   <Textarea
                     placeholder={column.fieldOptions?.join('\n') ?? ''}

--- a/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/mutations/useTranslationLogic.ts
+++ b/apps/frontend/src/features/admin-form/settings/components/MultiLanguageSection/mutations/useTranslationLogic.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { UseFormReturn } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
 import _ from 'lodash'
 
@@ -55,6 +56,7 @@ export const useTranslationLogic = ({
   isFormField,
   methods,
 }: UseTranslationLogicProps) => {
+  const { t } = useTranslation()
   const { getValues, setError, clearErrors } = methods
   const [, setSearchParams] = useSearchParams()
   const { editFieldMutation } = useEditFormField()
@@ -142,8 +144,9 @@ export const useTranslationLogic = ({
           ) {
             setError(`tableColumnDropdownTranslations.${index}`, {
               type: 'custom',
-              message:
-                'Make sure the number of translated options match the options in the question.',
+              message: t(
+                'features.adminForm.settings.multiLanguage.errors.optionsCountMismatch',
+              ),
             })
             return
           }
@@ -164,8 +167,9 @@ export const useTranslationLogic = ({
             ) {
               setError(`tableColumnDropdownTranslations.${index}`, {
                 type: 'custom',
-                message:
-                  'Make sure the number of translated options match the options in the question.',
+                message: t(
+                  'features.adminForm.settings.multiLanguage.errors.optionsCountMismatch',
+                ),
               })
               return
             }
@@ -214,8 +218,9 @@ export const useTranslationLogic = ({
           ) {
             setError('fieldOptionsTranslations', {
               type: 'custom',
-              message:
-                'Make sure the number of translated options match the options in the question.',
+              message: t(
+                'features.adminForm.settings.multiLanguage.errors.optionsCountMismatch',
+              ),
             })
             return
           }

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/en-sg.ts
@@ -1,5 +1,6 @@
 import { enSG as emailNotifications } from './email-notifications'
 import { enSG as general } from './general'
+import { enSG as multiLanguage } from './multi-language'
 import { enSG as payments } from './payments'
 import { enSG as webhooks } from './webhooks'
 
@@ -110,4 +111,5 @@ export const enSG = {
   emailNotifications,
   webhooks,
   payments,
+  multiLanguage,
 }

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/index.ts
@@ -1,5 +1,6 @@
 import { EmailNotifications } from './email-notifications'
 import { General } from './general'
+import { MultiLanguage } from './multi-language'
 import { Payments } from './payments'
 import { Webhooks } from './webhooks'
 
@@ -113,4 +114,5 @@ export interface Settings {
   emailNotifications: EmailNotifications
   webhooks: Webhooks
   payments: Payments
+  multiLanguage: MultiLanguage
 }

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/multi-language/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/multi-language/en-sg.ts
@@ -1,0 +1,25 @@
+export const enSG = {
+  title: 'Multi-language',
+  toggle: {
+    label: 'Enable multi-language',
+    description:
+      'This will allow respondents to select a language they prefer to view your form in. Translations are not automated.',
+  },
+  languageRow: {
+    hideShowTooltip: 'Hide/show language on form',
+    editTooltip: 'Edit translation',
+    selectDefaultAriaLabel: "Select {language} as the form's default language",
+    addTranslationsAriaLabel: 'Add {language} translations',
+  },
+  sections: {
+    question: 'Question',
+    description: 'Description',
+    column: 'Column',
+    options: 'Options',
+    disableSubmission: 'Disable Submission',
+  },
+  errors: {
+    optionsCountMismatch:
+      'Make sure the number of translated options match the options in the question.',
+  },
+}

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/multi-language/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/multi-language/index.ts
@@ -1,7 +1,8 @@
+import { type HasTitle } from '..'
+
 export * from './en-sg'
 
-export interface MultiLanguage {
-  title: string
+export interface MultiLanguage extends HasTitle {
   toggle: {
     label: string
     description: string

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/multi-language/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/multi-language/index.ts
@@ -1,0 +1,25 @@
+export * from './en-sg'
+
+export interface MultiLanguage {
+  title: string
+  toggle: {
+    label: string
+    description: string
+  }
+  languageRow: {
+    hideShowTooltip: string
+    editTooltip: string
+    selectDefaultAriaLabel: string
+    addTranslationsAriaLabel: string
+  }
+  sections: {
+    question: string
+    description: string
+    column: string
+    options: string
+    disableSubmission: string
+  }
+  errors: {
+    optionsCountMismatch: string
+  }
+}


### PR DESCRIPTION
## Problem
Closes #8445

## Solution
Extracted all hardcoded English strings from the `MultiLanguageSection` components into
i18n locale files, replacing them with `t()` calls via `react-i18next`.

Strings were added under a new `multi-language` namespace within the existing
admin-form settings locale structure (`i18n/locales/features/admin-form/settings/`),
following the same pattern as the previously extracted settings, not-found-error, and
landing-payments locales.

Components updated:
- `useTranslationLogic`
- `FormFieldTranslationContainer`
- `FormLogicTranslationContainer`
- `FormMultiLanguageToggle`
- `MultiLanguageSection`
- `OptionsTranslationContainer`
- `StartPageTranslationContainer`
- `TableTranslationContainer`

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:
- N/A

**Improvements**:
- `MultiLanguageSection` components are now i18n-ready

**Bug Fixes**:
- N/A

## Before & After Screenshots
**BEFORE**:
N/A — no visual changes; text renders identically.

**AFTER**:
N/A — no visual changes; text renders identically.

## Tests
- Open the form builder → Settings → Multi-language section and confirm all text
  (toggle, field/option/table/start-page/logic translation containers) renders
  correctly with no raw i18n keys showing.

## Deploy Notes
No new environment variables, scripts, or dependencies.