### PR TITLE
fix(spcp): accept iss param on OIDC login callback (inc-1274)

### DIFF
--- a/apps/backend/src/app/modules/spcp/spcp.middlewares.ts
+++ b/apps/backend/src/app/modules/spcp/spcp.middlewares.ts
@@ -5,5 +5,6 @@ export const spcpOidcLoginParamsMiddleware = celebrate({
     state: Joi.string().required(),
     code: Joi.string().required(),
     forwarded: Joi.string().optional(),
+    iss: Joi.string().optional(),
   }),
 })

--- a/apps/backend/src/app/routes/api/v3/corppass/__tests__/corppass.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/corppass/__tests__/corppass.routes.spec.ts
@@ -129,6 +129,35 @@ describe('corppass.oidc.router', () => {
       expect(response.headers['location']).toEqual(MOCK_DESTINATION)
     })
 
+    it('should succeed when NDI appends an iss param to the callback (RFC 9207)', async () => {
+      // Arrange
+      // Regression test for inc-1274: NDI began appending an `iss` query param
+      // to the OIDC callback, which previously failed strict validation with
+      // `"iss" is not allowed` and returned 400.
+      mockClient.exchangeAuthCodeAndDecodeVerifyToken.mockResolvedValueOnce(
+        'token' as unknown as JWTVerifyResult,
+      )
+      mockClient.extractNricOrForeignIdFromIdToken.mockReturnValueOnce(
+        MOCK_NRIC,
+      )
+      mockClient.extractCPEntityIdFromIdToken.mockReturnValueOnce(MOCK_UEN)
+      mockClient.createJWT.mockResolvedValue(MOCK_JWT)
+
+      // Act
+      const response = await request.get(LOGIN_ROUTE).query({
+        state: MOCK_OIDC_STATE,
+        code: MOCK_CP_OIDC_AUTHORISATION_CODE,
+        iss: 'https://stg-id.singpass.gov.sg',
+      })
+
+      // Assert
+      expect(response.status).toBe(302)
+      expect(response.headers['set-cookie']).toEqual([
+        expect.stringContaining(`jwtCp=${MOCK_JWT}`),
+      ])
+      expect(response.headers['location']).toEqual(MOCK_DESTINATION)
+    })
+
     it('should return 400 when token exchange fails', async () => {
       // Arrange
 


### PR DESCRIPTION
## Problem

Corppass callbacks require the `iss` parameter [RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification)](https://www.rfc-editor.org/rfc/rfc9207).

## Solution

Allow `iss` as an optional query param in the shared OIDC login-params middleware.

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `apps/backend/src/app/modules/spcp/spcp.middlewares.ts` — accept an optional `iss` query param on the OIDC login callback so RFC 9207 issuer identification no longer trips strict validation.

**Blast radius**: `spcpOidcLoginParamsMiddleware` is shared by **both** the Corppass and Singpass login routes, so this fix covers Singpass too — where NDI is expected to enable the same behaviour.

**Alternatives considered**:

- `.unknown(true)` on the schema (accept any extra key): rejected — silently accepts arbitrary params and loses the strict-validation guarantee. Allowing the one known, standard param is more intentional.
- Also validating that `iss` matches the expected NDI issuer (the RFC 9207 mix-up-attack mitigation): out of scope for this hotfix. The id token is already verified against NDI's JWKS. Tracking hardening as a follow-up rather than adding risk during an active incident.

## Tests

- Added a regression test in `corppass.routes.spec.ts` that sends `iss` on the callback and asserts a `302` + JWT cookie (previously `400`).
- `pnpm --filter formsg-backend test corppass.routes.spec.ts` → 10/10 pass.
- Singpass route suite (shared middleware) → 8/8 pass, confirming no regression.

## Deploy Notes

Hotfix — should be shipped to production to restore Corppass (and pre-emptively Singpass) logins. No new env vars, scripts, or dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)