### PR TITLE
feat(children-v2): v2.2 sponsored children — adapter merge (3/3, INERT, stacks on #9686)

### DIFF
--- a/apps/backend/src/app/modules/myinfo/__tests__/myinfo.adapter.spec.ts
+++ b/apps/backend/src/app/modules/myinfo/__tests__/myinfo.adapter.spec.ts
@@ -3,7 +3,11 @@ import {
   IPersonResponse,
   MyInfoVehicleFull,
 } from '@opengovsg/myinfo-gov-client'
-import { MyInfoAttribute } from 'formsg-shared/types'
+import {
+  ChildRecordType,
+  MyInfoAttribute,
+  MyInfoChildAttributes,
+} from 'formsg-shared/types'
 import type { SetRequired } from 'type-fest'
 
 import { MyInfoData } from '../myinfo.adapter'
@@ -33,6 +37,143 @@ import {
 
 describe('myinfo.adapter', () => {
   describe('MyInfoData', () => {
+    describe('getChildrenBirthRecords (sponsored support)', () => {
+      const REQUESTED = [
+        MyInfoAttribute.ChildName,
+        MyInfoAttribute.ChildBirthCertNo,
+        MyInfoAttribute.ChildGender,
+      ]
+
+      const localChild = {
+        name: { value: 'Local Tan' },
+        birthcertno: { value: 'S1111111A' },
+        sex: { code: 'M', desc: 'MALE' },
+      }
+      const sponsoredChild = {
+        nric: { value: 'T2222222B' },
+        name: { value: 'Sponsored Lee' },
+        sex: { code: 'F', desc: 'FEMALE' },
+        // sponsored-only immigration fields must NOT be surfaced
+        residentialstatus: { code: 'PR', desc: 'PR' },
+        nationality: { code: 'MY', desc: 'MALAYSIAN' },
+      }
+
+      it('merges sponsored children after local, with a unified identifier and per-child type', () => {
+        const response = {
+          uinFin: MOCK_UINFIN,
+          data: {
+            childrenbirthrecords: [localChild],
+            sponsoredchildrenrecords: [sponsoredChild],
+          },
+        } as unknown as IPersonResponse
+        const myInfoData = new MyInfoData(response)
+
+        const actual = myInfoData.getChildrenBirthRecords(REQUESTED)
+
+        expect(actual?.[MyInfoChildAttributes.ChildName]).toEqual([
+          'Local Tan',
+          'Sponsored Lee',
+        ])
+        // unified identifier: birthcertno for local, nric for sponsored
+        expect(actual?.[MyInfoChildAttributes.ChildBirthCertNo]).toEqual([
+          'S1111111A',
+          'T2222222B',
+        ])
+        expect(actual?.[MyInfoChildAttributes.ChildGender]).toEqual([
+          'MALE',
+          'FEMALE',
+        ])
+        expect(actual?.type).toEqual([
+          ChildRecordType.Nuclear,
+          ChildRecordType.Sponsored,
+        ])
+      })
+
+      it('still works with only local children (no sponsored records)', () => {
+        const response = {
+          uinFin: MOCK_UINFIN,
+          data: { childrenbirthrecords: [localChild] },
+        } as unknown as IPersonResponse
+        const myInfoData = new MyInfoData(response)
+
+        const actual = myInfoData.getChildrenBirthRecords(REQUESTED)
+
+        expect(actual?.[MyInfoChildAttributes.ChildName]).toEqual(['Local Tan'])
+        expect(actual?.[MyInfoChildAttributes.ChildBirthCertNo]).toEqual([
+          'S1111111A',
+        ])
+        expect(actual?.type).toEqual([ChildRecordType.Nuclear])
+      })
+
+      it('returns sponsored children even when there are no local records', () => {
+        const response = {
+          uinFin: MOCK_UINFIN,
+          data: { sponsoredchildrenrecords: [sponsoredChild] },
+        } as unknown as IPersonResponse
+        const myInfoData = new MyInfoData(response)
+
+        const actual = myInfoData.getChildrenBirthRecords(REQUESTED)
+
+        expect(actual?.[MyInfoChildAttributes.ChildName]).toEqual([
+          'Sponsored Lee',
+        ])
+        expect(actual?.[MyInfoChildAttributes.ChildBirthCertNo]).toEqual([
+          'T2222222B',
+        ])
+        expect(actual?.type).toEqual([ChildRecordType.Sponsored])
+      })
+
+      // Edge-case handling (PRD slice 04, provisional — gated by slice 01's
+      // Singpass filter-vs-disable ruling). Opt-in via excludeIneligible so
+      // legacy (v1) behaviour is unchanged by default.
+      describe('excludeIneligible', () => {
+        const deceasedChild = {
+          name: { value: 'Deceased Child' },
+          birthcertno: { value: 'S3333333C' },
+          sex: { desc: 'MALE' },
+          lifestatus: { code: 'D', desc: 'DECEASED' },
+        }
+        // A >=21 child: MyInfo returns only the identifier, no name.
+        const above21Child = {
+          birthcertno: { value: 'S4444444D' },
+        }
+
+        const response = {
+          uinFin: MOCK_UINFIN,
+          data: {
+            childrenbirthrecords: [localChild, deceasedChild, above21Child],
+          },
+        } as unknown as IPersonResponse
+
+        it('includes deceased and >=21 children by default (legacy behaviour)', () => {
+          const actual = new MyInfoData(response).getChildrenBirthRecords(
+            REQUESTED,
+          )
+
+          expect(actual?.[MyInfoChildAttributes.ChildName]).toEqual([
+            'Local Tan',
+            'Deceased Child',
+            '',
+          ])
+        })
+
+        it('filters out deceased and >=21 children when excludeIneligible is set', () => {
+          const actual = new MyInfoData(response).getChildrenBirthRecords(
+            REQUESTED,
+            { excludeIneligible: true },
+          )
+
+          expect(actual?.[MyInfoChildAttributes.ChildName]).toEqual([
+            'Local Tan',
+          ])
+          expect(actual?.[MyInfoChildAttributes.ChildBirthCertNo]).toEqual([
+            'S1111111A',
+          ])
+          expect(actual?.type).toEqual([ChildRecordType.Nuclear])
+        })
+      })
+    })
+
     describe('getFieldValueForAttr', () => {
       describe('Phone numbers', () => {
         it('should return empty string and readonly as false when key is not present', () => {

--- a/apps/backend/src/app/modules/myinfo/__tests__/myinfo.adapter.spec.ts
+++ b/apps/backend/src/app/modules/myinfo/__tests__/myinfo.adapter.spec.ts
@@ -7,6 +7,7 @@ import {
   ChildRecordType,
   MyInfoAttribute,
   MyInfoChildAttributes,
+  MyInfoChildVaxxStatus,
 } from 'formsg-shared/types'
 import type { SetRequired } from 'type-fest'
 
@@ -121,6 +122,30 @@ describe('myinfo.adapter', () => {
           'T2222222B',
         ])
         expect(actual?.type).toEqual([ChildRecordType.Sponsored])
+      })
+
+      it('surfaces Unknown vaccination status for sponsored children (not a false "not fulfilled")', () => {
+        const response = {
+          uinFin: MOCK_UINFIN,
+          data: {
+            childrenbirthrecords: [localChild],
+            sponsoredchildrenrecords: [sponsoredChild],
+          },
+        } as unknown as IPersonResponse
+        const myInfoData = new MyInfoData(response)
+
+        const actual = myInfoData.getChildrenBirthRecords([
+          MyInfoAttribute.ChildName,
+          MyInfoAttribute.ChildVaxxStatus,
+        ])
+
+        // Local child has no HPB data in this fixture → documented
+        // "missing = not fulfilled"; sponsored child isn't in HPB at all → Unknown
+        // (which prefill/hashing skips) rather than a false "not fulfilled".
+        expect(actual?.[MyInfoChildAttributes.ChildVaxxStatus]).toEqual([
+          MyInfoChildVaxxStatus.ONEM3D_NOT_FULFILLED,
+          MyInfoChildVaxxStatus.Unknown,
+        ])
       })
 
       // Edge-case handling (PRD slice 04, provisional — gated by slice 01's

--- a/apps/backend/src/app/modules/myinfo/myinfo.adapter.ts
+++ b/apps/backend/src/app/modules/myinfo/myinfo.adapter.ts
@@ -5,8 +5,10 @@ import {
   MyInfoChildBirthRecordBelow21,
   MyInfoScope,
   MyInfoSource,
+  MyInfoSponsoredChildBelow21,
 } from '@opengovsg/myinfo-gov-client'
 import {
+  ChildRecordType,
   MyInfoAttribute as InternalAttr,
   MyInfoChildAttributes,
   MyInfoChildData,
@@ -279,32 +281,41 @@ export class MyInfoData implements MyInfoDataTransformer<
    * @param childAttr The child attribute you're requesting.
    * @returns Array of children's values.
    */
-  #accessChildrenAttrFromMyInfo(childAttr: MyInfoChildAttributes): string[] {
-    const records = this.#personData
-      .childrenbirthrecords as Array<MyInfoChildBirthRecordBelow21>
-    if (records === undefined) {
-      return []
-    }
-    // Note: need ?. operator because above 21 children may
-    // not have these fields.
+  /**
+   * Reads a single child sub-field from one MyInfo record (local or sponsored).
+   * The `ChildBirthCertNo` sub-field is the unified identifier: it resolves to
+   * the birth certificate number for a local (nuclear) record and to the NRIC
+   * for a sponsored record (ADR-0002).
+   *
+   * Note: `?.` is needed because above-21 children may not have these fields.
+   */
+  #accessChildAttr(
+    childAttr: MyInfoChildAttributes,
+    record: MyInfoChildBirthRecordBelow21 | MyInfoSponsoredChildBelow21,
+    type: ChildRecordType,
+  ): string {
     switch (childAttr) {
       case MyInfoChildAttributes.ChildName:
-        return records.map((c) => c?.name?.value ?? '')
+        return record?.name?.value ?? ''
       case MyInfoChildAttributes.ChildDateOfBirth:
-        return records.map((c) => c?.dob?.value ?? '')
+        return record?.dob?.value ?? ''
       case MyInfoChildAttributes.ChildBirthCertNo:
-        return records.map((c) => c?.birthcertno?.value ?? '')
+        return type === ChildRecordType.Sponsored
+          ? ((record as MyInfoSponsoredChildBelow21)?.nric?.value ?? '')
+          : ((record as MyInfoChildBirthRecordBelow21)?.birthcertno?.value ??
+              '')
       case MyInfoChildAttributes.ChildVaxxStatus:
-        return records.map(
-          (c) =>
-            requirementToVaccinationEnum(c?.vaccinationrequirements) as string,
-        )
+        // Sponsored records don't carry HPB vaccination data; undefined is
+        // handled by requirementToVaccinationEnum.
+        return requirementToVaccinationEnum(
+          (record as MyInfoChildBirthRecordBelow21)?.vaccinationrequirements,
+        ) as string
       case MyInfoChildAttributes.ChildGender:
-        return records.map((c) => c?.sex?.desc ?? '')
+        return record?.sex?.desc ?? ''
       case MyInfoChildAttributes.ChildRace:
-        return records.map((c) => c?.race?.desc ?? '')
+        return record?.race?.desc ?? ''
       case MyInfoChildAttributes.ChildSecondaryRace:
-        return records.map((c) => c?.secondaryrace?.desc ?? '')
+        return record?.secondaryrace?.desc ?? ''
       default: {
         const never: never = childAttr
         return never
@@ -314,18 +325,56 @@ export class MyInfoData implements MyInfoDataTransformer<
 
   getChildrenBirthRecords(
     allMyInfoAttrs: InternalAttr[],
+    opts: { excludeIneligible?: boolean } = {},
   ): MyInfoChildData | undefined {
-    if (this.#personData?.childrenbirthrecords === undefined) {
+    const localRecords = this.#personData?.childrenbirthrecords as
+      | Array<MyInfoChildBirthRecordBelow21>
+      | undefined
+    const sponsoredRecords = this.#personData?.sponsoredchildrenrecords as
+      | Array<MyInfoSponsoredChildBelow21>
+      | undefined
+    if (localRecords === undefined && sponsoredRecords === undefined) {
       return
     }
     const myInfoAttrsSet = new Set(allMyInfoAttrs)
 
-    const result = Object.fromEntries(
+    // Local (nuclear) records first, then sponsored — each tagged with its
+    // record type so the picker can dedupe by the unified identifier and the
+    // response can surface the type column (ADR-0002).
+    let taggedRecords = [
+      ...(localRecords ?? []).map((record) => ({
+        record,
+        type: ChildRecordType.Nuclear,
+      })),
+      ...(sponsoredRecords ?? []).map((record) => ({
+        record,
+        type: ChildRecordType.Sponsored,
+      })),
+    ]
+
+    if (opts.excludeIneligible) {
+      // children-v2 edge cases (PRD slice 04, provisional — gated by slice 01).
+      // A >=21 child has only the identifier and no name; a deceased child has
+      // lifestatus DECEASED. Neither should appear in the picker.
+      taggedRecords = taggedRecords.filter(
+        ({ record }) =>
+          !!record?.name?.value &&
+          (record?.lifestatus?.desc ?? '').toUpperCase() !== 'DECEASED',
+      )
+    }
+
+    const result: MyInfoChildData = Object.fromEntries(
       MyInfoChildAttributesSorted
         // Filter out records that aren't requested by our scope.
         .filter((attr) => myInfoAttrsSet.has(attr as unknown as InternalAttr))
-        .map((attr) => [attr, this.#accessChildrenAttrFromMyInfo(attr)]),
+        .map((attr) => [
+          attr,
+          taggedRecords.map(({ record, type }) =>
+            this.#accessChildAttr(attr, record, type),
+          ),
+        ]),
     )
+    result.type = taggedRecords.map(({ type }) => type)
     return result
   }
 

--- a/apps/backend/src/app/modules/myinfo/myinfo.adapter.ts
+++ b/apps/backend/src/app/modules/myinfo/myinfo.adapter.ts
@@ -305,11 +305,16 @@ export class MyInfoData implements MyInfoDataTransformer<
           : ((record as MyInfoChildBirthRecordBelow21)?.birthcertno?.value ??
               '')
       case MyInfoChildAttributes.ChildVaxxStatus:
-        // Sponsored records don't carry HPB vaccination data; undefined is
-        // handled by requirementToVaccinationEnum.
-        return requirementToVaccinationEnum(
-          (record as MyInfoChildBirthRecordBelow21)?.vaccinationrequirements,
-        ) as string
+        // Sponsored records aren't in HPB's vaccination data at all, so surface
+        // Unknown (which prefill/hashing skips, leaving the field for the
+        // respondent) rather than a false "not fulfilled" claim. Local records
+        // keep the documented "missing = not fulfilled" mapping.
+        return type === ChildRecordType.Sponsored
+          ? MyInfoChildVaxxStatus.Unknown
+          : (requirementToVaccinationEnum(
+              (record as MyInfoChildBirthRecordBelow21)
+                ?.vaccinationrequirements,
+            ) as string)
       case MyInfoChildAttributes.ChildGender:
         return record?.sex?.desc ?? ''
       case MyInfoChildAttributes.ChildRace:

--- a/apps/backend/src/app/modules/myinfo/myinfo.adapter.ts
+++ b/apps/backend/src/app/modules/myinfo/myinfo.adapter.ts
@@ -250,6 +250,21 @@ const requirementToVaccinationEnum = (
     : MyInfoChildVaxxStatus.ONEM3D_NOT_FULFILLED
 }
 
+/**
+ * Resolves the unified child identifier (ADR-0002). The single
+ * `childbirthcertno` sub-field is populated from `birthcertno` for a local
+ * (nuclear) record and from `nric` for a sponsored record, so both kinds fill
+ * the same identifier slot without an empty-mandatory error. Keeping this in
+ * one place lets #accessChildAttr stay a straightforward sub-field reader.
+ */
+const resolveChildIdentifier = (
+  record: MyInfoChildBirthRecordBelow21 | MyInfoSponsoredChildBelow21,
+  type: ChildRecordType,
+): string =>
+  type === ChildRecordType.Sponsored
+    ? ((record as MyInfoSponsoredChildBelow21)?.nric?.value ?? '')
+    : ((record as MyInfoChildBirthRecordBelow21)?.birthcertno?.value ?? '')
+
 const MyInfoChildAttributesSorted = Object.values(MyInfoChildAttributes).sort()
 
 /**
@@ -300,10 +315,7 @@ export class MyInfoData implements MyInfoDataTransformer<
       case MyInfoChildAttributes.ChildDateOfBirth:
         return record?.dob?.value ?? ''
       case MyInfoChildAttributes.ChildBirthCertNo:
-        return type === ChildRecordType.Sponsored
-          ? ((record as MyInfoSponsoredChildBelow21)?.nric?.value ?? '')
-          : ((record as MyInfoChildBirthRecordBelow21)?.birthcertno?.value ??
-              '')
+        return resolveChildIdentifier(record, type)
       case MyInfoChildAttributes.ChildVaxxStatus:
         // Sponsored records aren't in HPB's vaccination data at all, so surface
         // Unknown (which prefill/hashing skips, leaving the field for the

--- a/docs/adr/0002-children-v2-sponsored-unified-identifier.md
+++ b/docs/adr/0002-children-v2-sponsored-unified-identifier.md
@@ -1,0 +1,64 @@
+# 2. MyInfo Children v2: sponsored support via a unified identifier + record type
+
+Date: 2026-06-28
+
+## Status
+
+Accepted
+
+## Context
+
+MyInfo returns a respondent's children in two separate scopes:
+
+- `childrenbirthrecords` — **local** registered birth records, identified by
+  `birthcertno`.
+- `sponsoredchildrenrecords` — **sponsored** children (typically born
+  overseas), identified by `nric`, plus immigration fields (`residentialstatus`,
+  `nationality`, `scprgrantdate`, `birthcountry`).
+
+Today FormSG only reads `childrenbirthrecords`, so sponsored children never
+appear — the headline gap for ~5–20% of parents (PRD slice 03). The two record
+types share the common sub-fields v2 surfaces (name, sex, race, dob, vaxx) but
+differ in their identifier and carry different extra fields.
+
+## Decision
+
+1. **Merge both scopes into one children list**, local records first then
+   sponsored, in `MyInfoData.getChildrenBirthRecords`.
+2. **Unified identifier = the existing `childbirthcertno` sub-field.** For a
+   sponsored record it is populated from `nric`; for a local record from
+   `birthcertno`. No new sub-field/attribute is introduced — the existing
+   identifier slot resolves to whichever applies. (The field label may later
+   read "Birth certificate no. / NRIC"; copy-only, deferred with the picker.)
+3. **Record type** is exposed as a parallel `type` array on `MyInfoChildData`
+   (`'nuclear'` | `'sponsored'`, see `ChildRecordType`), and threaded into
+   `ChildEntryV4.type` on submission (the v4 slot already exists). It surfaces
+   as its own response/CSV column.
+4. **Sponsored-only immigration fields are not surfaced** in v2.0
+   (`nationality`, `residentialstatus`, `scprgrantdate`, `birthcountry`) — they
+   are simply never mapped into `MyInfoChildData`.
+
+## Consequences
+
+**Positive**
+
+- Sponsored children appear alongside local ones with no empty-mandatory error
+  (the identifier is always populated). Reuses the existing sub-field plumbing.
+- `type` rides the answerObject v4 slot that already existed, so it flips on
+  with storage-mode v4 like the rest of v2.
+
+**Negative / watch-outs / deferred**
+
+- **Scope request gating**: MyInfo must be asked for the
+  `sponsoredchildrenrecords` scope, and only for v2 (version-2) fields — legacy
+  forms must not start fetching sponsored data. Wiring this into the
+  redirect-URL scope builder with version awareness is follow-up plumbing; the
+  adapter merge itself is version-agnostic (it merges whatever scopes returned).
+- **Dedup by identifier (FE picker)**: the picker must key on the unified
+  identifier (not name) so same-named children — and a local + sponsored record
+  for the same child — are distinguishable and de-duplicated. This is the
+  respondent-side rework deferred from slice 02; it lands with the picker visual
+  cycle.
+- **Type column rendering** in the individual response view + CSV depends on the
+  storage-mode v4 rollout (deferred, ADR-0001) to actually persist
+  `ChildEntryV4.type`.

--- a/packages/shared/types/field/base.ts
+++ b/packages/shared/types/field/base.ts
@@ -1,5 +1,7 @@
 import { Language } from '../form'
 
+import type { ChildRecordType } from './childrenCompoundField'
+
 export enum BasicField {
   Section = 'section',
   Statement = 'statement',
@@ -105,7 +107,11 @@ export type AllowedMyInfoFieldOption = Exclude<
 
 export type MyInfoChildData = Partial<{
   [key in MyInfoChildAttributes]: string[]
-}>
+}> & {
+  // Per-child record type (parallel to the sub-field arrays), present for
+  // children-v2: 'nuclear' (local) or 'sponsored'.
+  type?: ChildRecordType[]
+}
 
 export type AllowMyInfoBase = {
   myInfo?: {

--- a/packages/shared/types/field/childrenCompoundField.ts
+++ b/packages/shared/types/field/childrenCompoundField.ts
@@ -17,6 +17,17 @@ export enum ChildrenFieldVersion {
   V2 = 2,
 }
 
+/**
+ * Record type of a child returned by MyInfo, stamped per child in v2 (ADR-0002).
+ * - `Nuclear`: a local registered birth record (identified by `birthcertno`).
+ * - `Sponsored`: a sponsored child record, typically born overseas
+ *   (identified by `nric`).
+ */
+export enum ChildRecordType {
+  Nuclear = 'nuclear',
+  Sponsored = 'sponsored',
+}
+
 export interface ChildrenCompoundFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Children
   // Stores the sub-field data.


### PR DESCRIPTION
## What this is

**Part 3 of 3** of the MyInfo Children v2 split (#9678) — the **v2.2 sponsored-children** slice. It **stacks on PR-A (#9686)** (base `children-v2-core`); it does *not* depend on PR-B.

> ⚠️ **Base branch is `children-v2-core` (PR-A), not `develop`.**
> ⚠️ **This PR is reviewable-but-INERT — see below. It does not make sponsored children work yet.**

## What's in this PR

The adapter-level plumbing for sponsored children (ADR-0002):

- **`ChildRecordType`** enum (`nuclear` / `sponsored`) and an optional per-child **`type?: ChildRecordType[]`** slot on `MyInfoChildData`, parallel to the sub-field arrays.
- **`getChildrenBirthRecords` merges both MyInfo scopes** — local `childrenbirthrecords` + `sponsoredchildrenrecords` — into one children list, and tags each child with its `type`.
- **Unified identifier:** the existing `childbirthcertno` sub-field resolves to `nric` for a sponsored record / `birthcertno` for a local one, so both kinds validate without an empty-mandatory error and no new sub-field/enum is added.
- An opt-in **deceased / ≥21 picker filter** (`excludeIneligible`), built but off by default.

## ⚠️ Why this is inert (do not read it as "sponsored works")

- **The sponsored MyInfo scope is never requested.** This PR only *reads/merges* `sponsoredchildrenrecords` if MyInfo returns it — but no code adds that scope to the MyInfo request (version-aware scope building is deferred follow-up, per ADR-0002). So in production `sponsoredchildrenrecords` is `undefined` and nothing sponsored actually appears.
- **The deceased/≥21 filter is off** — production callers don't pass `excludeIneligible` (it's gated on a pending Singpass hide-vs-grey-out ruling).
- **The `type` column** in responses/CSV and the **FE picker dedup-by-identifier** ride the storage-mode v4 rollout (PR-B / later) and are not here.

It's shipped as reviewable-but-inert so the adapter contract can be reviewed now; it activates when the scope-request wiring lands.

## Anything breaking? No.

Backwards compatible and dormant. The merge is version-agnostic (it merges whatever scopes MyInfo returns, and none are requested yet); `MyInfoChildData.type` is optional.

## Tests

**TC4: sponsored merge (adapter unit level)**
- [ ] `getChildrenBirthRecords` merges local + sponsored records into one list, local first, each tagged with `type` (`nuclear`/`sponsored`) — covered by `myinfo.adapter.spec`.
- [ ] The `childbirthcertno` identifier resolves to `nric` for a sponsored child and `birthcertno` for a local child.
- [ ] With `excludeIneligible`, deceased / ≥21 records are filtered; without it (production default), they are not.

---

🤖 Assembled by Claude Code (part 3 of the #9678 split). Verified via type-check across backend/shared/frontend; backend Jest runs on CI (native-module mismatch blocks it in the authoring sandbox).
