### PR TITLE
fix(end-page): align thank-you paragraph typography with other admin content

### DIFF
--- a/apps/frontend/src/components/FormEndPage/EndPageBlock.tsx
+++ b/apps/frontend/src/components/FormEndPage/EndPageBlock.tsx
@@ -56,8 +56,8 @@ export const EndPageBlock = ({
   const mdComponents = useMdComponents({
     styles: {
       text: {
-        textStyle: 'subhead-1',
-        color: 'secondary.500',
+        textStyle: 'body-1',
+        color: 'secondary.700',
       },
     },
   })

--- a/apps/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
+++ b/apps/frontend/src/features/public-form/components/FormEndPage/FormEndPage.stories.tsx
@@ -53,6 +53,16 @@ Default.args = {
   handleSubmitFeedback: (inputs) => console.log(inputs),
 }
 
+export const BulletedParagraph = Template.bind({})
+BulletedParagraph.args = {
+  ...Default.args,
+  endPage: {
+    ...Default.args.endPage!,
+    paragraph:
+      'Thank you for registering. What happens next:\n\n* We will review your application\n* You will receive an email within 3 working days\n* Contact us at hello@example.gov.sg if you have questions',
+  },
+}
+
 export const ColorThemeGreen = Template.bind({})
 ColorThemeGreen.args = {
   ...Default.args,


### PR DESCRIPTION
Closes https://github.com/opengovsg/FormSG/issues/9434

## Problem

Markdown bullet points added to the thank-you page paragraph render with visibly different styling from the surrounding text — the paragraph text appears bolded while the bullets do not. Closes #9434.

## Solution

The bolded bullets were a symptom, not the bug: the end page styled its admin-authored paragraph with `subhead-1` (weight 500, `secondary.500`), while every other renderer of primary admin-authored paragraph content — FormInstructions, SectionField, ParagraphField — uses `body-1` (weight 400, `secondary.700`). A survey of all 15 `useMdComponents` consumers confirmed the end page was the sole outlier. Switching `EndPageBlock` to the shared baseline fixes both plain paragraphs and bullet lists in one move. A Storybook story with a bulleted paragraph was added as a repro.

**Alternatives considered**

- We first tried adding a list-style fallback inside the shared `useMdComponents` hook so `ul` elements would pick up the caller's text style, but dropped it — it only patched bullets, leaving plain end-page paragraphs still rendered at weight 500, and it added complexity to a shared hook to work around one caller's styling choice.
- We tried to trace why the end page originally used `subhead-1`, but the git history is flattened at the monorepo migration, so the original intent is unrecoverable. It likely aimed to make the thank-you message read as a subtitle under the h2 title — fine for one-liners, but it breaks down for multi-paragraph admin content with lists.

**Screenshots**

| Story | Before | After |
| --- | --- | --- |
| End page with bullets | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/fix-thank-you-page-styling/before-end-page-bullets.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/fix-thank-you-page-styling/after-end-page-bullets.png) |
| End page default | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/fix-thank-you-page-styling/before-end-page-default.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/fix-thank-you-page-styling/after-end-page-default.png) |

**Breaking Changes**

No - backwards compatible. Note the visual change applies to every form's thank-you page (paragraph weight 500 → 400, colour `secondary.500` → `secondary.700`) — worth a design sanity-check.

## Tests

**TC1: bulleted thank-you paragraph**

- [ ] Create a form; in the thank-you page settings, set a paragraph containing markdown bullets (`* item`)
- [ ] Submit the form
- [ ] Verify the intro text and the bullet items render at the same weight/colour, matching a paragraph field's styling

**TC2: existing plain thank-you paragraphs**

- [ ] Open any form with a plain (non-bulleted) thank-you paragraph and submit
- [ ] Verify the paragraph renders like other admin-authored body text (no bolding), and the title/Response ID area is unchanged

## Clean-up
- [ ] Close https://github.com/opengovsg/FormSG/pull/9756

🤖 Generated with [Claude Code](https://claude.com/claude-code)
