### PR TITLE
fix: prevent pollution of v1 and v2 metrics due to different scales

### DIFF
--- a/apps/backend/src/app/modules/admin-feedback/admin-feedback.controller.ts
+++ b/apps/backend/src/app/modules/admin-feedback/admin-feedback.controller.ts
@@ -1,5 +1,6 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import { AuthedSessionData } from 'express-session'
+import { featureFlags } from 'formsg-shared/constants'
 import { ErrorDto } from 'formsg-shared/types'
 import { StatusCodes } from 'http-status-codes'
 
@@ -43,18 +44,31 @@ const submitAdminFeedback: ControllerHandler<
 > = async (req, res) => {
   const sessionUserId = (req.session as AuthedSessionData).user._id
   const { rating, comment, triggerSource, formId } = req.body
+  const isFiveStarEnabled = req.growthbook?.isOn(
+    featureFlags.fiveStarAdminRating,
+  )
+  const metricTags = {
+    rating: `${rating}`,
+    ...(triggerSource ? { triggerSource } : {}),
+  }
 
-  // Dual-emit: old metric kept so existing dashboards don't break during
-  // migration. New metric (.v2) for the 1-5 scale. Remove the old metric
-  // once report card has migrated to .v2.
-  statsdClient.distribution('formsg.users.feedback.rating', rating, 1, {
-    rating: `${rating}`,
-    ...(triggerSource ? { triggerSource } : {}),
-  })
-  statsdClient.distribution('formsg.users.feedback.rating.v2', rating, 1, {
-    rating: `${rating}`,
-    ...(triggerSource ? { triggerSource } : {}),
-  })
+  // RATIONALE: Emit to the correct metric so that the different rating scales do not pollute each other.
+  // TODO [USER-FEEDBACK-RATING-V2]: Remove the old v1 metric once report card has migrated to .v2.
+  if (!isFiveStarEnabled) {
+    statsdClient.distribution(
+      'formsg.users.feedback.rating',
+      rating,
+      1,
+      metricTags,
+    )
+  } else {
+    statsdClient.distribution(
+      'formsg.users.feedback.rating.v2',
+      rating,
+      1,
+      metricTags,
+    )
+  }
 
   return AdminFeedbackService.insertAdminFeedback({
     userId: sessionUserId,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Currently, regardless of the feature flag `fiveStarAdminRating`, the metrics dual emit to v1 and v2 ratings, this is an issue as it causes pollution and inaccuracy to the ratings. 

For example, if `fiveStarAdminRating` is disabled, the scale is only 0-1. This causes the v2 ratings to be populated with 0/5 and 1/5 ratings. 
This also applies to when `fiveStarAdminRating` is enabled. This causes the v1 ratings to be populated with 2/1, 3/1, 4/1 and 5/1 ratings, which pull the average up incorrectly.   


## Solution
<!-- How did you solve the problem? -->
Only emit to the correct metric based on the `fiveStarAdminRating` flag. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible