### PR TITLE
fix(sdk): improve large attachment decryption and handling

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -65,6 +65,8 @@
     "directory": "packages/sdk"
   },
   "dependencies": {
+    "@stablelib/base64": "^1.0.1",
+    "@stablelib/utf8": "^1.0.2",
     "axios": "^1.15.2",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -68,8 +68,7 @@
     "@stablelib/base64": "^1.0.1",
     "@stablelib/utf8": "^1.0.2",
     "axios": "^1.15.2",
-    "tweetnacl": "^1.0.3",
-    "tweetnacl-util": "^0.15.1"
+    "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
     "@types/jest": "^29.5.8",

--- a/packages/sdk/spec/crypto-v3.spec.ts
+++ b/packages/sdk/spec/crypto-v3.spec.ts
@@ -1,5 +1,5 @@
 import mockAxios from 'jest-mock-axios'
-import { decodeUTF8 } from 'tweetnacl-util'
+import { decodeUTF8 } from '../src/util/encoding'
 
 import Crypto from '../src/crypto'
 import CryptoV3 from '../src/crypto-v3'

--- a/packages/sdk/spec/crypto.spec.ts
+++ b/packages/sdk/spec/crypto.spec.ts
@@ -2,9 +2,7 @@ import mockAxios from 'jest-mock-axios'
 import Crypto from '../src/crypto'
 import { SIGNING_KEYS } from '../src/resource/signing-keys'
 
-import {
-  encodeBase64,
-} from 'tweetnacl-util'
+import { encodeBase64 } from '../src/util/encoding'
 
 import {
   plaintext,

--- a/packages/sdk/spec/encoding.spec.ts
+++ b/packages/sdk/spec/encoding.spec.ts
@@ -1,0 +1,83 @@
+import {
+  decodeBase64,
+  decodeUTF8,
+  encodeBase64,
+  encodeUTF8,
+} from '../src/util/encoding'
+
+describe('encoding', () => {
+  describe('base64', () => {
+    it('should round-trip binary data', () => {
+      // Arrange
+      const bytes = new Uint8Array(256).map((_, i) => i)
+
+      // Act
+      const actual = decodeBase64(encodeBase64(bytes))
+
+      // Assert
+      expect(actual).toEqual(bytes)
+    })
+
+    it('should produce output identical to Buffer base64 for all padding lengths', () => {
+      // Arrange
+      // Lengths mod 3 of 0, 1 and 2 exercise every padding variant.
+      const inputs = [0, 1, 2, 3, 31, 32, 33].map((len) =>
+        new Uint8Array(len).map((_, i) => (i * 7 + len) % 256)
+      )
+
+      inputs.forEach((bytes) => {
+        // Act
+        const encoded = encodeBase64(bytes)
+
+        // Assert
+        expect(encoded).toBe(Buffer.from(bytes).toString('base64'))
+        expect(decodeBase64(encoded)).toEqual(bytes)
+      })
+    })
+
+    it('should decode multi-megabyte payloads', () => {
+      // Arrange
+      // Regression guard for tweetnacl-util's regex-based validation, which
+      // exceeded the call stack on large attachments in some JS engines.
+      const bytes = new Uint8Array(10 * 1024 * 1024).map((_, i) => i % 251)
+      const encoded = Buffer.from(bytes).toString('base64')
+
+      // Act
+      const actual = decodeBase64(encoded)
+
+      // Assert
+      // Buffer.equals instead of toEqual: jest deep-compares typed arrays
+      // element-wise, which takes ~45s at this size.
+      expect(Buffer.from(actual).equals(Buffer.from(bytes))).toBe(true)
+    })
+
+    it('should throw on invalid base64 input', () => {
+      // Assert
+      expect(() => decodeBase64('not@valid+base64!')).toThrow()
+    })
+  })
+
+  describe('utf8', () => {
+    it('should round-trip multi-byte strings', () => {
+      // Arrange
+      const input = 'héllo wörld — 你好 🎉'
+
+      // Act
+      const actual = encodeUTF8(decodeUTF8(input))
+
+      // Assert
+      expect(actual).toBe(input)
+    })
+
+    it('should encode strings identically to Buffer utf8', () => {
+      // Arrange
+      const input = 'héllo wörld — 你好 🎉'
+
+      // Act
+      const actual = decodeUTF8(input)
+
+      // Assert
+      expect(actual).toEqual(new Uint8Array(Buffer.from(input, 'utf8')))
+    })
+  })
+})

--- a/packages/sdk/src/crypto-base.ts
+++ b/packages/sdk/src/crypto-base.ts
@@ -1,7 +1,7 @@
 import nacl from 'tweetnacl'
-import { decodeBase64, encodeBase64 } from 'tweetnacl-util'
 
 import { generateKeypair } from './util/crypto'
+import { decodeBase64, encodeBase64 } from './util/encoding'
 import { EncryptedFileContent } from './types'
 
 export default class CryptoBase {

--- a/packages/sdk/src/crypto-v3.ts
+++ b/packages/sdk/src/crypto-v3.ts
@@ -1,16 +1,15 @@
 import {
-  decodeBase64,
-  decodeUTF8,
-  encodeBase64,
-  encodeUTF8,
-} from 'tweetnacl-util'
-
-import {
   decryptContent,
   encryptMessage,
   generateKeypair,
   verifySignedMessage,
 } from './util/crypto'
+import {
+  decodeBase64,
+  decodeUTF8,
+  encodeBase64,
+  encodeUTF8,
+} from './util/encoding'
 import { determineIsFormFieldsV3 } from './util/validate'
 import { adaptV3ToV4, deriveQuestionFromMeta } from './adapt-v3-to-v4'
 import CryptoBase from './crypto-base'

--- a/packages/sdk/src/crypto.ts
+++ b/packages/sdk/src/crypto.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 import nacl from 'tweetnacl'
-import { decodeBase64, decodeUTF8, encodeUTF8 } from 'tweetnacl-util'
 
 import {
   areAttachmentFieldIdsValid,
@@ -9,6 +8,7 @@ import {
   encryptMessage,
   verifySignedMessage,
 } from './util/crypto'
+import { decodeBase64, decodeUTF8, encodeUTF8 } from './util/encoding'
 import { determineIsFormFields } from './util/validate'
 import CryptoBase from './crypto-base'
 import { AttachmentDecryptionError, MissingPublicKeyError } from './errors'

--- a/packages/sdk/src/util/crypto.ts
+++ b/packages/sdk/src/util/crypto.ts
@@ -1,5 +1,4 @@
 import nacl from 'tweetnacl'
-import { decodeBase64, encodeBase64, encodeUTF8 } from 'tweetnacl-util'
 
 import {
   EncryptedAttachmentContent,
@@ -7,6 +6,8 @@ import {
   EncryptedFileContent,
   Keypair,
 } from '../types'
+
+import { decodeBase64, encodeBase64, encodeUTF8 } from './encoding'
 
 /**
  * Helper method to generate a new keypair for encryption.

--- a/packages/sdk/src/util/encoding.ts
+++ b/packages/sdk/src/util/encoding.ts
@@ -1,0 +1,25 @@
+import {
+  decode as base64ToBytes,
+  encode as bytesToBase64,
+} from '@stablelib/base64'
+import {
+  decode as bytesToUtf8String,
+  encode as utf8StringToBytes,
+} from '@stablelib/utf8'
+
+/**
+ * Loop-based binary <-> string conversions, replacing tweetnacl-util.
+ *
+ * tweetnacl-util's decodeBase64 validates its input with a regex over the
+ * entire payload; on engines with stack-bound regex backtracking (Hermes,
+ * older JSC/V8) this throws "Maximum call stack size exceeded" for
+ * multi-megabyte attachments. @stablelib decodes in a plain loop.
+ *
+ * Exported names keep tweetnacl-util's convention (decodeUTF8: string ->
+ * bytes, encodeUTF8: bytes -> string), which is the reverse of
+ * @stablelib/utf8's encode/decode naming.
+ */
+export const encodeBase64 = (arr: Uint8Array): string => bytesToBase64(arr)
+export const decodeBase64 = (s: string): Uint8Array => base64ToBytes(s)
+export const decodeUTF8 = (s: string): Uint8Array => utf8StringToBytes(s)
+export const encodeUTF8 = (arr: Uint8Array): string => bytesToUtf8String(arr)

--- a/packages/sdk/src/util/signature.ts
+++ b/packages/sdk/src/util/signature.ts
@@ -1,5 +1,6 @@
 import * as tweetnacl from 'tweetnacl'
-import { decodeBase64, decodeUTF8, encodeBase64 } from 'tweetnacl-util'
+
+import { decodeBase64, decodeUTF8, encodeBase64 } from './encoding'
 
 /**
  * Returns a signature from a basestring and secret key

--- a/packages/sdk/src/verification/index.ts
+++ b/packages/sdk/src/verification/index.ts
@@ -3,7 +3,6 @@
  * @author Jean Tan
  */
 import nacl from 'tweetnacl'
-import { decodeBase64, decodeUTF8, encodeBase64 } from 'tweetnacl-util'
 
 import { MissingPublicKeyError, MissingSecretKeyError } from '../errors'
 import {
@@ -11,6 +10,7 @@ import {
   VerificationOptions,
   VerificationSignatureOptions,
 } from '../types'
+import { decodeBase64, decodeUTF8, encodeBase64 } from '../util/encoding'
 import { parseVerificationSignature } from '../util/parser'
 
 import { formatToBaseString, isSignatureTimeValid } from './utils'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1246,13 +1246,10 @@ importers:
         version: 1.0.2
       axios:
         specifier: ^1.16.0
-        version: 1.18.1(debug@4.4.1)
+        version: 1.18.1
       tweetnacl:
         specifier: ^1.0.3
         version: 1.0.3
-      tweetnacl-util:
-        specifier: ^0.15.1
-        version: 0.15.1
     devDependencies:
       '@types/jest':
         specifier: ^29.5.8
@@ -1265,10 +1262,10 @@ importers:
         version: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
       jest-mock-axios:
         specifier: ^4.7.3
-        version: 4.9.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
+        version: 4.9.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.4.6(@babel/core@7.29.7)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.1.2(@babel/core@7.29.7))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.7)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.1.2(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -16519,7 +16516,7 @@ snapshots:
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -16738,7 +16735,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -21669,7 +21666,7 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.17.0
 
   acorn@6.4.2: {}
 
@@ -21686,6 +21683,12 @@ snapshots:
   addressparser@1.0.1: {}
 
   adm-zip@0.5.16: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
@@ -22016,6 +22019,16 @@ snapshots:
       axios: 1.18.1(debug@4.4.1)
       fast-deep-equal: 3.1.3
       is-buffer: 2.0.5
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axios@1.18.1(debug@4.4.1):
     dependencies:
@@ -23492,6 +23505,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -24030,7 +24047,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.28.1):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       esbuild: 0.28.1
     transitivePeerDependencies:
       - supports-color
@@ -24805,6 +24822,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  follow-redirects@1.16.0: {}
+
   follow-redirects@1.16.0(debug@4.4.1):
     optionalDependencies:
       debug: 4.4.1
@@ -25423,6 +25442,13 @@ snapshots:
 
   https-browserify@1.0.0: {}
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
       agent-base: 6.0.2(supports-color@8.1.1)
@@ -25882,7 +25908,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -25891,7 +25917,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -26377,6 +26403,19 @@ snapshots:
       pretty-format: 30.2.0
       slash: 3.0.0
       stack-utils: 2.0.6
+
+  jest-mock-axios@4.9.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3)):
+    dependencies:
+      '@jest/globals': 30.2.0
+      jest: 30.1.3(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
+      synchronous-promise: 2.0.17
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - node-notifier
+      - supports-color
+      - ts-node
 
   jest-mock-axios@4.9.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3)):
     dependencies:
@@ -31089,6 +31128,27 @@ snapshots:
 
   ts-easing@0.2.0: {}
 
+  ts-jest@29.4.6(@babel/core@7.29.7)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.1.2(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.4
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.7
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.1.2(@babel/core@7.29.7)
+      esbuild: 0.28.1
+      jest-util: 30.2.0
+
   ts-jest@29.4.6(@babel/core@7.29.7)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.1.2(@babel/core@7.29.7))(esbuild@0.28.1)(jest-util@30.2.0)(jest@30.1.3(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.28.1))(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
@@ -31204,7 +31264,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 18.19.130
-      acorn: 8.15.0
+      acorn: 8.17.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1238,6 +1238,12 @@ importers:
 
   packages/sdk:
     dependencies:
+      '@stablelib/base64':
+        specifier: ^1.0.1
+        version: 1.0.1
+      '@stablelib/utf8':
+        specifier: ^1.0.2
+        version: 1.0.2
       axios:
         specifier: ^1.16.0
         version: 1.18.1(debug@4.4.1)
@@ -1344,7 +1350,7 @@ importers:
         version: 12.1.1(eslint@8.57.1)
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3))
       mongoose:
         specifier: ~7.8.9
         version: 7.8.9
