### PR TITLE
feat: admin satisfaction revamp — 5-star rating, new triggers, feature flagged

### DIFF
--- a/apps/backend/src/app/models/__tests__/admin_feedback.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/admin_feedback.server.model.spec.ts
@@ -107,5 +107,47 @@ describe('form_feedback.server.model', () => {
         expect(actual.triggerSource).toEqual(source)
       }
     })
+
+    it('should accept rating values 1 through 5', async () => {
+      for (const rating of [1, 2, 3, 4, 5]) {
+        const actual = await FeedbackModel.create({
+          ...DEFAULT_PARAMS,
+          rating,
+        })
+        expect(actual.rating).toEqual(rating)
+      }
+    })
+
+    it('should reject rating value of 6', async () => {
+      const actualPromise = new FeedbackModel({
+        ...DEFAULT_PARAMS,
+        rating: 6,
+      }).save()
+
+      await expect(actualPromise).rejects.toThrow(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should still accept rating value of 0 (backwards compat with old thumbs-down records)', async () => {
+      const actual = await FeedbackModel.create({
+        ...DEFAULT_PARAMS,
+        rating: 0,
+      })
+      expect(actual.rating).toEqual(0)
+    })
+
+    it('should default ratingChanged to false', async () => {
+      const actual = await FeedbackModel.create(DEFAULT_PARAMS)
+      expect(actual.ratingChanged).toEqual(false)
+    })
+
+    it('should save with ratingChanged set to true', async () => {
+      const actual = await FeedbackModel.create({
+        ...DEFAULT_PARAMS,
+        ratingChanged: true,
+      })
+      expect(actual.ratingChanged).toEqual(true)
+    })
   })
 })

--- a/apps/backend/src/app/models/__tests__/admin_feedback.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/admin_feedback.server.model.spec.ts
@@ -61,5 +61,51 @@ describe('form_feedback.server.model', () => {
         mongoose.Error.ValidationError,
       )
     })
+
+    it('should save successfully with triggerSource and formId', async () => {
+      const paramsWithTrigger = {
+        ...DEFAULT_PARAMS,
+        triggerSource: 'publish',
+        formId: new Types.ObjectId(),
+      }
+      const actual = await FeedbackModel.create(paramsWithTrigger)
+
+      expect(actual).toEqual(
+        expect.objectContaining({
+          ...paramsWithTrigger,
+          created: expect.any(Date),
+          lastModified: expect.any(Date),
+        }),
+      )
+    })
+
+    it('should save successfully without triggerSource and formId (backwards compat)', async () => {
+      const actual = await FeedbackModel.create(DEFAULT_PARAMS)
+
+      expect(actual.triggerSource).toBeUndefined()
+      expect(actual.formId).toBeUndefined()
+    })
+
+    it('should throw validation error for invalid triggerSource enum value', async () => {
+      const paramsWithInvalidTrigger = {
+        ...DEFAULT_PARAMS,
+        triggerSource: 'invalid-source',
+      }
+      const actualPromise = new FeedbackModel(paramsWithInvalidTrigger).save()
+
+      await expect(actualPromise).rejects.toThrow(
+        mongoose.Error.ValidationError,
+      )
+    })
+
+    it('should accept all valid triggerSource values', async () => {
+      for (const source of ['field-edit', 'publish', 'workflow']) {
+        const actual = await FeedbackModel.create({
+          ...DEFAULT_PARAMS,
+          triggerSource: source,
+        })
+        expect(actual.triggerSource).toEqual(source)
+      }
+    })
   })
 })

--- a/apps/backend/src/app/models/admin_feedback.server.model.ts
+++ b/apps/backend/src/app/models/admin_feedback.server.model.ts
@@ -28,6 +28,15 @@ const AdminFeedbackSchema = new Schema<
       required: false,
       trim: true,
     },
