### PR TITLE
fix(frontend): gate useUser on isAuthenticated to prevent 401 spike

### DIFF
--- a/apps/frontend/src/contexts/GrowthbookContext.tsx
+++ b/apps/frontend/src/contexts/GrowthbookContext.tsx
@@ -8,6 +8,8 @@ import { UserDto } from 'formsg-shared/types/user'
 
 import { createGrowthbookInstance } from '~/growthbook'
 
+import { useAuth } from '~contexts/AuthContext'
+
 import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
 
@@ -35,7 +37,9 @@ const injectGrowthBookAttributes = (
 
 export const GrowthBookProvider = ({ children }: { children: ReactNode }) => {
   const { data: { growthbookClientKey } = {} } = useEnv()
-  const { user } = useUser()
+  const { isAuthenticated } = useAuth()
+
+  const { user } = useUser({ enabled: !!isAuthenticated })
 
   const growthbook = useMemo(
     () =>

--- a/apps/frontend/src/features/user/queries.ts
+++ b/apps/frontend/src/features/user/queries.ts
@@ -19,7 +19,9 @@ type UseUserReturn = {
   removeQuery: () => void
 }
 
-export const useUser = (): UseUserReturn => {
+export const useUser = ({
+  enabled = true,
+}: { enabled?: boolean } = {}): UseUserReturn => {
   const [, setIsLocalStorageAuthenticated] =
     useLocalStorage<boolean>(LOGGED_IN_KEY)
 
@@ -28,6 +30,7 @@ export const useUser = (): UseUserReturn => {
     isLoading,
     remove,
   } = useQuery(userKeys.base, () => fetchUser(), {
+    enabled,
     onSuccess: () => setIsLocalStorageAuthenticated(true),
     onError: (err) => {
       if (err instanceof HttpError && err.code === StatusCodes.UNAUTHORIZED) {


### PR DESCRIPTION
## Problem

Following the v7.30.0 release, FormSG saw a spike in 401 errors that triggered incident #1189. Root cause: PR #9579 hoisted `useUser()` into `GrowthBookProvider`, which wraps the entire app — including public form routes. Every public form page load fired an unauthenticated `fetchUser()` request, each returning 401.

The original review thread flagged this risk (*"public form routes might do a fetchLoggedInUserQuery every 10 mins, which will return 401... should not cause an issue"*) but the assumption that the 401s would be harmless turned out to be wrong at production traffic volume.

Closes <ISSUE_NUMBER>

## Solution

Keep the DRY goal of PR #9579 (single GrowthBook attribute injection site in `GrowthBookProvider`) but gate the underlying network call on `isAuthenticated`:

1. `useUser` now accepts an optional `enabled` flag, forwarded to React Query's `useQuery`. Default is `true`, so all existing call sites behave identically.
2. `GrowthBookProvider` reads `isAuthenticated` from `useAuth()` and passes `enabled: !!isAuthenticated` to `useUser`. This is legal because `AuthProvider` is rendered as an ancestor of `GrowthBookProvider` in `App.tsx`, making `GrowthBookProvider` a valid consumer of `AuthContext`.

`isAuthenticated` is a synchronous localStorage read, so the gate is correct on first render. Public form visitors never fire `fetchUser`; authenticated users behave identically to before. Session expiry self-heals via `useUser`'s existing `onError` handler, which clears the localStorage flag on a 401 and disables subsequent fetches.

**Breaking Changes**
- No — this PR is backwards compatible. `useUser`'s new `enabled` parameter defaults to `true`, preserving existing behavior at every call site that doesn't opt in.

## Tests

TC1: Public form route does not fire `fetchUser`
- [x] In an incognito window or while logged out, open a public form URL
- [x] Open DevTools → Network tab, filter on `user`
- [x] Verify no `GET /user` request is made on page load or while idle
- [x] Verify no 401 errors in the console
- [x] Verify the form loads and submits as expected

TC2: Authenticated admin still gets GrowthBook attributes
- [x] Log in as an admin user
- [x] Navigate to an admin route (workspace, form builder, settings)
- [x] Open DevTools → Network tab → verify `GET /user` fires and returns 200
- [x] In the console, run `window.growthbook?.getAttributes()` (or equivalent) and verify `adminEmail` and `adminAgency` are populated
- [x] Verify that any feature flag targeted on `adminEmail` / `adminAgency` evaluates correctly

TC3: Session expiry self-heals on the admin app
- [x] Log in as an admin user
- [x] In DevTools → Application → Cookies, delete the session cookie
- [x] Trigger a re-render (navigate between admin tabs)
- [x] Verify the resulting 401 clears `LOGGED_IN_KEY` from localStorage (Application → Local Storage)
- [x] Verify subsequent renders do not retry `GET /user`

TC4: Login flow re-enables GrowthBook attribute injection
- [x] Start logged out
- [x] Complete the login flow end-to-end
- [x] After redirect to the workspace, verify `GET /user` fires and GrowthBook attributes are set