### PR TITLE
fix(frontend): select radio on circle click with text selected

### DIFF
--- a/apps/frontend/src/components/Radio/Radio.test.tsx
+++ b/apps/frontend/src/components/Radio/Radio.test.tsx
@@ -1,0 +1,24 @@
+import { composeStories } from '@storybook/react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import * as stories from './Radio.stories'
+
+const { Default } = composeStories(stories)
+
+describe('Radio', () => {
+  it('preserves a consumer click handler when selecting the control', () => {
+    const onClick = vi.fn()
+    render(<Default onClick={onClick} />)
+    const radio = screen.getByRole('radio')
+    /* eslint-disable testing-library/no-node-access -- the visual circle is aria-hidden, so it cannot be queried by role */
+    const control = radio.parentElement?.querySelector('.chakra-radio__control')
+    /* eslint-enable testing-library/no-node-access */
+
+    expect(control).toBeInTheDocument()
+
+    fireEvent.click(control as Element)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(radio).toBeChecked()
+  })
+})

--- a/apps/frontend/src/components/Radio/Radio.tsx
+++ b/apps/frontend/src/components/Radio/Radio.tsx
@@ -46,7 +46,7 @@ import {
   useRadioGroupContext,
   UseRadioProps,
 } from '@chakra-ui/react'
-import { callAll, split } from '@chakra-ui/utils'
+import { callAll, callAllHandlers, split } from '@chakra-ui/utils'
 
 import { RADIO_THEME_KEY } from '~/theme/components/Radio'
 import { FieldColorScheme } from '~/theme/foundations/colours'
