### PR TITLE
feat(i18n): extract text from EditFieldDrawer edit-fieldtype components

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAddress/EditAddress.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditAddress/EditAddress.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FormControl } from '@chakra-ui/react'
 import { extend, pick } from 'lodash'
 
@@ -25,6 +26,7 @@ type EditAddressInputs = Pick<
 >
 
 export const EditAddress = ({ field }: EditAddressProps): JSX.Element => {
+  const { t } = useTranslation()
   const {
     register,
     formState: { errors },
@@ -50,17 +52,28 @@ export const EditAddress = ({ field }: EditAddressProps): JSX.Element => {
   return (
     <CreatePageDrawerContentContainer>
       <FormControl isRequired isReadOnly={isLoading} isInvalid={!!errors.title}>
-        <FormLabel>Field Name</FormLabel>
+        <FormLabel>
+          {t('features.adminForm.sidebar.fields.commonFieldComponents.title')}
+        </FormLabel>
         <Input autoFocus {...register('title', requiredValidationRule)} />
         <FormErrorMessage>{errors?.title?.message}</FormErrorMessage>
       </FormControl>
       <FormControl isReadOnly={isLoading} isInvalid={!!errors.description}>
-        <FormLabel>Description</FormLabel>
+        <FormLabel>
+          {t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.description',
+          )}
+        </FormLabel>
         <Textarea {...register('description')} />
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
       <FormControl isReadOnly={isLoading}>
-        <Toggle {...register('required')} label="Required" />
+        <Toggle
+          {...register('required')}
+          label={t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.required',
+          )}
+        />
       </FormControl>
       <FormFieldDrawerActions
         isLoading={isLoading}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditCheckbox/EditCheckbox.tsx
@@ -130,15 +130,17 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
         value:
           watchedInputs.validateByValue &&
           !watchedInputs.ValidationOptions.customMax,
-        message: 'Please enter selection limits',
+        message: t(
+          'features.adminForm.sidebar.fields.checkbox.error.selectionLimitRequired',
+        ),
       },
       min: {
         value: 1,
-        message: 'Cannot be less than 1',
+        message: t('features.adminForm.sidebar.fields.checkbox.error.min'),
       },
       max: {
         value: 10000,
-        message: 'Cannot be more than 10,000',
+        message: t('features.adminForm.sidebar.fields.checkbox.error.max'),
       },
       validate: {
         minLargerThanMax: (val) => {
@@ -147,7 +149,9 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
             !watchedInputs.validateByValue ||
             !watchedInputs.ValidationOptions.customMax ||
             Number(val) <= Number(watchedInputs.ValidationOptions.customMax) ||
-            'Minimum cannot be larger than maximum'
+            t(
+              'features.adminForm.sidebar.fields.checkbox.error.minLargerThanMax',
+            )
           )
         },
         max: (val) => {
@@ -160,12 +164,14 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
           return (
             !val ||
             Number(val) <= numOptions ||
-            'Cannot be more than number of options'
+            t(
+              'features.adminForm.sidebar.fields.checkbox.error.moreThanNumOptions',
+            )
           )
         },
       },
     }),
-    [watchedInputs],
+    [watchedInputs, t],
   )
 
   const customMaxValidationOptions: RegisterOptions<
@@ -177,15 +183,17 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
         value:
           watchedInputs.validateByValue &&
           !watchedInputs.ValidationOptions.customMin,
-        message: 'Please enter selection limits',
+        message: t(
+          'features.adminForm.sidebar.fields.checkbox.error.selectionLimitRequired',
+        ),
       },
       min: {
         value: 1,
-        message: 'Cannot be less than 1',
+        message: t('features.adminForm.sidebar.fields.checkbox.error.min'),
       },
       max: {
         value: 10000,
-        message: 'Cannot be more than 10,000',
+        message: t('features.adminForm.sidebar.fields.checkbox.error.max'),
       },
       validate: {
         maxLargerThanMin: (val) => {
@@ -194,7 +202,7 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
             !watchedInputs.validateByValue ||
             !watchedInputs.ValidationOptions.customMin ||
             Number(val) >= Number(watchedInputs.ValidationOptions.customMin) ||
-            'Maximum cannot be less than minimum'
+            t('features.adminForm.sidebar.fields.checkbox.error.maxLessThanMin')
           )
         },
         max: (val) => {
@@ -208,12 +216,14 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
           return (
             !val ||
             Number(val) <= numOptions ||
-            'Cannot be more than number of options'
+            t(
+              'features.adminForm.sidebar.fields.checkbox.error.moreThanNumOptions',
+            )
           )
         },
       },
     }),
