### PR TITLE
perf(ci): cache the release image locally during the crane copy

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -211,16 +211,27 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           SRC_IMAGE: ${{ steps.check-release-image.outputs.image }}
         run: |
-          # Registry-to-registry copy: crane streams the manifest and blobs from
-          # GHCR straight to ECR without pulling the whole image onto the runner,
-          # which is far faster than docker pull + tag + push. crane authenticates
-          # from the ~/.docker/config.json entries the ECR and GHCR login steps
-          # above already wrote.
+          # This image is needed in two places: in ECR (for the ECS deploy) and
+          # on the local docker daemon (for the static-assets extract below).
+          # They are independent transfers of the same image, so do them at once.
+          #
+          # crane copies GHCR->ECR registry-to-registry without touching the
+          # local daemon, which beats docker pull + push for the ECR leg. But
+          # that leaves nothing on the daemon, so the later `docker run` to
+          # extract apps/frontend/dist would pull the whole image itself (~90s).
+          # So pull it in the background while crane runs, then tag it as the ECR
+          # ref the static-assets step expects — by then it is already local, so
+          # `docker run` does no pull. crane authenticates from the docker config
+          # the ECR and GHCR login steps above already wrote.
           CRANE_VERSION=0.21.7
           curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
             | tar -xzf - -C /usr/local/bin crane
           chmod +x /usr/local/bin/crane
+          docker pull "$SRC_IMAGE" &
+          pull_pid=$!
           crane copy "$SRC_IMAGE" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          wait "$pull_pid"
+          docker tag "$SRC_IMAGE" "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
       - name: Set up Docker Buildx
         if: steps.check-release-image.outputs.image == ''


### PR DESCRIPTION
## Problem

crane landed in #9690, but it copies the release image GHCR to ECR registry-to-registry, so the image never lands on the runner's docker daemon. The "Copy Static Assets" step extracts `apps/frontend/dist` with `docker run`, which then pulls the whole ~22-layer image itself. That turned a ~12s extract into ~96s on release 7.34.4 ([run 28495610216, step 13](https://github.com/opengovsg/FormSG/actions/runs/28495610216/job/84462133464#step:13:19)). The Datadog sourcemaps step beside it is only ~1s, so the cost is entirely the pull, not the uploads.

## Solution

Pull the image in the background while `crane copy` runs (independent transfers of the same image), then `docker tag` it as the ECR ref locally. By the time the static-assets step runs the image is already on the daemon, so `docker run` does no pull and the extract drops back to ~12s. The pull now hides behind the ~37s crane copy instead of adding to the deploy's critical path.

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - CI only, no app or API changes

**Improvements**:
- The static-assets extract no longer re-pulls the whole image (~96s down to ~12s per app deploy).

## Tests

This only runs on release-tagged deploys (the crane reuse path), so a branch push can't exercise it (stg-alt2 builds from scratch). Watch the next release's app deploy: "Copy pre-built image to ECR" should show a `docker pull` running alongside crane, and "Copy Static Assets" should have no "Pulling fs layer" lines.

## Deploy Notes

None.
