### PR TITLE
fix: disable Others input when it isn't the selected option

### DIFF
--- a/apps/frontend/src/templates/Field/Checkbox/CheckboxField.test.tsx
+++ b/apps/frontend/src/templates/Field/Checkbox/CheckboxField.test.tsx
@@ -146,7 +146,12 @@ describe('radio validation', () => {
     // Arrange
     const user = userEvent.setup()
     const checkboxOptionLabel =
-      ValidationRequired.args?.schema?.fieldOptions?.[0] ?? ''
+      ValidationRequired.args?.schema?.fieldOptions?.[0]
+    if (!checkboxOptionLabel) {
+      throw new Error(
+        'Test setup: ValidationRequired story must define at least one field option',
+      )
+    }
     render(<ValidationRequired />)
     const othersInput = screen.getByLabelText('"Other" response')
     const checkboxOption = screen.getByLabelText(checkboxOptionLabel)

--- a/apps/frontend/src/templates/Field/Checkbox/CheckboxField.test.tsx
+++ b/apps/frontend/src/templates/Field/Checkbox/CheckboxField.test.tsx
@@ -142,6 +142,30 @@ describe('radio validation', () => {
     ).toBeInTheDocument()
   })
 
+  it('disables the "Others" input when an option other than "Others" is checked', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const checkboxOptionLabel =
+      ValidationRequired.args?.schema?.fieldOptions?.[0] ?? ''
+    render(<ValidationRequired />)
+    const othersInput = screen.getByLabelText('"Other" response')
+    const checkboxOption = screen.getByLabelText(checkboxOptionLabel)
+
+    // Assert
+    // Initially nothing is selected, so the input stays editable to allow
+    // typing to auto-select the "Others" option.
+    expect(othersInput).toBeEnabled()
+
+    // Act
+    // Check a non-"Others" option.
+    await user.click(checkboxOption)
+
+    // Assert
+    // "Others" input should now be greyed out (disabled) to signal that its
+    // content will not be submitted unless "Others" is also checked.
+    expect(othersInput).toBeDisabled()
+  })
+
   it('renders success when unchecking some options before submitting', async () => {
     // Arrange
     const user = userEvent.setup()

--- a/apps/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
+++ b/apps/frontend/src/templates/Field/Checkbox/CheckboxField.tsx
@@ -105,8 +105,8 @@ export const CheckboxField = ({
           name={checkboxInputName}
           control={control}
           rules={validationRules}
-          render={({ field: { ref, onBlur, ...field } }) => (
-            <CheckboxGroup {...field}>
+          render={({ field: { ref, onBlur, value, ...field } }) => (
+            <CheckboxGroup {...field} value={value}>
               {fieldOptions.map((o, idx) => (
                 <Checkbox
                   name={checkboxInputName}
@@ -155,6 +155,15 @@ export const CheckboxField = ({
                     <Checkbox.OthersInput
                       colorScheme={fieldColorScheme}
                       aria-label='"Other" response'
+                      // Grey out the "Others" input when the user has selected
+                      // option(s) that do not include "Others", to make it clear
+                      // that text typed here will not be submitted.
+                      isDisabled={
+                        schema.disabled ||
+                        (Array.isArray(value) &&
+                          value.length > 0 &&
+                          !value.includes(CHECKBOX_OTHERS_INPUT_VALUE))
+                      }
                       {...register(othersInputName, othersValidationRules)}
                       {...(isHighContrast && { variant: 'highContrast' })}
                     />

--- a/apps/frontend/src/templates/Field/Radio/RadioField.test.tsx
+++ b/apps/frontend/src/templates/Field/Radio/RadioField.test.tsx
@@ -135,7 +135,12 @@ describe('radio validation', () => {
   it('disables the "Others" input when another option is selected', async () => {
     // Arrange
     const user = userEvent.setup()
-    const radioOption = ValidationRequired.args?.schema?.fieldOptions?.[0] ?? ''
+    const radioOption = ValidationRequired.args?.schema?.fieldOptions?.[0]
+    if (!radioOption) {
+      throw new Error(
+        'Test setup: ValidationRequired story must define at least one field option',
+      )
+    }
     render(<ValidationRequired />)
     const othersInput = screen.getByLabelText('"Other" response')
     const otherRadioButton = screen.getByRole('radio', { name: /other/i })

--- a/apps/frontend/src/templates/Field/Radio/RadioField.test.tsx
+++ b/apps/frontend/src/templates/Field/Radio/RadioField.test.tsx
@@ -132,6 +132,29 @@ describe('radio validation', () => {
     ).toBeInTheDocument()
   })
 
+  it('disables the "Others" input when another option is selected', async () => {
+    // Arrange
+    const user = userEvent.setup()
+    const radioOption = ValidationRequired.args?.schema?.fieldOptions?.[0] ?? ''
+    render(<ValidationRequired />)
+    const othersInput = screen.getByLabelText('"Other" response')
+    const otherRadioButton = screen.getByRole('radio', { name: /other/i })
+    const altRadioButton = screen.getByLabelText(radioOption)
+
+    // Act
+    // Select "Others" and type a custom answer; input should be editable.
+    await user.click(otherRadioButton)
+    await user.type(othersInput, 'My custom answer')
+    expect(othersInput).toBeEnabled()
+    // Switch to a different option.
+    await user.click(altRadioButton)
+
+    // Assert
+    // "Others" input should now be greyed out (disabled) to signal that its
+    // content will not be submitted.
+    expect(othersInput).toBeDisabled()
+  })
+
   it('renders success when switching options before submitting', async () => {
     // Arrange
     const user = userEvent.setup()

--- a/apps/frontend/src/templates/Field/Radio/RadioField.tsx
+++ b/apps/frontend/src/templates/Field/Radio/RadioField.tsx
@@ -133,7 +133,13 @@ export const RadioField = ({
               >
                 <FormControl
                   isRequired={schema.required}
-                  isDisabled={schema.disabled}
+                  // Grey out the "Others" input unless the "Others" option is
+                  // the selected one. This makes it clear that text typed here
+                  // will not be submitted when another option is selected.
+                  isDisabled={
+                    schema.disabled ||
+                    (!!value && value !== RADIO_OTHERS_INPUT_VALUE)
+                  }
                   isReadOnly={isValid && isSubmitting}
                   isInvalid={!!get(errors, othersInputName)}
                 >


### PR DESCRIPTION
## Problem

Closes #9352

The "Others" free-text input stays editable even when "Others" isn't the selected option — i.e. when a different option has been chosen. Only the selected option is submitted, so any text left in the "Others" box is silently dropped. Because the field still looks active and populated, users can reasonably expect that text to be submitted when it won't be.

This is most likely to happen when a user fills in "Others", then accidentally selects a different option. Affects both `RadioField` and `CheckboxField`.

## Solution

Grey out (disable) the "Others" input whenever a non-"Others" option is selected, making it visually clear that its content won't be submitted.

**`RadioField`** — radio is single-select, so `value` is a single value:

```tsx
isDisabled={
  schema.disabled ||
  (!!value && value !== RADIO_OTHERS_INPUT_VALUE)
}
```

Disabled when an option is selected *and* that option is not "Others".

**`CheckboxField`** — checkbox is multi-select, so `value` is an array:

```tsx
isDisabled={
  schema.disabled ||
  (Array.isArray(value) &&
    value.length > 0 &&
    !value.includes(CHECKBOX_OTHERS_INPUT_VALUE))
}
```

Disabled when at least one option is checked *and* "Others" is not among them. `Array.isArray` guards against `value` being `undefined` before any interaction. This also required exposing `value` from the `Controller` render prop and passing it to `<CheckboxGroup>`, since it wasn't previously available to the input.

**Note on the empty state:** when nothing is selected, the input is deliberately left enabled, so that typing into it can still auto-select the "Others" option. Only an active *non-"Others"* selection disables it.

## Tests

Added a unit test to each field (Jest + React Testing Library):

- `RadioField` — selects "Others", types a custom answer, asserts the input is enabled, then selects a different option and asserts it is disabled.
- `CheckboxField` — asserts the input is enabled when nothing is selected, checks a non-"Others" option, and asserts it becomes disabled.

## Before / after

<!-- drop screenshots or a short screen recording here -->