### PR TITLE
refactor(admin-feedback): feedbackChanged rename + drop dead legacy metric

### DIFF
--- a/apps/backend/src/app/models/__tests__/admin_feedback.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/admin_feedback.server.model.spec.ts
@@ -171,17 +171,17 @@ describe('form_feedback.server.model', () => {
       )
     })
 
-    it('should default ratingChanged to false', async () => {
+    it('should default feedbackChanged to false', async () => {
       const actual = await FeedbackModel.create(DEFAULT_PARAMS)
-      expect(actual.ratingChanged).toEqual(false)
+      expect(actual.feedbackChanged).toEqual(false)
     })
 
-    it('should save with ratingChanged set to true', async () => {
+    it('should save with feedbackChanged set to true', async () => {
       const actual = await FeedbackModel.create({
         ...DEFAULT_PARAMS,
-        ratingChanged: true,
+        feedbackChanged: true,
       })
-      expect(actual.ratingChanged).toEqual(true)
+      expect(actual.feedbackChanged).toEqual(true)
     })
   })
 })

--- a/apps/backend/src/app/models/admin_feedback.server.model.ts
+++ b/apps/backend/src/app/models/admin_feedback.server.model.ts
@@ -44,7 +44,7 @@ const AdminFeedbackSchema = new Schema<
     formId: {
       type: Schema.Types.ObjectId,
     },