+    triggerSource: {
+      type: String,
+      enum: ['field-edit', 'publish', 'workflow'],
+      required: false,
+    },
+    formId: {
+      type: Schema.Types.ObjectId,
+      required: false,
+    },
   },
   {
     timestamps: {

--- a/apps/backend/src/app/models/admin_feedback.server.model.ts
+++ b/apps/backend/src/app/models/admin_feedback.server.model.ts
@@ -20,7 +20,7 @@ const AdminFeedbackSchema = new Schema<
     rating: {
       type: Number,
       min: 0,
-      max: 1,
+      max: 5,
       required: true,
     },
     comment: {
@@ -36,6 +36,10 @@ const AdminFeedbackSchema = new Schema<
     formId: {
       type: Schema.Types.ObjectId,
       required: false,
+    },
+    ratingChanged: {
+      type: Boolean,
+      default: false,
     },
   },
   {

--- a/apps/backend/src/app/modules/admin-feedback/__tests__/admin_feedback.service.spec.ts
+++ b/apps/backend/src/app/modules/admin-feedback/__tests__/admin_feedback.service.spec.ts
@@ -150,13 +150,8 @@ describe('feedback.service', () => {
     afterEach(() => jest.clearAllMocks())
 
     it('should update feedback successfully with both rating and comment changes', async () => {
-      const newRating = 0 as number
+      const newRating = 4
       const newComment = 'new comment'
-      const expectedResult = new AdminFeedbackModel({
-        userId: MOCK_USER_ID,
-        rating: newRating,
-        comment: newComment,
-      })
 
       // Act
       const actualResult = await AdminFeedbackService.updateAdminFeedback({
@@ -170,12 +165,39 @@ describe('feedback.service', () => {
 
       // Assert
       expect(actualResult.isOk()).toEqual(true)
-      expect(newFeedback?.comment).toEqual(expectedResult.comment)
-      expect(newFeedback?.rating).toEqual(expectedResult.rating)
+      expect(newFeedback?.comment).toEqual(newComment)
+      expect(newFeedback?.rating).toEqual(newRating)
+    })
+
+    it('should set ratingChanged to true when rating is updated', async () => {
+      const newRating = 5
+
+      await AdminFeedbackService.updateAdminFeedback({
+        feedbackId: MOCK_FEEDBACK_ID,
+        userId: MOCK_USER_ID,
+        rating: newRating,
+      })
+
+      const newFeedback = await AdminFeedbackModel.findById(MOCK_FEEDBACK_ID)
+
+      expect(newFeedback?.ratingChanged).toEqual(true)
+      expect(newFeedback?.rating).toEqual(newRating)
+    })
+
+    it('should not set ratingChanged when only comment is updated', async () => {
+      await AdminFeedbackService.updateAdminFeedback({
+        feedbackId: MOCK_FEEDBACK_ID,
+        userId: MOCK_USER_ID,
+        comment: 'just a comment',
+      })
+
+      const newFeedback = await AdminFeedbackModel.findById(MOCK_FEEDBACK_ID)
+
+      expect(newFeedback?.ratingChanged).toEqual(false)
     })
 
     it('should update feedback successfully with only rating change', async () => {
-      const newRating = 0 as number
+      const newRating = 3
       const expectedResult = new AdminFeedbackModel({
         userId: MOCK_USER_ID,
         rating: newRating,

--- a/apps/backend/src/app/modules/admin-feedback/__tests__/admin_feedback.service.spec.ts
+++ b/apps/backend/src/app/modules/admin-feedback/__tests__/admin_feedback.service.spec.ts
@@ -75,6 +75,42 @@ describe('feedback.service', () => {
       expect(actualResult._unsafeUnwrap()).toEqual(mock_feedback_no_comment)
     })
 
+    it('should return Admin Feedback document on successful insertion with triggerSource and formId', async () => {
+      const mockTriggerSource = 'publish'
+      const mockFormId = new ObjectId().toHexString()
+      const mockFeedbackWithTrigger = new AdminFeedbackModel({
+        userId: MOCK_USER_ID,
+        rating: MOCK_RATING,
+        comment: MOCK_COMMENT,
+        triggerSource: mockTriggerSource,
+        formId: mockFormId,
+      })
+
+      const insertSpy = jest
+        .spyOn(AdminFeedbackModel, 'create')
+        // @ts-ignore
+        .mockResolvedValueOnce(mockFeedbackWithTrigger)
+
+      const actualResult = await AdminFeedbackService.insertAdminFeedback({
+        userId: MOCK_USER_ID,
+        rating: MOCK_RATING,
+        comment: MOCK_COMMENT,
+        triggerSource: mockTriggerSource,
+        formId: mockFormId,
+      })
+
+      expect(insertSpy).toHaveBeenCalledTimes(1)
+      expect(insertSpy).toHaveBeenCalledWith({
+        userId: MOCK_USER_ID,
+        rating: MOCK_RATING,
+        comment: MOCK_COMMENT,
+        triggerSource: mockTriggerSource,
+        formId: mockFormId,
+      })
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(mockFeedbackWithTrigger)
+    })
+
     it('should return DatabaseError when error occurs whilst inserting feedback', async () => {
       // Arrange
       // Mock failure

--- a/apps/backend/src/app/modules/admin-feedback/admin-feedback.controller.ts
+++ b/apps/backend/src/app/modules/admin-feedback/admin-feedback.controller.ts
@@ -19,6 +19,10 @@ const valdiateSubmitAdminFeedbackParams = celebrate({
   [Segments.BODY]: Joi.object().keys({
     rating: Joi.number().min(0).max(1).required(),
     comment: Joi.string(),
+    triggerSource: Joi.string()
+      .valid('field-edit', 'publish', 'workflow')
+      .optional(),
+    formId: Joi.string().optional(),
   }),
 })
 
@@ -35,20 +39,23 @@ const valdiateSubmitAdminFeedbackParams = celebrate({
 const submitAdminFeedback: ControllerHandler<
   unknown,
   { message: string; feedback: IAdminFeedbackSchema } | ErrorDto,
-  { rating: number; comment?: string }
+  { rating: number; comment?: string; triggerSource?: string; formId?: string }
 > = async (req, res) => {
   const sessionUserId = (req.session as AuthedSessionData).user._id
-  const { rating, comment } = req.body
+  const { rating, comment, triggerSource, formId } = req.body
 
   // send rating to DD
   statsdClient.distribution('formsg.users.feedback.rating', rating, 1, {
     rating: `${rating}`,
+    ...(triggerSource ? { triggerSource } : {}),
   })
 
   return AdminFeedbackService.insertAdminFeedback({
     userId: sessionUserId,
     rating,
     comment,
+    triggerSource,
+    formId,
   })
     .map((adminFeedback) =>
       res.status(StatusCodes.OK).json({

--- a/apps/backend/src/app/modules/admin-feedback/admin-feedback.controller.ts
+++ b/apps/backend/src/app/modules/admin-feedback/admin-feedback.controller.ts
@@ -17,7 +17,7 @@ const logger = createLoggerWithLabel(module)
 
 const valdiateSubmitAdminFeedbackParams = celebrate({
   [Segments.BODY]: Joi.object().keys({
-    rating: Joi.number().min(0).max(1).required(),
+    rating: Joi.number().integer().min(1).max(5).required(),
     comment: Joi.string(),
     triggerSource: Joi.string()
       .valid('field-edit', 'publish', 'workflow')
@@ -44,8 +44,16 @@ const submitAdminFeedback: ControllerHandler<
   const sessionUserId = (req.session as AuthedSessionData).user._id
   const { rating, comment, triggerSource, formId } = req.body
 
-  // send rating to DD
+  // Dual-emit: old metric kept so existing queries don't lose data, new metric
+  // for Phase 3 (1-5 scale). WARNING: the old metric now receives 1-5 values
+  // instead of the original 0-1 binary. Dashboards consuming the old metric
+  // must migrate to .v2 and update their formulas accordingly.
+  // Remove the old metric once migration is confirmed.
   statsdClient.distribution('formsg.users.feedback.rating', rating, 1, {
+    rating: `${rating}`,
+    ...(triggerSource ? { triggerSource } : {}),
+  })
+  statsdClient.distribution('formsg.users.feedback.rating.v2', rating, 1, {
     rating: `${rating}`,
     ...(triggerSource ? { triggerSource } : {}),
   })
@@ -86,11 +94,13 @@ export const handleSubmitAdminFeedback = [
 
 const validateUpdateAdminFormFeedback = celebrate({
   [Segments.BODY]: Joi.object().keys({
-    rating: Joi.number().min(0).max(1),
+    rating: Joi.number().integer().min(1).max(5),
     comment: Joi.string(),
   }),
 })
 
+// No Datadog metric here. Metric fires on create only to avoid double-counting
+// when an admin changes their star rating.
 const updateAdminFeedback: ControllerHandler<
   { feedbackId: string },
   { message: string } | ErrorDto,

--- a/apps/backend/src/app/modules/admin-feedback/admin-feedback.service.ts
+++ b/apps/backend/src/app/modules/admin-feedback/admin-feedback.service.ts
@@ -14,7 +14,7 @@ const logger = createLoggerWithLabel(module)
 /**
  * Inserts given admin feedback to the database.
  * @param userId the userId of the admin that provided the feedback
- * @param rating the feedback rating to insert (0 for thumbs down, 1 for thumbs up)
+ * @param rating the feedback rating to insert (1-5 star scale)
  * @param comment the feedback comment to insert if available
  * @returns ok(IAdminFeedbackSchema) if successfully inserted
  * @returns err(DatabaseError) on database error
@@ -57,11 +57,12 @@ export const insertAdminFeedback = ({
 
 /**
  * Updates admin feedback in the database.
- * Will not update previous value if comment or rating is undefined
+ * Will not update previous value if comment or rating is undefined.
+ * Sets ratingChanged to true when a rating update is included.
  * @param feedbackId the id of the admin feedback to update
  * @param userId the id of the admin
  * @param comment the feedback comment to insert
- * @param rating the feedback rating to insert (0 for thumbs down, 1 for thumbs up)
+ * @param rating the feedback rating (1-5 star scale)
  * @returns ok(IAdminFeedbackSchema) if successfully inserted
  * @returns err(MissingAdminFeedbackError) if feedback document with the same feedbackId and userId is not found
  * @returns err(DatabaseError) on database error
@@ -77,14 +78,12 @@ export const updateAdminFeedback = ({
   comment?: string
   rating?: number
 }) => {
-  const updateObj = { rating, comment }
-
-  // filter out undefined properties
-  Object.keys(updateObj).forEach(
-    (key) =>
-      updateObj[key as keyof typeof updateObj] === undefined &&
-      delete updateObj[key as keyof typeof updateObj],
-  )
+  const updateObj: Record<string, unknown> = {}
+  if (comment !== undefined) updateObj.comment = comment
+  if (rating !== undefined) {
+    updateObj.rating = rating
+    updateObj.ratingChanged = true
+  }
 
   // if no update to be done, return ok
   if (isEmpty(updateObj)) return okAsync(true)

--- a/apps/backend/src/app/modules/admin-feedback/admin-feedback.service.ts
+++ b/apps/backend/src/app/modules/admin-feedback/admin-feedback.service.ts
@@ -23,16 +23,22 @@ export const insertAdminFeedback = ({
   userId,
   rating,
   comment,
+  triggerSource,
+  formId,
 }: {
   userId: string
   rating: number
   comment?: string
+  triggerSource?: string
+  formId?: string
 }) => {
   return ResultAsync.fromPromise(
     AdminFeedbackModel.create({
       userId,
       rating,
       comment,
+      triggerSource,
+      formId,
     }),
     (error) => {
       logger.error({

--- a/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -3162,7 +3162,7 @@ describe('admin-form.form.routes', () => {
 
   describe('POST /admin/forms/feedback', () => {
     const MOCK_COMMENT = 'mock comment'
-    const MOCK_RATING = 0
+    const MOCK_RATING = 3
 
     it('should return 200 when the request is successful', async () => {
       // Act
@@ -3205,7 +3205,7 @@ describe('admin-form.form.routes', () => {
       expect(resp.body.message).toEqual('Validation failed')
     })
 
-    it('should return 400 when rating is not 0 or 1', async () => {
+    it('should return 400 when rating is out of 1-5 range', async () => {
       // Act
       const resp = await request
         .post(`/admin/forms/feedback`)
@@ -3251,9 +3251,9 @@ describe('admin-form.form.routes', () => {
   })
   describe('PATCH /admin/forms/feedback/:feedbackId', () => {
     const MOCK_COMMENT = 'mock comment'
-    const MOCK_RATING = 0
+    const MOCK_RATING = 3
     const MOCK_NEW_COMMENT = 'new comment'
-    const MOCK_NEW_RATING = 1
+    const MOCK_NEW_RATING = 5
 
     let MOCK_ADMIN_FEEDBACK: IAdminFeedbackSchema
 

--- a/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -28,7 +28,6 @@ import {
   ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
 } from '~constants/localStorage'
 import { DASHBOARD_ROUTE } from '~constants/routes'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import { useToast } from '~hooks/useToast'
@@ -151,7 +150,6 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   }, [getWogadLogoutUrlMutation])
 
   const handleLogout = useCallback(() => {
-    sessionStorage.removeItem(ADMIN_FEEDBACK_SESSION_KEY)
     logout()
     removeQuery()
     if (emergencyContactKey) {

--- a/apps/frontend/src/constants/sessionStorage.ts
+++ b/apps/frontend/src/constants/sessionStorage.ts
@@ -1,8 +1,0 @@
-/**
- * Constants relating to sessionStorage.
- */
-
-/**
- * Key to store whether admin should be shown the feedback modal
- */
-export const ADMIN_FEEDBACK_SESSION_KEY = 'admin-feedback-key'

--- a/apps/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/apps/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -11,6 +11,8 @@ import { Banner } from '~components/Banner'
 import AdminForbiddenErrorPage from '~pages/AdminForbiddenError'
 import NotFoundErrorPage from '~pages/NotFoundError'
 import { useEnv } from '~features/env/queries'
+import { useUser } from '~features/user/queries'
+import AdminFeedbackContainer from '~features/workspace/components/AdminFeedbackContainer'
 
 import { StorageResponsesProvider } from '../responses/ResponsesPage/storage/StorageResponsesProvider'
 
@@ -45,6 +47,7 @@ export const AdminFormLayout = (): JSX.Element => {
   )
 
   const { error } = useAdminForm()
+  const { user } = useUser()
 
   if (get(error, 'code') === 404 || get(error, 'code') === 410) {
     return <NotFoundErrorPage />
@@ -75,6 +78,7 @@ export const AdminFormLayout = (): JSX.Element => {
       <StorageResponsesProvider>
         <Outlet />
       </StorageResponsesProvider>
+      {user && <AdminFeedbackContainer userId={user._id} />}
     </Flex>
   )
 }

--- a/apps/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/apps/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
-import { useFeatureValue } from '@growthbook/growthbook-react'
+import { useFeatureIsOn, useFeatureValue } from '@growthbook/growthbook-react'
 import { get } from 'lodash'
+
+import { featureFlags } from 'formsg-shared/constants'
 
 import { fillHeightCss } from '~utils/fillHeightCss'
 import { getBannerProps } from '~utils/getBannerProps'
@@ -46,6 +48,8 @@ export const AdminFormLayout = (): JSX.Element => {
     [bannerContent, bannerContentGB],
   )
 
+  const isFiveStarEnabled = useFeatureIsOn(featureFlags.fiveStarAdminRating)
+
   const { error } = useAdminForm()
   const { user } = useUser()
 
@@ -78,7 +82,9 @@ export const AdminFormLayout = (): JSX.Element => {
       <StorageResponsesProvider>
         <Outlet />
       </StorageResponsesProvider>
-      {user && <AdminFeedbackContainer userId={user._id} />}
+      {user && isFiveStarEnabled && (
+        <AdminFeedbackContainer userId={user._id} />
+      )}
     </Flex>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
@@ -9,10 +9,6 @@ import {
 } from 'formsg-shared/types/field'
 import { insertAt, replaceAt } from 'formsg-shared/utils/immutable-array-fns'
 
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
-
-import { useEnv } from '~features/env/queries'
 import { augmentWithMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
 
 import { PENDING_CREATE_FIELD_ID } from '../constants'
@@ -59,44 +55,20 @@ const getFormFieldsWhileEditing = (
 export const useBuilderFields = () => {
   const { data: formData, isLoading } = useCreateTabForm()
   const stateData = useFieldBuilderStore(stateDataSelector)
-  const [, setIsAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
-  const { data: { adminFeedbackFieldThreshold } = {} } = useEnv()
   const builderFields = useMemo(() => {
     let existingFields = formData?.form_fields
     if (isLoading || !existingFields) return null
     if (stateData.state === FieldBuilderState.EditingField) {
-      // check if existing fields meets threshold for admin feedback eligibility
-      if (
-        adminFeedbackFieldThreshold &&
-        existingFields.length >= adminFeedbackFieldThreshold
-      )
-        setIsAdminFeedbackEligible(true)
-
       existingFields = getFormFieldsWhileEditing(
         existingFields,
         stateData.field,
       )
     } else if (stateData.state === FieldBuilderState.CreatingField) {
-      // if existing fields is equal to threshold - 1, to include field being created
-      if (
-        adminFeedbackFieldThreshold &&
-        existingFields.length >= adminFeedbackFieldThreshold - 1
-      )
-        setIsAdminFeedbackEligible(true)
-
       existingFields = getFormFieldsWhileCreating(existingFields, stateData)
     }
 
     return existingFields.map(augmentWithMyInfo)
-  }, [
-    formData?.form_fields,
-    isLoading,
-    stateData,
-    setIsAdminFeedbackEligible,
-    adminFeedbackFieldThreshold,
-  ])
+  }, [formData?.form_fields, isLoading, stateData])
 
   return {
     builderFields,

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -10,6 +10,7 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
 import { useDebounce } from 'react-use'
 import { cloneDeep } from 'lodash'
 
@@ -20,11 +21,9 @@ import {
   FormFieldDto,
 } from 'formsg-shared/types/field'
 
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
-
 import { useCreateFormField } from '~features/admin-form/create/builder-and-design/mutations/useCreateFormField'
 import { useEditFormField } from '~features/admin-form/create/builder-and-design/mutations/useEditFormField'
+import { useCreateTabForm } from '~features/admin-form/create/builder-and-design/useCreateTabForm'
 import {
   setIsDirtySelector,
   useDirtyFieldStore,
@@ -37,7 +36,9 @@ import {
   updateEditStateSelector,
   useFieldBuilderStore,
 } from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
+import { useEnv } from '~features/env/queries'
 import { isMyInfo } from '~features/myinfo/utils'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import { EditFieldProps } from './types'
 
@@ -101,9 +102,9 @@ export const useEditFieldForm = <
 
   const { editFieldMutation } = useEditFormField()
   const { createFieldMutation } = useCreateFormField()
-  const [, setIsAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
+  const { formId } = useParams()
+  const { data: formData } = useCreateTabForm()
+  const { data: { adminFeedbackFieldThreshold } = {} } = useEnv()
 
   const isPendingField = useMemo(
     () => stateData.state === FieldBuilderState.CreatingField,
@@ -162,17 +163,33 @@ export const useEditFieldForm = <
       )
     }
 
-    // if field to be updated is MyInfo, enable admin feedback
-    if (isMyInfo(updatedFormField)) setIsAdminFeedbackEligible(true)
+    const isCreating = stateData.state === FieldBuilderState.CreatingField
+    const isMyInfoField = isMyInfo(updatedFormField)
+    // Count of fields already saved on the form. While creating, the pending
+    // field isn't part of this count yet, so we offset the threshold by 1.
+    const savedFieldCount = formData?.form_fields.length ?? 0
+    const meetsFieldThreshold =
+      !!adminFeedbackFieldThreshold &&
+      savedFieldCount >= adminFeedbackFieldThreshold - (isCreating ? 1 : 0)
 
-    if (stateData.state === FieldBuilderState.CreatingField) {
+    // Enable the admin feedback prompt once the save succeeds (onSaveSuccess
+    // closes the drawer), so the prompt appears after the drawer is gone, not
+    // mid-edit. Triggers on crossing the field-count threshold or on a MyInfo
+    // field save.
+    const onMutateSuccess = (newField: FormField) => {
+      onSaveSuccess(newField)
+      if (isMyInfoField || meetsFieldThreshold)
+        useAdminFeedbackStore.getState().setEligible('field-edit', formId)
+    }
+
+    if (isCreating) {
       return createFieldMutation.mutate(updatedFormField, {
-        onSuccess: onSaveSuccess,
+        onSuccess: onMutateSuccess,
       })
     } else if (stateData.state === FieldBuilderState.EditingField) {
       return editFieldMutation.mutate(
         { ...updatedFormField, _id: stateData.field._id } as FormFieldDto,
-        { onSuccess: onSaveSuccess },
+        { onSuccess: onMutateSuccess },
       )
     }
   })

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -10,7 +10,7 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Link as ReactLink } from 'react-router-dom'
+import { Link as ReactLink, useParams } from 'react-router-dom'
 import { useDebounce } from 'react-use'
 import {
   Box,
@@ -34,8 +34,6 @@ import {
 import { centsToDollars, dollarsToCents } from 'formsg-shared/utils/payments'
 
 import { ADMINFORM_SETTINGS_PAYMENTS_SUBROUTE } from '~constants/routes'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -45,6 +43,7 @@ import Toggle from '~components/Toggle'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import { useCreatePageSidebar } from '../../../../../common'
 import { FieldListTabIndex } from '../../../../constants'
@@ -242,9 +241,7 @@ const PaymentInputFields = ({
 
   const handleClose = () => setFieldListTabIndex(FieldListTabIndex.Basic)
 
-  const [, setisAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
+  const { formId } = useParams()
 
   // unpack payment data for paymentAmount if it exists
   const formDefaultValues =
@@ -318,14 +315,14 @@ const PaymentInputFields = ({
       }
     }
 
-    // update sessionStorage to enable admin feedback
-    setisAdminFeedbackEligible(true)
     return paymentsMutation.mutate(
       { ...paymentsData, enabled: true },
       {
         onSuccess: () => {
           setToInactive()
           handleClose()
+          // enable admin feedback after the panel closes
+          useAdminFeedbackStore.getState().setEligible('field-edit', formId)
         },
       },
     )

--- a/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
@@ -11,6 +11,7 @@ import {
 import { useToast } from '~hooks/useToast'
 
 import { adminFormKeys } from '~features/admin-form/common/queries'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import { useAdminFormWorkflow } from './hooks/useAdminFormWorkflow'
 import {
@@ -18,6 +19,7 @@ import {
   deleteWorkflowStep,
   updateWorkflowStep,
 } from './FormWorkflowService'
+import { isStepCompleted } from './workflow.utils'
 
 export const useWorkflowMutations = () => {
   const { formId } = useParams()
@@ -59,6 +61,12 @@ export const useWorkflowMutations = () => {
         toast({
           description: 'The step was successfully created.',
         })
+
+        // Trigger feedback when 2+ completed steps
+        const completedCount = updatedWorkflow.filter(isStepCompleted).length
+        if (completedCount >= 2) {
+          useAdminFeedbackStore.getState().setEligible('workflow', formId)
+        }
       },
       onError: handleError,
     },
@@ -109,6 +117,12 @@ export const useWorkflowMutations = () => {
         toast({
           description: 'The step was successfully updated.',
         })
+
+        // Trigger feedback when 2+ completed steps
+        const completedCount = updatedWorkflow.filter(isStepCompleted).length
+        if (completedCount >= 2) {
+          useAdminFeedbackStore.getState().setEligible('workflow', formId)
+        }
       },
       onError: handleError,
     },

--- a/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.test.ts
@@ -1,0 +1,123 @@
+import { WorkflowType } from 'formsg-shared/types/form'
+
+import { isStepCompleted } from './workflow.utils'
+
+describe('isStepCompleted', () => {
+  describe('static steps', () => {
+    it('should return true when step has fields and emails', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Static,
+          edit: ['field1'],
+          emails: ['user@example.com'],
+        }),
+      ).toBe(true)
+    })
+
+    it('should return false when step has fields but no emails', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Static,
+          edit: ['field1'],
+          emails: [],
+        }),
+      ).toBe(false)
+    })
+
+    it('should return false when step has emails but no fields', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Static,
+          edit: [],
+          emails: ['user@example.com'],
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('dynamic steps', () => {
+    it('should return true when step has fields and a respondent field', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Dynamic,
+          edit: ['field1'],
+          field: 'emailFieldId',
+        }),
+      ).toBe(true)
+    })
+
+    it('should return false when step has fields but no respondent field', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Dynamic,
+          edit: ['field1'],
+          field: '',
+        }),
+      ).toBe(false)
+    })
+
+    it('should return false when step has respondent field but no fields', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Dynamic,
+          edit: [],
+          field: 'emailFieldId',
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('conditional steps', () => {
+    it('should return true when step has fields and a conditional field', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Conditional,
+          edit: ['field1'],
+          conditional_field: 'condFieldId',
+        }),
+      ).toBe(true)
+    })
+
+    it('should return false when step has fields but no conditional field', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Conditional,
+          edit: ['field1'],
+          conditional_field: '',
+        }),
+      ).toBe(false)
+    })
+
+    it('should return false when step has conditional field but no fields', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Conditional,
+          edit: [],
+          conditional_field: 'condFieldId',
+        }),
+      ).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should return true with multiple fields assigned', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Static,
+          edit: ['field1', 'field2', 'field3'],
+          emails: ['user@example.com'],
+        }),
+      ).toBe(true)
+    })
+
+    it('should return true with multiple emails', () => {
+      expect(
+        isStepCompleted({
+          workflow_type: WorkflowType.Static,
+          edit: ['field1'],
+          emails: ['a@example.com', 'b@example.com'],
+        }),
+      ).toBe(true)
+    })
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.ts
@@ -1,0 +1,18 @@
+import { FormWorkflowStep, WorkflowType } from 'formsg-shared/types/form'
+
+/**
+ * A workflow step is "completed" when it has fields assigned
+ * and a respondent configured.
+ */
+export const isStepCompleted = (step: FormWorkflowStep): boolean => {
+  if (step.edit.length === 0) return false
+
+  switch (step.workflow_type) {
+    case WorkflowType.Static:
+      return step.emails.length > 0
+    case WorkflowType.Dynamic:
+      return !!step.field
+    case WorkflowType.Conditional:
+      return !!step.conditional_field
+  }
+}

--- a/apps/frontend/src/features/admin-form/settings/mutations.ts
+++ b/apps/frontend/src/features/admin-form/settings/mutations.ts
@@ -19,6 +19,8 @@ import { useToast } from '~hooks/useToast'
 import { convertUnicodeLocaleToLanguage } from '~utils/multiLanguage'
 import { formatOrdinal } from '~utils/stringFormat'
 
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
+
 import { updateFormPayments } from '../common/AdminFormPageService'
 import { adminFormKeys } from '../common/queries'
 
@@ -142,6 +144,11 @@ export const useMutateFormSettings = () => {
           : toastStatusClosedMessage
 
         handleSuccess({ newData, toastDescription: toastStatusMessage })
+
+        // Trigger admin feedback prompt when form goes public
+        if (isNowPublic) {
+          useAdminFeedbackStore.getState().setEligible('publish', formId)
+        }
       },
       onError: handleError,
     },

--- a/apps/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/apps/frontend/src/features/workspace/WorkspacePage.tsx
@@ -32,7 +32,6 @@ import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
 import { WorkspaceContent } from '~features/workspace/WorkspaceContent'
 
-import AdminFeedbackContainer from './components/AdminFeedbackContainer'
 import { WorkspaceMenuHeader } from './components/WorkspaceSideMenu/WorkspaceMenuHeader'
 import { WorkspaceMenuTabs } from './components/WorkspaceSideMenu/WorkspaceMenuTabs'
 import { useDashboard, useWorkspace } from './queries'
@@ -211,7 +210,6 @@ export const WorkspacePage = (): JSX.Element => {
           </WorkspaceProvider>
         </GridItem>
       </Grid>
-      {user && <AdminFeedbackContainer userId={user._id} />}
     </>
   )
 }

--- a/apps/frontend/src/features/workspace/WorkspaceService.ts
+++ b/apps/frontend/src/features/workspace/WorkspaceService.ts
@@ -248,9 +248,10 @@ export const createAdminFeedback = async (
 
 export const updateAdminFeedback = async (
   feedbackId: string,
-  comment: string,
+  params: { comment?: string; rating?: AdminFeedbackRating },
 ): Promise<boolean> => {
-  return ApiService.patch(`${ADMIN_FORM_ENDPOINT}/feedback/${feedbackId}`, {
-    comment,
-  }).then(({ data }) => data)
+  return ApiService.patch(
+    `${ADMIN_FORM_ENDPOINT}/feedback/${feedbackId}`,
+    params,
+  ).then(({ data }) => data)
 }

--- a/apps/frontend/src/features/workspace/WorkspaceService.ts
+++ b/apps/frontend/src/features/workspace/WorkspaceService.ts
@@ -1,6 +1,7 @@
 import {
   AdminFeedbackDto,
   AdminFeedbackRating,
+  AdminFeedbackTriggerSource,
   AdminUseEmailModeFeedbackDto,
   ErrorDto,
 } from 'formsg-shared/types'
@@ -235,10 +236,14 @@ export const deleteAdminForm = async (formId: string): Promise<void> => {
 
 export const createAdminFeedback = async (
   rating: AdminFeedbackRating,
+  triggerSource?: AdminFeedbackTriggerSource,
+  formId?: string,
 ): Promise<AdminFeedbackDto> => {
-  return ApiService.post(`${ADMIN_FORM_ENDPOINT}/feedback`, { rating }).then(
-    ({ data }) => data.feedback,
-  )
+  return ApiService.post(`${ADMIN_FORM_ENDPOINT}/feedback`, {
+    rating,
+    ...(triggerSource ? { triggerSource } : {}),
+    ...(formId ? { formId } : {}),
+  }).then(({ data }) => data.feedback)
 }
 
 export const updateAdminFeedback = async (

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.stories.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.stories.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { viewports } from '~/utils/storybook'
+
+import { AdminFeedbackBox } from './AdminFeedbackBox'
+
+export default {
+  title: 'Features/AdminFeedbackBox',
+  component: AdminFeedbackBox,
+} as Meta
+
+const Template: StoryFn = () => {
+  const [isOpen, setIsOpen] = useState(true)
+  return isOpen ? (
+    <AdminFeedbackBox
+      onClose={() => setIsOpen(false)}
+      triggerSource="field-edit"
+      formId="mock-form-id"
+    />
+  ) : (
+    <button onClick={() => setIsOpen(true)}>Reopen feedback</button>
+  )
+}
+
+export const Default = Template.bind({})
+Default.storyName = 'Empty state (no stars selected)'
+
+export const Mobile = Template.bind({})
+Mobile.storyName = 'Mobile viewport'
+Mobile.parameters = {
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
+}

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { GoThumbsdown, GoThumbsup } from 'react-icons/go'
-import { Flex, Link, Stack, Text } from '@chakra-ui/react'
+import { Flex, Stack, Text } from '@chakra-ui/react'
 
 import {
   AdminFeedbackRating,
@@ -12,20 +11,24 @@ import {
 import { BxX } from '~assets/icons'
 import { useIsMobile } from '~hooks/useIsMobile'
 import Button from '~components/Button'
+import { Rating } from '~components/Field/Rating/Rating'
 import BottomHugBox from '~components/Hug/BottomHugBox'
 import IconButton from '~components/IconButton'
 import Textarea from '~components/Textarea'
 
 import { useAdminFeedbackMutation } from '~features/workspace/mutations'
 
-enum FeedbackBoxContentState {
-  Rating,
-  CallForComment,
-  CommentBox,
-}
-
 type AdminFeedbackCommentForm = {
   comment: string
+}
+
+const getCommentLabel = (
+  rating: number,
+  labels: { low: string; mid: string; high: string },
+): string => {
+  if (rating <= 2) return labels.low
+  if (rating >= 4) return labels.high
+  return labels.mid
 }
 
 export const AdminFeedbackBox = ({
@@ -37,34 +40,57 @@ export const AdminFeedbackBox = ({
   triggerSource?: AdminFeedbackTriggerSource
   formId?: string
 }) => {
-  const [contentState, setContentState] = useState(
-    FeedbackBoxContentState.Rating,
-  )
+  const { t } = useTranslation()
+  const isMobile = useIsMobile()
+  const [ratingValue, setRatingValue] = useState(0)
   const [feedbackId, setFeedbackId] = useState('')
-  const [ratingValue, setRatingValue] = useState(AdminFeedbackRating.up)
   const { createAdminFeedbackMutation, updateAdminFeedbackMutation } =
     useAdminFeedbackMutation()
+  const { handleSubmit, register } = useForm<AdminFeedbackCommentForm>()
 
-  const handleRatingClick = useCallback(
-    (rating: AdminFeedbackRating) => {
-      createAdminFeedbackMutation
-        .mutateAsync({ rating, triggerSource, formId })
-        .then((data) => setFeedbackId(data._id))
-      setContentState(FeedbackBoxContentState.CallForComment)
-      setRatingValue(rating)
+  const { prompt, fieldTitle } = t('features.workspace.feedback.rating', {
+    returnObjects: true,
+  })
+  const {
+    label: commentLabels,
+    placeholder,
+    aria: { close: closeAriaLabel },
+  } = t('features.workspace.feedback.comment', { returnObjects: true })
+
+  const handleRatingChange = useCallback(
+    (newRating: number | undefined) => {
+      if (!newRating) return
+      setRatingValue(newRating)
+
+      if (!feedbackId) {
+        // First star click: create the feedback record
+        createAdminFeedbackMutation
+          .mutateAsync({
+            rating: newRating as AdminFeedbackRating,
+            triggerSource,
+            formId,
+          })
+          .then((data) => setFeedbackId(data._id))
+      } else {
+        // Subsequent star click: update the rating
+        updateAdminFeedbackMutation.mutateAsync({
+          feedbackId,
+          rating: newRating as AdminFeedbackRating,
+        })
+      }
     },
     [
+      feedbackId,
       createAdminFeedbackMutation,
+      updateAdminFeedbackMutation,
       triggerSource,
       formId,
-      setFeedbackId,
-      setContentState,
     ],
   )
 
-  const handleCommentClick = useCallback(
+  const handleCommentSubmit = useCallback(
     (data: AdminFeedbackCommentForm) => {
-      if (feedbackId && !!data.comment) {
+      if (feedbackId && data.comment) {
         updateAdminFeedbackMutation.mutateAsync({
           feedbackId,
           comment: data.comment,
@@ -75,161 +101,48 @@ export const AdminFeedbackBox = ({
     [feedbackId, updateAdminFeedbackMutation, onClose],
   )
 
-  const handleCallForCommentClick = () =>
-    setContentState(FeedbackBoxContentState.CommentBox)
-
   return (
     <BottomHugBox>
-      <AdminFeedbackBoxContentBuilder
-        state={contentState}
-        onRatingClick={handleRatingClick}
-        onCallForCommentClick={handleCallForCommentClick}
-        onCommentClick={handleCommentClick}
-        onClose={onClose}
-        ratingValue={ratingValue}
-      />
+      <Stack w={isMobile ? undefined : '28.5rem'}>
+        <Flex justifyContent="space-between" alignItems="center">
+          <Text textStyle="h6">{prompt}</Text>
+          <IconButton
+            aria-label={closeAriaLabel}
+            icon={<BxX />}
+            variant="clear"
+            color="black"
+            onClick={onClose}
+          />
+        </Flex>
+
+        <Rating
+          name="admin-feedback-rating"
+          numberOfRatings={5}
+          value={ratingValue}
+          onChange={handleRatingChange}
+          variant="star"
+          isRequired={false}
+          fieldTitle={fieldTitle}
+        />
+
+        {ratingValue > 0 && (
+          <Stack mt="0.5rem">
+            <Text textStyle="subhead-2">
+              {getCommentLabel(ratingValue, commentLabels)}
+            </Text>
+            <Textarea {...register('comment')} placeholder={placeholder} />
+            <Flex alignItems="flex-end" flexDirection="column">
+              <Button
+                mt="0.5rem"
+                float="right"
+                onClick={handleSubmit(handleCommentSubmit)}
+              >
+                {t('features.common.submit')}
+              </Button>
+            </Flex>
+          </Stack>
+        )}
+      </Stack>
     </BottomHugBox>
   )
-}
-
-const AdminFeedbackRatingContent = ({
-  onRatingClick,
-}: {
-  onRatingClick: (rating: AdminFeedbackRating) => void
-}) => {
-  const { t } = useTranslation()
-  const {
-    prompt,
-    aria: { up, down },
-  } = t('features.workspace.feedback.rating', { returnObjects: true })
-  return (
-    <Stack direction="row" alignItems="center" gap="0.75rem">
-      <Text textStyle="h6" mr="0.75rem">
-        {prompt}
-      </Text>
-      <IconButton
-        variant="clear"
-        icon={<GoThumbsup />}
-        colorScheme="theme-blue"
-        aria-label={up}
-        onClick={() => onRatingClick(AdminFeedbackRating.up)}
-      />
-      <IconButton
-        variant="clear"
-        icon={<GoThumbsdown />}
-        colorScheme="theme-red"
-        aria-label={down}
-        onClick={() => onRatingClick(AdminFeedbackRating.down)}
-      />
-    </Stack>
-  )
-}
-
-const AdminFeedbackCallForCommentContent = ({
-  onLinkClick,
-  ratingValue,
-}: {
-  onLinkClick: () => void
-  ratingValue: AdminFeedbackRating
-}) => {
-  const { t } = useTranslation()
-  const { title, link } = t(
-    ratingValue === AdminFeedbackRating.up
-      ? 'features.workspace.feedback.callForComment.up'
-      : 'features.workspace.feedback.callForComment.down',
-    { returnObjects: true },
-  )
-  return (
-    <Text textStyle="h6">
-      {title} <Link onClick={onLinkClick}>{link}</Link>
-    </Text>
-  )
-}
-
-const AdminFeedbackCommentContent = ({
-  onCommentClick,
-  onClose,
-  ratingValue,
-}: {
-  onCommentClick: (data: AdminFeedbackCommentForm) => void
-  onClose: () => void
-  ratingValue: AdminFeedbackRating
-}) => {
-  const { t } = useTranslation()
-  const { handleSubmit, register } = useForm<AdminFeedbackCommentForm>()
-  const isMobile = useIsMobile()
-
-  const ratingName = AdminFeedbackRating[
-    ratingValue
-  ] as keyof typeof AdminFeedbackRating
-  const {
-    title,
-    description,
-    placeholder,
-    aria: { close },
-  } = t('features.workspace.feedback.comment', {
-    returnObjects: true,
-  })
-
-  return (
-    <Stack w={isMobile ? undefined : '28.5rem'}>
-      <Flex justifyContent="space-between" alignItems="center" mb="1rem">
-        <Text textStyle="h2">{title}</Text>
-        <IconButton
-          aria-label={close}
-          icon={<BxX />}
-          variant="clear"
-          color="black"
-          onClick={onClose}
-        />
-      </Flex>
-      <Text textStyle="body-2">{description}</Text>
-      <Textarea
-        mt="1rem"
-        {...register('comment')}
-        placeholder={placeholder[ratingName]}
-      />
-      <Flex alignItems="flex-end" flexDirection="column">
-        <Button mt="1rem" float="right" onClick={handleSubmit(onCommentClick)}>
-          {t('features.common.submit')}
-        </Button>
-      </Flex>
-    </Stack>
-  )
-}
-
-const AdminFeedbackBoxContentBuilder = ({
-  state,
-  onRatingClick,
-  onCallForCommentClick,
-  onCommentClick,
-  onClose,
-  ratingValue,
-}: {
-  state: FeedbackBoxContentState
-  onRatingClick: (rating: AdminFeedbackRating) => void
-  onCallForCommentClick: () => void
-  onCommentClick: (data: AdminFeedbackCommentForm) => void
-  onClose: () => void
-  ratingValue: AdminFeedbackRating
-}) => {
-  switch (state) {
-    case FeedbackBoxContentState.Rating:
-      return <AdminFeedbackRatingContent onRatingClick={onRatingClick} />
-    case FeedbackBoxContentState.CallForComment:
-      return (
-        <AdminFeedbackCallForCommentContent
-          onLinkClick={onCallForCommentClick}
-          ratingValue={ratingValue}
-        />
-      )
-    case FeedbackBoxContentState.CommentBox:
-      return (
-        <AdminFeedbackCommentContent
-          onCommentClick={onCommentClick}
-          onClose={onClose}
-          ratingValue={ratingValue}
-        />
-      )
-  }
 }

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackBox/AdminFeedbackBox.tsx
@@ -4,7 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { GoThumbsdown, GoThumbsup } from 'react-icons/go'
 import { Flex, Link, Stack, Text } from '@chakra-ui/react'
 
-import { AdminFeedbackRating } from 'formsg-shared/types'
+import {
+  AdminFeedbackRating,
+  AdminFeedbackTriggerSource,
+} from 'formsg-shared/types'
 
 import { BxX } from '~assets/icons'
 import { useIsMobile } from '~hooks/useIsMobile'
@@ -25,7 +28,15 @@ type AdminFeedbackCommentForm = {
   comment: string
 }
 
-export const AdminFeedbackBox = ({ onClose }: { onClose: () => void }) => {
+export const AdminFeedbackBox = ({
+  onClose,
+  triggerSource,
+  formId,
+}: {
+  onClose: () => void
+  triggerSource?: AdminFeedbackTriggerSource
+  formId?: string
+}) => {
   const [contentState, setContentState] = useState(
     FeedbackBoxContentState.Rating,
   )
@@ -37,12 +48,18 @@ export const AdminFeedbackBox = ({ onClose }: { onClose: () => void }) => {
   const handleRatingClick = useCallback(
     (rating: AdminFeedbackRating) => {
       createAdminFeedbackMutation
-        .mutateAsync(rating)
+        .mutateAsync({ rating, triggerSource, formId })
         .then((data) => setFeedbackId(data._id))
       setContentState(FeedbackBoxContentState.CallForComment)
       setRatingValue(rating)
     },
-    [createAdminFeedbackMutation, setFeedbackId, setContentState],
+    [
+      createAdminFeedbackMutation,
+      triggerSource,
+      formId,
+      setFeedbackId,
+      setContentState,
+    ],
   )
 
   const handleCommentClick = useCallback(

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+import { AdminFeedbackTriggerSource } from 'formsg-shared/types'
+
 import { ADMIN_FEEDBACK_HISTORY_PREFIX } from '~constants/localStorage'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 
@@ -8,14 +10,13 @@ import { useEnv } from '~features/env/queries'
 import AdminFeedbackBox from '../AdminFeedbackBox'
 
 import {
-  AdminFeedbackTriggerSource,
   isEligibleSelector,
   resetSelector,
   useAdminFeedbackStore,
 } from './adminFeedbackStore'
 
 const triggerSourceSelector = (state: {
-  triggerSource: AdminFeedbackTriggerSource
+  triggerSource: AdminFeedbackTriggerSource | null
 }) => state.triggerSource
 const formIdSelector = (state: { formId: string | null }) => state.formId
 
@@ -35,7 +36,7 @@ export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
   // capture current time on page load to prevent re-renders from update to current time
   const currentTime = useRef(Date.now())
   // capture trigger metadata before reset clears the store
-  const capturedTriggerSource = useRef<AdminFeedbackTriggerSource>(null)
+  const capturedTriggerSource = useRef<AdminFeedbackTriggerSource | null>(null)
   const capturedFormId = useRef<string | null>(null)
 
   // check if admin is eligible in current session

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
@@ -1,29 +1,42 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { ADMIN_FEEDBACK_HISTORY_PREFIX } from '~constants/localStorage'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
 
 import { useEnv } from '~features/env/queries'
 
 import AdminFeedbackBox from '../AdminFeedbackBox'
 
+import {
+  AdminFeedbackTriggerSource,
+  isEligibleSelector,
+  resetSelector,
+  useAdminFeedbackStore,
+} from './adminFeedbackStore'
+
+const triggerSourceSelector = (state: {
+  triggerSource: AdminFeedbackTriggerSource
+}) => state.triggerSource
+const formIdSelector = (state: { formId: string | null }) => state.formId
+
 export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
   const { data: { adminFeedbackDisplayFrequency } = {} } = useEnv()
   const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
-  const isMobile = useIsMobile()
 
   const adminFeedbackKey = ADMIN_FEEDBACK_HISTORY_PREFIX + userId
 
   const [lastFeedbackTime, setLastFeedbackTime] =
     useLocalStorage<number>(adminFeedbackKey)
-  const [isAdminFeedbackEligible, setIsAdminFeedbackEligible] =
-    useSessionStorage<boolean>(ADMIN_FEEDBACK_SESSION_KEY, false)
+  const isAdminFeedbackEligible = useAdminFeedbackStore(isEligibleSelector)
+  const triggerSource = useAdminFeedbackStore(triggerSourceSelector)
+  const feedbackFormId = useAdminFeedbackStore(formIdSelector)
+  const resetAdminFeedbackEligible = useAdminFeedbackStore(resetSelector)
 
   // capture current time on page load to prevent re-renders from update to current time
   const currentTime = useRef(Date.now())
+  // capture trigger metadata before reset clears the store
+  const capturedTriggerSource = useRef<AdminFeedbackTriggerSource>(null)
+  const capturedFormId = useRef<string | null>(null)
 
   // check if admin is eligible in current session
   // and has yet to seen feedback beyond our stipulated frequency
@@ -38,23 +51,25 @@ export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
   // sets display of feedback box
   useEffect(() => {
     if (
-      // TODO: create mobile version of admin feedback
-      !isMobile &&
       // whether to show admin the feedback box
       showAdminFeedback
     ) {
+      // capture trigger metadata before reset clears them
+      capturedTriggerSource.current = triggerSource
+      capturedFormId.current = feedbackFormId
       setIsDisplayFeedback(true)
       // reset local storage and admin feedback eligibility when admin feedback is displayed
       setLastFeedbackTime(currentTime.current)
-      setIsAdminFeedbackEligible(false)
+      resetAdminFeedbackEligible()
     }
   }, [
     currentTime,
     showAdminFeedback,
+    triggerSource,
+    feedbackFormId,
     setIsDisplayFeedback,
     setLastFeedbackTime,
-    setIsAdminFeedbackEligible,
-    isMobile,
+    resetAdminFeedbackEligible,
   ])
 
   const closeAdminFeedback = useCallback(
@@ -63,7 +78,13 @@ export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
   )
   return (
     <>
-      {isDisplayFeedback && <AdminFeedbackBox onClose={closeAdminFeedback} />}
+      {isDisplayFeedback && (
+        <AdminFeedbackBox
+          onClose={closeAdminFeedback}
+          triggerSource={capturedTriggerSource.current ?? undefined}
+          formId={capturedFormId.current ?? undefined}
+        />
+      )}
     </>
   )
 }

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/adminFeedbackStore.ts
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/adminFeedbackStore.ts
@@ -1,0 +1,47 @@
+import create from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+/**
+ * Where the feedback prompt was triggered from. Phase 1 only sets
+ * 'field-edit'; 'publish' and 'workflow' are reserved for Phase 2.
+ */
+export type AdminFeedbackTriggerSource =
+  | 'field-edit'
+  | 'publish'
+  | 'workflow'
+  | null
+
+type AdminFeedbackStore = {
+  /**
+   * Whether the admin has done something that makes them eligible to see the
+   * feedback prompt in the current session. Resets on page reload (by design -
+   * the admin would need to trigger it again).
+   */
+  isEligible: boolean
+  /** Which action triggered the feedback prompt. Sent to backend with the rating. */
+  triggerSource: AdminFeedbackTriggerSource
+  /** The form the admin was working on when triggered. Sent to backend with the rating. */
+  formId: string | null
+  setEligible: (source: AdminFeedbackTriggerSource, formId?: string) => void
+  reset: () => void
+}
+
+const INITIAL_STATE = {
+  isEligible: false,
+  triggerSource: null,
+  formId: null,
+}
+
+export const isEligibleSelector = (state: AdminFeedbackStore) =>
+  state.isEligible
+
+export const resetSelector = (state: AdminFeedbackStore) => state.reset
+
+export const useAdminFeedbackStore = create<AdminFeedbackStore>()(
+  devtools((set) => ({
+    ...INITIAL_STATE,
+    setEligible: (source, formId) =>
+      set({ isEligible: true, triggerSource: source, formId: formId ?? null }),
+    reset: () => set(INITIAL_STATE),
+  })),
+)

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/adminFeedbackStore.ts
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/adminFeedbackStore.ts
@@ -1,15 +1,7 @@
 import create from 'zustand'
 import { devtools } from 'zustand/middleware'
 
-/**
- * Where the feedback prompt was triggered from. Phase 1 only sets
- * 'field-edit'; 'publish' and 'workflow' are reserved for Phase 2.
- */
-export type AdminFeedbackTriggerSource =
-  | 'field-edit'
-  | 'publish'
-  | 'workflow'
-  | null
+import { AdminFeedbackTriggerSource } from 'formsg-shared/types'
 
 type AdminFeedbackStore = {
   /**
@@ -19,7 +11,7 @@ type AdminFeedbackStore = {
    */
   isEligible: boolean
   /** Which action triggered the feedback prompt. Sent to backend with the rating. */
-  triggerSource: AdminFeedbackTriggerSource
+  triggerSource: AdminFeedbackTriggerSource | null
   /** The form the admin was working on when triggered. Sent to backend with the rating. */
   formId: string | null
   setEligible: (source: AdminFeedbackTriggerSource, formId?: string) => void

--- a/apps/frontend/src/features/workspace/mutations.ts
+++ b/apps/frontend/src/features/workspace/mutations.ts
@@ -237,8 +237,15 @@ export const useAdminFeedbackMutation = () => {
     }) => createAdminFeedback(rating, triggerSource, formId),
   )
   const updateAdminFeedbackMutation = useMutation(
-    ({ feedbackId, comment }: { feedbackId: string; comment: string }) =>
-      updateAdminFeedback(feedbackId, comment),
+    ({
+      feedbackId,
+      comment,
+      rating,
+    }: {
+      feedbackId: string
+      comment?: string
+      rating?: AdminFeedbackRating
+    }) => updateAdminFeedback(feedbackId, { comment, rating }),
   )
 
   return { createAdminFeedbackMutation, updateAdminFeedbackMutation }

--- a/apps/frontend/src/features/workspace/mutations.ts
+++ b/apps/frontend/src/features/workspace/mutations.ts
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 
 import {
   AdminFeedbackRating,
+  AdminFeedbackTriggerSource,
   AdminUseEmailModeFeedbackDto,
 } from 'formsg-shared/types'
 import {
@@ -225,7 +226,15 @@ export const useDeleteFormMutation = () => {
 }
 export const useAdminFeedbackMutation = () => {
   const createAdminFeedbackMutation = useMutation(
-    (rating: AdminFeedbackRating) => createAdminFeedback(rating),
+    ({
+      rating,
+      triggerSource,
+      formId,
+    }: {
+      rating: AdminFeedbackRating
+      triggerSource?: AdminFeedbackTriggerSource
+      formId?: string
+    }) => createAdminFeedback(rating, triggerSource, formId),
   )
   const updateAdminFeedbackMutation = useMutation(
     ({ feedbackId, comment }: { feedbackId: string; comment: string }) =>

--- a/apps/frontend/src/i18n/locales/features/workspace/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/en-sg.ts
@@ -44,30 +44,16 @@ export const enSG: Workspace = {
   },
   feedback: {
     rating: {
-      prompt: 'How was your form building experience?',
-      aria: {
-        up: 'Good',
-        down: 'Bad',
-      },
-    },
-    callForComment: {
-      up: {
-        title: "Thank you, you're the best!",
-        link: 'Want to tell us more?',
-      },
-      down: {
-        title: 'Thank you for your feedback.',
-        link: 'Tell us more so we can improve!',
-      },
+      prompt: 'How is your experience using FormSG?',
+      fieldTitle: 'Rate your experience',
     },
     comment: {
-      title: 'Great!',
-      description:
-        'Tell us about your form building experience in more detail!',
-      placeholder: {
-        up: 'string',
-        down: 'string',
+      label: {
+        low: 'What went wrong?',
+        mid: 'What could we improve?',
+        high: 'What did you enjoy most?',
       },
+      placeholder: 'Tell us more...',
       aria: {
         close: 'close feedback box',
       },

--- a/apps/frontend/src/i18n/locales/features/workspace/index.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/index.ts
@@ -47,28 +47,15 @@ export interface Workspace {
   feedback: {
     rating: {
       prompt: string
-      aria: {
-        up: string
-        down: string
-      }
-    }
-    callForComment: {
-      up: {
-        title: string
-        link: string
-      }
-      down: {
-        title: string
-        link: string
-      }
+      fieldTitle: string
     }
     comment: {
-      title: string
-      description: string
-      placeholder: {
-        up: string
-        down: string
+      label: {
+        low: string
+        mid: string
+        high: string
       }
+      placeholder: string
       aria: {
         close: string
       }

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -45,6 +45,7 @@ export const featureFlags = {
   answerObjectEncryption: 'answer-object-encryption' as const,
   enablePaperTrackingSetUpPage: 'enable-paper-tracking-set-up-page' as const,
   sidebarNavLabels: 'enable-sidebar-nav-labels' as const,
+  fiveStarAdminRating: '5star-admin-rating' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {

--- a/packages/shared/types/admin_feedback.ts
+++ b/packages/shared/types/admin_feedback.ts
@@ -1,8 +1,12 @@
 import { UserDto } from './user'
 
+export type AdminFeedbackTriggerSource = 'field-edit' | 'publish' | 'workflow'
+
 export type AdminFeedbackBase = {
   rating: number
   comment?: string
+  triggerSource?: AdminFeedbackTriggerSource
+  formId?: string
   userId?: UserDto['_id']
   created?: Date
   lastModified?: Date

--- a/packages/shared/types/admin_feedback.ts
+++ b/packages/shared/types/admin_feedback.ts
@@ -2,19 +2,17 @@ import { UserDto } from './user'
 
 export type AdminFeedbackTriggerSource = 'field-edit' | 'publish' | 'workflow'
 
+export type AdminFeedbackRating = 1 | 2 | 3 | 4 | 5
+
 export type AdminFeedbackBase = {
-  rating: number
+  rating: AdminFeedbackRating
   comment?: string
   triggerSource?: AdminFeedbackTriggerSource
   formId?: string
+  ratingChanged?: boolean
   userId?: UserDto['_id']
   created?: Date
   lastModified?: Date
 }
 
 export type AdminFeedbackDto = AdminFeedbackBase & { _id: string }
-
-export enum AdminFeedbackRating {
-  up = 1,
-  down = 0,
-}


### PR DESCRIPTION
## Problem

The admin feedback modal uses a binary thumbs up/down rating which gives no real granularity. The report card currently scales this 0/1 to a 1-5 range, creating false precision. The modal also only appears on the dashboard (low visibility) and only triggers on field edits (limited touchpoints).

## Solution

This PR implements the full admin satisfaction measurement revamp in three phases, shipped together behind a GrowthBook feature flag (`5star-admin-rating`).

### Phase 1: Move modal to builder page
Moved `AdminFeedbackContainer` from `WorkspacePage` to `AdminFormLayout`, so the modal appears where admins actually work. Replaced sessionStorage trigger with a zustand store (`adminFeedbackStore`). Removed the desktop-only check.

### Phase 2: Add publish + workflow triggers
Added feedback triggers on form publish (settings page) and workflow step completion (2+ completed steps). Extended the backend schema with optional `triggerSource` and `formId` fields. Added `triggerSource` as a Datadog tag.

### Phase 3: 1-5 star rating
Replaced thumbs up/down with a 5-star rating using the existing `Rating` component. Single-screen flow: stars + adaptive comment label + textarea. Rating saves on first click (create), updates on subsequent clicks. Added `ratingChanged` boolean to track change frequency. Dual-emit Datadog metrics (old + `.v2`) for migration safety.

### Feature flagging
Entire feedback system gated behind `useFeatureIsOn(featureFlags.fiveStarAdminRating)` in `AdminFormLayout.tsx`. Flag off = no modal at all. No backend gate needed.

**Alternatives considered**

We considered keeping both the old thumbs-up/down UI and the new 5-star UI, toggling between them based on the flag. This would preserve feedback collection during rollout. We chose against it because the old `AdminFeedbackRating` enum was replaced with a union type, the mutation signatures changed, and the translation keys were replaced. Maintaining two UIs and two type systems wasn't worth the brief collection gap during rollout.

We considered gating the backend too, but the frontend gate is sufficient. When the modal doesn't render, no requests reach the backend.

**Screenshots**

| State | Screenshot |
| --- | --- |
| Empty (no stars) | ![empty](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/admin-feedback/empty-state.png) |
| 2 stars - "What went wrong?" | ![2-stars](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/admin-feedback/2-stars-low.png) |
| 3 stars - "What could we improve?" | ![3-stars](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/admin-feedback/3-stars-mid.png) |
| 5 stars - "What did you enjoy most?" | ![5-stars](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/admin-feedback/5-stars-high.png) |

**Breaking Changes**

Yes - `AdminFeedbackRating` changed from enum to union type `1 | 2 | 3 | 4 | 5`. Old records with rating 0 are safe at the schema level (Mongoose min:0) but the API now rejects 0 (Joi min:1). Old and new rating values must NOT be aggregated together.

## Tests

### Feature flag

- [ ] **PR.1** `5star-admin-rating` flag OFF: no feedback modal appears anywhere, even if trigger conditions are met
- [ ] **PR.2** `5star-admin-rating` flag ON: modal appears when trigger conditions are met
- [ ] **PR.3** Flag OFF: no console errors related to feedback components

### Triggers

- [ ] **PR.4** Create the 5th field on a form and save: modal appears on builder page
- [ ] **PR.5** Create the 4th field (below threshold) and save: no modal
- [ ] **PR.6** Edit any field on a form that already has 5+ fields: modal appears
- [ ] **PR.7** Enable Payments and save: modal appears
- [ ] **PR.8** Publish a storage mode form: modal appears on settings page
- [ ] **PR.9** Publish an MRF form: modal appears on settings page
- [ ] **PR.10** Deactivate a form (set to private): no modal
- [ ] **PR.11** Save 2nd workflow step with respondent + fields: modal appears on workflow page
- [ ] **PR.12** Save 1st workflow step (only 1 completed): no modal
- [ ] **PR.13** Save 2nd step with fields but no respondent: no modal
- [ ] **PR.14** Open builder page without editing anything: no modal
- [ ] **PR.15** Navigate to dashboard after triggering conditions: no modal on dashboard

### Cooldown

- [ ] **PR.16** Dismiss modal without rating: no modal for 28 days
- [ ] **PR.17** Submit a rating: no modal for 28 days
- [ ] **PR.18** Trigger conditions met but within 28-day cooldown: no modal
- [ ] **PR.19** See modal on form A, dismiss. Edit form B (5+ fields) in same session: no modal (cooldown is cross-form)
- [ ] **PR.20** Respond to publish trigger, then trigger workflow immediately: no modal (cooldown is cross-trigger)

### Modal UI

- [ ] **PR.21** Modal initial state: 5 empty stars, question "How is your experience using FormSG?", X button visible, no comment box
- [ ] **PR.22** Click a star: comment box appears below stars, stars remain visible and clickable
- [ ] **PR.23** Click 1 or 2 stars: comment label reads "What went wrong?"
- [ ] **PR.24** Click 3 stars: comment label reads "What could we improve?"
- [ ] **PR.25** Click 4 or 5 stars: comment label reads "What did you enjoy most?"
- [ ] **PR.26** Click 2 stars, then change to 4 stars: label changes from "What went wrong?" to "What did you enjoy most?"
- [ ] **PR.27** Click X before selecting any star: modal closes, no API call made
- [ ] **PR.28** Click X after selecting a star: modal closes, rating already saved
- [ ] **PR.29** Mobile viewport: modal renders correctly
- [ ] **PR.30** Verify text styles: prompt uses `textStyle="h6"`, comment label uses `textStyle="subhead-2"` (code review)

### Backend

- [ ] **PR.31** POST rating of 3: accepted, DB record has `rating: 3`
- [ ] **PR.32** POST rating of 0: rejected (Joi validation min: 1)
- [ ] **PR.33** POST rating of 6: rejected (Joi validation max: 5)
- [ ] **PR.34** Click 3 stars, then 5 stars, submit comment: DB has `rating: 5`, `ratingChanged: true`
- [ ] **PR.35** Click 4 stars, never change, submit: DB has `rating: 4`, `ratingChanged: false`
- [ ] **PR.36** Check DB record after publish trigger: has `triggerSource: "publish"` and correct `formId`
- [ ] **PR.37** Check DB record after workflow trigger: has `triggerSource: "workflow"` and correct `formId`
- [ ] **PR.38** Check DB record after field-edit trigger: has `triggerSource: "field-edit"` and correct `formId`

### Metrics + data integrity

- [ ] **PR.39** Submit a rating, check Datadog: both `.rating` and `.rating.v2` fire with 1-5 value, `triggerSource` tag present
- [ ] **PR.40** Change rating (update fires), check Datadog: only the initial create metric recorded
- [ ] **PR.41** Old records with `rating: 0` in DB: still readable, no validation error
- [ ] **PR.42** Query mixing old (0/1) and new (1-5) records without date filter: confirms data separation warning

### Automated tests

- [ ] **PR.43** `admin_feedback.server.model.spec.ts` passes
- [ ] **PR.44** `admin_feedback.service.spec.ts` passes
- [ ] **PR.45** `workflow.utils.test.ts` passes

### Cleanup

Once the flag has been stable in production, a follow-up PR should:
- Remove the `useFeatureIsOn` check and `featureFlags.fiveStarAdminRating` constant
- Remove the old Datadog metric `formsg.users.feedback.rating` (after report card migrates to `.v2`)
- Remove the `ratingChanged` field if change rate is confirmed low (<5%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)