### PR TITLE
fix(ci): don't cancel in-flight deploys + speed up release build/deploy

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -47,13 +47,8 @@ jobs:
         run: |
           HASH=$(cat \
             pnpm-lock.yaml \
-            package.json \
             pnpm-workspace.yaml \
             Dockerfile.base \
-            apps/backend/package.json \
-            apps/frontend/package.json \
-            packages/shared/package.json \
-            packages/sdk/package.json \
             | sha256sum | cut -c1-16)
           echo "hash=$HASH" >> "$GITHUB_OUTPUT"
           echo "Dependency hash: $HASH"

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -115,6 +115,14 @@ on:
         description: 'S3 domain style bucket name for static assets'
         required: true
 
+# Serialize deploys per environment so two releases' deploys can't race the
+# same ECS service. Non-cancelling: a later deploy queues behind an in-flight
+# one rather than cancelling it. Keyed per site so stg/prod/stg-alt/uat are
+# independent of each other.
+concurrency:
+  group: deploy-${{ inputs.environment-site-name }}
+  cancel-in-progress: false
+
 # used to configure IAM to trust Github's OIDC provider
 permissions:
   id-token: write

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -115,10 +115,6 @@ on:
         description: 'S3 domain style bucket name for static assets'
         required: true
 
-# Serialize deploys per environment so two releases' deploys can't race the
-# same ECS service. Non-cancelling: a later deploy queues behind an in-flight
-# one rather than cancelling it. Keyed per site so stg/prod/stg-alt/uat are
-# independent of each other.
 concurrency:
   group: deploy-${{ inputs.environment-site-name }}
   cancel-in-progress: false
@@ -153,9 +149,6 @@ jobs:
           # the branch-triggered stg-alt/uat callers inputs.ref is empty and we
           # fall back to the ref that triggered the run.
           ref: ${{ inputs.ref || github.ref }}
-          # Shallow: the deploy only inspects HEAD and the checked-out tag
-          # (git rev-parse HEAD, git rev-list -n 1 <version>), never older
-          # history, so a full-history clone is wasted time.
           fetch-depth: 1
 
       - name: Setup secrets for datadog sourcemap deployment

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -225,7 +225,8 @@ jobs:
           # above already wrote.
           CRANE_VERSION=0.21.7
           curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
-            | tar -xz -C /usr/local/bin crane
+            | tar -xzf - -C /usr/local/bin crane
+          chmod +x /usr/local/bin/crane
           crane copy "$SRC_IMAGE" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
       - name: Set up Docker Buildx

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -153,7 +153,10 @@ jobs:
           # the branch-triggered stg-alt/uat callers inputs.ref is empty and we
           # fall back to the ref that triggered the run.
           ref: ${{ inputs.ref || github.ref }}
-          fetch-depth: 0
+          # Shallow: the deploy only inspects HEAD and the checked-out tag
+          # (git rev-parse HEAD, git rev-list -n 1 <version>), never older
+          # history, so a full-history clone is wasted time.
+          fetch-depth: 1
 
       - name: Setup secrets for datadog sourcemap deployment
         # Derive the version label from the checked-out ref/commit, not the run's
@@ -208,15 +211,22 @@ jobs:
             echo "No pre-built release image found for tagged commit, will build from scratch"
           fi
 
-      - name: Pull and push pre-built image to ECR
+      - name: Copy pre-built image to ECR
         if: steps.check-release-image.outputs.image != ''
         env:
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          SRC_IMAGE: ${{ steps.check-release-image.outputs.image }}
         run: |
-          docker pull ${{ steps.check-release-image.outputs.image }}
-          docker tag ${{ steps.check-release-image.outputs.image }} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          # Registry-to-registry copy: crane streams the manifest and blobs from
+          # GHCR straight to ECR without pulling the whole image onto the runner,
+          # which is far faster than docker pull + tag + push. crane authenticates
+          # from the ~/.docker/config.json entries the ECR and GHCR login steps
+          # above already wrote.
+          CRANE_VERSION=0.21.7
+          curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+            | tar -xz -C /usr/local/bin crane
+          crane copy "$SRC_IMAGE" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
       - name: Set up Docker Buildx
         if: steps.check-release-image.outputs.image == ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,6 @@ jobs:
   release:
     name: Cut release
     runs-on: ubuntu-latest