@@ -171,7 +171,7 @@ export const Radio = forwardRef<RadioProps, 'input'>(
 
     const checkboxProps = getCheckboxProps({
       ...otherProps,
-      onClick: handleControlClick,
+      onClick: callAllHandlers(props.onClick, handleControlClick),
     })
     const inputProps = getInputProps({}, mergedInputRef)
 

--- a/apps/frontend/src/components/Radio/Radio.tsx
+++ b/apps/frontend/src/components/Radio/Radio.tsx
@@ -20,10 +20,12 @@ import {
   ChangeEvent,
   ChangeEventHandler,
   KeyboardEvent,
+  MouseEvent,
   SyntheticEvent,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
@@ -152,8 +154,26 @@ export const Radio = forwardRef<RadioProps, 'input'>(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const [layoutProps, otherProps] = split(htmlProps, layoutPropNames as any)
 
-    const checkboxProps = getCheckboxProps(otherProps)
-    const inputProps = getInputProps({}, ref)
+    const inputRef = useRef<HTMLInputElement>(null)
+    const mergedInputRef = useMergeRefs(inputRef, ref)
+
+    // A selected text range can suppress the label's implicit input activation.
+    const handleControlClick = useCallback(
+      (e: MouseEvent<HTMLSpanElement>) => {
+        if (props.isDisabled || isChecked) return
+        if (!inputRef.current || inputRef.current.disabled) return
+
+        e.preventDefault()
+        inputRef.current.click()
+      },
+      [isChecked, props.isDisabled],
+    )
+
+    const checkboxProps = getCheckboxProps({
+      ...otherProps,
+      onClick: handleControlClick,
+    })
+    const inputProps = getInputProps({}, mergedInputRef)
 
     const handleSelect = useCallback(
       (e: SyntheticEvent) => {

--- a/apps/frontend/src/templates/Field/Radio/RadioField.test.tsx
+++ b/apps/frontend/src/templates/Field/Radio/RadioField.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from '@storybook/react'
-import { render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { REQUIRED_ERROR } from '~constants/validation'
@@ -44,6 +44,33 @@ describe('required field', () => {
       screen.getByText(new RegExp(`{"value":"${radioOption}"}`, 'i')),
     ).toBeInTheDocument()
     expect(screen.queryByText(REQUIRED_ERROR)).not.toBeInTheDocument()
+  })
+
+  it('selects the radio when clicking the circle while text is selected', async () => {
+    // Arrange
+    const radioOption =
+      WithoutOthersOption.args?.schema?.fieldOptions?.[0] ?? ''
+    render(<WithoutOthersOption />)
+    const fieldTitle = screen.getByText('Favourite fruit')
+    const firstRadioButton = screen.getByLabelText(radioOption)
+    /* eslint-disable testing-library/no-node-access -- the visual circle is aria-hidden, so it cannot be queried by role */
+    const firstRadioControl = firstRadioButton.parentElement?.querySelector(
+      '.chakra-radio__control',
+    )
+    /* eslint-enable testing-library/no-node-access */
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.selectNodeContents(fieldTitle)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    expect(firstRadioControl).toBeInTheDocument()
+
+    // Act
+    await act(async () => fireEvent.click(firstRadioControl as Element))
+
+    // Assert
+    expect(firstRadioButton).toBeChecked()
+    selection?.removeAllRanges()
   })
 
   it('renders success when valid radio field selected when submitted (with others option)', async () => {

--- a/apps/frontend/src/templates/Field/Radio/RadioField.test.tsx
+++ b/apps/frontend/src/templates/Field/Radio/RadioField.test.tsx
@@ -63,14 +63,18 @@ describe('required field', () => {
     range.selectNodeContents(fieldTitle)
     selection?.removeAllRanges()
     selection?.addRange(range)
-    expect(firstRadioControl).toBeInTheDocument()
 
-    // Act
-    await act(async () => fireEvent.click(firstRadioControl as Element))
+    try {
+      expect(firstRadioControl).toBeInTheDocument()
 
-    // Assert
-    expect(firstRadioButton).toBeChecked()
-    selection?.removeAllRanges()
+      // Act
+      await act(async () => fireEvent.click(firstRadioControl as Element))
+
+      // Assert
+      expect(firstRadioButton).toBeChecked()
+    } finally {
+      selection?.removeAllRanges()
+    }
   })
 
   it('renders success when valid radio field selected when submitted (with others option)', async () => {


### PR DESCRIPTION
## Problem

Closes #6228.

When text is selected elsewhere on the page, Chromium can suppress the wrapping label's implicit activation of FormSG's hidden radio input. In that state, clicking the visible radio circle does not select the option even though clicking the label text still works.

## Solution

- Keep the hidden radio input as the source of truth.
- Forward clicks on the unselected visible radio control to the hidden input directly.
- Compose the workaround with consumer-provided click handlers and respect prevented events.
- Preserve the existing selected-radio deselect path.
- Add regression tests for the selected-text interaction and consumer click-handler behavior.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Restores visible radio-circle selection when page text is selected, without waiting for a Chakra/React major-version upgrade.

## Before & After Screenshots

**BEFORE**:
N/A - interaction fix covered by focused component tests and Storybook manual verification.

**AFTER**:
N/A - interaction fix covered by focused component tests and Storybook manual verification.

## Tests

```bash
pnpm --filter formsg-frontend test --run src/components/Radio/Radio.test.tsx src/templates/Field/Radio/RadioField.test.tsx
pnpm --filter formsg-frontend exec tsc --noEmit
pnpm --filter formsg-frontend exec eslint src/components/Radio/Radio.tsx src/components/Radio/Radio.test.tsx src/templates/Field/Radio/RadioField.test.tsx
pnpm --filter formsg-frontend exec prettier src/components/Radio/Radio.tsx src/components/Radio/Radio.test.tsx src/templates/Field/Radio/RadioField.test.tsx --check
git diff --check
```

Manual verification:

- Storybook `Components/Radio/Playground`: normal circle click checks the radio.
- Storybook `Components/Radio/Playground`: with page text selected, clicking the visible radio circle checks the radio.
- Storybook `Components/Checkbox/Playground`: with page text selected, clicking the visible checkbox square already checks the checkbox.

## Deploy Notes

**New environment variables**:

- N/A

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
