### PR TITLE
fix: return 4xx instead of 5xx for MRF V4 field validation errors

### DIFF
--- a/apps/backend/src/app/modules/submission/submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/submission.utils.ts
@@ -160,6 +160,7 @@ import {
   UnsupportedSettingsError,
   ValidateFieldError,
   ValidateFieldErrorV3,
+  ValidateFieldErrorV4,
   VirusScanFailedError,
 } from './submission.errors'
 import {
@@ -341,6 +342,7 @@ const errorMapper: MapRouteError = (
       }
     case ValidateFieldError:
     case ValidateFieldErrorV3:
+    case ValidateFieldErrorV4:
     case DatabaseValidationError:
     case InvalidFileExtensionError:
     case AttachmentTooLargeError:


### PR DESCRIPTION
## Problem

Field-level validation failures on the multirespondent (MRF) V4 submission path return a **500 Internal Server Error** instead of a 400. For example, when a respondent submits a dropdown option that no longer exists on the form (stale form definition — admin edited options after the respondent loaded the form), `DropdownValidatorV4` correctly rejects the answer, but the respondent sees the generic "Something went wrong. Please try again." message instead of the "check your responses and try again" hint that would tell them to refresh.

This also pollutes 5xx alarms with what is really respondent error, and each occurrence logs a spurious "Unknown route error observed".

Root cause: `mapRouteError` in `submission.utils.ts` maps errors to HTTP statuses by error **class**. `ValidateFieldError` (V1) and `ValidateFieldErrorV3` are mapped to 400, but `ValidateFieldErrorV4` — introduced with the V4 BE handling (#9785) — was never added to that case group, so it falls through to the `default` branch and returns 500. (The `status = 400` baked into the `ValidateFieldErrorV4` constructor is never read by the mapper.)

## Solution

Add `ValidateFieldErrorV4` to the existing 400 case group in `mapRouteError`, alongside `ValidateFieldError` and `ValidateFieldErrorV3`. V4 validation failures now return the same 400 response and user-facing message ("There is something wrong with your form submission. Please check your responses and try again...") as the V1/V3 paths.

**Breaking Changes**
- No — this PR is backwards compatible. It only corrects the HTTP status (500 → 400) and user-facing message for an existing error path.

## Tests

TC1: V4 field validation failure returns 400
- [ ] Create an MRF form (no workflow needed) with a dropdown field, and open it as a respondent
- [ ] In another tab as admin, edit the dropdown field to remove/rename the options, and save
- [ ] Back in the respondent tab (without refreshing), select one of the old options and submit
- [ ] Verify that the API responds **400** (not 500) with message "There is something wrong with your form submission. Please check your responses and try again. If the problem persists, please refresh the page."
- [ ] Verify the backend logs `Invalid answer: DropdownValidatorV4: answer is not a valid dropdown option` but no longer logs `Unknown route error observed`

TC2: Regression — valid MRF submission still succeeds
- [ ] Submit the same MRF form with a currently-valid dropdown option selected
- [ ] Verify that the submission succeeds and appears in the form's responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
