### PR TITLE
feat: mrf payments respondent flow (3/4)

### DIFF
--- a/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
@@ -1033,8 +1033,7 @@ describe('Form Model', () => {
           })
 
           // Act
-          const saved = (await validForm.save()) as IMultirespondentFormSchema
-          const saved = (await validForm.save()) as IMultirespondentFormSchema
+          const saved = await validForm.save()
 
           // Assert
           expect(saved._id).toBeDefined()
@@ -1110,11 +1109,9 @@ describe('Form Model', () => {
         it('should reject adding a workflow step to a saved payment-enabled form', async () => {
           // Arrange
           const form = (await new MultirespondentForm({
-          const form = (await new MultirespondentForm({
             ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
             workflow: [],
             payments_field: ENABLED_PAYMENTS_FIELD,
-          }).save()) as IMultirespondentFormSchema
           }).save()) as IMultirespondentFormSchema
           form.workflow.push({
             _id: new ObjectId().toHexString(),

--- a/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
@@ -16,6 +16,7 @@ import {
   FormFieldDto,
   FormLogoState,
   FormPaymentsField,
+  FormPaymentsField,
   FormPermission,
   FormResponseMode,
   FormStartPage,
@@ -46,6 +47,7 @@ import {
   IFormDocument,
   IFormSchema,
   ILogicSchema,
+  IMultirespondentFormSchema,
   IMultirespondentFormSchema,
   IPopulatedUser,
 } from 'src/types'
@@ -1032,6 +1034,7 @@ describe('Form Model', () => {
 
           // Act
           const saved = (await validForm.save()) as IMultirespondentFormSchema
+          const saved = (await validForm.save()) as IMultirespondentFormSchema
 
           // Assert
           expect(saved._id).toBeDefined()
@@ -1107,9 +1110,11 @@ describe('Form Model', () => {
         it('should reject adding a workflow step to a saved payment-enabled form', async () => {
           // Arrange
           const form = (await new MultirespondentForm({
+          const form = (await new MultirespondentForm({
             ...MOCK_MULTIRESPONDENT_FORM_PARAMS,
             workflow: [],
             payments_field: ENABLED_PAYMENTS_FIELD,
+          }).save()) as IMultirespondentFormSchema
           }).save()) as IMultirespondentFormSchema
           form.workflow.push({
             _id: new ObjectId().toHexString(),
@@ -1555,7 +1560,7 @@ describe('Form Model', () => {
       } as FormPaymentsField
 
       const MOCK_WORKFLOW_STEP = {
-        _id: new ObjectId().toHexString(),
+        _id: new ObjectId(),
         workflow_type: WorkflowType.Static,
         emails: ['step@open.gov.sg'],
         edit: [],

--- a/apps/backend/src/app/models/pending_submission.server.model.ts
+++ b/apps/backend/src/app/models/pending_submission.server.model.ts
@@ -6,6 +6,8 @@ import {
   IEmailSubmissionSchema,
   IEncryptedSubmissionSchema,
   IEncryptSubmissionModel,
+  IMultirespondentSubmissionModel,
+  IMultirespondentSubmissionSchema,
   ISubmissionModel,
   ISubmissionSchema,
 } from 'src/types'
@@ -13,12 +15,15 @@ import {
 import {
   EmailSubmissionSchema,
   EncryptSubmissionSchema,
+  MultirespondentSubmissionSchema,
   SubmissionSchema,
 } from './submission.server.model'
 
 export const PENDING_SUBMISSION_SCHEMA_ID = 'PendingSubmission'
 const EMAIL_PENDING_SUBMISSION_SCHEMA_ID = 'EmailPendingSubmission'
 const ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID = 'EncryptPendingSubmission'
+const MULTIRESPONDENT_PENDING_SUBMISSION_SCHEMA_ID =
+  'MultirespondentPendingSubmission'
 
 const compilePendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
   const PendingSubmission = db.model<ISubmissionSchema, ISubmissionModel>(
@@ -34,6 +39,11 @@ const compilePendingSubmissionModel = (db: Mongoose): ISubmissionModel => {
     ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID,
     EncryptSubmissionSchema,
     SubmissionType.Encrypt,
+  )
+  PendingSubmission.discriminator(
+    MULTIRESPONDENT_PENDING_SUBMISSION_SCHEMA_ID,
+    MultirespondentSubmissionSchema,
+    SubmissionType.Multirespondent,
   )
   return PendingSubmission
 }
@@ -64,5 +74,15 @@ export const getEncryptPendingSubmissionModel = (
   return db.model<IEncryptedSubmissionSchema, IEncryptSubmissionModel>(
     ENCRYPT_PENDING_SUBMISSION_SCHEMA_ID,
   )
+}
+
+export const getMultirespondentPendingSubmissionModel = (
+  db: Mongoose,
+): IMultirespondentSubmissionModel => {
+  getPendingSubmissionModel(db)
+  return db.model<
+    IMultirespondentSubmissionSchema,
+    IMultirespondentSubmissionModel
+  >(MULTIRESPONDENT_PENDING_SUBMISSION_SCHEMA_ID)
 }
 export default getPendingSubmissionModel

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -621,6 +621,11 @@ export const MultirespondentSubmissionSchema = new Schema<
     type: String,
     trim: true,
   },
+  paymentId: {
+    type: Schema.Types.ObjectId,
+    // Defer loading of the ref due to circular dependency on schema IDs.
+    ref: () => PAYMENT_SCHEMA_ID,
+  },
 })
 
 type MultiRespondentAggregates = Pick<

--- a/apps/backend/src/app/modules/payments/__tests__/payment-proof.controller.spec.ts
+++ b/apps/backend/src/app/modules/payments/__tests__/payment-proof.controller.spec.ts
@@ -1,21 +1,20 @@
 import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import expressHandler from '__tests__/unit/backend/helpers/jest-express'
 import axios from 'axios'
-import { PaymentStatus, SubmissionType } from 'formsg-shared/types'
+import {
+  FormResponseMode,
+  PaymentStatus,
+  SubmissionType,
+} from 'formsg-shared/types'
 import mongoose, { Types } from 'mongoose'
-import { errAsync, ok, okAsync } from 'neverthrow'
+import { errAsync, okAsync } from 'neverthrow'
 
 import getPaymentModel from 'src/app/models/payment.server.model'
 import { getEncryptPendingSubmissionModel } from 'src/app/models/pending_submission.server.model'
 import * as ConvertHtmlToPdf from 'src/app/utils/convert-html-to-pdf'
-import {
-  IPaymentSchema,
-  IPopulatedEncryptedForm,
-  IPopulatedForm,
-} from 'src/types'
+import { IPaymentSchema, IPopulatedForm } from 'src/types'
 
 import * as FormService from '../../form/form.service'
-import * as EncryptSubmissionService from '../../submission/encrypt-submission/encrypt-submission.service'
 import * as PaymentProofController from '../payment-proof.controller'
 import { PaymentProofUploadS3Error } from '../payment-proof.errors'
 import * as PaymentProofService from '../payment-proof.service'
@@ -34,7 +33,6 @@ jest.mock('src/app/utils/convert-html-to-pdf')
 jest.mock(
   'src/app/modules/submission/encrypt-submission/encrypt-submission.service',
 )
-const MockEncryptSubmissionService = jest.mocked(EncryptSubmissionService)
 
 jest.mock('../../form/form.service')
 const MockFormService = jest.mocked(FormService)
@@ -53,6 +51,7 @@ describe('stripe.controller', () => {
     const mockSubmissionId = new Types.ObjectId().toHexString()
     const mockForm = {
       _id: MOCK_FORM_ID,
+      responseMode: FormResponseMode.Encrypt,
       admin: {
         agency: {
           business: mockBusinessInfo,
@@ -94,9 +93,6 @@ describe('stripe.controller', () => {
     it('should reject when receipt url is not present', async () => {
       // Arrange
       MockFormService.retrieveFullFormById.mockReturnValue(okAsync(mockForm))
-      MockEncryptSubmissionService.checkFormIsEncryptMode.mockReturnValue(
-        ok(mockForm as IPopulatedEncryptedForm),
-      )
       const mockReq = expressHandler.mockRequest({
         params: { formId: mockForm._id, paymentId: payment._id },
       })
@@ -122,9 +118,6 @@ describe('stripe.controller', () => {
     it('should reject when receipt download from stripe fails', async () => {
       // Arrange
       MockFormService.retrieveFullFormById.mockReturnValue(okAsync(mockForm))
-      MockEncryptSubmissionService.checkFormIsEncryptMode.mockReturnValue(
-        ok(mockForm as IPopulatedEncryptedForm),
-      )
       const mockReq = expressHandler.mockRequest({
         params: { formId: mockForm._id, paymentId: payment._id },
       })
@@ -156,9 +149,6 @@ describe('stripe.controller', () => {
     it('should return with error if upload to s3 fails', async () => {
       // Arrange
       MockFormService.retrieveFullFormById.mockReturnValue(okAsync(mockForm))
-      MockEncryptSubmissionService.checkFormIsEncryptMode.mockReturnValue(
-        ok(mockForm as IPopulatedEncryptedForm),
-      )
 
       const mockReq = expressHandler.mockRequest({
         params: { formId: mockForm._id, paymentId: payment._id },
@@ -212,9 +202,6 @@ describe('stripe.controller', () => {
     it('should return with redirect link', async () => {
       // Arrange
       MockFormService.retrieveFullFormById.mockReturnValue(okAsync(mockForm))
-      MockEncryptSubmissionService.checkFormIsEncryptMode.mockReturnValue(
-        ok(mockForm as IPopulatedEncryptedForm),
-      )
 
       const mockReq = expressHandler.mockRequest({
         params: { formId: mockForm._id, paymentId: payment._id },

--- a/apps/backend/src/app/modules/payments/__tests__/payment-proof.controller.spec.ts
+++ b/apps/backend/src/app/modules/payments/__tests__/payment-proof.controller.spec.ts
@@ -30,10 +30,6 @@ jest.mock('axios')
 jest.mock('src/app/modules/payments/stripe.utils')
 jest.mock('src/app/utils/convert-html-to-pdf')
 
-jest.mock(
-  'src/app/modules/submission/encrypt-submission/encrypt-submission.service',
-)
-
 jest.mock('../../form/form.service')
 const MockFormService = jest.mocked(FormService)
 

--- a/apps/backend/src/app/modules/payments/payment-proof.controller.ts
+++ b/apps/backend/src/app/modules/payments/payment-proof.controller.ts
@@ -5,7 +5,7 @@ import { ResultAsync } from 'neverthrow'
 import { createLoggerWithLabel } from '../../config/logger'
 import { ControllerHandler } from '../core/core.types'
 import * as FormService from '../form/form.service'
-import { checkFormIsEncryptMode } from '../submission/encrypt-submission/encrypt-submission.service'
+import { checkFormIsEncryptModeOrMultirespondent } from '../submission/submission.utils'
 import * as UserService from '../user/user.service'
 
 import { getPaymentLogMeta } from './payment.service.utils'
@@ -39,7 +39,9 @@ export const downloadPaymentInvoice: ControllerHandler<{
 
   return ResultAsync.combine([
     PaymentService.findPaymentById(paymentId),
-    FormService.retrieveFullFormById(formId).andThen(checkFormIsEncryptMode),
+    FormService.retrieveFullFormById(formId).andThen(
+      checkFormIsEncryptModeOrMultirespondent,
+    ),
   ])
     .map(async ([payment, populatedForm]) => {
       // TODO [PDF-LAMBDA-GENERATION]: Remove setting of Growthbook targetting once pdf generation rollout is complete

--- a/apps/backend/src/app/modules/payments/payment-proof.service.ts
+++ b/apps/backend/src/app/modules/payments/payment-proof.service.ts
@@ -7,6 +7,7 @@ import {
   IPaymentSchema,
   IPopulatedEncryptedForm,
   IPopulatedForm,
+  IPopulatedMultirespondentForm,
 } from '../../../types'
 import { aws as AwsConfig } from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
@@ -180,7 +181,7 @@ export const _retrieveReceiptUrlFromStripe = (
 
 const _generatePaymentInvoiceAsPdf = (
   payment: ICompletedPaymentSchema,
-  populatedForm: IPopulatedEncryptedForm,
+  populatedForm: IPopulatedEncryptedForm | IPopulatedMultirespondentForm,
   receiptUrl: string,
 ): ResultAsync<Buffer, StripeFetchError | InvoicePdfGenerationError> => {
   if (!payment.completedPayment?.receiptUrl) {
@@ -237,7 +238,7 @@ const _generatePaymentInvoiceAsPdf = (
 
 export const generatePaymentInvoiceUrl = (
   payment: IPaymentSchema,
-  populatedForm: IPopulatedEncryptedForm,
+  populatedForm: IPopulatedEncryptedForm | IPopulatedMultirespondentForm,
 ): ResultAsync<
   string,
   | StripeFetchError

--- a/apps/backend/src/app/modules/payments/payments.service.ts
+++ b/apps/backend/src/app/modules/payments/payments.service.ts
@@ -17,6 +17,8 @@ import { FormNotFoundError } from '../form/form.errors'
 import { retrieveFormById } from '../form/form.service'
 import { performEncryptPostSubmissionActions } from '../submission/encrypt-submission/encrypt-submission.service'
 import { isSubmissionEncryptMode } from '../submission/encrypt-submission/encrypt-submission.utils'
+import { performMultirespondentPaymentPostSubmissionActions } from '../submission/multirespondent-submission/multirespondent-submission.service'
+import { isSubmissionMultirespondentMode } from '../submission/multirespondent-submission/multirespondent-submission.utils'
 import {
   PendingSubmissionNotFoundError,
   SubmissionNotFoundError,
@@ -262,6 +264,18 @@ export const performPaymentPostSubmissionActions = (
                   )
                   // Ignore failures as they will be logged, but the webhook
                   // response should not be a failure
+                  .orElse(() => okAsync(submission))
+              )
+            }
+            if (isSubmissionMultirespondentMode(submission)) {
+              // A payment-enabled MRF sends no form-configured emails, so
+              // the initial webhook is the only post-payment action; the
+              // payer's receipt email is sent below for all modes.
+              return (
+                performMultirespondentPaymentPostSubmissionActions(submission)
+                  .map(() => submission)
+                  // Ignore failures as they will be logged, but the payment
+                  // confirmation flow should not fail because of them
                   .orElse(() => okAsync(submission))
               )
             }

--- a/apps/backend/src/app/modules/payments/payments.service.ts
+++ b/apps/backend/src/app/modules/payments/payments.service.ts
@@ -1,3 +1,4 @@
+import { GrowthBook } from '@growthbook/growthbook'
 import { PaymentStatus, Product, ProductItem } from 'formsg-shared/types'
 import { isEqual, omit } from 'lodash'
 import moment from 'moment-timezone'
@@ -210,6 +211,7 @@ export const confirmPaymentPendingSubmission = (
  */
 export const performPaymentPostSubmissionActions = (
   paymentId: IPaymentSchema['_id'],
+  growthbook?: GrowthBook,
 ): ResultAsync<
   void,
   | PaymentNotFoundError
@@ -272,7 +274,10 @@ export const performPaymentPostSubmissionActions = (
               // the initial webhook is the only post-payment action; the
               // payer's receipt email is sent below for all modes.
               return (
-                performMultirespondentPaymentPostSubmissionActions(submission)
+                performMultirespondentPaymentPostSubmissionActions(
+                  submission,
+                  growthbook,
+                )
                   .map(() => submission)
                   // Ignore failures as they will be logged, but the payment
                   // confirmation flow should not fail because of them

--- a/apps/backend/src/app/modules/payments/stripe.controller.ts
+++ b/apps/backend/src/app/modules/payments/stripe.controller.ts
@@ -25,7 +25,6 @@ import { InvalidDomainError } from '../auth/auth.errors'
 import { ControllerHandler } from '../core/core.types'
 import * as FormService from '../form/form.service'
 import * as PendingSubmissionModel from '../pending-submission/pending-submission.service'
-import { checkFormIsEncryptMode } from '../submission/encrypt-submission/encrypt-submission.service'
 import { checkFormIsEncryptModeOrMultirespondent } from '../submission/submission.utils'
 
 import { getPaymentLogMeta } from './payment.service.utils'
@@ -180,7 +179,7 @@ export const getPaymentInfo: ControllerHandler<
         .andThen((submission) =>
           FormService.retrieveFullFormById(submission.form),
         )
-        .andThen(checkFormIsEncryptMode) // Payment forms are encrypted
+        .andThen(checkFormIsEncryptModeOrMultirespondent) // Payment-capable modes
         .andThen((form) => {
           const stripeAccount = payment.targetAccountId
           // Early termination to prevent consumption of QPS limit to stripe

--- a/apps/backend/src/app/modules/payments/stripe.controller.ts
+++ b/apps/backend/src/app/modules/payments/stripe.controller.ts
@@ -306,7 +306,10 @@ export const reconcileAccount: ControllerHandler<
         meta: { ...logMeta, event },
       })
 
-      await StripeService.handleStripeEvent(event as Stripe.DiscriminatedEvent)
+      await StripeService.handleStripeEvent(
+        event as Stripe.DiscriminatedEvent,
+        req.growthbook,
+      )
         .andThen(() => {
           logger.warn({
             message:

--- a/apps/backend/src/app/modules/payments/stripe.events.controller.ts
+++ b/apps/backend/src/app/modules/payments/stripe.events.controller.ts
@@ -90,7 +90,7 @@ const _handleStripeEventUpdates: ControllerHandler<
 
   // Step 3: Process the event
   return (
-    StripeService.handleStripeEvent(event)
+    StripeService.handleStripeEvent(event, req.growthbook)
       // Step 4: Return response to Stripe based on result
       .match(
         () => res.sendStatus(StatusCodes.OK),

--- a/apps/backend/src/app/modules/payments/stripe.service.ts
+++ b/apps/backend/src/app/modules/payments/stripe.service.ts
@@ -1,5 +1,6 @@
 // Use 'stripe-event-types' for better type discrimination.
 /// <reference types="stripe-event-types" />
+import { GrowthBook } from '@growthbook/growthbook'
 import cuid from 'cuid'
 import { featureFlags } from 'formsg-shared/constants'
 import {
@@ -454,6 +455,7 @@ type HandleStripeEventResultError =
  */
 export const handleStripeEvent = (
   event: Stripe.DiscriminatedEvent,
+  growthbook?: GrowthBook,
 ): ResultAsync<void, HandleStripeEventResultError> => {
   const logMeta = {
     action: 'handleStripeEvent',
@@ -500,6 +502,7 @@ export const handleStripeEvent = (
 
             return PaymentsService.performPaymentPostSubmissionActions(
               paymentId,
+              growthbook,
             )
               .andThen(() => okAsync(undefined))
               .orElse((e) => {

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.utils.ts
@@ -16,6 +16,7 @@ import Stripe from 'stripe'
 import {
   IEncryptedSubmissionSchema,
   IPopulatedEncryptedForm,
+  IPopulatedMultirespondentForm,
   ISubmissionSchema,
   StorageModeSubmissionData,
 } from '../../../../types'
@@ -102,7 +103,7 @@ export const getPaymentAmount = (
  * @param paymentProducts
  */
 export const getPaymentIntentDescription = (
-  form: IPopulatedEncryptedForm,
+  form: IPopulatedEncryptedForm | IPopulatedMultirespondentForm,
   paymentProducts?: StorageModeSubmissionContentDto['paymentProducts'],
 ) => {
   const formPaymentFields = form.payments_field
@@ -165,7 +166,7 @@ export const formatMyInfoStorageResponseData = (
 }
 
 export const getStripePaymentMethod = (
-  form: IPopulatedEncryptedForm,
+  form: IPopulatedEncryptedForm | IPopulatedMultirespondentForm,
 ): Omit<Stripe.PaymentIntentCreateParams, 'amount' | 'currency'> => {
   const isPaynowOnly =
     form.payments_channel.payment_methods?.includes(PaymentMethodType.Paynow) &&

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -8,6 +8,7 @@ import {
   FormMetadata,
   FormResponseMode,
   FormStatus,
+  PaymentChannel,
   PublicMultirespondentSubmissionDto,
   SubmissionType,
   WorkflowType,
@@ -582,6 +583,76 @@ describe('multirespondent-submision.controller', () => {
 
       // Assert
       expect(mockRes.status).not.toHaveBeenCalled() // default is 200 ok
+    })
+
+    describe('payment-enabled forms', () => {
+      const buildPaymentSubmitReq = (growthbook?: {
+        isOn: jest.Mock
+      }): Parameters<typeof submitMultirespondentFormForTest>[0] => {
+        const mockReq = expressHandler.mockRequest({
+          params: {
+            formId: mockFormId,
+            submissionId: mockSubmissionId,
+          },
+          body: {} as any,
+        })
+        return merge(mockReq, {
+          growthbook,
+          formsg: {
+            formDef: {
+              _id: mockFormId,
+              authType: FormAuthType.NIL,
+              getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+              payments_field: { enabled: true },
+              payments_channel: { channel: PaymentChannel.Stripe },
+            },
+            encryptedPayload: {
+              encryptedContent: 'encryptedContent',
+              version: 1,
+              submissionPublicKey: 'submissionPublicKey',
+              encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+              responses: {},
+              workflowStep: 0,
+            },
+          } as any,
+        })
+      }
+
+      it('returns 422 and creates nothing when the mrf-payments flag is off', async () => {
+        // Arrange
+        const mockSubmitMrfReq = buildPaymentSubmitReq({
+          isOn: jest.fn().mockReturnValue(false),
+        })
+        const mockRes = expressHandler.mockResponse()
+
+        // Act
+        await submitMultirespondentFormForTest(mockSubmitMrfReq, mockRes)
+
+        // Assert
+        expect(mockRes.status).toHaveBeenCalledWith(
+          StatusCodes.UNPROCESSABLE_ENTITY,
+        )
+        expect(
+          MockMultiRespondentSubmissionService.createMultiRespondentFormSubmission,
+        ).not.toHaveBeenCalled()
+      })
+
+      it('returns 422 when growthbook is unavailable (kill switch defaults closed)', async () => {
+        // Arrange
+        const mockSubmitMrfReq = buildPaymentSubmitReq(undefined)
+        const mockRes = expressHandler.mockResponse()
+
+        // Act
+        await submitMultirespondentFormForTest(mockSubmitMrfReq, mockRes)
+
+        // Assert
+        expect(mockRes.status).toHaveBeenCalledWith(
+          StatusCodes.UNPROCESSABLE_ENTITY,
+        )
+        expect(
+          MockMultiRespondentSubmissionService.createMultiRespondentFormSubmission,
+        ).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -9,6 +9,7 @@ import {
   FormResponseMode,
   FormStatus,
   PaymentChannel,
+  PaymentType,
   PublicMultirespondentSubmissionDto,
   SubmissionType,
   WorkflowType,
@@ -652,6 +653,48 @@ describe('multirespondent-submision.controller', () => {
         expect(
           MockMultiRespondentSubmissionService.createMultiRespondentFormSubmission,
         ).not.toHaveBeenCalled()
+      })
+
+      it('returns 400 bad request when the pending submission fails to save, mirroring encrypt mode', async () => {
+        // Arrange
+        const mockSubmitMrfReq = buildPaymentSubmitReq({
+          isOn: jest.fn().mockReturnValue(true),
+        })
+        merge(mockSubmitMrfReq, {
+          formsg: {
+            formDef: {
+              title: 'mock payment form',
+              payments_field: {
+                enabled: true,
+                payment_type: PaymentType.Fixed,
+                amount_cents: 1000,
+              },
+              payments_channel: {
+                channel: PaymentChannel.Stripe,
+                target_account_id: 'acct_mock123',
+              },
+            },
+            encryptedPayload: {
+              paymentReceiptEmail: 'respondent@example.com',
+            },
+          },
+        })
+        MockMultiRespondentSubmissionService.createMultiRespondentFormPendingSubmission =
+          jest.fn().mockReturnValue(errAsync(new SubmissionSaveError()))
+        const mockRes = expressHandler.mockResponse()
+
+        // Act
+        await submitMultirespondentFormForTest(mockSubmitMrfReq, mockRes)
+
+        // Assert
+        expect(
+          MockMultiRespondentSubmissionService.createMultiRespondentFormPendingSubmission,
+        ).toHaveBeenCalled()
+        expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+        expect(mockRes.json).toHaveBeenCalledWith({
+          message:
+            'Could not save pending submission. For assistance, please contact the person who asked you to fill in this form.',
+        })
       })
     })
   })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -29,6 +29,7 @@ import {
   handleNdiResponses,
   validateMultirespondentRemindBody,
   validateMultirespondentSubmission,
+  validatePaymentSubmission,
 } from '../multirespondent-submission.middleware'
 import {
   checkFormIsMultirespondent,
@@ -1578,6 +1579,142 @@ describe('Multirespondent Submission Middleware', () => {
         expect(mockNext).toHaveBeenCalled()
         expect(mockRes.status).not.toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('validatePaymentSubmission', () => {
+    const MOCK_FORM_ID = new ObjectId().toHexString()
+    const PRODUCT_ID = new ObjectId().toHexString()
+
+    const PRODUCT_DEFINITION = {
+      _id: PRODUCT_ID,
+      name: 'Product A',
+      description: 'A product',
+      multi_qty: false,
+      min_qty: 1,
+      max_qty: 1,
+      amount_cents: 100_00,
+    }
+
+    // Uses the real PaymentsService.validatePaymentProducts, so these tests
+    // pin the full tamper-rejection behavior, not just the wiring.
+    const createPaymentReq = ({
+      formProducts,
+      paymentProducts,
+    }: {
+      formProducts?: unknown
+      paymentProducts?: unknown
+    }) => {
+      const req = createMockReq({ formId: MOCK_FORM_ID })
+      req.formsg = {
+        formDef: {
+          toObject: () => ({
+            _id: MOCK_FORM_ID,
+            payments_field: formProducts
+              ? { enabled: true, products: formProducts }
+              : undefined,
+          }),
+        },
+      }
+      if (paymentProducts) req.body.paymentProducts = paymentProducts
+      return req
+    }
+
+    it('should call next when the submission carries no payment products', async () => {
+      const mockReq = createPaymentReq({
+        formProducts: [PRODUCT_DEFINITION],
+      })
+      const mockRes = createMockRes()
+      const mockNext = jest.fn()
+
+      await validatePaymentSubmission(mockReq, mockRes as any, mockNext)
+
+      expect(mockNext).toHaveBeenCalled()
+      expect(mockRes.status).not.toHaveBeenCalled()
+    })
+
+    it('should call next when submitted products match the form definition', async () => {
+      const mockReq = createPaymentReq({
+        formProducts: [PRODUCT_DEFINITION],
+        paymentProducts: [
+          { data: PRODUCT_DEFINITION, selected: true, quantity: 1 },
+        ],
+      })
+      const mockRes = createMockRes()
+      const mockNext = jest.fn()
+
+      await validatePaymentSubmission(mockReq, mockRes as any, mockNext)
+
+      expect(mockNext).toHaveBeenCalled()
+      expect(mockRes.status).not.toHaveBeenCalled()
+    })
+
+    it('should return 400 when payment products are submitted to a form without product definitions', async () => {
+      const mockReq = createPaymentReq({
+        paymentProducts: [
+          { data: PRODUCT_DEFINITION, selected: true, quantity: 1 },
+        ],
+      })
+      const mockRes = createMockRes()
+      const mockNext = jest.fn()
+
+      await validatePaymentSubmission(mockReq, mockRes as any, mockNext)
+
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    })
+
+    it('should return 400 when a submitted product price is tampered', async () => {
+      const mockReq = createPaymentReq({
+        formProducts: [PRODUCT_DEFINITION],
+        paymentProducts: [
+          {
+            data: { ...PRODUCT_DEFINITION, amount_cents: 50 },
+            selected: true,
+            quantity: 1,
+          },
+        ],
+      })
+      const mockRes = createMockRes()
+      const mockNext = jest.fn()
+
+      await validatePaymentSubmission(mockReq, mockRes as any, mockNext)
+
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    })
+
+    it('should return 400 when quantity exceeds the single-quantity limit', async () => {
+      const mockReq = createPaymentReq({
+        formProducts: [PRODUCT_DEFINITION],
+        paymentProducts: [
+          { data: PRODUCT_DEFINITION, selected: true, quantity: 2 },
+        ],
+      })
+      const mockRes = createMockRes()
+      const mockNext = jest.fn()
+
+      await validatePaymentSubmission(mockReq, mockRes as any, mockNext)
+
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
+    })
+
+    it('should return 400 when the same product is selected twice', async () => {
+      const mockReq = createPaymentReq({
+        formProducts: [PRODUCT_DEFINITION],
+        paymentProducts: [
+          { data: PRODUCT_DEFINITION, selected: true, quantity: 1 },
+          { data: PRODUCT_DEFINITION, selected: true, quantity: 1 },
+        ],
+      })
+      const mockRes = createMockRes()
+      const mockNext = jest.fn()
+
+      await validatePaymentSubmission(mockReq, mockRes as any, mockNext)
+
+      expect(mockNext).not.toHaveBeenCalled()
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
     })
   })
 })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -32,7 +32,6 @@ import { MultirespondentSubmissionDto, SnapshottedFormDef } from 'src/types/api'
 import { DatabaseConflictError } from '../../../core/core.errors'
 import { FormRespondentSingleSubmissionValidationError } from '../../../form/form.errors'
 import * as FormService from '../../../form/form.service'
-import { WebhookValidationError } from '../../../webhook/webhook.errors'
 import {
   MrfReminderInvalidWorkflowStepError,
   MrfReminderRecipientEmailsEmptyError,
@@ -4688,22 +4687,131 @@ describe('multirespondent-submission.service', () => {
   })
 
   describe('performMultirespondentPaymentPostSubmissionActions', () => {
-    const MOCK_WEBHOOK_URL = 'https://example.com/webhook'
+    const MOCK_GENERIC_WEBHOOK_URL = 'https://example.com/webhook'
+    const MOCK_PLUMBER_WEBHOOK_URL = 'https://plumber.gov.sg/webhooks/abc'
+    const MOCK_ADMIN_EMAIL = 'admin@example.gov.sg'
+    // No mrfVersion, so the send takes the v3 legacy shape (raw submission,
+    // no reconstructed webhook view).
     const mockSubmission = {
       id: mockSubmissionId,
       form: mockFormId,
       submissionType: SubmissionType.Multirespondent,
     } as unknown as IMultirespondentSubmissionSchema
 
+    const mockPaymentMrfFormWithWebhook = (webhookUrl: string) =>
+      okAsync({
+        _id: mockFormId,
+        admin: { email: MOCK_ADMIN_EMAIL },
+        webhook: { url: webhookUrl, isRetryEnabled: true },
+      } as unknown as IPopulatedForm)
+
+    const growthbookWithFlags = ({
+      enableMrfWebhooks = false,
+      mrfStepWriteToken = false,
+    }: {
+      enableMrfWebhooks?: boolean
+      mrfStepWriteToken?: boolean
+    }) =>
+      ({
+        isOn: jest.fn((flag: string) =>
+          flag === featureFlags.enableMrfWebhooks
+            ? enableMrfWebhooks
+            : flag === featureFlags.mrfStepWriteToken
+              ? mrfStepWriteToken
+              : false,
+        ),
+        getAttributes: jest.fn(() => ({})),
+        setAttributes: jest.fn(),
+      }) as any
+
     afterEach(() => jest.restoreAllMocks())
 
-    it('should fire the initial webhook when the form has a webhook url', async () => {
+    it('should suppress the webhook to a generic endpoint when no growthbook instance is available (flags fail closed)', async () => {
       // Arrange
-      jest.spyOn(FormService, 'retrieveFullFormById').mockReturnValue(
-        okAsync({
-          webhook: { url: MOCK_WEBHOOK_URL, isRetryEnabled: true },
-        } as IPopulatedForm),
+      jest
+        .spyOn(FormService, 'retrieveFullFormById')
+        .mockReturnValue(
+          mockPaymentMrfFormWithWebhook(MOCK_GENERIC_WEBHOOK_URL),
+        )
+      const webhookSpy = jest.spyOn(WebhookFactory, 'sendInitialWebhook')
+
+      // Act
+      const actualResult =
+        await MultirespondentSubmissionService.performMultirespondentPaymentPostSubmissionActions(
+          mockSubmission,
+        )
+
+      // Assert
+      expect(webhookSpy).not.toHaveBeenCalled()
+      expect(actualResult.isOk()).toBeTrue()
+    })
+
+    it('should suppress the webhook to a generic endpoint when the MRF webhook flags are off', async () => {
+      // Arrange
+      jest
+        .spyOn(FormService, 'retrieveFullFormById')
+        .mockReturnValue(
+          mockPaymentMrfFormWithWebhook(MOCK_GENERIC_WEBHOOK_URL),
+        )
+      const webhookSpy = jest.spyOn(WebhookFactory, 'sendInitialWebhook')
+
+      // Act
+      const actualResult =
+        await MultirespondentSubmissionService.performMultirespondentPaymentPostSubmissionActions(
+          mockSubmission,
+          growthbookWithFlags({
+            enableMrfWebhooks: false,
+            mrfStepWriteToken: false,
+          }),
+        )
+
+      // Assert
+      expect(webhookSpy).not.toHaveBeenCalled()
+      expect(actualResult.isOk()).toBeTrue()
+    })
+
+    it('should fire the webhook to a generic endpoint when the MRF webhook flags are on, targeting the flags by form and admin', async () => {
+      // Arrange
+      jest
+        .spyOn(FormService, 'retrieveFullFormById')
+        .mockReturnValue(
+          mockPaymentMrfFormWithWebhook(MOCK_GENERIC_WEBHOOK_URL),
+        )
+      const webhookSpy = jest
+        .spyOn(WebhookFactory, 'sendInitialWebhook')
+        .mockReturnValue(okAsync(true))
+      const mockGrowthbook = growthbookWithFlags({
+        enableMrfWebhooks: true,
+        mrfStepWriteToken: true,
+      })
+
+      // Act
+      const actualResult =
+        await MultirespondentSubmissionService.performMultirespondentPaymentPostSubmissionActions(
+          mockSubmission,
+          mockGrowthbook,
+        )
+
+      // Assert
+      expect(mockGrowthbook.setAttributes).toHaveBeenCalledWith({
+        formId: String(mockFormId),
+        adminEmail: MOCK_ADMIN_EMAIL,
+      })
+      expect(webhookSpy).toHaveBeenCalledWith(
+        mockSubmission,
+        MOCK_GENERIC_WEBHOOK_URL,
+        true,
       )
+      expect(actualResult.isOk()).toBeTrue()
+    })
+
+    it('should fire the webhook to a plumber endpoint even without a growthbook instance', async () => {
+      // Arrange
+      jest
+        .spyOn(FormService, 'retrieveFullFormById')
+        .mockReturnValue(
+          mockPaymentMrfFormWithWebhook(MOCK_PLUMBER_WEBHOOK_URL),
+        )
       const webhookSpy = jest
         .spyOn(WebhookFactory, 'sendInitialWebhook')
         .mockReturnValue(okAsync(true))
@@ -4717,7 +4825,7 @@ describe('multirespondent-submission.service', () => {
       // Assert
       expect(webhookSpy).toHaveBeenCalledWith(
         mockSubmission,
-        MOCK_WEBHOOK_URL,
+        MOCK_PLUMBER_WEBHOOK_URL,
         true,
       )
       expect(actualResult.isOk()).toBeTrue()
@@ -4739,30 +4847,6 @@ describe('multirespondent-submission.service', () => {
       // Assert
       expect(webhookSpy).not.toHaveBeenCalled()
       expect(actualResult.isOk()).toBeTrue()
-    })
-
-    it('should return the webhook error when sending fails', async () => {
-      // Arrange
-      jest.spyOn(FormService, 'retrieveFullFormById').mockReturnValue(
-        okAsync({
-          webhook: { url: MOCK_WEBHOOK_URL, isRetryEnabled: false },
-        } as IPopulatedForm),
-      )
-      jest
-        .spyOn(WebhookFactory, 'sendInitialWebhook')
-        .mockReturnValue(errAsync(new WebhookValidationError()))
-
-      // Act
-      const actualResult =
-        await MultirespondentSubmissionService.performMultirespondentPaymentPostSubmissionActions(
-          mockSubmission,
-        )
-
-      // Assert
-      expect(actualResult.isErr()).toBeTrue()
-      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
-        WebhookValidationError,
-      )
     })
   })
 })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -23,6 +23,7 @@ import MailService from 'src/app/services/mail/mail.service'
 import * as MailUtils from 'src/app/services/mail/mail.utils'
 import {
   IMultirespondentSubmissionSchema,
+  IPopulatedForm,
   IPopulatedMultirespondentForm,
   WebhookView,
 } from 'src/types'
@@ -30,6 +31,8 @@ import { MultirespondentSubmissionDto, SnapshottedFormDef } from 'src/types/api'
 
 import { DatabaseConflictError } from '../../../core/core.errors'
 import { FormRespondentSingleSubmissionValidationError } from '../../../form/form.errors'
+import * as FormService from '../../../form/form.service'
+import { WebhookValidationError } from '../../../webhook/webhook.errors'
 import {
   MrfReminderInvalidWorkflowStepError,
   MrfReminderRecipientEmailsEmptyError,
@@ -4681,6 +4684,85 @@ describe('multirespondent-submission.service', () => {
       expect(sendSpy).toHaveBeenCalledTimes(1)
       expect(sendSpy.mock.calls[0][3]).toBeUndefined()
       expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('performMultirespondentPaymentPostSubmissionActions', () => {
+    const MOCK_WEBHOOK_URL = 'https://example.com/webhook'
+    const mockSubmission = {
+      id: mockSubmissionId,
+      form: mockFormId,
+      submissionType: SubmissionType.Multirespondent,
+    } as unknown as IMultirespondentSubmissionSchema
+
+    afterEach(() => jest.restoreAllMocks())
+
+    it('should fire the initial webhook when the form has a webhook url', async () => {
+      // Arrange
+      jest.spyOn(FormService, 'retrieveFullFormById').mockReturnValue(
+        okAsync({
+          webhook: { url: MOCK_WEBHOOK_URL, isRetryEnabled: true },
+        } as IPopulatedForm),
+      )
+      const webhookSpy = jest
+        .spyOn(WebhookFactory, 'sendInitialWebhook')
+        .mockReturnValue(okAsync(true))
+
+      // Act
+      const actualResult =
+        await MultirespondentSubmissionService.performMultirespondentPaymentPostSubmissionActions(
+          mockSubmission,
+        )
+
+      // Assert
+      expect(webhookSpy).toHaveBeenCalledWith(
+        mockSubmission,
+        MOCK_WEBHOOK_URL,
+        true,
+      )
+      expect(actualResult.isOk()).toBeTrue()
+    })
+
+    it('should not fire a webhook when the form has none configured', async () => {
+      // Arrange
+      jest
+        .spyOn(FormService, 'retrieveFullFormById')
+        .mockReturnValue(okAsync({ webhook: { url: '' } } as IPopulatedForm))
+      const webhookSpy = jest.spyOn(WebhookFactory, 'sendInitialWebhook')
+
+      // Act
+      const actualResult =
+        await MultirespondentSubmissionService.performMultirespondentPaymentPostSubmissionActions(
+          mockSubmission,
+        )
+
+      // Assert
+      expect(webhookSpy).not.toHaveBeenCalled()
+      expect(actualResult.isOk()).toBeTrue()
+    })
+
+    it('should return the webhook error when sending fails', async () => {
+      // Arrange
+      jest.spyOn(FormService, 'retrieveFullFormById').mockReturnValue(
+        okAsync({
+          webhook: { url: MOCK_WEBHOOK_URL, isRetryEnabled: false },
+        } as IPopulatedForm),
+      )
+      jest
+        .spyOn(WebhookFactory, 'sendInitialWebhook')
+        .mockReturnValue(errAsync(new WebhookValidationError()))
+
+      // Act
+      const actualResult =
+        await MultirespondentSubmissionService.performMultirespondentPaymentPostSubmissionActions(
+          mockSubmission,
+        )
+
+      // Assert
+      expect(actualResult.isErr()).toBeTrue()
+      expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
+        WebhookValidationError,
+      )
     })
   })
 })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -317,9 +317,16 @@ const _createPaymentSubmission = async ({
       logMeta,
     })
   if (createPendingSubmissionResult.isErr()) {
-    const { errorMessage, statusCode } = mapRouteError(
-      createPendingSubmissionResult.error,
-    )
+    const error = createPendingSubmissionResult.error
+    // Mirror encrypt mode: a pending-save failure blocks the respondent with
+    // a 400 so they can retry, rather than mapRouteError's generic 500.
+    if (error instanceof SubmissionSaveError) {
+      return res.status(StatusCodes.BAD_REQUEST).json({
+        message:
+          'Could not save pending submission. For assistance, please contact the person who asked you to fill in this form.',
+      })
+    }
+    const { errorMessage, statusCode } = mapRouteError(error)
     return res.status(statusCode).json({ message: errorMessage })
   }
   const pendingSubmission = createPendingSubmissionResult.value

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -146,6 +146,20 @@ const submitMultirespondentForm = async (
     form.payments_field?.enabled &&
     form.payments_channel?.channel === PaymentChannel.Stripe
   ) {
+    // Kill switch: with the flag off the submission is blocked outright — a
+    // payment submission must never fall through to the non-payment path.
+    const isMrfPaymentsEnabled = gb?.isOn(featureFlags.mrfPayments) ?? false
+    if (!isMrfPaymentsEnabled) {
+      logger.warn({
+        message:
+          'Blocked MRF payment submission: mrf-payments feature flag is off',
+        meta: logMeta,
+      })
+      return res.status(StatusCodes.UNPROCESSABLE_ENTITY).json({
+        message:
+          'Payments are currently unavailable for this form. Please try again later, or contact the form admin.',
+      })
+    }
     return _createPaymentSubmission({
       req,
       res,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -384,7 +384,6 @@ const _createPaymentSubmission = async ({
       await stripe.paymentIntents.cancel(paymentIntent.id, {
         stripeAccount: targetAccountId,
       })
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (stripeErr) {
       logger.error({
         message: 'Failed to cancel Stripe payment intent',
@@ -393,7 +392,7 @@ const _createPaymentSubmission = async ({
           pendingSubmissionId,
           paymentIntentId,
         },
-        error: err,
+        error: stripeErr,
       })
     }
     // Regardless of whether the cancellation succeeded or failed, block the

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -3,17 +3,28 @@ import { featureFlags } from 'formsg-shared/constants'
 import {
   ErrorDto,
   FormResponseMode,
+  PaymentChannel,
+  PaymentType,
   PublicMultirespondentSubmissionDto,
   SubmissionType,
 } from 'formsg-shared/types'
 import { getMultirespondentSubmissionEditPath } from 'formsg-shared/utils/urls'
 import { StatusCodes } from 'http-status-codes'
+import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
+import Stripe from 'stripe'
 
-import { Environment } from '../../../../types'
+import { Environment, IPopulatedMultirespondentForm } from '../../../../types'
+import { StripePaymentMetadataDto } from '../../../../types/payment'
 import config, { isTest } from '../../../config/config'
+import { paymentConfig } from '../../../config/features/payment.config'
 import { spcpMyInfoConfig } from '../../../config/features/spcp-myinfo.config'
-import { createLoggerWithLabel } from '../../../config/logger'
+import {
+  createLoggerWithLabel,
+  CustomLoggerParams,
+} from '../../../config/logger'
+import { stripe } from '../../../loaders/stripe'
+import getPaymentModel from '../../../models/payment.server.model'
 import * as CaptchaMiddleware from '../../../services/captcha/captcha.middleware'
 import * as TurnstileMiddleware from '../../../services/turnstile/turnstile.middleware'
 import { Pipeline } from '../../../utils/pipeline-middleware'
@@ -32,6 +43,11 @@ import {
   ensurePublicForm,
   ensureValidCaptcha,
 } from '../encrypt-submission/encrypt-submission.ensures'
+import {
+  getPaymentAmount,
+  getPaymentIntentDescription,
+  getStripePaymentMethod,
+} from '../encrypt-submission/encrypt-submission.utils'
 import * as ReceiverMiddleware from '../receiver/receiver.middleware'
 import {
   InvalidSubmissionTypeError,
@@ -48,6 +64,7 @@ import { ensureSubmitterIdIsWhitelisted } from './multirespondent-submission.ens
 import * as MultirespondentSubmissionMiddleware from './multirespondent-submission.middleware'
 import {
   checkFormIsMultirespondent,
+  createMultiRespondentFormPendingSubmission,
   createMultiRespondentFormSubmission,
   getPendingStepRecipientEmailsFromSubmittedStepsMeta,
   performMultiRespondentPostSubmissionCreateActions,
@@ -68,6 +85,7 @@ import {
 } from './multirespondent-submission.utils'
 
 const logger = createLoggerWithLabel(module)
+const Payment = getPaymentModel(mongoose)
 
 const appUrl =
   process.env.NODE_ENV === Environment.Dev
@@ -121,6 +139,22 @@ const submitMultirespondentForm = async (
 
   const encryptedPayload = req.formsg.encryptedPayload
 
+  // Handle submissions for payment-enabled (necessarily zero-step) forms:
+  // the submission is saved as a pending submission and only promoted to a
+  // real submission when the Stripe webhook confirms the payment.
+  if (
+    form.payments_field?.enabled &&
+    form.payments_channel?.channel === PaymentChannel.Stripe
+  ) {
+    return _createPaymentSubmission({
+      req,
+      res,
+      form,
+      logMeta,
+      formId,
+    })
+  }
+
   const createMultiRespondentFormSubmissionResult =
     await createMultiRespondentFormSubmission({
       form,
@@ -159,6 +193,234 @@ const submitMultirespondentForm = async (
 }
 
 export const submitMultirespondentFormForTest = submitMultirespondentForm
+
+/**
+ * Payment path for zero-step multirespondent forms. Mirrors the encrypt-mode
+ * flow: create a Payment document and a pending submission, then a Stripe
+ * payment intent. Nothing observable (admin views, notifications) happens
+ * until the charge.succeeded webhook promotes the pending submission.
+ */
+const _createPaymentSubmission = async ({
+  req,
+  res,
+  form,
+  logMeta,
+  formId,
+}: {
+  req: SubmitMultirespondentFormHandlerRequest
+  res: Parameters<SubmitMultirespondentFormHandlerType>[1]
+  form: IPopulatedMultirespondentForm
+  formId: string
+  logMeta: CustomLoggerParams['meta']
+}) => {
+  const encryptedPayload = req.formsg.encryptedPayload
+  const paymentProducts = encryptedPayload.paymentProducts
+
+  const amount = getPaymentAmount(
+    form.payments_field,
+    encryptedPayload.payments,
+    paymentProducts,
+  )
+
+  const isPaymentTypeProducts =
+    form.payments_field.payment_type === PaymentType.Products
+
+  logger.info({
+    message: 'Incoming payments',
+    meta: {
+      ...logMeta,
+      paymentProducts,
+      paymentType: form.payments_field.payment_type,
+      amount,
+    },
+  })
+
+  // Step 0: Perform validation checks
+  if (!amount) {
+    logger.error({
+      message: 'Error when creating payment: amount is missing',
+      meta: logMeta,
+    })
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message:
+        "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+    })
+  }
+
+  const paymentMinAmount =
+    form.payments_field.global_min_amount_override ||
+    paymentConfig.minPaymentAmountCents
+
+  if (
+    amount < paymentMinAmount ||
+    amount > paymentConfig.maxPaymentAmountCents
+  ) {
+    logger.error({
+      message: 'Error when creating payment: amount is not within bounds',
+      meta: logMeta,
+    })
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message:
+        "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+    })
+  }
+
+  const paymentReceiptEmail =
+    encryptedPayload.paymentReceiptEmail?.toLowerCase()
+  if (!paymentReceiptEmail) {
+    logger.error({
+      message:
+        'Error when creating payment: payment receipt email not provided.',
+      meta: logMeta,
+    })
+    return res.status(StatusCodes.BAD_REQUEST).json({
+      message:
+        "The form's payment settings are invalid. Please contact the admin of the form to rectify the issue.",
+    })
+  }
+
+  const targetAccountId = form.payments_channel.target_account_id
+
+  // Step 1: Create payment without payment intent id and pending submission id.
+  const payment = new Payment({
+    formId,
+    targetAccountId,
+    amount,
+    email: paymentReceiptEmail,
+    responses: [],
+    ...(isPaymentTypeProducts ? { products: paymentProducts } : {}),
+    gstEnabled: form.payments_field.gst_enabled,
+    payment_fields_snapshot: form.payments_field,
+  })
+  const paymentId = payment.id
+
+  // Step 2: Create and save pending submission.
+  const createPendingSubmissionResult =
+    await createMultiRespondentFormPendingSubmission({
+      form,
+      encryptedPayload,
+      paymentId,
+      logMeta,
+    })
+  if (createPendingSubmissionResult.isErr()) {
+    const { errorMessage, statusCode } = mapRouteError(
+      createPendingSubmissionResult.error,
+    )
+    return res.status(statusCode).json({ message: errorMessage })
+  }
+  const pendingSubmission = createPendingSubmissionResult.value
+  const pendingSubmissionId = pendingSubmission.id
+
+  // Step 3: Create the payment intent via API call to stripe.
+  const metadata: StripePaymentMetadataDto = {
+    env: config.envSiteName,
+    formTitle: form.title,
+    formId,
+    submissionId: pendingSubmissionId,
+    paymentId,
+    paymentContactEmail: paymentReceiptEmail,
+  }
+
+  const createPaymentIntentParams: Stripe.PaymentIntentCreateParams = {
+    amount,
+    currency: paymentConfig.defaultCurrency,
+    ...getStripePaymentMethod(form),
+    description: getPaymentIntentDescription(form, paymentProducts),
+    receipt_email: paymentReceiptEmail,
+    metadata,
+  }
+
+  let paymentIntent
+  try {
+    paymentIntent = await stripe.paymentIntents.create(
+      createPaymentIntentParams,
+      { stripeAccount: targetAccountId },
+    )
+  } catch (err) {
+    logger.error({
+      message: 'Error when creating payment intent',
+      meta: {
+        ...logMeta,
+        pendingSubmissionId,
+        createPaymentIntentParams,
+      },
+      error: err,
+    })
+    // Return a 502 error here since the issue was with Stripe.
+    return res.status(StatusCodes.BAD_GATEWAY).json({
+      message:
+        'There was a problem creating the payment intent. Please try again.',
+    })
+  }
+
+  const paymentIntentId = paymentIntent.id
+  logger.info({
+    message: 'Created payment intent from Stripe',
+    meta: {
+      ...logMeta,
+      pendingSubmissionId,
+      paymentIntentId,
+    },
+  })
+
+  // Step 4: Update payment document with payment intent id and pending
+  // submission id, and save it.
+  payment.paymentIntentId = paymentIntentId
+  payment.pendingSubmissionId = pendingSubmissionId
+  try {
+    await payment.save()
+  } catch (err) {
+    logger.error({
+      message: 'Error updating payment document with payment intent id',
+      meta: {
+        ...logMeta,
+        pendingSubmissionId,
+        paymentIntentId,
+      },
+      error: err,
+    })
+    // Cancel the payment intent if saving the document fails.
+    try {
+      await stripe.paymentIntents.cancel(paymentIntent.id, {
+        stripeAccount: targetAccountId,
+      })
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (stripeErr) {
+      logger.error({
+        message: 'Failed to cancel Stripe payment intent',
+        meta: {
+          ...logMeta,
+          pendingSubmissionId,
+          paymentIntentId,
+        },
+        error: err,
+      })
+    }
+    // Regardless of whether the cancellation succeeded or failed, block the
+    // submission so that user can try to resubmit
+    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      message:
+        'There was a problem updating the payment document. Please try again.',
+    })
+  }
+
+  logger.info({
+    message: 'Saved payment document to DB',
+    meta: {
+      ...logMeta,
+      pendingSubmissionId,
+      paymentIntentId,
+      paymentId,
+    },
+  })
+
+  return res.json({
+    message: 'Form submission successful',
+    submissionId: pendingSubmissionId,
+    timestamp: (pendingSubmission.created || new Date()).getTime(),
+    paymentData: { paymentId },
+  })
+}
 
 const updateMultirespondentSubmission = async (
   req: UpdateMultirespondentSubmissionHandlerRequest,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -547,6 +547,7 @@ export const handleMultirespondentSubmission = [
   MultirespondentSubmissionMiddleware.createFormsgAndRetrieveForm,
   MultirespondentSubmissionMiddleware.scanAndRetrieveAttachments,
   MultirespondentSubmissionMiddleware.validateMultirespondentSubmission,
+  MultirespondentSubmissionMiddleware.validatePaymentSubmission,
   MultirespondentSubmissionMiddleware.encryptSubmission,
   MultirespondentSubmissionMiddleware.handleNdiResponses,
   submitMultirespondentForm,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -15,6 +15,7 @@ import {
   FormDto,
   FormFieldDto,
   FormResponseMode,
+  isPaymentsProducts,
   SubmissionType,
 } from 'formsg-shared/types'
 import { StatusCodes } from 'http-status-codes'
@@ -52,6 +53,7 @@ import { assertFormAvailable } from '../../form/admin-form/admin-form.utils'
 import * as FormService from '../../form/form.service'
 import { MyInfoService } from '../../myinfo/myinfo.service'
 import { extractMyInfoLoginJwt } from '../../myinfo/myinfo.util'
+import * as PaymentsService from '../../payments/payments.service'
 import { getOidcService } from '../../spcp/spcp.oidc.service'
 import { createNdiResponsesV4FromRecord } from '../../spcp/spcp.util'
 import * as VerifiedContentService from '../../verified-content/verified-content.service'
@@ -746,6 +748,61 @@ export const validateMultirespondentSubmission = async (
         return sendRouteError(res, mapRouteError(error))
       })
   )
+}
+
+/**
+ * Middleware to validate payment content against the form definition,
+ * mirroring EncryptSubmissionMiddleware.validatePaymentSubmission. Without
+ * this, the charge is computed from the client's paymentProducts payload,
+ * so a respondent could tamper prices, quantities, or duplicates.
+ */
+export const validatePaymentSubmission = async (
+  req: MultirespondentSubmissionMiddlewareHandlerRequest,
+  res: Parameters<MultirespondentSubmissionMiddlewareHandlerType>[1],
+  next: NextFunction,
+) => {
+  const formDef = req.formsg.formDef.toObject()
+
+  const logMeta = {
+    action: 'validatePaymentSubmission',
+    formId: String(formDef._id),
+    ...createReqMeta(req),
+  }
+
+  const formDefProducts = formDef?.payments_field?.products
+  const submittedPaymentProducts = req.body.paymentProducts
+  if (submittedPaymentProducts) {
+    if (!isPaymentsProducts(formDefProducts)) {
+      // Payment definition does not allow for payment by product
+
+      logger.error({
+        message: 'Invalid form definition for payment by product',
+        meta: logMeta,
+      })
+
+      return res.status(StatusCodes.BAD_REQUEST).json({
+        message:
+          'The payment settings in this form have been updated. Please refresh and try again.',
+      })
+    }
+    return PaymentsService.validatePaymentProducts(
+      formDefProducts,
+      submittedPaymentProducts,
+    )
+      .map(() => next())
+      .mapErr((error) => {
+        logger.error({
+          message: 'Error validating payment submission',
+          meta: logMeta,
+          error,
+        })
+        const { statusCode, errorMessage } = mapRouteError(error)
+        return res.status(statusCode).json({
+          message: errorMessage,
+        })
+      })
+  }
+  return next()
 }
 
 export const setCurrentWorkflowStep = async (

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -36,6 +36,7 @@ import {
   SnapshottedFormDef,
 } from '../../../../types/api/multirespondent_submission'
 import { isDev } from '../../../config/config'
+import { paymentConfig } from '../../../config/features/payment.config'
 import formsgSdk from '../../../config/formsg-sdk'
 import { createLoggerWithLabel } from '../../../config/logger'
 import {
@@ -46,6 +47,7 @@ import { createReqMeta } from '../../../utils/request'
 import { isFieldResponseV4Equal } from '../../../utils/response-v4'
 import { DatabaseError } from '../../core/core.errors'
 import * as FeatureFlagService from '../../feature-flags/feature-flags.service'
+import { JoiPaymentProduct } from '../../form/admin-form/admin-form.payments.constants'
 import { assertFormAvailable } from '../../form/admin-form/admin-form.utils'
 import * as FormService from '../../form/form.service'
 import { MyInfoService } from '../../myinfo/myinfo.service'
@@ -114,8 +116,29 @@ const multirespondentSubmissionBodySchema = Joi.object({
   respondentEmails: Joi.array().items(Joi.string()),
 })
 
+// Payment fields are only accepted on submission creation: a payment-enabled
+// form is necessarily zero-step, so there are no later steps to update.
+const submitMultirespondentSubmissionBodySchema =
+  multirespondentSubmissionBodySchema.keys({
+    paymentProducts: Joi.array().items(
+      Joi.object().keys({
+        data: JoiPaymentProduct.required(),
+        selected: Joi.boolean(),
+        quantity: Joi.number().integer().positive().required(),
+      }),
+    ),
+    paymentReceiptEmail: Joi.string(),
+    payments: Joi.object({
+      amount_cents: Joi.number()
+        .integer()
+        .positive()
+        .min(paymentConfig.minPaymentAmountCents)
+        .max(paymentConfig.maxPaymentAmountCents),
+    }),
+  })
+
 export const validateMultirespondentSubmissionParams = celebrate({
-  [Segments.BODY]: multirespondentSubmissionBodySchema,
+  [Segments.BODY]: submitMultirespondentSubmissionBodySchema,
 })
 
 const multirespondentSubmissionKeySchema = Joi.object({
@@ -920,6 +943,9 @@ export const encryptSubmission = async (
     responses: responses as FieldResponsesV4,
     mrfVersion,
     ...mintedStepToken,
+    paymentReceiptEmail: req.body.paymentReceiptEmail,
+    paymentProducts: req.body.paymentProducts,
+    payments: req.body.payments,
   }
 
   return next()

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -36,6 +36,7 @@ import {
   createLoggerWithLabel,
   CustomLoggerParams,
 } from '../../../config/logger'
+import { getMultirespondentPendingSubmissionModel } from '../../../models/pending_submission.server.model'
 import { getMultirespondentSubmissionModel } from '../../../models/submission.server.model'
 import {
   AutoreplyPdfGenerationError,
@@ -97,6 +98,8 @@ import {
 
 const logger = createLoggerWithLabel(module)
 const MultirespondentSubmission = getMultirespondentSubmissionModel(mongoose)
+const MultirespondentPendingSubmission =
+  getMultirespondentPendingSubmissionModel(mongoose)
 const appUrl =
   process.env.NODE_ENV === Environment.Dev
     ? config.app.feAppUrl
@@ -938,6 +941,109 @@ export const createMultiRespondentFormSubmission = ({
 
       return { submission, snapshot }
     })
+}
+
+/**
+ * Saves an incoming payment-form submission as a *pending* submission: it is
+ * only promoted to a real submission when the Stripe webhook confirms the
+ * payment. Payment-enabled multirespondent forms are necessarily zero-step
+ * (no next-step recipients) and cannot enforce single submission, so this is
+ * a simpler variant of createMultiRespondentFormSubmission.
+ */
+export const createMultiRespondentFormPendingSubmission = ({
+  form,
+  encryptedPayload,
+  paymentId,
+  logMeta,
+}: {
+  form: IPopulatedMultirespondentForm
+  encryptedPayload: MultirespondentSubmissionDto
+  paymentId: string
+  logMeta: CustomLoggerParams['meta']
+}): ResultAsync<
+  IMultirespondentSubmissionSchema & { _id: mongoose.Types.ObjectId },
+  AttachmentUploadError | SubmissionSaveError
+> => {
+  logMeta = {
+    ...logMeta,
+    action: 'createMultiRespondentFormPendingSubmission',
+  }
+
+  return saveAttachmentsToDbIfExists({
+    formId: form._id,
+    attachments: encryptedPayload.attachments,
+  }).andThen((attachmentMetadata) => {
+    const {
+      submissionPublicKey,
+      encryptedSubmissionSecretKey,
+      encryptedContent,
+      verifiedContent,
+      responseMetadata,
+      version,
+      mrfVersion,
+      hashedSubmitterId,
+      stepTokenHash,
+      encryptedStepToken,
+    } = encryptedPayload
+
+    const submittedStepMeta: SubmittedNonApprovalStep = {
+      isApproval: false, // first step cannot be approval step
+      submittedAt: new Date().toISOString(),
+      submitterId: hashedSubmitterId,
+    }
+
+    const submissionContent: MultirespondentSubmissionContent = {
+      form: form._id,
+      authType: form.authType,
+      myInfoFields: form.getUniqueMyInfoAttrs(),
+      form_fields: form.form_fields,
+      form_logics: form.form_logics,
+      workflow: form.workflow,
+      submissionPublicKey,
+      encryptedSubmissionSecretKey,
+      encryptedContent,
+      verifiedContent,
+      attachmentMetadata,
+      version,
+      workflowStep: 0,
+      mrfVersion,
+      submittedSteps: [submittedStepMeta],
+      stepTokenHash,
+      encryptedStepToken,
+      paymentId,
+    }
+
+    const pendingSubmission = new MultirespondentPendingSubmission(
+      submissionContent,
+    )
+
+    return ResultAsync.fromPromise(pendingSubmission.save(), (error) => {
+      logger.error({
+        message: 'Multirespondent pending submission save error',
+        meta: logMeta,
+        error,
+      })
+      return new SubmissionSaveError()
+    }).map((pendingSubmission) => {
+      logger.info({
+        message: 'Saved pending submission to MongoDB',
+        meta: {
+          ...logMeta,
+          pendingSubmissionId: pendingSubmission.id,
+          responseMetadata,
+        },
+      })
+
+      if (responseMetadata) {
+        reportSubmissionResponseTime(responseMetadata, {
+          mode: 'multirespodent',
+          payment: 'true',
+        })
+      }
+
+      return pendingSubmission
+    })
+  })
 }
 
 interface CheckIfRespondentFormSummaryIsRequiredArgs {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -52,10 +52,6 @@ import {
 } from '../../form/form.errors'
 import * as FormService from '../../form/form.service'
 import { isFormMultirespondent } from '../../form/form.utils'
-import {
-  WebhookPushToQueueError,
-  WebhookValidationError,
-} from '../../webhook/webhook.errors'
 import { WebhookFactory } from '../../webhook/webhook.factory'
 import { getWebhookType } from '../../webhook/webhook.service'
 import {
@@ -1226,6 +1222,7 @@ const sendMrfInitialWebhookIfEligible = ({
   isRetryEnabled,
   growthbook,
   logMeta,
+  errorMessage = 'Multirespondent submission webhook error',
 }: {
   submission: IMultirespondentSubmissionSchema
   snapshot?: SubmissionSnapshotV4
@@ -1233,6 +1230,7 @@ const sendMrfInitialWebhookIfEligible = ({
   isRetryEnabled: boolean
   growthbook?: GrowthBook
   logMeta: CustomLoggerParams['meta']
+  errorMessage?: string
 }): void => {
   const webhookType = getWebhookType(webhookUrl)
   const isStepWriteTokenEnabled =
@@ -1263,7 +1261,7 @@ const sendMrfInitialWebhookIfEligible = ({
       isRetryEnabled,
     ).mapErr((error) => {
       logger.error({
-        message: 'Multirespondent submission webhook error',
+        message: errorMessage,
         meta: logMeta,
         error,
       })
@@ -1316,7 +1314,7 @@ const sendMrfInitialWebhookIfEligible = ({
     })
     .mapErr((error) => {
       logger.error({
-        message: 'Multirespondent submission webhook error',
+        message: errorMessage,
         meta: logMeta,
         error,
       })
@@ -1470,47 +1468,44 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
  * Performs post-submission actions for a multirespondent submission promoted
  * from a pending submission on payment confirmation. A payment-enabled MRF
  * sends no form-configured emails, so the only action mirrored from
- * submission creation is the initial webhook; the payer's receipt email is
- * sent by the payments machinery.
+ * submission creation is the initial webhook — routed through the same
+ * eligibility gate and payload policy as non-payment submissions; the
+ * payer's receipt email is sent by the payments machinery.
  * @param submission the promoted multirespondent submission
+ * @param growthbook growthbook instance of the triggering request, used to
+ * evaluate the MRF webhook rollout flags (absent means flags-off, so only
+ * plumber webhooks fire)
  */
 export const performMultirespondentPaymentPostSubmissionActions = (
   submission: IMultirespondentSubmissionSchema,
-): ResultAsync<
-  true,
-  | FormNotFoundError
-  | PossibleDatabaseError
-  | WebhookValidationError
-  | SubmissionNotFoundError
-  | WebhookPushToQueueError
-> => {
+  growthbook?: GrowthBook,
+): ResultAsync<true, FormNotFoundError | PossibleDatabaseError> => {
   const logMeta = {
     action: 'performMultirespondentPaymentPostSubmissionActions',
     submissionId: submission.id,
   }
 
-  return FormService.retrieveFullFormById(submission.form).andThen((form) => {
+  return FormService.retrieveFullFormById(submission.form).map((form) => {
     const webhookUrl = form.webhook?.url
-    if (!webhookUrl) return okAsync(true as const)
+    if (!webhookUrl) return true as const
 
-    logger.info({
-      message:
-        'Sending initial webhook for payment-confirmed multirespondent submission',
-      meta: logMeta,
+    // Mirror the submission paths: target the rollout flags by form and
+    // admin before evaluating webhook eligibility.
+    void growthbook?.setAttributes({
+      ...growthbook.getAttributes(),
+      formId: String(form._id),
+      adminEmail: form.admin.email,
     })
 
-    return WebhookFactory.sendInitialWebhook(
+    sendMrfInitialWebhookIfEligible({
       submission,
       webhookUrl,
-      !!form.webhook?.isRetryEnabled,
-    ).mapErr((error) => {
-      logger.error({
-        message: 'Multirespondent payment submission webhook error',
-        meta: logMeta,
-        error,
-      })
-      return error
+      isRetryEnabled: !!form.webhook?.isRetryEnabled,
+      growthbook,
+      logMeta,
+      errorMessage: 'Multirespondent payment submission webhook error',
     })
+    return true as const
   })
 }
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -46,8 +46,16 @@ import MailService from '../../../services/mail/mail.service'
 import { generateAutoreplyPdf } from '../../../services/mail/mail.utils'
 import { transformMongoError } from '../../../utils/handle-mongo-error'
 import { DatabaseError, PossibleDatabaseError } from '../../core/core.errors'
-import { FormRespondentSingleSubmissionValidationError } from '../../form/form.errors'
+import {
+  FormNotFoundError,
+  FormRespondentSingleSubmissionValidationError,
+} from '../../form/form.errors'
+import * as FormService from '../../form/form.service'
 import { isFormMultirespondent } from '../../form/form.utils'
+import {
+  WebhookPushToQueueError,
+  WebhookValidationError,
+} from '../../webhook/webhook.errors'
 import { WebhookFactory } from '../../webhook/webhook.factory'
 import { getWebhookType } from '../../webhook/webhook.service'
 import {
@@ -1456,6 +1464,54 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
       })
       return error
     })
+}
+
+/**
+ * Performs post-submission actions for a multirespondent submission promoted
+ * from a pending submission on payment confirmation. A payment-enabled MRF
+ * sends no form-configured emails, so the only action mirrored from
+ * submission creation is the initial webhook; the payer's receipt email is
+ * sent by the payments machinery.
+ * @param submission the promoted multirespondent submission
+ */
+export const performMultirespondentPaymentPostSubmissionActions = (
+  submission: IMultirespondentSubmissionSchema,
+): ResultAsync<
+  true,
+  | FormNotFoundError
+  | PossibleDatabaseError
+  | WebhookValidationError
+  | SubmissionNotFoundError
+  | WebhookPushToQueueError
+> => {
+  const logMeta = {
+    action: 'performMultirespondentPaymentPostSubmissionActions',
+    submissionId: submission.id,
+  }
+
+  return FormService.retrieveFullFormById(submission.form).andThen((form) => {
+    const webhookUrl = form.webhook?.url
+    if (!webhookUrl) return okAsync(true as const)
+
+    logger.info({
+      message:
+        'Sending initial webhook for payment-confirmed multirespondent submission',
+      meta: logMeta,
+    })
+
+    return WebhookFactory.sendInitialWebhook(
+      submission,
+      webhookUrl,
+      !!form.webhook?.isRetryEnabled,
+    ).mapErr((error) => {
+      logger.error({
+        message: 'Multirespondent payment submission webhook error',
+        meta: logMeta,
+        error,
+      })
+      return error
+    })
+  })
 }
 
 export const updateMultiRespondentFormSubmission = ({

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.types.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.types.ts
@@ -98,6 +98,8 @@ export type MultirespondentSubmissionContent = {
   // in-flight mrf steps which do not have a step token at time of creation.
   stepTokenHash?: string
   encryptedStepToken?: string
+  // Only present on payment-enabled (necessarily zero-step) forms.
+  paymentId?: string
 }
 
 export type StrippedAttachmentResponseV4 = Omit<

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -22,6 +22,7 @@ import {
   EmailRespondentConfirmationField,
   FormFieldSchema,
   IMultirespondentSubmissionSchema,
+  ISubmissionSchema,
   MultirespondentSubmissionData,
 } from '../../../../types'
 import { ParsedClearFormFieldResponsesV4 } from '../../../../types/api'
@@ -41,6 +42,12 @@ import {
 import { buildMrfMetadata } from '../submission.utils'
 
 import { MrfJwtPayload } from './multirespondent-submission.types'
+
+export const isSubmissionMultirespondentMode = (
+  submission: ISubmissionSchema,
+): submission is IMultirespondentSubmissionSchema => {
+  return submission.submissionType === SubmissionType.Multirespondent
+}
 
 /**
  * Creates and returns a MultirespondentSubmissionDto object from submissionData and

--- a/apps/backend/src/app/modules/verification/__tests__/verification.model.spec.ts
+++ b/apps/backend/src/app/modules/verification/__tests__/verification.model.spec.ts
@@ -419,6 +419,91 @@ describe('Verification Model', () => {
           expect(result!.paymentField.fieldType).toEqual(BasicField.Email)
         })
       })
+
+      describe('Multirespondent mode forms', () => {
+        it('should return null when there are no verifiable fields and payment not enabled', async () => {
+          const { form } = await dbHandler.insertMultirespondentForm({
+            formOptions: {
+              form_fields: [
+                generateDefaultField(BasicField.ShortText),
+                // Email and mobile fields, but with isVerifiable undefined
+                generateDefaultField(BasicField.Email),
+                generateDefaultField(BasicField.Mobile),
+              ],
+            },
+          })
+
+          const result = await VerificationModel.createTransactionFromForm(form)
+
+          expect(result).toBeNull()
+        })
+
+        it('should create transaction correctly when there is one verifiable field', async () => {
+          const verifiableField = generateDefaultField(BasicField.Email, {
+            isVerifiable: true,
+          })
+          const { form } = await dbHandler.insertMultirespondentForm({
+            formOptions: {
+              form_fields: [
+                generateDefaultField(BasicField.ShortText),
+                verifiableField,
+              ],
+            },
+          })
+
+          const result = await VerificationModel.createTransactionFromForm(form)
+
+          expect(result).toBeTruthy()
+          expect(result!.formId).toEqual(form._id)
+          expect(result!.fields[0]._id).toEqual(verifiableField._id)
+          expect(result!.fields[0].fieldType).toEqual(verifiableField.fieldType)
+        })
+
+        it('should create transaction correctly when there are no verifiable fields but payment is enabled', async () => {
+          const { form } = await dbHandler.insertMultirespondentForm({
+            formOptions: {
+              form_fields: [
+                generateDefaultField(BasicField.ShortText),
+                // Email and mobile fields, but with isVerifiable undefined
+                generateDefaultField(BasicField.Email),
+                generateDefaultField(BasicField.Mobile),
+              ],
+              payments_field: { enabled: true },
+            },
+          })
+
+          const result = await VerificationModel.createTransactionFromForm(form)
+
+          expect(result).toBeTruthy()
+          expect(result!.formId).toEqual(form._id)
+          expect(result!.paymentField._id).toEqual(PAYMENT_CONTACT_FIELD_ID)
+          expect(result!.paymentField.fieldType).toEqual(BasicField.Email)
+        })
+
+        it('should create transaction correctly when there are verifiable fields and payment is enabled', async () => {
+          const verifiableField = generateDefaultField(BasicField.Mobile, {
+            isVerifiable: true,
+          })
+          const { form } = await dbHandler.insertMultirespondentForm({
+            formOptions: {
+              form_fields: [
+                verifiableField,
+                generateDefaultField(BasicField.ShortText),
+              ],
+              payments_field: { enabled: true },
+            },
+          })
+
+          const result = await VerificationModel.createTransactionFromForm(form)
+
+          expect(result).toBeTruthy()
+          expect(result!.formId).toEqual(form._id)
+          expect(result!.fields[0]._id).toEqual(verifiableField._id)
+          expect(result!.fields[0].fieldType).toEqual(verifiableField.fieldType)
+          expect(result!.paymentField._id).toEqual(PAYMENT_CONTACT_FIELD_ID)
+          expect(result!.paymentField.fieldType).toEqual(BasicField.Email)
+        })
+      })
     })
 
     describe('incrementFieldRetries', () => {

--- a/apps/backend/src/app/modules/verification/verification.model.ts
+++ b/apps/backend/src/app/modules/verification/verification.model.ts
@@ -1,9 +1,5 @@
 import { PAYMENT_CONTACT_FIELD_ID } from 'formsg-shared/constants'
-import {
-  BasicField,
-  FormPaymentsField,
-  FormResponseMode,
-} from 'formsg-shared/types'
+import { BasicField, FormPaymentsField } from 'formsg-shared/types'
 import { TRANSACTION_EXPIRE_AFTER_SECONDS } from 'formsg-shared/utils/verification'
 import { pick } from 'lodash'
 import { Mongoose, Schema } from 'mongoose'
@@ -137,30 +133,20 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
     form: IFormSchema | IEncryptedFormSchema | IMultirespondentFormSchema,
   ): Promise<IVerificationSchema | null> {
     const formFields = getVerifiableFormFields(form.form_fields)
-    // Encrypt and multirespondent forms may be payment-enabled, in which
-    // case the payment contact email is verifiable even when no form field
-    // is — a transaction must still be created for it.
-    if (
-      form.responseMode === FormResponseMode.Encrypt ||
-      form.responseMode === FormResponseMode.Multirespondent
-    ) {
-      const { payments_field } = form as
-        | IEncryptedFormSchema
-        | IMultirespondentFormSchema
-      const paymentField = getVerifiablePaymentContactField(payments_field)
-      if (!formFields && !paymentField) return null
-      return this.create({
-        formId: form._id,
-        fields: formFields ?? [],
-        paymentField,
-      })
-    } else {
-      if (!formFields) return null
-      return this.create({
-        formId: form._id,
-        fields: formFields,
-      })
-    }
+    // Every supported response mode may be payment-enabled, in which case
+    // the payment contact email is verifiable even when no form field is.
+    // Deprecated email-mode forms carry no payments_field, so paymentField
+    // resolves to null and only their form fields matter.
+    const { payments_field } = form as
+      | IEncryptedFormSchema
+      | IMultirespondentFormSchema
+    const paymentField = getVerifiablePaymentContactField(payments_field)
+    if (!formFields && !paymentField) return null
+    return this.create({
+      formId: form._id,
+      fields: formFields ?? [],
+      paymentField,
+    })
   }
 
   VerificationSchema.statics.incrementFieldRetries = async function (

--- a/apps/backend/src/app/modules/verification/verification.model.ts
+++ b/apps/backend/src/app/modules/verification/verification.model.ts
@@ -12,6 +12,7 @@ import {
   FormFieldSchema,
   IEncryptedFormSchema,
   IFormSchema,
+  IMultirespondentFormSchema,
   IVerificationFieldSchema,
   IVerificationModel,
   IVerificationSchema,
@@ -133,11 +134,19 @@ const compileVerificationModel = (db: Mongoose): IVerificationModel => {
   }
 
   VerificationSchema.statics.createTransactionFromForm = async function (
-    form: IFormSchema | IEncryptedFormSchema,
+    form: IFormSchema | IEncryptedFormSchema | IMultirespondentFormSchema,
   ): Promise<IVerificationSchema | null> {
     const formFields = getVerifiableFormFields(form.form_fields)
-    if (form.responseMode === FormResponseMode.Encrypt) {
-      const { payments_field } = form as IEncryptedFormSchema
+    // Encrypt and multirespondent forms may be payment-enabled, in which
+    // case the payment contact email is verifiable even when no form field
+    // is — a transaction must still be created for it.
+    if (
+      form.responseMode === FormResponseMode.Encrypt ||
+      form.responseMode === FormResponseMode.Multirespondent
+    ) {
+      const { payments_field } = form as
+        | IEncryptedFormSchema
+        | IMultirespondentFormSchema
       const paymentField = getVerifiablePaymentContactField(payments_field)
       if (!formFields && !paymentField) return null
       return this.create({

--- a/apps/backend/src/types/api/multirespondent_submission.ts
+++ b/apps/backend/src/types/api/multirespondent_submission.ts
@@ -3,6 +3,8 @@ import {
   FormFieldDto,
   FormLogic,
   FormResponseMode,
+  PaymentFieldsDto,
+  ProductItem,
   ResponseMetadata,
   SubmissionAttachmentsMap,
 } from 'formsg-shared/types'
@@ -16,6 +18,9 @@ export type ParsedMultirespondentSubmissionBody = {
   version: number
   workflowStep: number
   respondentEmails?: string[]
+  paymentReceiptEmail?: string
+  paymentProducts?: Array<ProductItem>
+  payments?: PaymentFieldsDto
 }
 
 export type SnapshottedFormDef = Pick<
@@ -68,4 +73,7 @@ export type MultirespondentSubmissionDto = {
   stepToken?: string
   stepTokenHash?: string
   encryptedStepToken?: string
+  paymentReceiptEmail?: string
+  paymentProducts?: Array<ProductItem>
+  payments?: PaymentFieldsDto
 }

--- a/apps/backend/src/types/submission.ts
+++ b/apps/backend/src/types/submission.ts
@@ -163,6 +163,8 @@ export interface IMultirespondentSubmissionSchema
   // Allows for population and correct typing
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   form: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  paymentId: any
   submissionType: SubmissionType.Multirespondent
   getWebhookView(): Promise<WebhookView>
   mrfVersion: number

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
@@ -1,21 +1,26 @@
+import { useTranslation } from 'react-i18next'
 import { BiPlus } from 'react-icons/bi'
 import { Flex, Text } from '@chakra-ui/react'
 
 import { GUIDE_FORM_MRF } from '~constants/links'
 import Button from '~components/Button'
 import Link from '~components/Link'
+import Tooltip from '~components/Tooltip'
 
 import {
   setToCreatingSelector,
   useAdminWorkflowStore,
 } from '../adminWorkflowStore'
+import { useAdminFormWorkflow } from '../hooks/useAdminFormWorkflow'
 import { useIsWorkflowBuilderRedesign } from '../hooks/useIsWorkflowBuilderRedesign'
 
 import { WorkflowSvgr } from './WorkflowSvgr'
 
 export const EmptyWorkflow = (): JSX.Element => {
+  const { t } = useTranslation()
   const setToCreating = useAdminWorkflowStore(setToCreatingSelector)
   const isRedesign = useIsWorkflowBuilderRedesign()
+  const { isPaymentEnabled } = useAdminFormWorkflow()
 
   return (
     <Flex
@@ -38,13 +43,25 @@ export const EmptyWorkflow = (): JSX.Element => {
           Learn how to create a workflow
         </Link>
       </Text>
-      <Button
-        my="2.5rem"
-        leftIcon={<BiPlus fontSize="1.5rem" />}
-        onClick={setToCreating}
+      <Tooltip
+        label={
+          isPaymentEnabled
+            ? t('features.adminForm.sidebar.workflow.paymentEnabledNoSteps')
+            : undefined
+        }
+        // Disabled buttons swallow hover events; the wrapper span keeps the
+        // tooltip reachable exactly when it has something to say.
+        shouldWrapChildren={isPaymentEnabled}
       >
-        Create workflow
-      </Button>
+        <Button
+          my="2.5rem"
+          leftIcon={<BiPlus fontSize="1.5rem" />}
+          onClick={setToCreating}
+          isDisabled={isPaymentEnabled}
+        >
+          Create workflow
+        </Button>
+      </Tooltip>
       <WorkflowSvgr maxW="292px" />
     </Flex>
   )

--- a/apps/frontend/src/features/public-form/PublicFormProvider.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormProvider.tsx
@@ -674,7 +674,8 @@ export const PublicFormProvider = ({
   }
 
   const isPaymentEnabled =
-    data?.form.responseMode === FormResponseMode.Encrypt &&
+    (data?.form.responseMode === FormResponseMode.Encrypt ||
+      data?.form.responseMode === FormResponseMode.Multirespondent) &&
     data.form.payments_field.enabled
 
   const hasMyInfoError = !!data?.errorCodes?.find(
@@ -1298,26 +1299,63 @@ export const PublicFormProvider = ({
               }
             })
         }
-        case FormResponseMode.Multirespondent:
+        case FormResponseMode.Multirespondent: {
+          // Payment fields only apply on creation: a payment-enabled form is
+          // necessarily zero-step, so the update path never carries them.
+          const mrfPaymentData =
+            !previousSubmissionId && form.payments_field?.enabled
+              ? {
+                  paymentReceiptEmail: paymentReceiptEmailField?.value,
+                  paymentProducts: paymentProducts?.filter<ProductItem>(
+                    (product): product is ProductItem =>
+                      product.selected && product.quantity > 0,
+                  ),
+                  ...(form.payments_field.payment_type === PaymentType.Variable
+                    ? {
+                        payments: {
+                          amount_cents: dollarsToCents(
+                            paymentVariableInputAmountField ?? '0',
+                          ),
+                        },
+                      }
+                    : {}),
+                }
+              : {}
+
           return (
             previousSubmissionId
               ? updateMultirespondentSubmissionMutation
               : submitMultirespondentFormMutation
           )
-            .mutateAsync(formData, {
-              onSuccess: ({ submissionId, timestamp, mrfStep }) => {
-                trackSubmitForm(form)
-                setSubmissionData({
-                  id: submissionId,
+            .mutateAsync(
+              { ...formData, ...mrfPaymentData },
+              {
+                onSuccess: ({
+                  submissionId,
                   timestamp,
                   mrfStep,
-                })
+                  // payment forms will have non-empty paymentData field
+                  paymentData,
+                }) => {
+                  trackSubmitForm(form)
+                  if (paymentData) {
+                    navigate(getPaymentPageUrl(formId, paymentData.paymentId))
+                    storePaymentMemory(paymentData.paymentId)
+                    return
+                  }
+                  setSubmissionData({
+                    id: submissionId,
+                    timestamp,
+                    mrfStep,
+                  })
+                },
               },
-            })
+            )
             .then(() => clearDraftSubmission())
             .catch(async (error) => {
               showErrorToast(error, form)
             })
+        }
       }
     },
     [

--- a/apps/frontend/src/features/public-form/PublicFormService.ts
+++ b/apps/frontend/src/features/public-form/PublicFormService.ts
@@ -186,6 +186,9 @@ export type SubmitMultirespondentFormWithVirusScanningArgs =
     submissionSecretKey?: string
     stepToken?: string
     fieldIdToQuarantineKeyMap: FieldIdToQuarantineKeyType[]
+    paymentReceiptEmail?: string
+    paymentProducts?: Array<ProductItem>
+    payments?: PaymentFieldsDto
   }
 
 export const submitEmailModeForm = async ({
@@ -384,6 +387,9 @@ export const submitMultirespondentForm = async ({
   fieldIdToQuarantineKeyMap,
   respondentEmails,
   selectedFormLanguage = Language.ENGLISH,
+  paymentReceiptEmail,
+  paymentProducts,
+  payments,
 }: SubmitMultirespondentFormWithVirusScanningArgs) => {
   const filteredInputs = filterHiddenInputs({
     formFields,
@@ -398,6 +404,9 @@ export const submitMultirespondentForm = async ({
       responseMetadata,
       version: MULTIRESPONDENT_FORM_SUBMISSION_VERSION,
       respondentEmails: respondentEmails,
+      paymentReceiptEmail,
+      paymentProducts,
+      payments,
     },
     fieldIdToQuarantineKeyMap,
   )

--- a/apps/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
+++ b/apps/frontend/src/features/public-form/components/FormEndPage/FormEndPageContainer.tsx
@@ -22,8 +22,9 @@ export const FormEndPageContainer = (): JSX.Element | null => {
   const [isFeedbackSubmitted, setIsFeedbackSubmitted] = useState(false)
 
   const isPaymentEnabled =
-    form?.responseMode === FormResponseMode.Encrypt &&
-    form.payments_field.enabled
+    (form?.responseMode === FormResponseMode.Encrypt ||
+      form?.responseMode === FormResponseMode.Multirespondent) &&
+    form.payments_field?.enabled
 
   const isMrf = form?.responseMode === FormResponseMode.Multirespondent
   /**

--- a/apps/frontend/src/features/public-form/components/FormFields/FormFields.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FormFields.tsx
@@ -100,8 +100,9 @@ export const FormFields = ({
           </Stack>
         </Box>
       )}
-      {form?.responseMode === FormResponseMode.Encrypt &&
-        form?.payments_field.enabled && (
+      {(form?.responseMode === FormResponseMode.Encrypt ||
+        form?.responseMode === FormResponseMode.Multirespondent) &&
+        form?.payments_field?.enabled && (
           <Box
             mt="2.5rem"
             bg="white"

--- a/apps/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentSummary.tsx
+++ b/apps/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentSummary.tsx
@@ -78,7 +78,10 @@ export const PaymentSummary = ({
   colorTheme: FormColorTheme
   paymentInfoData: GetPaymentInfoDto
 }) => {
-  if (form.responseMode !== FormResponseMode.Encrypt) {
+  if (
+    form.responseMode !== FormResponseMode.Encrypt &&
+    form.responseMode !== FormResponseMode.Multirespondent
+  ) {
     return <></>
   }
   if (form.payments_field.payment_type === PaymentType.Products) {

--- a/apps/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentSummary.tsx
+++ b/apps/frontend/src/features/public-form/components/FormPaymentPage/components/PaymentSummary.tsx
@@ -4,10 +4,10 @@ import { Box, Divider, Flex, Text } from '@chakra-ui/react'
 import {
   ExtractTypeFromArray,
   FormColorTheme,
-  FormResponseMode,
   GetPaymentInfoDto,
   PaymentType,
-  PublicFormDto,
+  PublicStorageFormDto,
+  StrippedPublicMultirespondentFormDto,
 } from 'formsg-shared/types'
 import { centsToDollars } from 'formsg-shared/utils/payments'
 
@@ -72,18 +72,12 @@ export const PaymentSummary = ({
   colorTheme,
   paymentInfoData,
 }: {
-  form: PublicFormDto
+  form: PublicStorageFormDto | StrippedPublicMultirespondentFormDto
   paymentAmount: number
   paymentItemName?: string | null
   colorTheme: FormColorTheme
   paymentInfoData: GetPaymentInfoDto
 }) => {
-  if (
-    form.responseMode !== FormResponseMode.Encrypt &&
-    form.responseMode !== FormResponseMode.Multirespondent
-  ) {
-    return <></>
-  }
   if (form.payments_field.payment_type === PaymentType.Products) {
     return (
       <ProductsPaymentSummary

--- a/apps/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripePaymentBlock.tsx
+++ b/apps/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripePaymentBlock.tsx
@@ -11,7 +11,7 @@ import {
 import { PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js'
 
 import { GetPaymentInfoDto } from 'formsg-shared/types'
-import { FormColorTheme, FormResponseMode } from 'formsg-shared/types/form'
+import { FormColorTheme } from 'formsg-shared/types/form'
 
 import { useBrowserStm } from '~hooks/payments'
 import Button from '~components/Button'
@@ -159,11 +159,9 @@ export const StripePaymentBlock = ({
     return 'Please make payment.'
   }, [formTitle])
 
-  if (
-    !form ||
-    (form.responseMode !== FormResponseMode.Encrypt &&
-      form.responseMode !== FormResponseMode.Multirespondent)
-  ) {
+  // All supported response modes carry payment config; the structural check
+  // exists only to narrow away the deprecated email mode.
+  if (!form || !('payments_field' in form)) {
     return <></>
   }
 

--- a/apps/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripePaymentBlock.tsx
+++ b/apps/frontend/src/features/public-form/components/FormPaymentPage/stripe/components/StripePaymentBlock.tsx
@@ -159,7 +159,11 @@ export const StripePaymentBlock = ({
     return 'Please make payment.'
   }, [formTitle])
 
-  if (!form || form.responseMode !== FormResponseMode.Encrypt) {
+  if (
+    !form ||
+    (form.responseMode !== FormResponseMode.Encrypt &&
+      form.responseMode !== FormResponseMode.Multirespondent)
+  ) {
     return <></>
   }
 

--- a/apps/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/apps/frontend/src/features/public-form/utils/createSubmission.ts
@@ -112,6 +112,9 @@ type CreateMultirespondentSubmissionFormDataArgs =
     submissionSecretKey?: string
     stepToken?: string
     version: number
+    paymentReceiptEmail?: string
+    paymentProducts?: ProductItem[]
+    payments?: PaymentFieldsDto
   }
 
 /**

--- a/packages/shared/constants/form.ts
+++ b/packages/shared/constants/form.ts
@@ -30,6 +30,7 @@ export const STORAGE_PUBLIC_FORM_FIELDS = [
 
 export const MULTIRESPONDENT_PUBLIC_FORM_FIELDS = [
   ...PUBLIC_FORM_FIELDS,
+  'payments_field',
   'publicKey',
   'workflow',
   'hasStatusTracker',


### PR DESCRIPTION
## Problem

PR 3 of 4 in the MRF payments stack (base: #9798). Admins can now configure payments on a zero-step multirespondent form, but respondents still cannot pay: the public submission endpoints reject payment fields on MRF submissions and the payment page does not render for MRF forms.

## Solution

Respondent-facing payment flow for zero-step MRFs, mirroring the encrypt-mode flow.

- **Backend**: a multirespondent pending-submission discriminator with `paymentId`; on submit, create the Payment document, the pending submission and the Stripe payment intent (same sequence and failure handling as encrypt mode); serve payment info, receipts and invoices for MRF payments; create verification transactions for the payment contact email; fire the form webhook when an MRF payment is confirmed.
- **Frontend**: render the payment field, payment preview and payment end-page blocks for MRF respondents; the payment page itself is response-mode-agnostic (`/:formId/payment/:paymentId`), so all five payment view states work unchanged.
- **Kill switch**: the `mrf-payments` flag (introduced in #9798 for the admin enablement surfaces) also gates the respondent payment-submission path. With the flag off, a payment submission on a payment-enabled MRF is blocked outright with a 422 — it never falls through to the non-payment path — and the switch defaults closed if GrowthBook is unavailable. In-flight payments, receipt/invoice retrieval and Stripe unlinking remain available regardless, and non-payment MRF submissions are unaffected.

**Breaking Changes**
- No - this PR is backwards compatible. MRF submissions without payment fields behave exactly as before; the new payload keys are optional.

## Tests

Unit coverage: `multirespondent-submission.service.spec.ts`, `multirespondent-submission.controller.spec.ts`, `payment-proof.controller.spec.ts`.

TC1: Payment-enabled MRF happy path
- [ ] Submit a payment-enabled zero-step MRF as a respondent — verify redirect to the payment page and that a pending submission + Payment document are created
- [ ] Complete payment with a Stripe test card — verify the receipt page renders, the invoice downloads, and the submission is promoted
- [ ] Verify the form webhook fires on payment confirmation (if configured)

TC2: Payment amount validation
- [ ] Tamper the submission payload with an amount outside min/max bounds — verify a 400 is returned

TC3: Non-payment MRF regression
- [ ] Submit a normal (multi-step, no payments) MRF — verify the workflow behaves exactly as on develop

TC4: Stripe failure path
- [ ] With an invalid connected account, submit a payment — verify a 502 is returned and no Payment document is left half-updated

TC5: Kill switch
- [ ] With the `mrf-payments` flag off, submit a payment-enabled MRF — verify a 422 is returned and no pending submission or Payment document is created
- [ ] Verify receipts/invoices for already-paid submissions remain retrievable with the flag off

## Deploy Notes

No new flags. The existing `mrf-payments` flag (from #9798) now doubles as a kill switch: switching it off stops **new** payment submissions on live payment-enabled MRFs, while in-flight payments and receipt/invoice retrieval keep working.
