### PR TITLE
feat(mrf): V4 response migration — PR 3/5 FE sends and works in V4

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -94,7 +94,7 @@ const multirespondentSubmissionBodySchema = Joi.object({
       fieldType: Joi.string().valid(...Object.values(BasicField)),
       answer: Joi.required(),
       question: Joi.any().strip(),
-      provenance: Joi.object().optional(),
+      provenance: Joi.object().default({}),
       myInfo: Joi.object({ attr: Joi.string().required() }).optional(),
     }),
   ),

--- a/apps/backend/src/app/modules/submission/receiver/receiver.utils.ts
+++ b/apps/backend/src/app/modules/submission/receiver/receiver.utils.ts
@@ -55,8 +55,9 @@ export const mapRouteError: MapRouteError = (error) => {
  * Stale-FE compatibility shim for MRF submissions.
  *
  * If body.version indicates a V3 MRF submission (>=3 && <4), responses are V3-shaped.
- * Convert them to V4 in place and bump body.version to 4 so downstream code can
- * uniformly treat the body as V4. Runs BEFORE addAttachmentToResponses, so
+ * Convert them to V4 in place. body.version is left untouched (still 3), so
+ * downstream version checks must treat 3 and 4 alike; only body.responses is
+ * uniformly V4 after this point. Runs BEFORE addAttachmentToResponses, so
  * attachment buffers land in V4-shaped answer objects.
  *
  * Question text is left empty here — the form definition isn't yet loaded. Downstream

--- a/apps/backend/src/app/modules/submission/submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/submission.utils.ts
@@ -4,7 +4,6 @@ import crypto from 'crypto'
 import {
   AdminEmailPdfFeatureValue,
   featureFlags,
-  MULTIRESPONDENT_FORM_SUBMISSION_VERSION,
 } from 'formsg-shared/constants'
 import { FIELDS_TO_REJECT } from 'formsg-shared/constants/field/basic'
 import { MYINFO_ATTRIBUTE_MAP } from 'formsg-shared/constants/field/myinfo'
@@ -750,10 +749,11 @@ const encryptAttachment = async (
     const fileContentsView = new Uint8Array(attachment)
 
     label = 'Encrypt content'
-    const formsgSdkCrypto =
-      version < MULTIRESPONDENT_FORM_SUBMISSION_VERSION
-        ? formsgSdk.crypto
-        : formsgSdk.cryptoV3
+    // Crypto floor is fixed at the V3 cutover: submissions below wire version 3
+    // predate cryptoV3. Deliberately a literal — the MRF wire version constant
+    // moves on (4+), and shim-adapted stale-FE bodies keep version 3, so tying
+    // this to the constant would flip their crypto class as the wire advances.
+    const formsgSdkCrypto = version < 3 ? formsgSdk.crypto : formsgSdk.cryptoV3
     const encryptedAttachment = await formsgSdkCrypto.encryptFile(
       fileContentsView,
       publicKey,

--- a/apps/frontend/src/features/form/utils/__tests__/extractMrfPreviousStepResponseValue.test.ts
+++ b/apps/frontend/src/features/form/utils/__tests__/extractMrfPreviousStepResponseValue.test.ts
@@ -1,101 +1,280 @@
+import type { FieldResponseV4 } from '@opengovsg/formsg-sdk'
+
 import { CLIENT_RADIO_OTHERS_INPUT_VALUE } from 'formsg-shared/constants'
 import { CountryRegion } from 'formsg-shared/constants/countryRegion'
-import {
-  AttachmentFieldResponseV3,
-  BasicField,
-  FieldResponseV3,
-  FormFieldDto,
-} from 'formsg-shared/types'
+import { BasicField, FormFieldDto } from 'formsg-shared/types'
 
 import bufferToFile from '~utils/bufferToFile'
-import { RadioFieldValues } from '~templates/Field'
+import { FormFieldValues } from '~templates/Field'
+
+import { createResponsesV4 } from '~features/public-form/utils/createSubmission'
 
 import { extractMrfPreviousStepResponseValue } from '../extractMrfPreviousStepResponseValue'
 
 vi.mock('~utils/bufferToFile')
+
+const mockField = (fieldType: BasicField, id = 'a'.repeat(24)): FormFieldDto =>
+  ({ _id: id, fieldType }) as FormFieldDto
+
+const v4Response = (
+  fieldType: BasicField,
+  answer: unknown,
+): Pick<FieldResponseV4, 'fieldType' | 'answer'> =>
+  ({ fieldType, answer }) as Pick<FieldResponseV4, 'fieldType' | 'answer'>
 
 describe('extractMrfPreviousStepResponseValue', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('should return the correct CountryRegion enum value if matches', () => {
-    const field: FormFieldDto = { fieldType: BasicField.CountryRegion } as any
-    const previousResponse: FieldResponseV3 = { answer: 'SINGAPORE' } as any
+  it('should unwrap string-like answers to their raw value', () => {
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.ShortText),
+      v4Response(BasicField.ShortText, { value: 'Hello' }),
+    )
 
-    const result = extractMrfPreviousStepResponseValue(field, previousResponse)
+    expect(result).toBe('Hello')
+  })
+
+  it('should unwrap yes/no answers to their raw value', () => {
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.YesNo),
+      v4Response(BasicField.YesNo, { value: 'Yes' }),
+    )
+
+    expect(result).toBe('Yes')
+  })
+
+  it('should return the correct CountryRegion enum value if matches', () => {
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.CountryRegion),
+      v4Response(BasicField.CountryRegion, { value: 'SINGAPORE' }),
+    )
 
     expect(result).toBe(CountryRegion.Singapore)
   })
 
   it('should return undefined if CountryRegion does not match', () => {
-    const field: FormFieldDto = { fieldType: BasicField.CountryRegion } as any
-    const previousResponse: FieldResponseV3 = { answer: 'Bad Country' } as any
-
-    const result = extractMrfPreviousStepResponseValue(field, previousResponse)
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.CountryRegion),
+      v4Response(BasicField.CountryRegion, { value: 'Bad Country' }),
+    )
 
     expect(result).toBeUndefined()
+  })
+
+  it('should pass through verifiable answers with signature', () => {
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.Email),
+      v4Response(BasicField.Email, { value: 'a@example.com', signature: 's' }),
+    )
+
+    expect(result).toEqual({ value: 'a@example.com', signature: 's' })
   })
 
   it('should return a file object for Attachment if buffer is provided', () => {
     const mockFile = new File([''], 'file.txt')
     vi.mocked(bufferToFile).mockReturnValue(mockFile)
-
-    const field: FormFieldDto = { fieldType: BasicField.Attachment } as any
-    const previousResponse: FieldResponseV3 = {
-      answer: { answer: 'file.txt' } as AttachmentFieldResponseV3,
-    } as any
     const buffer = new Uint8Array(8)
 
     const result = extractMrfPreviousStepResponseValue(
-      field,
-      previousResponse,
+      mockField(BasicField.Attachment),
+      v4Response(BasicField.Attachment, {
+        value: 'file.txt',
+        hasBeenScanned: true,
+      }),
       buffer,
     )
 
+    expect(bufferToFile).toHaveBeenCalledWith(buffer, 'file.txt')
     expect(result).toEqual(mockFile)
   })
 
   it('should return undefined for Attachment if buffer is not provided', () => {
-    const field: FormFieldDto = { fieldType: BasicField.Attachment } as any
-    const previousResponse: FieldResponseV3 = {
-      answer: { answer: 'file.txt' } as AttachmentFieldResponseV3,
-    } as any
-
-    const result = extractMrfPreviousStepResponseValue(field, previousResponse)
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.Attachment),
+      v4Response(BasicField.Attachment, {
+        value: 'file.txt',
+        hasBeenScanned: true,
+      }),
+    )
 
     expect(result).toBeUndefined()
   })
 
