### PR TITLE
feat(frontend): update restrict email domains placeholder

### DIFF
--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
@@ -94,7 +94,7 @@ export const enSG: Fields = {
     restrictEmailDomains: {
       title: 'Restrict email domains',
       inputLabel: 'Domains allowed',
-      placeholder: '@data.gov.sg\n@agency.gov.sg',
+      placeholder: '@*.gov.sg\n@open.gov.sg\n@agency.gov.sg',
     },
     emailConfirmation: {
       title: 'Email confirmation',


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The "Domains allowed" placeholder under Email field → Restrict email domains only showed `@data.gov.sg` and `@agency.gov.sg`, which didn't communicate that wildcard subdomain patterns are supported.

## Solution
<!-- How did you solve the problem? -->

**Breaking Changes**
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible

**Features**:

- Update the placeholder text to surface the supported domain patterns, including a wildcard example:
  - `@*.gov.sg`
  - `@open.gov.sg`
  - `@agency.gov.sg`

## Before & After Screenshots

**BEFORE**:
<img width="1487" height="726" alt="image" src="https://github.com/user-attachments/assets/dd14504f-6ba6-41d0-aa8b-c66f0f2db86b" />


**AFTER**:
<img width="1487" height="726" alt="image" src="https://github.com/user-attachments/assets/dedfe74b-f3b7-426d-8407-b56cb81b93e1" />


## Tests
<!-- What tests should be run to confirm functionality? -->

- Manual: Open the Email field settings, enable "Restrict email domains", and confirm the "Domains allowed" textarea shows the three example domains across separate lines.