-    ratingChanged: {
+    feedbackChanged: {
       type: Boolean,
       default: false,
     },

--- a/apps/backend/src/app/modules/admin-feedback/__tests__/admin_feedback.service.spec.ts
+++ b/apps/backend/src/app/modules/admin-feedback/__tests__/admin_feedback.service.spec.ts
@@ -22,11 +22,11 @@ describe('feedback.service', () => {
     afterEach(() => jest.clearAllMocks())
 
     const MOCK_USER_ID = new ObjectId().toHexString()
-    const MOCK_RATING = 1
+    const MOCK_CSAT = 1
     const MOCK_COMMENT = 'mock comment'
     const MOCK_ADMIN_FEEDBACK = new AdminFeedbackModel({
       userId: MOCK_USER_ID,
-      csat: MOCK_RATING,
+      csat: MOCK_CSAT,
       comment: MOCK_COMMENT,
     })
 
@@ -41,7 +41,7 @@ describe('feedback.service', () => {
       // Act
       const actualResult = await AdminFeedbackService.insertAdminFeedback({
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
         comment: MOCK_COMMENT,
       })
 
@@ -54,7 +54,7 @@ describe('feedback.service', () => {
     it('should return Admin Feedback document on successful insertion without comment', async () => {
       const mock_feedback_no_comment = new AdminFeedbackModel({
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
       })
       // Arrange
       // Mock success.
@@ -66,7 +66,7 @@ describe('feedback.service', () => {
       // Act
       const actualResult = await AdminFeedbackService.insertAdminFeedback({
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
       })
 
       // Assert
@@ -80,7 +80,7 @@ describe('feedback.service', () => {
       const mockFormId = new ObjectId().toHexString()
       const mockFeedbackWithTrigger = new AdminFeedbackModel({
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
         comment: MOCK_COMMENT,
         triggerSource: mockTriggerSource,
         formId: mockFormId,
@@ -93,7 +93,7 @@ describe('feedback.service', () => {
 
       const actualResult = await AdminFeedbackService.insertAdminFeedback({
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
         comment: MOCK_COMMENT,
         triggerSource: mockTriggerSource,
         formId: mockFormId,
@@ -102,7 +102,7 @@ describe('feedback.service', () => {
       expect(insertSpy).toHaveBeenCalledTimes(1)
       expect(insertSpy).toHaveBeenCalledWith({
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
         comment: MOCK_COMMENT,
         triggerSource: mockTriggerSource,
         formId: mockFormId,
@@ -122,7 +122,7 @@ describe('feedback.service', () => {
       // Act
       const actualResult = await AdminFeedbackService.insertAdminFeedback({
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
       })
 
       // Assert
@@ -135,7 +135,7 @@ describe('feedback.service', () => {
   describe('updateAdminFeedback', () => {
     const MOCK_FEEDBACK_ID = new ObjectId().toHexString()
     const MOCK_USER_ID = new ObjectId().toHexString()
-    const MOCK_RATING = 1
+    const MOCK_CSAT = 1
     const MOCK_COMMENT = 'mock comment'
 
     beforeEach(async () => {
@@ -143,21 +143,21 @@ describe('feedback.service', () => {
       await AdminFeedbackModel.create({
         _id: MOCK_FEEDBACK_ID,
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
         comment: MOCK_COMMENT,
       })
     })
     afterEach(() => jest.clearAllMocks())
 
-    it('should update feedback successfully with both rating and comment changes', async () => {
-      const newRating = 4
+    it('should update feedback successfully with both csat and comment changes', async () => {
+      const newCsat = 4
       const newComment = 'new comment'
 
       // Act
       const actualResult = await AdminFeedbackService.updateAdminFeedback({
         feedbackId: MOCK_FEEDBACK_ID,
         userId: MOCK_USER_ID,
-        csat: newRating,
+        csat: newCsat,
         comment: newComment,
       })
 
@@ -166,25 +166,25 @@ describe('feedback.service', () => {
       // Assert
       expect(actualResult.isOk()).toEqual(true)
       expect(newFeedback?.comment).toEqual(newComment)
-      expect(newFeedback?.csat).toEqual(newRating)
+      expect(newFeedback?.csat).toEqual(newCsat)
     })
 
-    it('should set ratingChanged to true when rating is updated', async () => {
-      const newRating = 5
+    it('should set feedbackChanged to true when csat is updated', async () => {
+      const newCsat = 5
 
       await AdminFeedbackService.updateAdminFeedback({
         feedbackId: MOCK_FEEDBACK_ID,
         userId: MOCK_USER_ID,
-        csat: newRating,
+        csat: newCsat,
       })
 
       const newFeedback = await AdminFeedbackModel.findById(MOCK_FEEDBACK_ID)
 
-      expect(newFeedback?.ratingChanged).toEqual(true)
-      expect(newFeedback?.csat).toEqual(newRating)
+      expect(newFeedback?.feedbackChanged).toEqual(true)
+      expect(newFeedback?.csat).toEqual(newCsat)
     })
 
-    it('should not set ratingChanged when only comment is updated', async () => {
+    it('should set feedbackChanged when only comment is updated', async () => {
       await AdminFeedbackService.updateAdminFeedback({
         feedbackId: MOCK_FEEDBACK_ID,
         userId: MOCK_USER_ID,
@@ -193,14 +193,14 @@ describe('feedback.service', () => {
 
       const newFeedback = await AdminFeedbackModel.findById(MOCK_FEEDBACK_ID)
 
-      expect(newFeedback?.ratingChanged).toEqual(false)
+      expect(newFeedback?.feedbackChanged).toEqual(true)
     })
 
-    it('should update feedback successfully with only rating change', async () => {
-      const newRating = 3
+    it('should update feedback successfully with only csat change', async () => {
+      const newCsat = 3
       const expectedResult = new AdminFeedbackModel({
         userId: MOCK_USER_ID,
-        csat: newRating,
+        csat: newCsat,
         comment: MOCK_COMMENT,
       })
 
@@ -208,7 +208,7 @@ describe('feedback.service', () => {
       const actualResult = await AdminFeedbackService.updateAdminFeedback({
         feedbackId: MOCK_FEEDBACK_ID,
         userId: MOCK_USER_ID,
-        csat: newRating,
+        csat: newCsat,
       })
 
       const newFeedback = await AdminFeedbackModel.findById(MOCK_FEEDBACK_ID)
@@ -223,7 +223,7 @@ describe('feedback.service', () => {
       const newComment = 'new comment'
       const expectedResult = new AdminFeedbackModel({
         userId: MOCK_USER_ID,
-        csat: MOCK_RATING,
+        csat: MOCK_CSAT,
         comment: newComment,
       })
 

--- a/apps/backend/src/app/modules/admin-feedback/admin-feedback.controller.ts
+++ b/apps/backend/src/app/modules/admin-feedback/admin-feedback.controller.ts
@@ -44,13 +44,8 @@ const submitAdminFeedback: ControllerHandler<
   const sessionUserId = (req.session as AuthedSessionData).user._id
   const { rating, comment, triggerSource, formId } = req.body
 
-  // Dual-emit: old metric kept so existing dashboards don't break during
-  // migration. New `.csat` metric is the 1-5 CSAT measure. Remove the old
-  // metric once the report card has migrated to `.csat`.
-  statsdClient.distribution('formsg.users.feedback.rating', rating, 1, {
-    rating: `${rating}`,
-    ...(triggerSource ? { triggerSource } : {}),
-  })
+  // `.csat` is the 1-5 CSAT measure. The legacy `.rating` emit was dropped:
+  // the star feature never shipped, so no dashboard depends on it at this scale.
   statsdClient.distribution('formsg.users.feedback.csat', rating, 1, {
     csat: `${rating}`,
     ...(triggerSource ? { triggerSource } : {}),

--- a/apps/backend/src/app/modules/admin-feedback/admin-feedback.service.ts
+++ b/apps/backend/src/app/modules/admin-feedback/admin-feedback.service.ts
@@ -79,11 +79,9 @@ export const updateAdminFeedback = ({
 }) => {
   const updateObj: Record<string, unknown> = {}
   if (comment !== undefined) updateObj.comment = comment
-  if (csat !== undefined) {
-    updateObj.csat = csat
-    // `ratingChanged` is a pre-existing flag; it now reflects a `csat` edit.
-    updateObj.ratingChanged = true
-  }
+  if (csat !== undefined) updateObj.csat = csat
+  // Any post-creation edit (star or comment) marks the feedback as changed.
+  if (!isEmpty(updateObj)) updateObj.feedbackChanged = true
 
   // if no update to be done, return ok
   if (isEmpty(updateObj)) return okAsync(true)

--- a/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -3163,7 +3163,7 @@ describe('admin-form.form.routes', () => {
 
   describe('POST /admin/forms/feedback', () => {
     const MOCK_COMMENT = 'mock comment'
-    const MOCK_RATING = 3
+    const MOCK_CSAT = 3
 
     it('should return 200 when the request is successful', async () => {
       // Arrange
@@ -3172,7 +3172,7 @@ describe('admin-form.form.routes', () => {
       // Act
       const resp = await request
         .post(`/admin/forms/feedback`)
-        .send({ rating: MOCK_RATING, comment: MOCK_COMMENT })
+        .send({ rating: MOCK_CSAT, comment: MOCK_COMMENT })
 
       // Assert
       expect(resp.status).toBe(200)
@@ -3180,14 +3180,21 @@ describe('admin-form.form.routes', () => {
         'Successfully submitted admin feedback',
       )
       // Wire sends `rating`; it is stored and returned under the `csat` key.
-      expect(resp.body.feedback.csat).toEqual(MOCK_RATING)
+      expect(resp.body.feedback.csat).toEqual(MOCK_CSAT)
       expect(resp.body.feedback.rating).toBeUndefined()
       expect(resp.body.feedback.comment).toEqual(MOCK_COMMENT)
       expect(distributionSpy).toHaveBeenCalledWith(
         'formsg.users.feedback.csat',
-        MOCK_RATING,
+        MOCK_CSAT,
         1,
-        expect.objectContaining({ csat: `${MOCK_RATING}` }),
+        expect.objectContaining({ csat: `${MOCK_CSAT}` }),
+      )
+      // Legacy `.rating` metric was dropped (feature never shipped).
+      expect(distributionSpy).not.toHaveBeenCalledWith(
+        'formsg.users.feedback.rating',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
       )
     })
 
@@ -3195,14 +3202,14 @@ describe('admin-form.form.routes', () => {
       // Act
       const resp = await request
         .post(`/admin/forms/feedback`)
-        .send({ rating: MOCK_RATING })
+        .send({ rating: MOCK_CSAT })
 
       // Assert
       expect(resp.status).toBe(200)
       expect(resp.body.message).toContain(
         'Successfully submitted admin feedback',
       )
-      expect(resp.body.feedback.csat).toEqual(MOCK_RATING)
+      expect(resp.body.feedback.csat).toEqual(MOCK_CSAT)
       expect(resp.body.feedback.comment).toBeUndefined()
     })
 
@@ -3235,7 +3242,7 @@ describe('admin-form.form.routes', () => {
       // Act
       const resp = await request
         .post(`/admin/forms/feedback`)
-        .send({ rating: MOCK_RATING })
+        .send({ rating: MOCK_CSAT })
 
       // Assert
       expect(resp.status).toEqual(401)
@@ -3252,7 +3259,7 @@ describe('admin-form.form.routes', () => {
       // Act
       const resp = await request
         .post(`/admin/forms/feedback`)
-        .send({ rating: MOCK_RATING })
+        .send({ rating: MOCK_CSAT })
 
       // Assert
       expect(resp.status).toEqual(500)
@@ -3263,16 +3270,16 @@ describe('admin-form.form.routes', () => {
   })
   describe('PATCH /admin/forms/feedback/:feedbackId', () => {
     const MOCK_COMMENT = 'mock comment'
-    const MOCK_RATING = 3
+    const MOCK_CSAT = 3
     const MOCK_NEW_COMMENT = 'new comment'
-    const MOCK_NEW_RATING = 5
+    const MOCK_NEW_CSAT = 5
 
     let MOCK_ADMIN_FEEDBACK: IAdminFeedbackSchema
 
     beforeEach(async () => {
       MOCK_ADMIN_FEEDBACK = await AdminFeedbackModel.create({
         userId: defaultUser.id.toString(),
-        rating: MOCK_RATING,
+        csat: MOCK_CSAT,
         comment: MOCK_COMMENT,
       })
     })
@@ -3281,7 +3288,7 @@ describe('admin-form.form.routes', () => {
       // Act
       const resp = await request
         .patch(`/admin/forms/feedback/${MOCK_ADMIN_FEEDBACK.id.toString()}`)
-        .send({ rating: MOCK_NEW_RATING, comment: MOCK_NEW_COMMENT })
+        .send({ rating: MOCK_NEW_CSAT, comment: MOCK_NEW_COMMENT })
 
       const updatedFeedback = await AdminFeedbackModel.findById(
         MOCK_ADMIN_FEEDBACK.id.toString(),
@@ -3292,7 +3299,7 @@ describe('admin-form.form.routes', () => {
       expect(resp.body.message).toEqual('Successfully updated admin feedback')
       expect(updatedFeedback?.comment).toEqual(MOCK_NEW_COMMENT)
       // Wire sends `rating`; it is stored under the `csat` key.
-      expect(updatedFeedback?.csat).toEqual(MOCK_NEW_RATING)
+      expect(updatedFeedback?.csat).toEqual(MOCK_NEW_CSAT)
     })
 
     it('should return 200 without changes if request is successful without a body', async () => {
@@ -3343,7 +3350,7 @@ describe('admin-form.form.routes', () => {
       // Act
       const resp = await request
         .patch(`/admin/forms/feedback/${new Types.ObjectId().toString()}`)
-        .send({ rating: MOCK_NEW_RATING, comment: MOCK_NEW_COMMENT })
+        .send({ rating: MOCK_NEW_CSAT, comment: MOCK_NEW_COMMENT })
 
       // Assert
       expect(resp.status).toEqual(404)
@@ -3354,14 +3361,14 @@ describe('admin-form.form.routes', () => {
       // create new admin feedback with different userId from defaultuser
       const newFeedback = await AdminFeedbackModel.create({
         userId: new Types.ObjectId().toHexString(),
-        rating: MOCK_RATING,
+        csat: MOCK_CSAT,
         comment: MOCK_COMMENT,
       })
 
       // Act
       const resp = await request
         .patch(`/admin/forms/feedback/${newFeedback.id.toString()}`)
-        .send({ rating: MOCK_NEW_RATING, comment: MOCK_NEW_COMMENT })
+        .send({ rating: MOCK_NEW_CSAT, comment: MOCK_NEW_COMMENT })
 
       // Assert
       expect(resp.status).toEqual(404)

--- a/packages/shared/types/admin_feedback.ts
+++ b/packages/shared/types/admin_feedback.ts
@@ -12,7 +12,8 @@ export type AdminFeedbackBase = {
   comment?: string
   triggerSource?: AdminFeedbackTriggerSource
   formId?: string
-  ratingChanged?: boolean
+  /** True if the feedback was edited (star or comment) after creation. */
+  feedbackChanged?: boolean
   userId?: UserDto['_id']
   created?: Date
   lastModified?: Date


### PR DESCRIPTION
## Problem

Follow-ups from review of #9787:

- `ratingChanged` no longer matches what it tracks, and its semantics were subtly off: it flagged any PATCH carrying a star value (even unchanged), but ignored comment edits.
- The transitional `formsg.users.feedback.rating` emit is dead weight: the star feature flag was never toggled on, so no dashboard depends on it — and it would have pushed 1-5 values into a metric whose historical data is 0/1 thumbs.
- Test vocabulary still said "rating" for values stored as `csat`.

## Solution

- Rename `ratingChanged` → `feedbackChanged`; set on **any** post-creation edit (star or comment). Safe rename: field is write-only, introduced in #9684, never released.
- Drop the legacy `.rating` metric emit; keep only `formsg.users.feedback.csat`. Route spec asserts the legacy metric is no longer fired.
- Rename `MOCK_RATING` → `MOCK_CSAT` / `MOCK_NEW_CSAT`; wire payloads intentionally keep the `rating` key (`send({ rating: MOCK_CSAT })`) to document the wire→storage mapping. PATCH fixtures now create rows under `csat` (the shape new rows actually take).

**Breaking Changes**

No. Nothing reads `ratingChanged` or the legacy metric; feature flag is off.

## Tests

- Model + service specs: 28/28 pass
- Route feedback specs: 13/13 pass
- `tsc --noEmit`: no new errors (pre-existing failures identical on base)

🤖 Generated with [Claude Code](https://claude.com/claude-code)