-  it('should set value to CLIENT_RADIO_OTHERS_INPUT_VALUE if othersInput exists but value is empty', () => {
-    const field: FormFieldDto = { fieldType: BasicField.Radio } as any
-    const previousResponse: FieldResponseV3 = {
-      answer: { othersInput: 'some input', value: '' } as RadioFieldValues,
-    } as any
-
+  it('should map others radio answers to the client sentinel + othersInput', () => {
     const result = extractMrfPreviousStepResponseValue(
-      field,
-      previousResponse,
-    ) as RadioFieldValues
+      mockField(BasicField.Radio),
+      v4Response(BasicField.Radio, {
+        value: 'some input',
+        isOthersInput: true,
+      }),
+    )
 
-    expect(result.value).toBe(CLIENT_RADIO_OTHERS_INPUT_VALUE)
-    expect(result.othersInput).toBe('some input')
+    expect(result).toEqual({
+      value: CLIENT_RADIO_OTHERS_INPUT_VALUE,
+      othersInput: 'some input',
+    })
+  })
+
+  it('should map regular radio answers to { value }', () => {
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.Radio),
+      v4Response(BasicField.Radio, { value: 'Option 1', isOthersInput: false }),
+    )
+
+    expect(result).toEqual({ value: 'Option 1' })
+  })
+
+  it('should pass through checkbox answers', () => {
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.Checkbox),
+      v4Response(BasicField.Checkbox, {
+        value: ['A', 'B'],
+        othersInput: 'other',
+      }),
+    )
+
+    expect(result).toEqual({ value: ['A', 'B'], othersInput: 'other' })
+  })
+
+  it('should flatten table answers into rowNum-ordered row arrays', () => {
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.Table),
+      v4Response(BasicField.Table, {
+        'row-id-2': { rowNum: 1, value: { col1: 'r2c1', col2: 'r2c2' } },
+        'row-id-1': { rowNum: 0, value: { col1: 'r1c1', col2: 'r1c2' } },
+      }),
+    )
+
+    expect(result).toEqual([
+      { col1: 'r1c1', col2: 'r1c2' },
+      { col1: 'r2c1', col2: 'r2c2' },
+    ])
+  })
+
+  it('should unwrap address sub-fields into addressSubFields', () => {
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.Address),
+      v4Response(BasicField.Address, {
+        postalCode: { value: '123456' },
+        blockNumber: { value: '12A' },
+        streetName: { value: 'Main Street' },
+        buildingName: { value: '' },
+        levelNumber: { value: '05' },
+        unitNumber: { value: '01' },
+      }),
+    )
+
+    expect(result).toEqual({
+      addressSubFields: {
+        postalCode: '123456',
+        blockNumber: '12A',
+        streetName: 'Main Street',
+        buildingName: '',
+        levelNumber: '05',
+        unitNumber: '01',
+      },
+    })
+  })
+
+  it('should map signature answers to signature field values', () => {
+    const strokes = [
+      [
+        [1, 2, 0.5],
+        [3, 4, 0.6],
+      ],
+    ]
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.Signature),
+      v4Response(BasicField.Signature, { value: strokes, type: 'draw' }),
+    )
+
+    expect(result).toEqual({ type: 'draw', value: strokes })
   })
 
   it('should return undefined if previousFieldResponse is undefined', () => {
-    const field: FormFieldDto = { fieldType: BasicField.Radio } as any
-
-    const result = extractMrfPreviousStepResponseValue(field)
+    const result = extractMrfPreviousStepResponseValue(
+      mockField(BasicField.Radio),
+    )
 
     expect(result).toBeUndefined()
   })
 
-  it('should return the answer as-is for other field types', () => {
-    const field: FormFieldDto = { fieldType: 'Text' } as any
-    const previousResponse: FieldResponseV3 = { answer: 'Hello' } as any
+  it('should return undefined for non-input field types', () => {
+    for (const fieldType of [
+      BasicField.Section,
+      BasicField.Statement,
+      BasicField.Image,
+    ]) {
+      const result = extractMrfPreviousStepResponseValue(
+        mockField(fieldType),
+        v4Response(fieldType, { value: '' }),
+      )
+      expect(result).toBeUndefined()
+    }
+  })
 
-    const result = extractMrfPreviousStepResponseValue(field, previousResponse)
+  describe('round-trip with createResponsesV4', () => {
+    it('should recover the original form input values from built V4 responses', () => {
+      // Inputs → createResponsesV4 (wire V4) → extract (prefill) must be the
+      // identity for every prefillable field type, since step N+1 re-submits
+      // non-editable values through this exact loop.
+      const fieldIds = {
+        text: '0'.repeat(24),
+        yesNo: '1'.repeat(24),
+        email: '2'.repeat(24),
+        radioOthers: '3'.repeat(24),
+        checkbox: '4'.repeat(24),
+        table: '5'.repeat(24),
+        address: '6'.repeat(24),
+        signature: '7'.repeat(24),
+        countryRegion: '8'.repeat(24),
+      }
+      const formFields = [
+        mockField(BasicField.ShortText, fieldIds.text),
+        mockField(BasicField.YesNo, fieldIds.yesNo),
+        mockField(BasicField.Email, fieldIds.email),
+        mockField(BasicField.Radio, fieldIds.radioOthers),
+        mockField(BasicField.Checkbox, fieldIds.checkbox),
+        mockField(BasicField.Table, fieldIds.table),
+        mockField(BasicField.Address, fieldIds.address),
+        mockField(BasicField.Signature, fieldIds.signature),
+        mockField(BasicField.CountryRegion, fieldIds.countryRegion),
+      ]
+      const formInputs = {
+        [fieldIds.text]: 'hello',
+        [fieldIds.yesNo]: 'No',
+        [fieldIds.email]: { value: 'a@example.com', signature: 'sig' },
+        [fieldIds.radioOthers]: {
+          value: CLIENT_RADIO_OTHERS_INPUT_VALUE,
+          othersInput: 'custom',
+        },
+        [fieldIds.checkbox]: { value: ['A'], othersInput: 'other' },
+        [fieldIds.table]: [{ col1: 'a', col2: 'b' }],
+        [fieldIds.address]: {
+          addressSubFields: {
+            postalCode: '123456',
+            blockNumber: '12A',
+            streetName: 'Main Street',
+            buildingName: '',
+            levelNumber: '05',
+            unitNumber: '01',
+          },
+        },
+        [fieldIds.signature]: { type: 'draw', value: [[[1, 2, 0.5]]] },
+        [fieldIds.countryRegion]: CountryRegion.Singapore,
+      } as unknown as FormFieldValues
 
-    expect(result).toBe('Hello')
+      const wireResponses = createResponsesV4(formFields, formInputs, [])
+
+      for (const field of formFields) {
+        const extracted = extractMrfPreviousStepResponseValue(
+          field,
+          wireResponses[field._id],
+        )
+        expect(extracted).toEqual(formInputs[field._id])
+      }
+    })
   })
 })

--- a/apps/frontend/src/features/form/utils/extractMrfPreviousStepResponseValue.ts
+++ b/apps/frontend/src/features/form/utils/extractMrfPreviousStepResponseValue.ts
@@ -1,59 +1,130 @@
+import type {
+  AddressAnswerV4,
+  AttachmentAnswerV4,
+  CheckboxAnswerV4,
+  FieldResponseV4,
+  RadioAnswerV4,
+  SignatureAnswerV4,
+  StringAnswerV4,
+  TableAnswerV4,
+  VerifiableAnswerV4,
+} from '@opengovsg/formsg-sdk'
+import { ADDRESS_SUBFIELD_KEYS } from '@opengovsg/formsg-sdk'
+
 import { CLIENT_RADIO_OTHERS_INPUT_VALUE } from 'formsg-shared/constants'
 import { CountryRegion } from 'formsg-shared/constants/countryRegion'
