### PR TITLE
chore: speed up jest runs by removing default local code coverage collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
           languages: js
           service-name: ${{ secrets.DD_SERVICE }}
           api-key: ${{ secrets.DD_API_KEY }}
-      - run: pnpm test:shared
+      - run: pnpm test:shared:ci
         env:
           DD_TAGS: layer:shared
           NODE_OPTIONS: --max-old-space-size=4096 -r ${{ env.DD_TRACE_PACKAGE }}
@@ -348,7 +348,7 @@ jobs:
           languages: js
           service-name: ${{ secrets.DD_SERVICE }}
           api-key: ${{ secrets.DD_API_KEY }}
-      - run: pnpm test:sdk
+      - run: pnpm test:sdk:ci
         env:
           DD_TAGS: layer:sdk
           NODE_OPTIONS: --max-old-space-size=4096 -r ${{ env.DD_TRACE_PACKAGE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
           languages: js
           service-name: ${{ secrets.DD_SERVICE }}
           api-key: ${{ secrets.DD_API_KEY }}
-      - run: pnpm test:sdk:ci
+      - run: pnpm test:sdk:coverage
         env:
           DD_TAGS: layer:sdk
           NODE_OPTIONS: --max-old-space-size=4096 -r ${{ env.DD_TRACE_PACKAGE }}

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Test SDK
         if: ${{ steps.version.outputs.should-publish == 'true' }}
-        run: pnpm test:sdk
+        run: pnpm test:sdk:ci
 
       - name: Publish to npm
         if: ${{ steps.version.outputs.should-publish == 'true' }}

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Test SDK
         if: ${{ steps.version.outputs.should-publish == 'true' }}
-        run: pnpm test:sdk:ci
+        run: pnpm test:sdk:coverage
 
       - name: Publish to npm
         if: ${{ steps.version.outputs.should-publish == 'true' }}

--- a/apps/backend/jest.config.js
+++ b/apps/backend/jest.config.js
@@ -2,12 +2,8 @@
 module.exports = {
   preset: 'ts-jest',
   testMatch: ['**/?(*.)+(spec|test).[t]s?(x)'],
-  modulePaths: [
-    '<rootDir>',
-  ],
-  moduleDirectories: [
-    'node_modules',
-  ],
+  modulePaths: ['<rootDir>'],
+  moduleDirectories: ['node_modules'],
   // Map workspace package so Jest can resolve it (Jest does not fully support package.json "exports")
   moduleNameMapper: {
     '^formsg-shared$': '<rootDir>/../../packages/shared',
@@ -15,15 +11,9 @@ module.exports = {
   },
   testEnvironment: 'node',
   globalSetup: '<rootDir>/__tests__/setup/jest-global-setup.js',
-  testPathIgnorePatterns: [
-    '<rootDir>/dist/',
-    '<rootDir>/node_modules/',
-  ],
-  collectCoverage: true,
-  collectCoverageFrom: [
-    './src/**/*.{ts,js}',
-    '!**/__tests__/**',
-  ],
+  testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
+  collectCoverage: false,
+  collectCoverageFrom: ['./src/**/*.{ts,js}', '!**/__tests__/**'],
   coveragePathIgnorePatterns: ['./node_modules/', './tests'],
   coverageReporters: ['lcov', 'text'],
   testTimeout: 300000, // Set timeout to be 300s to reduce test flakiness

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,7 +11,7 @@
     "test:e2e-v2:server": "env-cmd -f ./__tests__/setup/.test-env pnpm test-e2e-server",
     "test-e2e-server": "concurrently --success last --kill-others \"pnpm exec mockpass\" \"pnpm exec maildev\" \"node dist/src/app/server.js\" \"node ./__tests__/setup/mock-webhook-server.js\"",
     "test": "env-cmd -f __tests__/setup/.test-env node --experimental-vm-modules node_modules/jest/bin/jest.js",
-    "test:ci": "env-cmd -f __tests__/setup/.test-env node --experimental-vm-modules node_modules/jest/bin/jest.js --maxWorkers=2 --logHeapUsage --workerIdleMemoryLimit=0.2",
+    "test:ci": "env-cmd -f __tests__/setup/.test-env node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage --maxWorkers=2 --logHeapUsage --workerIdleMemoryLimit=0.2",
     "test:watch": "env-cmd -f __tests__/setup/.test-env node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
     "lint": "pnpm exec eslint src/ --quiet --fix",
     "lint-ci": "pnpm exec eslint src/ --quiet"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:backend:watch": "pnpm --filter formsg-backend test:watch",
     "test:frontend": "pnpm --filter formsg-frontend test",
     "test:sdk": "pnpm --filter @opengovsg/formsg-sdk test",
-    "test:sdk:ci": "pnpm --filter @opengovsg/formsg-sdk test:ci",
+    "test:sdk:coverage": "pnpm --filter @opengovsg/formsg-sdk test:coverage",
     "test:e2e-v2": "pnpm build && pnpm exec playwright test",
     "test:e2e-v2:server": "pnpm --filter formsg-backend test:e2e-v2:server",
     "build": "pnpm clean && pnpm --recursive --filter formsg-sdk --filter formsg-shared --filter formsg-frontend --filter formsg-backend build",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   "scripts": {
     "test": "pnpm test:backend && pnpm test:shared && pnpm run test:frontend",
     "test:shared": "pnpm --filter formsg-shared test",
+    "test:shared:ci": "pnpm --filter formsg-shared test:ci",
     "test:backend": "pnpm --filter formsg-backend test",
     "test:backend:ci": "pnpm --filter formsg-backend test:ci",
     "test:backend:watch": "pnpm --filter formsg-backend test:watch",
     "test:frontend": "pnpm --filter formsg-frontend test",
     "test:sdk": "pnpm --filter @opengovsg/formsg-sdk test",
+    "test:sdk:ci": "pnpm --filter @opengovsg/formsg-sdk test:ci",
     "test:e2e-v2": "pnpm build && pnpm exec playwright test",
     "test:e2e-v2:server": "pnpm --filter formsg-backend test:e2e-v2:server",
     "build": "pnpm clean && pnpm --recursive --filter formsg-sdk --filter formsg-shared --filter formsg-frontend --filter formsg-backend build",

--- a/packages/sdk/jest.config.js
+++ b/packages/sdk/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testEnvironment: 'node',
   testRegex: '/spec/.*\\.(test|spec)?\\.(ts|tsx)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  collectCoverage: true,
+  collectCoverage: false,
   coverageThreshold: {
     global: {
       statements: 85,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -55,6 +55,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
     "test": "jest",
+    "test:ci": "jest --coverage",
     "lint": "eslint src/ --quiet --fix",
     "lint-ci": "eslint src/ --quiet"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -55,7 +55,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
     "test": "jest",
-    "test:ci": "jest --coverage",
+    "test:coverage": "jest --coverage",
     "lint": "eslint src/ --quiet --fix",
     "lint-ci": "eslint src/ --quiet"
   },

--- a/packages/shared/jest.config.js
+++ b/packages/shared/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   moduleDirectories: ['node_modules'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/node_modules/'],
-  collectCoverage: true,
+  collectCoverage: false,
   collectCoverageFrom: ['<rootDir>/**/*.{ts,js}', '!<rootDir>/**/__tests__/**'],
   coveragePathIgnorePatterns: [
     '<rootDir>/node_modules/',

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "pnpm exec jest --config jest.config.js",
+    "test:ci": "pnpm exec jest --config jest.config.js --coverage",
     "lint": "pnpm exec eslint . --quiet --fix",
     "lint-ci": "pnpm exec eslint . --quiet"
   },


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Jest is configured to collect code coverage by default for every backend test suite execution. 
This should be removed since: 
- it is not useful to collect this locally. It is only used for CI to report coverage to datadog, and thus we continue to enable it for ci test runs. 
- Collecting coverage is expensive and slow, which hinders agentic TDD flows and incurs extra token spend. 

## Benchmark (local)
Setup:
- Package: `apps/backend`
- Specs: 5 util unit files (`date`, `request`, `limit-rate`, `handle-mongo-error`, `convert-html-to-pdf`)
- Workers: `--maxWorkers=4`
- Machine: local Mac (Node 22)

| Mode | Wall clock | Jest reported time | Relative |
| --- | ---: | ---: | --- |
| Coverage **off** (warm) | ~1.8s | ~1.0s | baseline |
| Coverage **on** (1st) | ~7.2s | ~6.5s | ~4× slower |
| Coverage **on** (2nd) | ~4.4s | ~3.5s | ~2.5× slower |

**Takeaway:** for focused unit runs, turning coverage off is ~**2–4×** faster. Full-suite speedup should be smaller (Mongo/I/O dominate more) but still meaningful for day-to-day local use, expected 30-50% improvement.

## Solution
<!-- How did you solve the problem? -->
Set code coverage collection for jest to false by default. Enable only for CI so datadog continues to receive code coverage reports. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  