-    [watchedInputs],
+    [watchedInputs, t],
   )
 
   // Effect to clear validation option errors when selection limit is toggled off.
@@ -242,7 +252,12 @@ export const EditCheckbox = ({ field }: EditCheckboxProps): JSX.Element => {
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
       <FormControl isReadOnly={isLoading}>
-        <Toggle {...register('required')} label="Required" />
+        <Toggle
+          {...register('required')}
+          label={t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.required',
+          )}
+        />
       </FormControl>
       <FormControl isReadOnly={isLoading}>
         <Toggle

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDate/EditDate.tsx
@@ -280,7 +280,12 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
       <FormControl isReadOnly={isLoading}>
-        <Toggle {...register('required')} label="Required" />
+        <Toggle
+          {...register('required')}
+          label={t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.required',
+          )}
+        />
       </FormControl>
       <FormControl
         isReadOnly={isLoading}
@@ -358,7 +363,9 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
         <FormControl>
           <Toggle
             {...register('hasInvalidDays')}
-            label="Customise available days"
+            label={t(
+              'features.adminForm.sidebar.fields.date.customiseAvailableDays.title',
+            )}
           />
         </FormControl>
         {hasInvalidDaysRestriction && (
@@ -367,7 +374,9 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
               control={control}
               name="invalidDays"
               rules={{
-                required: 'Please select available days of the week',
+                required: t(
+                  'features.adminForm.sidebar.fields.date.customiseAvailableDays.requiredError',
+                ),
                 validate: (val) => {
                   const customMinDate = getValues(
                     'dateValidation.customMinDate',
@@ -388,7 +397,9 @@ export const EditDate = ({ field }: EditDateProps): JSX.Element => {
                       customMaxDate,
                       getRemainingDaysOfTheWeek(val),
                     ) ||
-                    "The selected days aren't available within your custom date range"
+                    t(
+                      'features.adminForm.sidebar.fields.date.customiseAvailableDays.noAvailableDaysError',
+                    )
                   )
                 },
               }}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditDropdown/EditDropdown.tsx
@@ -106,7 +106,12 @@ export const EditDropdown = ({ field }: EditDropdownProps): JSX.Element => {
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
       <FormControl isReadOnly={isLoading}>
-        <Toggle {...register('required')} label="Required" />
+        <Toggle
+          {...register('required')}
+          label={t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.required',
+          )}
+        />
       </FormControl>
       <FormControl
         isRequired
@@ -129,9 +134,9 @@ export const EditDropdown = ({ field }: EditDropdownProps): JSX.Element => {
         </FormErrorMessage>
         {isFieldUsedForConditionalRouting ? (
           <InlineMessage mt="1rem" variant="warning">
-            This field is linked to a step in your workflow. If you make any
-            changes, ensure that the options and emails are updated in your CSV
-            file.
+            {t(
+              'features.adminForm.sidebar.fields.dropdown.conditionalRoutingWarning',
+            )}
           </InlineMessage>
         ) : null}
       </FormControl>

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditEmail/EditEmail.tsx
@@ -115,23 +115,32 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
           const split = SPLIT_TEXTAREA_TRANSFORM.output(value)
           return (
             new Set(split).size === split.length ||
-            'Please remove duplicate email domains'
+            t(
+              'features.adminForm.sidebar.fields.email.restrictEmailDomains.error.duplicate',
+            )
           )
         },
         noEmpty: (value) => {
           const split = SPLIT_TEXTAREA_TRANSFORM.output(value)
-          return split.length > 0 || 'Please enter at least one email domain'
+          return (
+            split.length > 0 ||
+            t(
+              'features.adminForm.sidebar.fields.email.restrictEmailDomains.error.empty',
+            )
+          )
         },
         validEmailDomains: (value) => {
           const split = SPLIT_TEXTAREA_TRANSFORM.output(value)
           return (
             validateEmailDomains(split) ||
-            'Please enter only valid email domains starting with @'
+            t(
+              'features.adminForm.sidebar.fields.email.restrictEmailDomains.error.invalid',
+            )
           )
         },
       },
     }),
