### PR TITLE
fix(frontend): prevent Instructions tab crash (React error #31)

### DIFF
--- a/apps/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
+++ b/apps/frontend/src/features/public-form/components/SectionSidebar/SectionSidebar.tsx
@@ -51,7 +51,7 @@ export const SectionSidebar = (): JSX.Element => {
     if (!navigatedSectionId || !form) return
     if (navigatedSectionId === PUBLICFORM_INSTRUCTIONS_SECTIONID) {
       return {
-        title: t('features.publicForm.components.instructions'),
+        title: t('features.publicForm.components.instructions.title'),
         description: form.startPage.paragraph,
       }
     }


### PR DESCRIPTION
## Problem

On a public form with Instructions, clicking the "Instructions" tab in the left sidebar crashes with `Minified React error #31`, and the respondent has to restart their submission.

Flagged in #form-support. Datadog Error Tracking shows ~1,076 hits in production going back to v7.14.0 ([issue](https://ogp.datadoghq.com/error-tracking/issue/ee71c7b2-4448-11f1-8f9b-da7ad0900002)).

## Solution

The section sidebar built its "navigated to section" announcement title from `t('features.publicForm.components.instructions')`, which points at the parent object `{ title }` rather than the string. We use i18next-icu, which passes object arguments straight into the message instead of stringifying them, so React ends up trying to render the object and throws.

Pointed the key at its `.title` leaf instead, like the other two call sites already do.

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:
- Render the Instructions sidebar announcement title as a string so the public form no longer crashes.

## Tests

- Open a public form that has Instructions, click the Instructions tab in the sidebar, and confirm there is no console error.