-import {
-  AttachmentFieldResponseV3,
-  BasicField,
-  FieldResponseV3,
-  FormFieldDto,
-} from 'formsg-shared/types'
+import { BasicField, FormFieldDto } from 'formsg-shared/types'
 
 import bufferToFile from '~utils/bufferToFile'
-import { FormFieldValue, RadioFieldValues } from '~templates/Field'
+import {
+  AddressCompoundFieldValues,
+  FormFieldValue,
+  TableRowFieldValue,
+} from '~templates/Field'
 
 /**
- * Retrieves the filled value for a field from the previous step response for MRF.
+ * Retrieves the filled value for a field from the previous step response for
+ * MRF. Previous responses are served in V4 shape (the FE's working format);
+ * this is the inverse of createResponsesV4's input → V4 answer mapping.
  * @param field The field to extract the value for
- * @param previousFieldResponse The previous field response
+ * @param previousFieldResponse The previous field response (V4)
  * @param previousAttachmentFieldResponseFileBuffer The previous attachment field response file buffer (will only exist if the field is an attachment field)
  * @returns The filled value for the field
  */
 export const extractMrfPreviousStepResponseValue = (
   field: FormFieldDto,
-  previousFieldResponse?: FieldResponseV3,
+  previousFieldResponse?: Pick<FieldResponseV4, 'fieldType' | 'answer'>,
   previousAttachmentFieldResponseFileBuffer?: Uint8Array<ArrayBuffer>,
 ): FormFieldValue | undefined => {
-  if (previousFieldResponse) {
-    if (previousFieldResponse) {
-      switch (field.fieldType) {
-        case BasicField.CountryRegion: {
-          const selected = Object.values(CountryRegion).find(
-            (option) => option.toUpperCase() === previousFieldResponse.answer,
-          )
-          if (selected) {
-            return selected
-          }
-          return
-        }
-        case BasicField.Attachment: {
-          const attachmentData =
-            previousFieldResponse.answer as AttachmentFieldResponseV3
-          const fileName = attachmentData.answer
-          const fileData = previousAttachmentFieldResponseFileBuffer
-          if (fileData) {
-            return bufferToFile(fileData, fileName)
-          }
-          return
-        }
-        case BasicField.Radio: {
-          const radioAnswer = previousFieldResponse.answer as RadioFieldValues
-          if (radioAnswer.othersInput && !radioAnswer.value) {
-            radioAnswer.value = CLIENT_RADIO_OTHERS_INPUT_VALUE
-          }
-          return radioAnswer
-        }
-        default:
-          return previousFieldResponse.answer as FormFieldValue
+  if (!previousFieldResponse) return
+
+  switch (field.fieldType) {
+    case BasicField.Number:
+    case BasicField.Decimal:
+    case BasicField.ShortText:
+    case BasicField.LongText:
+    case BasicField.HomeNo:
+    case BasicField.Dropdown:
+    case BasicField.Rating:
+    case BasicField.Nric:
+    case BasicField.Uen:
+    case BasicField.Date:
+    case BasicField.YesNo: {
+      const answer = previousFieldResponse.answer as StringAnswerV4
+      return answer.value as FormFieldValue<typeof field.fieldType>
+    }
+    case BasicField.CountryRegion: {
+      // Stored answers may be uppercased (legacy V3 processing); match
+      // case-insensitively against the enum values used as inputs.
+      const answer = previousFieldResponse.answer as StringAnswerV4
+      const selected = Object.values(CountryRegion).find(
+        (option) => option.toUpperCase() === answer.value?.toUpperCase(),
+      )
+      return selected
+    }
+    case BasicField.Email:
+    case BasicField.Mobile: {
+      // VerifiableAnswerV4 has the same shape as VerifiableFieldValues
+      return previousFieldResponse.answer as VerifiableAnswerV4
+    }
+    case BasicField.Attachment: {
+      const answer = previousFieldResponse.answer as AttachmentAnswerV4
+      const fileData = previousAttachmentFieldResponseFileBuffer
+      if (fileData) {
+        return bufferToFile(fileData, answer.value)
       }
+      return
+    }
+    case BasicField.Radio: {
+      const answer = previousFieldResponse.answer as RadioAnswerV4
+      if (answer.isOthersInput) {
+        return {
+          value: CLIENT_RADIO_OTHERS_INPUT_VALUE,
+          othersInput: answer.value,
+        }
+      }
+      return { value: answer.value }
+    }
+    case BasicField.Checkbox: {
+      // CheckboxAnswerV4 has the same shape as CheckboxFieldValues; the
+      // others sentinel is carried inside the value array.
+      return previousFieldResponse.answer as CheckboxAnswerV4
+    }
+    case BasicField.Table: {
+      const answer = previousFieldResponse.answer as TableAnswerV4
+      return Object.values(answer)
+        .sort((a, b) => a.rowNum - b.rowNum)
+        .map((row) => {
+          const rowValue: TableRowFieldValue = {}
+          for (const [columnId, value] of Object.entries(row.value)) {
+            rowValue[columnId] = String(value)
+          }
+          return rowValue
+        })
+    }
+    case BasicField.Address: {
+      const answer = previousFieldResponse.answer as AddressAnswerV4
+      const addressSubFields =
+        {} as AddressCompoundFieldValues['addressSubFields']
+      for (const key of ADDRESS_SUBFIELD_KEYS) {
+        addressSubFields[key] = answer[key]?.value ?? ''
+      }
+      return { addressSubFields }
+    }
+    case BasicField.Signature: {
+      const answer = previousFieldResponse.answer as SignatureAnswerV4
+      return { type: 'draw', value: answer.value }
+    }
+    case BasicField.Children:
+    case BasicField.Section:
+    case BasicField.Image:
+    case BasicField.Statement:
+      // Children is unsupported for MRF; the rest carry no input value.
+      return
+    default: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _: never = field
+      return
     }
   }
 }

--- a/apps/frontend/src/features/form/utils/extractMrfPreviousStepResponseValue.ts
+++ b/apps/frontend/src/features/form/utils/extractMrfPreviousStepResponseValue.ts
@@ -86,8 +86,7 @@ export const extractMrfPreviousStepResponseValue = (
       return { value: answer.value }
     }
     case BasicField.Checkbox: {
-      // CheckboxAnswerV4 has the same shape as CheckboxFieldValues; the
-      // others sentinel is carried inside the value array.
+      // CheckboxAnswerV4 has the same shape as CheckboxFieldValues
       return previousFieldResponse.answer as CheckboxAnswerV4
     }
     case BasicField.Table: {
@@ -121,10 +120,7 @@ export const extractMrfPreviousStepResponseValue = (
     case BasicField.Statement:
       // Children is unsupported for MRF; the rest carry no input value.
       return
-    default: {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const _: never = field
-      return
-    }
+    default:
+      return previousFieldResponse.answer as FormFieldValue
   }
 }

--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -564,22 +564,12 @@ export const PublicFormProvider = ({
     if (encryptedPreviousSubmission?.mrfVersion != null) {
       if (submissionSecretKey) decryptAttachments()
     } else {
-      // Backward compatibility to retrieve attachments from the DB itself once
-      // the previous submission responses are decrypted.
-      if (previousSubmission) {
-        // Backward compatibility
-        const previousAttachments: Record<string, Uint8Array<ArrayBuffer>> = {}
-        Object.keys(previousSubmission.responses).forEach((id) => {
-          const response = previousSubmission.responses[id]
-          if (response.fieldType === BasicField.Attachment) {
-            previousAttachments[id] = Uint8Array.from(
-              //@ts-expect-error 'content' required for backward compatibility, but
-              // does not exist on AttachmentFieldResponseV3 in mrfVersion >= 1 versions
-              response.answer.content.data,
-            )
-          }
-        })
-        setPreviousAttachments(previousAttachments)
+      // Backward compatibility to retrieve attachments embedded in the
+      // encrypted blob itself (legacy submissions predating mrfVersion).
+      // These are harvested pre-adaptation by decryptSubmission, since the
+      // embedded content is dropped when responses are adapted to V4.
+      if (previousSubmission?.legacyAttachmentContents) {
+        setPreviousAttachments(previousSubmission.legacyAttachmentContents)
       }
     }
   }, [encryptedPreviousSubmission, previousSubmission, submissionSecretKey])

--- a/apps/frontend/src/features/public-form/PublicFormService.ts
+++ b/apps/frontend/src/features/public-form/PublicFormService.ts
@@ -40,7 +40,7 @@ import { FormFieldValues } from '~templates/Field'
 import {
   createClearSubmissionFormData,
   createClearSubmissionWithVirusScanningFormData,
-  createClearSubmissionWithVirusScanningFormDataV3,
+  createClearSubmissionWithVirusScanningFormDataV4,
   getAttachmentsMap,
 } from './utils/createSubmission'
 import { convertEncryptedAttachmentToFileContent } from './utils/decryptSubmission'
@@ -371,7 +371,7 @@ export const submitEmailModeFormWithFetch = async ({
   return processFetchResponse(response)
 }
 
-// Submit storage mode form with virus scanning (storage v2.1+)
+// Submit multirespondent form with virus scanning
 export const submitMultirespondentForm = async ({
   formFields,
   formLogics,
@@ -390,7 +390,7 @@ export const submitMultirespondentForm = async ({
     formLogics,
   })
 
-  const formData = createClearSubmissionWithVirusScanningFormDataV3(
+  const formData = createClearSubmissionWithVirusScanningFormDataV4(
     {
       formFields,
       formInputs: filteredInputs,
@@ -437,7 +437,7 @@ export const updateMultirespondentSubmission = async ({
     formLogics,
   })
 
-  const formData = createClearSubmissionWithVirusScanningFormDataV3(
+  const formData = createClearSubmissionWithVirusScanningFormDataV4(
     {
       formFields,
       formInputs: filteredInputs,

--- a/apps/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { Box, Stack } from '@chakra-ui/react'
 import { isEmpty } from 'lodash'
 
-import { FieldResponsesV3 } from 'formsg-shared/types'
 import { FormFieldDto } from 'formsg-shared/types/field'
 import {
   FormColorTheme,
@@ -26,7 +25,6 @@ import { PublicFormSubmitButton } from './PublicFormSubmitButton'
 import { VisibleFormFields } from './VisibleFormFields'
 
 export interface FormFieldsProps {
-  previousResponses?: FieldResponsesV3
   previousAttachments?: Record<string, Uint8Array>
   formFields: FormFieldDto[]
   formLogics: LogicDto[]

--- a/apps/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -63,7 +63,6 @@ export const FormFieldsContainer = (): JSX.Element | null => {
 
     return (
       <FormFields
-        previousResponses={previousSubmission?.responses}
         previousAttachments={previousAttachments}
         formFields={form.form_fields}
         formLogics={form.form_logics}
@@ -84,7 +83,6 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     isLoading,
     form,
     isAuthRequired,
-    previousSubmission?.responses,
     previousAttachments,
     workflowStep,
     handleSubmitForm,

--- a/apps/frontend/src/features/public-form/utils/createSubmission.test.ts
+++ b/apps/frontend/src/features/public-form/utils/createSubmission.test.ts
@@ -1,0 +1,313 @@
+import { adaptV3ToV4, type TableAnswerV4 } from '@opengovsg/formsg-sdk'
+
+import { BasicField, FormFieldDto } from 'formsg-shared/types'
+
+import { FormFieldValues } from '~templates/Field'
+import { RADIO_OTHERS_INPUT_VALUE } from '~templates/Field/Radio/constants'
+
+import { FieldIdToQuarantineKeyType } from '../PublicFormService'
+
+import { createResponsesV3, createResponsesV4 } from './createSubmission'
+
+const fieldId = (n: number) => n.toString(16).padStart(24, '0')
+
+const mockField = (id: string, fieldType: BasicField): FormFieldDto =>
+  ({ _id: id, fieldType, title: `Question ${id}` }) as FormFieldDto
+
+const TEXT_ID = fieldId(1)
+const YESNO_ID = fieldId(2)
+const EMAIL_ID = fieldId(3)
+const RADIO_ID = fieldId(4)
+const CHECKBOX_ID = fieldId(5)
+const TABLE_ID = fieldId(6)
+const ADDRESS_ID = fieldId(7)
+const ATTACHMENT_ID = fieldId(8)
+const SIGNATURE_ID = fieldId(9)
+const MOBILE_ID = fieldId(10)
+
+const QUARANTINE_MAP: FieldIdToQuarantineKeyType[] = [
+  { fieldId: ATTACHMENT_ID, quarantineBucketKey: 'quarantine/key-123' },
+]
+
+describe('createResponsesV4', () => {
+  it('wraps string-like and yes/no answers in { value }', () => {
+    const formFields = [
+      mockField(TEXT_ID, BasicField.ShortText),
+      mockField(YESNO_ID, BasicField.YesNo),
+    ]
+    const formInputs = {
+      [TEXT_ID]: 'hello world',
+      [YESNO_ID]: 'Yes',
+    } as FormFieldValues
+
+    const responses = createResponsesV4(formFields, formInputs, [])
+
+    expect(responses[TEXT_ID]).toEqual({
+      fieldType: BasicField.ShortText,
+      answer: { value: 'hello world' },
+      provenance: {},
+    })
+    expect(responses[YESNO_ID]).toEqual({
+      fieldType: BasicField.YesNo,
+      answer: { value: 'Yes' },
+      provenance: {},
+    })
+  })
+
+  it('includes signature on verifiable answers only when present', () => {
+    const formFields = [
+      mockField(EMAIL_ID, BasicField.Email),
+      mockField(MOBILE_ID, BasicField.Mobile),
+    ]
+    const formInputs = {
+      [EMAIL_ID]: { value: 'a@example.com', signature: 'sig' },
+      [MOBILE_ID]: { value: '+6598765432' },
+    } as FormFieldValues
+
+    const responses = createResponsesV4(formFields, formInputs, [])
+
+    expect(responses[EMAIL_ID].answer).toEqual({
+      value: 'a@example.com',
+      signature: 'sig',
+    })
+    expect(responses[MOBILE_ID].answer).toEqual({ value: '+6598765432' })
+  })
+
+  it('maps radio answers to { value, isOthersInput }', () => {
+    const formFields = [mockField(RADIO_ID, BasicField.Radio)]
+
+    const regular = createResponsesV4(
+      formFields,
+      { [RADIO_ID]: { value: 'Option A' } } as FormFieldValues,
+      [],
+    )
+    expect(regular[RADIO_ID].answer).toEqual({
+      value: 'Option A',
+      isOthersInput: false,
+    })
+
+    const others = createResponsesV4(
+      formFields,
+      {
+        [RADIO_ID]: {
+          value: RADIO_OTHERS_INPUT_VALUE,
+          othersInput: 'my custom answer',
+        },
+      } as FormFieldValues,
+      [],
+    )
+    expect(others[RADIO_ID].answer).toEqual({
+      value: 'my custom answer',
+      isOthersInput: true,
+    })
+  })
+
+  it('normalizes untouched checkbox value `false` to an empty selection', () => {
+    const formFields = [mockField(CHECKBOX_ID, BasicField.Checkbox)]
+    const formInputs = {
+      [CHECKBOX_ID]: { value: false, othersInput: 'other only' },
+    } as unknown as FormFieldValues
+
+    const responses = createResponsesV4(formFields, formInputs, [])
+
+    expect(responses[CHECKBOX_ID].answer).toEqual({
+      value: [],
+      othersInput: 'other only',
+    })
+  })
+
+  it('keys table rows by generated rowId with rowNum ordering', () => {
+    const formFields = [mockField(TABLE_ID, BasicField.Table)]
+    const formInputs = {
+      [TABLE_ID]: [
+        { col1: 'r1c1', col2: 'r1c2' },
+        { col1: 'r2c1', col2: 'r2c2' },
+      ],
+    } as unknown as FormFieldValues
+
+    const responses = createResponsesV4(formFields, formInputs, [])
+
+    const answer = responses[TABLE_ID].answer as TableAnswerV4
+    const rows = Object.entries(answer)
+    expect(rows).toHaveLength(2)
+    for (const [rowId] of rows) {
+      expect(rowId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      )
+    }
+    const byRowNum = Object.values(answer).sort((a, b) => a.rowNum - b.rowNum)
+    expect(byRowNum[0]).toEqual({
+      rowNum: 0,
+      value: { col1: 'r1c1', col2: 'r1c2' },
+    })
+    expect(byRowNum[1]).toEqual({
+      rowNum: 1,
+      value: { col1: 'r2c1', col2: 'r2c2' },
+    })
+  })
+
+  it('wraps each address sub-field in { value }', () => {
+    const formFields = [mockField(ADDRESS_ID, BasicField.Address)]
+    const formInputs = {
+      [ADDRESS_ID]: {
+        addressSubFields: {
+          postalCode: '123456',
+          blockNumber: '12A',
+          streetName: 'Main Street',
+          buildingName: '',
+          levelNumber: '05',
+          unitNumber: '01',
+        },
+      },
+    } as unknown as FormFieldValues
+
+    const responses = createResponsesV4(formFields, formInputs, [])
+
+    expect(responses[ADDRESS_ID].answer).toEqual({
+      postalCode: { value: '123456' },
+      blockNumber: { value: '12A' },
+      streetName: { value: 'Main Street' },
+      buildingName: { value: '' },
+      levelNumber: { value: '05' },
+      unitNumber: { value: '01' },
+    })
+  })
+
+  it('uses the quarantine bucket key for attachment answers', () => {
+    const formFields = [mockField(ATTACHMENT_ID, BasicField.Attachment)]
+    const formInputs = {
+      [ATTACHMENT_ID]: new File(['content'], 'file.pdf'),
+    } as unknown as FormFieldValues
+
+    const responses = createResponsesV4(formFields, formInputs, QUARANTINE_MAP)
+
+    expect(responses[ATTACHMENT_ID].answer).toEqual({
+      value: 'quarantine/key-123',
+      hasBeenScanned: false,
+    })
+  })
+
+  it('throws when an attachment has no quarantine bucket key', () => {
+    const formFields = [mockField(ATTACHMENT_ID, BasicField.Attachment)]
+    const formInputs = {
+      [ATTACHMENT_ID]: new File(['content'], 'file.pdf'),
+    } as unknown as FormFieldValues
+
+    expect(() => createResponsesV4(formFields, formInputs, [])).toThrow(
+      `Attachment response with fieldId ${ATTACHMENT_ID} not found among attachments uploaded to quarantine bucket`,
+    )
+  })
+
+  it('skips empty inputs the same way as V3', () => {
+    const formFields = [
+      mockField(TEXT_ID, BasicField.ShortText),
+      mockField(CHECKBOX_ID, BasicField.Checkbox),
+      mockField(TABLE_ID, BasicField.Table),
+      mockField(SIGNATURE_ID, BasicField.Signature),
+    ]
+    const formInputs = {
+      [TEXT_ID]: '',
+      [CHECKBOX_ID]: { value: false },
+      [TABLE_ID]: [{ col1: '', col2: '' }],
+      [SIGNATURE_ID]: { type: '', value: [] },
+    } as unknown as FormFieldValues
+
+    const responses = createResponsesV4(formFields, formInputs, [])
+
+    expect(responses).toEqual({})
+  })
+
+  it('stamps provenance: {} on every response (V4 detection is duck-typed on it)', () => {
+    const formFields = [
+      mockField(TEXT_ID, BasicField.ShortText),
+      mockField(RADIO_ID, BasicField.Radio),
+    ]
+    const formInputs = {
+      [TEXT_ID]: 'answer',
+      [RADIO_ID]: { value: 'Option A' },
+    } as FormFieldValues
+
+    const responses = createResponsesV4(formFields, formInputs, [])
+
+    for (const response of Object.values(responses)) {
+      expect(response.provenance).toEqual({})
+    }
+  })
+
+  describe('parity with adaptV3ToV4(createResponsesV3(x))', () => {
+    it('produces the same fieldType and answer for every field type', () => {
+      const formFields = [
+        mockField(TEXT_ID, BasicField.ShortText),
+        mockField(YESNO_ID, BasicField.YesNo),
+        mockField(EMAIL_ID, BasicField.Email),
+        mockField(MOBILE_ID, BasicField.Mobile),
+        mockField(RADIO_ID, BasicField.Radio),
+        mockField(CHECKBOX_ID, BasicField.Checkbox),
+        mockField(TABLE_ID, BasicField.Table),
+        mockField(ADDRESS_ID, BasicField.Address),
+        mockField(ATTACHMENT_ID, BasicField.Attachment),
+        mockField(SIGNATURE_ID, BasicField.Signature),
+      ]
+      const formInputs = {
+        [TEXT_ID]: 'hello',
+        [YESNO_ID]: 'No',
+        [EMAIL_ID]: { value: 'a@example.com', signature: 'sig' },
+        [MOBILE_ID]: { value: '+6598765432' },
+        [RADIO_ID]: {
+          value: RADIO_OTHERS_INPUT_VALUE,
+          othersInput: 'custom radio',
+        },
+        [CHECKBOX_ID]: { value: ['A', 'B'], othersInput: 'custom checkbox' },
+        [TABLE_ID]: [
+          { col1: 'r1c1', col2: 'r1c2' },
+          { col1: 'r2c1', col2: 'r2c2' },
+        ],
+        [ADDRESS_ID]: {
+          addressSubFields: {
+            postalCode: '123456',
+            blockNumber: '12A',
+            streetName: 'Main Street',
+            buildingName: 'Tower 1',
+            levelNumber: '05',
+            unitNumber: '01',
+          },
+        },
+        [ATTACHMENT_ID]: new File(['content'], 'file.pdf'),
+        [SIGNATURE_ID]: {
+          type: 'draw',
+          value: [
+            [
+              [1, 2, 0.5],
+              [3, 4, 0.6],
+            ],
+          ],
+        },
+      } as unknown as FormFieldValues
+
+      const v4 = createResponsesV4(formFields, formInputs, QUARANTINE_MAP)
+      const adapted = adaptV3ToV4(
+        createResponsesV3(
+          formFields,
+          formInputs,
+          QUARANTINE_MAP,
+        ) as unknown as Parameters<typeof adaptV3ToV4>[0],
+      )
+
+      expect(Object.keys(v4).sort()).toEqual(Object.keys(adapted).sort())
+
+      for (const id of Object.keys(v4)) {
+        expect(v4[id].fieldType as string).toEqual(adapted[id].fieldType)
+        if (v4[id].fieldType === BasicField.Table) {
+          // rowIds are freshly generated on both sides; compare row contents
+          const normalize = (answer: TableAnswerV4) =>
+            Object.values(answer).sort((a, b) => a.rowNum - b.rowNum)
+          expect(normalize(v4[id].answer as TableAnswerV4)).toEqual(
+            normalize(adapted[id].answer as TableAnswerV4),
+          )
+        } else {
+          expect(v4[id].answer).toEqual(adapted[id].answer)
+        }
+      }
+    })
+  })
+})

--- a/apps/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/apps/frontend/src/features/public-form/utils/createSubmission.ts
@@ -270,8 +270,7 @@ const createResponsesArray = (
 }
 
 /**
- * @deprecated Parity-test collateral for {@link createResponsesV4} — no
- * production callers. Delete in PR 4 of the MRF V4 migration.
+ * @deprecated For createResponsesV4
  */
 export const createResponsesV3 = (
   formFields: FormFieldDto[],

--- a/apps/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/apps/frontend/src/features/public-form/utils/createSubmission.ts
@@ -1,4 +1,13 @@
 import { datadogLogs } from '@datadog/browser-logs'
+import {
+  ADDRESS_SUBFIELD_KEYS,
+  type AddressAnswerV4,
+  type AnswerV4,
+  type ChildrenAnswerV4,
+  generateUUID,
+  type ResponseProvenance,
+  type TableAnswerV4,
+} from '@opengovsg/formsg-sdk'
 import { encode as encodeBase64 } from '@stablelib/base64'
 import { chain, forOwn, isEmpty, keyBy, omit, pick } from 'lodash'
 
@@ -260,7 +269,11 @@ const createResponsesArray = (
   return validateResponses(transformedResponses)
 }
 
-const createResponsesV3 = (
+/**
+ * @deprecated Parity-test collateral for {@link createResponsesV4} — no
+ * production callers. Delete in PR 4 of the MRF V4 migration.
+ */
+export const createResponsesV3 = (
   formFields: FormFieldDto[],
   formInputs: FormFieldValues,
   fieldIdToQuarantineKeyMap: FieldIdToQuarantineKeyType[],
@@ -418,6 +431,218 @@ const createResponsesV3 = (
             fieldType: ff.fieldType,
             answer: input,
           } as FieldResponseV3
+        }
+        break
+      }
+      default: {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const _: never = ff
+      }
+    }
+  }
+  return returnedInputs
+}
+
+/**
+ * Thin V4 wire response for MRF submissions: the FE sends fieldType + answer
+ * and the BE enriches the rest (question is sourced from the form definition).
+ *
+ * `provenance` is intentionally always present, even when empty: the SDK's
+ * isFieldResponsesV4 duck-types V4 responses on its presence at read time
+ * (BE step comparison, FE next-step decrypt, admin viewer). Omitting it would
+ * make stored blobs misdetect as V3 and get double-adapted on read.
+ */
+type MrfWireFieldResponseV4 = {
+  fieldType: BasicField
+  answer: AnswerV4
+  provenance: ResponseProvenance
+}
+
+export type MrfWireResponsesV4 = Record<string, MrfWireFieldResponseV4>
+
+const toWireResponseV4 = (
+  fieldType: BasicField,
+  answer: AnswerV4,
+): MrfWireFieldResponseV4 => ({
+  fieldType,
+  answer,
+  provenance: {},
+})
+
+/**
+ * Builds V4-shaped MRF wire responses directly from form inputs.
+ * Mirrors {@link createResponsesV3}'s per-field empty-skip semantics; answer
+ * shapes follow the SDK's adaptV3ToV4 conversions, which is what the BE
+ * receiver shim produces for stale V3 clients.
+ */
+export const createResponsesV4 = (
+  formFields: FormFieldDto[],
+  formInputs: FormFieldValues,
+  fieldIdToQuarantineKeyMap: FieldIdToQuarantineKeyType[],
+): MrfWireResponsesV4 => {
+  const returnedInputs: MrfWireResponsesV4 = {}
+  for (const ff of formFields) {
+    switch (ff.fieldType) {
+      case BasicField.Number:
+      case BasicField.Decimal:
+      case BasicField.ShortText:
+      case BasicField.LongText:
+      case BasicField.HomeNo:
+      case BasicField.Dropdown:
+      case BasicField.Rating:
+      case BasicField.Nric:
+      case BasicField.Uen:
+      case BasicField.Date:
+      case BasicField.CountryRegion:
+      case BasicField.YesNo: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input) break
+        returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, {
+          value: input,
+        })
+        break
+      }
+      case BasicField.Address: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (
+          !input ||
+          Object.values(input.addressSubFields).every((value) => !value)
+        )
+          break
+        const answer: Record<string, { value: string }> = {}
+        for (const key of ADDRESS_SUBFIELD_KEYS) {
+          answer[key] = { value: input.addressSubFields[key] ?? '' }
+        }
+        returnedInputs[ff._id] = toWireResponseV4(
+          ff.fieldType,
+          answer as AddressAnswerV4,
+        )
+        break
+      }
+      case BasicField.Email:
+      case BasicField.Mobile: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input?.value) break
+        returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, {
+          value: input.value,
+          ...(input.signature !== undefined && { signature: input.signature }),
+        })
+        break
+      }
+      case BasicField.Table: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input) break
+        if (input.every((row) => Object.values(row).every((value) => !value))) {
+          break
+        }
+        const answer: TableAnswerV4 = {}
+        input.forEach((row, rowNum) => {
+          answer[generateUUID()] = { rowNum, value: row }
+        })
+        returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, answer)
+        break
+      }
+      case BasicField.Checkbox: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (
+          (!input?.value || input?.value.length === 0) &&
+          !input?.othersInput
+        ) {
+          break
+        }
+        returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, {
+          // `false` is a react-hook-form artifact of untouched checkboxes;
+          // normalize to an empty selection for the wire.
+          value: input.value === false ? [] : input.value,
+          ...(input.othersInput !== undefined && {
+            othersInput: input.othersInput,
+          }),
+        })
+        break
+      }
+      case BasicField.Children: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (
+          !input ||
+          input.child.every((child) => child.every((value) => !value))
+        ) {
+          break
+        }
+        const answer: ChildrenAnswerV4 = {}
+        input.child.forEach((child, i) => {
+          const value: ChildrenAnswerV4[string]['value'] = {}
+          input.childFields.forEach((attr, j) => {
+            value[attr] = { value: child[j] ?? '', myInfo: { attr } }
+          })
+          answer[`child${i}`] = { value }
+        })
+        returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, answer)
+        break
+      }
+      case BasicField.Attachment: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        if (!input) break
+        // for each attachment response, find the corresponding quarantine bucket key
+        const fieldIdToQuarantineKeyEntry = fieldIdToQuarantineKeyMap.find(
+          (v) => v.fieldId === ff._id,
+        )
+        if (!fieldIdToQuarantineKeyEntry)
+          throw new Error(
+            `Attachment response with fieldId ${ff._id} not found among attachments uploaded to quarantine bucket`,
+          )
+        returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, {
+          value: fieldIdToQuarantineKeyEntry.quarantineBucketKey,
+          hasBeenScanned: false, //TODO: FRM-1839 + FRM-1590 conditionally set to true if not replaced by respondent 2 onwards
+        })
+        break
+      }
+      case BasicField.Radio: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        const isOthersSelected = input?.value === RADIO_OTHERS_INPUT_VALUE
+        if (!isOthersSelected && input?.value) {
+          returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, {
+            value: input.value,
+            isOthersInput: false,
+          })
+        } else if (isOthersSelected && input?.othersInput) {
+          returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, {
+            value: input.othersInput,
+            isOthersInput: true,
+          })
+        }
+        break
+      }
+      case BasicField.Section:
+      case BasicField.Image:
+      case BasicField.Statement: {
+        break
+      }
+      case BasicField.Signature: {
+        const input = formInputs[ff._id] as
+          | FormFieldValue<typeof ff.fieldType>
+          | undefined
+        // since default value is {type: '', value: []}, empty array = no input
+        if (input && input?.value.length > 0) {
+          returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, {
+            value: input.value,
+            type: 'draw',
+          })
         }
         break
       }