-    # Serialize only the version-bump cut so two dispatches can't race to bump
-    # off the same base commit. Scoped to this job (not the whole workflow) and
-    # non-cancelling so a new dispatch (a) never cancels in-flight deploys and
-    # (b) can be cut while a previous release waits at the prod approval gate.
-    # A second dispatch queues behind this cut, then bumps off the new HEAD.
     concurrency:
       group: release-cut
       cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,6 @@ name: Release
 on:
   workflow_dispatch:
 
-# Only one release may be in flight at a time, so two dispatches can't race to
-# bump the version off the same base commit.
-concurrency:
-  group: release
-  cancel-in-progress: true
-
 # Minimal by default; each job escalates to exactly what it needs.
 permissions:
   contents: read
@@ -40,6 +34,14 @@ jobs:
   release:
     name: Cut release
     runs-on: ubuntu-latest
+    # Serialize only the version-bump cut so two dispatches can't race to bump
+    # off the same base commit. Scoped to this job (not the whole workflow) and
+    # non-cancelling so a new dispatch (a) never cancels in-flight deploys and
+    # (b) can be cut while a previous release waits at the prod approval gate.
+    # A second dispatch queues behind this cut, then bumps off the new HEAD.
+    concurrency:
+      group: release-cut
+      cancel-in-progress: false
     # `release` GitHub Environment gates who can cut a tag (required reviewers
     # configured in repo settings).
     environment: release


### PR DESCRIPTION
## Problem

Two problems with the release pipeline, from run [28428479461](https://github.com/opengovsg/FormSG/actions/runs/28428479461):

1. A new release dispatch can cancel an in-flight run, which may impact a prod deploy mid rollout. Cause: workflow-level `concurrency: cancel-in-progress: true`
2. Release process was slow. The base image rebuilt from scratch every release (3m11s) even with unchanged dependencies, and the GHCR to ECR copy took ~1m51s per deploy. Deploying to staging took about 15 min.

## Solution

Reviewable commit by commit.

1. **Concurrency** (`release.yml`, `deploy-ecs.yml`). Moved the group onto the `release` job (`release-cut`, non-cancelling). The bump stays serialized, but a new dispatch no longer cancels a running deploy, and it can be cut while an earlier release sits at the prod gate. Skipping a broken release before prod is still the `production` approval gate's job. The deploy gets its own per-environment non-cancelling group so two releases queue per env instead of racing the same ECS service.
2. **Base-image cache key** (`build-base-images.yml`). The key hashed the package.json files, whose `version` gets rewritten on every release, so it never hit and the base image rebuilt each time. It now hashes only `pnpm-lock.yaml`, `pnpm-workspace.yaml` and `Dockerfile.base`. A real dependency change still busts it; a version bump does not.
3. **Deploy speed** (`deploy-ecs.yml`). Copy the release image to ECR with `crane copy` instead of `docker pull`/`tag`/`push` (~1m51s to ~20s), and shallow-clone the checkout. stg and prod are separate accounts, so the copy still runs once per env.

**Breaking Changes**
- [x] No - CI only, no app or API changes

**Improvements**:
- A new release no longer cancels an in-flight deploy.
- Base image is reused across releases instead of rebuilt every time.
- Release image copied to ECR with crane, and the deploy checkout is shallow.

Cut to staging-live: about 15 min down to about 10.

## Tests

Force-pushed this branch to `stg-alt2`. The [app deploy](https://github.com/opengovsg/FormSG/actions/runs/28485245949) passed, which exercised the shallow checkout and confirmed the workflow edits don't break the branch-triggered build path.

crane only runs on release-tagged deploys where a prebuilt image exists, so it was skipped on stg-alt2. Worth watching on the first real release, along with the base-image job skipping on a cache hit.

## Deploy Notes

**New dependencies**:
- `crane` (google/go-containerregistry v0.21.7): downloaded in the ECS deploy job to copy the release image from GHCR to ECR. It reads the docker credentials the existing ECR and GHCR login steps already write.
