### PR TITLE
fix(frontend): defer form title save to cta click in design drawer

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -195,7 +195,7 @@ export const StartPageView = () => {
           {...formBannerLogoProps}
         />
         <FormHeader
-          title={form?.title}
+          title={startPageData?.title ?? form?.title}
           showHeader
           loggedInId={
             form && form.authType !== FormAuthType.NIL

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -74,6 +74,10 @@ type DesignDrawerProps = {
   startPage: FormStartPage
 }
 
+interface DesignFormInput extends FormStartPageInput {
+  title: string
+}
+
 export const DesignInput = (): JSX.Element | null => {
   const { t } = useTranslation()
   const toast = useToast({ status: 'danger' })
@@ -126,10 +130,17 @@ export const DesignInput = (): JSX.Element | null => {
     clearErrors,
     setError,
     setFocus,
-  } = useForm<FormStartPageInput & { title: string }>({
+    setValue,
+  } = useForm<DesignFormInput>({
     mode: 'onBlur',
     defaultValues: { ...startPageData, title: settings?.title },
   })
+
+  useEffect(() => {
+    if (settings?.title) {
+      setValue('title', settings.title)
+    }
+  }, [settings?.title, setValue])
 
   // Update dirty state of builder so confirmation modal can be shown
   useEffect(() => {
@@ -195,13 +206,13 @@ export const DesignInput = (): JSX.Element | null => {
   const handleCloseDrawer = useCallback(() => handleClose(false), [handleClose])
 
   const handleUpdateDesign = handleSubmit(
-    async (startPageData: FormStartPageInput & { title: string }) => {
+    async (startPageData: DesignFormInput) => {
       const { logo, attachment, estTimeTaken, title, ...rest } = startPageData
       const estTimeTakenTransformed =
         estTimeTaken === '' ? undefined : estTimeTaken
 
       if (title !== settings?.title) {
-        mutateFormTitle.mutate(title)
+        await mutateFormTitle.mutateAsync(title)
       }
 
       if (logo.state !== FormLogoState.Custom) {
@@ -358,7 +369,7 @@ export const DesignInput = (): JSX.Element | null => {
 
       {showDesignDrawerFormTitle && (
         <FormControl
-          isReadOnly={startPageMutation.isLoading}
+          isReadOnly={startPageMutation.isLoading || mutateFormTitle.isLoading}
           isInvalid={!!errors.title}
           isRequired
         >

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -15,6 +15,7 @@ import {
   Flex,
   FormControl,
   FormLabel,
+  Input,
   Text,
   Textarea,
 } from '@chakra-ui/react'
@@ -29,6 +30,7 @@ import {
 } from 'formsg-shared/types'
 
 import { useToast } from '~hooks/useToast'
+import { useFormTitleValidationRules } from '~utils/formValidation'
 import { uploadLogo } from '~services/FileHandlerService'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import NumberInput from '~components/NumberInput'
@@ -37,6 +39,8 @@ import Radio from '~components/Radio'
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
 import { FormDetailsSection } from '~features/admin-form/settings/components/FormDetailsSection'
+import { useMutateFormSettings } from '~features/admin-form/settings/mutations'
+import { useAdminFormSettings } from '~features/admin-form/settings/queries'
 import { useEnv } from '~features/env/queries'
 import { getTitleBg } from '~features/public-form/components/FormStartPage/useFormHeader'
 
@@ -75,6 +79,11 @@ export const DesignInput = (): JSX.Element | null => {
   const toast = useToast({ status: 'danger' })
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
+
+  const { data: settings } = useAdminFormSettings()
+  const { mutateFormTitle } = useMutateFormSettings()
+  const { formName } = t('features.common', { returnObjects: true })
+  const formTitleValidationRules = useFormTitleValidationRules()
 
   const { startPageMutation } = useMutateFormPage()
   const { handleClose } = useCreatePageSidebar()
@@ -117,9 +126,9 @@ export const DesignInput = (): JSX.Element | null => {
     clearErrors,
     setError,
     setFocus,
-  } = useForm<FormStartPageInput>({
+  } = useForm<FormStartPageInput & { title: string }>({
     mode: 'onBlur',
-    defaultValues: startPageData,
+    defaultValues: { ...startPageData, title: settings?.title },
   })
 
   // Update dirty state of builder so confirmation modal can be shown
@@ -186,10 +195,15 @@ export const DesignInput = (): JSX.Element | null => {
   const handleCloseDrawer = useCallback(() => handleClose(false), [handleClose])
 
   const handleUpdateDesign = handleSubmit(
-    async (startPageData: FormStartPageInput) => {
-      const { logo, attachment, estTimeTaken, ...rest } = startPageData
+    async (startPageData: FormStartPageInput & { title: string }) => {
+      const { logo, attachment, estTimeTaken, title, ...rest } = startPageData
       const estTimeTakenTransformed =
         estTimeTaken === '' ? undefined : estTimeTaken
+
+      if (title !== settings?.title) {
+        mutateFormTitle.mutate(title)
+      }
+
       if (logo.state !== FormLogoState.Custom) {
         startPageMutation.mutate(
           {
@@ -342,8 +356,17 @@ export const DesignInput = (): JSX.Element | null => {
         <FormErrorMessage>{errors.colorTheme?.message}</FormErrorMessage>
       </FormControl>
 
-      {showDesignDrawerFormTitle && <FormDetailsSection />}
-
+      {showDesignDrawerFormTitle && (
+        <FormControl
+          isReadOnly={startPageMutation.isLoading}
+          isInvalid={!!errors.title}
+          isRequired
+        >
+          <FormLabel>{formName}</FormLabel>
+          <Input {...register('title', formTitleValidationRules)} />
+          <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+        </FormControl>
+      )}
       <FormControl
         isReadOnly={startPageMutation.isLoading}
         isInvalid={!!errors.estTimeTaken}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
@@ -29,6 +29,7 @@ export type FormStartPageInput = Omit<
   estTimeTaken: number | ''
   logo: FormLogoBase
   attachment: UploadedImage // Custom logo image
+  title?: string
 }
 
 export type DesignStore = {


### PR DESCRIPTION
## Problem
Every other field in that drawer only saves when "Save design" is clicked, but the form name was able to save immediately on blur which created inconsistencies with the rest of settings in the drawer

Closes #9350

## Solution
Moved the form title into the local frontend draft layer. The live preview window now listens to this local store draft. The actual save is now deferred until the user explicitly clicks the "Save design" CTA button. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible  