### PR TITLE
feat(children): remove Secondary Race and Allow-Multiple from the v1 children field (v2.0)

### DIFF
--- a/apps/backend/src/app/modules/submission/__tests__/children-back-compat.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/children-back-compat.spec.ts
@@ -1,0 +1,86 @@
+import { ObjectId } from 'bson'
+import { BasicField, MyInfoChildAttributes } from 'formsg-shared/types'
+
+import { ProcessedChildrenResponse } from '../submission.types'
+import { getAnswersForChild } from '../submission.utils'
+
+// v2.0 does not reshape, purge or split stored submissions, so already-stored
+// responses must keep exploding into exactly the same flat fields.
+describe('children v1 response back-compatibility', () => {
+  const _id = new ObjectId().toHexString()
+
+  it('should explode a stored secondary race answer unchanged', () => {
+    const response = {
+      _id,
+      question: 'Child',
+      fieldType: BasicField.Children,
+      answerArray: [['Phua Chu King', 'CHINESE', 'MALAY']],
+      childSubFieldsArray: [
+        MyInfoChildAttributes.ChildName,
+        MyInfoChildAttributes.ChildRace,
+        MyInfoChildAttributes.ChildSecondaryRace,
+      ],
+      isVisible: true,
+    } as unknown as ProcessedChildrenResponse
+
+    const answers = getAnswersForChild(response)
+
+    expect(answers).toHaveLength(3)
+    expect(answers.map((a) => [a._id, a.question, a.answer])).toEqual([
+      [
+        `childrenbirthrecords.${_id}.childname.0`,
+        'Child 1 Name',
+        'Phua Chu King',
+      ],
+      [`childrenbirthrecords.${_id}.childrace.0`, 'Child 1 Race', 'CHINESE'],
+      [
+        `childrenbirthrecords.${_id}.childsecondaryrace.0`,
+        'Child 1 Secondary race',
+        'MALAY',
+      ],
+    ])
+  })
+
+  it('should explode a stored multi-child answer unchanged, without auto-splitting', () => {
+    const response = {
+      _id,
+      question: 'Child',
+      fieldType: BasicField.Children,
+      answerArray: [
+        ['Phua Chu King', 'T1234567X'],
+        ['Phua Chu Beng', 'T7654321X'],
+      ],
+      childSubFieldsArray: [
+        MyInfoChildAttributes.ChildName,
+        MyInfoChildAttributes.ChildBirthCertNo,
+      ],
+      isVisible: true,
+    } as unknown as ProcessedChildrenResponse
+
+    const answers = getAnswersForChild(response)
+
+    expect(answers).toHaveLength(4)
+    expect(answers.map((a) => [a._id, a.question, a.answer])).toEqual([
+      [
+        `childrenbirthrecords.${_id}.childname.0`,
+        'Child 1 Name',
+        'Phua Chu King',
+      ],
+      [
+        `childrenbirthrecords.${_id}.childbirthcertno.0`,
+        'Child 1 Birth certificate number',
+        'T1234567X',
+      ],
+      [
+        `childrenbirthrecords.${_id}.childname.1`,
+        'Child 2 Name',
+        'Phua Chu Beng',
+      ],
+      [
+        `childrenbirthrecords.${_id}.childbirthcertno.1`,
+        'Child 2 Birth certificate number',
+        'T7654321X',
+      ],
+    ])
+  })
+})

