### PR TITLE
feat: edit release notes on recut

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if gh release view "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
-            echo "GitHub release ${{ steps.version.outputs.tag }} already exists; skipping creation."
+            echo "Updating existing GitHub release ${{ steps.version.outputs.tag }} with regenerated release notes."
+            gh api "repos/${{ github.repository }}/releases/generate-notes" \
+              -f "tag_name=${{ steps.version.outputs.tag }}" \
+              --jq .body > .release_notes.md
+            gh release edit "${{ steps.version.outputs.tag }}" --notes-file .release_notes.md
           else
             gh release create "${{ steps.version.outputs.tag }}" \
               --verify-tag \


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Release notes are not updated when the release is recut. 

## Solution
<!-- How did you solve the problem? -->
Edit the existing release if a recut is detected with the latest changes tied to the release tag. 

Note: we make sure to edit instead of recreating to preserve the discussion history and artifacts. (if any) 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  