### PR TITLE
feat(delightful-dashboards): Show results directly on dashboard

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesTab.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/StorageResponsesTab.tsx
@@ -1,23 +1,35 @@
 import { useTranslation } from 'react-i18next'
+import { useFeatureValue } from '@growthbook/growthbook-react'
+
+import { featureFlags } from 'formsg-shared/constants'
 
 import { FormActivationSvg } from '~features/admin-form/settings/components/FormActivationSvg'
 
 import { SecretKeyVerification } from '../../components/SecretKeyVerification'
 import { EmptyResponses } from '../common/EmptyResponses'
 
+import { UnlockedResponsesV2 } from './UnlockedResponses/UnlockedResponsesV2'
 import { useStorageResponsesContext } from './StorageResponsesContext'
 import { UnlockedResponses } from './UnlockedResponses'
 
 export const StorageResponsesTab = (): JSX.Element => {
   const { t } = useTranslation()
   const { totalResponsesCount, secretKey } = useStorageResponsesContext()
+  const isDelightfulDashboardEnabled = useFeatureValue(
+    featureFlags.delightfulDashboard,
+    false,
+  )
 
   if (totalResponsesCount === 0) {
     return <EmptyResponses />
   }
 
   return secretKey ? (
-    <UnlockedResponses />
+    isDelightfulDashboardEnabled ? (
+      <UnlockedResponsesV2 />
+    ) : (
+      <UnlockedResponses />
+    )
   ) : (
     <SecretKeyVerification
       heroSvg={<FormActivationSvg />}

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
@@ -173,6 +173,11 @@ const MRF_REMINDERS_COLUMN: Column<DecryptedResponse> = {
  */
 export const RESPONSES_TABLE_V2_PAGE_SIZE = 50
 
+// Fixed MRF row height so rows with a SendReminderButton (a full-height md
+// button) match rows without one: 2.75rem button + the td's 2 x 0.625rem
+// vertical padding.
+const MRF_ROW_MIN_HEIGHT = '4rem'
+
 export const ResponsesTableV2 = ({
   selectedFields,
   selectedSubmissionMetaFields,
@@ -386,6 +391,9 @@ export const ResponsesTableV2 = ({
                 minWidth: '100%',
                 width: 'max-content',
               }}
+              // Keep every MRF row at the reminder-button height so rows with
+              // and without the button line up.
+              minH={isMrf ? MRF_ROW_MIN_HEIGHT : undefined}
               px={0}
               // Read from row.original, not row.values: the Response ID column
               // sets an explicit id, so row.values.refNo is undefined.

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
@@ -21,14 +21,25 @@ import {
 } from '@chakra-ui/react'
 import { FormField } from '@opengovsg/formsg-sdk/dist/types'
 
+import { FormResponseMode, WorkflowStatus } from 'formsg-shared/types'
+
+import Badge from '~components/Badge'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+import { getPendingResponseAtString } from '~features/admin-form/responses/common/utils/mrfSubmissionView'
 import {
+  MRF_PENDING_RESPONSE_AT_LABEL,
+  MRF_REMINDERS_LABEL,
   MRF_RESPONSE_TIMESTAMP_LABEL,
+  MRF_WORKFLOW_STATUS_LABEL,
   RESPONSE_ID_LABEL,
 } from '~features/admin-form/responses/constants'
 
 import { DecryptedResponse } from '../../useDecryptedResponsesQuery'
 import { getDecryptedResponseInstance } from '../../utils/getDecryptedResponseInstance'
 import { useUnlockedResponses } from '../UnlockedResponsesProvider'
+
+import { SendReminderButton } from './SendReminderButton'
 
 // Base storage-mode columns, rendered alongside the selected field columns.
 const BASE_RESPONSE_TABLE_COLUMNS: Column<DecryptedResponse>[] = [
@@ -58,6 +69,104 @@ const BASE_RESPONSE_TABLE_COLUMNS: Column<DecryptedResponse>[] = [
   },
 ]
 
+const WorkflowStatusBadge = ({
+  workflowStatus,
+}: {
+  workflowStatus?: WorkflowStatus
+}) => {
+  const { t } = useTranslation()
+  if (!workflowStatus) return null
+  // Literal translation keys (the typed t() rejects a dynamic key).
+  const badges: Record<
+    WorkflowStatus,
+    { textColor: string; backgroundColor: string; label: string }
+  > = {
+    [WorkflowStatus.PENDING]: {
+      textColor: 'warning.700',
+      backgroundColor: 'warning.100',
+      label: t('features.common.pending'),
+    },
+    [WorkflowStatus.COMPLETED]: {
+      textColor: 'success.700',
+      backgroundColor: 'success.100',
+      label: t('features.common.completed'),
+    },
+    [WorkflowStatus.APPROVED]: {
+      textColor: 'success.700',
+      backgroundColor: 'success.100',
+      label: t('features.common.approved'),
+    },
+    [WorkflowStatus.REJECTED]: {
+      textColor: 'danger.700',
+      backgroundColor: 'danger.100',
+      label: t('features.common.notApproved'),
+    },
+  }
+  const badge = badges[workflowStatus]
+  return (
+    <Badge
+      width="fit-content"
+      display="flex"
+      textColor={badge.textColor}
+      textStyle="caption-1"
+      backgroundColor={badge.backgroundColor}
+    >
+      {badge.label}
+    </Badge>
+  )
+}
+
+// Workflow-status and pending-response columns for MRF forms, read from the
+// decrypted response's mrf metadata.
+const MRF_WORKFLOW_COLUMNS: Column<DecryptedResponse>[] = [
+  {
+    Header: MRF_WORKFLOW_STATUS_LABEL,
+    accessor: ({ mrf }) => (
+      <WorkflowStatusBadge workflowStatus={mrf?.workflowStatus} />
+    ),
+    width: 160,
+    minWidth: 160,
+  },
+  {
+    Header: MRF_PENDING_RESPONSE_AT_LABEL,
+    accessor: ({ mrf }) => {
+      const workflowStatus = mrf?.workflowStatus
+      const workflowCurrentStepNumber = mrf?.workflowCurrentStepNumber
+      const workflowNumTotalSteps = mrf?.workflowNumTotalSteps
+      if (
+        workflowStatus === undefined ||
+        workflowCurrentStepNumber === undefined ||
+        workflowNumTotalSteps === undefined
+      ) {
+        return ''
+      }
+      return getPendingResponseAtString({
+        workflowStatus,
+        workflowCurrentStepNumber,
+        workflowNumTotalSteps,
+      })
+    },
+    width: 180,
+    minWidth: 180,
+  },
+]
+
+// Reminders (Send-reminder action) column for MRF forms.
+const MRF_REMINDERS_COLUMN: Column<DecryptedResponse> = {
+  Header: MRF_REMINDERS_LABEL,
+  Cell: ({ row }) => {
+    const isPending =
+      row.original.mrf?.workflowStatus === WorkflowStatus.PENDING
+    const hasNextStepRecipientEmails =
+      row.original.mrf?.hasNextStepRecipientEmails
+    return isPending && hasNextStepRecipientEmails ? (
+      <SendReminderButton submissionId={row.original.refNo} />
+    ) : null
+  },
+  width: 160,
+  minWidth: 160,
+}
+
 /**
  * Rows per page. The whole working set is decrypted client-side, but the table
  * is not virtualised, so keep the mounted DOM small by paginating it locally.
@@ -82,6 +191,9 @@ export const ResponsesTableV2 = ({
   const { t } = useTranslation()
   const { currentPage: currentPage1Indexed, onRowClick } =
     useUnlockedResponses()
+
+  const { data: form } = useAdminForm()
+  const isMrf = form?.responseMode === FormResponseMode.Multirespondent
 
   const navigate = useNavigate()
 
@@ -121,8 +233,27 @@ export const ResponsesTableV2 = ({
       },
     }))
 
+    if (isMrf) {
+      // Match the column order in production today: #, Response ID, Workflow
+      // status, Pending response at, Response timestamp, Reminders — then the
+      // field-value columns.
+      const timestampColumn = filteredBaseColumns.find(
+        (column) => column.Header === MRF_RESPONSE_TIMESTAMP_LABEL,
+      )
+      const baseWithoutTimestamp = filteredBaseColumns.filter(
+        (column) => column.Header !== MRF_RESPONSE_TIMESTAMP_LABEL,
+      )
+      return [
+        ...baseWithoutTimestamp,
+        ...MRF_WORKFLOW_COLUMNS,
+        ...(timestampColumn ? [timestampColumn] : []),
+        MRF_REMINDERS_COLUMN,
+        ...selectFieldColumns,
+      ]
+    }
+
     return [...filteredBaseColumns, ...selectFieldColumns]
-  }, [selectedSubmissionMetaFields, selectedFields])
+  }, [isMrf, selectedSubmissionMetaFields, selectedFields])
 
   const {
     prepareRow,

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
@@ -267,10 +267,13 @@ export const ResponsesTableV2 = ({
                     key={cell.getCellProps().key}
                     display="flex"
                     alignItems="center"
-                    overflow="clip"
-                    textOverflow="ellipsis"
+                    overflow="hidden"
                   >
-                    {cell.render('Cell')}
+                    {/* Truncate long values instead of wrapping; widen the
+                        column to reveal more. */}
+                    <Text isTruncated minW={0}>
+                      {cell.render('Cell')}
+                    </Text>
                   </Td>
                 )
               })}

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
@@ -240,11 +240,21 @@ export const ResponsesTableV2 = ({
       <Tbody as="div" {...getTableBodyProps()}>
         {page.map((row) => {
           prepareRow(row)
+          const rowProps = row.getRowProps()
           return (
             <Tr
               as="div"
-              {...row.getRowProps()}
-              key={row.getRowProps().key}
+              {...rowProps}
+              key={rowProps.key}
+              // useFlexLayout sizes the row to the columns' combined min-widths,
+              // so cells overflow and the hover background stops short of the
+              // scrolled-in columns. Grow to content (max-content), but keep it
+              // at least viewport width (100%).
+              style={{
+                ...rowProps.style,
+                minWidth: '100%',
+                width: 'max-content',
+              }}
               px={0}
               // Read from row.original, not row.values: the Response ID column
               // sets an explicit id, so row.values.refNo is undefined.

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
@@ -1,0 +1,282 @@
+import { useCallback, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import {
+  Column,
+  useFlexLayout,
+  usePagination,
+  useResizeColumns,
+  useTable,
+} from 'react-table'
+import {
+  Box,
+  Flex,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react'
+import { FormField } from '@opengovsg/formsg-sdk/dist/types'
+
+import {
+  MRF_RESPONSE_TIMESTAMP_LABEL,
+  RESPONSE_ID_LABEL,
+} from '~features/admin-form/responses/constants'
+
+import { DecryptedResponse } from '../../useDecryptedResponsesQuery'
+import { getDecryptedResponseInstance } from '../../utils/getDecryptedResponseInstance'
+import { useUnlockedResponses } from '../UnlockedResponsesProvider'
+
+// Base storage-mode columns, rendered alongside the selected field columns.
+const BASE_RESPONSE_TABLE_COLUMNS: Column<DecryptedResponse>[] = [
+  {
+    Header: '#',
+    accessor: 'number',
+    width: 50,
+    minWidth: 50,
+    maxWidth: 50,
+  },
+  {
+    Header: RESPONSE_ID_LABEL,
+    id: RESPONSE_ID_LABEL,
+    accessor: 'refNo',
+    width: 300,
+    minWidth: 300,
+    disableResizing: true,
+  },
+  {
+    Header: MRF_RESPONSE_TIMESTAMP_LABEL,
+    id: MRF_RESPONSE_TIMESTAMP_LABEL,
+    accessor: 'submissionTime',
+    width: 250,
+    minWidth: 250,
+    disableResizing: true,
+  },
+]
+
+/**
+ * Rows per page. The whole working set is decrypted client-side, but the table
+ * is not virtualised, so keep the mounted DOM small by paginating it locally.
+ */
+export const RESPONSES_TABLE_V2_PAGE_SIZE = 50
+
+export const ResponsesTableV2 = ({
+  selectedFields,
+  selectedSubmissionMetaFields,
+  decryptedResponses,
+}: {
+  selectedFields: {
+    _id: string
+    title: string
+  }[]
+  selectedSubmissionMetaFields: {
+    _id: string
+    title: string
+  }[]
+  decryptedResponses: DecryptedResponse[]
+}) => {
+  const { t } = useTranslation()
+  const { currentPage: currentPage1Indexed, onRowClick } =
+    useUnlockedResponses()
+
+  const navigate = useNavigate()
+
+  const currentPage = useMemo(
+    () => (currentPage1Indexed ?? 1) - 1,
+    [currentPage1Indexed],
+  )
+
+  const columns = useMemo(() => {
+    const filteredBaseColumns = BASE_RESPONSE_TABLE_COLUMNS.filter((column) => {
+      return (
+        selectedSubmissionMetaFields.some(
+          (field) => field._id === column.Header,
+        ) || column.Header === '#'
+      )
+    })
+
+    const selectFieldColumns = selectedFields.map((field) => ({
+      Header: field.title,
+      id: field._id,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      accessor: (row: any) => {
+        const response = row.decryptedResponses.find(
+          (response: FormField) => response._id === field._id,
+        )
+        if (!response) return ''
+        try {
+          // Serialize the same way as the CSV export so answerArray-based
+          // fields (Checkbox, Table) render instead of showing up blank.
+          const instance = getDecryptedResponseInstance(response)
+          return Array.from({ length: instance.numCols }, (_, colIndex) =>
+            instance.getAnswer(colIndex),
+          ).join(';')
+        } catch {
+          return response.answer ?? ''
+        }
+      },
+    }))
+
+    return [...filteredBaseColumns, ...selectFieldColumns]
+  }, [selectedSubmissionMetaFields, selectedFields])
+
+  const {
+    prepareRow,
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    page,
+    gotoPage,
+  } = useTable<DecryptedResponse>(
+    {
+      columns,
+      data: decryptedResponses,
+      initialState: {
+        pageIndex: currentPage,
+        pageSize: RESPONSES_TABLE_V2_PAGE_SIZE,
+      },
+    },
+    usePagination,
+    useResizeColumns,
+    useFlexLayout,
+  )
+
+  useEffect(() => {
+    gotoPage(currentPage)
+  }, [currentPage, gotoPage])
+
+  const handleRowClick = useCallback(
+    (submissionId: string, responseNumber: number) => {
+      onRowClick()
+      return navigate(submissionId, {
+        state: {
+          responseNumber,
+        },
+      })
+    },
+    [navigate, onRowClick],
+  )
+
+  if (decryptedResponses.length === 0) {
+    return (
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        py="4rem"
+        color="secondary.400"
+      >
+        <Text textStyle="subhead-1">
+          {t(
+            'features.adminForm.responses.responsesPage.storage.unlockedResponses.unlockedResponses.noResponsesToDisplay',
+          )}
+        </Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Table
+      as="div"
+      variant="solid"
+      colorScheme="secondary"
+      {...getTableProps()}
+    >
+      <Thead as="div" pos="sticky" top={0}>
+        {headerGroups.map((headerGroup) => (
+          <Tr
+            as="div"
+            {...headerGroup.getHeaderGroupProps()}
+            key={headerGroup.getHeaderGroupProps().key}
+            // To toggle _groupHover styles to show divider when header is hovered.
+            data-group
+          >
+            {headerGroup.headers.map((column) => (
+              <Th
+                as="div"
+                pos="relative"
+                {...column.getHeaderProps()}
+                key={column.getHeaderProps().key}
+              >
+                <Flex align="center">{column.render('Header')}</Flex>
+
+                {column.disableResizing ? null : (
+                  <Flex
+                    {...column.getResizerProps()}
+                    justify="center"
+                    top={0}
+                    right={0}
+                    zIndex={1}
+                    transitionProperty="background"
+                    transitionDuration="normal"
+                    pos="absolute"
+                    h="100%"
+                    borderX="8px solid"
+                    borderColor="secondary.500"
+                    _hover={{
+                      bg: column.isResizing ? 'white' : 'secondary.200',
+                    }}
+                    _groupHover={{
+                      bg: column.isResizing ? 'white' : 'secondary.300',
+                      _hover: {
+                        bg: column.isResizing ? 'white' : 'secondary.200',
+                      },
+                    }}
+                    w="17px"
+                    sx={{
+                      touchAction: 'none',
+                    }}
+                  />
+                )}
+              </Th>
+            ))}
+          </Tr>
+        ))}
+      </Thead>
+      <Tbody as="div" {...getTableBodyProps()}>
+        {page.map((row) => {
+          prepareRow(row)
+          return (
+            <Tr
+              as="div"
+              {...row.getRowProps()}
+              key={row.getRowProps().key}
+              px={0}
+              // Read from row.original, not row.values: the Response ID column
+              // sets an explicit id, so row.values.refNo is undefined.
+              onClick={() =>
+                handleRowClick(row.original.refNo, row.original.number)
+              }
+              cursor="pointer"
+              _hover={{
+                bg: 'primary.100',
+              }}
+              _active={{
+                bg: 'primary.200',
+              }}
+            >
+              {row.cells.map((cell) => {
+                return (
+                  <Td
+                    as="div"
+                    {...cell.getCellProps()}
+                    key={cell.getCellProps().key}
+                    display="flex"
+                    alignItems="center"
+                    overflow="clip"
+                    textOverflow="ellipsis"
+                  >
+                    {cell.render('Cell')}
+                  </Td>
+                )
+              })}
+            </Tr>
+          )
+        })}
+      </Tbody>
+    </Table>
+  )
+}

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/ResponsesTable/ResponsesTableV2.tsx
@@ -38,22 +38,23 @@ const BASE_RESPONSE_TABLE_COLUMNS: Column<DecryptedResponse>[] = [
     width: 50,
     minWidth: 50,
     maxWidth: 50,
+    // Fixed-width index column; no resize handle.
+    disableResizing: true,
   },
   {
     Header: RESPONSE_ID_LABEL,
     id: RESPONSE_ID_LABEL,
     accessor: 'refNo',
-    width: 300,
-    minWidth: 300,
-    disableResizing: true,
+    // Fits a full 24-char ObjectId; resizable down to minWidth.
+    width: 250,
+    minWidth: 100,
   },
   {
     Header: MRF_RESPONSE_TIMESTAMP_LABEL,
     id: MRF_RESPONSE_TIMESTAMP_LABEL,
     accessor: 'submissionTime',
     width: 250,
-    minWidth: 250,
-    disableResizing: true,
+    minWidth: 100,
   },
 ]
 

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponsesV2.tsx
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/UnlockedResponses/UnlockedResponsesV2.tsx
@@ -1,0 +1,244 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Box,
+  Container,
+  Flex,
+  Grid,
+  Skeleton,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
+
+import { BasicField, FormFieldDto } from 'formsg-shared/types'
+
+import {
+  DateRangePicker,
+  dateRangePickerHelper,
+} from '~components/DateRangePicker'
+import Pagination from '~components/Pagination'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+import {
+  MRF_RESPONSE_TIMESTAMP_LABEL,
+  RESPONSE_ID_LABEL,
+} from '~features/admin-form/responses/constants'
+
+import { useStorageResponsesContext } from '../StorageResponsesContext'
+import { useDecryptedResponsesQuery } from '../useDecryptedResponsesQuery'
+
+import {
+  RESPONSES_TABLE_V2_PAGE_SIZE,
+  ResponsesTableV2,
+} from './ResponsesTable/ResponsesTableV2'
+import { DownloadButton } from './DownloadButton'
+import { SubmissionSearchbar } from './SubmissionSearchbar'
+import { useUnlockedResponses } from './UnlockedResponsesProvider'
+
+// Cap on responses the dashboard will decrypt/render in one date range; kept
+// low as the table is not virtualised yet.
+const RESPONSES_DASHBOARD_MAX_RESPONSE_COUNT = 1000
+
+// Field types with no meaningful single-cell answer, excluded as columns.
+const DASHBOARD_EXCLUDED_FIELD_TYPES = new Set<BasicField>([
+  BasicField.Section,
+  BasicField.Statement,
+  BasicField.Signature,
+  BasicField.Attachment,
+  BasicField.Image,
+  BasicField.Address,
+  BasicField.Children,
+])
+
+const filterFieldsForDashboardView = (formFields: FormFieldDto[]) =>
+  formFields.filter(
+    (field) => !DASHBOARD_EXCLUDED_FIELD_TYPES.has(field.fieldType),
+  )
+
+// Always-shown meta columns; `_id` must match the column Header in
+// ResponsesTableV2.
+const getSubmissionMetaFieldsForDashboard = (): {
+  _id: string
+  title: string
+}[] => [
+  {
+    _id: RESPONSE_ID_LABEL,
+    title: RESPONSE_ID_LABEL,
+  },
+  {
+    _id: MRF_RESPONSE_TIMESTAMP_LABEL,
+    title: 'Response Timestamp',
+  },
+]
+
+export const UnlockedResponsesV2 = (): JSX.Element | null => {
+  const { t } = useTranslation()
+  const { data: form, isLoading: isLoadingForm } = useAdminForm()
+  const {
+    secretKey,
+    isLoading: isLoadingSecretKey,
+    dateRange,
+    setDateRange,
+    dateRangeResponsesCount,
+  } = useStorageResponsesContext()
+  const {
+    count,
+    filteredCount,
+    currentPage,
+    setCurrentPage,
+    submissionId,
+    setSubmissionId,
+    isAnyFetching,
+  } = useUnlockedResponses()
+  const [startDate, endDate] = dateRange
+
+  const responsesCount = dateRangeResponsesCount ?? 0
+  const isOverResponseCap =
+    responsesCount > RESPONSES_DASHBOARD_MAX_RESPONSE_COUNT
+
+  const { data: decryptedResponses = [], isFetching: isFetchingAndDecrypting } =
+    useDecryptedResponsesQuery({
+      formId: form?._id ?? '',
+      secretKey: secretKey ?? '',
+      startDate,
+      endDate,
+      // Decrypting the working set is expensive, so never start over the cap
+      // (or when there is nothing to decrypt).
+      enabled:
+        !isLoadingForm &&
+        !isLoadingSecretKey &&
+        !!secretKey &&
+        !!form &&
+        !isOverResponseCap &&
+        responsesCount > 0,
+    })
+
+  // Narrow to the searched response ID, if any.
+  const responsesToDisplay = useMemo(
+    () =>
+      submissionId
+        ? decryptedResponses.filter(
+            (response) => response.refNo === submissionId,
+          )
+        : decryptedResponses,
+    [decryptedResponses, submissionId],
+  )
+
+  const countToUse = submissionId ? filteredCount : count
+
+  if (!secretKey || !form) return null
+
+  const submissionMetaFields = getSubmissionMetaFieldsForDashboard()
+  const fieldsForDashboardView = filterFieldsForDashboardView(
+    form.form_fields ?? [],
+  )
+
+  return (
+    <Flex flexDir="column" h="100%">
+      <Grid
+        mb="1rem"
+        alignItems="end"
+        color="secondary.500"
+        gridTemplateColumns={{ base: 'auto 1fr', lg: 'auto 1fr auto' }}
+        gridGap="0.5rem"
+        gridTemplateAreas={{
+          base: "'submissions search' 'export export'",
+          lg: "'submissions search export'",
+        }}
+      >
+        <Stack
+          align="center"
+          spacing="1rem"
+          direction="row"
+          gridArea="submissions"
+        >
+          <Skeleton isLoaded={!isAnyFetching}>
+            <Text textStyle="h4" mb="0.5rem">
+              <Text as="span" color="primary.500">
+                {countToUse?.toLocaleString()}
+              </Text>{' '}
+              {t(
+                submissionId
+                  ? 'features.adminForm.responses.responsesPage.storage.unlockedResponses.unlockedResponses.resultsFound'
+                  : 'features.adminForm.responses.responsesPage.storage.unlockedResponses.unlockedResponses.responsesToDate',
+                { count: countToUse ?? 0 },
+              )}
+            </Text>
+          </Skeleton>
+        </Stack>
+
+        <Flex gridArea="search" justifySelf="end">
+          <SubmissionSearchbar
+            submissionId={submissionId}
+            setSubmissionId={setSubmissionId}
+            isAnyFetching={isAnyFetching}
+          />
+        </Flex>
+
+        <Stack
+          direction={{ base: 'column', sm: 'row' }}
+          justifySelf={{ base: 'start', sm: 'end' }}
+          gridArea="export"
+          maxW="100%"
+        >
+          <DateRangePicker
+            value={dateRangePickerHelper.dateStringToDatePickerValue(dateRange)}
+            onChange={(nextDateRange) =>
+              setDateRange(
+                dateRangePickerHelper.datePickerValueToDateString(
+                  nextDateRange,
+                ),
+              )
+            }
+          />
+          <DownloadButton />
+        </Stack>
+      </Grid>
+
+      <Box mb="3rem" overflow="auto" flex={1}>
+        {isOverResponseCap ? (
+          <Container p={0} maxW="42.5rem">
+            <Stack spacing="1rem" align="center" py="4rem">
+              <Text as="h2" color="primary.500" textStyle="h2">
+                {t(
+                  'features.adminForm.responses.responsesPage.storage.unlockedResponses.unlockedResponses.tooManyResponsesTitle',
+                )}
+              </Text>
+              <Text textStyle="body-1" color="secondary.500">
+                {t(
+                  'features.adminForm.responses.responsesPage.storage.unlockedResponses.unlockedResponses.tooManyResponsesBody',
+                  { responseCount: responsesCount.toLocaleString() },
+                )}
+              </Text>
+            </Stack>
+          </Container>
+        ) : isFetchingAndDecrypting ? (
+          <Skeleton height="2.5rem" />
+        ) : (
+          <ResponsesTableV2
+            selectedSubmissionMetaFields={submissionMetaFields}
+            selectedFields={fieldsForDashboardView}
+            decryptedResponses={responsesToDisplay}
+          />
+        )}
+      </Box>
+
+      <Box
+        display={
+          isOverResponseCap ||
+          isFetchingAndDecrypting ||
+          responsesToDisplay.length === 0
+            ? 'none'
+            : ''
+        }
+      >
+        <Pagination
+          totalCount={responsesToDisplay.length}
+          currentPage={currentPage ?? 1} //1-indexed
+          pageSize={RESPONSES_TABLE_V2_PAGE_SIZE}
+          onPageChange={setCurrentPage}
+        />
+      </Box>
+    </Flex>
+  )
+}

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptedResponsesQuery.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/useDecryptedResponsesQuery.ts
@@ -1,0 +1,162 @@
+import { useQuery, UseQueryResult } from 'react-query'
+import { FormField } from '@opengovsg/formsg-sdk/dist/types'
+import { formatInTimeZone } from 'date-fns-tz'
+
+import {
+  DateString,
+  SubmissionMetadata,
+  SubmissionType,
+} from 'formsg-shared/types'
+
+import { env } from '~/env'
+
+import {
+  killWorkers,
+  makeWorkerApiAndCleanup,
+} from '../../common/utils/decryptionWorker'
+import { adminFormResponsesKeys } from '../../queries'
+
+import { getEncryptedResponsesStream } from './StorageResponsesService'
+import { CleanableDecryptionWorkerApi } from './types'
+
+export type DecryptedResponse = {
+  decryptedResponses: FormField[]
+} & SubmissionMetadata
+
+const decryptedResponsesKey = (
+  formId: string,
+  dateRange?: { startDate?: DateString; endDate?: DateString },
+) =>
+  [
+    ...adminFormResponsesKeys.id(formId),
+    'decrypted',
+    dateRange?.startDate ?? 'all',
+    dateRange?.endDate ?? 'all',
+  ] as const
+
+const NUM_WORKERS = window.navigator.hardwareConcurrency || 4
+
+async function fetchAndDecryptResponses({
+  formId,
+  secretKey,
+  startDate,
+  endDate,
+}: {
+  formId: string
+  secretKey: string
+  startDate?: DateString
+  endDate?: DateString
+}): Promise<DecryptedResponse[]> {
+  const workerPool: CleanableDecryptionWorkerApi[] = []
+
+  try {
+    for (let i = 0; i < NUM_WORKERS; i++) {
+      workerPool.push(makeWorkerApiAndCleanup())
+    }
+
+    const stream = await getEncryptedResponsesStream(formId, {
+      downloadAttachments: false,
+      startDate,
+      endDate,
+    })
+
+    const reader = stream.getReader()
+    let currentSubmissionIndex = 0
+
+    const submissionDecryptPromises: Promise<DecryptedResponse | undefined>[] =
+      []
+
+    let read: (result: ReadableStreamReadResult<string>) => void
+
+    await reader.read().then(
+      (read = async (result) => {
+        if (result.done) return
+        const { workerApi } = workerPool[currentSubmissionIndex % NUM_WORKERS]
+        const decryptResponsePromise = workerApi
+          .parseAndDecryptSubmissionData({
+            submissionStreamDtoString: result.value,
+            secretKey,
+            // Resolved on the main thread so the worker need not import env.ts
+            // (which references window).
+            workerCtxOptions: { formsgSdkMode: env.formsgSdkMode },
+          })
+          .then((result) => {
+            if (result.isParseSuccessful && result.isDecryptionSuccessful) {
+              const submissionTime = formatInTimeZone(
+                result.parsedSubmission.created,
+                'Asia/Singapore',
+                'dd MMM yyyy hh:mm:ss a',
+              )
+              return {
+                // Placeholder; the real '#' is assigned by display order below,
+                // since these promises resolve out of order.
+                number: 0,
+                decryptedResponses: result.decryptedResponses,
+                refNo: result.parsedSubmission._id,
+                submissionTime,
+                payments: null,
+                mrf:
+                  result.parsedSubmission.submissionType ===
+                  SubmissionType.Multirespondent
+                    ? result.parsedSubmission.mrfMeta
+                    : undefined,
+              } as DecryptedResponse
+            }
+            return undefined
+          })
+        submissionDecryptPromises.push(decryptResponsePromise)
+        currentSubmissionIndex++
+        return reader.read().then(read)
+      }),
+    )
+
+    const results = await Promise.all(submissionDecryptPromises)
+
+    // Number rows by final position (stream order) so '#' is sequential.
+    return results
+      .filter((result): result is DecryptedResponse => result !== undefined)
+      .map((result, index) => ({ ...result, number: index + 1 }))
+  } finally {
+    killWorkers(workerPool)
+  }
+}
+
+interface UseDecryptedResponsesQueryParams {
+  formId: string
+  secretKey: string
+  startDate?: DateString
+  endDate?: DateString
+  enabled?: boolean
+}
+
+/**
+ * Fetches and decrypts responses for the given form/date range, cached by
+ * React Query. Decryption is expensive, so results are cached and never
+ * auto-refetched.
+ */
+export const useDecryptedResponsesQuery = ({
+  formId,
+  secretKey,
+  startDate,
+  endDate,
+  enabled = true,
+}: UseDecryptedResponsesQueryParams): UseQueryResult<DecryptedResponse[]> => {
+  return useQuery<DecryptedResponse[]>(
+    decryptedResponsesKey(formId, { startDate, endDate }),
+    () =>
+      fetchAndDecryptResponses({
+        formId,
+        secretKey,
+        startDate,
+        endDate,
+      }),
+    {
+      enabled: enabled && !!formId && !!secretKey,
+      staleTime: Infinity,
+      cacheTime: 30 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+    },
+  )
+}

--- a/apps/frontend/src/features/admin-form/responses/constants.ts
+++ b/apps/frontend/src/features/admin-form/responses/constants.ts
@@ -1,4 +1,5 @@
 // TODO(#8204) Use text labels in i18n files
+export const RESPONSE_ID_LABEL = 'Response ID'
 export const MRF_RESPONSE_TIMESTAMP_LABEL = 'Response timestamp'
 export const MRF_PENDING_RESPONSE_AT_LABEL = 'Pending response at'
 export const MRF_WORKFLOW_STATUS_LABEL = 'Workflow status'

--- a/apps/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
@@ -90,6 +90,7 @@ export const enSG: ResponsesResponsesPage = {
         resultsFound: '{count, plural, =1 {result} other {results}} found',
         responsesToDate:
           '{count, plural, =1 {response} other {responses}} to date',
+        noResponsesToDisplay: 'No responses to display.',
       },
     },
     storageResponsesTab: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/responses/responses-page/en-sg.ts
@@ -91,6 +91,9 @@ export const enSG: ResponsesResponsesPage = {
         responsesToDate:
           '{count, plural, =1 {response} other {responses}} to date',
         noResponsesToDisplay: 'No responses to display.',
+        tooManyResponsesTitle: 'Too many responses to display',
+        tooManyResponsesBody:
+          'There are {responseCount} responses in this date range. Select a narrower date range.',
       },
     },
     storageResponsesTab: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
@@ -77,6 +77,7 @@ export interface ResponsesResponsesPage {
       unlockedResponses: {
         resultsFound: string
         responsesToDate: string
+        noResponsesToDisplay: string
       }
     }
     storageResponsesTab: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/responses/responses-page/index.ts
@@ -78,6 +78,8 @@ export interface ResponsesResponsesPage {
         resultsFound: string
         responsesToDate: string
         noResponsesToDisplay: string
+        tooManyResponsesTitle: string
+        tooManyResponsesBody: string
       }
     }
     storageResponsesTab: {

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -33,6 +33,7 @@ export const featureFlags = {
   sidebarNavLabels: 'enable-sidebar-nav-labels' as const,
   fiveStarAdminRating: '5star-admin-rating' as const,
   workflowBuilderRedesign: 'workflow-builder-redesign' as const,
+  delightfulDashboard: 'delightful-dashboard' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {


### PR DESCRIPTION
## Problem

- The results page only shows Response ID + timestamp, which are not meaningful for processing. Admins — especially school admins — cannot tell who or what a submission is about without clicking into every response or exporting a CSV. This is repeatedly cited as the reason the results dashboard is not usable for day-to-day ops.
- No quick way to search or filter for specific submissions — admins fall back to exporting CSVs multiple times and filtering in Excel/Google Sheets
- Our usefulness score for dashboard is at 2.4/5 (below hygiene of 4.2/5)

## Solution

- [Team PRD](https://app.notion.com/p/opengov/Delightful-dashboards-v1-30577dbba7888022ad1deba9db21882d)
- [AI-agent PRD](https://app.notion.com/p/opengov/To-issues-document-3a277dbba7888080958ccdca6bb5219d?source=copy_link)

Behind the `delightful-dashboard` flag, the Responses tab renders a new `UnlockedResponsesV2` that decrypts responses client-side and surfaces their **field values directly as table columns** (alongside submission-meta columns), instead of only Response ID + timestamp (and workflow details). Rows stay clickable to open the full individual response. Client-side decryption is gated behind a 1,000-response cap per date range; over-cap, the container shows a "narrow the range" prompt before any decryption runs. The date range is sourced from `StorageResponsesContext` so the picker, the decrypt query key, and the cap gate all agree on one range.

**Alternatives considered**
- We considered keeping the hackathon table's `isResponseLimitExceeded` prop for port-fidelity, but the over-cap state now lives in the container (before decryption, mirroring ChartsPage), so the table would never see it — dead surface that invites a divergent second over-cap UI later.
- We considered keeping V2's own local `useState` date range from the hackathon, but develop already owns `dateRange` in `StorageResponsesContext` (shared with the download and count queries); a second source of truth would let the cap gate and the decrypt disagree.

**Screenshots**

Storage-mode (MRF) form's Responses tab — flag off (v1) vs on (v2). V2 adds the form's field-answer columns (e.g. **Name**) beside the meta/workflow columns.

| Page | Before (flag off) | After (flag on) |
| --- | --- | --- |
| `/admin/form/:id/results` → Responses | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/delightful-dashboards/before-results.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/delightful-dashboards/after-results.png) |

**Breaking Changes**

No - backwards compatible; new behaviour is behind the `delightful-dashboard` feature flag (off by default).

## Tests

**TC1: Field values render as columns**

- [ ] Enable the `delightful-dashboard` flag; open a storage-mode form's Results → Responses and enter the secret key
- [ ] Field answers (incl. Checkbox/Table) render as columns alongside Response ID + timestamp

**TC2: Click into an individual response**

- [ ] Click a row; it opens that submission's individual response view with all fields (no regression)

**TC3 (MRF): workflow columns**

- [ ] Open an MRF form's dashboard → Workflow status, Pending response at, and Reminders columns render (before the field columns)

**TC4: Search by response ID**

- [ ] Search a response ID → the table narrows to the matching row and the count shows the result count