--- a/apps/backend/src/app/modules/submission/submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/submission.utils.ts
@@ -915,8 +915,9 @@ export const getAnswersForChild = (
         _id: `${MyInfoAttribute.ChildrenBirthRecords}.${response._id}.${subFields[idx]}.${childIdx}`,
         fieldType: response.fieldType,
         // qnChildIdx represents the index of the MyInfo field
-        // childIdx represents the index of the child in this MyInfo field
-        // as there might be >1 child for each MyInfo child field if "Add another child" is used
+        // childIdx represents the index of the child in this MyInfo field.
+        // New submissions have one child; responses stored before v2.0 can have
+        // more and must keep exploding the same way.
         question: `Child ${qnChildIdx + childIdx + 1} ${
           MYINFO_ATTRIBUTE_MAP[subfield].description
         }`,

--- a/apps/backend/src/app/utils/field-validation/validators/__tests__/children-validation.spec.ts
+++ b/apps/backend/src/app/utils/field-validation/validators/__tests__/children-validation.spec.ts
@@ -1,0 +1,97 @@
+import { generateDefaultField } from '__tests__/unit/backend/helpers/generate-form-data'
+import {
+  BasicField,
+  ChildrenCompoundFieldBase,
+  MyInfoChildAttributes,
+} from 'formsg-shared/types'
+
+import { ProcessedChildrenResponse } from 'src/app/modules/submission/submission.types'
+import { validateField } from 'src/app/utils/field-validation'
+import { FieldValidationSchema } from 'src/types'
+
+const SUBFIELDS = [
+  MyInfoChildAttributes.ChildName,
+  MyInfoChildAttributes.ChildBirthCertNo,
+]
+
+const generateChildrenField = (
+  customParams?: Partial<ChildrenCompoundFieldBase>,
+) =>
+  generateDefaultField(BasicField.Children, {
+    childrenSubFields: SUBFIELDS,
+    ...customParams,
+  }) as FieldValidationSchema
+
+const generateChildrenResponse = (
+  formField: FieldValidationSchema,
+  answerArray: string[][],
+  childSubFieldsArray: MyInfoChildAttributes[] = SUBFIELDS,
+): ProcessedChildrenResponse =>
+  ({
+    _id: formField._id,
+    question: 'Child',
+    fieldType: BasicField.Children,
+    answerArray,
+    childSubFieldsArray,
+    isVisible: true,
+  }) as unknown as ProcessedChildrenResponse
+
+const TWO_CHILDREN = [
+  ['Phua Chu King', 'T1234567X'],
+  ['Phua Chu Beng', 'T7654321X'],
+]
+
+describe('Children field validation', () => {
+  it('should accept a single child', () => {
+    const formField = generateChildrenField()
+    const response = generateChildrenResponse(formField, [
+      ['Phua Chu King', 'T1234567X'],
+    ])
+
+    const validateResult = validateField('formId', formField, response)
+
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  it('should reject more than one child', () => {
+    const formField = generateChildrenField()
+    const response = generateChildrenResponse(formField, TWO_CHILDREN)
+
+    const validateResult = validateField('formId', formField, response)
+
+    expect(validateResult.isErr()).toBe(true)
+  })
+
+  // allowMultiple survives on existing form documents (v2.0 does not migrate
+  // them), so it must no longer buy a second child.
+  it('should reject more than one child even when the legacy allowMultiple flag is set', () => {
+    const formField = generateChildrenField({ allowMultiple: true })
+    const response = generateChildrenResponse(formField, TWO_CHILDREN)
+
+    const validateResult = validateField('formId', formField, response)
+
+    expect(validateResult.isErr()).toBe(true)
+  })
+
+  // Secondary Race is removed builder-forward only, so existing forms that
+  // still collect it must keep validating.
+  it('should still validate an existing form that collects secondary race', () => {
+    const legacySubFields = [
+      MyInfoChildAttributes.ChildName,
+      MyInfoChildAttributes.ChildSecondaryRace,
+    ]
+    const formField = generateChildrenField({
+      childrenSubFields: legacySubFields,
+    })
+    const response = generateChildrenResponse(
+      formField,
+      [['Phua Chu King', 'CHINESE']],
+      legacySubFields,
+    )
+
+    const validateResult = validateField('formId', formField, response)
+
+    expect(validateResult.isOk()).toBe(true)
+  })
+})

--- a/apps/backend/src/app/utils/field-validation/validators/childrenValidator.ts
+++ b/apps/backend/src/app/utils/field-validation/validators/childrenValidator.ts
@@ -1,3 +1,4 @@
+import { MAX_CHILDREN_PER_FIELD } from 'formsg-shared/constants/field/myinfo'
 import {
   ChildrenCompoundFieldBase,
   MyInfoChildAttributes,
@@ -42,6 +43,21 @@ const validChildAnswerFirstArray: ChildrenValidator = (response) => {
     ? right(response)
     : left(
         `ChildrenValidator (validChildAnswerFirstArray):\t first subarray length is invalid`,
+      )
+}
+
+/**
+ * Returns a validator to check that at most one child was answered. Keyed on
+ * MAX_CHILDREN_PER_FIELD, not the legacy `allowMultiple` flag, which survives
+ * unmigrated on existing form documents and must not grant a second child.
+ */
+const validSingleChild: ChildrenValidator = (response) => {
+  const { answerArray } = response
+
+  return answerArray.length <= MAX_CHILDREN_PER_FIELD
+    ? right(response)
+    : left(
+        `ChildrenValidator (validSingleChild):\t more than ${MAX_CHILDREN_PER_FIELD} child answered`,
       )
 }
 
@@ -160,6 +176,7 @@ export const constructChildrenValidator: ChildrenValidatorConstructor = (
 ) =>
   flow(
     childrenAnswerValidator,
+    chain(validSingleChild),
     chain(validChildAnswerFirstArray),
     chain(validChildAnswerConsistency),
     chain(validChildAnswersNonEmpty),

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.stories.tsx
@@ -1,0 +1,59 @@
+import { Meta, StoryFn } from '@storybook/react'
+
+import {
+  BasicField,
+  FormFieldDto,
+  MyInfoAttribute,
+  MyInfoChildAttributes,
+} from 'formsg-shared/types'
+
+import { createFormBuilderMocks } from '~/mocks/msw/handlers/admin-form'
+
+import { EditFieldDrawerDecorator, StoryRouter } from '~utils/storybook'
+
+import { EditMyInfoChildren } from './EditMyInfoChildren'
+import { ChildrenCompoundFieldMyInfo } from '.'
+
+type StoryField = ChildrenCompoundFieldMyInfo & { _id: FormFieldDto['_id'] }
+
+const DEFAULT_CHILDREN_FIELD: StoryField = {
+  title: 'Child',
+  description: '',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.Children,
+  childrenSubFields: [MyInfoChildAttributes.ChildName],
+  myInfo: { attr: MyInfoAttribute.ChildrenBirthRecords },
+  globalId: 'unused',
+  _id: 'children_field_id',
+}
+
+export default {
+  title: 'Features/AdminForm/EditFieldDrawer/EditMyInfoChildren',
+  component: EditMyInfoChildren,
+  decorators: [
+    StoryRouter({
+      initialEntries: ['/61540ece3d4a6e50ac0cc6ff'],
+      path: '/:formId',
+    }),
+    EditFieldDrawerDecorator,
+  ],
+  parameters: {
+    chromatic: { pauseAnimationAtEnd: true },
+    msw: createFormBuilderMocks({}, 0),
+  },
+  args: {
+    field: DEFAULT_CHILDREN_FIELD,
+  },
+} as Meta<StoryArgs>
+
+interface StoryArgs {
+  field: StoryField
+}
+
+const Template: StoryFn<StoryArgs> = ({ field }) => {
+  return <EditMyInfoChildren field={field} />
+}
+
+export const Default = Template.bind({})
+Default.storyName = 'EditMyInfoChildren'

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.test.tsx
@@ -1,0 +1,18 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+
+import * as stories from './EditMyInfoChildren.stories'
+
+const { Default } = composeStories(stories)
+
+describe('EditMyInfoChildren', () => {
+  it('does not offer the allow-multiple toggle', async () => {
+    render(<Default />)
+
+    await screen.findByText('Collect the following child data')
+
+    expect(
+      screen.queryByText(/allow respondent to add multiple children/i),
+    ).toBeNull()
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/EditFieldDrawer/edit-fieldtype/EditMyInfoChildren/EditMyInfoChildren.tsx
@@ -1,7 +1,7 @@
 import { Controller } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
 import { BiCheck, BiData, BiX } from 'react-icons/bi'
-import { Box, FormControl, HStack, Icon, Text, VStack } from '@chakra-ui/react'
+import { Box, HStack, Icon, Text, VStack } from '@chakra-ui/react'
 import { extend } from 'lodash'
 
 import { MyInfoChildAttributes } from 'formsg-shared/types'
@@ -10,7 +10,6 @@ import { SINGPASS_FAQ } from '~constants/links'
 import { MultiSelect } from '~components/Dropdown'
 import InlineMessage from '~components/InlineMessage'
 import Link from '~components/Link'
-import { Toggle } from '~components/Toggle/Toggle'
 
 import { CREATE_MYINFO_CHILDREN_SUBFIELDS_OPTIONS } from '~features/admin-form/create/builder-and-design/constants'
 
@@ -32,7 +31,7 @@ const VerifiedIcon = ({ isVerified }: { isVerified: boolean }): JSX.Element => {
   )
 }
 
-const EDIT_MYINFO_CHILDREN = ['allowMultiple', 'childrenSubFields'] as const
+const EDIT_MYINFO_CHILDREN = ['childrenSubFields'] as const
 
 type EditMyInfoChildrenProps = EditFieldProps<ChildrenCompoundFieldMyInfo>
 type EditMyInfoChildrenInputs = Pick<
@@ -45,23 +44,17 @@ export const EditMyInfoChildren = ({
 }: EditMyInfoChildrenProps): JSX.Element => {
   const { t } = useTranslation()
   const extendedField = extendWithMyInfo(field)
-  const {
-    control,
-    register,
-    buttonText,
-    handleUpdateField,
-    isLoading,
-    handleCancel,
-  } = useEditFieldForm<EditMyInfoChildrenInputs, ChildrenCompoundFieldMyInfo>({
-    field,
-    transform: {
-      // MyInfo fields are not editable (except for Child compound field),
-      // so omit any transformation and output the original field
-      input: (inputField) => inputField,
-      output: (formOutput, originalField) =>
-        extend({}, originalField, formOutput),
-    },
-  })
+  const { control, buttonText, handleUpdateField, isLoading, handleCancel } =
+    useEditFieldForm<EditMyInfoChildrenInputs, ChildrenCompoundFieldMyInfo>({
+      field,
+      transform: {
+        // MyInfo fields are not editable (except for Child compound field),
+        // so omit any transformation and output the original field
+        input: (inputField) => inputField,
+        output: (formOutput, originalField) =>
+          extend({}, originalField, formOutput),
+      },
+    })
 
   return (
     <CreatePageDrawerContentContainer>
@@ -139,16 +132,6 @@ export const EditMyInfoChildren = ({
             )}
           />
         </Box>
-      </VStack>
-      <VStack align="flex-start">
-        <FormControl isReadOnly={isLoading}>
-          <Toggle
-            {...register('allowMultiple')}
-            label={t(
-              'features.adminForm.sidebar.fields.myInfoPreview.children.allowMultiple',
-            )}
-          />
-        </FormControl>
       </VStack>
       <VStack align="flex-start">
         <Text textStyle="subhead-1">

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/__tests__/constants.test.ts
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/__tests__/constants.test.ts
@@ -1,0 +1,19 @@
+import { MyInfoChildAttributes } from 'formsg-shared/types'
+
+import { CREATE_MYINFO_CHILDREN_SUBFIELDS_OPTIONS } from '../constants'
+
+// These are the options the children field's sub-field MultiSelect renders, and
+// that dropdown cannot be opened under jsdom, so assert the source of truth.
+describe('CREATE_MYINFO_CHILDREN_SUBFIELDS_OPTIONS', () => {
+  it('offers every child sub-field except secondary race and the always-collected name', () => {
+    expect(
+      CREATE_MYINFO_CHILDREN_SUBFIELDS_OPTIONS.map((o) => o.value),
+    ).toEqual([
+      MyInfoChildAttributes.ChildBirthCertNo,
+      MyInfoChildAttributes.ChildDateOfBirth,
+      MyInfoChildAttributes.ChildVaxxStatus,
+      MyInfoChildAttributes.ChildGender,
+      MyInfoChildAttributes.ChildRace,
+    ])
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/constants.ts
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/constants.ts
@@ -1,3 +1,4 @@
+import { SELECTABLE_MYINFO_CHILD_ATTRIBUTES } from 'formsg-shared/constants/field/myinfo'
 import {
   BasicField,
   ChildrenCompoundFieldBase,
@@ -98,7 +99,6 @@ export const MYINFO_DATEFIELD_META: MyInfoFieldMeta<DateFieldBase> = {
 export const MYINFO_CHILDRENFIELD_META: MyInfoFieldMeta<ChildrenCompoundFieldBase> =
   {
     childrenSubFields: [MyInfoChildAttributes.ChildName],
-    allowMultiple: false,
   }
 
 export const CREATE_MYINFO_PERSONAL_FIELDS_ORDERED =
@@ -139,17 +139,18 @@ export enum FieldListTabIndex {
   Payments,
 }
 
+// Name is always collected, so it is not offered as a choice.
 export const CREATE_MYINFO_CHILDREN_SUBFIELDS_OPTIONS: {
   value: MyInfoChildAttributes
   label: string
-}[] = Object.values(MyInfoChildAttributes)
-  .filter((e) => e !== MyInfoChildAttributes.ChildName)
-  .map((value) => {
-    return {
-      value,
-      label: MYINFO_FIELD_TO_DRAWER_META[value].label,
-    }
-  })
+}[] = SELECTABLE_MYINFO_CHILD_ATTRIBUTES.filter(
+  (e) => e !== MyInfoChildAttributes.ChildName,
+).map((value) => {
+  return {
+    value,
+    label: MYINFO_FIELD_TO_DRAWER_META[value].label,
+  }
+})
 
 export const BASIC_FIELDS_FREE_TEXT = [
   BasicField.ShortText,

--- a/apps/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.stories.tsx
+++ b/apps/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.stories.tsx
@@ -86,7 +86,25 @@ const Template: StoryFn<StoryChildrenCompoundFieldProps> = ({
   )
 }
 
-export const AllowMultipleChildren = Template.bind({})
-AllowMultipleChildren.args = {
+export const SingleChild = Template.bind({})
+SingleChild.args = {
+  schema: baseSchema,
+}
+
+/** An existing form document whose stored allowMultiple flag is still `true`. */
+export const LegacyAllowMultipleFlag = Template.bind({})
+LegacyAllowMultipleFlag.args = {
   schema: merge({}, baseSchema, { allowMultiple: true }),
+}
+
+/** An existing form that still lists secondary race in `childrenSubFields`. */
+export const LegacySecondaryRaceSubField = Template.bind({})
+LegacySecondaryRaceSubField.args = {
+  schema: merge({}, baseSchema, {
+    childrenSubFields: [
+      MyInfoChildAttributes.ChildName,
+      MyInfoChildAttributes.ChildRace,
+      MyInfoChildAttributes.ChildSecondaryRace,
+    ],
+  }),
 }

--- a/apps/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.test.tsx
+++ b/apps/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.test.tsx
@@ -1,0 +1,35 @@
+import { composeStories } from '@storybook/react'
+import { render, screen } from '@testing-library/react'
+
+import * as stories from './ChildrenCompoundField.stories'
+
+const { SingleChild, LegacyAllowMultipleFlag, LegacySecondaryRaceSubField } =
+  composeStories(stories)
+
+describe('one child per field', () => {
+  // allowMultiple survives on existing form documents, so it must no longer
+  // offer a second child.
+  it('does not offer to add another child even when the legacy allowMultiple flag is set', () => {
+    render(<LegacyAllowMultipleFlag />)
+
+    expect(
+      screen.queryByRole('button', { name: /add another child/i }),
+    ).toBeNull()
+  })
+
+  it('does not offer to remove the single child', () => {
+    render(<SingleChild />)
+
+    expect(screen.queryByRole('button', { name: /remove child/i })).toBeNull()
+  })
+})
+
+// Secondary Race is removed builder-forward only, so existing forms that still
+// collect it must keep rendering it.
+describe('legacy secondary race sub-field', () => {
+  it('still renders for an existing form that collects it', () => {
+    render(<LegacySecondaryRaceSubField />)
+
+    expect(screen.getByText('Secondary race')).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/apps/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -4,26 +4,20 @@ import {
   FieldArrayWithId,
   FieldError,
   useFieldArray,
-  UseFieldArrayRemove,
   useFormContext,
   UseFormReturn,
   useFormState,
 } from 'react-hook-form'
-import { BiPlus, BiTrash } from 'react-icons/bi'
 import {
   Box,
-  Divider,
   Flex,
   FormControl,
-  HStack,
   Input as ChakraInput,
   Spacer,
-  Text,
   VisuallyHidden,
   VStack,
 } from '@chakra-ui/react'
 import { get } from 'lodash'
-import simplur from 'simplur'
 
 import { DATE_DISPLAY_FORMAT } from 'formsg-shared/constants/dates'
 import { MYINFO_ATTRIBUTE_MAP } from 'formsg-shared/constants/field/myinfo'
@@ -38,12 +32,10 @@ import { formatMyinfoDate } from 'formsg-shared/utils/dates'
 
 import { REQUIRED_ERROR } from '~constants/validation'
 import { createChildrenValidationRules } from '~utils/fieldValidation'
-import { Button } from '~components/Button/Button'
 import { DatePicker } from '~components/DatePicker'
 import { SingleSelect } from '~components/Dropdown/SingleSelect'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import { FormLabel } from '~components/FormControl/FormLabel/FormLabel'
-import { IconButton } from '~components/IconButton/IconButton'
 
 import { BaseFieldProps, FieldContainer } from '../FieldContainer'
 import {
@@ -57,11 +49,18 @@ export interface ChildrenCompoundFieldProps extends BaseFieldProps {
   myInfoChildrenBirthRecords?: MyInfoChildData
 }
 
+const ARIA_CHILDREN_DESCRIPTION =
+  `This is a children field. There is 1 child.` +
+  `Each child has multiple fields to fill.` +
+  `You can fill the child by selecting the child's name from the child name dropdown.`
+
 /**
  * Compound field for child information.
  * This is "compound" because it can contain multiple subfields.
  * The internal data representation is an array of arrays, where each
- * subarray contains strings that represent the subfield array inputs.
+ * subarray contains strings that represent the subfield array inputs. The outer
+ * array holds one child, but stays an array so stored multi-child responses keep
+ * their shape.
  *
  * @precondition Must have a parent `react-hook-form#FormProvider` component.
  */
@@ -86,12 +85,10 @@ export const ChildrenCompoundField = ({
     | undefined
   const childError: FieldError[] | undefined = error ? error[0] : undefined
 
-  const { fields, append, remove } = useFieldArray<ChildrenCompoundFieldInputs>(
-    {
-      control: formContext.control,
-      name: `${schema._id}.child`,
-    },
-  )
+  const { fields, append } = useFieldArray<ChildrenCompoundFieldInputs>({
+    control: formContext.control,
+    name: `${schema._id}.child`,
+  })
 
   useEffect(() => {
     if (schema.childrenSubFields) {
@@ -109,19 +106,6 @@ export const ChildrenCompoundField = ({
     }
   }, [fields, append])
 
-  const ariaChildrenDescription = useMemo(() => {
-    let description = simplur`This is a children field. There [is|are] ${fields.length} child[|ren].`
-    description += `Each child has multiple fields to fill.`
-    description += `You can fill the child by selecting the child's name from the child name dropdown.`
-    if (schema.allowMultiple) {
-      description += ` You can add another child if you'd like by clicking the "Add another child" button below`
-    }
-
-    return description
-  }, [fields.length, schema.allowMultiple])
-
-  const numChild = fields.length ?? 0
-
   return (
     <FieldContainer
       schema={schema}
@@ -129,7 +113,7 @@ export const ChildrenCompoundField = ({
       errorKey={childrenInputName}
     >
       <VisuallyHidden id={`children-desc-${schema._id}`}>
-        {ariaChildrenDescription}
+        {ARIA_CHILDREN_DESCRIPTION}
       </VisuallyHidden>
       <VStack
         spacing={6}
@@ -147,10 +131,8 @@ export const ChildrenCompoundField = ({
                   currChildBodyIdx,
                   schema,
                   disableRequiredValidation,
-                  fields,
                   field,
                   colorTheme,
-                  remove,
                   myInfoChildrenBirthRecords,
                   isSubmitting,
                   formContext,
@@ -160,26 +142,6 @@ export const ChildrenCompoundField = ({
             ))}
           </VStack>
         </>
-        {schema.allowMultiple ? (
-          <HStack>
-            <Button
-              isDisabled={isSubmitting}
-              alignSelf="start"
-              leftIcon={<BiPlus />}
-              aria-label="Add another child"
-              onClick={() => {
-                append([''])
-              }}
-            >
-              Add another child
-            </Button>
-            <Spacer />
-            <Text
-              textStyle="body-2"
-              color="secondary.400"
-            >{simplur`${numChild} child[|ren] added`}</Text>
-          </HStack>
-        ) : null}
       </VStack>
     </FieldContainer>
   )
@@ -189,14 +151,8 @@ interface ChildrenBodyProps {
   currChildBodyIdx: number
   schema: ChildrenCompoundFieldSchema
   disableRequiredValidation?: boolean
-  fields: FieldArrayWithId<
-    ChildrenCompoundFieldInputs,
-    `${string}.child`,
-    'id'
-  >[]
   field: FieldArrayWithId<ChildrenCompoundFieldInputs, `${string}.child`, 'id'>
   colorTheme: FormColorTheme
-  remove: UseFieldArrayRemove
   myInfoChildrenBirthRecords?: MyInfoChildData
   isSubmitting: boolean
 
@@ -211,10 +167,8 @@ const ChildrenBody = ({
   currChildBodyIdx,
   schema,
   disableRequiredValidation,
-  fields,
   field,
   colorTheme,
-  remove,
   myInfoChildrenBirthRecords,
   isSubmitting,
   formContext,
@@ -352,19 +306,6 @@ const ChildrenBody = ({
               </FormErrorMessage>
             </FormControl>
           </Box>
-          <IconButton
-            variant="clear"
-            colorScheme="danger"
-            icon={<BiTrash />}
-            aria-label="Remove child"
-            alignSelf="end"
-            isDisabled={fields.length <= 1}
-            onClick={() => {
-              if (fields.length > 1) {
-                remove(fields.length - 1)
-              }
-            }}
-          />
         </Flex>
       </VStack>
       {schema.childrenSubFields
@@ -489,14 +430,6 @@ const ChildrenBody = ({
               return <div>Unsupported child subfield</div>
           }
         })}
-      {/* No divider on last child */}
-      {currChildBodyIdx < fields.length - 1 ? (
-        <>
-          <Spacer h="36px" />
-          <Divider />
-          <Spacer h="36px" />
-        </>
-      ) : null}
     </VStack>
   )
 }

--- a/apps/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
+++ b/apps/frontend/src/templates/Field/ChildrenCompound/ChildrenCompoundField.tsx
@@ -50,8 +50,8 @@ export interface ChildrenCompoundFieldProps extends BaseFieldProps {
 }
 
 const ARIA_CHILDREN_DESCRIPTION =
-  `This is a children field. There is 1 child.` +
-  `Each child has multiple fields to fill.` +
+  `This is a children field. There is 1 child. ` +
+  `Each child has multiple fields to fill. ` +
   `You can fill the child by selecting the child's name from the child name dropdown.`
 
 /**

--- a/packages/shared/constants/field/myinfo/__tests__/children.spec.ts
+++ b/packages/shared/constants/field/myinfo/__tests__/children.spec.ts
@@ -1,0 +1,37 @@
+import { MyInfoChildAttributes } from '../../../../types/field'
+import {
+  DEPRECATED_MYINFO_CHILD_ATTRIBUTES,
+  MYINFO_ATTRIBUTE_MAP,
+  SELECTABLE_MYINFO_CHILD_ATTRIBUTES,
+} from '../index'
+
+describe('children field attributes', () => {
+  it('should offer every child sub-field except secondary race', () => {
+    expect(SELECTABLE_MYINFO_CHILD_ATTRIBUTES).toEqual([
+      MyInfoChildAttributes.ChildName,
+      MyInfoChildAttributes.ChildBirthCertNo,
+      MyInfoChildAttributes.ChildDateOfBirth,
+      MyInfoChildAttributes.ChildVaxxStatus,
+      MyInfoChildAttributes.ChildGender,
+      MyInfoChildAttributes.ChildRace,
+    ])
+  })
+
+  it('should account for every attribute as either selectable or deprecated', () => {
+    expect(
+      [
+        ...SELECTABLE_MYINFO_CHILD_ATTRIBUTES,
+        ...DEPRECATED_MYINFO_CHILD_ATTRIBUTES,
+      ].sort(),
+    ).toEqual(Object.values(MyInfoChildAttributes).sort())
+  })
+
+  // Existing responses render their sub-field label from this map, so dropping
+  // the secondary race entry would break them.
+  it('should keep secondary race resolvable in MYINFO_ATTRIBUTE_MAP', () => {
+    expect(
+      MYINFO_ATTRIBUTE_MAP[MyInfoChildAttributes.ChildSecondaryRace]
+        ?.description,
+    ).toBe('Secondary race')
+  })
+})

--- a/packages/shared/constants/field/myinfo/children.ts
+++ b/packages/shared/constants/field/myinfo/children.ts
@@ -1,0 +1,21 @@
+import { MyInfoChildAttributes } from '../../../types/field'
+
+/**
+ * Child sub-fields no longer offered in the form builder. MyInfo returns
+ * `secondaryrace` empty while every child sub-field is mandatory on submission,
+ * so a form collecting it could not be submitted. Removed builder-forward only —
+ * the enum member, its display metadata and the scope mapping all stay so
+ * existing forms and stored responses keep working; datafix/outreach retires them.
+ */
+export const DEPRECATED_MYINFO_CHILD_ATTRIBUTES: MyInfoChildAttributes[] = [
+  MyInfoChildAttributes.ChildSecondaryRace,
+]
+
+/** Child sub-fields an admin may add to a children field in the builder. */
+export const SELECTABLE_MYINFO_CHILD_ATTRIBUTES: MyInfoChildAttributes[] =
+  Object.values(MyInfoChildAttributes).filter(
+    (attr) => !DEPRECATED_MYINFO_CHILD_ATTRIBUTES.includes(attr),
+  )
+
+/** A children field collects exactly one child. */
+export const MAX_CHILDREN_PER_FIELD = 1

--- a/packages/shared/constants/field/myinfo/index.ts
+++ b/packages/shared/constants/field/myinfo/index.ts
@@ -22,6 +22,7 @@ export * from './myinfo-occupations'
 export * from './myinfo-races'
 export * from './myinfo-hdb-types'
 export * from './myinfo-housing-types'
+export * from './children'
 
 export type MyInfoVerifiedType = 'SG' | 'PR' | 'F'
 

--- a/packages/shared/types/field/childrenCompoundField.ts
+++ b/packages/shared/types/field/childrenCompoundField.ts
@@ -4,8 +4,10 @@ export interface ChildrenCompoundFieldBase extends MyInfoableFieldBase {
   fieldType: BasicField.Children
   // Stores the sub-field data.
   childrenSubFields?: MyInfoChildAttributes[]
-  // Whether the response should accept more than one children.
-  // Default (undefined) is no.
+  /**
+   * @deprecated A children field collects exactly one child. Retained only
+   * because existing form documents carry it; nothing reads it.
+   */
   allowMultiple?: boolean
 }
 


### PR DESCRIPTION
## Problem

The MyInfo Children field (whitelist beta, heavy MOE use) carries two builder
options that shouldn't be there. **Secondary Race** is returned empty by MyInfo
for children while every child sub-field is mandatory on submission — so any form
collecting it simply cannot be submitted. **"Allow respondent to add multiple
children"** produces multi-child answers that the v2 design drops entirely
(one child per field, no `child-N` numbering).

## Solution

- [Agent spec](https://app.notion.com/p/27777dbba78880b2a014fbc121b71a8e) — issue 01
- Phase **v2.0 only**: clean up the existing v1 (Storage/Encrypt) field

Removes both options from the builder. Removing Secondary Race is what resolves
the empty-mandatory submission failure; removing Allow-Multiple means a children
field collects exactly one child, enforced on both the public form and the server.

- `SELECTABLE_MYINFO_CHILD_ATTRIBUTES` / `MAX_CHILDREN_PER_FIELD` in
  `formsg-shared` are the single source of truth, so a future deprecation is one
  list edit.
- Single-child is enforced on `MAX_CHILDREN_PER_FIELD`, **not** on `allowMultiple`
  — the flag survives on existing form documents and v2.0 does not migrate them,
  so a stale `allowMultiple: true` must not buy a second child. The flag is kept
  on the type, marked `@deprecated`, read by nothing.

Removal is **builder-forward only**. Explicitly not in this PR:

- **No data migration, reshape or purge.** Existing responses — Secondary Race
  values and >1-child answers — still decrypt and export unchanged.
  `getAnswersForChild` is untouched and its output is pinned by a regression spec.
- **No auto-split** of forms that collect >1 child, and no forced migration.
  Existing forms are retired by datafix / manual outreach.
- **No v4 / MRF work.** The field stays on v1; children is still blocked on MRF,
  which is v2.1's to remove.
- **Not exposed in v3** — `validateFieldV3` is only reached from inside
  `tableValidator`, so no live submission path routes a children field through v3.
  No change needed.
- `myinfo.adapter.ts`, `ndi-config.ts` and the `ChildSecondaryRace` enum member
  all stay — existing forms and stored responses still need them to resolve.

**Screenshots**

Rendered from Storybook — `develop` for before, this branch for after, same story
and same field args on both sides.

| What | Before | After |
| --- | --- | --- |
| Builder — child data options | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/myinfo-children-v2-0/builder-options-before.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/myinfo-children-v2-0/builder-options-after.png) |
| Builder — allow-multiple toggle | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/myinfo-children-v2-0/builder-toggle-before.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/myinfo-children-v2-0/builder-toggle-after.png) |
| Public form — one child per field | ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/myinfo-children-v2-0/respondent-before.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/myinfo-children-v2-0/respondent-after.png) |

Row 1: "Secondary Race" is gone from the option list (6 options → 5). The list
normally scroll-clips after 4 rows, so it was un-clipped for the capture — a
cropped list could not show that an option is absent. Row 2: the toggle is gone.
Row 3: the same field with a stored `allowMultiple: true` loses "Add another
child", the remove-child button and the "1 child added" counter — the remaining
`×` is SingleSelect's own clear button, not a remove-child control.

**Breaking Changes**

No — backwards compatible. Stored responses are untouched and still decrypt.
Respondents on an existing multi-child form now submit one child instead of
several; that is the intended v2.0 behaviour change, and no stored data is
altered.

## Tests

Unit tests added:

- `children-back-compat.spec.ts` — stored Secondary Race and multi-child answers
  explode unchanged.
- `children-validation.spec.ts` — one child accepted; two rejected, including
  with a legacy `allowMultiple: true`; an existing Secondary Race form still
  validates.
- `children.spec.ts` — the selectable sub-field list, and Secondary Race still
  resolvable in `MYINFO_ATTRIBUTE_MAP` so existing responses keep rendering.
- `constants.test.ts` — the builder's sub-field options.
- `EditMyInfoChildren.test.tsx` (+ first Storybook story for the drawer) — no
  allow-multiple toggle.
- `ChildrenCompoundField.test.tsx` — no add/remove-child affordance under a
  legacy `allowMultiple: true`; a legacy Secondary Race sub-field still renders.

```
packages/shared   jest     12 suites /  93 tests   passed
apps/backend      jest     22 suites / 572 tests   passed
apps/frontend     vitest   52 files  / 300 tests   passed  (full suite)
```

Manual (UAT/staging, not production):

**TC1: Builder no longer offers either option**

- [ ] Open a Storage-mode form, add the MyInfo Children field
- [ ] Confirm "Child's secondary race" is absent from the child data dropdown
- [ ] Confirm the "Allow respondent to add multiple children" toggle is gone

**TC2: One child per field, and it submits**

- [ ] Fill the form via Singpass, select a child
- [ ] Confirm there is no "Add another child" button and no remove-child button
- [ ] Submit and confirm success (this is the empty-mandatory failure no longer firing)
- [ ] Confirm the response view and CSV show exactly one child

**TC3: Existing data still readable**

- [ ] Open an existing form's responses that include Secondary Race values
- [ ] Confirm they still decrypt and export with the same columns as before
- [ ] Repeat for an existing response with >1 child — confirm all children still
      appear, unsplit
