### PR TITLE
feat: progressive disclosure + plain-language copy for email notifications page

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -367,7 +367,7 @@ const getEmailsToNotifyAboutMrfOutcome = ({
   const othersEmailsToNotify =
     form.emails && Array.isArray(form.emails) ? form.emails : []
 
-  // Emails to notify under the 'An email field on your form' setting
+  // Emails to notify under the 'An email address collected from an email field' setting
   const stepOneEmailNotificationFieldId = form.stepOneEmailNotificationFieldId
   const respondentInStepOneToNotify = stepOneEmailNotificationFieldId
     ? getEmailFromResponses(stepOneEmailNotificationFieldId, responses)

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -363,11 +363,11 @@ const getEmailsToNotifyAboutMrfOutcome = ({
     submissionId,
   }
 
-  // Emails to notify under the 'others' setting
+  // Emails to notify under the 'Any email address you choose' setting
   const othersEmailsToNotify =
     form.emails && Array.isArray(form.emails) ? form.emails : []
 
-  // Emails to notify under the 'Respondent in step 1' setting
+  // Emails to notify under the 'An email field on your form' setting
   const stepOneEmailNotificationFieldId = form.stepOneEmailNotificationFieldId
   const respondentInStepOneToNotify = stepOneEmailNotificationFieldId
     ? getEmailFromResponses(stepOneEmailNotificationFieldId, responses)
@@ -377,7 +377,7 @@ const getEmailsToNotifyAboutMrfOutcome = ({
     ? [respondentInStepOneToNotify]
     : []
 
-  // Emails to notify under the 'Other respondents in your workflow' setting
+  // Emails to notify under the 'People who are filling up a workflow step' setting
   const stepsToNotifyUpToCurrentStep = form.workflow.slice(
     1, // exclude first step since notification is indicated by `stepOneEmailNotificationFieldId`
     currentStepNumber + 1,

--- a/apps/frontend/src/features/admin-form/settings/SettingsEmailsPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsEmailsPage.stories.tsx
@@ -174,6 +174,60 @@ PrivateMultiRespondentForm.parameters = {
   },
 }
 
+// No workflow (0 steps): only the "Any email address you choose" field shows,
+// with the no-workflow description copy.
+export const PrivateMultiRespondentFormNoWorkflow = Template.bind({})
+PrivateMultiRespondentFormNoWorkflow.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Multirespondent,
+        overrides: {
+          status: FormStatus.Private,
+          emails: ['admin@example.com'],
+          stepsToNotify: [],
+          stepOneEmailNotificationFieldId: undefined,
+          workflow: [],
+        },
+      }),
+    },
+  },
+}
+
+// One workflow step: shows "Any email address you choose" plus the email-field
+// dropdown, but not the "People who are filling up a workflow step" multi-select.
+export const PrivateMultiRespondentFormSingleStep = Template.bind({})
+PrivateMultiRespondentFormSingleStep.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        mode: FormResponseMode.Multirespondent,
+        overrides: {
+          form_fields: [
+            {
+              _id: 'email_field_id',
+              fieldType: BasicField.Email,
+              title: 'Respondent 1 Email',
+            } as FormFieldDto,
+          ],
+          status: FormStatus.Private,
+          stepOneEmailNotificationFieldId: 'email_field_id',
+          emails: ['admin@example.com'],
+          stepsToNotify: [],
+          workflow: [
+            {
+              _id: 'field_id_1',
+              workflow_type: WorkflowType.Dynamic,
+              field: 'email_field_id',
+              edit: [],
+            },
+          ],
+        },
+      }),
+    },
+  },
+}
+
 export const PrivateMultiRespondentFormWithInvalidStepOneEmailNotificationFieldId =
   Template.bind({})
 PrivateMultiRespondentFormWithInvalidStepOneEmailNotificationFieldId.parameters =

--- a/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -164,59 +164,8 @@ const MrfEmailNotificationsForm = ({
             'features.adminForm.settings.emailNotifications.section.mrf.selectRecipient',
           )}
         </Text>
