### PR TITLE
feat(frontend): simplify empty form placeholder copy

### DIFF
--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
@@ -44,8 +44,7 @@ export const enSG: Fields = {
     or: 'OR',
     dropFieldHere: 'Drop your field here',
     tapToAddField: 'Tap here to add a field',
-    dragFromBuilderToStart:
-      'Drag a field from the Builder on the left to start',
+    dragFromBuilderToStart: 'Drag a field from the left to start',
   },
   fieldRowContainer: {
     hiddenByLogicTooltip: 'This field may be hidden by your form logic',


### PR DESCRIPTION
## Problem

The empty-form placeholder shown on the form canvas read:

> Drag a field from the **Builder** on the left to start

There is no "Builder" concept anywhere in the UI. Fields are dragged from the **Fields** tab on the left, so the term doesn't map to anything the admin actually sees.

## Change

Simplify the copy to drop the nonexistent term:

> Drag a field from the left to start

Before:

<img width="1487" height="686" alt="image" src="https://github.com/user-attachments/assets/6ba19658-d412-4993-8d7f-9f8a66bc6acc" />

After:

<img width="1487" height="686" alt="image" src="https://github.com/user-attachments/assets/5668c8cb-ff6d-4358-8d6a-50f1a4e9c0a2" />



