### PR TITLE
feat(workflow-builder-redesign): copy changes across workflow builder

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
@@ -9,11 +9,13 @@ import {
   setToCreatingSelector,
   useAdminWorkflowStore,
 } from '../adminWorkflowStore'
+import { useIsWorkflowBuilderRedesign } from '../hooks/useIsWorkflowBuilderRedesign'
 
 import { WorkflowSvgr } from './WorkflowSvgr'
 
 export const EmptyWorkflow = (): JSX.Element => {
   const setToCreating = useAdminWorkflowStore(setToCreatingSelector)
+  const isRedesign = useIsWorkflowBuilderRedesign()
 
   return (
     <Flex
@@ -24,12 +26,14 @@ export const EmptyWorkflow = (): JSX.Element => {
       pt={{ base: '0.5rem', md: '2.75rem' }}
     >
       <Text textStyle="h2" as="h2">
-        Create a workflow to collect responses from multiple respondents in the
-        same form submission
+        {isRedesign
+          ? 'Create a workflow to collect responses from multiple people in the same form submission'
+          : 'Create a workflow to collect responses from multiple respondents in the same form submission'}
       </Text>
       <Text textStyle="body-1" mt="1rem">
-        Assign respondents to specific steps, and control which fields they can
-        fill.{' '}
+        {isRedesign
+          ? 'Assign people to specific steps, and control which fields they can fill in.'
+          : 'Assign respondents to specific steps, and control which fields they can fill.'}{' '}
         <Link isExternal href={GUIDE_FORM_MRF}>
           Learn how to create a workflow
         </Link>

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/ApprovalsBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/ApprovalsBlock.tsx
@@ -11,6 +11,7 @@ import Toggle from '~components/Toggle'
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 
 import { useAdminFormWorkflow } from '../../../hooks/useAdminFormWorkflow'
+import { useIsWorkflowBuilderRedesign } from '../../../hooks/useIsWorkflowBuilderRedesign'
 import { EditStepInputs } from '../../../types'
 
 import { FIELDS_TO_EDIT_NAME } from './EditStepBlock'
@@ -27,6 +28,7 @@ export const ApprovalsBlock = ({
   stepNumber,
 }: ApprovalsBlockProps): JSX.Element => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   const {
     control,
     setValue,
@@ -94,7 +96,9 @@ export const ApprovalsBlock = ({
         labelStyles={textStyles.h4}
         label={t('features.adminForm.sidebar.workflow.approvals.toggle.label')}
         description={t(
-          'features.adminForm.sidebar.workflow.approvals.toggle.description',
+          isRedesign
+            ? 'features.adminForm.sidebar.workflow.approvals.toggle.descriptionRedesign'
+            : 'features.adminForm.sidebar.workflow.approvals.toggle.description',
         )}
         tooltipText={t(
           'features.adminForm.sidebar.workflow.approvals.toggle.tooltip',
@@ -111,7 +115,9 @@ export const ApprovalsBlock = ({
               validate: (value) => {
                 if (!value && isApprovalToggleChecked) {
                   return t(
-                    'features.adminForm.sidebar.workflow.approvals.validation.noField',
+                    isRedesign
+                      ? 'features.adminForm.sidebar.workflow.approvals.validation.noFieldRedesign'
+                      : 'features.adminForm.sidebar.workflow.approvals.validation.noField',
                   )
                 }
                 if (value && approvalFieldsFromOtherSteps.includes(value)) {
@@ -121,7 +127,9 @@ export const ApprovalsBlock = ({
                 }
                 if (value && !selectedEditFields.includes(value)) {
                   return t(
-                    'features.adminForm.sidebar.workflow.approvals.validation.fieldNotAssignedToUser',
+                    isRedesign
+                      ? 'features.adminForm.sidebar.workflow.approvals.validation.fieldNotAssignedToUserRedesign'
+                      : 'features.adminForm.sidebar.workflow.approvals.validation.fieldNotAssignedToUser',
                   )
                 }
               },

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
@@ -13,6 +13,7 @@ import { EditStepInputs } from '~features/admin-form/create/workflow/types'
 import { NON_RESPONSE_FIELD_SET } from '~features/form/constants'
 
 import { useAdminFormWorkflow } from '../../../hooks/useAdminFormWorkflow'
+import { useIsWorkflowBuilderRedesign } from '../../../hooks/useIsWorkflowBuilderRedesign'
 
 import { FIELDS_TO_EDIT_NAME } from './EditStepBlock'
 import { EditStepBlockContainer } from './EditStepBlockContainer'
@@ -29,6 +30,7 @@ export const QuestionsBlock = ({
   isFirstStep,
 }: QuestionsBlockProps): JSX.Element => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   const { formFields = [], idToFieldMap } = useAdminFormWorkflow()
   const {
     formState: { errors },
@@ -69,10 +71,16 @@ export const QuestionsBlock = ({
           tooltipVariant="info"
           tooltipPlacement="top"
           tooltipText={t(
-            'features.adminForm.sidebar.workflow.questions.tooltip',
+            isRedesign
+              ? 'features.adminForm.sidebar.workflow.questions.tooltipRedesign'
+              : 'features.adminForm.sidebar.workflow.questions.tooltip',
           )}
         >
-          {t('features.adminForm.sidebar.workflow.questions.label')}
+          {t(
+            isRedesign
+              ? 'features.adminForm.sidebar.workflow.questions.labelRedesign'
+              : 'features.adminForm.sidebar.workflow.questions.label',
+          )}
         </FormLabel>
         <Controller
           control={control}
@@ -81,7 +89,9 @@ export const QuestionsBlock = ({
             <MultiSelect
               isDisabled={isLoading}
               placeholder={t(
-                'features.adminForm.sidebar.workflow.questions.placeholder',
+                isRedesign
+                  ? 'features.adminForm.sidebar.workflow.questions.placeholderRedesign'
+                  : 'features.adminForm.sidebar.workflow.questions.placeholder',
               )}
               items={items}
               isSelectedItemFullWidth

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/ConditionalRoutingOption.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/ConditionalRoutingOption.tsx
@@ -31,6 +31,8 @@ import { useEditFormField } from '~features/admin-form/create/builder-and-design
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { FormFieldWithQuestionNo } from '~features/form/types'
 
+import { useIsWorkflowBuilderRedesign } from '../../../../../hooks/useIsWorkflowBuilderRedesign'
+
 import { ConditionalRoutingMappingDeleteModal } from './ConditionalRoutingMappingDeleteModal'
 import { ConditionalRoutingOptionModal } from './ConditionalRoutingOptionModal'
 import { useWorkflowTypeValidation } from './hooks'
@@ -354,6 +356,7 @@ export const ConditionalRoutingOption = ({
   }
 
   const workflowTypeValidation = useWorkflowTypeValidation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
 
   const handleOpenModal = () => {
     conditionalRoutingConfigSetValue('csvFile', null)
@@ -435,7 +438,9 @@ export const ConditionalRoutingOption = ({
                         ({ value: fieldValue }) => fieldValue === selectedValue,
                       ) ||
                       t(
-                        'features.adminForm.sidebar.workflow.conditionalRouting.validation.notDropdown',
+                        isRedesign
+                          ? 'features.adminForm.sidebar.workflow.conditionalRouting.validation.notDropdownRedesign'
+                          : 'features.adminForm.sidebar.workflow.conditionalRouting.validation.notDropdown',
                       )
                     )
                   },
@@ -478,7 +483,9 @@ export const ConditionalRoutingOption = ({
                     isDisabled={!isSelectedConditionalFieldFound}
                   >
                     {t(
-                      'features.adminForm.sidebar.workflow.conditionalRouting.addEmailsToOptions',
+                      isRedesign
+                        ? 'features.adminForm.sidebar.workflow.conditionalRouting.addEmailsToOptionsRedesign'
+                        : 'features.adminForm.sidebar.workflow.conditionalRouting.addEmailsToOptions',
                     )}
                   </Button>
                 )

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/ConditionalRoutingOptionModal.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/ConditionalRoutingOptionModal.tsx
@@ -25,6 +25,8 @@ import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import { ModalCloseButton } from '~components/Modal'
 import { ProgressIndicator } from '~components/ProgressIndicator/ProgressIndicator'
 
+import { useIsWorkflowBuilderRedesign } from '../../../../../hooks/useIsWorkflowBuilderRedesign'
+
 import carouselImage1 from './carouselImages/image-carousel-1.png'
 import carouselImage2 from './carouselImages/image-carousel-2.png'
 import carouselImage3 from './carouselImages/image-carousel-3.png'
@@ -54,6 +56,7 @@ const StepOneModalContent = ({
   onClose,
 }: StepOneModalContentProps) => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
 
   //carousel image variables
   const carouselImages = [
@@ -87,7 +90,9 @@ const StepOneModalContent = ({
       <ModalHeader>
         <Text mb="0.25rem">
           {t(
-            'features.adminForm.sidebar.workflow.conditionalRouting.modals.addMapping.step1.title',
+            isRedesign
+              ? 'features.adminForm.sidebar.workflow.conditionalRouting.modals.addMapping.step1.titleRedesign'
+              : 'features.adminForm.sidebar.workflow.conditionalRouting.modals.addMapping.step1.title',
           )}
         </Text>
         <ProgressIndicator

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/DynamicRespondentOption.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/DynamicRespondentOption.tsx
@@ -8,6 +8,8 @@ import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Radio from '~components/Radio'
 
+import { useIsWorkflowBuilderRedesign } from '../../../../../hooks/useIsWorkflowBuilderRedesign'
+
 import { useWorkflowTypeValidation } from './hooks'
 import { FieldItem, RespondentOptionProps } from './types'
 
@@ -29,6 +31,7 @@ export const DynamicRespondentOption = ({
   } = formMethods
 
   const workflowTypeValidation = useWorkflowTypeValidation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   return (
     <>
       <Radio
@@ -70,7 +73,9 @@ export const DynamicRespondentOption = ({
                       ({ value: fieldValue }) => fieldValue === selectedValue,
                     ) ||
                     t(
-                      'features.adminForm.sidebar.workflow.dynamicRespondent.mustBeEmail',
+                      isRedesign
+                        ? 'features.adminForm.sidebar.workflow.dynamicRespondent.mustBeEmailRedesign'
+                        : 'features.adminForm.sidebar.workflow.dynamicRespondent.mustBeEmail',
                     )
                   )
                 },

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/StaticRespondentOption.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/StaticRespondentOption.tsx
@@ -9,6 +9,8 @@ import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Radio from '~components/Radio'
 import { TagInput } from '~components/TagInput'
 
+import { useIsWorkflowBuilderRedesign } from '../../../../../hooks/useIsWorkflowBuilderRedesign'
+
 import { useWorkflowTypeValidation } from './hooks'
 import { RespondentOptionProps } from './types'
 
@@ -25,6 +27,7 @@ export const StaticRespondentOption = ({
   const staticTagInputErrorMessage = get(errors, 'emails.message')
 
   const workflowTypeValidation = useWorkflowTypeValidation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   return (
     <>
       <Radio
@@ -40,7 +43,7 @@ export const StaticRespondentOption = ({
           },
         }}
       >
-        <Text>Specific email(s)</Text>
+        <Text>{isRedesign ? 'Specific emails' : 'Specific email(s)'}</Text>
         {selectedWorkflowType === WorkflowType.Static ? (
           <FormControl
             pt="0.5rem"
@@ -62,7 +65,9 @@ export const StaticRespondentOption = ({
                   isEmails: (emails) =>
                     !emails ||
                     emails.every((email) => isEmail(email)) ||
-                    'Please enter valid email(s) (e.g. me@example.com) separated by commas, as invalid emails will not be saved',
+                    (isRedesign
+                      ? "Enter valid emails separated by commas, like me@example.com. Invalid emails won't be saved."
+                      : 'Please enter valid email(s) (e.g. me@example.com) separated by commas, as invalid emails will not be saved'),
                 },
               }}
               render={({ field }) => (

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/hooks.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/hooks.ts
@@ -2,16 +2,23 @@ import { useTranslation } from 'react-i18next'
 
 import { WorkflowType } from 'formsg-shared/types/form/workflow'
 
+import { useIsWorkflowBuilderRedesign } from '../../../../../hooks/useIsWorkflowBuilderRedesign'
+
 export const useWorkflowTypeValidation = () => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   return {
     required: t(
-      'features.adminForm.sidebar.workflow.conditionalRouting.errors.respondentType.required',
+      isRedesign
+        ? 'features.adminForm.sidebar.workflow.conditionalRouting.errors.respondentType.requiredRedesign'
+        : 'features.adminForm.sidebar.workflow.conditionalRouting.errors.respondentType.required',
     ),
     validate: (value: WorkflowType) => {
       if (!Object.values(WorkflowType).includes(value)) {
         return t(
-          'features.adminForm.sidebar.workflow.conditionalRouting.errors.respondentType.invalid',
+          isRedesign
+            ? 'features.adminForm.sidebar.workflow.conditionalRouting.errors.respondentType.invalidRedesign'
+            : 'features.adminForm.sidebar.workflow.conditionalRouting.errors.respondentType.invalid',
         )
       }
     },

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/RespondentBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/RespondentBlock.tsx
@@ -13,6 +13,7 @@ import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants
 import { EditStepInputs } from '~features/admin-form/create/workflow/types'
 
 import { useAdminFormWorkflow } from '../../../../hooks/useAdminFormWorkflow'
+import { useIsWorkflowBuilderRedesign } from '../../../../hooks/useIsWorkflowBuilderRedesign'
 import { isFirstStepByStepNumber } from '../../utils/isFirstStepByStepNumber'
 import { EditStepBlockContainer } from '../EditStepBlockContainer'
 
@@ -40,6 +41,7 @@ export const RespondentBlock = ({
 
   const { emailFormFields = [], dropdownFormFields = [] } =
     useAdminFormWorkflow()
+  const isRedesign = useIsWorkflowBuilderRedesign()
 
   const emailFieldItems = emailFormFields.map(
     ({ _id, questionNumber, title, fieldType }) => ({
@@ -59,11 +61,17 @@ export const RespondentBlock = ({
         <Stack spacing="0.5rem">
           <Text style={textStyles.h4}>
             {t(
-              'features.adminForm.sidebar.workflow.respondentBlock.stepRespondent',
+              isRedesign
+                ? 'features.adminForm.sidebar.workflow.respondentBlock.stepRespondentRedesign'
+                : 'features.adminForm.sidebar.workflow.respondentBlock.stepRespondent',
             )}
           </Text>
           <Text>
-            {t('features.adminForm.sidebar.workflow.respondentBlock.anyone')}
+            {t(
+              isRedesign
+                ? 'features.adminForm.sidebar.workflow.respondentBlock.anyoneRedesign'
+                : 'features.adminForm.sidebar.workflow.respondentBlock.anyone',
+            )}
           </Text>
         </Stack>
       ) : (
@@ -73,7 +81,11 @@ export const RespondentBlock = ({
           isInvalid={!!errors.workflow_type}
         >
           <FormLabel style={textStyles.h4}>
-            {t('features.adminForm.sidebar.workflow.respondentBlock.select')}
+            {t(
+              isRedesign
+                ? 'features.adminForm.sidebar.workflow.respondentBlock.selectRedesign'
+                : 'features.adminForm.sidebar.workflow.respondentBlock.select',
+            )}
           </FormLabel>
           <Stack spacing="0.25rem">
             <Radio.RadioGroup value={selectedWorkflowType}>

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveStepBlock/InactiveStepBlock.tsx
@@ -20,6 +20,7 @@ import {
   useAdminWorkflowStore,
 } from '../../../adminWorkflowStore'
 import { useAdminFormWorkflow } from '../../../hooks/useAdminFormWorkflow'
+import { useIsWorkflowBuilderRedesign } from '../../../hooks/useIsWorkflowBuilderRedesign'
 import { StepLabel } from '../StepLabel'
 import { isFirstStepByStepNumber } from '../utils/isFirstStepByStepNumber'
 
@@ -100,6 +101,7 @@ export const InactiveStepBlock = ({
   step,
 }: InactiveStepBlockProps): JSX.Element | null => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   const { idToFieldMap } = useAdminFormWorkflow()
   const setToEditing = useAdminWorkflowStore(setToEditingSelector)
   const stateData = useAdminWorkflowStore(createOrEditDataSelector)
@@ -176,13 +178,17 @@ export const InactiveStepBlock = ({
           <Stack>
             <Text textStyle="subhead-3">
               {t(
-                'features.adminForm.sidebar.workflow.respondentBlock.stepRespondent',
+                isRedesign
+                  ? 'features.adminForm.sidebar.workflow.respondentBlock.stepRespondentRedesign'
+                  : 'features.adminForm.sidebar.workflow.respondentBlock.stepRespondent',
               )}
             </Text>
             {isFirstStep ? (
               <Text>
                 {t(
-                  'features.adminForm.sidebar.workflow.respondentBlock.anyone',
+                  isRedesign
+                    ? 'features.adminForm.sidebar.workflow.respondentBlock.anyoneRedesign'
+                    : 'features.adminForm.sidebar.workflow.respondentBlock.anyone',
                 )}
               </Text>
             ) : (

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowCompletionMessageBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowCompletionMessageBlock.tsx
@@ -4,16 +4,19 @@ import { Link, Text } from '@chakra-ui/react'
 
 import InlineMessage from '~components/InlineMessage'
 
+import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
+
 export const WorkflowCompletionMessageBlock = (): JSX.Element => {
   const { t } = useTranslation()
-  const { prefix, link, suffix } = t(
+  const isRedesign = useIsWorkflowBuilderRedesign()
+  const { prefix, prefixRedesign, link, suffix } = t(
     'features.adminForm.sidebar.workflow.approvals.complete',
     { returnObjects: true },
   )
   return (
     <InlineMessage variant="info">
       <Text>
-        {prefix}{' '}
+        {isRedesign ? prefixRedesign : prefix}{' '}
         <Link as={ReactLink} to={'settings/email-notifications'}>
           {link}
         </Link>

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign.ts
@@ -1,0 +1,11 @@
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+/**
+ * Single source of truth for reading the `workflow-builder-redesign` GrowthBook
+ * flag. Every workflow builder redesign seam should gate on this hook so the
+ * flag can be retired from one place once the redesign fully rolls out.
+ */
+export const useIsWorkflowBuilderRedesign = (): boolean =>
+  useFeatureIsOn(featureFlags.workflowBuilderRedesign)

--- a/apps/frontend/src/features/admin-form/settings/components/EmailNotificationsSection/RespondentCopyToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/EmailNotificationsSection/RespondentCopyToggle.tsx
@@ -5,11 +5,14 @@ import { Skeleton } from '@chakra-ui/react'
 import Badge from '~components/Badge'
 import Toggle from '~components/Toggle'
 
+import { useIsWorkflowBuilderRedesign } from '~features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign'
+
 import { useMutateFormSettings } from '../../mutations'
 import { useAdminFormSettings } from '../../queries'
 
 export const RespondentCopyToggle = (): JSX.Element => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
 
@@ -36,7 +39,9 @@ export const RespondentCopyToggle = (): JSX.Element => {
         isLoading={mutateFormRespondentCopy.isLoading}
         isChecked={hasRespondentCopy}
         label={t(
-          'features.adminForm.settings.emailNotifications.section.regular.info',
+          isRedesign
+            ? 'features.adminForm.settings.emailNotifications.section.regular.infoRedesign'
+            : 'features.adminForm.settings.emailNotifications.section.regular.info',
         )}
         onChange={() => handleToggleRespondentCopy()}
       />

--- a/apps/frontend/src/features/admin-form/settings/components/EmailNotificationsSection/StatusTrackerToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/EmailNotificationsSection/StatusTrackerToggle.tsx
@@ -8,11 +8,14 @@ import { MultirespondentFormSettings } from 'formsg-shared/types'
 
 import Toggle from '~components/Toggle'
 
+import { useIsWorkflowBuilderRedesign } from '~features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign'
+
 import { useMutateFormSettings } from '../../mutations'
 import { useAdminFormSettings } from '../../queries'
 
 export const StatusTrackerToggle = (): JSX.Element => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings<MultirespondentFormSettings>()
 
@@ -24,6 +27,20 @@ export const StatusTrackerToggle = (): JSX.Element => {
   const { mutateMrfStatusTracker } = useMutateFormSettings()
 
   const ToggleDescription = () => {
+    if (isRedesign) {
+      return (
+        <Text textStyle="body-2" color="secondary.400">
+          <Link target="_blank" href={STATUS_TRACKER_PREVIEW_LINK}>
+            {t(
+              'features.adminForm.settings.emailNotifications.section.regular.statusTrackerDescriptionRedesign',
+            )}
+          </Link>{' '}
+          <Link target="_blank" href={STATUS_TRACKER_PREVIEW_LINK}>
+            <Icon as={BiLinkExternal} verticalAlign="middle" />
+          </Link>
+        </Text>
+      )
+    }
     return (
       <Text textStyle="body-2" color="secondary.400">
         {t(
@@ -52,7 +69,9 @@ export const StatusTrackerToggle = (): JSX.Element => {
         isLoading={mutateMrfStatusTracker.isLoading}
         isChecked={hasStatusTracker}
         label={t(
-          'features.adminForm.settings.emailNotifications.section.regular.statusTrackerInfo',
+          isRedesign
+            ? 'features.adminForm.settings.emailNotifications.section.regular.statusTrackerInfoRedesign'
+            : 'features.adminForm.settings.emailNotifications.section.regular.statusTrackerInfo',
         )}
         onChange={() => handleToggleStatusTracker()}
       />

--- a/apps/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormEmailSection.tsx
@@ -25,6 +25,7 @@ import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import FormLabel from '~components/FormControl/FormLabel'
 import { TagInput } from '~components/TagInput'
 
+import { useIsWorkflowBuilderRedesign } from '~features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign'
 import { useUser } from '~features/user/queries'
 
 import { useMutateFormSettings } from '../mutations'
@@ -104,6 +105,7 @@ export const FormEmailSection = ({
   isHighContrast = true,
 }: EmailFormSectionProps): JSX.Element => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   const initialEmailSet = useMemo(
     () => new Set(settings.emails),
     [settings.emails],
@@ -160,7 +162,9 @@ export const FormEmailSection = ({
               opacity="1"
             >
               {t(
-                'features.adminForm.settings.emailNotifications.section.regular.description',
+                isRedesign
+                  ? 'features.adminForm.settings.emailNotifications.section.regular.descriptionRedesign'
+                  : 'features.adminForm.settings.emailNotifications.section.regular.description',
               )}
             </FormLabel.Description>
           ) : null}

--- a/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -20,6 +20,7 @@ import { TagInput } from '~components/TagInput'
 
 import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { useAdminFormWorkflow } from '~features/admin-form/create/workflow/hooks/useAdminFormWorkflow'
+import { useIsWorkflowBuilderRedesign } from '~features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign'
 import { useUser } from '~features/user/queries'
 
 import { useMutateFormSettings } from '../mutations'
@@ -49,6 +50,7 @@ const MrfEmailNotificationsForm = ({
   isHighContrast,
 }: MrfEmailNotificationsFormProps) => {
   const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
   const {
     isLoading,
     formWorkflow,
@@ -211,7 +213,9 @@ const MrfEmailNotificationsForm = ({
           {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
             <FormLabel.Description color="secondary.400" mt="0.5rem">
               {t(
-                'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
+                isRedesign
+                  ? 'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.descriptionRedesign'
+                  : 'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
               )}
             </FormLabel.Description>
           ) : (
@@ -257,7 +261,9 @@ const MrfEmailNotificationsForm = ({
           <Box my="1.5rem">
             <FormLabel mb="0.75rem" textColor="secondary.700">
               {t(
-                'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
+                isRedesign
+                  ? 'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overallRedesign'
+                  : 'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
               )}
             </FormLabel>
             <Skeleton isLoaded={!isLoading}>

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/en-sg.ts
@@ -21,10 +21,12 @@ export const enSG = {
           tooltipText:
             "Include the admin's email to notify them whenever a response is submitted",
           description: 'Separate multiple email addresses with a comma',
+          descriptionRedesign: 'Separate multiple emails with a comma',
         },
         stepN: {
           label: {
             overall: 'People who are filling up a workflow step',
+            overallRedesign: 'People who fill in a workflow step',
             each: 'People in Step {stepNumber}',
           },
           placeholder: 'Select steps from your form',
@@ -34,9 +36,14 @@ export const enSG = {
     regular: {
       label: 'Notifications for new responses',
       info: 'Allow respondents to receive a copy of their submission',
+      infoRedesign: 'Allow people to receive a copy of their submission',
       description: 'Separate multiple email addresses with a comma',
+      descriptionRedesign: 'Separate multiple emails with a comma',
       statusTrackerInfo: 'Allow respondents to track their submission status',
+      statusTrackerInfoRedesign:
+        'Allow people to track their submission status',
       statusTrackerDescription: 'View a sample status tracking link',
+      statusTrackerDescriptionRedesign: 'See a sample status tracking page',
     },
   },
 }

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/email-notifications/index.ts
@@ -19,6 +19,7 @@ export interface EmailNotifications extends HasTitle {
         stepN: {
           label: {
             overall: string
+            overallRedesign: string
             each: string
           }
           placeholder: string
@@ -26,6 +27,7 @@ export interface EmailNotifications extends HasTitle {
         others: {
           label: string
           description: string
+          descriptionRedesign: string
           tooltipText: string
         }
       }
@@ -33,9 +35,13 @@ export interface EmailNotifications extends HasTitle {
     regular: {
       label: string
       info: string
+      infoRedesign: string
       description: string
+      descriptionRedesign: string
       statusTrackerInfo: string
+      statusTrackerInfoRedesign: string
       statusTrackerDescription: string
+      statusTrackerDescriptionRedesign: string
     }
   }
 }

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -12,8 +12,11 @@ export const enSG: Workflow = {
   title: 'Add workflow',
   respondentBlock: {
     stepRespondent: 'Respondent in this step',
+    stepRespondentRedesign: 'Who fills in this step?',
     anyone: 'Anyone who has access to your form',
+    anyoneRedesign: 'Anyone with your form link can fill in Step 1.',
     select: 'Select a respondent',
+    selectRedesign: 'Who fills in this step?',
     fieldsToFill: 'Fields to fill',
     clickToEdit: 'Click to edit',
   },
@@ -21,14 +24,17 @@ export const enSG: Workflow = {
     title: 'An email field from the form',
     required: 'Please select a field.',
     mustBeEmail: 'Field is not an email field',
+    mustBeEmailRedesign: 'Choose an email field.',
     select: 'Select a field',
   },
   conditionalRouting: {
     title: 'Emails assigned to options in a dropdown field',
     addEmailsToOptions: 'Add emails to options',
+    addEmailsToOptionsRedesign: 'Assign emails to options',
     validation: {
       noField: 'Please select a field.',
       notDropdown: 'Field is not an dropdown field',
+      notDropdownRedesign: 'Choose a dropdown field.',
     },
     modals: {
       deleteStep: {
@@ -48,6 +54,7 @@ export const enSG: Workflow = {
       addMapping: {
         step1: {
           title: 'Add emails to options',
+          titleRedesign: 'Assign emails to options',
           download: {
             templateCreated:
               'We have created a CSV template with the options from the field you selected.',
@@ -105,7 +112,9 @@ export const enSG: Workflow = {
     errors: {
       respondentType: {
         required: 'Please select a respondent type',
+        requiredRedesign: 'Please choose who fills in this step',
         invalid: 'The selected respondent type is invalid',
+        invalidRedesign: 'The selected option is invalid',
       },
       csv: {
         required: 'Please upload a CSV file',
@@ -122,8 +131,11 @@ export const enSG: Workflow = {
   questions: {
     tooltip:
       'Respondent will only be able to fill the fields you have selected',
+    tooltipRedesign: 'This person can only fill in the fields you select.',
     label: 'Select field(s) for this respondent to fill',
+    labelRedesign: 'Choose the fields this person fills in',
     placeholder: 'Select field(s) from your form',
+    placeholderRedesign: 'Select fields from your form',
   },
   approvals: {
     title: 'Approvals',
@@ -134,21 +146,28 @@ export const enSG: Workflow = {
       label: 'Make this step an approval',
       description:
         'If respondent selects Yes, the form is Approved and continues to the next step. If they select No, the form is Not approved and stops at this step.',
+      descriptionRedesign:
+        'If this person selects Yes, the form is Approved and continues to the next step. If they select No, the form is Not approved and stops at this step.',
       tooltip:
         'Use this for steps that involve any type of decision, such as reviews or endorsements. Decision will be shown on dashboard and tracking links.',
       placeholder: 'Select a Yes/No field from your form',
     },
     validation: {
       noField: 'Please select a Yes/No field',
+      noFieldRedesign: 'Select a Yes/No field.',
       fieldAlreadyUsed:
         'The selected field has been assigned to another step. Please choose a different field',
       fieldNotAssignedToUser:
         'The selected Yes/No field has not been assigned to this respondent',
+      fieldNotAssignedToUserRedesign:
+        'The selected Yes/No field has not been assigned to this person',
     },
     addStep: 'Add step',
     complete: {
       prefix:
         'When the workflow is complete, email notifications can be sent to respondents and other parties. Set up',
+      prefixRedesign:
+        'When the workflow is done, email notifications can be sent to people and other parties. Set up',
       link: 'email notifications',
       suffix: 'in Settings.',
     },

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -10,8 +10,11 @@ export interface Workflow {
   title: string
   respondentBlock: {
     stepRespondent: string
+    stepRespondentRedesign: string
     anyone: string
+    anyoneRedesign: string
     select: string
+    selectRedesign: string
     fieldsToFill: string
     clickToEdit: string
   }
@@ -19,14 +22,17 @@ export interface Workflow {
     title: string
     required: string
     mustBeEmail: string
+    mustBeEmailRedesign: string
     select: string
   }
   conditionalRouting: {
     title: string
     addEmailsToOptions: string
+    addEmailsToOptionsRedesign: string
     validation: {
       noField: string
       notDropdown: string
+      notDropdownRedesign: string
     }
     modals: {
       deleteStep: {
@@ -44,6 +50,7 @@ export interface Workflow {
       addMapping: {
         step1: {
           title: string
+          titleRedesign: string
           nextButton: string
           download: {
             templateCreated: string
@@ -88,7 +95,9 @@ export interface Workflow {
     errors: {
       respondentType: {
         required: string
+        requiredRedesign: string
         invalid: string
+        invalidRedesign: string
       }
       csv: {
         required: string
@@ -103,8 +112,11 @@ export interface Workflow {
   }
   questions: {
     tooltip: string
+    tooltipRedesign: string
     label: string
+    labelRedesign: string
     placeholder: string
+    placeholderRedesign: string
   }
   approvals: {
     title: string
@@ -113,17 +125,21 @@ export interface Workflow {
     toggle: {
       label: string
       description: string
+      descriptionRedesign: string
       tooltip: string
       placeholder: string
     }
     validation: {
       noField: string
+      noFieldRedesign: string
       fieldAlreadyUsed: string
       fieldNotAssignedToUser: string
+      fieldNotAssignedToUserRedesign: string
     }
     addStep: string
     complete: {
       prefix: string
+      prefixRedesign: string
       link: string
       suffix: string
     }

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -46,6 +46,7 @@ export const featureFlags = {
   enablePaperTrackingSetUpPage: 'enable-paper-tracking-set-up-page' as const,
   sidebarNavLabels: 'enable-sidebar-nav-labels' as const,
   fiveStarAdminRating: '5star-admin-rating' as const,
+  workflowBuilderRedesign: 'workflow-builder-redesign' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {


### PR DESCRIPTION
## Problem

Part of [FRM-2490](https://linear.app/ogp/issue/FRM-2490). PRD: [FRM-2486](https://linear.app/ogp/issue/FRM-2486).

A content-design review found confusing terminology throughout the MRF workflow builder:
This PR fixes the ~24 strings that exist in the live product today. 

## Solution

All new copy is gated behind the `workflow-builder-redesign` flag from [FRM-2487](https://linear.app/ogp/issue/FRM-2487) ([#9730](https://github.com/opengovsg/FormSG/pull/9730), not yet merged; this PR branches off it and will retarget to `develop` once that lands). 

The copy lives in static i18n objects read via `t('...path')`, with no runtime variant switch. So gating happens at the call site: every changed string gets a `Redesign`-suffixed sibling key holding the new copy, and each component reads the flag once (`const isRedesign = useIsWorkflowBuilderRedesign()`) then does `t(isRedesign ? '...Redesign' : '...')`. `StatusTrackerToggle` also needs a small JSX restructure so the flag-ON copy wraps the whole descriptive phrase as the link, instead of the old standalone "here" link.

<details>
<summary><strong>Full list of copy changes (old → new)</strong></summary>

**`sidebar/workflow/en-sg.ts`**

| Old | New |
| --- | --- |
| Respondent in this step | Who fills in this step? |
| Anyone who has access to your form | Anyone with your form link can fill in Step 1. |
| Select a respondent | Who fills in this step? |
| Field is not an email field | Choose an email field. |
| Add emails to options | Assign emails to options |
| Field is not an dropdown field | Choose a dropdown field. |
| Please select a respondent type | Please choose who fills in this step |
| The selected respondent type is invalid | The selected option is invalid |
| Respondent will only be able to fill the fields you have selected | This person can only fill in the fields you select. |
| Select field(s) for this respondent to fill | Choose the fields this person fills in |
| Select field(s) from your form | Select fields from your form |
| If respondent selects Yes, the form is Approved and continues to the next step. If they select No, the form is Not approved and stops at this step. | If this person selects Yes, the form is Approved and continues to the next step. If they select No, the form is Not approved and stops at this step. |
| Please select a Yes/No field | Select a Yes/No field. |
| The selected Yes/No field has not been assigned to this respondent | The selected Yes/No field has not been assigned to this person |
| When the workflow is complete, email notifications can be sent to respondents and other parties. Set up | When the workflow is done, email notifications can be sent to people and other parties. Set up |

**`settings/email-notifications/en-sg.ts`**

| Old | New |
| --- | --- |
| People who are filling up a workflow step | People who fill in a workflow step |
| Separate multiple email addresses with a comma | Separate multiple emails with a comma |
| Allow respondents to receive a copy of their submission | Allow people to receive a copy of their submission |
| Allow respondents to track their submission status | Allow people to track their submission status |
| View a sample status tracking link (+ "here" link) | See a sample status tracking page (whole phrase linked) |

**Hardcoded strings**

| File | Old | New |
| --- | --- | --- |
| `EmptyWorkflow.tsx` | Create a workflow to collect responses from multiple respondents in the same form submission | Create a workflow to collect responses from multiple people in the same form submission |
| `EmptyWorkflow.tsx` | Assign respondents to specific steps, and control which fields they can fill. | Assign people to specific steps, and control which fields they can fill in. |
| `StaticRespondentOption.tsx` | Specific email(s) | Specific emails |
| `StaticRespondentOption.tsx` | Please enter valid email(s) (e.g. me@example.com) separated by commas, as invalid emails will not be saved | Enter valid emails separated by commas, like me@example.com. Invalid emails won't be saved. |

</details>

**Alternatives considered**

- We considered a `useWorkflowCopy()` helper hook that pre-resolves all changed strings, but skipped it. 
- It would move components off the house `t()`-at-point-of-use convention and add an abstraction that itself has to be deleted at flag retirement. The inline ternary is more idiomatic, and the retirement diff (delete old key, unwrap ternary) is the same either way. 
- We also considered leaving the two already-hardcoded components (`EmptyWorkflow`, `StaticRespondentOption`) as-is instead of gating them, but decided consistency across every changed string mattered more 

Two shared strings (`RespondentCopyToggle`, `FormEmailSection`) render on regular non-MRF forms too, not just the workflow builder. We gated them anyway instead of excluding them. 

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

Flag defaults to OFF, so the workflow builder and email-notification settings are unchanged for all users until the flag is turned on.

**Screenshots**

| Page | **BEFORE** | **AFTER** |
| --- | --- | --- |
| Workflow tab overview | <img width="800" alt="workflow tab before" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2490-copy-changes/before-workflow-overview.png" /> | <img width="800" alt="workflow tab after" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2490-copy-changes/after-workflow-overview.png" /> |
| Step 2, respondent options | <img width="800" alt="step 2 respondent options before" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2490-copy-changes/before-step2-respondent-options.png" /> | <img width="800" alt="step 2 respondent options after" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2490-copy-changes/after-step2-respondent-options.png" /> |
| Settings, Email notifications | <img width="800" alt="email notifications before" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2490-copy-changes/before-email-notifications.png" /> | <img width="800" alt="email notifications after" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2490-copy-changes/after-email-notifications.png" /> |

## Tests

**TC1: Flag OFF (default)**
- [ ] Open an MRF form's Workflow tab. Every string reads exactly as it does on `develop` today.
- [ ] Open Settings > Email notifications on both an MRF and a regular form. Copy unchanged.

**TC2: Flag ON** (`window._growthbook.setForcedFeatures(new Map([['workflow-builder-redesign', true]]))`)
- [ ] Workflow tab: headings read "Who fills in this step?", Step 1 hint reads "Anyone with your form link can fill in Step 1.", status tracker line reads "See a sample status tracking page" as a single link with no standalone "here".
- [ ] Step 2 edit view: radio group shows "Specific emails" (no "(s)"), field label reads "Choose the fields this person fills in", approval description reads "If this person selects Yes...".
- [ ] Routing/CSV modal button and header read "Assign emails to options".
- [ ] Settings > Email notifications: "People who fill in a workflow step", comma-helper reads "Separate multiple emails with a comma". Check this also on a regular (non-MRF) form, since these two strings are shared.
