### PR TITLE
feat: mrf payments schema changes (1/4)

### DIFF
--- a/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
@@ -15,6 +15,7 @@ import {
   FormField,
   FormFieldDto,
   FormLogoState,
+  FormPaymentsField,
   FormPermission,
   FormResponseMode,
   FormStartPage,
@@ -2275,6 +2276,132 @@ describe('Form Model', () => {
         // Assert
         expect(actual).toEqual(null)
         await expect(Form.countDocuments()).resolves.toEqual(0)
+      })
+    })
+
+    describe('updatePaymentsById', () => {
+      const PAYMENTS_ENABLED = {
+        enabled: true,
+        description: 'some description',
+        name: 'some name',
+        amount_cents: 5000,
+        payment_type: PaymentType.Fixed,
+      } as FormPaymentsField
+
+      it('should enable payments on a storage mode form with no emails', async () => {
+        // Arrange
+        const form = await EncryptedForm.create({
+          ...MOCK_ENCRYPTED_FORM_PARAMS,
+          emails: [],
+        })
+
+        // Act
+        const actual = await EncryptedForm.updatePaymentsById(
+          form._id,
+          PAYMENTS_ENABLED,
+        )
+
+        // Assert
+        expect(actual?.payments_field?.enabled).toEqual(true)
+      })
+
+      it('should enable payments on a legacy storage mode form with no emails field at all', async () => {
+        // Arrange: pre-migration documents may lack `emails` entirely, and
+        // storage mode forms never have `workflow`; the filter must treat
+        // missing paths the same as empty arrays.
+        const form = await EncryptedForm.create(MOCK_ENCRYPTED_FORM_PARAMS)
+        await EncryptedForm.collection.updateOne(
+          { _id: form._id },
+          { $unset: { emails: 1 } },
+        )
+
+        // Act
+        const actual = await EncryptedForm.updatePaymentsById(
+          form._id,
+          PAYMENTS_ENABLED,
+        )
+
+        // Assert
+        expect(actual?.payments_field?.enabled).toEqual(true)
+      })
+
+      it('should return null when enabling payments on a form with emails', async () => {
+        // Arrange: emails may have been added concurrently after the service
+        // layer's in-memory guard passed.
+        const form = await EncryptedForm.create({
+          ...MOCK_ENCRYPTED_FORM_PARAMS,
+          emails: [MOCK_ADMIN_EMAIL],
+        })
+
+        // Act
+        const actual = await EncryptedForm.updatePaymentsById(
+          form._id,
+          PAYMENTS_ENABLED,
+        )
+
+        // Assert
+        expect(actual).toEqual(null)
+        const untouchedForm = await EncryptedForm.findById(form._id)
+        expect(untouchedForm?.payments_field?.enabled).toEqual(false)
+      })
+
+      it('should return null when enabling payments on a form with single submission enabled', async () => {
+        // Arrange
+        const form = await EncryptedForm.create({
+          ...MOCK_ENCRYPTED_FORM_PARAMS,
+          emails: [],
+          isSingleSubmission: true,
+        })
+
+        // Act
+        const actual = await EncryptedForm.updatePaymentsById(
+          form._id,
+          PAYMENTS_ENABLED,
+        )
+
+        // Assert
+        expect(actual).toEqual(null)
+      })
+
+      it('should return null when enabling payments on a multirespondent form with workflow steps', async () => {
+        // Arrange
+        const form = await MultirespondentForm.create({
+          ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+          workflow: [
+            {
+              workflow_type: WorkflowType.Static,
+              emails: [],
+              edit: [],
+            },
+          ],
+        })
+
+        // Act
+        const actual = await MultirespondentForm.updatePaymentsById(
+          form._id,
+          PAYMENTS_ENABLED,
+        )
+
+        // Assert
+        expect(actual).toEqual(null)
+      })
+
+      it('should allow disabling payments regardless of emails or single submission', async () => {
+        // Arrange
+        const form = await EncryptedForm.create({
+          ...MOCK_ENCRYPTED_FORM_PARAMS,
+          emails: [MOCK_ADMIN_EMAIL],
+          isSingleSubmission: true,
+        })
+
+        // Act
+        const actual = await EncryptedForm.updatePaymentsById(form._id, {
+          ...PAYMENTS_ENABLED,
+          enabled: false,
+        })
+
+        // Assert
+        expect(actual?.payments_field?.enabled).toEqual(false)
       })
     })
 

--- a/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
@@ -941,6 +941,7 @@ describe('Form Model', () => {
           },
         },
         FORM_DEFAULTS,
