### PR TITLE
feat: add publish and workflow feedback triggers

### DIFF
--- a/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -28,7 +28,6 @@ import {
   ROLLOUT_ANNOUNCEMENT_KEY_PREFIX,
 } from '~constants/localStorage'
 import { DASHBOARD_ROUTE } from '~constants/routes'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
 import { useToast } from '~hooks/useToast'
@@ -151,7 +150,6 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   }, [getWogadLogoutUrlMutation])
 
   const handleLogout = useCallback(() => {
-    sessionStorage.removeItem(ADMIN_FEEDBACK_SESSION_KEY)
     logout()
     removeQuery()
     if (emergencyContactKey) {

--- a/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
+++ b/apps/frontend/src/app/AdminNavBar/AdminNavBar.tsx
@@ -39,6 +39,7 @@ import { AvatarMenu, AvatarMenuDivider } from '~templates/AvatarMenu/AvatarMenu'
 import { EmergencyContactModal } from '~features/user/emergency-contact/EmergencyContactModal'
 import { useUser } from '~features/user/queries'
 import { TransferOwnershipModal } from '~features/user/transfer-ownership/TransferOwnershipModal'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import Menu from '../../components/Menu'
 
@@ -150,6 +151,10 @@ export const AdminNavBar = ({ isMenuOpen }: AdminNavBarProps): JSX.Element => {
   }, [getWogadLogoutUrlMutation])
 
   const handleLogout = useCallback(() => {
+    // `logout` is an API call, not a page load, so the in-memory feedback store
+    // survives it. Clear it so the next admin in this tab does not inherit the
+    // previous admin's eligibility, triggerSource and formId.
+    useAdminFeedbackStore.getState().reset()
     logout()
     removeQuery()
     if (emergencyContactKey) {

--- a/apps/frontend/src/components/Hug/BottomHugBox.tsx
+++ b/apps/frontend/src/components/Hug/BottomHugBox.tsx
@@ -7,7 +7,10 @@ const BottomHugBox = ({ children }: { children: JSX.Element }) => {
       bottom="1.5rem"
       left="50%"
       transform="translateX(-50%)"
-      zIndex="2"
+      // Must sit above docked page chrome (e.g. the field list drawer's sticky
+      // section headers, which use zIndex="docked"), but below overlay/modal so
+      // real dialogs still cover it.
+      zIndex="sticky"
     >
       <Flex
         px="1.5rem"

--- a/apps/frontend/src/constants/sessionStorage.ts
+++ b/apps/frontend/src/constants/sessionStorage.ts
@@ -1,8 +1,0 @@
-/**
- * Constants relating to sessionStorage.
- */
-
-/**
- * Key to store whether admin should be shown the feedback modal
- */
-export const ADMIN_FEEDBACK_SESSION_KEY = 'admin-feedback-key'

--- a/apps/frontend/src/features/admin-form/common/AdminFormLayout.tsx
+++ b/apps/frontend/src/features/admin-form/common/AdminFormLayout.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from 'react'
 import { Outlet, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
-import { useFeatureValue } from '@growthbook/growthbook-react'
+import { useFeatureIsOn, useFeatureValue } from '@growthbook/growthbook-react'
 import { get } from 'lodash'
+
+import { featureFlags } from 'formsg-shared/constants'
 
 import { fillHeightCss } from '~utils/fillHeightCss'
 import { getBannerProps } from '~utils/getBannerProps'
@@ -11,6 +13,8 @@ import { Banner } from '~components/Banner'
 import AdminForbiddenErrorPage from '~pages/AdminForbiddenError'
 import NotFoundErrorPage from '~pages/NotFoundError'
 import { useEnv } from '~features/env/queries'
+import { useUser } from '~features/user/queries'
+import AdminFeedbackContainer from '~features/workspace/components/AdminFeedbackContainer'
 
 import { StorageResponsesProvider } from '../responses/ResponsesPage/storage/StorageResponsesProvider'
 
@@ -44,7 +48,10 @@ export const AdminFormLayout = (): JSX.Element => {
     [bannerContent, bannerContentGB],
   )
 
+  const isFiveStarEnabled = useFeatureIsOn(featureFlags.fiveStarAdminRating)
+
   const { error } = useAdminForm()
+  const { user } = useUser()
 
   if (get(error, 'code') === 404 || get(error, 'code') === 410) {
     return <NotFoundErrorPage />
@@ -75,6 +82,9 @@ export const AdminFormLayout = (): JSX.Element => {
       <StorageResponsesProvider>
         <Outlet />
       </StorageResponsesProvider>
+      {user && isFiveStarEnabled && (
+        <AdminFeedbackContainer userId={user._id} />
+      )}
     </Flex>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/useBuilderFields.tsx
@@ -9,10 +9,6 @@ import {
 } from 'formsg-shared/types/field'
 import { insertAt, replaceAt } from 'formsg-shared/utils/immutable-array-fns'
 
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
-
-import { useEnv } from '~features/env/queries'
 import { augmentWithMyInfo } from '~features/myinfo/utils/augmentWithMyInfo'
 
 import { PENDING_CREATE_FIELD_ID } from '../constants'
@@ -59,44 +55,20 @@ const getFormFieldsWhileEditing = (
 export const useBuilderFields = () => {
   const { data: formData, isLoading } = useCreateTabForm()
   const stateData = useFieldBuilderStore(stateDataSelector)
-  const [, setIsAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
-  const { data: { adminFeedbackFieldThreshold } = {} } = useEnv()
   const builderFields = useMemo(() => {
     let existingFields = formData?.form_fields
     if (isLoading || !existingFields) return null
     if (stateData.state === FieldBuilderState.EditingField) {
-      // check if existing fields meets threshold for admin feedback eligibility
-      if (
-        adminFeedbackFieldThreshold &&
-        existingFields.length >= adminFeedbackFieldThreshold
-      )
-        setIsAdminFeedbackEligible(true)
-
       existingFields = getFormFieldsWhileEditing(
         existingFields,
         stateData.field,
       )
     } else if (stateData.state === FieldBuilderState.CreatingField) {
-      // if existing fields is equal to threshold - 1, to include field being created
-      if (
-        adminFeedbackFieldThreshold &&
-        existingFields.length >= adminFeedbackFieldThreshold - 1
-      )
-        setIsAdminFeedbackEligible(true)
-
       existingFields = getFormFieldsWhileCreating(existingFields, stateData)
     }
 
     return existingFields.map(augmentWithMyInfo)
-  }, [
-    formData?.form_fields,
-    isLoading,
-    stateData,
-    setIsAdminFeedbackEligible,
-    adminFeedbackFieldThreshold,
-  ])
+  }, [formData?.form_fields, isLoading, stateData])
 
   return {
     builderFields,

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/common/useEditFieldForm.ts
@@ -10,6 +10,7 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
+import { useParams } from 'react-router-dom'
 import { useDebounce } from 'react-use'
 import { cloneDeep } from 'lodash'
 
@@ -20,11 +21,9 @@ import {
   FormFieldDto,
 } from 'formsg-shared/types/field'
 
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
-
 import { useCreateFormField } from '~features/admin-form/create/builder-and-design/mutations/useCreateFormField'
 import { useEditFormField } from '~features/admin-form/create/builder-and-design/mutations/useEditFormField'
+import { useCreateTabForm } from '~features/admin-form/create/builder-and-design/useCreateTabForm'
 import {
   setIsDirtySelector,
   useDirtyFieldStore,
@@ -37,7 +36,9 @@ import {
   updateEditStateSelector,
   useFieldBuilderStore,
 } from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
+import { useEnv } from '~features/env/queries'
 import { isMyInfo } from '~features/myinfo/utils'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import { EditFieldProps } from './types'
 
@@ -101,9 +102,9 @@ export const useEditFieldForm = <
 
   const { editFieldMutation } = useEditFormField()
   const { createFieldMutation } = useCreateFormField()
-  const [, setIsAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
+  const { formId } = useParams()
+  const { data: formData } = useCreateTabForm()
+  const { data: { adminFeedbackFieldThreshold } = {} } = useEnv()
 
   const isPendingField = useMemo(
     () => stateData.state === FieldBuilderState.CreatingField,
@@ -162,17 +163,33 @@ export const useEditFieldForm = <
       )
     }
 
-    // if field to be updated is MyInfo, enable admin feedback
-    if (isMyInfo(updatedFormField)) setIsAdminFeedbackEligible(true)
+    const isCreating = stateData.state === FieldBuilderState.CreatingField
+    const isMyInfoField = isMyInfo(updatedFormField)
+    // Count of fields already saved on the form. While creating, the pending
+    // field isn't part of this count yet, so we offset the threshold by 1.
+    const savedFieldCount = formData?.form_fields.length ?? 0
+    const meetsFieldThreshold =
+      !!adminFeedbackFieldThreshold &&
+      savedFieldCount >= adminFeedbackFieldThreshold - (isCreating ? 1 : 0)
 
-    if (stateData.state === FieldBuilderState.CreatingField) {
+    // Enable the admin feedback prompt once the save succeeds (onSaveSuccess
+    // closes the drawer), so the prompt appears after the drawer is gone, not
+    // mid-edit. Triggers on crossing the field-count threshold or on a MyInfo
+    // field save.
+    const onMutateSuccess = (newField: FormField) => {
+      onSaveSuccess(newField)
+      if (isMyInfoField || meetsFieldThreshold)
+        useAdminFeedbackStore.getState().setEligible('field-edit', formId)
+    }
+
+    if (isCreating) {
       return createFieldMutation.mutate(updatedFormField, {
-        onSuccess: onSaveSuccess,
+        onSuccess: onMutateSuccess,
       })
     } else if (stateData.state === FieldBuilderState.EditingField) {
       return editFieldMutation.mutate(
         { ...updatedFormField, _id: stateData.field._id } as FormFieldDto,
-        { onSuccess: onSaveSuccess },
+        { onSuccess: onMutateSuccess },
       )
     }
   })

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/field-panels/PaymentsInputPanel/PaymentsInputPanel.tsx
@@ -10,7 +10,7 @@ import {
   useWatch,
 } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Link as ReactLink } from 'react-router-dom'
+import { Link as ReactLink, useParams } from 'react-router-dom'
 import { useDebounce } from 'react-use'
 import {
   Box,
@@ -34,8 +34,6 @@ import {
 import { centsToDollars, dollarsToCents } from 'formsg-shared/utils/payments'
 
 import { ADMINFORM_SETTINGS_PAYMENTS_SUBROUTE } from '~constants/routes'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
@@ -45,6 +43,7 @@ import Toggle from '~components/Toggle'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useAdminForm } from '~features/admin-form/common/queries'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import { useCreatePageSidebar } from '../../../../../common'
 import { FieldListTabIndex } from '../../../../constants'
@@ -242,9 +241,7 @@ const PaymentInputFields = ({
 
   const handleClose = () => setFieldListTabIndex(FieldListTabIndex.Basic)
 
-  const [, setisAdminFeedbackEligible] = useSessionStorage<boolean>(
-    ADMIN_FEEDBACK_SESSION_KEY,
-  )
+  const { formId } = useParams()
 
   // unpack payment data for paymentAmount if it exists
   const formDefaultValues =
@@ -318,14 +315,14 @@ const PaymentInputFields = ({
       }
     }
 
-    // update sessionStorage to enable admin feedback
-    setisAdminFeedbackEligible(true)
     return paymentsMutation.mutate(
       { ...paymentsData, enabled: true },
       {
         onSuccess: () => {
           setToInactive()
           handleClose()
+          // enable admin feedback after the panel closes
+          useAdminFeedbackStore.getState().setEligible('field-edit', formId)
         },
       },
     )

--- a/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
@@ -11,6 +11,7 @@ import {
 import { useToast } from '~hooks/useToast'
 
 import { adminFormKeys } from '~features/admin-form/common/queries'
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
 
 import { useAdminFormWorkflow } from './hooks/useAdminFormWorkflow'
 import {
@@ -18,6 +19,7 @@ import {
   deleteWorkflowStep,
   updateWorkflowStep,
 } from './FormWorkflowService'
+import { isStepCompleted } from './workflow.utils'
 
 export const useWorkflowMutations = () => {
   const { formId } = useParams()
@@ -59,6 +61,12 @@ export const useWorkflowMutations = () => {
         toast({
           description: 'The step was successfully created.',
         })
+
+        // Trigger feedback when 2+ completed steps
+        const completedCount = updatedWorkflow.filter(isStepCompleted).length
+        if (completedCount >= 2) {
+          useAdminFeedbackStore.getState().setEligible('workflow', formId)
+        }
       },
       onError: handleError,
     },
@@ -109,6 +117,12 @@ export const useWorkflowMutations = () => {
         toast({
           description: 'The step was successfully updated.',
         })
+
+        // Trigger feedback when 2+ completed steps
+        const completedCount = updatedWorkflow.filter(isStepCompleted).length
+        if (completedCount >= 2) {
+          useAdminFeedbackStore.getState().setEligible('workflow', formId)
+        }
       },
       onError: handleError,
     },

--- a/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
@@ -19,7 +19,7 @@ import {
   deleteWorkflowStep,
   updateWorkflowStep,
 } from './FormWorkflowService'
-import { isStepCompleted } from './workflow.utils'
+import { isWorkflowFeedbackEligible } from './workflow.utils'
 
 export const useWorkflowMutations = () => {
   const { formId } = useParams()
@@ -62,11 +62,7 @@ export const useWorkflowMutations = () => {
           description: 'The step was successfully created.',
         })
 
-        // Trigger feedback when 2+ completed steps
-        const completedCount = updatedWorkflow.filter((step, i) =>
-          isStepCompleted(step, i),
-        ).length
-        if (completedCount >= 2) {
+        if (isWorkflowFeedbackEligible(updatedWorkflow)) {
           useAdminFeedbackStore.getState().setEligible('workflow', formId)
         }
       },
@@ -120,11 +116,7 @@ export const useWorkflowMutations = () => {
           description: 'The step was successfully updated.',
         })
 
-        // Trigger feedback when 2+ completed steps
-        const completedCount = updatedWorkflow.filter((step, i) =>
-          isStepCompleted(step, i),
-        ).length
-        if (completedCount >= 2) {
+        if (isWorkflowFeedbackEligible(updatedWorkflow)) {
           useAdminFeedbackStore.getState().setEligible('workflow', formId)
         }
       },

--- a/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
@@ -63,7 +63,9 @@ export const useWorkflowMutations = () => {
         })
 
         // Trigger feedback when 2+ completed steps
-        const completedCount = updatedWorkflow.filter(isStepCompleted).length
+        const completedCount = updatedWorkflow.filter((step, i) =>
+          isStepCompleted(step, i),
+        ).length
         if (completedCount >= 2) {
           useAdminFeedbackStore.getState().setEligible('workflow', formId)
         }
@@ -119,7 +121,9 @@ export const useWorkflowMutations = () => {
         })
 
         // Trigger feedback when 2+ completed steps
-        const completedCount = updatedWorkflow.filter(isStepCompleted).length
+        const completedCount = updatedWorkflow.filter((step, i) =>
+          isStepCompleted(step, i),
+        ).length
         if (completedCount >= 2) {
           useAdminFeedbackStore.getState().setEligible('workflow', formId)
         }

--- a/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.test.ts
@@ -1,0 +1,45 @@
+import { WorkflowType } from 'formsg-shared/types/form'
+
+import { isStepCompleted } from './workflow.utils'
+
+describe('isStepCompleted', () => {
+  it('should return true for a completed static step', () => {
+    expect(
+      isStepCompleted({
+        workflow_type: WorkflowType.Static,
+        edit: ['field1'],
+        emails: ['user@example.com'],
+      }),
+    ).toBe(true)
+  })
+
+  it('should return true for a completed dynamic step', () => {
+    expect(
+      isStepCompleted({
+        workflow_type: WorkflowType.Dynamic,
+        edit: ['field1'],
+        field: 'emailFieldId',
+      }),
+    ).toBe(true)
+  })
+
+  it('should return true for a completed conditional step', () => {
+    expect(
+      isStepCompleted({
+        workflow_type: WorkflowType.Conditional,
+        edit: ['field1'],
+        conditional_field: 'condFieldId',
+      }),
+    ).toBe(true)
+  })
+
+  it('should return false when edit is empty', () => {
+    expect(
+      isStepCompleted({
+        workflow_type: WorkflowType.Static,
+        edit: [],
+        emails: ['user@example.com'],
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.test.ts
@@ -5,41 +5,95 @@ import { isStepCompleted } from './workflow.utils'
 describe('isStepCompleted', () => {
   it('should return true for a completed static step', () => {
     expect(
-      isStepCompleted({
-        workflow_type: WorkflowType.Static,
-        edit: ['field1'],
-        emails: ['user@example.com'],
-      }),
+      isStepCompleted(
+        {
+          workflow_type: WorkflowType.Static,
+          edit: ['field1'],
+          emails: ['user@example.com'],
+        },
+        1,
+      ),
     ).toBe(true)
   })
 
   it('should return true for a completed dynamic step', () => {
     expect(
-      isStepCompleted({
-        workflow_type: WorkflowType.Dynamic,
-        edit: ['field1'],
-        field: 'emailFieldId',
-      }),
+      isStepCompleted(
+        {
+          workflow_type: WorkflowType.Dynamic,
+          edit: ['field1'],
+          field: 'emailFieldId',
+        },
+        1,
+      ),
     ).toBe(true)
   })
 
   it('should return true for a completed conditional step', () => {
     expect(
-      isStepCompleted({
-        workflow_type: WorkflowType.Conditional,
-        edit: ['field1'],
-        conditional_field: 'condFieldId',
-      }),
+      isStepCompleted(
+        {
+          workflow_type: WorkflowType.Conditional,
+          edit: ['field1'],
+          conditional_field: 'condFieldId',
+        },
+        1,
+      ),
     ).toBe(true)
   })
 
   it('should return false when edit is empty', () => {
     expect(
-      isStepCompleted({
-        workflow_type: WorkflowType.Static,
-        edit: [],
-        emails: ['user@example.com'],
-      }),
+      isStepCompleted(
+        {
+          workflow_type: WorkflowType.Static,
+          edit: [],
+          emails: ['user@example.com'],
+        },
+        1,
+      ),
+    ).toBe(false)
+  })
+
+  it('should return false for a static step with no respondent', () => {
+    expect(
+      isStepCompleted(
+        {
+          workflow_type: WorkflowType.Static,
+          edit: ['field1'],
+          emails: [],
+        },
+        1,
+      ),
+    ).toBe(false)
+  })
+
+  // The first step's respondent is always "anyone who has access to your
+  // form", stored as a Static step with no emails. It counts as completed once
+  // it has fields, otherwise the trigger would need three steps to fire.
+  it('should return true for the first step despite having no emails', () => {
+    expect(
+      isStepCompleted(
+        {
+          workflow_type: WorkflowType.Static,
+          edit: ['field1'],
+          emails: [],
+        },
+        0,
+      ),
+    ).toBe(true)
+  })
+
+  it('should return false for the first step when it has no fields', () => {
+    expect(
+      isStepCompleted(
+        {
+          workflow_type: WorkflowType.Static,
+          edit: [],
+          emails: [],
+        },
+        0,
+      ),
     ).toBe(false)
   })
 })

--- a/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.test.ts
@@ -1,99 +1,97 @@
-import { WorkflowType } from 'formsg-shared/types/form'
+import { FormWorkflowStep, WorkflowType } from 'formsg-shared/types/form'
 
-import { isStepCompleted } from './workflow.utils'
+import { isWorkflowFeedbackEligible } from './workflow.utils'
 
-describe('isStepCompleted', () => {
-  it('should return true for a completed static step', () => {
-    expect(
-      isStepCompleted(
-        {
-          workflow_type: WorkflowType.Static,
-          edit: ['field1'],
-          emails: ['user@example.com'],
-        },
-        1,
-      ),
-    ).toBe(true)
+// The first step's respondent is always "anyone who has access to your form",
+// stored as a Static step with no emails, so these fixtures deliberately leave
+// `emails` empty for it.
+const firstStep = (edit: string[] = ['field1']): FormWorkflowStep => ({
+  workflow_type: WorkflowType.Static,
+  edit,
+  emails: [],
+})
+
+const staticStep = (
+  edit: string[] = ['field1'],
+  emails: string[] = ['user@example.com'],
+): FormWorkflowStep => ({
+  workflow_type: WorkflowType.Static,
+  edit,
+  emails,
+})
+
+describe('isWorkflowFeedbackEligible', () => {
+  it('should return true for a first step plus a completed static step', () => {
+    expect(isWorkflowFeedbackEligible([firstStep(), staticStep()])).toBe(true)
   })
 
-  it('should return true for a completed dynamic step', () => {
+  it('should return true for a first step plus a completed dynamic step', () => {
     expect(
-      isStepCompleted(
+      isWorkflowFeedbackEligible([
+        firstStep(),
         {
           workflow_type: WorkflowType.Dynamic,
           edit: ['field1'],
           field: 'emailFieldId',
         },
-        1,
-      ),
+      ]),
     ).toBe(true)
   })
 
-  it('should return true for a completed conditional step', () => {
+  it('should return true for a first step plus a completed conditional step', () => {
     expect(
-      isStepCompleted(
+      isWorkflowFeedbackEligible([
+        firstStep(),
         {
           workflow_type: WorkflowType.Conditional,
           edit: ['field1'],
           conditional_field: 'condFieldId',
         },
-        1,
-      ),
+      ]),
     ).toBe(true)
   })
 
-  it('should return false when edit is empty', () => {
+  it('should return false for the first step alone', () => {
+    expect(isWorkflowFeedbackEligible([firstStep()])).toBe(false)
+  })
+
+  it('should return false for an empty workflow', () => {
+    expect(isWorkflowFeedbackEligible([])).toBe(false)
+  })
+
+  it('should return false when the second step has no fields', () => {
+    expect(isWorkflowFeedbackEligible([firstStep(), staticStep([])])).toBe(
+      false,
+    )
+  })
+
+  it('should return false when the second step has no respondent', () => {
     expect(
-      isStepCompleted(
-        {
-          workflow_type: WorkflowType.Static,
-          edit: [],
-          emails: ['user@example.com'],
-        },
-        1,
-      ),
+      isWorkflowFeedbackEligible([firstStep(), staticStep(['field1'], [])]),
     ).toBe(false)
   })
 
-  it('should return false for a static step with no respondent', () => {
-    expect(
-      isStepCompleted(
-        {
-          workflow_type: WorkflowType.Static,
-          edit: ['field1'],
-          emails: [],
-        },
-        1,
-      ),
-    ).toBe(false)
+  it('should return false when the first step has no fields and only one later step is complete', () => {
+    expect(isWorkflowFeedbackEligible([firstStep([]), staticStep()])).toBe(
+      false,
+    )
   })
 
-  // The first step's respondent is always "anyone who has access to your
-  // form", stored as a Static step with no emails. It counts as completed once
-  // it has fields, otherwise the trigger would need three steps to fire.
-  it('should return true for the first step despite having no emails', () => {
+  it('should return true when the first step has no fields but two later steps are complete', () => {
     expect(
-      isStepCompleted(
-        {
-          workflow_type: WorkflowType.Static,
-          edit: ['field1'],
-          emails: [],
-        },
-        0,
-      ),
+      isWorkflowFeedbackEligible([firstStep([]), staticStep(), staticStep()]),
     ).toBe(true)
   })
 
-  it('should return false for the first step when it has no fields', () => {
+  // The empty-emails exemption is positional. Only index 0 gets it, otherwise
+  // any later Static step left unconfigured would count towards the threshold.
+  it('should not exempt a later static step with no emails', () => {
     expect(
-      isStepCompleted(
-        {
-          workflow_type: WorkflowType.Static,
-          edit: [],
-          emails: [],
-        },
-        0,
-      ),
+      isWorkflowFeedbackEligible([
+        firstStep(),
+        staticStep(['field1'], []),
+        staticStep(['field1'], []),
+      ]),
     ).toBe(false)
   })
 })

--- a/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.ts
@@ -1,11 +1,24 @@
 import { FormWorkflowStep, WorkflowType } from 'formsg-shared/types/form'
 
+import { isFirstStepByStepNumber } from './components/WorkflowContent/utils/isFirstStepByStepNumber'
+
 /**
  * A workflow step is "completed" when it has fields assigned
  * and a respondent configured.
+ *
+ * The first step is the exception: its respondent is always "anyone who has
+ * access to your form", which is stored as a Static step with an empty
+ * `emails` array. Without that exception it could never be completed, so the
+ * trigger would need three visible steps to see two completed ones.
+ *
+ * `stepNumber` must be the step's position in the full, unfiltered workflow.
  */
-export const isStepCompleted = (step: FormWorkflowStep): boolean => {
+export const isStepCompleted = (
+  step: FormWorkflowStep,
+  stepNumber: number,
+): boolean => {
   if (step.edit.length === 0) return false
+  if (isFirstStepByStepNumber(stepNumber)) return true
 
   switch (step.workflow_type) {
     case WorkflowType.Static:

--- a/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.ts
@@ -2,6 +2,9 @@ import { FormWorkflowStep, WorkflowType } from 'formsg-shared/types/form'
 
 import { isFirstStepByStepNumber } from './components/WorkflowContent/utils/isFirstStepByStepNumber'
 
+/** How many completed steps count as "the admin has set up a workflow". */
+const COMPLETED_STEPS_FOR_FEEDBACK = 2
+
 /**
  * A workflow step is "completed" when it has fields assigned
  * and a respondent configured.
@@ -12,8 +15,10 @@ import { isFirstStepByStepNumber } from './components/WorkflowContent/utils/isFi
  * trigger would need three visible steps to see two completed ones.
  *
  * `stepNumber` must be the step's position in the full, unfiltered workflow.
+ * Callers should prefer `isWorkflowFeedbackEligible`, which owns that
+ * invariant.
  */
-export const isStepCompleted = (
+const isStepCompleted = (
   step: FormWorkflowStep,
   stepNumber: number,
 ): boolean => {
@@ -29,3 +34,13 @@ export const isStepCompleted = (
       return !!step.conditional_field
   }
 }
+
+/**
+ * Whether a workflow has enough completed steps to prompt the admin for
+ * feedback. Takes the whole workflow so the positional first-step rule stays
+ * an implementation detail.
+ */
+export const isWorkflowFeedbackEligible = (
+  workflow: FormWorkflowStep[],
+): boolean =>
+  workflow.filter(isStepCompleted).length >= COMPLETED_STEPS_FOR_FEEDBACK

--- a/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/workflow.utils.ts
@@ -1,0 +1,18 @@
+import { FormWorkflowStep, WorkflowType } from 'formsg-shared/types/form'
+
+/**
+ * A workflow step is "completed" when it has fields assigned
+ * and a respondent configured.
+ */
+export const isStepCompleted = (step: FormWorkflowStep): boolean => {
+  if (step.edit.length === 0) return false
+
+  switch (step.workflow_type) {
+    case WorkflowType.Static:
+      return step.emails.length > 0
+    case WorkflowType.Dynamic:
+      return !!step.field
+    case WorkflowType.Conditional:
+      return !!step.conditional_field
+  }
+}

--- a/apps/frontend/src/features/admin-form/settings/mutations.ts
+++ b/apps/frontend/src/features/admin-form/settings/mutations.ts
@@ -19,6 +19,8 @@ import { useToast } from '~hooks/useToast'
 import { convertUnicodeLocaleToLanguage } from '~utils/multiLanguage'
 import { formatOrdinal } from '~utils/stringFormat'
 
+import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedbackContainer/adminFeedbackStore'
+
 import { updateFormPayments } from '../common/AdminFormPageService'
 import { adminFormKeys } from '../common/queries'
 
@@ -142,6 +144,11 @@ export const useMutateFormSettings = () => {
           : toastStatusClosedMessage
 
         handleSuccess({ newData, toastDescription: toastStatusMessage })
+
+        // Trigger admin feedback prompt when form goes public
+        if (isNowPublic) {
+          useAdminFeedbackStore.getState().setEligible('publish', formId)
+        }
       },
       onError: handleError,
     },

--- a/apps/frontend/src/features/workspace/WorkspacePage.tsx
+++ b/apps/frontend/src/features/workspace/WorkspacePage.tsx
@@ -32,7 +32,6 @@ import { useEnv } from '~features/env/queries'
 import { useUser } from '~features/user/queries'
 import { WorkspaceContent } from '~features/workspace/WorkspaceContent'
 
-import AdminFeedbackContainer from './components/AdminFeedbackContainer'
 import { WorkspaceMenuHeader } from './components/WorkspaceSideMenu/WorkspaceMenuHeader'
 import { WorkspaceMenuTabs } from './components/WorkspaceSideMenu/WorkspaceMenuTabs'
 import { useDashboard, useWorkspace } from './queries'
@@ -54,7 +53,6 @@ export const WorkspacePage = (): JSX.Element => {
   // TODO [MRF-CUTOVER]: Remove this infobox (and MRF_CUTOVER_FAQ_LINK) once the
   // cutover is complete and the flag is retired.
   const isMrfCutoverEnabled = useFeatureIsOn(featureFlags.mrfCutover)
-  const isFiveStarEnabled = useFeatureIsOn(featureFlags.fiveStarAdminRating)
 
   const { user } = useUser()
   const { data: dashboardForms, isLoading: isDashboardLoading } = useDashboard()
@@ -212,9 +210,6 @@ export const WorkspacePage = (): JSX.Element => {
           </WorkspaceProvider>
         </GridItem>
       </Grid>
-      {user && isFiveStarEnabled && (
-        <AdminFeedbackContainer userId={user._id} />
-      )}
     </>
   )
 }

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/AdminFeedbackContainer.tsx
@@ -1,26 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { ADMIN_FEEDBACK_HISTORY_PREFIX } from '~constants/localStorage'
-import { ADMIN_FEEDBACK_SESSION_KEY } from '~constants/sessionStorage'
-import { useIsMobile } from '~hooks/useIsMobile'
 import { useLocalStorage } from '~hooks/useLocalStorage'
-import { useSessionStorage } from '~hooks/useSessionStorage'
 
 import { useEnv } from '~features/env/queries'
 
 import AdminFeedbackBox from '../AdminFeedbackBox'
 
+import {
+  isEligibleSelector,
+  resetSelector,
+  useAdminFeedbackStore,
+} from './adminFeedbackStore'
+
 export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
   const { data: { adminFeedbackDisplayFrequency } = {} } = useEnv()
   const [isDisplayFeedback, setIsDisplayFeedback] = useState(false)
-  const isMobile = useIsMobile()
 
   const adminFeedbackKey = ADMIN_FEEDBACK_HISTORY_PREFIX + userId
 
   const [lastFeedbackTime, setLastFeedbackTime] =
     useLocalStorage<number>(adminFeedbackKey)
-  const [isAdminFeedbackEligible, setIsAdminFeedbackEligible] =
-    useSessionStorage<boolean>(ADMIN_FEEDBACK_SESSION_KEY, false)
+  const isAdminFeedbackEligible = useAdminFeedbackStore(isEligibleSelector)
+  const resetAdminFeedbackEligible = useAdminFeedbackStore(resetSelector)
 
   // capture current time on page load to prevent re-renders from update to current time
   const currentTime = useRef(Date.now())
@@ -37,24 +39,18 @@ export const AdminFeedbackContainer = ({ userId }: { userId: string }) => {
 
   // sets display of feedback box
   useEffect(() => {
-    if (
-      // TODO: create mobile version of admin feedback
-      !isMobile &&
-      // whether to show admin the feedback box
-      showAdminFeedback
-    ) {
+    if (showAdminFeedback) {
       setIsDisplayFeedback(true)
       // reset local storage and admin feedback eligibility when admin feedback is displayed
       setLastFeedbackTime(currentTime.current)
-      setIsAdminFeedbackEligible(false)
+      resetAdminFeedbackEligible()
     }
   }, [
     currentTime,
     showAdminFeedback,
     setIsDisplayFeedback,
     setLastFeedbackTime,
-    setIsAdminFeedbackEligible,
-    isMobile,
+    resetAdminFeedbackEligible,
   ])
 
   const closeAdminFeedback = useCallback(

--- a/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/adminFeedbackStore.ts
+++ b/apps/frontend/src/features/workspace/components/AdminFeedbackContainer/adminFeedbackStore.ts
@@ -1,0 +1,32 @@
+import create from 'zustand'
+import { devtools } from 'zustand/middleware'
+
+import { AdminFeedbackTriggerSource } from 'formsg-shared/types'
+
+type AdminFeedbackStore = {
+  isEligible: boolean
+  triggerSource: AdminFeedbackTriggerSource | null
+  formId: string | null
+  setEligible: (source: AdminFeedbackTriggerSource, formId?: string) => void
+  reset: () => void
+}
+
+const INITIAL_STATE = {
+  isEligible: false,
+  triggerSource: null,
+  formId: null,
+}
+
+export const isEligibleSelector = (state: AdminFeedbackStore) =>
+  state.isEligible
+
+export const resetSelector = (state: AdminFeedbackStore) => state.reset
+
+export const useAdminFeedbackStore = create<AdminFeedbackStore>()(
+  devtools((set) => ({
+    ...INITIAL_STATE,
+    setEligible: (source, formId) =>
+      set({ isEligible: true, triggerSource: source, formId: formId ?? null }),
+    reset: () => set(INITIAL_STATE),
+  })),
+)


### PR DESCRIPTION
## Problem

Part 4 of admin satisfaction rating split (see #9683, #9684, #9688). Adds two new trigger points that tell the zustand feedback store when a user has done enough work to warrant a satisfaction prompt.

## Solution

Two trigger points call `setEligible()` on the admin feedback store:

1. **Publish trigger** — when a form goes public, the settings mutation marks the user as eligible for the `'publish'` feedback prompt. `mutateFormStatus` serves every response mode, so this fires for email-mode forms too. That's intended: the admin published a form, which is the accomplishment the prompt asks about.
2. **Workflow trigger** — when creating or updating a workflow step, if the workflow has 2+ "completed" steps (fields assigned + respondent configured), marks the user eligible for the `'workflow'` feedback prompt. Not wired to step deletion, since deleting can only lower the count and so can never newly cross the threshold.

`isWorkflowFeedbackEligible(workflow)` owns the rule. Step completion depends on `WorkflowType` (Static needs emails, Dynamic needs a field, Conditional needs a conditional field).

**The first step is an exception.** Its respondent is always "anyone who has access to your form", which isn't stored anywhere — it's persisted as a `Static` step with an empty `emails` array, and the UI hardcodes that string for `stepNumber === 0`. Under the naive rule the first step could never be completed, so "2+ completed steps" silently behaved as "3+ visible steps". It now counts as completed once it has fields.

The threshold and the first-step exception live behind one exported function; `isStepCompleted` is private because its `stepNumber` must be the position in the full, unfiltered workflow, and keeping it internal means no caller can pass a filtered or sorted index and get a valid-looking wrong answer.

**Breaking Changes**

No — backwards compatible. The feedback box itself is gated behind the `5star-admin-rating` feature flag at `AdminFormLayout.tsx` (PR 1). Note the gate is on *rendering*: these triggers write store state regardless of the flag, but with the flag off nothing reads it.

## Tests

10 unit tests on `isWorkflowFeedbackEligible`, covering each `WorkflowType`, the empty workflow, both incomplete-step cases, the first-step exception, and a negative test pinning that the exception is positional (a *later* Static step with no emails must not count).

**TC1: Publish triggers feedback**

- [ ] Enable feature flag: `window._growthbook.setForcedFeatures(new Map([['5star-admin-rating', true]]))`
- [ ] Open a storage-mode form, click Publish
- [ ] Verify feedback modal appears

**TC2: Workflow triggers feedback**

- [ ] Enable feature flag
- [ ] Open an MRF form, configure step 1 with fields, then add a second step with fields + respondent
- [ ] Verify feedback modal appears after the 2nd completed step

**TC3: Incomplete workflow does not trigger**

- [ ] Enable feature flag
- [ ] Add 1 complete workflow step and 1 incomplete step (no fields assigned)
- [ ] Verify no feedback modal

Note: the eligibility store is in-memory, so don't reload the page between the trigger and the check. The stale-timeframe throttle in `AdminFeedbackContainer` also suppresses repeat prompts within the configured frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)