-        <Box>
-          <FormControl
-            isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
-            isDisabled={isDisabled}
-          >
-            <FormLabel
-              textColor="secondary.700"
-              mb="0.75rem"
-              tooltipVariant="info"
-              tooltipPlacement="top"
-              tooltipText={t(
-                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
-              )}
-              isHighContrast={isHighContrast}
-            >
-              {t(
-                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
-              )}
-            </FormLabel>
-            <Controller<FormData>
-              name={OTHER_PARTIES_EMAIL_INPUT_NAME}
-              control={control}
-              rules={
-                optionalAdminEmailValidationRules as RegisterOptions<FormData>
-              }
-              render={({ field }) => (
-                <TagInput
-                  placeholder={
-                    isDisabled ? undefined : otherPartiesEmailInputPlaceholder
-                  }
-                  {...field}
-                  value={field.value as string[]}
-                  isDisabled={isDisabled}
-                  onBlur={handleOtherPartiesEmailInputBlur}
-                  tagValidation={isEmail}
-                />
-              )}
-            />
-            {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
-              <FormLabel.Description color="secondary.400" mt="0.5rem">
-                {t(
-                  'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
-                )}
-              </FormLabel.Description>
-            ) : (
-              <FormErrorMessage>
-                {get(errors, `${OTHER_PARTIES_EMAIL_INPUT_NAME}.message`)}
-              </FormErrorMessage>
-            )}
-          </FormControl>
-        </Box>
         {workflowStepCount >= 1 && (
-          <Box my="1.5rem">
+          <Box>
             <FormLabel mb="0.75rem" textColor="secondary.700">
               {t(
                 'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.label',
@@ -296,6 +245,57 @@ const MrfEmailNotificationsForm = ({
             </Skeleton>
           </Box>
         )}
+      </Box>
+      <Box my="1.5rem">
+        <FormControl
+          isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
+          isDisabled={isDisabled}
+        >
+          <FormLabel
+            textColor="secondary.700"
+            mb="0.75rem"
+            tooltipVariant="info"
+            tooltipPlacement="top"
+            tooltipText={t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
+            )}
+            isHighContrast={isHighContrast}
+          >
+            {t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
+            )}
+          </FormLabel>
+          <Controller<FormData>
+            name={OTHER_PARTIES_EMAIL_INPUT_NAME}
+            control={control}
+            rules={
+              optionalAdminEmailValidationRules as RegisterOptions<FormData>
+            }
+            render={({ field }) => (
+              <TagInput
+                placeholder={
+                  isDisabled ? undefined : otherPartiesEmailInputPlaceholder
+                }
+                {...field}
+                value={field.value as string[]}
+                isDisabled={isDisabled}
+                onBlur={handleOtherPartiesEmailInputBlur}
+                tagValidation={isEmail}
+              />
+            )}
+          />
+          {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
+            <FormLabel.Description color="secondary.400" mt="0.5rem">
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
+              )}
+            </FormLabel.Description>
+          ) : (
+            <FormErrorMessage>
+              {get(errors, `${OTHER_PARTIES_EMAIL_INPUT_NAME}.message`)}
+            </FormErrorMessage>
+          )}
+        </FormControl>
       </Box>
     </form>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -3,6 +3,7 @@ import { Controller, RegisterOptions, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import {
   Box,
+  Divider,
   FormControl,
   FormErrorMessage,
   Skeleton,
@@ -163,6 +164,57 @@ const MrfEmailNotificationsForm = ({
           )}
         </Text>
         <Box>
+          <FormControl
+            isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
+            isDisabled={isDisabled}
+          >
+            <FormLabel
+              textColor="secondary.700"
+              mb="0.75rem"
+              tooltipVariant="info"
+              tooltipPlacement="top"
+              tooltipText={t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
+              )}
+              isHighContrast={isHighContrast}
+            >
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
+              )}
+            </FormLabel>
+            <Controller<FormData>
+              name={OTHER_PARTIES_EMAIL_INPUT_NAME}
+              control={control}
+              rules={
+                optionalAdminEmailValidationRules as RegisterOptions<FormData>
+              }
+              render={({ field }) => (
+                <TagInput
+                  placeholder={
+                    isDisabled ? undefined : otherPartiesEmailInputPlaceholder
+                  }
+                  {...field}
+                  value={field.value as string[]}
+                  isDisabled={isDisabled}
+                  onBlur={handleOtherPartiesEmailInputBlur}
+                  tagValidation={isEmail}
+                />
+              )}
+            />
+            {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
+              <FormLabel.Description color="secondary.400" mt="0.5rem">
+                {t(
+                  'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
+                )}
+              </FormLabel.Description>
+            ) : (
+              <FormErrorMessage>
+                {get(errors, `${OTHER_PARTIES_EMAIL_INPUT_NAME}.message`)}
+              </FormErrorMessage>
+            )}
+          </FormControl>
+        </Box>
+        <Box my="1.5rem">
           <FormLabel mb="0.75rem" textColor="secondary.700">
             {t(
               'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.label',
@@ -191,6 +243,7 @@ const MrfEmailNotificationsForm = ({
             />
           </Skeleton>
         </Box>
+        <Divider my="2.5rem" />
         <Box my="1.5rem">
           <FormLabel mb="0.75rem" textColor="secondary.700">
             {t(
@@ -234,57 +287,6 @@ const MrfEmailNotificationsForm = ({
             />
           </Skeleton>
         </Box>
-      </Box>
-      <Box my="1.5rem">
-        <FormControl
-          isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
-          isDisabled={isDisabled}
-        >
-          <FormLabel
-            textColor="secondary.700"
-            mb="0.75rem"
-            tooltipVariant="info"
-            tooltipPlacement="top"
-            tooltipText={t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
-            )}
-            isHighContrast={isHighContrast}
-          >
-            {t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
-            )}
-          </FormLabel>
-          <Controller<FormData>
-            name={OTHER_PARTIES_EMAIL_INPUT_NAME}
-            control={control}
-            rules={
-              optionalAdminEmailValidationRules as RegisterOptions<FormData>
-            }
-            render={({ field }) => (
-              <TagInput
-                placeholder={
-                  isDisabled ? undefined : otherPartiesEmailInputPlaceholder
-                }
-                {...field}
-                value={field.value as string[]}
-                isDisabled={isDisabled}
-                onBlur={handleOtherPartiesEmailInputBlur}
-                tagValidation={isEmail}
-              />
-            )}
-          />
-          {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
-            <FormLabel.Description color="secondary.400" mt="0.5rem">
-              {t(
-                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
-              )}
-            </FormLabel.Description>
-          ) : (
-            <FormErrorMessage>
-              {get(errors, `${OTHER_PARTIES_EMAIL_INPUT_NAME}.message`)}
-            </FormErrorMessage>
-          )}
-        </FormControl>
       </Box>
     </form>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -255,16 +255,11 @@ const MrfEmailNotificationsForm = ({
         )}
         {workflowStepCount >= 2 && (
           <Box my="1.5rem">
-            <FormLabel mb="0.25rem" textColor="secondary.700">
+            <FormLabel mb="0.75rem" textColor="secondary.700">
               {t(
                 'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
               )}
             </FormLabel>
-            <FormLabel.Description color="secondary.400" mb="0.75rem">
-              {t(
-                'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.description',
-              )}
-            </FormLabel.Description>
             <Skeleton isLoaded={!isLoading}>
               <Controller
                 control={control}

--- a/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -3,7 +3,6 @@ import { Controller, RegisterOptions, useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import {
   Box,
-  Divider,
   FormControl,
   FormErrorMessage,
   Skeleton,
@@ -65,6 +64,8 @@ const MrfEmailNotificationsForm = ({
       ...step,
       stepNumber: index + 1,
     })) ?? []
+
+  const workflowStepCount = formWorkflowStepsWithStepNumber.length
 
   const emailFieldItems = emailFormFields.map(
     ({ _id, questionNumber, title, fieldType }) => ({
@@ -214,84 +215,87 @@ const MrfEmailNotificationsForm = ({
             )}
           </FormControl>
         </Box>
-        <Box my="1.5rem">
-          <FormLabel mb="0.75rem" textColor="secondary.700">
-            {t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.label',
-            )}
-          </FormLabel>
-          <Skeleton isLoaded={!isLoading}>
-            <Controller
-              control={control}
-              name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
-              render={({
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                field: { value, onBlur, ...rest },
-              }) => (
-                <SingleSelect
-                  isDisabled={isLoading || isDisabled}
-                  placeholder={t(
-                    'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.placeholder',
-                  )}
-                  items={emailFieldItems}
-                  onBlur={handleSubmit(onSubmit)}
-                  isClearable
-                  value={value}
-                  {...rest}
-                />
+        {workflowStepCount >= 1 && (
+          <Box my="1.5rem">
+            <FormLabel mb="0.75rem" textColor="secondary.700">
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.label',
               )}
-            />
-          </Skeleton>
-        </Box>
-        <Divider my="2.5rem" />
-        <Box my="1.5rem">
-          <FormLabel mb="0.25rem" textColor="secondary.700">
-            {t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
-            )}
-          </FormLabel>
-          <FormLabel.Description color="secondary.400" mb="0.75rem">
-            {t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.description',
-            )}
-          </FormLabel.Description>
-          <Skeleton isLoaded={!isLoading}>
-            <Controller
-              control={control}
-              name={WORKFLOW_EMAIL_MULTISELECT_NAME}
-              render={({
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                field: { value: values = [], onChange, onBlur, ...rest },
-              }) => (
-                <MultiSelect
-                  items={formWorkflowStepsWithStepNumber
-                    .filter((step) => step.stepNumber > 1)
-                    .map(({ step_name, stepNumber, _id: value }) => ({
-                      label:
-                        t(
-                          'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.each',
-                          { stepNumber },
-                        ) + (step_name ? ` (${step_name})` : ''),
-                      value,
-                    }))}
-                  values={values}
-                  onChange={onChange}
-                  onBlur={handleSubmit(onSubmit)}
-                  placeholder={
-                    isDisabled
-                      ? null
-                      : t(
-                          'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.placeholder',
-                        )
-                  }
-                  isSelectedItemFullWidth
-                  isDisabled={isLoading || isDisabled}
-                  {...rest}
-                />
+            </FormLabel>
+            <Skeleton isLoaded={!isLoading}>
+              <Controller
+                control={control}
+                name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
+                render={({
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  field: { value, onBlur, ...rest },
+                }) => (
+                  <SingleSelect
+                    isDisabled={isLoading || isDisabled}
+                    placeholder={t(
+                      'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.placeholder',
+                    )}
+                    items={emailFieldItems}
+                    onBlur={handleSubmit(onSubmit)}
+                    isClearable
+                    value={value}
+                    {...rest}
+                  />
+                )}
+              />
+            </Skeleton>
+          </Box>
+        )}
+        {workflowStepCount >= 2 && (
+          <Box my="1.5rem">
+            <FormLabel mb="0.25rem" textColor="secondary.700">
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
               )}
-            />
-          </Skeleton>
-        </Box>
+            </FormLabel>
+            <FormLabel.Description color="secondary.400" mb="0.75rem">
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.description',
+              )}
+            </FormLabel.Description>
+            <Skeleton isLoaded={!isLoading}>
+              <Controller
+                control={control}
+                name={WORKFLOW_EMAIL_MULTISELECT_NAME}
+                render={({
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  field: { value: values = [], onChange, onBlur, ...rest },
+                }) => (
+                  <MultiSelect
+                    items={formWorkflowStepsWithStepNumber
+                      .filter((step) => step.stepNumber > 1)
+                      .map(({ step_name, stepNumber, _id: value }) => ({
+                        label:
+                          t(
+                            'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.each',
+                            { stepNumber },
+                          ) + (step_name ? ` (${step_name})` : ''),
+                        value,
+                      }))}
+                    values={values}
+                    onChange={onChange}
+                    onBlur={handleSubmit(onSubmit)}
+                    placeholder={
+                      isDisabled
+                        ? null
+                        : t(
+                            'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.placeholder',
+                          )
+                    }
+                    isSelectedItemFullWidth
+                    isDisabled={isLoading || isDisabled}
+                    {...rest}
+                  />
+                )}
+              />
+            </Skeleton>
+          </Box>
+        )}
       </Box>
     </form>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -153,17 +153,75 @@ const MrfEmailNotificationsForm = ({
       ? undefined
       : 'me@example.com'
 
+  const sectionText: string =
+    workflowStepCount >= 1
+      ? t(
+          'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientWorkflow',
+        )
+      : t(
+          'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientNoWorkflow',
+        )
+
   const optionalAdminEmailValidationRules =
     useOptionalAdminEmailValidationRules()
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Box>
+      <Box my="1.5rem">
         <Text textStyle="body-1" textColor="secondary.700" mb="1.5rem">
-          {t(
-            'features.adminForm.settings.emailNotifications.section.mrf.selectRecipient',
-          )}
+          {sectionText}
         </Text>
+        <FormControl
+          isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
+          isDisabled={isDisabled}
+        >
+          <FormLabel
+            textColor="secondary.700"
+            mb="0.75rem"
+            tooltipVariant="info"
+            tooltipPlacement="top"
+            tooltipText={t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
+            )}
+            isHighContrast={isHighContrast}
+          >
+            {t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
+            )}
+          </FormLabel>
+          <Controller<FormData>
+            name={OTHER_PARTIES_EMAIL_INPUT_NAME}
+            control={control}
+            rules={
+              optionalAdminEmailValidationRules as RegisterOptions<FormData>
+            }
+            render={({ field }) => (
+              <TagInput
+                placeholder={
+                  isDisabled ? undefined : otherPartiesEmailInputPlaceholder
+                }
+                {...field}
+                value={field.value as string[]}
+                isDisabled={isDisabled}
+                onBlur={handleOtherPartiesEmailInputBlur}
+                tagValidation={isEmail}
+              />
+            )}
+          />
+          {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
+            <FormLabel.Description color="secondary.400" mt="0.5rem">
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
+              )}
+            </FormLabel.Description>
+          ) : (
+            <FormErrorMessage>
+              {get(errors, `${OTHER_PARTIES_EMAIL_INPUT_NAME}.message`)}
+            </FormErrorMessage>
+          )}
+        </FormControl>
+      </Box>
+      <Box>
         {workflowStepCount >= 1 && (
           <Box>
             <FormLabel mb="0.75rem" textColor="secondary.700">
@@ -245,57 +303,6 @@ const MrfEmailNotificationsForm = ({
             </Skeleton>
           </Box>
         )}
-      </Box>
-      <Box my="1.5rem">
-        <FormControl
-          isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
-          isDisabled={isDisabled}
-        >
-          <FormLabel
-            textColor="secondary.700"
-            mb="0.75rem"
-            tooltipVariant="info"
-            tooltipPlacement="top"
-            tooltipText={t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
-            )}
-            isHighContrast={isHighContrast}
-          >
-            {t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
-            )}
-          </FormLabel>
-          <Controller<FormData>
-            name={OTHER_PARTIES_EMAIL_INPUT_NAME}
-            control={control}
-            rules={
-              optionalAdminEmailValidationRules as RegisterOptions<FormData>
-            }
-            render={({ field }) => (
-              <TagInput
-                placeholder={
-                  isDisabled ? undefined : otherPartiesEmailInputPlaceholder
-                }
-                {...field}
-                value={field.value as string[]}
-                isDisabled={isDisabled}
-                onBlur={handleOtherPartiesEmailInputBlur}
-                tagValidation={isEmail}
-              />
-            )}
-          />
-          {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
-            <FormLabel.Description color="secondary.400" mt="0.5rem">
-              {t(
-                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
-              )}
-            </FormLabel.Description>
-          ) : (
-            <FormErrorMessage>
-              {get(errors, `${OTHER_PARTIES_EMAIL_INPUT_NAME}.message`)}
-            </FormErrorMessage>
-          )}
-        </FormControl>
       </Box>
     </form>
   )

--- a/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -245,11 +245,16 @@ const MrfEmailNotificationsForm = ({
         </Box>
         <Divider my="2.5rem" />
         <Box my="1.5rem">
-          <FormLabel mb="0.75rem" textColor="secondary.700">
+          <FormLabel mb="0.25rem" textColor="secondary.700">
             {t(
               'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
             )}
           </FormLabel>
+          <FormLabel.Description color="secondary.400" mb="0.75rem">
+            {t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.description',
+            )}
+          </FormLabel.Description>
           <Skeleton isLoaded={!isLoading}>
             <Controller
               control={control}

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
@@ -25,8 +25,15 @@ export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
   // capture current time on page load to prevent re-renders from update to current time
   const currentTime = useRef(Date.now())
 
-  // DEV: always show admin feedback (eligibility + frequency gates bypassed)
-  const showAdminFeedback = true
+  // check if admin is eligible in current session
+  // and has yet to seen feedback beyond our stipulated frequency
+  const showAdminFeedback =
+    isAdminFeedbackEligible &&
+    // if feedbackTime has not been seen
+    (!lastFeedbackTime ||
+      // or if last feedback time seen is more than frequency (frequency env var must be defined)
+      (!!adminFeedbackDisplayFrequency &&
+        currentTime.current - lastFeedbackTime > adminFeedbackDisplayFrequency))
 
   // sets display of feedback box
   useEffect(() => {

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
@@ -25,15 +25,8 @@ export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
   // capture current time on page load to prevent re-renders from update to current time
   const currentTime = useRef(Date.now())
 
-  // check if admin is eligible in current session
-  // and has yet to seen feedback beyond our stipulated frequency
-  const showAdminFeedback =
-    isAdminFeedbackEligible &&
-    // if feedbackTime has not been seen
-    (!lastFeedbackTime ||
-      // or if last feedback time seen is more than frequency (frequency env var must be defined)
-      (!!adminFeedbackDisplayFrequency &&
-        currentTime.current - lastFeedbackTime > adminFeedbackDisplayFrequency))
+  // DEV: always show admin feedback (eligibility + frequency gates bypassed)
+  const showAdminFeedback = true
 
   // sets display of feedback box
   useEffect(() => {

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
@@ -8,7 +8,7 @@ export const enSG = {
   section: {
     mrf: {
       selectRecipientNoWorkflow:
-        'Select who to notify when the form and/or workflow is complete:',
+        'Select who to notify when a response has been submitted',
       selectRecipientWorkflow:
         'Select who to notify when the workflow is complete',
       respondents: {
@@ -19,7 +19,7 @@ export const enSG = {
         others: {
           label: 'Any email address you choose',
           tooltipText:
-            "Include the admin's email to inform them whenever a workflow is completed",
+            "Include the admin's email to notify them whenever a response is submitted",
           description: 'Separate multiple email addresses with a comma',
         },
         stepN: {
@@ -27,7 +27,6 @@ export const enSG = {
             overall: 'People who are filling up a workflow step',
             each: 'Respondent(s) in Step {stepNumber}',
           },
-          description: 'Only if you have a workflow enabled for your form',
           placeholder: 'Select steps from your form',
         },
       },

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
@@ -17,7 +17,7 @@ export const enSG = {
           placeholder: 'Select an email field from your form',
         },
         others: {
-          label: 'Any email address you choose',
+          label: 'Any email addresses you choose',
           tooltipText:
             "Include the admin's email to notify them whenever a response is submitted",
           description: 'Separate multiple email addresses with a comma',
@@ -25,7 +25,7 @@ export const enSG = {
         stepN: {
           label: {
             overall: 'People who are filling up a workflow step',
-            each: 'Respondent(s) in Step {stepNumber}',
+            each: 'People in Step {stepNumber}',
           },
           placeholder: 'Select steps from your form',
         },

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
@@ -7,8 +7,10 @@ export const enSG = {
   },
   section: {
     mrf: {
-      selectRecipient:
+      selectRecipientNoWorkflow:
         'Select who to notify when the form and/or workflow is complete:',
+      selectRecipientWorkflow:
+        'Select who to notify when the workflow is complete',
       respondents: {
         step1: {
           label: 'An email address collected from an email field',

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
@@ -11,7 +11,7 @@ export const enSG = {
         'Select who to notify when the form and/or workflow is complete:',
       respondents: {
         step1: {
-          label: 'An email field on your form',
+          label: 'An email address collected from an email field',
           placeholder: 'Select an email field from your form',
         },
         others: {
@@ -25,6 +25,7 @@ export const enSG = {
             overall: 'People who are filling up a workflow step',
             each: 'Respondent(s) in Step {stepNumber}',
           },
+          description: 'Only if you have a workflow enabled for your form',
           placeholder: 'Select steps from your form',
         },
       },

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
@@ -11,21 +11,21 @@ export const enSG = {
         'Select who to notify when the form and/or workflow is complete:',
       respondents: {
         step1: {
-          label: 'Respondent in Step 1',
+          label: 'An email field on your form',
           placeholder: 'Select an email field from your form',
         },
-        stepN: {
-          label: {
-            overall: 'Other respondents in your workflow',
-            each: 'Respondent(s) in Step {stepNumber}',
-          },
-          placeholder: 'Select respondents from your form',
-        },
         others: {
-          label: 'Others',
+          label: 'Any email address you choose',
           tooltipText:
             "Include the admin's email to inform them whenever a workflow is completed",
           description: 'Separate multiple email addresses with a comma',
+        },
+        stepN: {
+          label: {
+            overall: 'People who are filling up a workflow step',
+            each: 'Respondent(s) in Step {stepNumber}',
+          },
+          placeholder: 'Select steps from your form',
         },
       },
     },

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
@@ -20,6 +20,7 @@ export interface EmailNotifications extends HasTitle {
             overall: string
             each: string
           }
+          description: string
           placeholder: string
         }
         others: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
@@ -21,7 +21,6 @@ export interface EmailNotifications extends HasTitle {
             overall: string
             each: string
           }
-          description: string
           placeholder: string
         }
         others: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
@@ -9,7 +9,8 @@ export interface EmailNotifications extends HasTitle {
   }
   section: {
     mrf: {
-      selectRecipient: string
+      selectRecipientWorkflow: string
+      selectRecipientNoWorkflow: string
       respondents: {
         step1: {
           label: string


### PR DESCRIPTION
## Problem

The Email notifications page (Settings > Email notifications) shows
workflow-specific fields and jargon to every admin, even those without a
workflow. That makes it unusable for non-workflow admins and blocks the wider
rollout of unified mode (merging Storage and MRF).

## Solution

The page now adapts to the form's workflow step count and uses plain-language
labels throughout. Fields are reordered so the most universally relevant one
comes first, and workflow-only fields appear only when they apply:

- **0 steps (no workflow):** only "Any email address you choose", with the
  description "Select who to notify when a response has been submitted".
- **1 step:** adds "An email address collected from an email field"; description
  switches to "Select who to notify when the workflow is complete".
- **2+ steps:** also adds "People who are filling up a workflow step".

Copy lives in the i18n locale file; backend notification logic is unchanged
(only inline comments were relabelled). Two Storybook stories were added to lock
the 0-step and 1-step states.

**Screenshots**

Visual verification passed for all three states via Storybook (screenshots to be
attached). Summary of what renders:

| Before | After |
| --- | --- |
| <img width="2502" height="1858" alt="image" src="https://github.com/user-attachments/assets/d0b56cf7-bea8-482f-bef0-fa4af8232e91" /> | <img width="2502" height="1778" alt="image" src="https://github.com/user-attachments/assets/95054aba-b84e-4637-9f6b-626ca3a6e061" /> <img width="2502" height="1778" alt="image" src="https://github.com/user-attachments/assets/b53fe520-7d88-43b7-979c-18fef645e1cf" /> <img width="2502" height="1778" alt="image" src="https://github.com/user-attachments/assets/1726be83-494e-4bfa-96f8-da55317d2d1c" /> |




| Story | Description | Fields |
| --- | --- | --- |
| `PrivateMultiRespondentFormNoWorkflow` (0 steps) | "...when a response has been submitted" | Any email address only |
| `PrivateMultiRespondentFormSingleStep` (1 step) | "...when the workflow is complete" | Any email address + email-field dropdown |
| `PrivateMultiRespondentForm` (2+ steps) | "...when the workflow is complete" | all three, in order |

**Breaking Changes**

No - backwards compatible. Display logic and copy only; no data or API changes.

## Tests

**TC1: MRF form with no workflow (0 steps)**

- [x] Only "Any email address you choose" shows
- [x] Description reads "Select who to notify when a response has been submitted"
- [x] Field tooltip reads "...notify them whenever a response is submitted"

**TC2: MRF form with 1 workflow step**

- [x] "Any email address you choose" + "An email address collected from an email field" show
- [x] "People who are filling up a workflow step" is hidden
- [x] Description reads "Select who to notify when the workflow is complete"

**TC3: MRF form with 2+ workflow steps**

- [x] All three fields show, in order
- [x] Saving each field persists (blur triggers save)
