### PR TITLE
feat: extract text from Logic Components

### DIFF
--- a/apps/frontend/src/features/admin-form/create/logic/CreatePageLogicTab.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/CreatePageLogicTab.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiPlus } from 'react-icons/bi'
 import { Box, Container, Flex, Spacer } from '@chakra-ui/react'
 
@@ -11,6 +12,7 @@ import { useAdminFormLogic } from './hooks/useAdminFormLogic'
 import { useAdminLogicStore } from './adminLogicStore'
 
 export const CreatePageLogicTab = (): JSX.Element => {
+  const { t } = useTranslation()
   const { createOrEditData, setToCreating, reset } = useAdminLogicStore(
     useCallback((state) => {
       return {
@@ -51,7 +53,7 @@ export const CreatePageLogicTab = (): JSX.Element => {
               bottom={{ base: '5rem', md: undefined }}
               right={{ base: '1rem', md: undefined }}
               icon={<BiPlus fontSize="1.5rem" />}
-              aria-label="Add logic"
+              aria-label={t('features.adminForm.sidebar.logic.addLogicBtn')}
               isDisabled={!!createOrEditData}
               onClick={setToCreating}
             />

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/EditConditionBlock.tsx
@@ -88,10 +88,10 @@ export const EditConditionBlock = ({
       resetField(`${name}.field`)
       setError(`${name}.field`, {
         type: 'manual',
-        message: 'This field was deleted, please select another field',
+        message: t('features.adminForm.sidebar.logic.errors.fieldDeleted'),
       })
     }
-  }, [ifFieldIdValue, idToFieldMap, name, resetField, setError])
+  }, [ifFieldIdValue, idToFieldMap, name, resetField, setError, t])
 
   /**
    * Effect to reset the field if the field to apply a condition on is changed.

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/SaveActionGroup.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/SaveActionGroup.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { BiTrash } from 'react-icons/bi'
 import { Box, Flex, Stack } from '@chakra-ui/react'
 
@@ -15,13 +16,14 @@ export interface SaveActionGroupProps {
 }
 
 export const SaveActionGroup = ({
-  submitButtonLabel = 'Save changes',
+  submitButtonLabel,
   handleCancel,
   handleDelete,
   handleSubmit,
   isLoading,
   ariaLabelName,
 }: SaveActionGroupProps): JSX.Element => {
+  const { t } = useTranslation()
   const isMobile = useIsMobile()
 
   return (
@@ -34,7 +36,9 @@ export const SaveActionGroup = ({
         <IconButton
           variant="clear"
           colorScheme="danger"
-          aria-label={`Delete ${ariaLabelName}`}
+          aria-label={t('features.adminForm.sidebar.logic.aria.delete', {
+            name: ariaLabelName,
+          })}
           icon={<BiTrash />}
           onClick={handleDelete}
           isDisabled={isLoading}
@@ -52,7 +56,8 @@ export const SaveActionGroup = ({
           onClick={handleSubmit}
           isFullWidth={isMobile}
         >
-          {submitButtonLabel}
+          {submitButtonLabel ??
+            t('features.adminForm.sidebar.logic.saveChangesBtn')}
         </Button>
         <Button
           variant="clear"
@@ -61,7 +66,7 @@ export const SaveActionGroup = ({
           onClick={handleCancel}
           isFullWidth={isMobile}
         >
-          Cancel
+          {t('features.adminForm.sidebar.logic.cancelBtn')}
         </Button>
       </Stack>
     </Flex>

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
 import { Stack } from '@chakra-ui/react'
 import { merge } from 'lodash'
 
@@ -108,6 +109,7 @@ export const EditLogicBlock = ({
   submitButtonLabel,
   handleOpenDeleteModal,
 }: EditLogicBlockProps) => {
+  const { t } = useTranslation()
   const {
     formMethods,
     logicConditionBlocks,
@@ -159,7 +161,9 @@ export const EditLogicBlock = ({
         handleDelete={handleOpenDeleteModal}
         handleCancel={setToInactive}
         submitButtonLabel={submitButtonLabel}
-        ariaLabelName="logic"
+        ariaLabelName={t(
+          'features.adminForm.sidebar.logic.logic',
+        ).toLowerCase()}
       />
     </EditConditionWrapper>
   )

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
@@ -161,9 +161,7 @@ export const EditLogicBlock = ({
         handleDelete={handleOpenDeleteModal}
         handleCancel={setToInactive}
         submitButtonLabel={submitButtonLabel}
-        ariaLabelName={t(
-          'features.adminForm.sidebar.logic.logic',
-        ).toLowerCase()}
+        ariaLabelName={t('features.adminForm.sidebar.logic.aria.logicName')}
       />
     </EditConditionWrapper>
   )

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/FieldLogicBadge.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Box, Icon, Stack, Text } from '@chakra-ui/react'
 
 import { BxsErrorCircle, BxsInfoCircle } from '~assets/icons'
@@ -15,7 +16,7 @@ interface FieldLogicBadgeProps {
   field?: FormFieldWithQuestionNo
   defaults?: {
     variant: 'error' | 'info'
-    message: string
+    message?: string
   }
 }
 
@@ -26,9 +27,17 @@ export const FieldLogicBadge = ({
   field,
   defaults = {
     variant: 'error',
-    message: 'This field was deleted, please select another field',
   },
 }: FieldLogicBadgeProps) => {
+  const { t } = useTranslation()
+
+  const message = useMemo(
+    () =>
+      defaults.message ??
+      t('features.adminForm.sidebar.logic.errors.fieldDeleted'),
+    [defaults.message, t],
+  )
+
   const fieldMeta = useMemo(
     () => (field ? BASICFIELD_TO_DRAWER_META[field.fieldType] : null),
     [field],
@@ -53,8 +62,13 @@ export const FieldLogicBadge = ({
   }, [defaults.variant, fieldMeta])
 
   const tooltipLabel = useMemo(
-    () => (!fieldMeta ? defaults.message : `${fieldMeta.label} field`),
-    [fieldMeta, defaults.message],
+    () =>
+      !fieldMeta
+        ? message
+        : t('features.adminForm.sidebar.logic.fieldBadge.fieldLabel', {
+            label: fieldMeta.label,
+          }),
+    [fieldMeta, message, t],
   )
 
   const tooltipIcon = useMemo(() => {
@@ -79,7 +93,7 @@ export const FieldLogicBadge = ({
           <Text noOfLines={1}>{getLogicFieldLabel(field)}</Text>
         ) : (
           <Text textColor={textColor} noOfLines={1}>
-            {defaults.message}
+            {message}
           </Text>
         )}
       </Stack>

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/InactiveLogicBlock.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { BiPencil } from 'react-icons/bi'
 import { Box, Divider, Stack, StackDivider, Text } from '@chakra-ui/react'
 
@@ -24,6 +25,7 @@ interface InactiveLogicBlockProps {
 export const InactiveLogicBlock = ({
   logic,
 }: InactiveLogicBlockProps): JSX.Element | null => {
+  const { t } = useTranslation()
   const { idToFieldMap } = useAdminFormLogic()
   const setToEditing = useAdminLogicStore(setToEditingSelector)
   const stateData = useAdminLogicStore(createOrEditDataSelector)
@@ -41,14 +43,17 @@ export const InactiveLogicBlock = ({
         )
         return (
           <>
-            <Text>then show</Text>
+            <Text>
+              {t('features.adminForm.sidebar.logic.inactiveBlock.thenShow')}
+            </Text>
             <Stack direction="column" spacing="0.25rem">
               {allInvalid ? (
                 <FieldLogicBadge
                   defaults={{
                     variant: 'error',
-                    message:
-                      'All fields were deleted, please select at least one field',
+                    message: t(
+                      'features.adminForm.sidebar.logic.thenBlock.errors.atLeastOneFieldRequired',
+                    ),
                   }}
                 />
               ) : (
@@ -58,8 +63,9 @@ export const InactiveLogicBlock = ({
                     field={idToFieldMap[fieldId]}
                     defaults={{
                       variant: 'info',
-                      message:
-                        'This field was deleted and has been removed from your logic',
+                      message: t(
+                        'features.adminForm.sidebar.logic.inactiveBlock.fieldRemoved',
+                      ),
                     }}
                   />
                 ))
@@ -71,12 +77,16 @@ export const InactiveLogicBlock = ({
       case LogicType.PreventSubmit:
         return (
           <>
-            <Text>then disable submission</Text>
+            <Text>
+              {t(
+                'features.adminForm.sidebar.logic.inactiveBlock.thenDisableSubmission',
+              )}
+            </Text>
             <LogicBadge>{logic.preventSubmitMessage}</LogicBadge>
           </>
         )
     }
-  }, [logic, idToFieldMap])
+  }, [logic, idToFieldMap, t])
 
   const handleClick = useCallback(() => {
     if (isPreventEdit) {
@@ -112,13 +122,18 @@ export const InactiveLogicBlock = ({
               color="secondary.500"
             >
               <Stack>
-                <Text>{index === 0 ? 'If' : 'and'}</Text>
+                <Text>
+                  {index === 0
+                    ? t('features.adminForm.sidebar.logic.inactiveBlock.if')
+                    : t('features.adminForm.sidebar.logic.and')}
+                </Text>
                 <FieldLogicBadge
                   field={idToFieldMap[condition.field]}
                   defaults={{
                     variant: 'error',
-                    message:
-                      'This field was deleted, please select another field',
+                    message: t(
+                      'features.adminForm.sidebar.logic.errors.fieldDeleted',
+                    ),
                   }}
                 />
               </Stack>
@@ -143,7 +158,7 @@ export const InactiveLogicBlock = ({
         top={{ base: '0.5rem', md: '2rem' }}
         right={{ base: '0.5rem', md: '2rem' }}
         pos="absolute"
-        aria-label="Delete logic"
+        aria-label={t('features.adminForm.sidebar.logic.modals.delete.title')}
         variant="clear"
         onClick={handleClick}
         icon={<BiPencil fontSize="1.5rem" />}

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/LogicContent.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import { Stack } from '@chakra-ui/react'
 
 import InlineMessage from '~components/InlineMessage'
@@ -13,6 +14,7 @@ import { LogicBlockFactory } from './LogicBlockFactory'
 import { NewLogicBlock } from './NewLogicBlock'
 
 export const LogicContent = (): JSX.Element | null => {
+  const { t } = useTranslation()
   const isCreatingState = useAdminLogicStore(isCreatingStateSelector)
   const { formLogics, isLoading, hasError } = useAdminFormLogic()
 
@@ -22,8 +24,7 @@ export const LogicContent = (): JSX.Element | null => {
     <Stack color="secondary.500" spacing="1rem">
       {hasError ? (
         <InlineMessage variant="error">
-          There are errors in your form's logic, please fix them before sharing
-          your form
+          {t('features.adminForm.sidebar.logic.errors.formError')}
         </InlineMessage>
       ) : null}
       <HeaderBlock />

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/NewLogicBlock/NewLogicBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/NewLogicBlock/NewLogicBlock.tsx
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 
 import {
   setToInactiveSelector,
@@ -16,6 +17,7 @@ export interface NewLogicBlockProps {
 export const NewLogicBlock = ({
   _defaultValues,
 }: NewLogicBlockProps): JSX.Element => {
+  const { t } = useTranslation()
   const { createLogicMutation } = useLogicMutations()
   const setToInactive = useAdminLogicStore(setToInactiveSelector)
   const handleSubmit = useCallback(
@@ -31,7 +33,7 @@ export const NewLogicBlock = ({
       isLoading={createLogicMutation.isLoading}
       defaultValues={_defaultValues}
       onSubmit={handleSubmit}
-      submitButtonLabel="Add logic"
+      submitButtonLabel={t('features.adminForm.sidebar.logic.addLogicBtn')}
     />
   )
 }

--- a/apps/frontend/src/features/admin-form/create/logic/mutations.ts
+++ b/apps/frontend/src/features/admin-form/create/logic/mutations.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useMutation, useQueryClient } from 'react-query'
 import { useParams } from 'react-router-dom'
 
@@ -15,6 +16,7 @@ import {
 } from './FormLogicService'
 
 export const useLogicMutations = () => {
+  const { t } = useTranslation()
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
@@ -46,7 +48,9 @@ export const useLogicMutations = () => {
           return prev
         })
         toast({
-          description: 'The logic was successfully created.',
+          description: t(
+            'features.adminForm.sidebar.logic.mutations.createSuccess',
+          ),
         })
       },
       onError: handleError,
@@ -67,7 +71,9 @@ export const useLogicMutations = () => {
           return prev
         })
         toast({
-          description: 'The logic was successfully deleted.',
+          description: t(
+            'features.adminForm.sidebar.logic.mutations.deleteSuccess',
+          ),
         })
       },
       onError: handleError,
@@ -91,7 +97,9 @@ export const useLogicMutations = () => {
           return prev
         })
         toast({
-          description: 'The logic was successfully updated.',
+          description: t(
+            'features.adminForm.sidebar.logic.mutations.updateSuccess',
+          ),
         })
       },
       onError: handleError,

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/en-sg.ts
@@ -6,6 +6,7 @@ export const enSG: Logic = {
   title: 'Start creating logic for your form',
   and: 'and',
   saveChangesBtn: 'Save changes',
+  cancelBtn: 'Cancel',
   helperText:
     'Show or hide fields depending on user input, or disable form submission for invalid answers.',
   helperTextCta: 'Learn to work with logic',
@@ -24,6 +25,20 @@ export const enSG: Logic = {
     show: 'show',
     selectField: 'Select a field',
     selectResultType: 'Select a type of result',
+  },
+  inactiveBlock: {
+    if: 'If',
+    thenShow: 'then show',
+    thenDisableSubmission: 'then disable submission',
+    fieldRemoved: 'This field was deleted and has been removed from your logic',
+  },
+  fieldBadge: {
+    fieldLabel: '{{label}} field',
+  },
+  mutations: {
+    createSuccess: 'The logic was successfully created.',
+    updateSuccess: 'The logic was successfully updated.',
+    deleteSuccess: 'The logic was successfully deleted.',
   },
   logicCondition: {
     [LogicConditionState.Equal]: LogicConditionState.Equal,
@@ -78,11 +93,15 @@ export const enSG: Logic = {
     removeBlock: 'Remove logic condition block',
     criteria: 'Logic criteria',
     condition: 'Logic condition',
+    delete: 'Delete {{name}}',
   },
   errors: {
     conditionRequired: 'Please select a condition',
     fieldRequired: 'Please select a field.',
     fieldInvalid: 'Field is invalid or unable to accept logic.',
+    fieldDeleted: 'This field was deleted, please select another field',
+    formError:
+      "There are errors in your form's logic, please fix them before sharing your form",
     disabledSubmissionMessage:
       'Please enter a message to display when submission is prevented',
     missingLogicCriteria: 'Please enter logic criteria.',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/en-sg.ts
@@ -94,6 +94,7 @@ export const enSG: Logic = {
     criteria: 'Logic criteria',
     condition: 'Logic condition',
     delete: 'Delete {{name}}',
+    logicName: 'logic',
   },
   errors: {
     conditionRequired: 'Please select a condition',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/index.ts
@@ -6,6 +6,7 @@ export interface Logic {
   title: string
   and: string
   saveChangesBtn: string
+  cancelBtn: string
   helperText: string
   helperTextCta: string
   allowedFields: string
@@ -22,6 +23,20 @@ export interface Logic {
     show: string
     selectField: string
     selectResultType: string
+  }
+  inactiveBlock: {
+    if: string
+    thenShow: string
+    thenDisableSubmission: string
+    fieldRemoved: string
+  }
+  fieldBadge: {
+    fieldLabel: string
+  }
+  mutations: {
+    createSuccess: string
+    updateSuccess: string
+    deleteSuccess: string
   }
   logicCondition: {
     [LogicConditionState.Equal]: string
@@ -68,11 +83,14 @@ export interface Logic {
     removeBlock: string
     criteria: string
     condition: string
+    delete: string
   }
   errors: {
     conditionRequired: string
     fieldRequired: string
     fieldInvalid: string
+    fieldDeleted: string
+    formError: string
     disabledSubmissionMessage: string
     missingLogicCriteria: string
     missingLogicType: string

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/index.ts
@@ -84,6 +84,7 @@ export interface Logic {
     criteria: string
     condition: string
     delete: string
+    logicName: string
   }
   errors: {
     conditionRequired: string


### PR DESCRIPTION
## Problem

Closes #8404

Hardcoded user-facing text in the admin form Logic components couldn't be
translated. This PR extracts those strings into i18n locale files so the app
can support multiple languages, and centralises the copy for maintainability.

## Solution

**New locale files** (`apps/frontend/src/i18n/locales/features/admin-form/sidebar/logic/`)
- `en-sg.ts` — the English copy (key → value)
- `index.ts` — TypeScript interface every logic translation key must satisfy, so
  `tsc` verifies each `t('...')` key actually exists

**New keys**
- `cancelBtn`
- `inactiveBlock` → `if`, `thenShow`, `thenDisableSubmission`, `fieldRemoved`
- `fieldBadge` → `fieldLabel`
- `mutations` → `createSuccess`, `updateSuccess`, `deleteSuccess`
- `aria` → `delete`, `logicName`
- `errors` → `fieldDeleted`, `formError`

**Components updated (9)**
- `EditConditionBlock` — error message → `t('...errors.fieldDeleted')`
- `SaveActionGroup` — Cancel / Save changes / delete label (with interpolation)
- `EditLogicBlock` — translated the `ariaLabelName` prop
- `FieldLogicBadge` — field label + fallback message (kept backward-compatible)
- `InactiveLogicBlock` — "then show", "then disable submission", "If"/"and", delete labels
- `NewLogicBlock` — reused existing `addLogicBtn` key
- `LogicContent` — long-form error banner
- `CreatePageLogicTab` — reused `addLogicBtn` for `aria-label`
- `mutations.ts` — 3 success toast messages

**Before**
```tsx
<Button>Save changes</Button>
```

**After**
```tsx
<Button>{t('features.adminForm.sidebar.logic.saveChangesBtn')}</Button>
```

## Breaking Changes

> No — backwards compatible. `FieldLogicBadge` is shared across features, so its
> new props are optional and existing callers are unaffected.

## Tests

- [x] Logic sidebar renders correctly with translated strings
- [x] `tsc` passes — the `Logic` interface enforces that every key exists
- [ ] Existing unit/integration tests pass (CI pending maintainer approval)

## Deploy Notes

New environment variables: **None**
New scripts: **None**
New dependencies: **None**
New dev dependencies: **None**