### PR TITLE
feat(paper-forms): progress bar on set-up pages

### DIFF
--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
@@ -9,6 +9,7 @@ import {
 
 import { CreateFormDetailsScreen } from './CreateFormDetailsScreen'
 import { CreateFormOriginScreen } from './CreateFormOriginScreen'
+import { CreateFormProgressBar } from './CreateFormProgressBar'
 import { CreateFormStorageModeScreen } from './CreateFormStorageModeScreen'
 import {
   EmailModeCreationScreen,
@@ -16,16 +17,34 @@ import {
 } from './EmailModeFeedbackAndCreateScreen'
 import { SaveSecretKeyScreen } from './SaveSecretKeyScreen'
 
+// Set-up pages the progress bar spans, in order.
+const PROGRESS_STEP_ORDER = [
+  CreateFormFlowStates.Details,
+  CreateFormFlowStates.Origin,
+  CreateFormFlowStates.Landing,
+]
+
 /**
  * @preconditions Requires CreateFormWizardProvider parent
  * Display screen content depending on the current step (with animation).
  */
 export const CreateFormModalContent = () => {
-  const { direction, currentStep } = useCreateFormWizard()
+  const { direction, currentStep, isPaperTrackingSetUpPageEnabled } =
+    useCreateFormWizard()
+
+  const progressStepIdx = PROGRESS_STEP_ORDER.indexOf(currentStep)
+  const showProgressBar =
+    isPaperTrackingSetUpPageEnabled && progressStepIdx !== -1
 
   return (
     <>
       {currentStep !== CreateFormFlowStates.Landing && <ModalCloseButton />}
+      {showProgressBar && (
+        <CreateFormProgressBar
+          currentStepIdx={progressStepIdx}
+          numSteps={PROGRESS_STEP_ORDER.length}
+        />
+      )}
       <XMotionBox keyProp={currentStep} custom={direction}>
         {currentStep === CreateFormFlowStates.Details && (
           <CreateFormDetailsScreen />

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
@@ -33,7 +33,9 @@ export const CreateFormModalContent = () => {
 
   const progressStepIdx = PROGRESS_STEP_ORDER.indexOf(currentStep)
   const showProgressBar =
-    isPaperTrackingSetUpPageEnabled && progressStepIdx !== -1
+    isPaperTrackingSetUpPageEnabled &&
+    progressStepIdx >= 0 &&
+    progressStepIdx < PROGRESS_STEP_ORDER.length
 
   return (
     <>

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormModalContent.tsx
@@ -17,7 +17,6 @@ import {
 } from './EmailModeFeedbackAndCreateScreen'
 import { SaveSecretKeyScreen } from './SaveSecretKeyScreen'
 
-// Set-up pages the progress bar spans, in order.
 const PROGRESS_STEP_ORDER = [
   CreateFormFlowStates.Details,
   CreateFormFlowStates.Origin,

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.tsx
@@ -56,12 +56,12 @@ export const CreateFormOriginScreen = ({
   return (
     <>
       <ModalHeader color="secondary.700">
-        <Container maxW="42.5rem" p={0}>
+        <Container maxW="45rem" p={0}>
           {t(`${ORIGIN_I18N_PREFIX}.question`)}
         </Container>
       </ModalHeader>
       <ModalBody whiteSpace="pre-wrap">
-        <Container maxW="42.5rem" p={0}>
+        <Container maxW="45rem" p={0}>
           <FormControl
             isRequired
             isInvalid={!!errors.formOrigins?.value}

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormProgressBar.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormProgressBar.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from '@testing-library/react'
+
+import { render } from '~/test-utils'
+
+import { CreateFormProgressBar } from './CreateFormProgressBar'
+
+describe('CreateFormProgressBar', () => {
+  it('reports the current step through progressbar aria attributes', () => {
+    render(<CreateFormProgressBar currentStepIdx={1} numSteps={3} />)
+
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '2')
+    expect(bar).toHaveAttribute('aria-valuemin', '1')
+    expect(bar).toHaveAttribute('aria-valuemax', '3')
+    expect(bar).toHaveAccessibleName('Step 2 of 3')
+  })
+
+  it('fills proportionally to the current step', () => {
+    render(<CreateFormProgressBar currentStepIdx={0} numSteps={4} />)
+
+    expect(screen.getByTestId('progress-fill')).toHaveStyle({ width: '25%' })
+  })
+
+  it('is fully filled on the final step', () => {
+    render(<CreateFormProgressBar currentStepIdx={2} numSteps={3} />)
+
+    expect(screen.getByTestId('progress-fill')).toHaveStyle({ width: '100%' })
+  })
+})

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormProgressBar.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormProgressBar.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@chakra-ui/react'
+import { Box, Container } from '@chakra-ui/react'
 
 interface CreateFormProgressBarProps {
   currentStepIdx: number
@@ -14,26 +14,30 @@ export const CreateFormProgressBar = ({
   const progress = (currentStep / numSteps) * 100
 
   return (
-    <Box
-      role="progressbar"
-      aria-valuenow={currentStep}
-      aria-valuemin={1}
-      aria-valuemax={numSteps}
-      aria-label={`Step ${currentStep} of ${numSteps}`}
-      h="0.25rem"
-      w="100%"
-      bg="neutral.200"
-      borderRadius="2px"
-      overflow="hidden"
-    >
-      <Box
-        data-testid="progress-fill"
-        h="100%"
-        w={`${progress}%`}
-        bg="primary.500"
-        borderRadius="2px"
-        transition="width 0.35s cubic-bezier(0.4, 0, 0.2, 1)"
-      />
+    <Box px="1.5rem" pt="1.5rem">
+      <Container maxW="45rem" p={0}>
+        <Box
+          role="progressbar"
+          aria-valuenow={currentStep}
+          aria-valuemin={1}
+          aria-valuemax={numSteps}
+          aria-label={`Step ${currentStep} of ${numSteps}`}
+          h="0.25rem"
+          w="100%"
+          bg="neutral.200"
+          borderRadius="2px"
+          overflow="hidden"
+        >
+          <Box
+            data-testid="progress-fill"
+            h="100%"
+            w={`${progress}%`}
+            bg="primary.500"
+            borderRadius="2px"
+            transition="width 0.35s cubic-bezier(0.4, 0, 0.2, 1)"
+          />
+        </Box>
+      </Container>
     </Box>
   )
 }

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormProgressBar.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormProgressBar.tsx
@@ -22,7 +22,8 @@ export const CreateFormProgressBar = ({
       aria-label={`Step ${currentStep} of ${numSteps}`}
       h="0.25rem"
       w="100%"
-      bg="neutral.300"
+      bg="neutral.200"
+      borderRadius="2px"
       overflow="hidden"
     >
       <Box
@@ -30,7 +31,8 @@ export const CreateFormProgressBar = ({
         h="100%"
         w={`${progress}%`}
         bg="primary.500"
-        transition="width 0.3s ease"
+        borderRadius="2px"
+        transition="width 0.35s cubic-bezier(0.4, 0, 0.2, 1)"
       />
     </Box>
   )

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormProgressBar.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormProgressBar.tsx
@@ -1,0 +1,37 @@
+import { Box } from '@chakra-ui/react'
+
+interface CreateFormProgressBarProps {
+  currentStepIdx: number
+  numSteps: number
+}
+
+/** Progress bar shown across the paper-tracking create-form set-up pages. */
+export const CreateFormProgressBar = ({
+  currentStepIdx,
+  numSteps,
+}: CreateFormProgressBarProps): JSX.Element => {
+  const currentStep = currentStepIdx + 1
+  const progress = (currentStep / numSteps) * 100
+
+  return (
+    <Box
+      role="progressbar"
+      aria-valuenow={currentStep}
+      aria-valuemin={1}
+      aria-valuemax={numSteps}
+      aria-label={`Step ${currentStep} of ${numSteps}`}
+      h="0.25rem"
+      w="100%"
+      bg="neutral.300"
+      overflow="hidden"
+    >
+      <Box
+        data-testid="progress-fill"
+        h="100%"
+        w={`${progress}%`}
+        bg="primary.500"
+        transition="width 0.3s ease"
+      />
+    </Box>
+  )
+}

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
@@ -73,7 +73,7 @@ export const SaveSecretKeyContent = ({
   return (
     <>
       <ModalBody whiteSpace="pre-wrap">
-        <Container maxW="42.5rem" p={0}>
+        <Container maxW="45rem" p={0}>
           <Box
             bg="white"
             borderRadius="4px"


### PR DESCRIPTION
## Problem

The paper-tracking create-form set-up flow (behind `enable-paper-tracking-set-up-page`)
walks admins through several set-up pages, but gives no sense of how far along
they are. This adds a progress bar across those pages.

## Solution

- [Team PRD](https://app.notion.com/p/opengov/Progress-bar-on-set-up-page-3a377dbba788802d90a0fdfd201f2bf4)
- [Agent PRD](https://app.notion.com/p/opengov/Epics-PRDs-90d21439b23f497a9e58ed0d85b05232?p=3a377dbba7888029a68cc15e1352816b&pm=s)

Adds a thin linear progress bar to the create-form modal, spanning the three
paper-tracking set-up pages in order: **title → data-source question → secret key**.
It fills proportionally as the admin advances.

- Rendered in `CreateFormModalContent`, driven by the wizard's `currentStep`.
- Appears **only** when `enable-paper-tracking-set-up-page` is on, so the
  non-flagged create-form flow is visually unchanged.
- Exposes `progressbar` ARIA semantics (`aria-valuenow/min/max`, label) for accessibility.

This builds on develop's existing `CreateFormModal` wizard — no changes to the
flow, steps, or any other behaviour.

**Screenshots**

| Page | Before | After |
| --- | --- | --- |
| Title (step 1/3) | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/paper-forms-progress-bar/before-1-title.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/paper-forms-progress-bar/after-1-title.png) |
| Data source (step 2/3) | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/paper-forms-progress-bar/before-2-datasource.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/paper-forms-progress-bar/after-2-datasource.png) |
| Secret key (step 3/3) | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/paper-forms-progress-bar/before-3-secretkey.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/paper-forms-progress-bar/after-3-secretkey.png) |

**Breaking Changes**

No - backwards compatible. Purely additive UI, gated behind an existing flag.

## Tests

Unit test added (`CreateFormProgressBar.test.tsx`): aria step reporting + proportional fill.

Manual:

**TC1: Bar appears and advances (flag on)**

- [ ] Enable `enable-paper-tracking-set-up-page`
- [ ] Open "Create form" → progress bar visible on the title step (~1/3)
- [ ] Proceed to the data-source question → bar advances (~2/3)
- [ ] Create the form → secret-key screen shows the bar full (3/3)

**TC2: No change when flag off**

- [ ] With the flag off, open "Create form"
- [ ] Confirm no progress bar appears and the flow is unchanged