@@ -5226,6 +5232,9 @@ packages:
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
+  '@stablelib/utf8@1.0.2':
+    resolution: {integrity: sha512-sDL1aB2U8FIpj7SjQJMxbOFIFkKvDKQGPHSrYejHZhtLNSK3qHe6ZIfa0woWkOiaJsdYslFzrc0VWXJZHmSIQQ==}
 
   '@storybook/addon-a11y@8.6.18':
     resolution: {integrity: sha512-LFvudttdIfDTNWprA8/N1vbiWbJRrNscyt2OP9Qwi85E1d3LKLy+e8AWiqY08gpy2OUYujK7AjxfpKtNeddrxw==}
@@ -20381,6 +20390,8 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
+  '@stablelib/utf8@1.0.2': {}
+
   '@storybook/addon-a11y@8.6.18(storybook@8.6.18(prettier@3.8.1))':
     dependencies:
       '@storybook/addon-highlight': 8.6.18(storybook@8.6.18(prettier@3.8.1))
@@ -25990,25 +26001,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.0.10)(typescript@5.9.3))
@@ -26746,18 +26738,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@18.19.130)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@18.19.130)(typescript@5.9.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.0.10)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros


### PR DESCRIPTION
## Problem

SDK consumers report `convertEncryptedAttachmentToFileContent failed: Maximum call stack size exceeded` when downloading and decrypting attachments (`decryptWithAttachments`).

