### PR TITLE
fix(admin-form): show unsupported field error

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.test.tsx
@@ -1,0 +1,45 @@
+import { screen } from '@testing-library/react'
+
+import { BasicField, FieldCreateDto } from 'formsg-shared/types/field'
+
+import { render } from '~/test-utils'
+
+import { getFieldCreationMeta } from '../../utils/fieldCreation'
+
+import { MemoFieldDrawerContent } from './EditFieldDrawer'
+
+vi.mock('~features/user/queries', () => ({
+  useUser: () => ({ user: undefined, isLoading: false }),
+}))
+
+const TODO_PLACEHOLDER_TEXT = 'TODO: Insert field options here'
+
+const getUnsupportedFieldMessage = (fieldType: string) =>
+  `Unable to edit this field type (${fieldType}). Please contact support if this issue persists.`
+
+describe('MemoFieldDrawerContent', () => {
+  it('shows an unsupported field error for non-MyInfo children fields', () => {
+    const field = getFieldCreationMeta(BasicField.Children)
+
+    render(<MemoFieldDrawerContent field={field} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      getUnsupportedFieldMessage(BasicField.Children),
+    )
+    expect(screen.queryByText(TODO_PLACEHOLDER_TEXT)).not.toBeInTheDocument()
+  })
+
+  it('shows an unsupported field error for an unregistered runtime field type', () => {
+    const field = {
+      ...getFieldCreationMeta(BasicField.ShortText),
+      fieldType: 'unsupported_field' as BasicField,
+    } as FieldCreateDto
+
+    render(<MemoFieldDrawerContent field={field} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      getUnsupportedFieldMessage('unsupported_field'),
+    )
+    expect(screen.queryByText(TODO_PLACEHOLDER_TEXT)).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.tsx
@@ -6,6 +6,8 @@ import {
   MyInfoAttribute,
 } from 'formsg-shared/types/field'
 
+import InlineMessage from '~components/InlineMessage'
+
 import {
   BASICFIELD_TO_DRAWER_META,
   MYINFO_FIELD_TO_DRAWER_META,
@@ -108,6 +110,21 @@ interface MemoFieldDrawerContentProps {
   field: FieldCreateDto
 }
 
+interface UnsupportedFieldTypeMessageProps {
+  fieldType: string
+}
+
+const UnsupportedFieldTypeMessage = ({
+  fieldType,
+}: UnsupportedFieldTypeMessageProps): JSX.Element => {
+  return (
+    <InlineMessage m="1.5rem" role="alert" variant="error">
+      Unable to edit this field type ({fieldType}). Please contact support if
+      this issue persists.
+    </InlineMessage>
+  )
+}
+
 export const MemoFieldDrawerContent = memo<MemoFieldDrawerContentProps>(
   ({ field, ...props }) => {
     const { user } = useUser()
@@ -126,7 +143,9 @@ export const MemoFieldDrawerContent = memo<MemoFieldDrawerContentProps>(
       return <EditMyInfo {...props} field={field} />
     }
 
-    switch (field.fieldType) {
+    const fieldType = field.fieldType
+
+    switch (fieldType) {
       case BasicField.Attachment:
         return <EditAttachment {...props} field={field} />
       case BasicField.Checkbox:
@@ -173,8 +192,12 @@ export const MemoFieldDrawerContent = memo<MemoFieldDrawerContentProps>(
         return <EditAddress {...props} field={field} />
       case BasicField.Signature:
         return <EditSignature {...props} field={field} />
-      default:
-        return <div>TODO: Insert field options here</div>
+      case BasicField.Children:
+        return <UnsupportedFieldTypeMessage fieldType={fieldType} />
+      default: {
+        const _exhaustiveCheck: never = fieldType
+        return <UnsupportedFieldTypeMessage fieldType={_exhaustiveCheck} />
+      }
     }
   },
 )


### PR DESCRIPTION
## Problem
Closes #9539 

When `MemoFieldDrawerContent` receives a `BasicField` value without a matching switch case, the edit drawer previously rendered raw developer placeholder text: `TODO: Insert field options here`. This could be visible to admin users instead of a proper user-facing state.

## Solution

Replaced the placeholder fallback with a graceful unsupported field error state in the edit drawer. The switch now stores `field.fieldType` in `fieldType`, handles known unsupported `BasicField.Children`, and uses a TypeScript exhaustive `never` check in the default branch so newly added `BasicField` values must be handled at compile time.

**Breaking Changes** 

- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  

**Features**:

- N/A

**Improvements**:

- Added an explicit `UnsupportedFieldTypeMessage` for field types that cannot be edited.
- Added an exhaustive switch check so missing `BasicField` cases are caught by TypeScript.

**Bug Fixes**:

- Removed the raw `TODO: Insert field options here` fallback from `MemoFieldDrawerContent`.
- Added test coverage for unsupported non-MyInfo children fields and unregistered runtime field types.

## Before & After Screenshots

**BEFORE**:
<!-- Drawer showed raw placeholder text: `TODO: Insert field options here` -->
<img width="884" height="228" alt="image" src="https://github.com/user-attachments/assets/91b64a73-687b-4a77-913d-cc2b88cb2268" />

**AFTER**:
<!-- Drawer shows an inline error message: `Unable to edit this field type (...). Please contact support if this issue persists.` -->
<img width="1707" height="404" alt="image" src="https://github.com/user-attachments/assets/389c993f-f656-4376-9690-e4783c7a9fec" />

## Tests

Targeted test:

```bash
cd apps/frontend
./node_modules/.bin/vitest run src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/EditFieldDrawer.test.tsx