-    [requiredValidationRule],
+    [requiredValidationRule, t],
   )
 
   const { data: form } = useCreateTabForm()
@@ -201,7 +210,11 @@ export const EditEmail = ({ field }: EditEmailProps): JSX.Element => {
               />
             </FormControl>
             <FormControl isRequired isReadOnly={isLoading} mt="1.5rem">
-              <FormLabel>Subject</FormLabel>
+              <FormLabel>
+                {t(
+                  'features.adminForm.sidebar.fields.email.emailConfirmation.subject.title',
+                )}
+              </FormLabel>
               <Input
                 autoFocus
                 placeholder={t(

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditLongText/EditLongText.tsx
@@ -116,24 +116,27 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
           return (
             !!val ||
             !getValues('ValidationOptions.selectedValidation') ||
-            'Please enter number of characters'
+            t('features.adminForm.sidebar.fields.number.error.numOfCharacter')
           )
         },
         validNumber: (val) => {
           // Check whether input is a valid number, avoid e
-          return !isNaN(Number(val)) || 'Please enter a valid number'
+          return (
+            !isNaN(Number(val)) ||
+            t('features.adminForm.sidebar.fields.number.error.validNumber')
+          )
         },
       },
       min: {
         value: 1,
-        message: 'Cannot be less than 1',
+        message: t('features.adminForm.sidebar.fields.number.error.min'),
       },
       max: {
         value: 10000,
-        message: 'Cannot be more than 10000',
+        message: t('features.adminForm.sidebar.fields.number.error.max'),
       },
     }),
-    [getValues],
+    [getValues, t],
   )
 
   return (
@@ -155,13 +158,22 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
       <FormControl isReadOnly={isLoading}>
-        <Toggle {...register('required')} label="Required" />
+        <Toggle
+          {...register('required')}
+          label={t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.required',
+          )}
+        />
       </FormControl>
       <FormControl
         isReadOnly={isLoading}
         isInvalid={!isEmpty(errors.ValidationOptions)}
       >
-        <FormLabel isRequired>Number of characters allowed</FormLabel>
+        <FormLabel isRequired>
+          {t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.noCharactersAllowed',
+          )}
+        </FormLabel>
         <SimpleGrid
           mt="0.5rem"
           columns={{ base: 2, md: 1, lg: 2 }}
