### PR TITLE
fix(paper forms tracking): reword origin question and new-process option

### DIFF
--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
@@ -20,9 +20,9 @@ import { CreateFormOriginScreen } from './CreateFormOriginScreen'
 vi.mock('react-i18next', () => {
   const P = 'features.workspace.modals.forms.create.origin'
   const translations: Record<string, string> = {
-    [`${P}.question`]: 'How is this being filled today?',
+    [`${P}.question`]: 'How is this data being collected today?',
     [`${P}.options.paper`]: 'Paper form',
-    [`${P}.options.digitalNew`]: 'This is a new process',
+    [`${P}.options.digitalNew`]: "This data isn't collected",
     [`${P}.options.digitalEmail`]: 'Emails',
     [`${P}.options.digitalDocument`]: 'Documents (e.g. PDF, Word)',
     [`${P}.options.digitalSpreadsheet`]: 'Spreadsheets (e.g. Excel, Sheets)',

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -77,10 +77,10 @@ export const enSG: CreateFormModal = {
     suffix: '.',
   },
   origin: {
-    question: 'How is this being filled today?',
+    question: 'How is this data being collected today?',
     options: {
       paper: 'Paper form',
-      digitalNew: 'This is a new process',
+      digitalNew: "This data isn't collected",
       digitalEmail: 'Emails',
       digitalDocument: 'Documents (e.g. PDF, Word)',
       digitalSpreadsheet: 'Spreadsheets (e.g. Excel, Sheets)',


### PR DESCRIPTION
## Problem

The form-origin step asks "How is this being filled today?", which frames the question around form-filling — admins digitising a brand-new process have nothing that is "being filled", and the "This is a new process" option doesn't read as an answer to the question.

## Solution

Copy-only change to the origin step: the question becomes "How is this data being collected today?" and the new-process option becomes "This data isn't collected", so every option reads as a direct answer. Only the i18n strings and the test's translation mock change — no logic, and the stored origin value (`digitalNew`) is untouched, so existing analytics are unaffected.

**Screenshots**

| Page | Before | After |
| --- | --- | --- |
| Create form → origin step | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/paper-forms-origin-copy-v2/before-origin-step.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/paper-forms-origin-copy-v2/after-origin-step.png) |

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: Origin step shows the new copy**

- [ ] Workspace → Create form → enter a title → Next step
- [ ] The origin step asks "How is this data being collected today?" with option "This data isn't collected"
- [ ] Select "This data isn't collected" and proceed — form creation completes as before
