### PR TITLE
fix: localise attachment decryption toast

### DIFF
--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -698,7 +698,7 @@ export const PublicFormProvider = ({
     if (hasPreviousSubmissionDecryptionError) {
       toast({
         status: 'danger',
-        description: 'Failed to decrypt attachment',
+        description: t('features.publicForm.errors.attachmentDecryption'),
       })
     }
   }, [hasMyInfoError, hasPreviousSubmissionDecryptionError, toast, t])

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -20,6 +20,7 @@ export const enSG: PublicForm = {
 
     myinfo:
       'Your Myinfo details could not be retrieved. Refresh your browser and log in, or try again later.',
+    attachmentDecryption: 'Failed to decrypt attachment',
     submitFailure:
       'An error occurred whilst processing your submission. Please refresh and try again.',
     verifiedFieldExpired:

--- a/apps/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/index.ts
@@ -17,6 +17,7 @@ export interface PublicForm {
       message: string
     }
     myinfo: string
+    attachmentDecryption: string
     submitFailure: string
     verifiedFieldExpired: string
   }


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Closes #9674

The attachment decryption error toast in `PublicFormProvider` used a hardcoded English description, so it did not go through i18n and could not respect the respondent's selected form language or fallback behaviour.

## Solution
Updated the attachment decryption error toast to use the public form i18n key instead of a hardcoded string.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible

**Features**:
- N/A
**Improvements**:

- Added `features.publicForm.errors.attachmentDecryption` to the public form i18n structure.
- Added the English fallback value for the attachment decryption error toast.
- Updated the toast description to use `t('features.publicForm.errors.attachmentDecryption')`.

**Bug Fixes**:

- Fixes the attachment decryption error toast being hardcoded in English.

## Before & After Screenshots

**BEFORE**:
<!-- [insert screenshot here] -->
N/A — this change affects toast localisation behaviour and does not change layout.

**AFTER**:
<!-- [insert screenshot here] -->
N/A — verified through unit test that the toast description uses the i18n key instead of the hardcoded English string.

## Tests
- `pnpm --filter formsg-frontend test run src/features/public-form/PublicFormProvider.test.tsx`
- `pnpm --filter formsg-frontend exec tsc --noEmit`
- `pnpm exec eslint src/features/public-form/PublicFormProvider.tsx src/features/public-form/PublicFormProvider.test.tsx src/i18n/locales/features/public-form/en-sg.ts src/i18n/locales/features/public-form/index.ts`

## Deploy Notes
<!-- Notes regarding deployment of the contained body of work.  -->
<!-- These should note any new dependencies, new scripts, etc. -->

**New environment variables**:

- `env var` : env var details

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