@@ -189,7 +201,9 @@ export const EditLongText = ({ field }: EditLongTextProps): JSX.Element => {
                 flex={1}
                 inputMode="numeric"
                 showSteppers={false}
-                placeholder="Number of characters"
+                placeholder={t(
+                  'features.adminForm.sidebar.fields.commonFieldComponents.charactersAllowedPlaceholder',
+                )}
                 isDisabled={!watchedSelectedValidation}
                 onChange={validateNumberInput(onChange)}
                 {...rest}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/EditMyInfo.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfo/EditMyInfo.tsx
@@ -1,3 +1,4 @@
+import { Trans, useTranslation } from 'react-i18next'
 import { BiCheck, BiData, BiX } from 'react-icons/bi'
 import { HStack, Icon, Text, VStack } from '@chakra-ui/react'
 
@@ -32,6 +33,7 @@ const VerifiedIcon = ({ isVerified }: { isVerified: boolean }): JSX.Element => {
 type EditMyInfoProps = EditFieldProps<MyInfoField>
 
 export const EditMyInfo = ({ field }: EditMyInfoProps): JSX.Element => {
+  const { t } = useTranslation()
   const extendedField = extendWithMyInfo(field)
   const fieldBuilderState = useFieldBuilderStore(fieldBuilderStateSelector)
   const { buttonText, handleUpdateField, isLoading, handleCancel } =
@@ -47,7 +49,9 @@ export const EditMyInfo = ({ field }: EditMyInfoProps): JSX.Element => {
   return (
     <CreatePageDrawerContentContainer>
       <VStack align="flex-start">
-        <Text textStyle="subhead-1">Data source</Text>
+        <Text textStyle="subhead-1">
+          {t('features.adminForm.sidebar.fields.myInfoPreview.dataSource')}
+        </Text>
         {extendedField.dataSource.map((dataSource, idx) => (
           <HStack key={idx} align="flex-start">
             <Icon fontSize="1.5rem" as={BiData}></Icon>
@@ -56,32 +60,42 @@ export const EditMyInfo = ({ field }: EditMyInfoProps): JSX.Element => {
         ))}
       </VStack>
       <VStack align="flex-start">
-        <Text textStyle="subhead-1">Verified for</Text>
+        <Text textStyle="subhead-1">
+          {t('features.adminForm.sidebar.fields.myInfoPreview.verifiedFor')}
+        </Text>
         {/* NOTE: Not creating an array from the keys then enumerating because order has to be enforced in UI.
          *  This allows the object to be created with arbitrary ordered keys.
          */}
         <HStack>
           <VerifiedIcon isVerified={extendedField.verifiedFor.singaporeans} />
-          <Text>Singaporeans</Text>
+          <Text>
+            {t('features.adminForm.sidebar.fields.myInfoPreview.singaporeans')}
+          </Text>
         </HStack>
         <HStack>
           <VerifiedIcon isVerified={extendedField.verifiedFor.pr} />
-          <Text>Permanent Residents</Text>
+          <Text>
+            {t(
+              'features.adminForm.sidebar.fields.myInfoPreview.permanentResidents',
+            )}
+          </Text>
         </HStack>
         <HStack>
           <VerifiedIcon
             isVerified={extendedField.verifiedFor.singpassforeigners}
           />
           <Text>
-            Foreigners with{' '}
-            <Link isExternal href={SINGPASS_FAQ}>
-              Singpass
-            </Link>
+            <Trans
+              i18nKey="features.adminForm.sidebar.fields.myInfoPreview.foreignersWithSingpass"
+              components={{ link: <Link isExternal href={SINGPASS_FAQ} /> }}
+            />
           </Text>
         </HStack>
       </VStack>
       <VStack align="flex-start">
-        <Text textStyle="subhead-1">Field details</Text>
+        <Text textStyle="subhead-1">
+          {t('features.adminForm.sidebar.fields.myInfoPreview.fieldDetails')}
+        </Text>
         <Text>{extendedField.details}</Text>
       </VStack>
       {fieldBuilderState === FieldBuilderState.CreatingField && (

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
@@ -1,4 +1,5 @@
 import { Controller } from 'react-hook-form'
+import { Trans, useTranslation } from 'react-i18next'
 import { BiCheck, BiData, BiX } from 'react-icons/bi'
 import { Box, FormControl, HStack, Icon, Text, VStack } from '@chakra-ui/react'
 import { extend } from 'lodash'
@@ -42,6 +43,7 @@ type EditMyInfoChildrenInputs = Pick<
 export const EditMyInfoChildren = ({
   field,
 }: EditMyInfoChildrenProps): JSX.Element => {
+  const { t } = useTranslation()
   const extendedField = extendWithMyInfo(field)
   const {
     control,
@@ -64,7 +66,9 @@ export const EditMyInfoChildren = ({
   return (
     <CreatePageDrawerContentContainer>
       <VStack align="flex-start">
-        <Text textStyle="subhead-1">Data source</Text>
+        <Text textStyle="subhead-1">
+          {t('features.adminForm.sidebar.fields.myInfoPreview.dataSource')}
+        </Text>
         {extendedField.dataSource.map((dataSource, idx) => (
           <HStack key={idx} align="flex-start">
             <Icon fontSize="1.5rem" as={BiData}></Icon>
@@ -73,32 +77,44 @@ export const EditMyInfoChildren = ({
         ))}
       </VStack>
       <VStack align="flex-start">
-        <Text textStyle="subhead-1">Verified for</Text>
+        <Text textStyle="subhead-1">
+          {t('features.adminForm.sidebar.fields.myInfoPreview.verifiedFor')}
+        </Text>
         {/* NOTE: Not creating an array from the keys then enumerating because order has to be enforced in UI.
          *  This allows the object to be created with arbitrary ordered keys.
          */}
         <HStack>
           <VerifiedIcon isVerified={extendedField.verifiedFor.singaporeans} />
-          <Text>Singaporeans</Text>
+          <Text>
+            {t('features.adminForm.sidebar.fields.myInfoPreview.singaporeans')}
+          </Text>
         </HStack>
         <HStack>
           <VerifiedIcon isVerified={extendedField.verifiedFor.pr} />
-          <Text>Permanent Residents</Text>
+          <Text>
+            {t(
+              'features.adminForm.sidebar.fields.myInfoPreview.permanentResidents',
+            )}
+          </Text>
         </HStack>
         <HStack>
           <VerifiedIcon
             isVerified={extendedField.verifiedFor.singpassforeigners}
           />
           <Text>
-            Foreigners with{' '}
-            <Link isExternal href={SINGPASS_FAQ}>
-              Singpass
-            </Link>
+            <Trans
+              i18nKey="features.adminForm.sidebar.fields.myInfoPreview.foreignersWithSingpass"
+              components={{ link: <Link isExternal href={SINGPASS_FAQ} /> }}
+            />
           </Text>
         </HStack>
       </VStack>
       <VStack align="flex-start">
-        <Text textStyle="subhead-1">Collect the following child data</Text>
+        <Text textStyle="subhead-1">
+          {t(
+            'features.adminForm.sidebar.fields.myInfoPreview.children.collectChildData',
+          )}
+        </Text>
         <Box alignSelf="stretch">
           <Controller
             control={control}
@@ -128,12 +144,16 @@ export const EditMyInfoChildren = ({
         <FormControl isReadOnly={isLoading}>
           <Toggle
             {...register('allowMultiple')}
-            label="Allow respondent to add multiple children"
+            label={t(
+              'features.adminForm.sidebar.fields.myInfoPreview.children.allowMultiple',
+            )}
           />
         </FormControl>
       </VStack>
       <VStack align="flex-start">
-        <Text textStyle="subhead-1">Field details</Text>
+        <Text textStyle="subhead-1">
+          {t('features.adminForm.sidebar.fields.myInfoPreview.fieldDetails')}
+        </Text>
         <Text>{extendedField.details}</Text>
       </VStack>
       <FormFieldDrawerActions

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -132,24 +132,27 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
           return (
             !!val ||
             !getValues('ValidationOptions.selectedValidation') ||
-            'Please enter number of characters'
+            t('features.adminForm.sidebar.fields.number.error.numOfCharacter')
           )
         },
         validNumber: (val) => {
           // Check whether input is a valid number, avoid e
-          return !isNaN(Number(val)) || 'Please enter a valid number'
+          return (
+            !isNaN(Number(val)) ||
+            t('features.adminForm.sidebar.fields.number.error.validNumber')
+          )
         },
       },
       min: {
         value: 1,
-        message: 'Cannot be less than 1',
+        message: t('features.adminForm.sidebar.fields.number.error.min'),
       },
       max: {
         value: 10000,
-        message: 'Cannot be more than 10000',
+        message: t('features.adminForm.sidebar.fields.number.error.max'),
       },
     }),
-    [getValues],
+    [getValues, t],
   )
 
   // Effect to clear validation option errors when selection limit is toggled off.
@@ -179,13 +182,22 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
         <FormErrorMessage>{errors?.description?.message}</FormErrorMessage>
       </FormControl>
       <FormControl isReadOnly={isLoading}>
-        <Toggle {...register('required')} label="Required" />
+        <Toggle
+          {...register('required')}
+          label={t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.required',
+          )}
+        />
       </FormControl>
       <FormControl
         isReadOnly={isLoading}
         isInvalid={!isEmpty(errors.ValidationOptions)}
       >
-        <FormLabel isRequired>Number of characters allowed</FormLabel>
+        <FormLabel isRequired>
+          {t(
+            'features.adminForm.sidebar.fields.commonFieldComponents.noCharactersAllowed',
+          )}
+        </FormLabel>
         <SimpleGrid
           mt="0.5rem"
           columns={{ base: 2, md: 1, lg: 2 }}
@@ -210,7 +222,9 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 flex={1}
                 inputMode="numeric"
                 showSteppers={false}
-                placeholder="Number of characters"
+                placeholder={t(
+                  'features.adminForm.sidebar.fields.commonFieldComponents.charactersAllowedPlaceholder',
+                )}
                 isDisabled={!watchedSelectedValidation}
                 onChange={validateNumberInput(onChange)}
                 {...rest}
@@ -225,8 +239,11 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
       <FormControl isReadOnly={isLoading}>
         <Toggle
           {...register('allowPrefill')}
-          label="Enable pre-fill"
-          description={`Use Field ID in the form URL to pre-fill this field for respondents. [Learn how](${GUIDE_PREFILL})`}
+          label={t('features.adminForm.sidebar.fields.shortText.prefill.label')}
+          description={t(
+            'features.adminForm.sidebar.fields.shortText.prefill.description',
+            { guidePrefill: GUIDE_PREFILL },
+          )}
         />
         {watchAllowPrefill ? (
           <>
@@ -236,7 +253,9 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 isDisabled={!field._id}
                 value={
                   field._id ??
-                  'Field ID will be generated after this field is saved'
+                  t(
+                    'features.adminForm.sidebar.fields.shortText.prefill.fieldIdPlaceholder',
+                  )
                 }
                 hasInputRightElement={Boolean(field._id)}
               />
@@ -244,7 +263,9 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 <InputRightElement>
                   <CopyButton
                     stringToCopy={field._id}
-                    aria-label="Copy field ID value"
+                    aria-label={t(
+                      'features.adminForm.sidebar.fields.shortText.prefill.copyFieldIdAriaLabel',
+                    )}
                   />
                 </InputRightElement>
               ) : null}
@@ -262,8 +283,12 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 {...rest}
                 isChecked={!!value}
                 onChange={onChange}
-                label="Prevent pre-fill editing"
-                description="This prevents respondents from clicking the field to edit it. However, field content can still be modified via the URL."
+                label={t(
+                  'features.adminForm.sidebar.fields.shortText.prefill.lockLabel',
+                )}
+                description={t(
+                  'features.adminForm.sidebar.fields.shortText.prefill.lockDescription',
+                )}
               />
             )}
           />

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditShortText/EditShortText.tsx
@@ -284,10 +284,10 @@ export const EditShortText = ({ field }: EditShortTextProps): JSX.Element => {
                 isChecked={!!value}
                 onChange={onChange}
                 label={t(
-                  'features.adminForm.sidebar.fields.shortText.prefill.lockLabel',
+                  'features.adminForm.sidebar.fields.shortText.prefill.lock.label',
                 )}
                 description={t(
-                  'features.adminForm.sidebar.fields.shortText.prefill.lockDescription',
+                  'features.adminForm.sidebar.fields.shortText.prefill.lock.description',
                 )}
               />
             )}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTableColumns.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditTable/EditTableColumns.tsx
@@ -129,7 +129,9 @@ export const EditTableColumns = ({
             id={`columns.${index}.columnType`}
           >
             <VisuallyHidden>
-              <FormLabel>Column type</FormLabel>
+              <FormLabel>
+                {t('features.adminForm.sidebar.fields.table.columnType')}
+              </FormLabel>
             </VisuallyHidden>
             <Controller
               name={`columns.${index}.columnType`}

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
@@ -188,9 +188,11 @@ export const enSG: Fields = {
       fieldIdPlaceholder:
         'Field ID will be generated after this field is saved',
       copyFieldIdAriaLabel: 'Copy field ID value',
-      lockLabel: 'Prevent pre-fill editing',
-      lockDescription:
-        'This prevents respondents from clicking the field to edit it. However, field content can still be modified via the URL.',
+      lock: {
+        label: 'Prevent pre-fill editing',
+        description:
+          'This prevents respondents from clicking the field to edit it. However, field content can still be modified via the URL.',
+      },
     },
   },
   number: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/en-sg.ts
@@ -72,6 +72,18 @@ export const enSG: Fields = {
       minimum: 'Minimum',
       maximum: 'Maximum',
     },
+    error: {
+      selectionLimitRequired: 'Please enter selection limits',
+      min: 'Cannot be less than 1',
+      max: 'Cannot be more than 10,000',
+      minLargerThanMax: 'Minimum cannot be larger than maximum',
+      maxLessThanMin: 'Maximum cannot be less than minimum',
+      moreThanNumOptions: 'Cannot be more than number of options',
+    },
+  },
+  dropdown: {
+    conditionalRoutingWarning:
+      'This field is linked to a step in your workflow. If you make any changes, ensure that the options and emails are updated in your CSV file.',
   },
   paragraph: 'Paragraph',
   section: {
@@ -94,6 +106,11 @@ export const enSG: Fields = {
       title: 'Restrict email domains',
       inputLabel: 'Domains allowed',
       placeholder: '@*.gov.sg\n@open.gov.sg\n@agency.gov.sg',
+      error: {
+        duplicate: 'Please remove duplicate email domains',
+        empty: 'Please enter at least one email domain',
+        invalid: 'Please enter only valid email domains starting with @',
+      },
     },
     emailConfirmation: {
       title: 'Email confirmation',
@@ -159,8 +176,22 @@ export const enSG: Fields = {
       maxRowGreaterThanMin: 'Maximum rows must be greater than minimum rows',
     },
     column: 'Column',
+    columnType: 'Column type',
     ariaLabelDelete: 'Delete column',
     addColumn: 'Add column',
+  },
+  shortText: {
+    prefill: {
+      label: 'Enable pre-fill',
+      description:
+        'Use Field ID in the form URL to pre-fill this field for respondents. [Learn how]({guidePrefill})',
+      fieldIdPlaceholder:
+        'Field ID will be generated after this field is saved',
+      copyFieldIdAriaLabel: 'Copy field ID value',
+      lockLabel: 'Prevent pre-fill editing',
+      lockDescription:
+        'This prevents respondents from clicking the field to edit it. However, field content can still be modified via the URL.',
+    },
   },
   number: {
     validation: 'Number validation',
@@ -177,6 +208,7 @@ export const enSG: Fields = {
       validationType: 'Please select a validation type',
       numOfCharacter: 'Please enter number of characters',
       validDecimal: 'Please enter a valid decimal',
+      validNumber: 'Please enter a valid number',
       min: 'Cannot be less than 1',
       max: 'Cannot be more than 10000',
       rangeValue: 'Please enter range values',
@@ -194,6 +226,18 @@ export const enSG: Fields = {
   },
   fieldListOption: {
     useForApprovals: 'Use for approvals',
+  },
+  myInfoPreview: {
+    dataSource: 'Data source',
+    verifiedFor: 'Verified for',
+    singaporeans: 'Singaporeans',
+    permanentResidents: 'Permanent Residents',
+    foreignersWithSingpass: 'Foreigners with <link>Singpass</link>',
+    fieldDetails: 'Field details',
+    children: {
+      collectChildData: 'Collect the following child data',
+      allowMultiple: 'Allow respondent to add multiple children',
+    },
   },
   myInfoPanel: {
     sections: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/index.ts
@@ -179,8 +179,10 @@ export interface Fields {
       description: string
       fieldIdPlaceholder: string
       copyFieldIdAriaLabel: string
-      lockLabel: string
-      lockDescription: string
+      lock: {
+        label: string
+        description: string
+      }
     }
   }
   number: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/fields/index.ts
@@ -70,6 +70,17 @@ export interface Fields {
       minimum: string
       maximum: string
     }
+    error: {
+      selectionLimitRequired: string
+      min: string
+      max: string
+      minLargerThanMax: string
+      maxLessThanMin: string
+      moreThanNumOptions: string
+    }
+  }
+  dropdown: {
+    conditionalRoutingWarning: string
   }
   paragraph: string
   section: {
@@ -92,6 +103,11 @@ export interface Fields {
       title: string
       inputLabel: string
       placeholder: string
+      error: {
+        duplicate: string
+        empty: string
+        invalid: string
+      }
     }
     emailConfirmation: {
       title: string
@@ -153,8 +169,19 @@ export interface Fields {
       maxRowGreaterThanMin: string
     }
     column: string
+    columnType: string
     ariaLabelDelete: string
     addColumn: string
+  }
+  shortText: {
+    prefill: {
+      label: string
+      description: string
+      fieldIdPlaceholder: string
+      copyFieldIdAriaLabel: string
+      lockLabel: string
+      lockDescription: string
+    }
   }
   number: {
     validation: string
@@ -171,6 +198,7 @@ export interface Fields {
       validationType: string
       numOfCharacter: string
       validDecimal: string
+      validNumber: string
       min: string
       max: string
       rangeValue: string
@@ -187,6 +215,18 @@ export interface Fields {
   }
   fieldListOption: {
     useForApprovals: string
+  }
+  myInfoPreview: {
+    dataSource: string
+    verifiedFor: string
+    singaporeans: string
+    permanentResidents: string
+    foreignersWithSingpass: string
+    fieldDetails: string
+    children: {
+      collectChildData: string
+      allowMultiple: string
+    }
   }
   myInfoPanel: {
     sections: {


### PR DESCRIPTION
## Problem
Closes #8419

The `EditFieldDrawer` `edit-fieldtype` components had hardcoded user-facing
English, so none of it was reachable by the i18n layer.

## Solution
Extracts hardcoded strings into the i18n locale files. No behaviour or copy
changes — wording and punctuation are preserved exactly.

Components: `EditAddress`, `EditCheckbox`, `EditDate`, `EditDropdown`,
`EditEmail`, `EditLongText`, `EditMyInfo`, `EditMyInfoChildren`,
`EditShortText`, `EditTableColumns`.

26 new keys added under `i18n/locales/features/admin-form/sidebar/fields/`
(`index.ts` + `en-sg.ts`); the rest reuse existing keys. Only `en-sg` needs
updating, as `types.ts` marks the other locales optional with
`fallbackTranslation`.

**Known gap (intentional):** enum-derived dropdown values are left
un-extracted — `EditDate.tsx:310` (`DateSelectedValidation`),
`EditShortText.tsx:211` and `EditLongText.tsx:190`
(`TextSelectedValidation`). Wiring them up means converting `items` from
`string[]` to `ComboboxItem[]`, which touches submitted-value plumbing and is
out of scope for a text extraction. The keys from #7815
(`date.dateValidation.*`, `rating.shapes.*`, `number.fieldRestriction.*`)
remain the intended landing spot. Happy to open a follow-up issue if you'd
like.

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
    - Details ...
- [x] No - this PR is backwards compatible

**Features**:
- None

**Improvements**:
- User-facing text in the ten field-editor drawers is now translatable

**Bug Fixes**:
- None

## Before & After Screenshots
No visual change — rendered copy is byte-identical to before.

## Tests
There is no existing test coverage under `edit-fieldtype/`, so the passing
suite shows nothing else broke rather than proving these components render. I
separately verified that all 26 new keys resolve against the real locale
bundle, including ICU interpolation and `<Trans>` markup.

- `tsc --noEmit` — clean
- `eslint` — 0 errors (2 pre-existing warnings, verified identical on a clean tree)
- `prettier -c` — clean
- `vitest run` — 281 tests passed across 43 files
- `storybook build` — clean

## Deploy Notes
None — no new environment variables, scripts, dependencies or dev dependencies.