### PR TITLE
fix: save prefilled values in draft

### DIFF
--- a/apps/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -88,6 +88,20 @@ const PREFILLABLE_LOCKED_SHORTTEXT_FIELD: ShortTextFieldSchema = {
   _id: '5da04eafe397fc0013f63b23',
 }
 
+const PREFILLABLE_EMPTY_SHORTTEXT_FIELD: ShortTextFieldSchema = {
+  ValidationOptions: {
+    customVal: null,
+    selectedValidation: null,
+  },
+  allowPrefill: true, // Prefillable, but supplied an empty value via the URL.
+  title: 'Short Text With Empty Prefill',
+  description: '',
+  required: false,
+  disabled: false,
+  fieldType: BasicField.ShortText,
+  _id: '5da04eafe397fc0013f63b24',
+}
+
 const generateMswHandlersForColorTheme = (colorTheme: FormColorTheme) => {
   return [
     ...envHandlers,
@@ -1017,6 +1031,105 @@ WithSaveDraftEnabledAndClickFormHeaderSaveDraftButton.play = async ({
         storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
       })) as DraftSubmission | undefined
       expect(savedDraft).toBeDefined()
+    },
+  )
+
+  await step('Cleanup saved draft', async () => {
+    await _removeFromIndexedDBForTest({
+      key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+      storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+    })
+  })
+}
+
+// Regression: only prefilled fields that carry a value should be persisted in
+// the draft. An empty prefill (e.g. `?field=`) must not be saved.
+export const WithSaveDraftEnabledOnlyPersistsPrefilledFieldsWithValues =
+  Template.bind({})
+WithSaveDraftEnabledOnlyPersistsPrefilledFieldsWithValues.parameters = {
+  router: {
+    path: '/:formId',
+    initialEntries: [
+      `/61540ece3d4a6e50ac0cc6ff?${PREFILLABLE_NORMAL_SHORTTEXT_FIELD._id}=PrefilledValue&${PREFILLABLE_EMPTY_SHORTTEXT_FIELD._id}=`,
+    ],
+  },
+  msw: [
+    getPublicFormResponse({
+      overrides: {
+        form: {
+          responseMode: FormResponseMode.Encrypt,
+          isSaveDraftEnabled: true,
+          form_fields: [
+            PREFILLABLE_NORMAL_SHORTTEXT_FIELD,
+            PREFILLABLE_EMPTY_SHORTTEXT_FIELD,
+          ],
+        },
+      },
+    }),
+    ...DEFAULT_MSW_HANDLERS,
+  ],
+}
+WithSaveDraftEnabledOnlyPersistsPrefilledFieldsWithValues.play = async ({
+  step,
+}) => {
+  const screen = within(document.body)
+
+  let formHeaderSaveDraftButton: HTMLElement
+
+  await step(
+    'Scroll down the page to reveal the form header save draft button',
+    async () => {
+      await window.scrollBy(0, 500)
+    },
+  )
+
+  await step('Find the form header save draft button', async () => {
+    await waitFor(
+      async () => {
+        const allSaveDraftButtons = screen.getAllByLabelText('Save a draft')
+        const foundFormHeaderSaveDraftButton = allSaveDraftButtons.find(
+          (button) => button.closest('.chakra-slide') !== null,
+        )
+        if (!foundFormHeaderSaveDraftButton) {
+          throw new Error('Form header save draft button not found')
+        }
+        formHeaderSaveDraftButton = foundFormHeaderSaveDraftButton
+        expect(formHeaderSaveDraftButton).toBeInTheDocument()
+      },
+      { timeout: 3000 },
+    )
+  })
+
+  await step('Click the form header save draft button', async () => {
+    await userEvent.click(formHeaderSaveDraftButton)
+  })
+
+  await step(
+    'Assert that the saved draft success toast message appears',
+    async () => {
+      await waitFor(
+        async () => {
+          await expect(document.body).toHaveTextContent(
+            'Draft saved. Reopen this link in this browser to resume filling it.',
+          )
+        },
+        { timeout: 3000 },
+      )
+    },
+  )
+
+  await step(
+    'Assert only the prefilled field with a value is persisted in the draft',
+    async () => {
+      const savedDraft = (await _getFromIndexedDBForTest({
+        key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
+        storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
+      })) as DraftSubmission | undefined
+      // The empty-prefill field (5da04eafe397fc0013f63b24) is filtered out, so
+      // only the field prefilled with a value remains.
+      expect(savedDraft?.draftResponses).toEqual({
+        [PREFILLABLE_NORMAL_SHORTTEXT_FIELD._id]: 'PrefilledValue',
+      })
     },
   )
 

--- a/apps/frontend/src/features/public-form/PublicFormPage.stories.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormPage.stories.tsx
@@ -1042,11 +1042,8 @@ WithSaveDraftEnabledAndClickFormHeaderSaveDraftButton.play = async ({
   })
 }
 
