### PR TITLE
feat(frontend): finalize MRF cutover FAQ link

### DIFF
--- a/packages/shared/constants/links.ts
+++ b/packages/shared/constants/links.ts
@@ -16,6 +16,5 @@ export const KILL_EMAIL_MODE_LINK =
 export const STATUS_TRACKER_PREVIEW_LINK =
   'https://go.gov.sg/mrf-preview-status-tracking'
 
-// TODO [MRF-CUTOVER]: Placeholder FAQ link for the MRF cutover dashboard
-// infobox. Confirm the final go.gov.sg short link before launch.
-export const MRF_CUTOVER_FAQ_LINK = 'https://go.gov.sg/formsg-guide-v4-faq'
+export const MRF_CUTOVER_FAQ_LINK =
+  'https://go.gov.sg/formsg-guide-faq-simplified-modes'


### PR DESCRIPTION
Finalizes the `MRF_CUTOVER_FAQ_LINK` for the MRF cutover dashboard infobox.

- Removes the `TODO [MRF-CUTOVER]` placeholder comment now that the link is confirmed.
- Updates the URL to `https://go.gov.sg/formsg-guide-faq-simplified-modes`.

Targets the `mrf-cutover-copy-changes-v2` branch so it flows into #9621.

🤖 Generated with [Claude Code](https://claude.com/claude-code)