### PR TITLE
feat: instrument virus scanner logs with formid

### DIFF
--- a/apps/backend/src/app/modules/submission/submission.service.ts
+++ b/apps/backend/src/app/modules/submission/submission.service.ts
@@ -1160,11 +1160,13 @@ type TriggerGuardDutyScanningError =
  */
 export const triggerGuardDutyScanning = (
   quarantineFileKey: string,
+  logMeta: Record<string, unknown> = {},
 ): ResultAsync<
   ParseVirusScannerLambdaPayloadOkType,
   TriggerGuardDutyScanningError
 > => {
-  const logMeta = {
+  const meta = {
+    ...logMeta,
     action: 'triggerGuardDutyScanning',
     quarantineFileKey,
   }
@@ -1172,7 +1174,7 @@ export const triggerGuardDutyScanning = (
   if (!validate(quarantineFileKey)) {
     logger.error({
       message: 'GUARDDUTY Invalid quarantine file key - not a valid uuid',
-      meta: logMeta,
+      meta,
     })
 
     return errAsync(new GuardDutyInvalidFileKeyError())
@@ -1187,7 +1189,7 @@ export const triggerGuardDutyScanning = (
       logger.error({
         message:
           'GUARDDUTY Error encountered when invoking virus scanning lambda',
-        meta: logMeta,
+        meta,
         error,
       })
 
@@ -1199,7 +1201,7 @@ export const triggerGuardDutyScanning = (
         logger.error({
           message:
             'GUARDDUTY Error returned from virus scanning lambda or parsing lambda output',
-          meta: logMeta,
+          meta,
           error: error,
         })
 
@@ -1218,7 +1220,7 @@ export const triggerGuardDutyScanning = (
     // if data or data.Payload is undefined
     logger.error({
       message: 'data or data.Payload from virus scanner lambda is undefined',
-      meta: logMeta,
+      meta,
     })
     return errAsync(new GuardDutyParseVirusScannerLambdaPayloadError())
   })
@@ -1249,7 +1251,7 @@ export const triggerGuardDutyScanThenDownloadCleanFileChain = <
   }
   // Step 3: Trigger lambda to scan attachments.
   return (
-    triggerGuardDutyScanning(response.answer)
+    triggerGuardDutyScanning(response.answer, logMeta)
       .mapErr((error) => {
         if (error instanceof GuardDutyMaliciousFileDetectedError) {
           logger.error({


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, our `triggerGuardDutyScanning` logs do not include any useful meta that links it to form for investigation. This is a further issue since due to our retention policy, some traces may not be indexed. This means that these logs are not useful for investigating incidents.  

Example of indexed trace being missing after retention period, meaning we can no longer track which form this virus scan is associated with: 
<img width="817" height="184" alt="image" src="https://github.com/user-attachments/assets/a6893b58-a14d-40b8-b5cb-8762a8b4477e" />

Example of current metadata, which only includes the quarantine file key. This key might not exist or already be deleted. We are also not able to determine much from this randomly generated key, reducing the effectiveness of this log:  
<img width="186" height="207" alt="image" src="https://github.com/user-attachments/assets/01b8596b-c847-465d-b3bf-112ac62c7d1d" />


## Solution
<!-- How did you solve the problem? -->
Append `formId` to the logMeta.

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  