+        PAYMENTS_DEFAULTS,
       )
 
       it('should create and save successfully with a workflow', async () => {
@@ -1009,6 +1010,117 @@ describe('Form Model', () => {
         await expect(invalidForm.save()).rejects.toThrow(
           mongoose.Error.ValidationError,
         )
+      })
+
+      describe('payment invariants', () => {
+        const ENABLED_PAYMENTS_FIELD = {
+          enabled: true,
+          payment_type: PaymentType.Variable,
+          min_amount: 100,
+          max_amount: 1000,
+        }
+
+        it('should save successfully with payments enabled on a zero-step form', async () => {
+          // Arrange
+          const validForm = new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [],
+            payments_field: ENABLED_PAYMENTS_FIELD,
+          })
+
+          // Act
+          const saved = await validForm.save()
+
+          // Assert
+          expect(saved._id).toBeDefined()
+          expect(saved.payments_field.enabled).toBe(true)
+        })
+
+        it('should reject payments enabled with workflow steps', async () => {
+          // Arrange
+          const invalidForm = new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [
+              {
+                _id: new ObjectId(),
+                workflow_type: WorkflowType.Static,
+                emails: ['test@open.gov.sg'],
+                edit: [],
+              },
+            ],
+            payments_field: ENABLED_PAYMENTS_FIELD,
+          })
+
+          // Act + Assert
+          await expect(invalidForm.save()).rejects.toThrow(
+            'Payments cannot be enabled on a multirespondent form with workflow steps',
+          )
+        })
+
+        it('should reject payments enabled with email notifications', async () => {
+          // Arrange
+          const invalidForm = new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [],
+            emails: ['notify@open.gov.sg'],
+            payments_field: ENABLED_PAYMENTS_FIELD,
+          })
+
+          // Act + Assert
+          await expect(invalidForm.save()).rejects.toThrow(
+            'Payments cannot be enabled on a multirespondent form with email notifications',
+          )
+        })
+
+        it('should reject payments enabled with a respondent email notification field', async () => {
+          // Arrange
+          const invalidForm = new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [],
+            stepOneEmailNotificationFieldId: new ObjectId().toHexString(),
+            payments_field: ENABLED_PAYMENTS_FIELD,
+          })
+
+          // Act + Assert
+          await expect(invalidForm.save()).rejects.toThrow(
+            'Payments cannot be enabled on a multirespondent form with a respondent email notification',
+          )
+        })
+
+        it('should reject payments enabled with single submission enforcement', async () => {
+          // Arrange
+          const invalidForm = new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [],
+            isSingleSubmission: true,
+            payments_field: ENABLED_PAYMENTS_FIELD,
+          })
+
+          // Act + Assert
+          await expect(invalidForm.save()).rejects.toThrow(
+            'Payments cannot be enabled on a multirespondent form with single submission enforcement',
+          )
+        })
+
+        it('should reject adding a workflow step to a saved payment-enabled form', async () => {
+          // Arrange
+          const form = await new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [],
+            payments_field: ENABLED_PAYMENTS_FIELD,
+          }).save()
+          form.workflow.push({
+            _id: new ObjectId(),
+            workflow_type: WorkflowType.Static,
+            emails: ['test@open.gov.sg'],
+            edit: [],
+          })
+
+          // Act + Assert
+          await expect(form.save()).rejects.toThrow(
+            'Payments cannot be enabled on a multirespondent form with workflow steps',
+          )
+        })
       })
     })
 

