### PR TITLE
chore: removing unusued & stale gb flags

### DIFF
--- a/apps/backend/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
@@ -46,14 +46,6 @@ const _handleTextPrompt: ControllerHandler<
   const { formId } = req.params
   const sessionUserId = (req.session as AuthedSessionData).user._id
 
-  const gb = req.growthbook
-
-  if (!gb?.isOn(featureFlags.mfb)) {
-    return res.status(StatusCodes.FORBIDDEN).json({
-      message: 'This feature is currently unavailable.',
-    })
-  }
-
   // Step 1: Retrieve currently logged in user.
   return UserService.getPopulatedUserById(sessionUserId)
     .andThen((user) =>

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
@@ -1,7 +1,6 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { AuthedSessionData } from 'express-session'
 import {
-  featureFlags,
   MFB_TEXT_PROMPT_MAX_CHAR,
   MFB_VISION_MAX_IMAGES_COUNT,
 } from 'formsg-shared/constants'
@@ -132,13 +131,6 @@ const _handleVisionPrompt: ControllerHandler<
   const { formId } = req.params
   const sessionUserId = (req.session as AuthedSessionData).user._id
   const { imageDataUrls } = req.body
-  const gb = req.growthbook
-
-  if (!gb?.isOn(featureFlags.mfbVision)) {
-    return res.status(StatusCodes.FORBIDDEN).json({
-      message: 'This feature is currently unavailable.',
-    })
-  }
 
   // Step 1: Retrieve currently logged in user.
   return (

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
@@ -71,7 +71,6 @@ export const EmptyFormPlaceholder = forwardRef<
     return isMobile ? t('tapToAddField') : t('dragFromBuilderToStart')
   }, [isDraggingOver, isMobile, t])
 
