### PR TITLE
fix(rum-privacy): mask secret key and decrypted responses in session replays

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.test.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.test.tsx
@@ -1,7 +1,12 @@
 import { PropsWithChildren } from 'react'
 import { screen } from '@testing-library/react'
 
-import { BasicField, FormResponseMode } from 'formsg-shared/types'
+import {
+  BasicField,
+  FormResponseMode,
+  PaymentStatus,
+  SubmissionPaymentDto,
+} from 'formsg-shared/types'
 
 import { isMaskedInReplay, render } from '~/test-utils'
 
@@ -67,12 +72,26 @@ const MOCK_RESPONSES: AugmentedDecryptedResponse[] = [
   },
 ] as AugmentedDecryptedResponse[]
 
+const MOCK_PAYER_EMAIL = 'mock-payer@example.com'
+
+const MOCK_PAYMENT: SubmissionPaymentDto = {
+  id: 'mock-payment-id',
+  paymentIntentId: 'mock-payment-intent-id',
+  email: MOCK_PAYER_EMAIL,
+  amount: 1000,
+  status: PaymentStatus.Succeeded,
+  paymentDate: 'Mon, 6 Jul 2026, 12:00:00 pm',
+  transactionFee: 50,
+  receiptUrl: 'https://example.com/mock-receipt-url',
+}
+
 vi.mock('./queries', () => ({
   useIndividualSubmission: () => ({
     data: {
       refNo: 'mock-submission-id',
       submissionTime: 'Mon, 6 Jul 2026, 12:00:00 pm',
       responses: MOCK_RESPONSES,
+      payment: MOCK_PAYMENT,
     },
     isLoading: false,
     isError: false,
@@ -80,7 +99,7 @@ vi.mock('./queries', () => ({
 }))
 
 describe('IndividualResponsePage', () => {
-  it('masks decrypted answers and attachment names in session replays', () => {
+  it('masks decrypted answers, attachment names and payment details in session replays', () => {
     render(<IndividualResponsePage />)
 
     const answer = screen.getByText(MOCK_DECRYPTED_ANSWER)
@@ -88,5 +107,8 @@ describe('IndividualResponsePage', () => {
 
     const attachmentName = screen.getByText(MOCK_ATTACHMENT_FILENAME)
     expect(isMaskedInReplay(attachmentName)).toBe(true)
+
+    const payerEmail = screen.getByText(MOCK_PAYER_EMAIL)
+    expect(isMaskedInReplay(payerEmail)).toBe(true)
   })
 })

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.test.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.test.tsx
@@ -1,0 +1,92 @@
+import { PropsWithChildren } from 'react'
+import { screen } from '@testing-library/react'
+
+import { BasicField, FormResponseMode } from 'formsg-shared/types'
+
+import { isMaskedInReplay, render } from '~/test-utils'
+
+import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
+
+import { IndividualResponsePage } from './IndividualResponsePage'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+  Trans: ({ children }: PropsWithChildren) => children,
+}))
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({
+    formId: 'mock-form-id',
+    submissionId: 'mock-submission-id',
+  }),
+}))
+
+vi.mock('~features/admin-form/common/queries', () => ({
+  useAdminForm: () => ({
+    data: { _id: 'mock-form-id', responseMode: FormResponseMode.Encrypt },
+  }),
+}))
+
+vi.mock('~features/user/queries', () => ({
+  useUser: () => ({ user: undefined }),
+}))
+
+vi.mock('../ResponsesPage/storage', () => ({
+  useStorageResponsesContext: () => ({ secretKey: 'mock-secret-key' }),
+}))
+
+vi.mock('./IndividualResponseNavbar', () => ({
+  IndividualResponseNavbar: () => <div data-testid="navbar" />,
+}))
+
+vi.mock('./mutations', () => ({
+  useMutateDownloadAttachments: () => ({
+    downloadAttachmentMutation: { mutate: vi.fn(), isLoading: false },
+    downloadAttachmentsAsZipMutation: { mutate: vi.fn(), isLoading: false },
+  }),
+}))
+
+const MOCK_DECRYPTED_ANSWER = 'mock decrypted answer text'
+const MOCK_ATTACHMENT_FILENAME = 'mock-attachment.pdf'
+
+const MOCK_RESPONSES: AugmentedDecryptedResponse[] = [
+  {
+    _id: 'field-1',
+    fieldType: BasicField.ShortText,
+    question: 'What is your name?',
+    questionNumber: 1,
+    answer: MOCK_DECRYPTED_ANSWER,
+  },
+  {
+    _id: 'field-2',
+    fieldType: BasicField.Attachment,
+    question: 'Upload a document',
+    questionNumber: 2,
+    answer: MOCK_ATTACHMENT_FILENAME,
+    downloadUrl: 'https://example.com/mock-download-url',
+  },
+] as AugmentedDecryptedResponse[]
+
+vi.mock('./queries', () => ({
+  useIndividualSubmission: () => ({
+    data: {
+      refNo: 'mock-submission-id',
+      submissionTime: 'Mon, 6 Jul 2026, 12:00:00 pm',
+      responses: MOCK_RESPONSES,
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}))
+
+describe('IndividualResponsePage', () => {
+  it('masks decrypted answers and attachment names in session replays', () => {
+    render(<IndividualResponsePage />)
+
+    const answer = screen.getByText(MOCK_DECRYPTED_ANSWER)
+    expect(isMaskedInReplay(answer)).toBe(true)
+
+    const attachmentName = screen.getByText(MOCK_ATTACHMENT_FILENAME)
+    expect(isMaskedInReplay(attachmentName)).toBe(true)
+  })
+})

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.test.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.test.tsx
@@ -8,7 +8,7 @@ import {
   SubmissionPaymentDto,
 } from 'formsg-shared/types'
 
-import { isMaskedInReplay, render } from '~/test-utils'
+import { isMaskedInDatadogReplay, render } from '~/test-utils'
 
 import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
 
@@ -103,12 +103,12 @@ describe('IndividualResponsePage', () => {
     render(<IndividualResponsePage />)
 
     const answer = screen.getByText(MOCK_DECRYPTED_ANSWER)
-    expect(isMaskedInReplay(answer)).toBe(true)
+    expect(isMaskedInDatadogReplay(answer)).toBe(true)
 
     const attachmentName = screen.getByText(MOCK_ATTACHMENT_FILENAME)
-    expect(isMaskedInReplay(attachmentName)).toBe(true)
+    expect(isMaskedInDatadogReplay(attachmentName)).toBe(true)
 
     const payerEmail = screen.getByText(MOCK_PAYER_EMAIL)
-    expect(isMaskedInReplay(payerEmail)).toBe(true)
+    expect(isMaskedInDatadogReplay(payerEmail)).toBe(true)
   })
 })

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -83,7 +83,12 @@ const StackRow = ({
       spacing={{ base: '0', md: '0.5rem' }}
       direction={{ base: 'column', md: 'row' }}
     >
-      <Text as="span" textStyle="subhead-1" whiteSpace="nowrap">
+      <Text
+        as="span"
+        textStyle="subhead-1"
+        whiteSpace="nowrap"
+        data-dd-privacy="allow"
+      >
         {label}:
       </Text>
       <Skeleton isLoaded={!isLoading && !isError}>
@@ -96,6 +101,7 @@ const StackRow = ({
                 display="inline-flex"
                 wordBreak="break-word"
                 gap="0.25rem"
+                data-dd-action-name="Click on status tracker link"
               >
                 {statusTrackerUrl}{' '}
                 <Box fontSize="1.25rem" display="flex" alignItems="center">
@@ -274,6 +280,7 @@ export const IndividualResponsePage = (): JSX.Element => {
               </Text>
               <Skeleton isLoaded={!isLoading && !isError}>
                 <Button
+                  data-dd-action-name="Click on attachment field download button"
                   variant="link"
                   isDisabled={downloadAttachmentsAsZipMutation.isLoading}
                   onClick={handleDownload}

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -204,9 +204,13 @@ export const IndividualResponsePage = (): JSX.Element => {
     <Flex flexDir="column" marginTop={{ base: '-1.5rem', md: '-3rem' }}>
       <IndividualResponseNavbar />
 
+      {/* Mask the whole response content (metadata, decrypted answers,
+      attachments, payment details) in Datadog session replays — fail closed
+      so every row type and future addition is covered. */}
       <Stack
         px={{ md: '1.75rem', lg: '2rem' }}
         spacing={{ base: '1.5rem', md: '2.5rem' }}
+        data-dd-privacy="mask"
       >
         <Stack bg="primary.100" p="1.5rem" textStyle="monospace">
           <StackRow

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -210,9 +210,6 @@ export const IndividualResponsePage = (): JSX.Element => {
     <Flex flexDir="column" marginTop={{ base: '-1.5rem', md: '-3rem' }}>
       <IndividualResponseNavbar />
 
-      {/* Mask the whole response content (metadata, decrypted answers,
-      attachments, payment details) in Datadog session replays — fail closed
-      so every row type and future addition is covered. */}
       <Stack
         px={{ md: '1.75rem', lg: '2rem' }}
         spacing={{ base: '1.5rem', md: '2.5rem' }}

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.test.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react'
 
 import { BasicField } from 'formsg-shared/types'
 
-import { isMaskedInReplay, render } from '~/test-utils'
+import { isMaskedInDatadogReplay, render } from '~/test-utils'
 
 import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
 
@@ -33,6 +33,6 @@ describe('PrintableResponse', () => {
     )
 
     const answer = screen.getByText(MOCK_DECRYPTED_ANSWER)
-    expect(isMaskedInReplay(answer)).toBe(true)
+    expect(isMaskedInDatadogReplay(answer)).toBe(true)
   })
 })

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.test.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from '@testing-library/react'
+
+import { BasicField } from 'formsg-shared/types'
+
+import { isMaskedInReplay, render } from '~/test-utils'
+
+import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
+
+import { PrintableResponse } from './PrintableResponse'
+
+const MOCK_DECRYPTED_ANSWER = 'mock printable answer text'
+
+const MOCK_RESPONSES: AugmentedDecryptedResponse[] = [
+  {
+    _id: 'field-1',
+    fieldType: BasicField.ShortText,
+    question: 'What is your name?',
+    questionNumber: 1,
+    answer: MOCK_DECRYPTED_ANSWER,
+  },
+] as AugmentedDecryptedResponse[]
+
+describe('PrintableResponse', () => {
+  it('masks decrypted answers in session replays', () => {
+    render(
+      <PrintableResponse
+        formTitle="Mock form"
+        formId="mock-form-id"
+        decryptedResponses={MOCK_RESPONSES}
+        responseId="mock-submission-id"
+        submissionTime="Mon, 6 Jul 2026, 12:00:00 pm"
+      />,
+    )
+
+    const answer = screen.getByText(MOCK_DECRYPTED_ANSWER)
+    expect(isMaskedInReplay(answer)).toBe(true)
+  })
+})

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -202,8 +202,6 @@ export const PrintableResponse = ({
   submissionTime: string
 }) => {
   return (
-    // Mask the whole printable view in Datadog session replays — it renders
-    // every decrypted answer as plain text.
     <Box py="16px" fontFamily="sans-serif" data-dd-privacy="mask">
       <Box
         py="24px"

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/PrintableResponse.tsx
@@ -202,7 +202,9 @@ export const PrintableResponse = ({
   submissionTime: string
 }) => {
   return (
-    <Box py="16px" fontFamily="sans-serif">
+    // Mask the whole printable view in Datadog session replays — it renders
+    // every decrypted answer as plain text.
+    <Box py="16px" fontFamily="sans-serif" data-dd-privacy="mask">
       <Box
         py="24px"
         w="100%"

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.test.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form'
 import { Modal, ModalContent } from '@chakra-ui/react'
 import { screen } from '@testing-library/react'
 
-import { isMaskedInReplay, render } from '~/test-utils'
+import { isMaskedInDatadogReplay, render } from '~/test-utils'
 
 import {
   SaveSecretKeyContent,
@@ -55,6 +55,6 @@ describe('SaveSecretKeyContent', () => {
     render(<TestHarness />)
 
     const secretKey = screen.getByText(MOCK_SECRET_KEY)
-    expect(isMaskedInReplay(secretKey)).toBe(true)
+    expect(isMaskedInDatadogReplay(secretKey)).toBe(true)
   })
 })

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.test.tsx
@@ -1,0 +1,60 @@
+import { PropsWithChildren } from 'react'
+import { useForm } from 'react-hook-form'
+import { Modal, ModalContent } from '@chakra-ui/react'
+import { screen } from '@testing-library/react'
+
+import { isMaskedInReplay, render } from '~/test-utils'
+
+import {
+  SaveSecretKeyContent,
+  SaveSecretKeyFormInput,
+} from './SaveSecretKeyContent'
+import { useSaveSecretKey } from './useSaveSecretKey'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+  Trans: ({ children }: PropsWithChildren) => children,
+}))
+
+const MOCK_SECRET_KEY = 'mock-secret-key-abc123'
+
+const mockUseSaveSecretKey: typeof useSaveSecretKey = () => ({
+  isSubmitEnabled: true,
+  hasCopiedKey: false,
+  handleCopyKey: vi.fn(),
+  hasDownloadedKey: false,
+  handleDownloadKey: vi.fn(),
+  mailToHref: 'mailto:',
+})
+
+const TestHarness = () => {
+  const { register } = useForm<SaveSecretKeyFormInput>()
+  return (
+    <Modal isOpen onClose={vi.fn()}>
+      <ModalContent>
+        <SaveSecretKeyContent
+          contentTitle="Save your secret key"
+          secretKey={MOCK_SECRET_KEY}
+          formTitle="Mock form"
+          formId="mock-form-id"
+          onClose={vi.fn()}
+          isFormStateValid
+          handleTrackEmail={vi.fn()}
+          onSubmitClick={vi.fn()}
+          registerStorageAck={register}
+          isLoading={false}
+          useSaveSecretKeyHook={mockUseSaveSecretKey}
+        />
+      </ModalContent>
+    </Modal>
+  )
+}
+
+describe('SaveSecretKeyContent', () => {
+  it('masks the displayed secret key in session replays', () => {
+    render(<TestHarness />)
+
+    const secretKey = screen.getByText(MOCK_SECRET_KEY)
+    expect(isMaskedInReplay(secretKey)).toBe(true)
+  })
+})

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
@@ -73,10 +73,7 @@ export const SaveSecretKeyContent = ({
   return (
     <>
       <ModalBody whiteSpace="pre-wrap">
-        {/* Mask the whole save-secret-key screen (not just the key line) in
-        Datadog session replays — fail closed so future additions inside the
-        screen are covered too. */}
-        <Container maxW="42.5rem" p={0} data-dd-privacy="mask">
+        <Container maxW="42.5rem" p={0}>
           <Box
             bg="white"
             borderRadius="4px"
@@ -144,6 +141,7 @@ export const SaveSecretKeyContent = ({
                   color="secondary.500"
                   borderRadius="4px"
                   data-chromatic="ignore" // secret key always changes in Chromatic so this should be ignored
+                  data-dd-privacy="mask"
                 >
                   {secretKey}
                 </Code>

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
@@ -73,7 +73,10 @@ export const SaveSecretKeyContent = ({
   return (
     <>
       <ModalBody whiteSpace="pre-wrap">
-        <Container maxW="42.5rem" p={0}>
+        {/* Mask the whole save-secret-key screen (not just the key line) in
+        Datadog session replays — fail closed so future additions inside the
+        screen are covered too. */}
+        <Container maxW="42.5rem" p={0} data-dd-privacy="mask">
           <Box
             bg="white"
             borderRadius="4px"

--- a/apps/frontend/src/test-utils.tsx
+++ b/apps/frontend/src/test-utils.tsx
@@ -15,11 +15,8 @@ export { customRender as render }
 
 /**
  * Whether the element is masked in Datadog session replay recordings.
- * Datadog resolves privacy from the nearest ancestor carrying a
- * `data-dd-privacy` attribute; under the global `mask-user-input` privacy
- * level, page text with no such ancestor is recorded verbatim.
  */
-export const isMaskedInReplay = (element: HTMLElement): boolean =>
+export const isMaskedInDatadogReplay = (element: HTMLElement): boolean =>
   element.closest('[data-dd-privacy]')?.getAttribute('data-dd-privacy') ===
   'mask'
 

--- a/apps/frontend/src/test-utils.tsx
+++ b/apps/frontend/src/test-utils.tsx
@@ -14,6 +14,16 @@ const customRender = (ui: React.ReactElement, options?: RenderOptions) =>
 export { customRender as render }
 
 /**
+ * Whether the element is masked in Datadog session replay recordings.
+ * Datadog resolves privacy from the nearest ancestor carrying a
+ * `data-dd-privacy` attribute; under the global `mask-user-input` privacy
+ * level, page text with no such ancestor is recorded verbatim.
+ */
+export const isMaskedInReplay = (element: HTMLElement): boolean =>
+  element.closest('[data-dd-privacy]')?.getAttribute('data-dd-privacy') ===
+  'mask'
+
+/**
  * Extends react-testing-library functions.
  * See https://polvara.me/posts/five-things-you-didnt-know-about-testing-library
  */


### PR DESCRIPTION
## Problem

Datadog RUM session replay records at 100% of sampled sessions with `defaultPrivacyLevel: 'mask-user-input'`, which only masks form controls — any sensitive value rendered as plain page text is recorded verbatim. Two critical leaks: the **form secret key**, shown as plain text during form creation, and **all decrypted respondent answers** when an admin views an individual response. Anyone with access to our Datadog replays can read a form's secret key and decrypt its responses, breaking FormSG's end-to-end encryption promise.

PRD: [Datadog RUM replays not masking secret keys](https://app.notion.com/p/39077dbba78880db9f5bff035e976169)

## Solution

Targeted masking with Datadog's per-element override: `data-dd-privacy="mask"` on the container of the save-secret-key screen, the individual response view's content, and the printable response view. Each mask sits on a whole container rather than the individual sensitive line, so the surface fails closed as content is added. The global `defaultPrivacyLevel` is deliberately unchanged. A shared `isMaskedInReplay` test helper models Datadog's nearest-ancestor privacy resolution, and each masked surface has a unit test asserting the sensitive text renders inside a masked container.

> **Note for reviewers:** this branch previously implemented the opposite approach — global `mask` with a provenance allow-list. Per eng review (2026-07-07), the approach was reversed to targeted masking and the branch was rebuilt from scratch; the 12 allow-list commits were dropped in a force-push.

**Alternatives considered**

- We considered flipping the global privacy level to `mask` and opting readable surfaces back in with an allow-list (the branch's previous incarnation). We dropped it because it inverts the codebase's allow-by-default mental model — every new component, over 90% of them non-sensitive, would need an explicit opt-in. Targeted masking keeps the urgent fix small; the deny-by-default question may be revisited separately.
- We considered the `dd-privacy-mask` CSS class instead of the `data-dd-privacy` attribute, but className merging through Chakra's styled system can silently drop classes, while `data-*` attributes pass through untouched.

**Breaking Changes**

No - backwards compatible.

## Tests

No screenshots: the change adds invisible `data-*` attributes only. Masking happens client-side before replay data is sent, so true verification is watching staging replays (set GrowthBook `ddSampleRateAdmin` non-zero first).

**TC1: Form creation — secret key masked**

- [ ] Create a storage-mode form in staging and watch the session replay
- [ ] The secret key on the save screen is wireframed

**TC2: Decrypted individual response — answers masked**

- [ ] Unlock and view an individual response (including the print view) and watch the replay
- [ ] Every answer, attachment name and payment detail is wireframed

**TC3: Everything else unchanged**

- [ ] Form building, workspace, toasts and navigation are still readable in the replay
- [ ] Spot-check whether clicks inside masked regions surface element text as RUM action names; record the observed behaviour in the PRD
- [ ] Return the GrowthBook flag to its prior value

🤖 Generated with [Claude Code](https://claude.com/claude-code)
