### PR TITLE
fix: reject OTP generation when form is not public

### DIFF
--- a/apps/backend/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/apps/backend/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -28,7 +28,11 @@ import {
 import expressHandler from '../../../../../__tests__/unit/backend/helpers/jest-express'
 import config from '../../../config/config'
 import { DatabaseError, MalformedParametersError } from '../../core/core.errors'
-import { FormNotFoundError } from '../../form/form.errors'
+import {
+  FormDeletedError,
+  FormNotFoundError,
+  PrivateFormError,
+} from '../../form/form.errors'
 import * as FormService from '../../form/form.service'
 import {
   MOCK_MYINFO_JWT,
@@ -293,6 +297,7 @@ describe('Verification controller', () => {
 
     beforeEach(async () => {
       MockFormService.retrieveFullFormById.mockReturnValue(okAsync(MOCK_FORM))
+      MockFormService.isFormPublic.mockReturnValue(ok(true))
 
       MockOtpUtils.generateOtpWithHash.mockReturnValue(
         okAsync({
@@ -1018,6 +1023,60 @@ describe('Verification controller', () => {
       expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
       expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 404 when form is private', async () => {
+      // Arrange
+      MockFormService.isFormPublic.mockReturnValueOnce(
+        err(new PrivateFormError('Form is private', MOCK_FORM.title)),
+      )
+      const expectedResponse = {
+        message:
+          'This form is no longer active, so OTPs can no longer be requested.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_FORM_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.NOT_FOUND)
+      expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
+    })
+
+    it('should return 410 when form is archived', async () => {
+      // Arrange
+      MockFormService.isFormPublic.mockReturnValueOnce(
+        err(new FormDeletedError()),
+      )
+      const expectedResponse = {
+        message:
+          'This form has been deleted, so OTPs can no longer be requested.',
+      }
+
+      // Act
+      await VerificationController._handleGenerateOtp(
+        MOCK_FORM_REQ,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockFormService.retrieveFullFormById).toHaveBeenCalledWith(
+        MOCK_FORM_ID,
+      )
+      expect(MockOtpUtils.generateOtpWithHash).not.toHaveBeenCalled()
+      expect(MockVerificationService.sendNewOtp).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.GONE)
       expect(mockRes.json).toHaveBeenCalledWith(expectedResponse)
     })
 

--- a/apps/backend/src/app/modules/verification/__tests__/verification.controller.spec.ts
+++ b/apps/backend/src/app/modules/verification/__tests__/verification.controller.spec.ts
@@ -1032,8 +1032,7 @@ describe('Verification controller', () => {
         err(new PrivateFormError('Form is private', MOCK_FORM.title)),
       )
       const expectedResponse = {
-        message:
-          'This form is no longer active, so OTPs can no longer be requested.',
+        message: 'This form has been taken down, so OTPs cannot be requested',
       }
 
       // Act
@@ -1059,8 +1058,7 @@ describe('Verification controller', () => {
         err(new FormDeletedError()),
       )
       const expectedResponse = {
-        message:
-          'This form has been deleted, so OTPs can no longer be requested.',
+        message: 'This form is no longer active, so OTPs cannot be requested',
       }
 
       // Act

--- a/apps/backend/src/app/modules/verification/verification.controller.ts
+++ b/apps/backend/src/app/modules/verification/verification.controller.ts
@@ -88,8 +88,10 @@ export const handleCreateVerificationTransaction: ControllerHandler<
  * @returns 400 when the provided phone number is not valid
  * @returns 400 when the field type is not supported for validation
  * @returns 404 when the requested form was not found
+ * @returns 404 when the form is not public
  * @returns 404 when the transaction was not found
  * @returns 404 when the field was not found
+ * @returns 410 when the form has been deleted
  * @returns 422 when the user requested for a new otp without waiting
  * @returns 500 when the otp could not be hashed
  * @returns 500 when there is a database error
@@ -112,7 +114,10 @@ export const _handleGenerateOtp: ControllerHandler<
   // Step 1: Ensure that the form for the specified transaction exists
   return (
     FormService.retrieveFullFormById(formId)
-      // Step 2: Verify SPCP/MyInfo, if form requires it
+      // Step 2: Ensure that the form is public; OTPs must not be issued for
+      // forms that are private or archived
+      .andThen((form) => FormService.isFormPublic(form).map(() => form))
+      // Step 3: Verify SPCP/MyInfo, if form requires it
       .andThen((form) => {
         // If previousSubmissionId exists, this means it is coming from a 2+ step MRF workflow
         // verify MRF JWT and skip SPCP/MyInfo since Singpass is currently only enabled for MRF first step
@@ -255,11 +260,11 @@ export const _handleGenerateOtp: ControllerHandler<
             return okAsync(form)
         }
       })
-      // Step 3: Generate OTP
+      // Step 4: Generate OTP
       .andThen((form) =>
         generateOtpWithHash(logMeta, SALT_ROUNDS).andThen(
           ({ otp, hashedOtp, otpPrefix }) =>
-            // Step 3: Send Otp
+            // Step 5: Send Otp
             {
               return VerificationService.sendNewOtp({
                 fieldId,

--- a/apps/backend/src/app/modules/verification/verification.util.ts
+++ b/apps/backend/src/app/modules/verification/verification.util.ts
@@ -28,7 +28,11 @@ import {
   DatabaseValidationError,
   MalformedParametersError,
 } from '../core/core.errors'
-import { FormNotFoundError } from '../form/form.errors'
+import {
+  FormDeletedError,
+  FormNotFoundError,
+  PrivateFormError,
+} from '../form/form.errors'
 import {
   MyInfoCookieStateError,
   MyInfoInvalidLoginCookieError,
@@ -243,6 +247,18 @@ export const mapRouteError: MapRouteError = (
       return {
         errorMessage: coreErrorMsg,
         statusCode: StatusCodes.NOT_FOUND,
+      }
+    case PrivateFormError:
+      return {
+        errorMessage:
+          'This form is no longer active, so OTPs can no longer be requested.',
+        statusCode: StatusCodes.NOT_FOUND,
+      }
+    case FormDeletedError:
+      return {
+        errorMessage:
+          'This form has been deleted, so OTPs can no longer be requested.',
+        statusCode: StatusCodes.GONE,
       }
     case SmsLimitExceededError:
     case OtpRequestError:

--- a/apps/backend/src/app/modules/verification/verification.util.ts
+++ b/apps/backend/src/app/modules/verification/verification.util.ts
@@ -251,13 +251,13 @@ export const mapRouteError: MapRouteError = (
     case PrivateFormError:
       return {
         errorMessage:
-          'This form is no longer active, so OTPs can no longer be requested.',
+          'This form has been taken down, so OTPs cannot be requested',
         statusCode: StatusCodes.NOT_FOUND,
       }
     case FormDeletedError:
       return {
         errorMessage:
-          'This form has been deleted, so OTPs can no longer be requested.',
+          'This form is no longer active, so OTPs cannot be requested',
         statusCode: StatusCodes.GONE,
       }
     case SmsLimitExceededError:

--- a/apps/backend/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -299,8 +299,7 @@ describe('public-forms.verification.routes', () => {
         { status: FormStatus.Private },
       )
       const expectedResponse = {
-        message:
-          'This form is no longer active, so OTPs can no longer be requested.',
+        message: 'This form has been taken down, so OTPs cannot be requested',
       }
 
       // Act

--- a/apps/backend/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/forms/__tests__/public-forms.verification.routes.spec.ts
@@ -5,7 +5,7 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import bcrypt from 'bcrypt'
 import { ObjectId } from 'bson'
 import { subMinutes, subYears } from 'date-fns'
-import { BasicField } from 'formsg-shared/types'
+import { BasicField, FormStatus } from 'formsg-shared/types'
 import {
   NUM_OTP_RETRIES,
   WAIT_FOR_OTP_SECONDS,
@@ -18,6 +18,7 @@ import nodemailer from 'nodemailer'
 import Mail from 'nodemailer/lib/mailer'
 import session, { Session } from 'supertest-session'
 
+import { getEmailFormModel } from 'src/app/models/form.server.model'
 import {
   generateFieldParams,
   MOCK_HASHED_OTP,
@@ -91,6 +92,8 @@ describe('public-forms.verification.routes', () => {
       mailDomain: MOCK_VALID_EMAIL_DOMAIN,
       formOptions: {
         form_fields: [emailField, mobileField],
+        // OTP generation requires the form to be public
+        status: FormStatus.Public,
       },
     })
     mockVerifiableFormId = String(verifiableForm._id)
@@ -287,6 +290,31 @@ describe('public-forms.verification.routes', () => {
       // Assert
       expect(response.status).toBe(StatusCodes.CREATED)
       expect(response.body).toContainKey('otpPrefix')
+    })
+
+    it('should return 404 when the form is not public', async () => {
+      // Arrange
+      await getEmailFormModel(mongoose).findByIdAndUpdate(
+        mockVerifiableFormId,
+        { status: FormStatus.Private },
+      )
+      const expectedResponse = {
+        message:
+          'This form is no longer active, so OTPs can no longer be requested.',
+      }
+
+      // Act
+      const response = await request
+        .post(
+          `/forms/${mockVerifiableFormId}/fieldverifications/${mockTransactionId}/fields/${mockEmailFieldId}/otp/generate`,
+        )
+        .send({
+          answer: 'open@gov.sg',
+        })
+
+      // Assert
+      expect(response.status).toBe(StatusCodes.NOT_FOUND)
+      expect(response.body).toEqual(expectedResponse)
     })
 
     it('should return 400 when fieldType is email but the provided email is not valid', async () => {

--- a/apps/backend/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
+++ b/apps/backend/src/app/routes/api/v3/forms/public-forms.verification.routes.ts
@@ -59,8 +59,10 @@ PublicFormsVerificationRouter.route(
  * @returns 400 when the provided phone number is not valid
  * @returns 400 when the field type is not supported for validation
  * @returns 404 when the requested form was not found
+ * @returns 404 when the form is not public
  * @returns 404 when the transaction was not found
  * @returns 404 when the field was not found
+ * @returns 410 when the form has been deleted
  * @returns 422 when the user requested for a new otp without waiting
  * @returns 500 when the otp could not be hashed
  * @returns 500 when there is a database error


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

The public `POST /api/v3/forms/:formId/fieldverifications/:transactionId/fields/:fieldId/otp/generate` endpoint only checked that the form *exists*, not that it is public. Anyone with a form ID and a live transaction could keep requesting OTPs against a **closed or archived** form and get a 201 back — triggering real SMS and email sends for a form that can no longer accept submissions. This is both an abuse vector (unsolicited OTP sends, SMS cost) and inconsistent with the rest of the public API, which rejects non-public forms.

## Solution
<!-- How did you solve the problem? -->

Gate `_handleGenerateOtp` on `FormService.isFormPublic` immediately after the form is retrieved, before any auth verification or OTP generation/sending. This mirrors the existing pattern in the feedback and issue controllers.

**Breaking Changes**
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
- No — this PR is backwards compatible. Public forms behave exactly as before; only requests against private/archived forms change from 201 (or 500) to 404/410, which no legitimate client flow depends on.

## Tests
<!-- What tests should be run to confirm functionality? -->

Unit tests: `pnpm test src/app/modules/verification/__tests__/verification.controller.spec.ts` in `apps/backend` (91 passing, includes new 404/410 cases).

TC1: OTP generation blocked on a closed form
- [ ] Create a form with a verifiable email field, open it, and load the public form to obtain a transaction ID
- [ ] Close the form (set to Private) in the admin settings
- [ ] Call `POST /api/v3/forms/:formId/fieldverifications/:transactionId/fields/:fieldId/otp/generate` with a valid `{"answer": "<email>"}` body
- [ ] Verify that the response is **404** with message "This form is no longer active, so OTPs can no longer be requested."
- [ ] Verify that no OTP email is received

TC2: OTP generation still works on a public form (regression)
- [ ] On an open form with a verifiable email field and a verifiable mobile field, request an OTP for each field via the public form UI
- [ ] Verify that both OTPs arrive (email and SMS) and the responses are 201
- [ ] Verify the OTPs and submit the form successfully

TC3 MRF step 2 respondent on an open form (regression)
- [ ] Create a 2-step MRF form with a verifiable email field in step 2 and submit step 1
- [ ] As the step-2 respondent, request and verify an OTP for the email field
- [ ] Verify that the OTP is issued (201) and step 2 can be submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)