### PR TITLE
feat: zustand store + move feedback modal to builder page

### DIFF
--- a/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -28,7 +28,6 @@ import {
   ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
 } from '~constants/localStorage'
 import { DASHBOARD_ROUTE } from '~constants/routes'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import { useToast } from '~hooks/useToast'
@@ -151,7 +150,6 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   }, [getWogadLogoutUrlMutation])
 
   const handleLogout = useCallback(() => {
-    sessionStorage.removeItem(ADMIN_FEEDBACK_SESSION_KEY)
     logout()
     removeQuery()
     if (emergencyContactKey) {

--- a/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -39,6 +39,7 @@ import { AvatarMenu, AvatarMenuDivider } from '~templates/AvatarMenu/AvatarMenu'
 import { EmergencyContactModal } from '~features/user/emergency-contact/EmergencyContactModal'
 import { useUser } from '~features/user/queries'
 import { TransferOwnershipModal } from '~features/user/transfer-ownership/TransferOwnershipModal'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import Menu from '../../components/Menu'
 
@@ -150,6 +151,10 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   }, [getWogadLogoutUrlMutation])
 
   const handleLogout = useCallback(() => {
+    // `logout` is an API call, not a page load, so the in-memory feedback store
+    // survives it. Clear it so the next admin in this tab does not inherit the
+    // previous admin's eligibility, triggerSource and formId.
+    useAdminFeedbackStore.getState().reset()
     logout()
     removeQuery()
     if (emergencyContactKey) {

--- a/apps/frontend/src/components/Hug/BottomHugBox.tsx
+++ b/apps/frontend/src/components/Hug/BottomHugBox.tsx
@@ -7,7 +7,10 @@ const BottomHugBox = ({ children }: { children: JSX.Element }) => {
       bottom="1.5rem"
       left="50%"
       transform="translateX(-50%)"
-      zIndex="2"
+      // Must sit above docked page chrome (e.g. the field list drawer's sticky
+      // section headers, which use zIndex="docked"), but below overlay/modal so
+      // real dialogs still cover it.
+      zIndex="sticky"
     >
       <Flex
         px="1.5rem"

--- a/apps/frontend/src/constants/sessionStorage.ts
+++ b/apps/frontend/src/constants/sessionStorage.ts
@@ -1,8 +1,0 @@
-/**
- * Constants relating to sessionStorage.
- */
-
-/**
- * Key to store whether admin should be shown the feedback modal
- */
-export const ADMIN_FEEDBACK_SESSION_KEY = 'admin-feedback-key'

--- a/apps/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/apps/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
-import { useFeatureValue } from '@growthbook/growthbook-react'
+import { useFeatureIsOn, useFeatureValue } from '@growthbook/growthbook-react'
 import { get } from 'lodash'
+
+import { featureFlags } from 'formsg-shared/constants'
 
 import { fillHeightCss } from '~utils/fillHeightCss'
 import { getBannerProps } from '~utils/getBannerProps'
@@ -11,6 +13,8 @@ import { Banner } from '~components/Banner'
 import AdminForbiddenErrorPage from '~pages/AdminForbiddenError'
 import NotFoundErrorPage from '~pages/NotFoundError'
 import { useEnv } from '~features/env/queries'
+import { useUser } from '~features/user/queries'
+import AdminFeedbackContainer from '~features/workspace/components/AdminFeedbackContainer'
 
 import { StorageResponsesProvider } from '../responses/ResponsesPage/storage/StorageResponsesProvider'
 
@@ -44,7 +48,10 @@ export const AdminFormLayout = (): JSX.Element => {
     [bannerContent, bannerContentGB],
   )
 
+  const isFiveStarEnabled = useFeatureIsOn(featureFlags.fiveStarAdminRating)
+
   const { error } = useAdminForm()
+  const { user } = useUser()
 
   if (get(error, 'code') === 404 || get(error, 'code') === 410) {
     return <NotFoundErrorPage />
@@ -75,6 +82,9 @@ export const AdminFormLayout = (): JSX.Element => {
       <StorageResponsesProvider>
         <Outlet />
       </StorageResponsesProvider>
+      {user && isFiveStarEnabled && (
+        <AdminFeedbackContainer userId={user._id} />
+      )}
     </Flex>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
@@ -9,10 +9,6 @@ import {
 } from 'formsg-shared/types/field'
 import { insertAt, replaceAt } from 'formsg-shared/utils/immutable-array-fns'
 
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
-
-import { useEnv } from '~features/env/queries'
 import { augmentWithMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
 
 import { PENDING_CREATE_FIELD_ID } from '../constants'
@@ -59,44 +55,20 @@ const getFormFieldsWhileEditing = (
 export const useBuilderFields = () => {
   const { data: formData, isLoading } = useCreateTabForm()
   const stateData = useFieldBuilderStore(stateDataSelector)
-  const [, setIsAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
-  const { data: { adminFeedbackFieldThreshold } = {} } = useEnv()
   const builderFields = useMemo(() => {
     let existingFields = formData?.form_fields
     if (isLoading || !existingFields) return null
     if (stateData.state === FieldBuilderState.EditingField) {
-      // check if existing fields meets threshold for admin feedback eligibility
-      if (
-        adminFeedbackFieldThreshold &&
-        existingFields.length >= adminFeedbackFieldThreshold
-      )
-        setIsAdminFeedbackEligible(true)
-
       existingFields = getFormFieldsWhileEditing(
         existingFields,
         stateData.field,
       )
     } else if (stateData.state === FieldBuilderState.CreatingField) {
-      // if existing fields is equal to threshold - 1, to include field being created
-      if (
-        adminFeedbackFieldThreshold &&
-        existingFields.length >= adminFeedbackFieldThreshold - 1
-      )
-        setIsAdminFeedbackEligible(true)
-
       existingFields = getFormFieldsWhileCreating(existingFields, stateData)
     }
 
     return existingFields.map(augmentWithMyInfo)
-  }, [
-    formData?.form_fields,
-    isLoading,
-    stateData,
-    setIsAdminFeedbackEligible,
-    adminFeedbackFieldThreshold,
-  ])
+  }, [formData?.form_fields, isLoading, stateData])
 
   return {
     builderFields,

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -10,6 +10,7 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
 import { useDebounce } from 'react-use'
 import { cloneDeep } from 'lodash'
 
@@ -20,11 +21,9 @@ import {
   FormFieldDto,
 } from 'formsg-shared/types/field'
 
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
-
 import { useCreateFormField } from '~features/admin-form/create/builder-and-design/mutations/useCreateFormField'
 import { useEditFormField } from '~features/admin-form/create/builder-and-design/mutations/useEditFormField'
+import { useCreateTabForm } from '~features/admin-form/create/builder-and-design/useCreateTabForm'
 import {
   setIsDirtySelector,
   useDirtyFieldStore,
@@ -37,7 +36,9 @@ import {
   updateEditStateSelector,
   useFieldBuilderStore,
 } from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
+import { useEnv } from '~features/env/queries'
 import { isMyInfo } from '~features/myinfo/utils'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import { EditFieldProps } from './types'
 
@@ -101,9 +102,9 @@ export const useEditFieldForm = <
 
   const { editFieldMutation } = useEditFormField()
   const { createFieldMutation } = useCreateFormField()
-  const [, setIsAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
+  const { formId } = useParams()
+  const { data: formData } = useCreateTabForm()
+  const { data: { adminFeedbackFieldThreshold } = {} } = useEnv()
 
   const isPendingField = useMemo(
     () => stateData.state === FieldBuilderState.CreatingField,
@@ -162,17 +163,33 @@ export const useEditFieldForm = <
       )
     }
 
-    // if field to be updated is MyInfo, enable admin feedback
-    if (isMyInfo(updatedFormField)) setIsAdminFeedbackEligible(true)
+    const isCreating = stateData.state === FieldBuilderState.CreatingField
+    const isMyInfoField = isMyInfo(updatedFormField)
+    // Count of fields already saved on the form. While creating, the pending
+    // field isn't part of this count yet, so we offset the threshold by 1.
+    const savedFieldCount = formData?.form_fields.length ?? 0
+    const meetsFieldThreshold =
+      !!adminFeedbackFieldThreshold &&
+      savedFieldCount >= adminFeedbackFieldThreshold - (isCreating ? 1 : 0)
 
-    if (stateData.state === FieldBuilderState.CreatingField) {
+    // Enable the admin feedback prompt once the save succeeds (onSaveSuccess
+    // closes the drawer), so the prompt appears after the drawer is gone, not
+    // mid-edit. Triggers on crossing the field-count threshold or on a MyInfo
+    // field save.
+    const onMutateSuccess = (newField: FormField) => {
+      onSaveSuccess(newField)
+      if (isMyInfoField || meetsFieldThreshold)
+        useAdminFeedbackStore.getState().setEligible('field-edit', formId)
+    }
+
+    if (isCreating) {
       return createFieldMutation.mutate(updatedFormField, {
-        onSuccess: onSaveSuccess,
+        onSuccess: onMutateSuccess,
       })
     } else if (stateData.state === FieldBuilderState.EditingField) {
       return editFieldMutation.mutate(
         { ...updatedFormField, _id: stateData.field._id } as FormFieldDto,
-        { onSuccess: onSaveSuccess },
+        { onSuccess: onMutateSuccess },
       )
     }
   })

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -10,7 +10,7 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Link as ReactLink } from 'react-router-dom'
+import { Link as ReactLink, useParams } from 'react-router-dom'
 import { useDebounce } from 'react-use'
 import {
   Box,
@@ -34,8 +34,6 @@ import {
 import { centsToDollars, dollarsToCents } from 'formsg-shared/utils/payments'
 
 import { ADMINFORM_SETTINGS_PAYMENTS_SUBROUTE } from '~constants/routes'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -45,6 +43,7 @@ import Toggle from '~components/Toggle'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import { useCreatePageSidebar } from '../../../../../common'
 import { FieldListTabIndex } from '../../../../constants'
@@ -242,9 +241,7 @@ const PaymentInputFields = ({
 
   const handleClose = () => setFieldListTabIndex(FieldListTabIndex.Basic)
 
-  const [, setisAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
+  const { formId } = useParams()
 
   // unpack payment data for paymentAmount if it exists
   const formDefaultValues =
@@ -318,14 +315,14 @@ const PaymentInputFields = ({
       }
     }
 
-    // update sessionStorage to enable admin feedback
-    setisAdminFeedbackEligible(true)
     return paymentsMutation.mutate(
       { ...paymentsData, enabled: true },
       {
         onSuccess: () => {
           setToInactive()
           handleClose()
+          // enable admin feedback after the panel closes
+          useAdminFeedbackStore.getState().setEligible('field-edit', formId)
         },
       },
     )

--- a/apps/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/apps/frontend/src/features/workspace/WorkspacePage.tsx
@@ -32,7 +32,6 @@ import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
 import { WorkspaceContent } from '~features/workspace/WorkspaceContent'
 
-import AdminFeedbackContainer from './components/AdminFeedbackContainer'
 import { WorkspaceMenuHeader } from './components/WorkspaceSideMenu/WorkspaceMenuHeader'
 import { WorkspaceMenuTabs } from './components/WorkspaceSideMenu/WorkspaceMenuTabs'
 import { useDashboard, useWorkspace } from './queries'
@@ -54,7 +53,6 @@ export const WorkspacePage = (): JSX.Element => {
   // TODO [MRF-CUTOVER]: Remove this infobox (and MRF_CUTOVER_FAQ_LINK) once the
   // cutover is complete and the flag is retired.
   const isMrfCutoverEnabled = useFeatureIsOn(featureFlags.mrfCutover)
-  const isFiveStarEnabled = useFeatureIsOn(featureFlags.fiveStarAdminRating)
 
   const { user } = useUser()
   const { data: dashboardForms, isLoading: isDashboardLoading } = useDashboard()
@@ -212,9 +210,6 @@ export const WorkspacePage = (): JSX.Element => {
           </WorkspaceProvider>
         </GridItem>
       </Grid>
-      {user && isFiveStarEnabled && (
-        <AdminFeedbackContainer userId={user._id} />
-      )}
     </>
   )
 }

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
@@ -1,26 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { ADMIN_FEEDBACK_HISTORY_PREFIX } from '~constants/localStorage'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
 
 import { useEnv } from '~features/env/queries'
 
 import AdminFeedbackBox from '../AdminFeedbackBox'
 
+import {
+  isEligibleSelector,
+  resetSelector,
+  useAdminFeedbackStore,
+} from './adminFeedbackStore'
+
 export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
   const { data: { adminFeedbackDisplayFrequency } = {} } = useEnv()
   const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
-  const isMobile = useIsMobile()
 
   const adminFeedbackKey = ADMIN_FEEDBACK_HISTORY_PREFIX + userId
 
   const [lastFeedbackTime, setLastFeedbackTime] =
     useLocalStorage<number>(adminFeedbackKey)
-  const [isAdminFeedbackEligible, setIsAdminFeedbackEligible] =
-    useSessionStorage<boolean>(ADMIN_FEEDBACK_SESSION_KEY, false)
+  const isAdminFeedbackEligible = useAdminFeedbackStore(isEligibleSelector)
+  const resetAdminFeedbackEligible = useAdminFeedbackStore(resetSelector)
 
   // capture current time on page load to prevent re-renders from update to current time
   const currentTime = useRef(Date.now())
@@ -37,24 +39,18 @@ export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
 
   // sets display of feedback box
   useEffect(() => {
-    if (
-      // TODO: create mobile version of admin feedback
-      !isMobile &&
-      // whether to show admin the feedback box
-      showAdminFeedback
-    ) {
+    if (showAdminFeedback) {
       setIsDisplayFeedback(true)
       // reset local storage and admin feedback eligibility when admin feedback is displayed
       setLastFeedbackTime(currentTime.current)
-      setIsAdminFeedbackEligible(false)
+      resetAdminFeedbackEligible()
     }
   }, [
     currentTime,
     showAdminFeedback,
     setIsDisplayFeedback,
     setLastFeedbackTime,
-    setIsAdminFeedbackEligible,
-    isMobile,
+    resetAdminFeedbackEligible,
   ])
 
   const closeAdminFeedback = useCallback(

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/adminFeedbackStore.ts
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/adminFeedbackStore.ts
@@ -1,0 +1,32 @@
+import create from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+import { AdminFeedbackTriggerSource } from 'formsg-shared/types'
+
+type AdminFeedbackStore = {
+  isEligible: boolean
+  triggerSource: AdminFeedbackTriggerSource | null
+  formId: string | null
+  setEligible: (source: AdminFeedbackTriggerSource, formId?: string) => void
+  reset: () => void
+}
+
+const INITIAL_STATE = {
+  isEligible: false,
+  triggerSource: null,
+  formId: null,
+}
+
+export const isEligibleSelector = (state: AdminFeedbackStore) =>
+  state.isEligible
+
+export const resetSelector = (state: AdminFeedbackStore) => state.reset
+
+export const useAdminFeedbackStore = create<AdminFeedbackStore>()(
+  devtools((set) => ({
+    ...INITIAL_STATE,
+    setEligible: (source, formId) =>
+      set({ isEligible: true, triggerSource: source, formId: formId ?? null }),
+    reset: () => set(INITIAL_STATE),
+  })),
+)


### PR DESCRIPTION
## Problem

The admin feedback modal lives on the dashboard (WorkspacePage) where admins rarely spend time. Trigger state is stored in sessionStorage, which doesn't integrate with React's rendering cycle and can't carry metadata like which action triggered the prompt.

## Solution

Replace sessionStorage with a zustand store and move the feedback container from the dashboard to the form builder page (AdminFormLayout), where admins actively work. The modal still shows the existing thumbs up/down UI. The feature flag from PR 1 gates the render.

Key changes:
- New `adminFeedbackStore.ts` (34 lines): zustand store with `isEligible`, `triggerSource`, `formId`
- `AdminFeedbackContainer` uses store selectors instead of sessionStorage
- Container moved from `WorkspacePage` to `AdminFormLayout` (behind `useFeatureIsOn`)
- Field-edit triggers (`useEditFieldForm`, `PaymentsInputPanel`) call `setEligible('field-edit', formId)` instead of setting sessionStorage
- `useBuilderFields` cleaned up (removed 24 lines of old threshold logic)
- Desktop-only check removed (mobile admins now see the prompt too)
- `sessionStorage.ts` deleted

This is PR 3 of 5 in the admin satisfaction revamp stack:
1. Feature flag (#9683)
2. Backend schema + validation (#9684)
3. **Zustand store + move modal** (this PR)
4. Publish + workflow triggers
5. Star rating UI

**Breaking Changes**

No. This PR keeps the existing thumbs up/down UI and only changes where the modal renders (builder instead of dashboard) and how trigger state is stored (zustand instead of sessionStorage). The 5-star rating UI is a later PR (5) in this stack. PR 2 (#9684) widened the backend to accept ratings 0-5 so it's forward-compatible, but the frontend here still submits 0/1.

## Tests

**Build**
- [ ] `pnpm build` passes

**Modal show/hide (flag ON)**
- [ ] Edit a single field on a form → modal becomes eligible and appears on the builder page
- [ ] Add/edit a payment input → modal becomes eligible and appears
- [ ] Navigate to the dashboard after triggering → no modal there (only renders in builder now)
- [ ] Modal does NOT reappear within the display-frequency window of the last showing
- [ ] Modal reappears after the frequency window elapses AND eligibility is re-triggered
- [ ] After showing once, eligibility resets (won't re-fire until a new field/payment edit)
- [ ] Mobile viewport: modal appears (desktop-only check removed)

**Flag OFF**
- [ ] No modal anywhere (dashboard or builder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
