### PR TITLE
fix(submission): preserve validation message keys

### DIFF
--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.middleware.ts
@@ -264,12 +264,7 @@ export const scanAndRetrieveAttachments = async (
       error: scanAndRetrieveFilesResult.error,
     })
 
-    const { statusCode, errorMessage } = mapRouteError(
-      scanAndRetrieveFilesResult.error,
-    )
-    return res.status(statusCode).json({
-      message: errorMessage,
-    })
+    return sendRouteError(res, mapRouteError(scanAndRetrieveFilesResult.error))
   }
 
   logger.info({
@@ -331,10 +326,7 @@ export const validatePaymentSubmission = async (
           meta: logMeta,
           error,
         })
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({
-          message: errorMessage,
-        })
+        return sendRouteError(res, mapRouteError(error))
       })
   }
   return next()
@@ -441,9 +433,7 @@ export const validateStorageSubmission = async (
         meta: logMeta,
         error,
       })
-      const { statusCode, errorMessage } = mapRouteError(error)
-      return res.status(statusCode).json({
-        message: errorMessage,
+      return sendRouteError(res, mapRouteError(error), {
         spcpSubmissionFailure,
       })
     })
@@ -567,12 +557,7 @@ export const validateEncryptSubmission = async (
       meta: logMeta,
       error: incomingSubmissionResult.error,
     })
-    const { statusCode, errorMessage } = mapRouteError(
-      incomingSubmissionResult.error,
-    )
-    return res.status(statusCode).json({
-      message: errorMessage,
-    })
+    return sendRouteError(res, mapRouteError(incomingSubmissionResult.error))
   }
 
   logger.info({
@@ -644,12 +629,10 @@ export const createFormsgAndRetrieveForm = async (
         'Trying to submit non-encrypt mode submission on encrypt-form submission endpoint',
       meta: logMeta,
     })
-    const { statusCode, errorMessage } = mapRouteError(
-      checkFormIsEncryptModeResult.error,
+    return sendRouteError(
+      res,
+      mapRouteError(checkFormIsEncryptModeResult.error),
     )
-    return res.status(statusCode).json({
-      message: errorMessage,
-    })
   }
 
   // Step 4b: Set formsg.encryptedFormDef in req.body


### PR DESCRIPTION
## Problem
PR #9664 added `messageKey` handling, but the storage submission validation error path still manually serialized `mapRouteError(error)` and only returned `message`. This made MyInfo login validation failures drop `messageKey`.

Refs #9213

## Solution

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:
- Use `sendRouteError(...)` in storage submission validation so mapped `errorMessageKey`s are included in the response.

## Before & After Screenshots

**BEFORE**:
N/A

**AFTER**:
N/A

## Tests
- `pnpm test:backend public-forms.submissions.routes.spec.ts --runInBand` (45 passed; Jest open-handle warning)

## Deploy Notes

**New environment variables**:
- N/A

**New scripts**:
- N/A

**New dependencies**:
- N/A

**New dev dependencies**:
- N/A