`convertEncryptedAttachmentToFileContent` decodes the entire encrypted attachment with `decodeBase64` from `tweetnacl-util`, which first validates the payload with a regex (`/^(?:[A-Za-z0-9+\/]{2}[A-Za-z0-9+\/]{2})*(?:...)?$/`) over the whole string. On engines with stack-bound regex backtracking (Hermes/React Native, older JSC and V8), a repeated-group quantifier over a multi-megabyte string overflows the stack and throws `RangeError: Maximum call stack size exceeded`. Modern Node is unaffected, which is why only some consumers hit it.

This was identified in opengovsg/formsg-javascript-sdk#26 ("Replace tweetnacl-util with StableLib", targeted at v0.8.0) but the swap never shipped. The FormSG frontend already avoids it by using `@stablelib/base64` for its own copy of this function.

Closes opengovsg/formsg-javascript-sdk#26

## Solution

Add an internal `util/encoding.ts` backed by `@stablelib/base64` / `@stablelib/utf8` (plain-loop codecs, no regex validation), swap all `tweetnacl-util` imports to it, and drop the dependency. `tweetnacl` (the actual NaCl crypto) is unchanged.

**Breaking Changes**
- [x] No - this PR is backwards compatible

Encoded output is byte-identical (standard padded base64) and invalid input still throws; verified by parity tests against `Buffer`.

**Alternatives considered**:
- Direct aliased stablelib imports per file (as the frontend does): rejected — `@stablelib/utf8`'s encode/decode naming is inverted relative to tweetnacl-util's, so per-site aliases would be actively misleading. A single wrapper keeps the swap mechanical.
- @stablelib v2: rejected — ESM-only, and this package ships CJS + ESM.

**Bug Fixes**:
- Attachment decryption no longer overflows the call stack on multi-megabyte attachments on Hermes/older-JSC/older-V8 runtimes.

## Tests

- New `spec/encoding.spec.ts`: base64/utf8 round-trips, byte parity with `Buffer` across all padding lengths, 10MB decode regression guard, throw-on-invalid-input.
- Full SDK suite: 12 suites / 155 tests pass; CJS + ESM builds pass.

## Deploy Notes

Needs an SDK version bump + npm publish to reach affected consumers.

**New dependencies**:
- `@stablelib/base64@^1.0.1`, `@stablelib/utf8@^1.0.2` : loop-based codecs replacing `tweetnacl-util` (removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)