### PR TITLE
fix(ci): persist deploy key for tagging and version bump commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,14 @@ jobs:
       version: ${{ steps.version.outputs.tag }}
       sdk-tag: ${{ steps.sdk.outputs.tag }}
     steps:
-      # actions/checkout persists the GITHUB_TOKEN for the origin remote, so the
+      # actions/checkout persists the DEPLOY_KEY for the origin remote, so the
       # push steps below can write the bump commit and tags back to develop.
       - name: Checkout develop
         uses: actions/checkout@v4.3.1
         with:
           ref: develop
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          persist-credentials: true
           fetch-depth: 0
 
       - name: Configure git identity


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The push command still uses github tokens instead of `DEPLOY_KEY` for pushing the commits and tags.

Related to #9661.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [x] No - this PR is backwards compatible  

**Bug Fixes**:

- Persist and use the `DEPLOY_KEY` for pushing the commits and tags.
