### PR TITLE
feat(workflow-builder-redesign): add workflow-builder-redesign feature flag foundation

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign.ts
@@ -1,0 +1,11 @@
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+/**
+ * Single source of truth for reading the `workflow-builder-redesign` GrowthBook
+ * flag. Every workflow builder redesign seam should gate on this hook so the
+ * flag can be retired from one place once the redesign fully rolls out.
+ */
+export const useIsWorkflowBuilderRedesign = (): boolean =>
+  useFeatureIsOn(featureFlags.workflowBuilderRedesign)

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -46,6 +46,7 @@ export const featureFlags = {
   enablePaperTrackingSetUpPage: 'enable-paper-tracking-set-up-page' as const,
   sidebarNavLabels: 'enable-sidebar-nav-labels' as const,
   fiveStarAdminRating: '5star-admin-rating' as const,
+  workflowBuilderRedesign: 'workflow-builder-redesign' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {


### PR DESCRIPTION
## Problem

Part of [FRM-2487](https://linear.app/ogp/issue/FRM-2487) — PRD: [FRM-2486](https://linear.app/ogp/issue/FRM-2486).

The Workflow Builder Redesign ships incrementally across many PRs. Every
change must sit behind a single GrowthBook flag so it can be built and merged
into `develop` without affecting the live builder, and rolled out by admin
email. This PR lays that foundation.

## Solution

**Improvements**:
- Register the GrowthBook boolean flag `workflow-builder-redesign` in
  `packages/shared/constants/feature-flags.ts`.
- Add a shared hook `useIsWorkflowBuilderRedesign()` in
  `apps/frontend/.../create/workflow/hooks/` — the single source of truth every
  redesign seam reads from, so the flag can be retired from one place at rollout.

No consumers yet; this is flag plumbing only. The beta badge and first visible
seam from FRM-2487 follow in a later PR.

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

Flag defaults to OFF, so the workflow builder is unchanged until enabled.

## Tests

- [ ] `pnpm build:frontend` passes (tsc + vite) — flag constant typed, hook compiles
- [ ] Flag OFF (default): `useIsWorkflowBuilderRedesign()` returns `false`, builder unchanged
- [ ] Flag ON (`window._growthbook.setForcedFeatures(new Map([['workflow-builder-redesign', true]]))`): hook returns `true`

## Deploy Notes

GrowthBook flag `workflow-builder-redesign` already created. No new env vars, scripts, or dependencies.