--- a/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
@@ -1110,7 +1110,7 @@ describe('Form Model', () => {
             payments_field: ENABLED_PAYMENTS_FIELD,
           }).save()
           form.workflow.push({
-            _id: new ObjectId(),
+            _id: new ObjectId().toHexString(),
             workflow_type: WorkflowType.Static,
             emails: ['test@open.gov.sg'],
             edit: [],
@@ -1120,6 +1120,86 @@ describe('Form Model', () => {
           await expect(form.save()).rejects.toThrow(
             'Payments cannot be enabled on a multirespondent form with workflow steps',
           )
+        })
+      })
+
+      describe('payment account methods', () => {
+        const MOCK_STRIPE_ACCOUNT = {
+          accountId: 'acct_mockAccountId',
+          publishableKey: 'pk_mockPublishableKey',
+        }
+
+        it('addPaymentAccountId should connect Stripe when channel is unconnected', async () => {
+          // Arrange
+          const form = await new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [],
+          }).save()
+
+          // Act
+          const updated = await form.addPaymentAccountId(MOCK_STRIPE_ACCOUNT)
+
+          // Assert
+          expect(updated.payments_channel).toEqual(
+            expect.objectContaining({
+              channel: PaymentChannel.Stripe,
+              target_account_id: MOCK_STRIPE_ACCOUNT.accountId,
+              publishable_key: MOCK_STRIPE_ACCOUNT.publishableKey,
+              payment_methods: [],
+            }),
+          )
+        })
+
+        it('addPaymentAccountId should not overwrite an already connected channel', async () => {
+          // Arrange
+          const form = await new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [],
+          }).save()
+          await form.addPaymentAccountId(MOCK_STRIPE_ACCOUNT)
+
+          // Act
+          const updated = await form.addPaymentAccountId({
+            accountId: 'acct_anotherAccountId',
+            publishableKey: 'pk_anotherPublishableKey',
+          })
+
+          // Assert
+          expect(updated.payments_channel.target_account_id).toEqual(
+            MOCK_STRIPE_ACCOUNT.accountId,
+          )
+          expect(updated.payments_channel.publishable_key).toEqual(
+            MOCK_STRIPE_ACCOUNT.publishableKey,
+          )
+        })
+
+        it('removePaymentAccount should reset the channel and disable payments', async () => {
+          // Arrange
+          const form = await new MultirespondentForm({
+            ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
+            workflow: [],
+            payments_field: {
+              enabled: true,
+              payment_type: PaymentType.Variable,
+              min_amount: 100,
+              max_amount: 1000,
+            },
+          }).save()
+          await form.addPaymentAccountId(MOCK_STRIPE_ACCOUNT)
+
+          // Act
+          const updated = await form.removePaymentAccount()
+
+          // Assert
+          expect(updated.payments_channel).toEqual(
+            expect.objectContaining({
+              channel: PaymentChannel.Unconnected,
+              target_account_id: '',
+              publishable_key: '',
+              payment_methods: [],
+            }),
+          )
+          expect(updated.payments_field.enabled).toBe(false)
         })
       })
     })

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -1551,9 +1551,12 @@ const compileFormModel = (db: Mongoose): IFormModel => {
   ) {
     // Enabling payments re-asserts the notification and single-submission
     // guards atomically in the query, closing the race against concurrent
-    // settings updates. `workflow` only exists on multirespondent documents
-    // and `emails` may be absent on legacy documents, so empty arrays are
-    // matched via `field.0` non-existence rather than `$size`.
+    // settings updates. `workflow` and `stepOneEmailNotificationFieldId` are
+    // multirespondent-only fields (they match vacuously on storage mode);
+    // `emails` exists on both modes and must be empty to enable payments in
+    // either. Empty arrays are matched via `field.0` non-existence rather
+    // than `$size` so legacy storage-mode documents missing `emails`
+    // entirely also pass.
     const filter = newPayments.enabled
       ? {
           _id: formId,

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -548,6 +548,54 @@ MultirespondentFormWorkflowPath.discriminator(
   WorkflowStepConditionalSchema,
 )
 
+// Payments on multirespondent forms are only supported when the form behaves
+// as a single-submission form: no workflow steps, no form-configured email
+// notifications, no single-submission enforcement. This document-level guard
+// covers every save() path (creation, duplication, instance methods); update
+// paths that bypass document validation (findByIdAndUpdate) must enforce the
+// same conditions atomically via their query filter.
+MultirespondentFormSchema.pre<IMultirespondentFormSchema>(
+  'validate',
+  function (next) {
+    if (!this.payments_field?.enabled) {
+      return next()
+    }
+    if ((this.workflow?.length ?? 0) > 0) {
+      return next(
+        this.invalidate(
+          'payments_field.enabled',
+          'Payments cannot be enabled on a multirespondent form with workflow steps',
+        ) as mongoose.Error.ValidationError,
+      )
+    }
+    if ((this.emails?.length ?? 0) > 0) {
+      return next(
+        this.invalidate(
+          'payments_field.enabled',
+          'Payments cannot be enabled on a multirespondent form with email notifications',
+        ) as mongoose.Error.ValidationError,
+      )
+    }
+    if (this.stepOneEmailNotificationFieldId) {
+      return next(
+        this.invalidate(
+          'payments_field.enabled',
+          'Payments cannot be enabled on a multirespondent form with a respondent email notification',
+        ) as mongoose.Error.ValidationError,
+      )
+    }
+    if (this.isSingleSubmission) {
+      return next(
+        this.invalidate(
+          'payments_field.enabled',
+          'Payments cannot be enabled on a multirespondent form with single submission enforcement',
+        ) as mongoose.Error.ValidationError,
+      )
+    }
+    return next()
+  },
+)
+
 const compileFormModel = (db: Mongoose): IFormModel => {
   const User = getUserModel(db)
 

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -1549,8 +1549,23 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     formId: string,
     newPayments: FormPaymentsField,
   ) {
-    return this.findByIdAndUpdate(
-      formId,
+    // Enabling payments re-asserts the notification and single-submission
+    // guards atomically in the query, closing the race against concurrent
+    // settings updates. `workflow` only exists on multirespondent documents
+    // and `emails` may be absent on legacy documents, so empty arrays are
+    // matched via `field.0` non-existence rather than `$size`.
+    const filter = newPayments.enabled
+      ? {
+          _id: formId,
+          'workflow.0': { $exists: false },
+          'emails.0': { $exists: false },
+          stepOneEmailNotificationFieldId: { $in: [null, ''] },
+          isSingleSubmission: { $ne: true },
+        }
+      : { _id: formId }
+
+    return this.findOneAndUpdate(
+      filter,
       { payments_field: newPayments },
       { new: true, runValidators: true },
     ).exec()

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -475,7 +475,45 @@ const MultirespondentFormSchema = new Schema<IMultirespondentFormSchema>({
     type: Boolean,
     default: false,
   },
+
+  payments_channel: formPaymentsChannelSchema,
+
+  payments_field: formPaymentsFieldSchema,
+
+  business: formBusinessSchema,
 })
+
+MultirespondentFormSchema.methods.addPaymentAccountId = function ({
+  accountId,
+  publishableKey,
+}: {
+  accountId: FormPaymentsChannel['target_account_id']
+  publishableKey: FormPaymentsChannel['publishable_key']
+}) {
+  if (this.payments_channel?.channel === PaymentChannel.Unconnected) {
+    this.payments_channel = {
+      // Definitely Stripe for now, may be different later on.
+      channel: PaymentChannel.Stripe,
+      target_account_id: accountId,
+      publishable_key: publishableKey,
+      payment_methods: [],
+    }
+  }
+  return this.save()
+}
+
+MultirespondentFormSchema.methods.removePaymentAccount = async function () {
+  this.payments_channel = {
+    channel: PaymentChannel.Unconnected,
+    target_account_id: '',
+    publishable_key: '',
+    payment_methods: [],
+  }
+  if (this.payments_field) {
+    this.payments_field.enabled = false
+  }
+  return this.save()
+}
 
 MultirespondentFormSchema.methods.getWhitelistedSubmitterIds = function () {
   return this.get('whitelistedSubmitterIds', null, {

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -561,36 +561,32 @@ MultirespondentFormSchema.pre<IMultirespondentFormSchema>(
       return next()
     }
     if ((this.workflow?.length ?? 0) > 0) {
-      return next(
-        this.invalidate(
-          'payments_field.enabled',
-          'Payments cannot be enabled on a multirespondent form with workflow steps',
-        ) as mongoose.Error.ValidationError,
+      this.invalidate(
+        'payments_field.enabled',
+        'Payments cannot be enabled on a multirespondent form with workflow steps',
       )
+      return next()
     }
     if ((this.emails?.length ?? 0) > 0) {
-      return next(
-        this.invalidate(
-          'payments_field.enabled',
-          'Payments cannot be enabled on a multirespondent form with email notifications',
-        ) as mongoose.Error.ValidationError,
+      this.invalidate(
+        'payments_field.enabled',
+        'Payments cannot be enabled on a multirespondent form with email notifications',
       )
+      return next()
     }
     if (this.stepOneEmailNotificationFieldId) {
-      return next(
-        this.invalidate(
-          'payments_field.enabled',
-          'Payments cannot be enabled on a multirespondent form with a respondent email notification',
-        ) as mongoose.Error.ValidationError,
+      this.invalidate(
+        'payments_field.enabled',
+        'Payments cannot be enabled on a multirespondent form with a respondent email notification',
       )
+      return next()
     }
     if (this.isSingleSubmission) {
-      return next(
-        this.invalidate(
-          'payments_field.enabled',
-          'Payments cannot be enabled on a multirespondent form with single submission enforcement',
-        ) as mongoose.Error.ValidationError,
+      this.invalidate(
+        'payments_field.enabled',
+        'Payments cannot be enabled on a multirespondent form with single submission enforcement',
       )
+      return next()
     }
     return next()
   },

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -215,6 +215,35 @@ export const formPaymentsFieldSchema = {
   },
 }
 
+export const formPaymentsChannelSchema = {
+  channel: {
+    type: String,
+    enum: Object.values(PaymentChannel),
+    default: PaymentChannel.Unconnected,
+  },
+  target_account_id: {
+    type: String,
+    default: '',
+    validate: [/^\S*$/i, 'target_account_id must not contain whitespace.'],
+  },
+  publishable_key: {
+    type: String,
+    default: '',
+    validate: [/^\S*$/i, 'publishable_key must not contain whitespace.'],
+  },
+  payment_methods: {
+    type: [String],
+    default: [],
+  },
+}
+
+export const formBusinessSchema = {
+  type: {
+    address: { type: String, default: '', trim: true },
+    gstRegNo: { type: String, default: '', trim: true },
+  },
+}
+
 const whitelistedSubmitterIdNestedPath = new Schema(
   {
     isWhitelistEnabled: {
@@ -268,36 +297,11 @@ const EncryptedFormSchema = new Schema<IEncryptedFormSchema>({
       isWhitelistEnabled: false,
     }),
   },
-  payments_channel: {
-    channel: {
-      type: String,
-      enum: Object.values(PaymentChannel),
-      default: PaymentChannel.Unconnected,
-    },
-    target_account_id: {
-      type: String,
-      default: '',
-      validate: [/^\S*$/i, 'target_account_id must not contain whitespace.'],
-    },
-    publishable_key: {
-      type: String,
-      default: '',
-      validate: [/^\S*$/i, 'publishable_key must not contain whitespace.'],
-    },
-    payment_methods: {
-      type: [String],
-      default: [],
-    },
-  },
+  payments_channel: formPaymentsChannelSchema,
 
   payments_field: formPaymentsFieldSchema,
 
-  business: {
-    type: {
-      address: { type: String, default: '', trim: true },
-      gstRegNo: { type: String, default: '', trim: true },
-    },
-  },
+  business: formBusinessSchema,
 
   isForceConvertToStorageMode: {
     type: Boolean,

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -1991,6 +1991,86 @@ describe('admin-form.service', () => {
       })
     })
 
+    describe('payment-enabled multirespondent form', () => {
+      const PAYMENT_ENABLED_MRF = jest.mocked({
+        _id: new ObjectId(),
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Multirespondent,
+        payments_field: { enabled: true },
+      } as unknown as IPopulatedMultirespondentForm)
+
+      const STRIPE_CONNECTED_MRF = jest.mocked({
+        _id: new ObjectId(),
+        status: FormStatus.Public,
+        responseMode: FormResponseMode.Multirespondent,
+        payments_channel: { channel: PaymentChannel.Stripe },
+        payments_field: { enabled: false },
+      } as unknown as IPopulatedMultirespondentForm)
+
+      it.each([
+        [
+          'emails',
+          { emails: ['test@example.com'] } satisfies SettingsUpdateDto,
+        ],
+        [
+          'stepOneEmailNotificationFieldId',
+          {
+            stepOneEmailNotificationFieldId: new ObjectId().toHexString(),
+          } as SettingsUpdateDto,
+        ],
+        [
+          'isSingleSubmission',
+          { isSingleSubmission: true } satisfies SettingsUpdateDto,
+        ],
+      ])(
+        'should not allow %s update when payments are enabled',
+        async (_name, settingsToUpdate) => {
+          // Act
+          const actualResult = await AdminFormService.updateFormSettings(
+            PAYMENT_ENABLED_MRF,
+            settingsToUpdate,
+          )
+
+          // Assert
+          expect(actualResult.isErr()).toBeTrue()
+          expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
+            MalformedParametersError,
+          )
+        },
+      )
+
+      it('should allow clearing emails when payments are enabled', async () => {
+        // Arrange
+        const settingsToUpdate: SettingsUpdateDto = { emails: [] }
+
+        // Act
+        const actualResult = await AdminFormService.updateFormSettings(
+          PAYMENT_ENABLED_MRF,
+          settingsToUpdate,
+        )
+
+        // Assert
+        expect(actualResult.isOk()).toBeTrue()
+      })
+
+      it('should allow emails update on a Stripe-connected MRF with payments disabled', async () => {
+        // Arrange: unlike encrypt mode, mere Stripe connection must not
+        // freeze MRF notification settings.
+        const settingsToUpdate: SettingsUpdateDto = {
+          emails: ['test@example.com'],
+        }
+
+        // Act
+        const actualResult = await AdminFormService.updateFormSettings(
+          STRIPE_CONNECTED_MRF,
+          settingsToUpdate,
+        )
+
+        // Assert
+        expect(actualResult.isOk()).toBeTrue()
+      })
+    })
+
     it('should not allow set form to public when form is email mode and isForceConvertToStorageMode is true', async () => {
       // Arrange
       const settingsToUpdate: SettingsUpdateDto = {
@@ -3902,7 +3982,7 @@ describe('admin-form.service', () => {
         } as unknown as IPopulatedForm
 
         jest
-          .spyOn(MultirespondentFormModel, 'findByIdAndUpdate')
+          .spyOn(MultirespondentFormModel, 'findOneAndUpdate')
           // @ts-ignore
           .mockReturnValue({
             exec: jest.fn().mockResolvedValue({
@@ -3945,7 +4025,7 @@ describe('admin-form.service', () => {
         } as unknown as IPopulatedForm
 
         jest
-          .spyOn(MultirespondentFormModel, 'findByIdAndUpdate')
+          .spyOn(MultirespondentFormModel, 'findOneAndUpdate')
           // @ts-ignore
           .mockReturnValue({
             exec: jest.fn().mockResolvedValue({
@@ -3968,6 +4048,103 @@ describe('admin-form.service', () => {
 
         // Assert
         expect(result.isOk()).toBe(true)
+      })
+    })
+
+    describe('payment gate', () => {
+      const NEW_STEP = {
+        workflow_type: WorkflowType.Static,
+        emails: ['step1@example.com'],
+        edit: [],
+      }
+
+      it('should reject adding a workflow step when payments are enabled', async () => {
+        // Arrange
+        const mockForm = {
+          _id: new ObjectId().toHexString(),
+          responseMode: FormResponseMode.Multirespondent,
+          form_fields: [],
+          workflow: [],
+          payments_field: { enabled: true },
+        } as unknown as IPopulatedForm
+
+        // Act
+        const result = await AdminFormService.createWorkflowStep(
+          mockForm,
+          NEW_STEP as any,
+        )
+
+        // Assert
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+          MalformedParametersError,
+        )
+      })
+
+      it('should include the payments precondition in the update filter', async () => {
+        // Arrange
+        const mockFormId = new ObjectId().toHexString()
+        const mockForm = {
+          _id: mockFormId,
+          responseMode: FormResponseMode.Multirespondent,
+          form_fields: [],
+          workflow: [],
+          payments_field: { enabled: false },
+        } as unknown as IPopulatedForm
+
+        const updateSpy = jest
+          .spyOn(MultirespondentFormModel, 'findOneAndUpdate')
+          // @ts-ignore
+          .mockReturnValue({
+            exec: jest.fn().mockResolvedValue({
+              _id: mockFormId,
+              workflow: [NEW_STEP],
+            }),
+          })
+
+        // Act
+        const result = await AdminFormService.createWorkflowStep(
+          mockForm,
+          NEW_STEP as any,
+        )
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+        expect(updateSpy).toHaveBeenCalledWith(
+          { _id: mockFormId, 'payments_field.enabled': { $ne: true } },
+          { workflow: [NEW_STEP] },
+          { new: true, runValidators: true },
+        )
+      })
+
+      it('should reject when payments were enabled concurrently (filter misses)', async () => {
+        // Arrange
+        const mockForm = {
+          _id: new ObjectId().toHexString(),
+          responseMode: FormResponseMode.Multirespondent,
+          form_fields: [],
+          workflow: [],
+          payments_field: { enabled: false },
+        } as unknown as IPopulatedForm
+
+        jest
+          .spyOn(MultirespondentFormModel, 'findOneAndUpdate')
+          // @ts-ignore
+          .mockReturnValue({
+            exec: jest.fn().mockResolvedValue(null),
+          })
+
+        // Act
+        const result = await AdminFormService.createWorkflowStep(
+          mockForm,
+          NEW_STEP as any,
+        )
+
+        // Assert
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+          MalformedParametersError,
+        )
       })
     })
   })

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -29,6 +29,7 @@ import {
   FormWorkflowDto,
   FormWorkflowStepDto,
   LogicDto,
+  MultirespondentFormSettings,
   PaymentChannel,
   SettingsUpdateDto,
   StartPageUpdateDto,
@@ -106,6 +107,7 @@ import {
   getLogicById,
   isFormEmailMode,
   isFormEncryptMode,
+  isFormMultirespondent,
 } from '../form.utils'
 
 import { PRESIGNED_POST_EXPIRY_SECS } from './admin-form.constants'
@@ -1582,6 +1584,14 @@ export const createWorkflowStep = (
     )
   }
 
+  if ((originalForm as IPopulatedMultirespondentForm).payments_field?.enabled) {
+    return errAsync(
+      new MalformedParametersError(
+        'Remove the payment field before adding workflow steps',
+      ),
+    )
+  }
+
   if (
     newWorkflowStep.workflow_type === WorkflowType.Dynamic &&
     newWorkflowStep.field
@@ -1680,8 +1690,11 @@ export const createWorkflowStep = (
   ) as IMultirespondentFormModel
 
   return ResultAsync.fromPromise(
-    MultirespondentFormModel.findByIdAndUpdate(
-      originalMrfForm._id,
+    // findOneAndUpdate skips the schema's payment-invariant pre-validate
+    // hook, so the payments precondition rides in the query filter — this
+    // also closes the race against a concurrent enable-payments update.
+    MultirespondentFormModel.findOneAndUpdate(
+      { _id: originalMrfForm._id, 'payments_field.enabled': { $ne: true } },
       { workflow: updatedWorkflow },
       {
         new: true,
@@ -1703,7 +1716,13 @@ export const createWorkflowStep = (
     },
   ).andThen((updatedForm) => {
     if (!updatedForm) {
-      return errAsync(new FormNotFoundError())
+      // The form exists (it was fetched to enter this function), so a miss
+      // here means the payments precondition failed.
+      return errAsync(
+        new MalformedParametersError(
+          'Remove the payment field before adding workflow steps',
+        ),
+      )
     }
     return okAsync((updatedForm as IMultirespondentFormSchema).workflow)
   })
@@ -1960,6 +1979,27 @@ export const updateFormSettings = (
       return errAsync(
         new MalformedParametersError(
           'Cannot update form settings when payments_field is enabled',
+        ),
+      )
+    }
+  }
+
+  // A payment-enabled multirespondent form sends no form-configured emails
+  // (the payer's receipt is the only email) and cannot enforce single
+  // submission. Unlike encrypt mode above, this arms only on the payment
+  // field being enabled — a merely Stripe-connected MRF keeps full use of
+  // its notification settings.
+  if (isFormMultirespondent(originalForm)) {
+    const mrfBody = body as MultirespondentFormSettings
+    if (
+      originalForm.payments_field?.enabled &&
+      ((mrfBody.emails && mrfBody.emails.length > 0) ||
+        mrfBody.stepOneEmailNotificationFieldId ||
+        body.isSingleSubmission)
+    ) {
+      return errAsync(
+        new MalformedParametersError(
+          'Cannot update email notification or single submission settings when payments are enabled',
         ),
       )
     }

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1575,7 +1575,10 @@ export const updateFormWhitelistSetting = (
 export const createWorkflowStep = (
   originalForm: IPopulatedForm,
   newWorkflowStep: FormWorkflowStepDto,
-): ResultAsync<FormWorkflowDto, DatabaseError | FormNotFoundError> => {
+): ResultAsync<
+  FormWorkflowDto,
+  DatabaseError | FormNotFoundError | MalformedParametersError
+> => {
   if (originalForm.responseMode !== FormResponseMode.Multirespondent) {
     return errAsync(
       new FormInvalidResponseModeError(

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1989,9 +1989,7 @@ export const updateFormSettings = (
 
   // A payment-enabled multirespondent form sends no form-configured emails
   // (the payer's receipt is the only email) and cannot enforce single
-  // submission. Unlike encrypt mode above, this arms only on the payment
-  // field being enabled — a merely Stripe-connected MRF keeps full use of
-  // its notification settings.
+  // submission.
   if (isFormMultirespondent(originalForm)) {
     const mrfBody = body as MultirespondentFormSettings
     if (

--- a/apps/backend/src/types/form.ts
+++ b/apps/backend/src/types/form.ts
@@ -380,6 +380,11 @@ export interface IMultirespondentForm extends IForm {
   stepOneEmailNotificationFieldId: string
   hasStatusTracker: boolean
   whitelistedSubmitterIds?: WhitelistedSubmitterIds
+  // Nested objects will always be returned from mongoose finds, even if they
+  // are not defined in DB. See https://github.com/Automattic/mongoose/issues/5310
+  payments_channel: FormPaymentsChannel
+  payments_field: FormPaymentsField
+  business?: FormBusinessField
 }
 
 export type IMultirespondentFormSchema = IMultirespondentForm & IFormSchema

--- a/apps/backend/src/types/form.ts
+++ b/apps/backend/src/types/form.ts
@@ -340,8 +340,6 @@ export interface IPopulatedForm extends Omit<IFormDocument, 'toJSON'> {
 
 export interface IEncryptedForm extends IForm {
   publicKey: string
-  // Nested objects will always be returned from mongoose finds, even if they
-  // are not defined in DB. See https://github.com/Automattic/mongoose/issues/5310
   payments_channel: FormPaymentsChannel
   payments_field: FormPaymentsField
   business?: FormBusinessField

--- a/apps/backend/src/types/form.ts
+++ b/apps/backend/src/types/form.ts
@@ -518,7 +518,9 @@ export type IEncryptedFormModel = Model<IEncryptedFormSchema> & IFormModel
 
 export type IEmailFormModel = IFormModel & Model<IEmailFormSchema>
 
-export type IMultirespondentFormModel = IFormModel &
-  Model<IMultirespondentFormSchema>
+// Model first so `new MultirespondentForm()` documents are typed as
+// IMultirespondentFormSchema, mirroring IEncryptedFormModel above.
+export type IMultirespondentFormModel = Model<IMultirespondentFormSchema> &
+  IFormModel
 
 export type IOnboardedForm<T extends IForm> = T

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -244,10 +244,6 @@ export interface WhitelistedSubmitterIdsWithReferenceOid extends WhitelistedSubm
   encryptedWhitelistedSubmitterIds: string // Object id of the encrypted whitelist
 }
 
-/**
- * Base for response modes that can collect payments. A form having these
- * fields does not mean it charges respondents — see `payments_field.enabled`.
- */
 export interface PaymentFormBase extends FormBase {
   payments_channel: FormPaymentsChannel
   payments_field: FormPaymentsField

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -261,7 +261,7 @@ export interface StorageFormBase extends PaymentFormBase {
   whitelistedSubmitterIds?: WhitelistedSubmitterIds | null
 }
 
-export interface MultirespondentFormBase extends FormBase {
+export interface MultirespondentFormBase extends PaymentFormBase {
   responseMode: FormResponseMode.Multirespondent
   publicKey: string
   workflow: FormWorkflow

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -244,13 +244,20 @@ export interface WhitelistedSubmitterIdsWithReferenceOid extends WhitelistedSubm
   encryptedWhitelistedSubmitterIds: string // Object id of the encrypted whitelist
 }
 
-export interface StorageFormBase extends FormBase {
-  responseMode: FormResponseMode.Encrypt
-  publicKey: string
-  emails: string[]
+/**
+ * Base for response modes that can collect payments. A form having these
+ * fields does not mean it charges respondents — see `payments_field.enabled`.
+ */
+export interface PaymentFormBase extends FormBase {
   payments_channel: FormPaymentsChannel
   payments_field: FormPaymentsField
   business?: FormBusinessField
+}
+
+export interface StorageFormBase extends PaymentFormBase {
+  responseMode: FormResponseMode.Encrypt
+  publicKey: string
+  emails: string[]
   whitelistedSubmitterIds?: WhitelistedSubmitterIds | null
 }
 


### PR DESCRIPTION
## Problem

Payments are currently only available on storage mode (Encrypt) forms. We want to support collecting payments on multirespondent forms (MRF), starting with forms that behave as single-submission forms (no workflow steps). This is PR 1 of 4 in the MRF payments stack — it lays the schema and type groundwork; admin endpoints (2/4), respondent flow (3/4), and hardening (4/4) follow.

## Solution

Schema and type changes only — no endpoints are opened yet.

- **Shared types**: extract a `PaymentFormBase` from `StorageFormBase` holding `payments_channel`, `payments_field` and `business`, and have both `StorageFormBase` and `MultirespondentFormBase` extend it.
- **Form model**: extract the `payments_channel` and `business` sub-schemas from the encrypt schema for reuse, and add `payments_channel`, `payments_field` and `business` to `MultirespondentFormSchema`, plus `addPaymentAccountId` / `removePaymentAccount` instance methods mirroring the encrypt-mode ones.
- **Payment invariants**: a pre-validate hook rejects enabling payments on an MRF that has workflow steps, form-configured email notifications, a respondent email notification field, or single-submission enforcement. Update paths that bypass document validation enforce the same invariant atomically via their query filter (`createWorkflowStep`) or an explicit guard (`updateFormSettings`).

**Breaking Changes**
- No - this PR is backwards compatible. New fields carry schema defaults; existing MRF documents hydrate with defaults (nested objects are materialised by mongoose on find).

## Tests

Unit coverage: `form.server.model.spec.ts` (payment invariants, instance methods) and `admin-form.service.spec.ts` (workflow-step and settings gates).

TC1: Payment invariants on MRF documents
- [ ] Create an MRF with no workflow steps and `payments_field.enabled: true` — verify it saves
- [ ] Attempt to save an MRF with workflow steps and payments enabled — verify it is rejected with a validation error
- [ ] Repeat for email notifications, respondent email notification field, and single submission — verify each is rejected

TC2: Workflow-step gate
- [ ] On a payment-enabled MRF, attempt to add a workflow step via the admin API — verify it fails with "Remove the payment field before adding workflow steps"

TC3: Settings gate
- [ ] On a payment-enabled MRF, attempt to update email notifications or single submission settings — verify the update is rejected

## Deploy Notes

No migration required — existing MRF documents pick up defaults on hydration.