-  const isMfbTextEnabled = useFeatureIsOn(featureFlags.mfb)
   const isMfbVisionEnabled = useFeatureIsOn(featureFlags.mfbVision)
 
   return (
@@ -108,7 +107,7 @@ export const EmptyFormPlaceholder = forwardRef<
           >
             {placeholderText}
           </Text>
-          {isMfbTextEnabled || isMfbVisionEnabled ? (
+          {isMfbVisionEnabled ? (
             <>
               <OrDivider isMobile={isMobile} orText={t('or')} />
               <Box h="2.75rem"></Box>
@@ -116,7 +115,7 @@ export const EmptyFormPlaceholder = forwardRef<
           ) : null}
         </Center>
       </chakra.button>
-      {isMfbTextEnabled || isMfbVisionEnabled ? (
+      {isMfbVisionEnabled ? (
         <Box
           bottom="2.375rem"
           w="100%"

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignPlaceholder/EmptyFormPlaceholder.tsx
@@ -10,9 +10,6 @@ import {
   Icon,
   Text,
 } from '@chakra-ui/react'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
-
-import { featureFlags } from 'formsg-shared/constants'
 
 import { BxsWidget } from '~assets/icons/BxsWidget'
 import { useIsMobile } from '~hooks/useIsMobile'
@@ -71,8 +68,6 @@ export const EmptyFormPlaceholder = forwardRef<
     return isMobile ? t('tapToAddField') : t('dragFromBuilderToStart')
   }, [isDraggingOver, isMobile, t])
 
-  const isMfbVisionEnabled = useFeatureIsOn(featureFlags.mfbVision)
-
   return (
     <Box position="relative" h="13.75rem" m={{ base: 0, lg: '1.625rem' }}>
       <chakra.button
@@ -107,26 +102,20 @@ export const EmptyFormPlaceholder = forwardRef<
           >
             {placeholderText}
           </Text>
-          {isMfbVisionEnabled ? (
-            <>
-              <OrDivider isMobile={isMobile} orText={t('or')} />
-              <Box h="2.75rem"></Box>
-            </>
-          ) : null}
+          <OrDivider isMobile={isMobile} orText={t('or')} />
+          <Box h="2.75rem"></Box>
         </Center>
       </chakra.button>
-      {isMfbVisionEnabled ? (
-        <Box
-          bottom="2.375rem"
-          w="100%"
-          px={{ base: '1rem', md: '2rem' }}
-          position="absolute"
-          display="flex"
-          justifyContent="center"
-        >
-          <MagicFormBuilderButton onClick={toggleIsModalOpen} />
-        </Box>
-      ) : null}
+      <Box
+        bottom="2.375rem"
+        w="100%"
+        px={{ base: '1rem', md: '2rem' }}
+        position="absolute"
+        display="flex"
+        justifyContent="center"
+      >
+        <MagicFormBuilderButton onClick={toggleIsModalOpen} />
+      </Box>
     </Box>
   )
 })

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -46,7 +46,6 @@ const FieldSearchBar = ({
 }) => {
   const { toggleIsModalOpen, isModalOpen } = useMagicFormBuilder()
 
-  const isMfbTextEnabled = useFeatureIsOn(featureFlags.mfb)
   const isMfbVisionEnabled = useFeatureIsOn(featureFlags.mfbVision)
 
   return (
@@ -61,7 +60,7 @@ const FieldSearchBar = ({
           onChange={onChange}
           placeholder={placeholder}
         />
-        {(isMfbTextEnabled || isMfbVisionEnabled) && (
+        {isMfbVisionEnabled && (
           <MagicFormBuilderSmallButton
             onClick={toggleIsModalOpen}
             isActive={isModalOpen}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/FieldListDrawer/FieldListDrawer.tsx
@@ -15,9 +15,6 @@ import {
   Tabs,
   Text,
 } from '@chakra-ui/react'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
-
-import { featureFlags } from 'formsg-shared/constants'
 
 import { Tab } from '~components/Tabs'
 
@@ -46,8 +43,6 @@ const FieldSearchBar = ({
 }) => {
   const { toggleIsModalOpen, isModalOpen } = useMagicFormBuilder()
 
-  const isMfbVisionEnabled = useFeatureIsOn(featureFlags.mfbVision)
-
   return (
     <>
       <InputGroup>
@@ -60,12 +55,10 @@ const FieldSearchBar = ({
           onChange={onChange}
           placeholder={placeholder}
         />
-        {isMfbVisionEnabled && (
-          <MagicFormBuilderSmallButton
-            onClick={toggleIsModalOpen}
-            isActive={isModalOpen}
-          />
-        )}
+        <MagicFormBuilderSmallButton
+          onClick={toggleIsModalOpen}
+          isActive={isModalOpen}
+        />
       </InputGroup>
     </>
   )

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
@@ -271,7 +271,6 @@ const MagicFormBuilderCreateFormPrompt = ({
 
   const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
 
-  const isMfbTextEnabled = useFeatureIsOn(featureFlags.mfb)
   const isMfbVisionEnabled = useFeatureIsOn(featureFlags.mfbVision)
 
   return (
@@ -281,7 +280,7 @@ const MagicFormBuilderCreateFormPrompt = ({
       </ModalHeader>
       <ModalBody>
         <>
-          {isTest || (isMfbTextEnabled && isMfbVisionEnabled) ? (
+          {isTest || isMfbVisionEnabled ? (
             <Tabs isFitted index={selectedTab} onChange={setSelectedTab}>
               <TabList px="2px" mb="1rem">
                 <Tab
@@ -317,22 +316,14 @@ const MagicFormBuilderCreateFormPrompt = ({
                 </TabPanel>
               </TabPanels>
             </Tabs>
-          ) : isMfbTextEnabled ? (
+          ) : (
             <TextPromptModalBodyContent
               register={register}
               setValue={setValue}
               errors={errors}
               watch={watch}
             />
-          ) : isMfbVisionEnabled ? (
-            <VisionPromptModalBodyContent
-              control={visionControl}
-              errors={visionErrors}
-              clearErrors={clearVisionErrors}
-              setError={setVisionError}
-              isVisionPromptSubmitLoading={isVisionPromptSubmitLoading}
-            />
-          ) : null}
+          )}
         </>
       </ModalBody>
       <ModalFooter justifyContent="flex-end">

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/MagicFormBuilder/components/MagicFormBuilderPromptModal.tsx
@@ -36,10 +36,8 @@ import {
   Text,
   Textarea,
 } from '@chakra-ui/react'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
 
 import {
-  featureFlags,
   MFB_TEXT_PROMPT_MAX_CHAR,
   MFB_VISION_MAX_IMAGES_COUNT,
 } from 'formsg-shared/constants'
@@ -269,62 +267,47 @@ const MagicFormBuilderCreateFormPrompt = ({
     isVisionPromptSubmitLoading ? PROMPT_TYPE.VISION : PROMPT_TYPE.TEXT,
   )
 
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-
-  const isMfbVisionEnabled = useFeatureIsOn(featureFlags.mfbVision)
-
   return (
     <>
       <ModalHeader display="flex" alignItems="center">
         <Text textStyle="h2">Create fields with AI</Text>
       </ModalHeader>
       <ModalBody>
-        <>
-          {isTest || isMfbVisionEnabled ? (
-            <Tabs isFitted index={selectedTab} onChange={setSelectedTab}>
-              <TabList px="2px" mb="1rem">
-                <Tab
-                  isDisabled={isVisionPromptSubmitLoading}
-                  value={PROMPT_TYPE.TEXT}
-                >
-                  Text
-                </Tab>
-                <Tab
-                  isDisabled={isTextPromptSubmitLoading}
-                  value={PROMPT_TYPE.VISION}
-                >
-                  Pdf
-                </Tab>
-              </TabList>
-              <TabPanels>
-                <TabPanel>
-                  <TextPromptModalBodyContent
-                    register={register}
-                    setValue={setValue}
-                    errors={errors}
-                    watch={watch}
-                  />
-                </TabPanel>
-                <TabPanel>
-                  <VisionPromptModalBodyContent
-                    control={visionControl}
-                    errors={visionErrors}
-                    clearErrors={clearVisionErrors}
-                    setError={setVisionError}
-                    isVisionPromptSubmitLoading={isVisionPromptSubmitLoading}
-                  />
-                </TabPanel>
-              </TabPanels>
-            </Tabs>
-          ) : (
-            <TextPromptModalBodyContent
-              register={register}
-              setValue={setValue}
-              errors={errors}
-              watch={watch}
-            />
-          )}
-        </>
+        <Tabs isFitted index={selectedTab} onChange={setSelectedTab}>
+          <TabList px="2px" mb="1rem">
+            <Tab
+              isDisabled={isVisionPromptSubmitLoading}
+              value={PROMPT_TYPE.TEXT}
+            >
+              Text
+            </Tab>
+            <Tab
+              isDisabled={isTextPromptSubmitLoading}
+              value={PROMPT_TYPE.VISION}
+            >
+              Pdf
+            </Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <TextPromptModalBodyContent
+                register={register}
+                setValue={setValue}
+                errors={errors}
+                watch={watch}
+              />
+            </TabPanel>
+            <TabPanel>
+              <VisionPromptModalBodyContent
+                control={visionControl}
+                errors={visionErrors}
+                clearErrors={clearVisionErrors}
+                setError={setVisionError}
+                isVisionPromptSubmitLoading={isVisionPromptSubmitLoading}
+              />
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
       </ModalBody>
       <ModalFooter justifyContent="flex-end">
         <NextAndBackButtonGroup

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptionWorkers.ts
@@ -79,7 +79,6 @@ const useDecryptionWorkers = ({
 
   const { data: adminForm } = useAdminForm()
   const { user } = useUser()
-  const useV4 = useFeatureIsOn(featureFlags.answerObjectDecryption)
 
   useEffect(() => {
     return () => killWorkers(workers)
@@ -200,7 +199,6 @@ const useDecryptionWorkers = ({
                 // Resolved here (on the main thread) so the worker doesn't
                 // need to import env.ts (which references window).
                 formsgSdkMode: env.formsgSdkMode,
-                useV4,
               })
               // Step 2: Update the Csv record status based on the decryption result.
               .then(async (decryptResult) => {
@@ -495,7 +493,6 @@ const useDecryptionWorkers = ({
       onDecryptionProgress,
       onPdfGenerationProgress,
       user?._id,
-      useV4,
       workers,
     ],
   )

--- a/apps/frontend/src/features/admin-form/responses/queries.ts
+++ b/apps/frontend/src/features/admin-form/responses/queries.ts
@@ -34,13 +34,8 @@ export const adminFormResponsesKeys = {
       ...builtParams,
     ] as const
   },
-  individual: (id: string, submissionId: string, useV4?: boolean) =>
-    [
-      ...adminFormResponsesKeys.id(id),
-      'individual',
-      submissionId,
-      { useV4 },
-    ] as const,
+  individual: (id: string, submissionId: string) =>
+    [...adminFormResponsesKeys.id(id), 'individual', submissionId] as const,
   secretKey: (id: string) => [...adminFormResponsesKeys.id(id), 'secretKey'],
 }
 

--- a/apps/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -1,7 +1,4 @@
 import { Divider, Stack } from '@chakra-ui/react'
-import { useFeatureIsOn } from '@growthbook/growthbook-react'
-
-import { featureFlags } from 'formsg-shared/constants/feature-flags'
 
 import { FormCaptchaToggle } from './components/FormCaptchaToggle'
 import { FormCustomisationSection } from './components/FormCustomisationSection'
@@ -13,10 +10,6 @@ import { FormStatusToggle } from './components/FormStatusToggle'
 import { GeneralTabHeader } from './components/GeneralTabHeader'
 
 export const SettingsGeneralPage = (): JSX.Element => {
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-  const isSaveDraftFeatureEnabled =
-    useFeatureIsOn(featureFlags.saveDraft) || isTest
-
   return (
     <Stack divider={<Divider />} spacing="2.5rem">
       <>
@@ -25,8 +18,7 @@ export const SettingsGeneralPage = (): JSX.Element => {
         <FormLimitToggle />
         <FormCustomisationSection />
       </>
-      {/* TODO [Save Draft v1.0]: Remove feature flagonce save draft is out of beta  */}
-      {isSaveDraftFeatureEnabled && <FormSaveDraftToggle />}
+      <FormSaveDraftToggle />
       <FormCaptchaToggle />
       <FormIssueNotificationToggle />
       <FormDetailsSection />

--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -836,11 +836,7 @@ export const PublicFormProvider = ({
       storeName: SAVE_DRAFT_INDEXEDDB_STORE_NAME,
     })
 
-  // TODO [Save Draft v1.0]: Remove feature flag once save draft is out of beta
-  const isSaveDraftFeatureEnabled =
-    useFeatureIsOn(featureFlags.saveDraft) || isTest
-  const isSaveDraftEnabled =
-    isSaveDraftFeatureEnabled && Boolean(form?.isSaveDraftEnabled)
+  const isSaveDraftEnabled = Boolean(form?.isSaveDraftEnabled)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   // RATIONALE: draftSubmission.lastUpdated is used as a source of truth to see if the draftSubmission has changed.

--- a/apps/frontend/src/features/public-form/components/FloatingToolBar/FloatingToolbar.tsx
+++ b/apps/frontend/src/features/public-form/components/FloatingToolBar/FloatingToolbar.tsx
@@ -12,19 +12,7 @@ import { FloatingIssueFeedbackButton } from './FloatingIssueFeedbackButton'
 import { FloatingSaveDraftButton } from './FloatingSaveDraftButton'
 
 export const FloatingToolBar = (): JSX.Element | null => {
-  const {
-    isPreview,
-    formId,
-    submissionData,
-    isSaveDraftEnabled,
-    onSaveDraft,
-    draftLastSavedDateTimeString,
-  } = usePublicFormContext()
-
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-  const gb = useGrowthBook()
-  const enableFloatingSaveDraftButton =
-    gb?.isOn(featureFlags.enableSaveDraftButtonFloating) || isTest
+  const { isPreview, formId, submissionData } = usePublicFormContext()
 
   if (submissionData) return null
 
@@ -39,24 +27,6 @@ export const FloatingToolBar = (): JSX.Element | null => {
       zIndex="docked"
     >
       <FloatingIssueFeedbackButton isPreview={isPreview} formId={formId} />
-      {isSaveDraftEnabled && enableFloatingSaveDraftButton && (
-        <FloatingSaveDraftButton
-          onSaveDraft={() => {
-            datadogLogs.logger.log(
-              'User clicked save draft from floating toolbar',
-              {
-                meta: {
-                  action: 'saveDraft',
-                  variant: 'FloatingToolbar',
-                  formId,
-                },
-              },
-            )
-            onSaveDraft()
-          }}
-          draftLastSavedDateTimeString={draftLastSavedDateTimeString}
-        />
-      )}
     </Stack>
   )
 }

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -5,7 +5,6 @@ export const featureFlags = {
   validateStripeEmailDomain: 'validateStripeEmailDomain' as const,
   chartsMaxResponseCount: 'charts-max-response-count' as const,
   addingTwilioDisabled: 'adding-twilio-disabled' as const,
-  saveDraft: 'save-draft' as const,
   postmanSms: 'postmanSms' as const,
   designDrawerFormTitle: 'design-drawer-form-title' as const,
   adminPrintPdf: 'admin-print-pdf' as const,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -16,7 +16,6 @@ export const featureFlags = {
   enableMrfWebhooks: 'enable-mrf-webhooks' as const,
   useFormsgEsrvcId: 'use-formsg-esrvcid' as const,
   lambdaPdfGeneration: 'lambda-pdf-generation' as const,
-  enableSaveDraftButtonFloating: 'enable-save-draft-button-floating' as const,
   enableSaveDraftButtonHeader: 'enable-save-draft-button-header' as const,
   adminEmailPdf: 'admin-email-pdf' as const,
   ogpHeader: 'enable-ogp-header' as const,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -8,6 +8,7 @@ export const featureFlags = {
   mfb: 'magic-form-builder' as const,
   mfbVision: 'magic-form-builder-vision' as const,
   saveDraft: 'save-draft' as const,
+  postmanSms: 'postmanSms' as const,
   designDrawerFormTitle: 'design-drawer-form-title' as const,
   adminPrintPdf: 'admin-print-pdf' as const,
   ogpSuiteSso: 'ogp-suite-sso' as const,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -5,7 +5,6 @@ export const featureFlags = {
   validateStripeEmailDomain: 'validateStripeEmailDomain' as const,
   chartsMaxResponseCount: 'charts-max-response-count' as const,
   addingTwilioDisabled: 'adding-twilio-disabled' as const,
-  mfbVision: 'magic-form-builder-vision' as const,
   saveDraft: 'save-draft' as const,
   postmanSms: 'postmanSms' as const,
   designDrawerFormTitle: 'design-drawer-form-title' as const,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -30,7 +30,6 @@ export const featureFlags = {
   useTemplateWallSubmit: 'use-template-wall-submit' as const,
   ddSampleRateAdmin: 'dd-sample-rate-admin' as const,
   ddSampleRatePublic: 'dd-sample-rate-public' as const,
-  answerObjectDecryption: 'answer-object-decryption' as const,
   standardisedEmailTemplate: 'standardised-email-template' as const,
   mrfCutover: 'mrf-cutover' as const,
   answerObjectEncryption: 'answer-object-encryption' as const,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -3,20 +3,11 @@ export const featureFlags = {
   goLinks: 'goLinks' as const,
   turnstile: 'turnstile' as const,
   validateStripeEmailDomain: 'validateStripeEmailDomain' as const,
-  /**
-   * @deprecated since 2024-Aug-02
-   * On growthbook, kept permenently ON for all ENV
-   * */
-  myinfoSgid: 'myinfo-sgid' as const,
   chartsMaxResponseCount: 'charts-max-response-count' as const,
   addingTwilioDisabled: 'adding-twilio-disabled' as const,
-  postmanSms: 'postmanSms' as const,
   mfb: 'magic-form-builder' as const,
   mfbVision: 'magic-form-builder-vision' as const,
-  guardduty: 'guardduty' as const,
   saveDraft: 'save-draft' as const,
-  respondentCopy: 'respondent-copy' as const,
-  statusTracker: 'status-tracker' as const,
   designDrawerFormTitle: 'design-drawer-form-title' as const,
   adminPrintPdf: 'admin-print-pdf' as const,
   ogpSuiteSso: 'ogp-suite-sso' as const,
@@ -24,7 +15,6 @@ export const featureFlags = {
   enableMrfWebhooks: 'enable-mrf-webhooks' as const,
   useFormsgEsrvcId: 'use-formsg-esrvcid' as const,
   lambdaPdfGeneration: 'lambda-pdf-generation' as const,
-  singpassMrf: 'singpass-mrf' as const,
   enableSaveDraftButtonFloating: 'enable-save-draft-button-floating' as const,
   enableSaveDraftButtonHeader: 'enable-save-draft-button-header' as const,
   adminEmailPdf: 'admin-email-pdf' as const,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -5,7 +5,6 @@ export const featureFlags = {
   validateStripeEmailDomain: 'validateStripeEmailDomain' as const,
   chartsMaxResponseCount: 'charts-max-response-count' as const,
   addingTwilioDisabled: 'adding-twilio-disabled' as const,
-  mfb: 'magic-form-builder' as const,
   mfbVision: 'magic-form-builder-vision' as const,
   saveDraft: 'save-draft' as const,
   postmanSms: 'postmanSms' as const,


### PR DESCRIPTION
## Problem

Removing a bunch of gb flags to clear out dead code

  Easy removals — flag was already unused, only the constant declaration was deleted

  | Flag key | GrowthBook name |
  |---|---|
  | `myinfoSgid` | `myinfo-sgid` |
  | `guardduty` | `guardduty` |
  | `respondentCopy` | `respondent-copy` |
  | `statusTracker` | `status-tracker` |
  | `singpassMrf` | `singpass-mrf` |
  | `answerObjectDecryption` | `answer-object-decryption` |


  (all deleted in a7c07d6ea "remove unused gb variables" and ec84a135c "remove answer-object-decryption"
   — one-line deletions from feature-flags.ts, no other file touched)

  Required conditional-code cleanup — flag was actively gating behavior in one or more files

  Flag key: enableSaveDraftButtonFloating
  GrowthBook name: enable-save-draft-button-floating
  Where the conditional lived: FloatingToolbar.tsx — deleted 32 lines that conditionally rendered the
    floating save-draft toolbar
  ────────────────────────────────────────
  Flag key: mfb
  GrowthBook name: magic-form-builder
  Where the conditional lived: Backend admin-form.assistance.controller.ts + 3 frontend files
    (FieldListDrawer, EmptyFormPlaceholder, MagicFormBuilderPromptModal)
  ────────────────────────────────────────
  Flag key: mfbVision
  GrowthBook name: magic-form-builder-vision
  Where the conditional lived: Same 4 files as mfb — collapsed the tab/vision branching once both flags
    were removed
  ────────────────────────────────────────
  Flag key: saveDraft
  GrowthBook name: save-draft
  Where the conditional lived: PublicFormProvider.tsx (draft-restore gating) + SettingsGeneralPage.tsx
    (admin toggle visibility)

## Solution
<!-- How did you solve the problem? -->

1. Verified that feature-flag is not called in the code
2. Verified that for feature-flags called in the code, all values in gb are TRUE - so removal the conditional will not cause regression
3. Verified on stg-alt

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  