### PR TITLE
fix: use rowNum to compare incoming vs prev response vs. deep equality

### DIFF
--- a/apps/backend/src/app/utils/__tests__/response-v4.spec.ts
+++ b/apps/backend/src/app/utils/__tests__/response-v4.spec.ts
@@ -1,0 +1,140 @@
+import type { FieldResponseV4 } from '@opengovsg/formsg-sdk'
+
+import { isFieldResponseV4Equal } from '../response-v4'
+
+describe('isFieldResponseV4Equal', () => {
+  const makeTableResponse = (
+    answer: FieldResponseV4['answer'],
+  ): FieldResponseV4 =>
+    ({
+      fieldType: 'table',
+      question: 'Table question',
+      answer,
+      provenance: {},
+    }) as FieldResponseV4
+
+  describe('table fields', () => {
+    it('should return true when rows match but row keys differ', () => {
+      // Arrange
+      // Same content adapted twice from V3 mints different row keys.
+      const incoming = makeTableResponse({
+        '06e4a2bc-f496-4e75-b326-65bcd209fa76': {
+          rowNum: 0,
+          value: { col1: 'a', col2: 'b' },
+        },
+        '1cec1e99-0201-427e-ada0-fe6b1cd60904': {
+          rowNum: 1,
+          value: { col1: 'c', col2: 'd' },
+        },
+      })
+      const previous = makeTableResponse({
+        '89e090e1-362b-4320-9906-38f96656e8cd': {
+          rowNum: 0,
+          value: { col1: 'a', col2: 'b' },
+        },
+        '2365c0c9-69fc-40c9-a55f-9834369cab3d': {
+          rowNum: 1,
+          value: { col1: 'c', col2: 'd' },
+        },
+      })
+
+      // Act + Assert
+      expect(isFieldResponseV4Equal(incoming, previous)).toBe(true)
+    })
+
+    it('should return true when rows are enumerated in different orders', () => {
+      // Arrange
+      const incoming = makeTableResponse({
+        rowB: { rowNum: 1, value: { col1: 'c' } },
+        rowA: { rowNum: 0, value: { col1: 'a' } },
+      })
+      const previous = makeTableResponse({
+        rowX: { rowNum: 0, value: { col1: 'a' } },
+        rowY: { rowNum: 1, value: { col1: 'c' } },
+      })
+
+      // Act + Assert
+      expect(isFieldResponseV4Equal(incoming, previous)).toBe(true)
+    })
+
+    it('should return false when a cell value differs', () => {
+      // Arrange
+      const incoming = makeTableResponse({
+        rowA: { rowNum: 0, value: { col1: 'a' } },
+      })
+      const previous = makeTableResponse({
+        rowX: { rowNum: 0, value: { col1: 'CHANGED' } },
+      })
+
+      // Act + Assert
+      expect(isFieldResponseV4Equal(incoming, previous)).toBe(false)
+    })
+
+    it('should return false when row counts differ', () => {
+      // Arrange
+      const incoming = makeTableResponse({
+        rowA: { rowNum: 0, value: { col1: 'a' } },
+        rowB: { rowNum: 1, value: { col1: 'c' } },
+      })
+      const previous = makeTableResponse({
+        rowX: { rowNum: 0, value: { col1: 'a' } },
+      })
+
+      // Act + Assert
+      expect(isFieldResponseV4Equal(incoming, previous)).toBe(false)
+    })
+
+    it('should return false when rowNums differ for the same content', () => {
+      // Arrange
+      const incoming = makeTableResponse({
+        rowA: { rowNum: 0, value: { col1: 'a' } },
+      })
+      const previous = makeTableResponse({
+        rowX: { rowNum: 1, value: { col1: 'a' } },
+      })
+
+      // Act + Assert
+      expect(isFieldResponseV4Equal(incoming, previous)).toBe(false)
+    })
+  })
+
+  describe('non-table fields', () => {
+    it('should return false when field types differ', () => {
+      // Arrange
+      const l = {
+        fieldType: 'textfield',
+        question: 'Q',
+        answer: { value: 'a' },
+        provenance: {},
+      } as FieldResponseV4
+      const r = {
+        fieldType: 'number',
+        question: 'Q',
+        answer: { value: 'a' },
+        provenance: {},
+      } as FieldResponseV4
+
+      // Act + Assert
+      expect(isFieldResponseV4Equal(l, r)).toBe(false)
+    })
+
+    it('should compare non-table answers by deep equality', () => {
+      // Arrange
+      const l = {
+        fieldType: 'textfield',
+        question: 'Q',
+        answer: { value: 'a' },
+        provenance: {},
+      } as FieldResponseV4
+      const r = {
+        fieldType: 'textfield',
+        question: 'Q',
+        answer: { value: 'a' },
+        provenance: { submittedAt: '2026-07-21T01:44:40.231Z' },
+      } as FieldResponseV4
+
+      // Act + Assert
+      expect(isFieldResponseV4Equal(l, r)).toBe(true)
+    })
+  })
+})

--- a/apps/backend/src/app/utils/response-v4.ts
+++ b/apps/backend/src/app/utils/response-v4.ts
@@ -1,4 +1,8 @@
-import type { AttachmentAnswerV4, FieldResponseV4 } from '@opengovsg/formsg-sdk'
+import type {
+  AttachmentAnswerV4,
+  FieldResponseV4,
+  TableAnswerV4,
+} from '@opengovsg/formsg-sdk'
 import _ from 'lodash'
 
 export const isFieldResponseV4Equal = (
@@ -11,6 +15,18 @@ export const isFieldResponseV4Equal = (
     const lMd5 = (l.answer as AttachmentAnswerV4).md5Hash
     const rMd5 = (r.answer as AttachmentAnswerV4).md5Hash
     return !lMd5 || !rMd5 || lMd5 === rMd5
+  }
+
+  if (l.fieldType === 'table') {
+    // Row keys are minted fresh on every V3→V4 adaptation, so the same table
+    // content can carry different keys on each side. Compare rows by rowNum
+    // order and content instead of by key.
+    const sortRows = (answer: TableAnswerV4) =>
+      Object.values(answer).sort((a, b) => a.rowNum - b.rowNum)
+    return _.isEqual(
+      sortRows(l.answer as TableAnswerV4),
+      sortRows(r.answer as TableAnswerV4),
+    )
   }
 
   return _.isEqual(l.answer, r.answer)


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

V4 Be handling of table field is experiencing an error:

- when we convert responses from v3 to v4, table responses in v4 have a new schema of row-uuid (absent in v3 schema)
this uuid gets [generated](https://github.com/opengovsg/FormSG/blob/7ca2dc1a63153a900cd9fefc1196c8e1fa08130f/packages/sdk/src/adapt-v3-to-v4.ts#L79-L80) in adaptV3toV4 
- we perform adaptV3ToV4 twice in the submission flow:
   - 1st, for incoming responses when BE receives
   - 2nd, for prev responses, to compare against incoming
- the uuids generated will be unique and fail equality check
- `Submitted responses on a non-editable field...` gets thrown
- if a previous response is saved in v4, because the FE still passing v3 to the BE and adaptV3ToV4 will run, the uuids similarly won't match

## Solution
<!-- How did you solve the problem? -->

Instead of using deep equality check, use `rowNum` to compare non-editable table fields

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No - this PR is backwards compatible  

## Tests
<!-- What tests should be run to confirm functionality? -->

**TC1: Table field in MRF response**
- [ ] Create an MRF form, with a table field
- [ ] Create 2 workflow steps, assign table field to the 1st step
- [ ] Successfully complete a workflow submission (step 1 and 2)