--- a/apps/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/apps/frontend/src/features/public-form/utils/createSubmission.ts
@@ -211,11 +211,11 @@ export const createClearSubmissionWithVirusScanningFormData = (
 }
 
 /**
- * Used for MRF submissions v3 (after virus scanning).
+ * Used for MRF submissions v4 (after virus scanning).
  * @returns formData containing form responses and attachments.
  * @throws Error if form inputs are invalid or contain malicious attachment(s).
  */
-export const createClearSubmissionWithVirusScanningFormDataV3 = (
+export const createClearSubmissionWithVirusScanningFormDataV4 = (
   formDataArgs: CreateMultirespondentSubmissionFormDataArgs,
   fieldIdToQuarantineKeyMap: FieldIdToQuarantineKeyType[],
 ) => {
@@ -225,7 +225,7 @@ export const createClearSubmissionWithVirusScanningFormDataV3 = (
   // TODO: Move validation to before response array creation so it can be used for encryption v2-3
   createResponsesArray(formFields, formInputs)
 
-  const responses = createResponsesV3(
+  const responses = createResponsesV4(
     formFields,
     formInputs,
     fieldIdToQuarantineKeyMap,

--- a/apps/frontend/src/features/public-form/utils/decryptSubmission.ts
+++ b/apps/frontend/src/features/public-form/utils/decryptSubmission.ts
@@ -8,6 +8,7 @@ import { decode as decodeBase64 } from '@stablelib/base64'
 
 import {
   BasicField,
+  FieldResponsesV3,
   PublicMultirespondentSubmissionDto,
 } from 'formsg-shared/types'
 
@@ -38,7 +39,7 @@ export type DecryptedSubmission = Omit<
 const normalizeToV4 = (rawResponses: unknown): FieldResponsesV4 =>
   isFieldResponsesV4(rawResponses as Record<string, unknown>)
     ? (rawResponses as FieldResponsesV4)
-    : adaptV3ToV4(rawResponses as FormFieldsV3, { provenance: {} })
+    : adaptV3ToV4(rawResponses as FieldResponsesV3, { provenance: {} })
 
 const harvestLegacyAttachmentContents = (
   rawResponses: Record<string, { fieldType?: string; answer?: unknown }>,

--- a/apps/frontend/src/features/public-form/utils/decryptSubmission.ts
+++ b/apps/frontend/src/features/public-form/utils/decryptSubmission.ts
@@ -1,5 +1,5 @@
-import type { FieldResponseV4 } from '@opengovsg/formsg-sdk'
-import { adaptV4ToV3, isFieldResponsesV4 } from '@opengovsg/formsg-sdk'
+import type { FieldResponsesV4, FormFieldsV3 } from '@opengovsg/formsg-sdk'
+import { adaptV3ToV4, isFieldResponsesV4 } from '@opengovsg/formsg-sdk'
 import {
   EncryptedAttachmentContent,
   EncryptedFileContent,
@@ -7,11 +7,55 @@ import {
 import { decode as decodeBase64 } from '@stablelib/base64'
 
 import {
-  FieldResponsesV3,
+  BasicField,
   PublicMultirespondentSubmissionDto,
 } from 'formsg-shared/types'
 
 import formsgSdk from '~utils/formSdk'
+
+export type DecryptedSubmission = Omit<
+  PublicMultirespondentSubmissionDto,
+  'encryptedContent' | 'version'
+> & {
+  responses: FieldResponsesV4
+  submissionSecretKey: string
+  /**
+   * Attachment contents embedded in the encrypted blob itself, keyed by field
+   * ID. Only present for legacy submissions stored before attachments moved
+   * out of the blob (mrfVersion == null) — the embedded `content` key is not
+   * part of the V3 response types and is dropped by adaptV3ToV4, so it is
+   * harvested here before adaptation.
+   */
+  legacyAttachmentContents?: Record<string, Uint8Array<ArrayBuffer>>
+}
+
+/**
+ * Normalizes decrypted responses to V4, the FE's working format.
+ * V3-stored blobs (mrfVersion 1 / legacy) are adapted to V4; question text is
+ * irrelevant for prefill so no form fields are provided, and provenance is
+ * left empty rather than fabricating timestamps.
+ */
+const normalizeToV4 = (rawResponses: unknown): FieldResponsesV4 =>
+  isFieldResponsesV4(rawResponses as Record<string, unknown>)
+    ? (rawResponses as FieldResponsesV4)
+    : adaptV3ToV4(rawResponses as FormFieldsV3, { provenance: {} })
+
+const harvestLegacyAttachmentContents = (
+  rawResponses: Record<string, { fieldType?: string; answer?: unknown }>,
+): Record<string, Uint8Array<ArrayBuffer>> | undefined => {
+  if (isFieldResponsesV4(rawResponses)) return undefined
+  const contents: Record<string, Uint8Array<ArrayBuffer>> = {}
+  for (const [id, response] of Object.entries(rawResponses)) {
+    if (response.fieldType !== BasicField.Attachment) continue
+    const content = (
+      response.answer as { content?: { data?: ArrayLike<number> } } | undefined
+    )?.content
+    if (content?.data) {
+      contents[id] = Uint8Array.from(content.data)
+    }
+  }
+  return Object.keys(contents).length > 0 ? contents : undefined
+}
 
 /**
  * Decrypts a submission using the secret key
@@ -26,27 +70,17 @@ export const decryptSubmission = ({
 }: {
   submission?: PublicMultirespondentSubmissionDto
   secretKey?: string
-}):
-  | (Omit<
-      PublicMultirespondentSubmissionDto,
-      'encryptedContent' | 'version'
-    > & {
-      responses: FieldResponsesV3
-      submissionSecretKey: string
-    })
-  | undefined => {
+}): DecryptedSubmission | undefined => {
   if (!submission) throw Error('Encrypted submission undefined')
   if (!secretKey) throw Error('Secret key undefined')
 
-  // For testing, do not perform decryption and return the encrypted content directly
-  // (which will be a un-encrypted FieldResponsesV3 object)
+  // For testing, do not perform decryption and return the encrypted content
+  // directly (an un-encrypted V3 or V4 responses object)
   const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
   if (isTest) {
     return {
       ...submission,
-      responses: JSON.parse(
-        submission.encryptedContent,
-      ) as unknown as FieldResponsesV3,
+      responses: normalizeToV4(JSON.parse(submission.encryptedContent)),
       submissionSecretKey: secretKey,
     }
   }
@@ -59,19 +93,13 @@ export const decryptSubmission = ({
   )
   if (!decryptedContent) throw new Error('Could not decrypt the response')
 
-  // If the submission was encrypted in V4 format, convert back to V3
-  // since the respondent form view expects V3 shape
   const rawResponses = decryptedContent.responses
-  const responses: FieldResponsesV3 = isFieldResponsesV4(rawResponses)
-    ? (adaptV4ToV3(
-        rawResponses as Record<string, FieldResponseV4>,
-      ) as FieldResponsesV3)
-    : (rawResponses as FieldResponsesV3)
 
   // Add metadata for display.
   return {
     ...rest,
-    responses,
+    responses: normalizeToV4(rawResponses),
+    legacyAttachmentContents: harvestLegacyAttachmentContents(rawResponses),
     submissionSecretKey: secretKey,
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,6 +12,7 @@ export {
   ADDRESS_SUBFIELD_KEYS,
   GENERIC_STRING_FIELD_TYPES,
 } from './constants-v4'
+export { generateUUID } from './util/crypto'
 
 export type {
   DecryptedContent,

--- a/packages/shared/constants/form.ts
+++ b/packages/shared/constants/form.ts
@@ -115,7 +115,9 @@ export const E2EE_SUBMISSION_VERSION = 1
 // Encryption boundary shift implementation PR: https://github.com/opengovsg/FormSG/pull/6587
 export const VIRUS_SCANNER_SUBMISSION_VERSION = 2.1
 // MRF RFC: https://www.notion.so/opengov/RFC-Multi-respondent-forms-8ab40a8c17674937b345450d9dd2c81d?pvs=4
-export const MULTIRESPONDENT_FORM_SUBMISSION_VERSION = 3
+// Version 4: FE sends V4-shaped responses natively. The BE receiver shim
+// still adapts version-3 bodies from stale clients (adaptMrfV3BodyToV4).
+export const MULTIRESPONDENT_FORM_SUBMISSION_VERSION = 4
 
 // TODO: (Kill Email Mode) Remove this form after kill email mode is fully implemented.
 export const TEST_EMAIL_MODE_DEPRECATION_FEEDBACK_FORM_ID =


### PR DESCRIPTION
## Problem

PR 2 (#9637) made the BE process MRF submissions as V4 end-to-end, but the FE is still V3 on both sides of the wire:

- **Sending:** the FE builds V3 responses (`createResponsesV3`) and submits `version: 3`, so every MRF submission takes the receiver's stale-client shim (`adaptMrfV3BodyToV4`) and emits its WARN log. The shim can't be removed (PR 5) until this traffic drains.
- **Reading:** the FE's working format for previous-step responses is V3 — freshly decrypted V4 blobs are downgraded via `adaptV4ToV3` for prefill, keeping a V3 dependency alive that PR 4 is supposed to delete.

This PR makes the FE V4-native in both directions: it sends V4 on the wire and works in V4 internally.

## Solution

Five commits, BE-compatible ones first:

1. **`feat(sdk): export generateUUID`** — the FE V4 builder mints table rowIds with the exact generator the BE shim uses (Web Crypto-based, browser-safe).

2. **`refactor(backend): pin MRF attachment-crypto floor to version 3`** — `submission.utils.ts` selected the attachment crypto class via `version < MULTIRESPONDENT_FORM_SUBMISSION_VERSION`. That constant is about to move to 4 while shim-adapted stale-FE bodies keep `version: 3` (the shim does not bump `body.version` — its docstring claimed otherwise and is corrected here). Pinning the literal keeps the floor's meaning fixed; behaviorally a no-op today since `encryptFile` lives once on `CryptoBase`.

3. **`feat(frontend): add createResponsesV4 thin wire builder`** — builds V4 wire responses directly from form inputs, mirroring `createResponsesV3`'s empty-skip semantics. The wire is thin: `fieldType + answer + provenance: {}` — `question` is omitted (the BE strips it and enriches from the form definition). `provenance: {}` is **load-bearing**: the SDK's `isFieldResponsesV4` duck-types V4 on its presence at read time; omitting it would make stored blobs misdetect as V3 and get double-adapted on decryption. Guarded by a parity unit test: `adaptV3ToV4(createResponsesV3(x)) ≈ createResponsesV4(x)` across all field types (one deliberate divergence: the untouched-checkbox react-hook-form artifact `value: false` is normalized to `[]`).

4. **`feat(frontend)!: send MRF submissions as V4`** — `MULTIRESPONDENT_FORM_SUBMISSION_VERSION` bumped 3 → 4; the MRF FormData builder swaps to `createResponsesV4` (renamed `...FormDataV3` → `...FormDataV4`). All receiver guards were audited: they use literals (`>= 3`, shim window `>= 3 && < 4`), so `version: 4` skips the shim and flows natively.

5. **`feat(frontend): make V4 the FE working format for previous MRF responses`** — `decryptSubmission` now serves previous responses as V4 (V3-stored blobs are adapted **up** via `adaptV3ToV4`; the FE no longer uses `adaptV4ToV3` at all). `extractMrfPreviousStepResponseValue` is rewritten as the explicit inverse of `createResponsesV4`, pinned by a round-trip identity test (`inputs → createResponsesV4 → extract ≡ inputs`) — the exact loop step-N+1 re-submits non-editable values through. Legacy pre-`mrfVersion` submissions embed attachment bytes inside the encrypted blob and `adaptV3ToV4` drops that key, so `decryptSubmission` harvests them pre-adaptation (`legacyAttachmentContents`) for the provider's backward-compat path.

**Related:** the SDK question-backfill fix on `fix/mrf-v4-decrypt-question-backfill` (empty `question` on stored V4 blobs breaking the admin individual page / PDF / CSV) should ship **before or with** this PR — the thin wire here stores blobs without question text by design, relying on that read-side backfill.

**Migration roadmap (5 PRs):**

1. **PR 1 (#9633, merged) — Foundation:** V4 types, utils, validators. Pure additions.
2. **PR 2 (#9637, merged) — BE V4-native end-to-end:** internal pipeline flip + V3→V4 receiver shim for stale clients; webhook forms keep V3 encryption (`mrfVersion: 1`).
3. **PR 3 (this) — FE V4-native:** sends V4 thin wire (`version: 4`), works in V4 internally (previous responses served as V4).
4. **PR 4 — Cleanup:** delete V3 validators, V3 parsed types, V3 logic eval (BE), and the FE V3 builder (kept in this PR only as parity-test collateral).
5. **PR 5 — Remove V3 receiver shim** once the `adaptMrfV3BodyToV4` WARN log confirms V3 wire traffic has drained (stale tabs / cached SPA bundles).

**Breaking Changes**
- No external contract changes. MRF submissions are sent with `version: 4` and V4-shaped responses, which the BE has accepted natively since #9637; stale FE bundles still sending `version: 3` continue to work via the receiver shim. Webhook payloads remain V3 (`mrfVersion: 1`). FE and BE halves of this PR ride the same release; the BE commits are backward-compatible if deployed first.

## Tests

Unit: FE vitest 309 passing (includes the new parity + round-trip suites), BE submission-module jest 363 passing (shim `version: 3` specs stay green), SDK 146 passing.

TC1: Native V4 first-step submission
- [ ] Submit step 1 of an MRF (short text, radio+others, checkbox+others, 2-row table, address, attachment, email, signature; no webhook)
- [ ] Verify in devtools that the wire body responses contain only `{fieldType, answer, provenance: {}}` and `version: 4`
- [ ] Verify the submission succeeds, the DB record has `version: 4` and `mrfVersion: 2`
- [ ] Verify no `Adapting V3 MRF submission to V4` WARN log is emitted

TC2: Step-2 prefill from a V4-stored previous submission
- [ ] Open the step-2 link for the TC1 submission
- [ ] Verify every field type prefills correctly, including the attachment (downloadable File) and radio "Others"
- [ ] Edit an editable field and resubmit with non-editable fields untouched
- [ ] Verify the submission succeeds (non-editable comparison + backfill). Note: non-editable **table** fields depend on the rowNum-comparison fix (`fix/table-response-validation`) — verify against a branch that includes it

TC3: Step-2 prefill from a V3-stored previous submission (adaptV3ToV4 read path)
- [ ] Use a webhook-configured MRF (stores `mrfVersion: 1`) or a pre-cutover in-flight chain; submit step 1
- [ ] Open the step-2 link and verify all previous answers prefill correctly
- [ ] Submit step 2 and verify it succeeds

TC4: Webhook form V3 encryption fallback (regression)
- [ ] Submit an MRF with a webhook URL configured
- [ ] Verify the stored `mrfVersion` is `1` and the webhook consumer receives a V3-shaped payload

TC5: Stale-FE simulation (receiver shim regression)
- [ ] Replay a `version: 3` V3-shaped body via curl
- [ ] Verify the shim WARN log is emitted and the submission succeeds end-to-end

TC6: Admin views (guard against double-adaptation)
- [ ] Open the individual response page for the TC1 submission; verify answers render un-nested and the attachment is downloadable
- [ ] Export CSV and verify answers appear correctly

TC7: Build & static checks
- [ ] FE typecheck + vitest, BE build + jest, SDK build + jest all pass (verified locally: clean)
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)