### PR TITLE
feat(webhooks): show workflow-data callout on MRF webhook settings

### DIFF
--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
@@ -1,5 +1,5 @@
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
-import { Meta, StoryFn } from '@storybook/react'
+import { Decorator, Meta, StoryFn } from '@storybook/react'
 
 import { featureFlags } from 'formsg-shared/constants'
 import { FormResponseMode, FormSettings } from 'formsg-shared/types/form'
@@ -53,17 +53,27 @@ StorageModeEmpty.parameters = {
   },
 }
 
-const mrfCutoverOnGrowthBook = new GrowthBook({
-  features: { [featureFlags.mrfCutover]: { defaultValue: true } },
-})
+const withGrowthBookFeatures = (
+  features: Record<string, boolean>,
+): Decorator => {
+  const growthbook = new GrowthBook({
+    features: Object.fromEntries(
+      Object.entries(features).map(([flag, on]) => [
+        flag,
+        { defaultValue: on },
+      ]),
+    ),
+  })
+  return (Story) => (
+    <GrowthBookProvider growthbook={growthbook}>
+      <Story />
+    </GrowthBookProvider>
+  )
+}
 
 export const StorageModeMrfCutoverOn = Template.bind({})
 StorageModeMrfCutoverOn.decorators = [
-  (Story) => (
-    <GrowthBookProvider growthbook={mrfCutoverOnGrowthBook}>
-      <Story />
-    </GrowthBookProvider>
-  ),
+  withGrowthBookFeatures({ [featureFlags.mrfCutover]: true }),
 ]
 StorageModeMrfCutoverOn.parameters = {
   msw: {
@@ -94,17 +104,9 @@ StorageModeRetryEnabled.parameters = {
   },
 }
 
-const mrfWebhooksGrowthBook = new GrowthBook({
-  features: { [featureFlags.enableMrfWebhooks]: { defaultValue: true } },
-})
-
 export const MrfMode = Template.bind({})
 MrfMode.decorators = [
-  (Story) => (
-    <GrowthBookProvider growthbook={mrfWebhooksGrowthBook}>
-      <Story />
-    </GrowthBookProvider>
-  ),
+  withGrowthBookFeatures({ [featureFlags.enableMrfWebhooks]: true }),
 ]
 MrfMode.parameters = {
   msw: {
@@ -118,20 +120,12 @@ MrfMode.parameters = {
   },
 }
 
-const mrfWebhooksAndCutoverGrowthBook = new GrowthBook({
-  features: {
-    [featureFlags.enableMrfWebhooks]: { defaultValue: true },
-    [featureFlags.mrfCutover]: { defaultValue: true },
-  },
-})
-
 export const MrfModeMrfCutoverOn = Template.bind({})
 MrfModeMrfCutoverOn.decorators = [
-  (Story) => (
-    <GrowthBookProvider growthbook={mrfWebhooksAndCutoverGrowthBook}>
-      <Story />
-    </GrowthBookProvider>
-  ),
+  withGrowthBookFeatures({
+    [featureFlags.enableMrfWebhooks]: true,
+    [featureFlags.mrfCutover]: true,
+  }),
 ]
 MrfModeMrfCutoverOn.parameters = MrfMode.parameters
 

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.stories.tsx
@@ -94,6 +94,47 @@ StorageModeRetryEnabled.parameters = {
   },
 }
 
+const mrfWebhooksGrowthBook = new GrowthBook({
+  features: { [featureFlags.enableMrfWebhooks]: { defaultValue: true } },
+})
+
+export const MrfMode = Template.bind({})
+MrfMode.decorators = [
+  (Story) => (
+    <GrowthBookProvider growthbook={mrfWebhooksGrowthBook}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+MrfMode.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Multirespondent,
+        },
+      }),
+    },
+  },
+}
+
+const mrfWebhooksAndCutoverGrowthBook = new GrowthBook({
+  features: {
+    [featureFlags.enableMrfWebhooks]: { defaultValue: true },
+    [featureFlags.mrfCutover]: { defaultValue: true },
+  },
+})
+
+export const MrfModeMrfCutoverOn = Template.bind({})
+MrfModeMrfCutoverOn.decorators = [
+  (Story) => (
+    <GrowthBookProvider growthbook={mrfWebhooksAndCutoverGrowthBook}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+MrfModeMrfCutoverOn.parameters = MrfMode.parameters
+
 export const UnsupportedEmailMode = Template.bind({})
 
 export const UnsupportedMultirespondentMode = Template.bind({})

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.test.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.test.tsx
@@ -1,0 +1,43 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+
+import * as stories from './SettingsWebhooksPage.stories'
+
+const {
+  MrfMode,
+  MrfModeMrfCutoverOn,
+  StorageModeMrfCutoverOn,
+  StorageModeEmpty,
+} = composeStories(stories)
+
+const WORKFLOW_CALLOUT_TEXT = /will receive workflow data from step 2 onwards/i
+
+describe('SettingsWebhooksPage workflow callout visibility', () => {
+  it('hides the callout on an MRF form when mrf-cutover is off', async () => {
+    render(<MrfMode />)
+    await screen.findByText('Endpoint URL')
+
+    expect(screen.queryByText(WORKFLOW_CALLOUT_TEXT)).not.toBeInTheDocument()
+  })
+
+  it('hides the callout on a Storage form even when mrf-cutover is on', async () => {
+    render(<StorageModeMrfCutoverOn />)
+    await screen.findByText('Endpoint URL')
+
+    expect(screen.queryByText(WORKFLOW_CALLOUT_TEXT)).not.toBeInTheDocument()
+  })
+
+  it('shows the callout on an MRF form when mrf-cutover is on', async () => {
+    render(<MrfModeMrfCutoverOn />)
+    await screen.findByText('Endpoint URL')
+
+    expect(screen.getByText(WORKFLOW_CALLOUT_TEXT)).toBeInTheDocument()
+  })
+
+  it('hides the callout on a Storage form when mrf-cutover is off', async () => {
+    render(<StorageModeEmpty />)
+    await screen.findByText('Endpoint URL')
+
+    expect(screen.queryByText(WORKFLOW_CALLOUT_TEXT)).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsWebhooksPage.tsx
@@ -47,6 +47,10 @@ export const SettingsWebhooksPage = (): JSX.Element => {
     )
   }
 
+  const showWorkflowInfobox =
+    isMrfCutoverEnabled &&
+    settings?.responseMode === FormResponseMode.Multirespondent
+
   const showV1SchemaInfobox =
     isMrfCutoverEnabled &&
     settings?.responseMode === FormResponseMode.Encrypt &&
@@ -60,7 +64,7 @@ export const SettingsWebhooksPage = (): JSX.Element => {
       {showV1SchemaInfobox && (
         <WebhookV1SchemaInfobox formId={formId as FormId} />
       )}
-      <WebhooksSection />
+      <WebhooksSection showWorkflowInfobox={showWorkflowInfobox} />
     </Skeleton>
   )
 }

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookWorkflowInfobox.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookWorkflowInfobox.stories.tsx
@@ -1,0 +1,12 @@
+import { Meta, StoryFn } from '@storybook/react'
+
+import { WebhookWorkflowInfobox } from './WebhookWorkflowInfobox'
+
+export default {
+  title: 'Features/AdminForm/Settings/WebhookWorkflowInfobox',
+  component: WebhookWorkflowInfobox,
+} as Meta
+
+const Template: StoryFn = () => <WebhookWorkflowInfobox />
+
+export const Default = Template.bind({})

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookWorkflowInfobox.test.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookWorkflowInfobox.test.tsx
@@ -1,0 +1,38 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+
+import { MRF_CUTOVER_FAQ_LINK } from 'formsg-shared/constants/links'
+
+import { OGP_PLUMBER } from '~constants/links'
+
+import * as stories from './WebhookWorkflowInfobox.stories'
+
+const { Default } = composeStories(stories)
+
+describe('WebhookWorkflowInfobox', () => {
+  it('renders the workflow-data heads-up message', () => {
+    render(<Default />)
+
+    expect(
+      screen.getByText(/will receive workflow data from step 2 onwards/i),
+    ).toBeInTheDocument()
+  })
+
+  it('links "Plumber" to plumber.gov.sg', () => {
+    render(<Default />)
+
+    expect(screen.getByRole('link', { name: 'Plumber' })).toHaveAttribute(
+      'href',
+      OGP_PLUMBER,
+    )
+  })
+
+  it('links "Learn more" to the simplified-modes FAQ', () => {
+    render(<Default />)
+
+    expect(screen.getByRole('link', { name: /learn more/i })).toHaveAttribute(
+      'href',
+      MRF_CUTOVER_FAQ_LINK,
+    )
+  })
+})

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookWorkflowInfobox.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhookWorkflowInfobox.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next'
+
+import { MRF_CUTOVER_FAQ_LINK } from 'formsg-shared/constants/links'
+
+import { OGP_PLUMBER } from '~constants/links'
+import InlineMessage from '~components/InlineMessage'
+
+export const WebhookWorkflowInfobox = (): JSX.Element => {
+  const { t } = useTranslation()
+
+  return (
+    <InlineMessage variant="info" useMarkdown mb="1rem">
+      {t('features.adminForm.settings.webhooks.workflowInfobox', {
+        plumberUrl: OGP_PLUMBER,
+        learnMoreUrl: MRF_CUTOVER_FAQ_LINK,
+      })}
+    </InlineMessage>
+  )
+}

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksSection.tsx
@@ -2,10 +2,12 @@ import { Stack } from '@chakra-ui/react'
 
 import { RetryToggle } from './RetryToggle'
 import { WebhookUrlInput } from './WebhookUrlInput'
+import { WebhookWorkflowInfobox } from './WebhookWorkflowInfobox'
 
 export const WebhooksSection = (): JSX.Element => {
   return (
     <Stack mt="2.5rem" spacing="2.5rem">
+      <WebhookWorkflowInfobox />
       <WebhookUrlInput />
       <RetryToggle />
     </Stack>

--- a/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/WebhooksSection/WebhooksSection.tsx
@@ -4,10 +4,16 @@ import { RetryToggle } from './RetryToggle'
 import { WebhookUrlInput } from './WebhookUrlInput'
 import { WebhookWorkflowInfobox } from './WebhookWorkflowInfobox'
 
-export const WebhooksSection = (): JSX.Element => {
+interface WebhooksSectionProps {
+  showWorkflowInfobox: boolean
+}
+
+export const WebhooksSection = ({
+  showWorkflowInfobox,
+}: WebhooksSectionProps): JSX.Element => {
   return (
     <Stack mt="2.5rem" spacing="2.5rem">
-      <WebhookWorkflowInfobox />
+      {showWorkflowInfobox && <WebhookWorkflowInfobox />}
       <WebhookUrlInput />
       <RetryToggle />
     </Stack>

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/webhooks/en-sg.ts
@@ -9,4 +9,5 @@ export const enSG = {
     label: 'Enable retries',
     description: `Your system must meet certain requirements before retries can be safely enabled. [Learn more]({url})`,
   },
+  workflowInfobox: `If your form has workflow steps, only [Plumber]({plumberUrl}) will receive workflow data from step 2 onwards. [Learn more]({learnMoreUrl})`,
 }

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/webhooks/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/webhooks/index.ts
@@ -11,4 +11,5 @@ export interface Webhooks extends HasTitle {
     label: string
     description: string
   }
+  workflowInfobox: string
 }

--- a/packages/shared/constants/links.ts
+++ b/packages/shared/constants/links.ts
@@ -15,3 +15,6 @@ export const KILL_EMAIL_MODE_LINK =
 
 export const STATUS_TRACKER_PREVIEW_LINK =
   'https://go.gov.sg/mrf-preview-status-tracking'
+
+export const MRF_CUTOVER_FAQ_LINK =
+  'https://go.gov.sg/formsg-guide-faq-simplified-modes'


### PR DESCRIPTION
## Problem

After the MRF cutover, every new form is an MRF and admins can connect a webhook — but a generic (non-Plumber) webhook does not receive the multi-step Workflow the way Plumber does. Admins have no way to know this at the moment they configure a webhook, so they may wire up the wrong integration and be surprised when workflow data doesn't arrive downstream.

## Solution

Adds an always-on informational callout at the top of the webhook settings, above the endpoint URL field, telling admins that if their form has workflow steps, only [Plumber](https://plumber.gov.sg/) will receive workflow data from step 2 onwards, with a "Learn more" link to the simplified-modes FAQ. The callout is a neutral heads-up, not an error, and shows regardless of whether a workflow is configured yet or whether the entered URL is a Plumber link.

Visibility is gated at the page: the callout renders only when the `mrf-cutover` feature flag is on **and** the form is an MRF (Multirespondent). `SettingsWebhooksPage` computes the decision (it already reads the flag and response mode, next to the sibling `WebhookV1SchemaInfobox` gate) and passes a single boolean into `WebhooksSection`, which stays a dumb layout component.

> **Release note:** the copy describes behaviour the backend does not yet do — today every webhook receives the full payload on every step. Do not flip `mrf-cutover` for real admins until eng's webhook change lands and matches the copy.

**Alternatives considered**

- We considered inlining the `InlineMessage` directly in `WebhooksSection` (as the original issue literally says), but rendered it as its own `WebhookWorkflowInfobox` component instead. The section's other children (`WebhookUrlInput`, `RetryToggle`) call `useAdminFormSettings`, so testing the static callout through the section would drag in react-query/MSW plumbing for no benefit. The standalone component tests in isolation and mirrors the existing `WebhookV1SchemaInfobox` in the same directory.
- For the gate tests, we considered testing `WebhooksSection` directly with the boolean prop, but the gate logic under test lives in `SettingsWebhooksPage` — a section-level test would not catch a page regression (e.g. dropping the responseMode condition). The two MRF quadrant stories also turn on `enable-mrf-webhooks`, because without it an MRF form renders `WebhooksUnsupportedMsg` instead of the webhook section and the "hidden" assertions would pass vacuously; the tests anchor on the "Endpoint URL" label first to prove the section actually rendered.
- No Figma/design source was supplied (only the copy), so the visual gate was skipped. The callout reuses the shared `InlineMessage` (`variant="info"`, `useMarkdown`) exactly as the neighbouring `WebhookV1SchemaInfobox` does, so it is visually consistent with existing settings infoboxes by construction; Chromatic picks it up via the new page stories.

**Screenshots**

Captured from the new page stories on this branch — "before" is the `mrf-cutover` flag off, "after" is the flag on (a develop checkout has no MRF webhook stories to capture).

| Page | Before (`mrf-cutover` off) | After (`mrf-cutover` on) |
| --- | --- | --- |
| Settings → Webhooks (MRF form) | ![before](https://raw.githubusercontent.com/yin-boop/FormSG/screenshots/.github/screenshots/webhooks-infobox/before-webhook-settings.png) | ![after](https://raw.githubusercontent.com/yin-boop/FormSG/screenshots/.github/screenshots/webhooks-infobox/after-webhook-settings.png) |

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: Callout shows on an MRF form with `mrf-cutover` on**

- [ ] Enable the `mrf-cutover` and `enable-mrf-webhooks` GrowthBook flags for your admin
- [ ] Open Settings → Webhooks on a Multirespondent form
- [ ] An info (not error) callout appears above the Endpoint URL field
- [ ] "Plumber" opens https://plumber.gov.sg/ and "Learn more" opens https://go.gov.sg/formsg-guide-faq-simplified-modes

**TC2: Callout hidden when the flag is off or the form is Storage mode**

- [ ] With `mrf-cutover` off, open Settings → Webhooks on the same MRF form — no callout
- [ ] With `mrf-cutover` on, open Settings → Webhooks on a Storage-mode form — no callout

**TC3: Callout is unconditional on workflow/URL**

- [ ] On the gated MRF form, confirm the callout shows before any workflow steps exist and does not change when a Plumber URL is entered