-// Regression: only prefilled fields that carry a value should be persisted in
-// the draft. An empty prefill (e.g. `?field=`) must not be saved.
-export const WithSaveDraftEnabledOnlyPersistsPrefilledFieldsWithValues =
-  Template.bind({})
-WithSaveDraftEnabledOnlyPersistsPrefilledFieldsWithValues.parameters = {
+export const WithSaveDraftEnabledPersistsPrefilledFields = Template.bind({})
+WithSaveDraftEnabledPersistsPrefilledFields.parameters = {
   router: {
     path: '/:formId',
     initialEntries: [
@@ -1069,9 +1066,7 @@ WithSaveDraftEnabledOnlyPersistsPrefilledFieldsWithValues.parameters = {
     ...DEFAULT_MSW_HANDLERS,
   ],
 }
-WithSaveDraftEnabledOnlyPersistsPrefilledFieldsWithValues.play = async ({
-  step,
-}) => {
+WithSaveDraftEnabledPersistsPrefilledFields.play = async ({ step }) => {
   const screen = within(document.body)
 
   let formHeaderSaveDraftButton: HTMLElement
@@ -1119,16 +1114,15 @@ WithSaveDraftEnabledOnlyPersistsPrefilledFieldsWithValues.play = async ({
   )
 
   await step(
-    'Assert only the prefilled field with a value is persisted in the draft',
+    'Assert prefilled field even without a value is persisted in the draft',
     async () => {
       const savedDraft = (await _getFromIndexedDBForTest({
         key: STORAGE_MODE_PUBLIC_FORM_SAVE_DRAFT_KEY,
         storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
       })) as DraftSubmission | undefined
-      // The empty-prefill field (5da04eafe397fc0013f63b24) is filtered out, so
-      // only the field prefilled with a value remains.
       expect(savedDraft?.draftResponses).toEqual({
         [PREFILLABLE_NORMAL_SHORTTEXT_FIELD._id]: 'PrefilledValue',
+        [PREFILLABLE_EMPTY_SHORTTEXT_FIELD._id]: '',
       })
     },
   )

--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -12,11 +12,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useDisclosure } from '@chakra-ui/react'
 import { datadogLogs } from '@datadog/browser-logs'
-import {
-  useFeatureIsOn,
-  useFeatureValue,
-  useGrowthBook,
-} from '@growthbook/growthbook-react'
+import { useFeatureIsOn, useGrowthBook } from '@growthbook/growthbook-react'
 import { differenceInMilliseconds, format, isPast } from 'date-fns'
 import { flow, times } from 'lodash'
 import get from 'lodash/get'

--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -940,9 +940,7 @@ export const PublicFormProvider = ({
       previousRestoredDraftResponses: draftResponsesToRestore,
       currentFormFieldValues: formMethods.getValues(),
       dirtyFieldIds: Object.keys(dirtyFields),
-      prefilledFieldIds: Object.keys(fieldPrefillMap).filter(
-        (fieldId) => fieldPrefillMap[fieldId].prefillValue !== '',
-      ),
+      prefilledFieldIds: Object.keys(fieldPrefillMap),
       currentStepNumberWorkflowStep,
       formFields,
     })

--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -947,6 +947,7 @@ export const PublicFormProvider = ({
       prefilledFieldIds: Object.keys(fieldPrefillMap).filter(
         (fieldId) => fieldPrefillMap[fieldId].prefillValue !== '',
       ),
+      currentWorkflowStep: currentStepNumberWorkflowStep,
       formFields,
     })
 

--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -944,6 +944,9 @@ export const PublicFormProvider = ({
       previousRestoredDraftResponses: draftResponsesToRestore,
       currentFormFieldValues: formMethods.getValues(),
       dirtyFieldIds: Object.keys(dirtyFields),
+      prefilledFieldIds: Object.keys(fieldPrefillMap).filter(
+        (fieldId) => fieldPrefillMap[fieldId].prefillValue !== '',
+      ),
       formFields,
     })
 

--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -943,7 +943,7 @@ export const PublicFormProvider = ({
       prefilledFieldIds: Object.keys(fieldPrefillMap).filter(
         (fieldId) => fieldPrefillMap[fieldId].prefillValue !== '',
       ),
-      currentWorkflowStep: currentStepNumberWorkflowStep,
+      currentStepNumberWorkflowStep,
       formFields,
     })
 

--- a/apps/frontend/src/features/public-form/utils/saveDraft.test.ts
+++ b/apps/frontend/src/features/public-form/utils/saveDraft.test.ts
@@ -92,6 +92,7 @@ describe('saveDraft', () => {
       const result = getDraftToSave({
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
+        prefilledFieldIds: [],
         formFields,
       })
 
@@ -128,6 +129,7 @@ describe('saveDraft', () => {
       const result = getDraftToSave({
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
+        prefilledFieldIds: [],
         formFields,
       })
 
@@ -158,6 +160,7 @@ describe('saveDraft', () => {
       const result = getDraftToSave({
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
+        prefilledFieldIds: [],
         formFields,
       })
 
@@ -191,6 +194,7 @@ describe('saveDraft', () => {
       const result = getDraftToSave({
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
+        prefilledFieldIds: [],
         formFields,
       })
 
@@ -226,6 +230,7 @@ describe('saveDraft', () => {
         previousRestoredDraftResponses,
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
+        prefilledFieldIds: [],
         formFields,
       })
 
@@ -250,6 +255,7 @@ describe('saveDraft', () => {
       const result = getDraftToSave({
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
+        prefilledFieldIds: [],
         formFields,
       })
 
@@ -277,11 +283,63 @@ describe('saveDraft', () => {
         previousRestoredDraftResponses: null,
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
+        prefilledFieldIds: [],
         formFields,
       })
 
       expect(result.draftResponses).toEqual({
         field1: 'test value 1',
+      })
+    })
+
+    it('should save provided prefilled fields even when they are not dirty', () => {
+      const formFields = [
+        createMockFormField('prefill1', BasicField.ShortText),
+        createMockFormField('field2', BasicField.LongText),
+      ]
+      const formFieldValues = {
+        prefill1: 'prefilled value',
+        field2: 'user typed value',
+      }
+      const dirtyFieldIds = ['field2']
+      const prefilledFieldIds = ['prefill1']
+
+      vi.mocked(isMyInfo).mockReturnValue(false)
+
+      const result = getDraftToSave({
+        currentFormFieldValues: formFieldValues,
+        dirtyFieldIds,
+        prefilledFieldIds,
+        formFields,
+      })
+
+      // Assert: also includes non-dirty prefilled field in the draft
+      expect(result.draftResponses).toEqual({
+        prefill1: 'prefilled value',
+        field2: 'user typed value',
+      })
+    })
+
+    it('should save the latest current form value for a provided prefilled field eg, when user changes the prefilled value', () => {
+      const prefilledValue = 'user edited value'
+      const formFields = [createMockFormField('prefill1', BasicField.ShortText)]
+      const formFieldValues = {
+        prefill1: prefilledValue,
+      }
+      const dirtyFieldIds = ['prefill1']
+      const prefilledFieldIds = ['prefill1']
+
+      vi.mocked(isMyInfo).mockReturnValue(false)
+
+      const result = getDraftToSave({
+        currentFormFieldValues: formFieldValues,
+        dirtyFieldIds,
+        prefilledFieldIds,
+        formFields,
+      })
+
+      expect(result.draftResponses).toEqual({
+        prefill1: prefilledValue,
       })
     })
   })

--- a/apps/frontend/src/features/public-form/utils/saveDraft.test.ts
+++ b/apps/frontend/src/features/public-form/utils/saveDraft.test.ts
@@ -1,4 +1,9 @@
-import { BasicField, FormFieldDto } from 'formsg-shared/types'
+import {
+  BasicField,
+  FormFieldDto,
+  StrippedFormWorkflowStepDto,
+  WorkflowType,
+} from 'formsg-shared/types'
 
 import { isMyInfo } from '~features/myinfo/utils'
 
@@ -75,6 +80,15 @@ describe('saveDraft', () => {
     }
   }
 
+  const createMockWorkflowStep = (
+    editableFieldIds: string[],
+  ): StrippedFormWorkflowStepDto => ({
+    _id: 'step1',
+    workflow_type: WorkflowType.Dynamic,
+    field: 'approver1',
+    edit: editableFieldIds,
+  })
+
   describe('getDraftToSave', () => {
     it('should create draft with current form field values', () => {
       const formFields = [
@@ -93,6 +107,7 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds: [],
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
@@ -130,6 +145,7 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds: [],
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
@@ -161,6 +177,7 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds: [],
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
@@ -195,6 +212,7 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds: [],
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
@@ -231,6 +249,7 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds: [],
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
@@ -256,6 +275,7 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds: [],
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
@@ -284,6 +304,7 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds: [],
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
@@ -310,6 +331,7 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds,
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
@@ -335,11 +357,73 @@ describe('saveDraft', () => {
         currentFormFieldValues: formFieldValues,
         dirtyFieldIds,
         prefilledFieldIds,
+        currentStepNumberWorkflowStep: undefined,
         formFields,
       })
 
       expect(result.draftResponses).toEqual({
         prefill1: prefilledValue,
+      })
+    })
+
+    it('should only save fields that are editable in the current MRF workflow step', () => {
+      const formFields = [
+        createMockFormField('editable1', BasicField.ShortText),
+        createMockFormField('nonEditable1', BasicField.ShortText),
+      ]
+      const formFieldValues = {
+        editable1: 'editable value',
+        nonEditable1: 'non-editable value',
+      }
+      // Both fields are dirty, but only editable1 is editable in the workflow step.
+      const dirtyFieldIds = ['editable1', 'nonEditable1']
+      const currentStepNumberWorkflowStep = createMockWorkflowStep([
+        'editable1',
+      ])
+
+      vi.mocked(isMyInfo).mockReturnValue(false)
+
+      const result = getDraftToSave({
+        currentFormFieldValues: formFieldValues,
+        dirtyFieldIds,
+        prefilledFieldIds: [],
+        currentStepNumberWorkflowStep,
+        formFields,
+      })
+
+      // Assert: the field disabled by the workflow step is excluded from the draft.
+      expect(result.draftResponses).toEqual({
+        editable1: 'editable value',
+      })
+    })
+
+    it('should exclude a non-editable prefilled field in the current MRF workflow step', () => {
+      const formFields = [
+        createMockFormField('editablePrefill', BasicField.ShortText),
+        createMockFormField('nonEditablePrefill', BasicField.ShortText),
+      ]
+      const formFieldValues = {
+        editablePrefill: 'editable prefill',
+        nonEditablePrefill: 'non-editable prefill',
+      }
+      const dirtyFieldIds: string[] = []
+      const prefilledFieldIds = ['editablePrefill', 'nonEditablePrefill']
+      const currentStepNumberWorkflowStep = createMockWorkflowStep([
+        'editablePrefill',
+      ])
+
+      vi.mocked(isMyInfo).mockReturnValue(false)
+
+      const result = getDraftToSave({
+        currentFormFieldValues: formFieldValues,
+        dirtyFieldIds,
+        prefilledFieldIds,
+        currentStepNumberWorkflowStep,
+        formFields,
+      })
+
+      expect(result.draftResponses).toEqual({
+        editablePrefill: 'editable prefill',
       })
     })
   })

--- a/apps/frontend/src/features/public-form/utils/saveDraft.test.ts
+++ b/apps/frontend/src/features/public-form/utils/saveDraft.test.ts
@@ -335,7 +335,6 @@ describe('saveDraft', () => {
         formFields,
       })
 
-      // Assert: also includes non-dirty prefilled field in the draft
       expect(result.draftResponses).toEqual({
         prefill1: 'prefilled value',
         field2: 'user typed value',
@@ -375,7 +374,6 @@ describe('saveDraft', () => {
         editable1: 'editable value',
         nonEditable1: 'non-editable value',
       }
-      // Both fields are dirty, but only editable1 is editable in the workflow step.
       const dirtyFieldIds = ['editable1', 'nonEditable1']
       const currentStepNumberWorkflowStep = createMockWorkflowStep([
         'editable1',
@@ -391,7 +389,6 @@ describe('saveDraft', () => {
         formFields,
       })
 
-      // Assert: the field disabled by the workflow step is excluded from the draft.
       expect(result.draftResponses).toEqual({
         editable1: 'editable value',
       })

--- a/apps/frontend/src/features/public-form/utils/saveDraft.ts
+++ b/apps/frontend/src/features/public-form/utils/saveDraft.ts
@@ -1,4 +1,11 @@
-import { difference, intersection, isEmpty, mapValues, pick } from 'lodash'
+import {
+  difference,
+  intersection,
+  isEmpty,
+  mapValues,
+  pick,
+  union,
+} from 'lodash'
 
 import { BasicField, FormFieldDto } from 'formsg-shared/types'
 
@@ -22,11 +29,13 @@ export const getDraftToSave = ({
   previousRestoredDraftResponses,
   currentFormFieldValues: formFieldValues,
   dirtyFieldIds,
+  prefilledFieldIds,
   formFields,
 }: {
   previousRestoredDraftResponses?: FormFieldValues | null
   currentFormFieldValues: FormFieldValues
   dirtyFieldIds: string[]
+  prefilledFieldIds: string[]
   formFields: FormFieldDto[]
 }): DraftSubmission => {
   // Note: payment fields are not included in formFields to keep the implementation simple,
@@ -54,18 +63,20 @@ export const getDraftToSave = ({
     )
     .map((field) => field._id)
 
-  const currentDirtyFieldValues = pick(formFieldValues, dirtyFieldIds)
+  // RATIONALE: Persist dirty (edited) and prefilled fields since they include a value which should be included in the draft.
+  const fieldIdsToSave = union(dirtyFieldIds, prefilledFieldIds)
+  const fieldValuesToSave = pick(formFieldValues, fieldIdsToSave)
 
-  const allDirtyFieldValues = {
+  const allFieldValuesToSave = {
     ...(previousRestoredDraftResponses ?? {}),
-    ...currentDirtyFieldValues,
+    ...fieldValuesToSave,
   }
   const fieldIdsToInclude = difference(
     currentlyExistingFieldIds,
     myInfoFieldIds,
   )
 
-  const updatedDraftResponses = pick(allDirtyFieldValues, fieldIdsToInclude)
+  const updatedDraftResponses = pick(allFieldValuesToSave, fieldIdsToInclude)
 
   // Avoid saving 'signature' property values from verifiable fields in the draft.
   // This is to prevent signature from being reused and to force the user to

--- a/apps/frontend/src/features/public-form/utils/saveDraft.ts
+++ b/apps/frontend/src/features/public-form/utils/saveDraft.ts
@@ -7,10 +7,16 @@ import {
   union,
 } from 'lodash'
 
-import { BasicField, FormFieldDto } from 'formsg-shared/types'
+import {
+  BasicField,
+  FormFieldDto,
+  StrippedFormFieldDto,
+  StrippedFormWorkflowStepDto,
+} from 'formsg-shared/types'
 
 import { FormFieldValues, VerifiableFieldValues } from '~templates/Field'
 
+import { isFieldEnabledByMrfWorkflow } from '~features/form/utils/augmentFieldWithMrfWorkflowDisabling'
 import { isMyInfo } from '~features/myinfo/utils'
 
 import { DraftSubmission } from '../PublicFormContext'
@@ -30,12 +36,14 @@ export const getDraftToSave = ({
   currentFormFieldValues: formFieldValues,
   dirtyFieldIds,
   prefilledFieldIds,
+  currentStepNumberWorkflowStep,
   formFields,
 }: {
   previousRestoredDraftResponses?: FormFieldValues | null
   currentFormFieldValues: FormFieldValues
   dirtyFieldIds: string[]
   prefilledFieldIds: string[]
+  currentStepNumberWorkflowStep: StrippedFormWorkflowStepDto | undefined
   formFields: FormFieldDto[]
 }): DraftSubmission => {
   // Note: payment fields are not included in formFields to keep the implementation simple,
@@ -63,8 +71,16 @@ export const getDraftToSave = ({
     )
     .map((field) => field._id)
 
-  // RATIONALE: Persist dirty (edited) and prefilled fields since they include a value which should be included in the draft.
-  const fieldIdsToSave = union(dirtyFieldIds, prefilledFieldIds)
+  const editableFieldIds = formFields
+    .filter((field) =>
+      isFieldEnabledByMrfWorkflow(currentStepNumberWorkflowStep, field),
+    )
+    .map((field) => field._id)
+  // RATIONALE: Dirty (edited) and prefilled fields that are editable for this workflow step (if exists) should be included in the draft.
+  const fieldIdsToSave = intersection(
+    union(dirtyFieldIds, prefilledFieldIds),
+    editableFieldIds,
+  )
   const fieldValuesToSave = pick(formFieldValues, fieldIdsToSave)
 
   const allFieldValuesToSave = {

--- a/apps/frontend/src/features/public-form/utils/saveDraft.ts
+++ b/apps/frontend/src/features/public-form/utils/saveDraft.ts
@@ -10,7 +10,6 @@ import {
 import {
   BasicField,
   FormFieldDto,
-  StrippedFormFieldDto,
   StrippedFormWorkflowStepDto,
 } from 'formsg-shared/types'
 


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
The prefill values are not saved when save draft is clicked. 

How to reproduce the bug: 
1. make a form with locked prefill + save draft enabled 
https://form.gov.sg/6a45d6c86f4dea31e2bd2e51?6a45d6d05ecc1799e380c228=123 i have a prefill here and its locked
2. click save draft
3. come back to https://form.gov.sg/6a45d6c86f4dea31e2bd2e51 without the prefill query params in the url
4. the previous pre-filled value from save draft is not saved and its blank (editable)

[FRM-2480](https://linear.app/ogp/issue/FRM-2480/save-draft-does-not-preserve-pre-fill-values-on-resume-link)

## Solution
<!-- How did you solve the problem? -->
Include ids of fields with non-empty values in the saved draft. 
Also, ensure that only fields editable for the current workflow step are saved in the draft, necessary since the prefilled value might not be editable in current step. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->
TC1: Save draft works normally for Storage mode 
- [ ] Create a storage form with multiple field types, including 2 short fields with prefills, one locked and another unlocked. 
- [ ] Enable save draft 
- [ ] Fill in the fields and save draft. 
- [ ] Reload the page and assert the draft is restored. 
- [ ] Enter prefills for the short fields in the query param. 
- [ ] Save draft. 
- [ ] Reload the page and assert the draft is restored in the base URL without query param.  
- [ ] Enter prefills for the short fields in the query param. 
- [ ] Edit the unlocked field and save draft. 
- [ ] Reload the page and assert the draft is restored in the base URL without query param.  

TC2: Save draft works normally for MRF
- [ ] Create a MRF with multiple field types and 2 steps.
- [ ] Create a locked and unlocked prefill for step 1 and step 2 (4 fields total). 
- [ ] Enable save draft 
- [ ] Fill in the fields and save draft. 
- [ ] Reload the page and assert the draft is restored. 
- [ ] Submit step 1. 
- [ ] Fill in fields for step 2. 
- [ ] Save draft. 
- [ ] Reload the page for step 2 and assert the draft is restored. 
- [ ] Submit the draft. 

TC3: Save draft works for prefill step 1 and 2
- [ ] Use form from TC2 
- [ ] Insert the prefill for both in query param. 
- [ ] Save draft. 
- [ ] Go to the base non query param url. 
- [ ] Assert the draft includes the previously prefilled values. 
- [ ] Edit the restored values and save draft.  
- [ ] Reload the page. Assert the draft is restored. 
- [ ] Go to the prefill url. Assert the prefill overrides the url. 
- [ ] Submit the form and assert the value is correct. 
- [ ] Go to step 2 and enter the query param in url. 
- [ ] Assert the prefill is input.
- [ ] Edit the prefill and save draft. 
- [ ] Reload without the query param for step 2. 
- [ ] Assert the draft is restored.
- [ ] Submit the form. 
- [ ] Assert the submission is correct.  