### PR TITLE
fix(mrf): re-validate only changed fields on MRF submissions

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -33,6 +33,7 @@ import {
   ITableFieldSchema,
   MultirespondentSubmissionData,
 } from 'src/types'
+import { ParsedClearFormFieldResponsesV4 } from 'src/types/api'
 
 import * as fieldValidation from '../../../../utils/field-validation'
 import { ValidateFieldErrorV4 } from '../../submission.errors'
@@ -479,6 +480,61 @@ describe('multirespondent-submission.utils', () => {
       })
 
       expect(validateFieldV4Mock).toHaveBeenCalledTimes(2)
+    })
+
+    it('should thread previousResponses through to validateFieldV4 as prevResponse', () => {
+      // Regression test: the V4 migration dropped previousResponses, causing
+      // carried-forward verifiable fields (verified in an earlier MRF step,
+      // whose OTP signature has since expired) to be re-authenticated and
+      // rejected. Threading prevResponse lets checkIsResponseChangedV4 skip
+      // fields the current respondent did not change.
+      const validateFieldV4Mock = jest
+        .spyOn(fieldValidation, 'validateFieldV4')
+        .mockReturnValue(ok(true))
+      const mockFormId = 'mockFormId'
+      const emailFieldId = 'emailField'
+      const mockVisibleFieldIds = new Set([emailFieldId])
+      const mockFormFields = [
+        generateDefaultField(BasicField.Email, { _id: emailFieldId }),
+      ]
+      const carriedForwardAnswer = {
+        value: 'alice@example.com',
+        signature: 'stale-but-unchanged-signature',
+      }
+      const mockResponses = {
+        [emailFieldId]: {
+          fieldType: BasicField.Email,
+          question: 'Email',
+          answer: carriedForwardAnswer,
+          provenance: {},
+        },
+      } as unknown as ParsedClearFormFieldResponsesV4
+      const mockPreviousResponses = {
+        [emailFieldId]: {
+          fieldType: BasicField.Email,
+          question: 'Email',
+          answer: carriedForwardAnswer,
+          provenance: {},
+        },
+      } as unknown as ParsedClearFormFieldResponsesV4
+
+      // Act
+      validateMrfFieldResponses({
+        formId: mockFormId,
+        visibleFieldIds: mockVisibleFieldIds,
+        formFields: mockFormFields as FormFieldDto[],
+        responses: mockResponses,
+        previousResponses: mockPreviousResponses,
+      })
+
+      // Assert
+      expect(validateFieldV4Mock).toHaveBeenCalledWith({
+        formId: mockFormId,
+        formField: mockFormFields[0],
+        response: mockResponses[emailFieldId],
+        prevResponse: mockPreviousResponses[emailFieldId],
+        isVisible: true,
+      })
     })
   })
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -674,12 +674,13 @@ export const validateMultirespondentSubmission = async (
                   return previousResponses
                 })
               })
-              .andThen(() => {
+              .andThen((previousResponses) => {
                 return validateMrfFieldResponses({
                   formId,
                   visibleFieldIds,
                   formFields: form_fields,
                   responses: req.body.responses,
+                  previousResponses,
                 })
               }),
           )

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -191,11 +191,13 @@ export const validateMrfFieldResponses = ({
   visibleFieldIds,
   formFields,
   responses,
+  previousResponses,
 }: {
   formId: string
   visibleFieldIds: FieldIdSet
   formFields: FormFieldDto[]
   responses: ParsedClearFormFieldResponsesV4
+  previousResponses?: ParsedClearFormFieldResponsesV4
 }): Result<
   ParsedClearFormFieldResponsesV4,
   ValidateFieldErrorV4 | ProcessingError
@@ -228,6 +230,7 @@ export const validateMrfFieldResponses = ({
       formId,
       formField,
       response,
+      prevResponse: previousResponses?.[responseId],
       isVisible: visibleFieldIds.has(responseId),
     })
     if (validateFieldV4Result.isErr()) {


### PR DESCRIPTION
## Problem

- MRF submissions with a verified email/mobile field fail at step 2+ with `CommonValidatorV4.makeSignatureValidator: answer does not have valid signature`.
- Root cause: PR #9637 (V4 migration) dropped the `previousResponses` plumbing, so `validateFieldV4` always ran with `prevResponse` undefined → `checkIsResponseChangedV4` returns `true` → every field re-validated every step.
- Carried-forward verified fields keep their original OTP signature; by step 2 it has expired, so `authenticate()` returns `false` and the whole submission is rejected.

## Solution

**Breaking Changes**
- [x] No - this PR is backwards compatible (restores pre-migration behaviour)

**Bug Fixes**:

- `validateMrfFieldResponses` re-accepts optional `previousResponses` and threads `prevResponse` into each `validateFieldV4` call.
- Middleware passes through the `previousResponses` it already computes (was returned by `.map()` then ignored by `.andThen()`).
- Unchanged carried-forward fields now skip re-validation (V3 behaviour); changed fields are still fully validated.

## Note for reviewers

- Restores intended V3 semantics: an expired-but-**unchanged** carried-forward signature is trusted implicitly ("an earlier step verified it"). Treating expired-but-unchanged signatures as explicitly acceptable would be a separate design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)