### PR TITLE
fix(mrf): drop the initial-send snapshot read-back; thread the in-memory object (S4d)

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -108,10 +108,13 @@ describe('multirespondent-submision.controller', () => {
       .fn()
       .mockReturnValue(ok(mockMrfForm))
 
+    // Both saves return the committed row together with the snapshot object
+    // they PUT, so the controller can thread it into the post-submission
+    // actions without a read-back.
     MockMultiRespondentSubmissionService.createMultiRespondentFormSubmission =
-      jest.fn().mockReturnValue(okAsync(mockMrfSubmission))
+      jest.fn().mockReturnValue(okAsync({ submission: mockMrfSubmission }))
     MockMultiRespondentSubmissionService.updateMultiRespondentFormSubmission =
-      jest.fn().mockReturnValue(okAsync(mockMrfSubmission))
+      jest.fn().mockReturnValue(okAsync({ submission: mockMrfSubmission }))
     MockMultiRespondentSubmissionService.performMultiRespondentPostSubmissionCreateActions =
       jest.fn().mockReturnValue(okAsync(true))
     MockMultiRespondentSubmissionService.performMultiRespondentPostSubmissionUpdateActions =

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -203,7 +203,7 @@ describe('multirespondent-submission.service', () => {
       )
       expect(saveProtoSpy).not.toHaveBeenCalled()
       expect(result.isOk()).toBe(true)
-      expect(result._unsafeUnwrap()).toEqual(mockSavedDoc)
+      expect(result._unsafeUnwrap().submission).toEqual(mockSavedDoc)
 
       saveIfSpy.mockRestore()
       saveProtoSpy.mockRestore()
@@ -241,7 +241,7 @@ describe('multirespondent-submission.service', () => {
       expect(saveIfSpy).not.toHaveBeenCalled()
       expect(saveProtoSpy).toHaveBeenCalled()
       expect(result.isOk()).toBe(true)
-      const savedSubmission = result._unsafeUnwrap()
+      const savedSubmission = result._unsafeUnwrap().submission
       expect(savedSubmission).toEqual(mockSavedSubmission)
 
       saveIfSpy.mockRestore()
@@ -3493,7 +3493,7 @@ describe('multirespondent-submission.service', () => {
 
       expect(result.isOk()).toBe(true)
       const saved = await getMultirespondentSubmissionModel(mongoose).findById(
-        result._unsafeUnwrap()._id,
+        result._unsafeUnwrap().submission._id,
       )
       expect(saved?.stepTokenHash).toBe(stepToken.hash(raw))
       expect(saved?.encryptedStepToken).toBe('wrapped-token-A')
@@ -3912,7 +3912,7 @@ describe('multirespondent-submission.service', () => {
       expect(snapshot.encryptedSubmissionSecretKey).toBe('wrapped-read-key-v4')
 
       const saved = await getMultirespondentSubmissionModel(mongoose).findById(
-        result._unsafeUnwrap()._id,
+        result._unsafeUnwrap().submission._id,
       )
       expect(saved?.submittedSteps?.[0]?.snapshotToken).toBe('tok-create')
     })
@@ -4030,19 +4030,59 @@ describe('multirespondent-submission.service', () => {
       },
     )
 
+    // ---- D10: no S3 GET on the initial send ----
+
+    it('reconstructs from the in-memory snapshot, with the S3 read path stubbed to fail', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      // Any S3 GET on the initial send is a defect: stub the read path to fail
+      // so a surviving read-back would drop the webhook.
+      MockSnapshotStore.readV4Snapshot.mockReturnValue(
+        errAsync(new SnapshotDataIntegrityError('S3 GET must not be reached')),
+      )
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        okAsync({ token: 'tok-inmem', key: 'key-inmem' }),
+      )
+
+      const created = await createMultiRespondentFormSubmission({
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: { action: 'test' },
+      })
+      expect(created.isOk()).toBe(true)
+      const { submission, snapshot } = created._unsafeUnwrap()
+      expect(snapshot?.encryptedContent).toBe('v4-encrypted-content')
+
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        snapshot,
+        submissionId: submission._id.toString(),
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: {} as any,
+        growthbook: growthbookWith(true),
+      })
+      await flushPromises()
+
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const view = sendSpy.mock.calls[0][3]
+      expect(view?.data.encryptedContent).toBe('v4-encrypted-content')
+      expect(view?.data.encryptedSubmissionSecretKey).toBe(
+        'wrapped-read-key-v4',
+      )
+    })
+
     // ---- Reconstruction wired ----
 
     it('passes a reconstructed pre-built view for a plumber v4 send', async () => {
       const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
-      MockSnapshotStore.readV4Snapshot.mockReturnValue(
-        okAsync(
-          buildSnapshot({ encryptedSubmissionSecretKey: 'frozen-read-key' }),
-        ),
-      )
       const submission = buildSubmissionWithToken('tok-A')
 
       await performMultiRespondentPostSubmissionCreateActions({
         submission,
+        snapshot: buildSnapshot({
+          encryptedSubmissionSecretKey: 'frozen-read-key',
+        }),
         submissionId: submission._id.toString(),
         form: buildV4Form(),
         encryptedPayload: buildV4Payload(),
@@ -4060,7 +4100,7 @@ describe('multirespondent-submission.service', () => {
       expect(view?.data.encryptedContent).toBe('frozen-content')
     })
 
-    it('takes the legacy path (no 4th arg) for a plumber send without a recorded token', async () => {
+    it('takes the legacy path (no 4th arg) for a plumber send with no snapshot', async () => {
       const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
       const submission = buildSubmissionWithToken(undefined)
 
@@ -4079,18 +4119,17 @@ describe('multirespondent-submission.service', () => {
       expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
     })
 
-    // ---- Fail-loud on data-integrity ----
+    // ---- D10: a recorded token never triggers a read on the initial send ----
 
-    it('fails loud and does not send when the snapshot read errs with a data-integrity error', async () => {
+    it('ignores the recorded token on the initial send and never reads S3', async () => {
       const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
-      const incrSpy = jest.mocked(webhookStatsdClient.increment)
-      MockSnapshotStore.readV4Snapshot.mockReturnValue(
-        errAsync(new SnapshotDataIntegrityError('missing')),
-      )
+      // A token IS recorded on the row, yet the send must still not read S3 —
+      // the object it needs is already in hand.
       const submission = buildSubmissionWithToken('tok-A')
 
       await performMultiRespondentPostSubmissionUpdateActions({
         submission,
+        snapshot: buildSnapshot(),
         submissionId: submission._id.toString(),
         snapshottedFormDef: buildSnapshottedFormDef(),
         currentStepNumber: 0,
@@ -4100,13 +4139,16 @@ describe('multirespondent-submission.service', () => {
       })
       await flushPromises()
 
-      expect(sendSpy).not.toHaveBeenCalled()
-      expect(incrSpy).toHaveBeenCalledWith('mrf.snapshot.data_integrity_error')
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy.mock.calls[0][3]?.data.encryptedContent).toBe(
+        'frozen-content',
+      )
     })
 
     // ---- Case A winner / 409 ----
 
-    it('records the winner token which reconstruction then reads (Case A / 409 winner)', async () => {
+    it("records the winner token and hands the winner's own snapshot to reconstruction (Case A / 409 winner)", async () => {
       const Model = getMultirespondentSubmissionModel(mongoose)
       const row = await Model.create({
         form: mockFormId,
@@ -4134,13 +4176,17 @@ describe('multirespondent-submission.service', () => {
         logMeta: { action: 'test' },
       })
       expect(result.isOk()).toBe(true)
-      const winner = result._unsafeUnwrap()
+      const { submission: winner, snapshot: winnerSnapshot } =
+        result._unsafeUnwrap()
       expect(winner.submittedSteps?.[1]?.snapshotToken).toBe('winner-token')
+      // The winner's own object is what travels to reconstruction — the token
+      // is recorded for the RETRY path, not consumed by the initial send.
+      expect(winnerSnapshot?.submissionIndex).toBe(1)
 
-      // The send path reads exactly the winner's recorded token.
       const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
       await performMultiRespondentPostSubmissionUpdateActions({
         submission: winner,
+        snapshot: winnerSnapshot,
         submissionId: winner._id.toString(),
         snapshottedFormDef: buildSnapshottedFormDef(),
         currentStepNumber: 1,
@@ -4150,11 +4196,11 @@ describe('multirespondent-submission.service', () => {
       })
       await flushPromises()
 
-      expect(MockSnapshotStore.readV4Snapshot).toHaveBeenCalledWith(
-        expect.objectContaining({ submissionIndex: 1, token: 'winner-token' }),
-      )
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
       expect(sendSpy).toHaveBeenCalledTimes(1)
-      expect(sendSpy.mock.calls[0][3]).toBeDefined()
+      expect(sendSpy.mock.calls[0][3]?.data.encryptedContent).toBe(
+        'v4-encrypted-content',
+      )
     })
 
     it('surfaces a lost concurrent-write race as a 409 even after a successful snapshot write', async () => {
@@ -4289,9 +4335,6 @@ describe('multirespondent-submission.service', () => {
         MockSnapshotStore.writeV4Snapshot.mockReturnValue(
           okAsync({ token: 'order-token', key: 'order-key' }),
         )
-        MockSnapshotStore.readV4Snapshot.mockReturnValue(
-          okAsync(buildSnapshot()),
-        )
 
         const created = await createMultiRespondentFormSubmission({
           form: buildV4Form(),
@@ -4299,10 +4342,11 @@ describe('multirespondent-submission.service', () => {
           logMeta: { action: 'test' },
         })
         expect(created.isOk()).toBe(true)
-        const submission = created._unsafeUnwrap()
+        const { submission, snapshot } = created._unsafeUnwrap()
 
         await performMultiRespondentPostSubmissionCreateActions({
           submission,
+          snapshot,
           submissionId: submission._id.toString(),
           form: buildV4Form(),
           encryptedPayload: buildV4Payload(),

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -138,8 +138,6 @@ const submitMultirespondentForm = async (
     return res.status(statusCode).json({ message: errorMessage })
   }
 
-  // The snapshot the save just PUT travels with the row across the HTTP
-  // response so the send path can reconstruct from it without an S3 read-back.
   const { submission, snapshot } =
     createMultiRespondentFormSubmissionResult.value
 
@@ -240,8 +238,6 @@ const updateMultirespondentSubmission = async (
     return res.status(statusCode).json({ message: errorMessage })
   }
 
-  // The snapshot the save just PUT travels with the row across the HTTP
-  // response so the send path can reconstruct from it without an S3 read-back.
   const { submission, snapshot } =
     updateMultiRespondentFormSubmissionResult.value
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -138,7 +138,10 @@ const submitMultirespondentForm = async (
     return res.status(statusCode).json({ message: errorMessage })
   }
 
-  const submission = createMultiRespondentFormSubmissionResult.value
+  // The snapshot the save just PUT travels with the row across the HTTP
+  // response so the send path can reconstruct from it without an S3 read-back.
+  const { submission, snapshot } =
+    createMultiRespondentFormSubmissionResult.value
 
   // Send success back to client
   res.json({
@@ -150,6 +153,7 @@ const submitMultirespondentForm = async (
 
   await performMultiRespondentPostSubmissionCreateActions({
     submission,
+    snapshot,
     submissionId: submission._id.toString(),
     form,
     encryptedPayload,
@@ -236,7 +240,10 @@ const updateMultirespondentSubmission = async (
     return res.status(statusCode).json({ message: errorMessage })
   }
 
-  const submission = updateMultiRespondentFormSubmissionResult.value
+  // The snapshot the save just PUT travels with the row across the HTTP
+  // response so the send path can reconstruct from it without an S3 read-back.
+  const { submission, snapshot } =
+    updateMultiRespondentFormSubmissionResult.value
 
   // Send success back to client
   res.json({
@@ -250,6 +257,7 @@ const updateMultirespondentSubmission = async (
 
   await performMultiRespondentPostSubmissionUpdateActions({
     submission,
+    snapshot,
     submissionId,
     snapshottedFormDef,
     currentStepNumber,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -49,7 +49,6 @@ import { FormRespondentSingleSubmissionValidationError } from '../../form/form.e
 import { isFormMultirespondent } from '../../form/form.utils'
 import { WebhookFactory } from '../../webhook/webhook.factory'
 import { getWebhookType } from '../../webhook/webhook.service'
-import { webhookStatsdClient } from '../../webhook/webhook.statsd-client'
 import {
   AttachmentUploadError,
   ExpectedResponseNotFoundError,
@@ -70,15 +69,10 @@ import {
 } from '../submission.utils'
 import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
-import {
-  SnapshotDataIntegrityError,
-  SnapshotWriteError,
-} from './webhook/submission-snapshot.errors'
+import { SnapshotWriteError } from './webhook/submission-snapshot.errors'
 import { buildV4Snapshot } from './webhook/submission-snapshot.producer'
-import {
-  readV4Snapshot,
-  writeV4Snapshot,
-} from './webhook/submission-snapshot.store'
+import { SubmissionSnapshotV4 } from './webhook/submission-snapshot.schema'
+import { writeV4Snapshot } from './webhook/submission-snapshot.store'
 import { getWebhookPayloadPolicy } from './webhook/webhook-payload-policy'
 import { reconstructMrfWebhookData } from './webhook/webhook-reconstruction'
 import { MultirespondentSubmissionContent } from './multirespondent-submission.types'
@@ -100,6 +94,27 @@ const appUrl =
   process.env.NODE_ENV === Environment.Dev
     ? config.app.feAppUrl
     : config.app.appUrl
+
+/**
+ * What a save returns: the committed row, plus the snapshot object that was
+ * PUT for the step it just committed.
+ *
+ * D10 — the initial send reconstructs from THIS object. It is never read back
+ * out of S3 (a transient GET would drop the webhook for a healthy submission)
+ * and never re-derived from the row (that only works for v4 and would become a
+ * live-row fallback for v1). The producer and the sender sit either side of the
+ * HTTP response, so the object travels: save -> controller -> post-submission
+ * actions -> reconstruction.
+ *
+ * `snapshot` is absent exactly when no snapshot was written (the write-condition
+ * is false), which is also when the send takes the legacy live-row path.
+ */
+export type SavedMultirespondentSubmission = {
+  submission: IMultirespondentSubmissionSchema & {
+    _id: mongoose.Types.ObjectId
+  }
+  snapshot?: SubmissionSnapshotV4
+}
 
 export const checkFormIsMultirespondent = (
   form: IPopulatedForm,
@@ -724,7 +739,7 @@ export const createMultiRespondentFormSubmission = ({
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
 }): ResultAsync<
-  IMultirespondentSubmissionSchema & { _id: mongoose.Types.ObjectId },
+  SavedMultirespondentSubmission,
   AttachmentUploadError | SubmissionSaveError | SnapshotWriteError
 > => {
   logMeta = {
@@ -861,23 +876,28 @@ export const createMultiRespondentFormSubmission = ({
       // step entry BEFORE committing the row. A write failure aborts the save
       // (fail-loud, no commit-first). When the write-condition is false, behave
       // exactly as before (no snapshot, no token).
+      //
+      // The object is kept so it can be returned to the caller and handed
+      // straight to reconstruction — the send path never reads it back (D10).
+      const snapshot = shouldWriteSnapshot
+        ? buildV4Snapshot({
+            formId: String(form._id),
+            submissionId: String(submissionObjectId),
+            submissionIndex: 0,
+            workflowStep: 0,
+            encryptedContent,
+            encryptedSubmissionSecretKey,
+            verifiedContent,
+            attachmentMetadata: Object.fromEntries(
+              attachmentMetadata ?? new Map(),
+            ),
+            createdAt: submittedStepMeta.submittedAt,
+          })
+        : undefined
+
       const writeSnapshotIfNeeded: ResultAsync<undefined, SnapshotWriteError> =
-        shouldWriteSnapshot
-          ? writeV4Snapshot(
-              buildV4Snapshot({
-                formId: String(form._id),
-                submissionId: String(submissionObjectId),
-                submissionIndex: 0,
-                workflowStep: 0,
-                encryptedContent,
-                encryptedSubmissionSecretKey,
-                verifiedContent,
-                attachmentMetadata: Object.fromEntries(
-                  attachmentMetadata ?? new Map(),
-                ),
-                createdAt: submittedStepMeta.submittedAt,
-              }),
-            ).map(({ token }) => {
+        snapshot
+          ? writeV4Snapshot(snapshot).map(({ token }) => {
               submittedStepMeta.snapshotToken = token
               return undefined
             })
@@ -888,6 +908,7 @@ export const createMultiRespondentFormSubmission = ({
           saveSubmission().then((submission) => ({
             submission,
             responseMetadata,
+            snapshot,
           })),
           (error) => {
             if (
@@ -905,7 +926,7 @@ export const createMultiRespondentFormSubmission = ({
         ),
       )
     })
-    .map(({ submission, responseMetadata }) => {
+    .map(({ submission, responseMetadata, snapshot }) => {
       const submissionId = submission.id
       logger.info({
         message: 'Saved submission to MongoDB',
@@ -920,7 +941,7 @@ export const createMultiRespondentFormSubmission = ({
         })
       }
 
-      return submission
+      return { submission, snapshot }
     })
 }
 
@@ -1090,31 +1111,34 @@ const generatePdfAttachmentIfRequired = ({
 }
 
 /**
- * Fire-and-forget the initial MRF webhook, applying the S4 send gate, v4
- * snapshot reconstruction, and payload-size guard. Errors are logged (and, for
- * the alarmable seams, emitted as statsd metrics) rather than propagated — the
+ * Fire-and-forget the initial MRF webhook, applying the S4 send gate and v4
+ * snapshot reconstruction. Errors are logged rather than propagated — the
  * caller's response has already been sent.
  *
  * Send gate: plumber is always sent; generic (== zapier) is gated behind the
  * `enable-mrf-webhooks` flag (default off ⇒ not sent).
  *
- * v4 path (plumber + a recorded snapshot token): point-read the frozen
- * snapshot, reconstruct the wire payload from it + the live row, and deliver a
- * pre-built view. A data-integrity failure or an over-sized payload fails loud
- * (no live-row fallback, no silent truncation). All other consumers (generic,
- * or plumber without a token i.e. flag-off legacy V3) take the legacy
- * getWebhookView path unchanged.
+ * v4 path (plumber + the in-memory snapshot the save just wrote): reconstruct
+ * the wire payload from that object + the live row and deliver a pre-built
+ * view. D10 — there is NO S3 read here. The object is threaded down from the
+ * save; a read-back would only re-verify what the create-if-absent PUT already
+ * guaranteed, while adding a failure surface that drops the webhook for a
+ * healthy submission. The retry path (S5) still reads S3, because it has no
+ * in-memory object.
+ *
+ * All other consumers (generic, or plumber with no snapshot i.e. flag-off
+ * legacy V3) take the legacy getWebhookView path unchanged.
  */
 const sendMrfInitialWebhookIfEligible = ({
   submission,
-  formId,
+  snapshot,
   webhookUrl,
   isRetryEnabled,
   growthbook,
   logMeta,
 }: {
   submission: IMultirespondentSubmissionSchema
-  formId: string
+  snapshot?: SubmissionSnapshotV4
   webhookUrl: string
   isRetryEnabled: boolean
   growthbook?: GrowthBook
@@ -1135,12 +1159,10 @@ const sendMrfInitialWebhookIfEligible = ({
   })
 
   const submissionIndex = (submission.submittedSteps?.length ?? 1) - 1
-  const recordedToken =
-    submission.submittedSteps?.[submissionIndex]?.snapshotToken
 
-  // Legacy path: generic consumers, or plumber without a recorded token
+  // Legacy path: generic consumers, or plumber with no snapshot for this step
   // (flag-off legacy V3). Byte-identical to the pre-S4 behaviour.
-  if (!(webhookType === 'plumber' && recordedToken)) {
+  if (!(webhookType === 'plumber' && snapshot)) {
     WebhookFactory.sendInitialWebhook(
       submission,
       webhookUrl,
@@ -1155,56 +1177,36 @@ const sendMrfInitialWebhookIfEligible = ({
     return
   }
 
-  // v4 snapshot-reconstruction path.
-  readV4Snapshot({
-    formId,
-    submissionId: String(submission._id),
-    submissionIndex,
-    token: recordedToken,
-  })
-    .andThen((snapshot) =>
-      ResultAsync.fromPromise(
-        submission.getWebhookView(),
-        () => new DatabaseError(),
-      ).andThen((liveView) => {
-        const policy = getWebhookPayloadPolicy({
-          webhookType: 'plumber',
-          webhookFormat: 'v4',
-          submissionIndex,
-          submittedStepsLength: submission.submittedSteps?.length ?? 0,
-        })
-        // S4 ships NO step token even if policy.includeEncryptedStepToken is
-        // true — reconstruction does not add one and neither do we.
-        const data = reconstructMrfWebhookData({
-          liveData: liveView.data,
-          snapshot,
-          submissionIndex,
-          policy,
-        })
-        const view: WebhookView = { data }
+  // v4 snapshot-reconstruction path, straight from the in-memory object.
+  ResultAsync.fromPromise(
+    submission.getWebhookView(),
+    () => new DatabaseError(),
+  )
+    .andThen((liveView) => {
+      const policy = getWebhookPayloadPolicy({
+        webhookType: 'plumber',
+        webhookFormat: 'v4',
+        submissionIndex,
+        submittedStepsLength: submission.submittedSteps?.length ?? 0,
+      })
+      // S4 ships NO step token even if policy.includeEncryptedStepToken is
+      // true — reconstruction does not add one and neither do we.
+      const data = reconstructMrfWebhookData({
+        liveData: liveView.data,
+        snapshot,
+        submissionIndex,
+        policy,
+      })
+      const view: WebhookView = { data }
 
-        return WebhookFactory.sendInitialWebhook(
-          submission,
-          webhookUrl,
-          isRetryEnabled,
-          view,
-        ).map(() => undefined)
-      }),
-    )
+      return WebhookFactory.sendInitialWebhook(
+        submission,
+        webhookUrl,
+        isRetryEnabled,
+        view,
+      ).map(() => undefined)
+    })
     .mapErr((error) => {
-      // Data-integrity failure: fail loud. Never fall back to the live-row view.
-      if (error instanceof SnapshotDataIntegrityError) {
-        logger.error({
-          message: 'MRF webhook snapshot data integrity error',
-          meta: {
-            ...logMeta,
-            submissionIndex,
-          },
-          error,
-        })
-        webhookStatsdClient.increment('mrf.snapshot.data_integrity_error')
-        return
-      }
       logger.error({
         message: 'Multirespondent submission webhook error',
         meta: logMeta,
@@ -1215,6 +1217,7 @@ const sendMrfInitialWebhookIfEligible = ({
 
 export const performMultiRespondentPostSubmissionCreateActions = ({
   submission,
+  snapshot,
   submissionId,
   form,
   encryptedPayload,
@@ -1223,6 +1226,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   growthbook,
 }: {
   submission: IMultirespondentSubmissionSchema
+  snapshot?: SubmissionSnapshotV4
   submissionId: string
   form: IPopulatedMultirespondentForm
   encryptedPayload: MultirespondentSubmissionDto
@@ -1303,7 +1307,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   if (webhookUrl) {
     sendMrfInitialWebhookIfEligible({
       submission,
-      formId: String(form._id),
+      snapshot,
       webhookUrl,
       isRetryEnabled: !!form.webhook?.isRetryEnabled,
       growthbook,
@@ -1364,7 +1368,7 @@ export const updateMultiRespondentFormSubmission = ({
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
 }): ResultAsync<
-  IMultirespondentSubmissionSchema & { _id: mongoose.Types.ObjectId },
+  SavedMultirespondentSubmission,
   | AttachmentUploadError
   | SubmissionSaveError
   | SubmissionNotFoundError
@@ -1497,23 +1501,28 @@ export const updateMultiRespondentFormSubmission = ({
         !!snapshottedFormDef.webhook?.url &&
         !!snapshottedFormDef.webhook?.isRetryEnabled
 
+      //
+      // The object is kept so it can be returned to the caller and handed
+      // straight to reconstruction — the send path never reads it back (D10).
+      const snapshot = shouldWriteSnapshot
+        ? buildV4Snapshot({
+            formId: String(snapshottedFormDef._id),
+            submissionId: String(submission._id),
+            submissionIndex,
+            workflowStep,
+            encryptedContent,
+            encryptedSubmissionSecretKey,
+            verifiedContent,
+            attachmentMetadata: Object.fromEntries(
+              attachmentMetadata ?? new Map(),
+            ),
+            createdAt: submittedStepMeta.submittedAt,
+          })
+        : undefined
+
       const writeSnapshotIfNeeded: ResultAsync<undefined, SnapshotWriteError> =
-        shouldWriteSnapshot
-          ? writeV4Snapshot(
-              buildV4Snapshot({
-                formId: String(snapshottedFormDef._id),
-                submissionId: String(submission._id),
-                submissionIndex,
-                workflowStep,
-                encryptedContent,
-                encryptedSubmissionSecretKey,
-                verifiedContent,
-                attachmentMetadata: Object.fromEntries(
-                  attachmentMetadata ?? new Map(),
-                ),
-                createdAt: submittedStepMeta.submittedAt,
-              }),
-            ).map(({ token }) => {
+        snapshot
+          ? writeV4Snapshot(snapshot).map(({ token }) => {
               submittedStepMeta.snapshotToken = token
               return undefined
             })
@@ -1528,7 +1537,9 @@ export const updateMultiRespondentFormSubmission = ({
         ]
 
         return ResultAsync.fromPromise(
-          submission.save().then(() => ({ submission, responseMetadata })),
+          submission
+            .save()
+            .then(() => ({ submission, responseMetadata, snapshot })),
           (error) => {
             if (error instanceof mongoose.Error.VersionError) {
               return transformMongoError(error)
@@ -1543,18 +1554,19 @@ export const updateMultiRespondentFormSubmission = ({
         )
       })
     })
-    .map(({ submission, responseMetadata }) => {
+    .map(({ submission, responseMetadata, snapshot }) => {
       logger.info({
         message: 'Saved submission to MongoDB',
         meta: { ...logMeta, submissionId: submission.id, responseMetadata },
       })
 
-      return submission
+      return { submission, snapshot }
     })
 }
 
 export const performMultiRespondentPostSubmissionUpdateActions = ({
   submission,
+  snapshot,
   submissionId,
   snapshottedFormDef,
   currentStepNumber,
@@ -1564,6 +1576,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   growthbook,
 }: {
   submission: IMultirespondentSubmissionSchema
+  snapshot?: SubmissionSnapshotV4
   submissionId: string
   snapshottedFormDef: SnapshottedFormDef
   currentStepNumber: number
@@ -1616,7 +1629,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   if (webhookUrl) {
     sendMrfInitialWebhookIfEligible({
       submission,
-      formId: String(snapshottedFormDef._id),
+      snapshot,
       webhookUrl,
       isRetryEnabled: !!snapshottedFormDef.webhook?.isRetryEnabled,
       growthbook,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/initial-send-route-parity.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/initial-send-route-parity.spec.ts
@@ -1,0 +1,249 @@
+// GATE — the two v4 initial-send routes must produce the same wire payload for
+// the same step.
+//
+// Route A: snapshot-backed. A snapshot was written for the step, so the send
+//   reconstructs the payload from the in-memory object plus the live row.
+// Route B: no snapshot (the write-condition was false, e.g. retries disabled),
+//   so the send falls through to the legacy live-row `getWebhookView`.
+//
+// Whether a step got a snapshot is a storage decision. It must not change what
+// a consumer receives. Pinning that here is what lets S6's snapshot
+// write-condition stay a one-line rule instead of a payload-shape decision —
+// today the two routes agree only incidentally.
+//
+// Equality is asserted MODULO ATTACHMENT PRESIGNED URLS: `sendWebhook` mints a
+// fresh 1-hour presigned URL per attachment at send time, each with its own
+// signature and expiry, so literal byte-equality cannot hold on a fixture that
+// has attachments. The URL *keys* and their S3 targets are still compared.
+//
+// `version` is also excluded, and pinned separately below, because the two
+// routes ALREADY disagree on it on develop — see the second test for the full
+// story. Excluding it is what lets this gate catch the NEXT divergence instead
+// of staying red on an existing one.
+import dbHandler from '__tests__/unit/backend/helpers/jest-db'
+import axios, { AxiosResponse } from 'axios'
+import { ObjectId } from 'bson'
+import { MULTIRESPONDENT_FORM_SUBMISSION_VERSION } from 'formsg-shared/constants'
+import { SubmissionType, WorkflowType } from 'formsg-shared/types'
+import mongoose from 'mongoose'
+
+import { getMultirespondentSubmissionModel } from 'src/app/models/submission.server.model'
+import * as WebhookValidationModule from 'src/app/modules/webhook/webhook.validation'
+import { IMultirespondentSubmissionSchema, WebhookView } from 'src/types'
+import { WebhookData } from 'src/types/submission'
+
+import { sendWebhook } from '../../../../webhook/webhook.service'
+import { buildV4Snapshot } from '../submission-snapshot.producer'
+import { getWebhookPayloadPolicy } from '../webhook-payload-policy'
+import { reconstructMrfWebhookData } from '../webhook-reconstruction'
+
+jest.mock('axios')
+const MockAxios = jest.mocked(axios)
+
+jest.mock('src/app/modules/webhook/webhook.validation')
+const MockWebhookValidation = jest.mocked(WebhookValidationModule)
+
+const MOCK_WEBHOOK_URL = 'https://plumber.gov.sg/webhooks/parity'
+
+const MOCK_AXIOS_RESPONSE = {
+  data: { result: 'ok' },
+  status: 200,
+  statusText: 'success',
+  headers: {},
+  config: {},
+} as AxiosResponse
+
+const MultirespondentSubmissionModel =
+  getMultirespondentSubmissionModel(mongoose)
+
+const formId = new ObjectId()
+const fieldId = new ObjectId().toHexString()
+const attachmentFieldId = new ObjectId().toHexString()
+
+const ENCRYPTED_CONTENT = 'v4-encrypted-content'
+const ENCRYPTED_SUBMISSION_SECRET_KEY = 'wrapped-read-key-v4'
+const VERIFIED_CONTENT = 'v4-verified-content'
+const ATTACHMENT_METADATA = {
+  [attachmentFieldId]: `${formId.toHexString()}/attachment-object-key`,
+}
+
+const workflow = [
+  {
+    _id: new ObjectId().toHexString(),
+    workflow_type: WorkflowType.Static,
+    emails: [],
+    edit: [fieldId],
+  },
+  {
+    _id: new ObjectId().toHexString(),
+    workflow_type: WorkflowType.Static,
+    emails: ['next@example.com'],
+    edit: [fieldId],
+  },
+]
+
+/**
+ * Drops the two fields that are compared separately: the presigned URL values
+ * (volatile by construction) and `version` (a pinned pre-existing divergence).
+ * Attachment field ids and the S3 object each URL points at are KEPT, so an
+ * attachment going missing or pointing somewhere else still fails the gate.
+ */
+const comparablePayload = (data: WebhookData): unknown => {
+  const rest: Partial<WebhookData> = { ...data }
+  delete rest.version
+  return {
+    ...rest,
+    attachmentDownloadUrls: Object.fromEntries(
+      Object.entries(data.attachmentDownloadUrls ?? {}).map(([key, url]) => [
+        key,
+        new URL(url).pathname,
+      ]),
+    ),
+  }
+}
+
+const capturePostedPayload = async (
+  submission: IMultirespondentSubmissionSchema,
+  view?: WebhookView,
+): Promise<WebhookData> => {
+  MockAxios.post.mockClear()
+  MockAxios.post.mockResolvedValue(MOCK_AXIOS_RESPONSE)
+
+  const liveView = view ?? (await submission.getWebhookView())
+  const result = await sendWebhook(liveView, MOCK_WEBHOOK_URL)
+  expect(result.isOk()).toBe(true)
+
+  return (MockAxios.post.mock.calls[0][1] as WebhookView).data
+}
+
+describe('[GATE] v4 initial-send route parity', () => {
+  beforeAll(async () => {
+    await dbHandler.connect()
+  })
+  afterEach(async () => {
+    await dbHandler.clearDatabase()
+    jest.clearAllMocks()
+  })
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  beforeEach(() => {
+    MockWebhookValidation.validateWebhookUrl.mockResolvedValue(undefined)
+  })
+
+  /**
+   * A row committed by the v4 initial send: latest step, V4 content, an
+   * attachment, and a recorded snapshot token.
+   */
+  const createRow = async (): Promise<IMultirespondentSubmissionSchema> =>
+    await MultirespondentSubmissionModel.create({
+      form: formId,
+      submissionType: SubmissionType.Multirespondent,
+      form_fields: [],
+      form_logics: [],
+      workflow,
+      submissionPublicKey: 'submission-public-key',
+      encryptedSubmissionSecretKey: ENCRYPTED_SUBMISSION_SECRET_KEY,
+      encryptedContent: ENCRYPTED_CONTENT,
+      verifiedContent: VERIFIED_CONTENT,
+      attachmentMetadata: new Map(Object.entries(ATTACHMENT_METADATA)),
+      version: MULTIRESPONDENT_FORM_SUBMISSION_VERSION,
+      workflowStep: 0,
+      mrfVersion: 2,
+      submittedSteps: [
+        {
+          isApproval: false,
+          submittedAt: new Date().toISOString(),
+          snapshotToken: 'tok-parity',
+        },
+      ],
+    })
+
+  /** Sends the same step both ways and returns the two posted payloads. */
+  const bothRoutes = async (): Promise<{
+    snapshotBacked: WebhookData
+    liveRow: WebhookData
+  }> => {
+    const submission = await createRow()
+    const submissionIndex = (submission.submittedSteps?.length ?? 1) - 1
+
+    // Route A — snapshot-backed. The snapshot is built from exactly what the
+    // save committed, as the initial send does.
+    const snapshot = buildV4Snapshot({
+      formId: formId.toHexString(),
+      submissionId: String(submission._id),
+      submissionIndex,
+      workflowStep: submission.workflowStep,
+      encryptedContent: ENCRYPTED_CONTENT,
+      encryptedSubmissionSecretKey: ENCRYPTED_SUBMISSION_SECRET_KEY,
+      verifiedContent: VERIFIED_CONTENT,
+      attachmentMetadata: ATTACHMENT_METADATA,
+      createdAt: submission.submittedSteps?.[submissionIndex]
+        ?.submittedAt as string,
+    })
+    const liveView = await submission.getWebhookView()
+    const snapshotBacked = await capturePostedPayload(submission, {
+      data: reconstructMrfWebhookData({
+        liveData: liveView.data,
+        snapshot,
+        submissionIndex,
+        policy: getWebhookPayloadPolicy({
+          webhookType: 'plumber',
+          webhookFormat: 'v4',
+          submissionIndex,
+          submittedStepsLength: submission.submittedSteps?.length ?? 0,
+        }),
+      }),
+    })
+
+    // Route B — no snapshot for this step, so the legacy live-row view is sent.
+    const liveRow = await capturePostedPayload(submission)
+
+    return { snapshotBacked, liveRow }
+  }
+
+  it('produces the same payload whether or not the step was snapshotted', async () => {
+    const { snapshotBacked, liveRow } = await bothRoutes()
+
+    expect(comparablePayload(snapshotBacked)).toEqual(
+      comparablePayload(liveRow),
+    )
+  })
+
+  // KNOWN DIVERGENCE, pinned rather than fixed here.
+  //
+  // The snapshot route derives the wire version from the frozen content shape
+  // (`contentShapeToSubmissionVersion('v4') === 3`, pinned by S4/#9744). The
+  // live-row route sends the row's own `version`, which the front end sets from
+  // MULTIRESPONDENT_FORM_SUBMISSION_VERSION — bumped 3 -> 4 by #9782 AFTER that
+  // mapping was pinned. So the same plumber form reports 3 with retries on
+  // (snapshotted) and 4 with retries off (not snapshotted).
+  //
+  // Reconciling them changes what plumber receives, so it is a deliberate
+  // product call and not #9807's to make. This pins both values so the drift is
+  // visible and any change to either is deliberate.
+  it('pins the pre-existing wire-version divergence between the two routes', async () => {
+    const { snapshotBacked, liveRow } = await bothRoutes()
+
+    expect(snapshotBacked.version).toBe(3)
+    expect(liveRow.version).toBe(MULTIRESPONDENT_FORM_SUBMISSION_VERSION)
+    expect(MULTIRESPONDENT_FORM_SUBMISSION_VERSION).toBe(4)
+  })
+
+  it('presigns attachment URLs at send time, which is why parity is asserted modulo them', async () => {
+    const submission = await createRow()
+
+    const first = await capturePostedPayload(submission)
+    const second = await capturePostedPayload(submission)
+
+    const firstUrl = first.attachmentDownloadUrls?.[attachmentFieldId] as string
+    const secondUrl = second.attachmentDownloadUrls?.[
+      attachmentFieldId
+    ] as string
+
+    // A signature and an expiry are minted per send, so the query string is not
+    // stable even though the object being pointed at is.
+    expect(firstUrl).toContain('Signature=')
+    expect(firstUrl).toContain('Expires=')
+    expect(new URL(firstUrl).pathname).toBe(new URL(secondUrl).pathname)
+  })
+})

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.roundtrip.localstack.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.roundtrip.localstack.spec.ts
@@ -1,0 +1,109 @@
+// Live round-trip test for the snapshot store against a running Localstack
+// (docker-compose + init-localstack.sh creates the bucket).
+//
+// D10 removed the S3 read-back from the initial send, which also removed the
+// end-to-end coverage that path gave incidentally: before, every snapshot-backed
+// send proved that what `writeV4Snapshot` PUT could be fetched and parsed again.
+// The retry path (S5) still depends on exactly that round trip, so it is
+// asserted here explicitly instead of as a side effect of sending.
+//
+// Skips gracefully when Localstack is unreachable (e.g. unit-test CI without the
+// docker stack), so it is a no-op there rather than a failure.
+import { aws as AwsConfig } from 'src/app/config/config'
+
+import { buildV4Snapshot } from '../submission-snapshot.producer'
+import { parseSnapshot } from '../submission-snapshot.schema'
+import {
+  buildSnapshotKey,
+  readV4Snapshot,
+  writeV4Snapshot,
+} from '../submission-snapshot.store'
+
+const REACHABILITY_ERRORS = [
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'UnknownEndpoint',
+  'TimeoutError',
+  'NetworkingError',
+]
+
+const isUnreachable = (err: unknown): boolean => {
+  const code = (err as { code?: string })?.code ?? ''
+  const name = (err as { name?: string })?.name ?? ''
+  return (
+    REACHABILITY_ERRORS.includes(code) || REACHABILITY_ERRORS.includes(name)
+  )
+}
+
+/**
+ * True when Localstack answers at all. Probed with a raw GET for a key that
+ * cannot exist: a NoSuchKey response proves the endpoint is live.
+ */
+const isLocalstackReachable = async (): Promise<boolean> => {
+  try {
+    await AwsConfig.s3
+      .getObject({
+        Bucket: AwsConfig.submissionHistoryV4S3Bucket,
+        Key: `__reachability-probe__/${Date.now()}`,
+      })
+      .promise()
+    return true
+  } catch (err) {
+    if (isUnreachable(err)) return false
+    return true
+  }
+}
+
+describe('submission snapshot S3 round trip (Localstack)', () => {
+  const coords = {
+    formId: `roundtrip-form-${Date.now()}`,
+    submissionId: 'roundtrip-submission',
+    submissionIndex: 3,
+  }
+
+  const snapshot = buildV4Snapshot({
+    ...coords,
+    workflowStep: 2,
+    encryptedContent: 'encrypted-content-blob',
+    encryptedSubmissionSecretKey: 'wrapped-read-key',
+    verifiedContent: 'verified-content-blob',
+    attachmentMetadata: { 'field-1': 'form-1/attachment-1' },
+    createdAt: '2026-07-22T00:00:00.000Z',
+  })
+
+  it('writes a snapshot, reads it back and parses it through the shared parser', async () => {
+    if (!(await isLocalstackReachable())) {
+      // eslint-disable-next-line no-console
+      console.warn('Localstack unreachable — skipping snapshot round trip.')
+      return
+    }
+
+    const written = await writeV4Snapshot(snapshot)
+    expect(written.isOk()).toBe(true)
+    const { token, key } = written._unsafeUnwrap()
+    expect(key).toBe(buildSnapshotKey({ ...coords, token }))
+
+    // The reader parses through the shared fail-loud parser, so an object that
+    // survives this is one the retry path can actually deliver.
+    const read = await readV4Snapshot({ ...coords, token })
+    expect(read.isOk()).toBe(true)
+    expect(read._unsafeUnwrap()).toEqual(snapshot)
+
+    // And the raw bytes on the object are exactly what the parser accepts —
+    // asserted independently of the reader so a change in either is caught.
+    const raw = await AwsConfig.s3
+      .getObject({ Bucket: AwsConfig.submissionHistoryV4S3Bucket, Key: key })
+      .promise()
+    const parsed = parseSnapshot(raw.Body?.toString() ?? '')
+    expect(parsed.isOk()).toBe(true)
+    expect(parsed._unsafeUnwrap()).toEqual(snapshot)
+
+    await AwsConfig.s3
+      .deleteObject({ Bucket: AwsConfig.submissionHistoryV4S3Bucket, Key: key })
+      .promise()
+      .catch(() => undefined)
+  }, 20000)
+})


### PR DESCRIPTION
Closes #9807. Part of slice S4 of #9803 (D10, R6, and the coverage replacement in R1).

> **Was stacked on #9810** (`feat/9805-mrf-remove-payload-size-guard`), which removes the payload-size guard from the same block of the initial-send function. #9810 merged while this was in flight, so this branch has been rebased onto `feat/9744-mrf-v4-minimal-e2e` and now targets it directly — no ordering constraint left.

## Problem

The MRF initial send PUT the snapshot to S3 and then GET the same object back to reconstruct from it.

A `putObject` 200 with `If-None-Match: '*'` already establishes durability and uncontended placement, so the read-back mostly re-verified what the PUT guaranteed — while adding a failure surface on the happy path. It is a live defect, not a theoretical one: a transient GET collapsed into `SnapshotDataIntegrityError` and **dropped the webhook for a submission whose snapshot was perfectly healthy**.

## Solution

Drop the read-back and hand the in-memory snapshot object straight to reconstruction.

`createMultiRespondentFormSubmission` and `updateMultiRespondentFormSubmission` now return `{ submission, snapshot? }`. The controller threads the object across the HTTP response into the post-submission actions, which hand it to `reconstructMrfWebhookData`. The producer and the sender are in different functions with the response between them, so the object has to travel.

The v4 send branch is now selected on the presence of the snapshot object rather than the recorded `snapshotToken` — the two are produced by the same branch, so the condition is unchanged, but the thing the path needs is now the thing that selects it.

Removing the read-back also makes initial-vs-retry byte-identity true by construction rather than by a runtime round trip.

**Not done, deliberately:** the snapshot is *not* re-derived from the row in post-actions. `buildV4Snapshot` is pure over fields that all live on the row, so it would work — *for v4*. It cannot work for v1, where the form-key copy exists nowhere on the row. S6 would have to rip it out, and if that were missed the v1 initial send would rebuild from the row and ship submission-key V4 bytes to a generic consumer: D9's forbidden live-row fallback, reached by a side door.

**`readV4Snapshot` and its error taxonomy are untouched and still exported.** After this change it has zero production callers until the retry path (S5, #9745) lands, which has no in-memory object and must fetch by recorded token. That is intended. Splitting its transient/data-integrity errors is D11 and belongs to S5.

## Test obligations that came with it

**Localstack round trip** (`submission-snapshot.roundtrip.localstack.spec.ts`) — the end-to-end coverage the read-back gave incidentally is replaced explicitly: write a snapshot, read it back, parse it through the shared fail-loud parser. Goes through the real `writeV4Snapshot`/`readV4Snapshot` so key construction, the create-if-absent precondition and the parser are all on the asserted path; it also re-fetches the raw object and parses it directly, so a change in the reader and a change in the parser cannot cancel each other out. Follows the existing convention in this directory: skips with a warning when Localstack is unreachable. **Verified against a live Localstack S3 (PUT 200 / GET 200 / GET 200 / DELETE 204 in the container log), not just skipped.**

**Route parity gate** (`initial-send-route-parity.spec.ts`) — pins the two v4 initial-send routes (snapshot-backed vs no-snapshot live-row, same step) to the same payload. Whether a step got a snapshot is a storage decision and must not change what a consumer receives; pinning it is what lets S6's write-condition stay a one-line rule.

Asserted **modulo attachment presigned URLs**: `createWebhookSubmissionView` mints a fresh 1-hour URL per attachment at send time, each with its own signature and expiry, so literal byte-equality cannot hold on a realistic fixture. The URL keys and the S3 object each points at are still compared, and a third test demonstrates why the carve-out is needed.

## ⚠️ Finding: the gate caught a pre-existing `version` divergence

The gate found a live divergence it was designed to find — but one that predates this issue and is not this issue's to fix.

- The snapshot route derives the wire version from the frozen content shape: `contentShapeToSubmissionVersion('v4') === 3`, pinned by S4/#9744 and by #9803's glossary.
- The live-row route sends the row's own `version`, which the front end sets from `MULTIRESPONDENT_FORM_SUBMISSION_VERSION` — **bumped 3 → 4 by #9782 ("FE sends and works in V4"), after that mapping was pinned.**

Net effect on `develop` today: **the same plumber MRF form reports `version: 3` with retries enabled (snapshotted) and `version: 4` with retries disabled (not snapshotted).** The #9803 premise that "MRF rows always store `version: 3`" is no longer true.

Reconciling them changes what plumber receives on the wire, so it is a deliberate product call rather than #9807's to make. The gate therefore compares every other field and **pins both values explicitly** in a separate test, so the drift is visible and any change to either is deliberate. This keeps the gate able to catch the *next* divergence instead of sitting red on an existing one. **Please decide whether this needs its own issue before S6.**

### Alternatives considered

- **Change `contentShapeToSubmissionVersion('v4')` to 4 (or make it track `MULTIRESPONDENT_FORM_SUBMISSION_VERSION`):** rejected here — it silently changes the payload plumber receives and edits a mapping #9744 deliberately pinned.
- **Leave the parity gate red or skipped:** rejected — a gate nobody can run teaches nothing.
- **Keep branching the send on the recorded token and read the object separately:** rejected — two sources of truth for one condition, and the failure mode is a v4 branch entered with no snapshot, which `reconstructMrfWebhookData` answers by throwing.

## Verification

- `apps/backend` MRF + webhook suites: **288 passed / 20 suites**, including the Localstack round trip run for real.
- `npx tsc -p apps/backend/tsconfig.build.json --noEmit`: clean.
- Full `tsconfig.json`: 111 errors before and after this branch, byte-identical apart from line-number shifts — no new errors, including none added to `multirespondent-submission.controller.spec.ts`.
- `eslint` clean over the touched module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
