### PR TITLE
feat(mrf): record snapshot tokens per format (#9803 D7, pulled forward)

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -793,14 +793,14 @@ describe('Submission Model', () => {
           status: WorkflowStatus.APPROVED,
           nextStepRecipientEmails: ['next@example.com'],
           submitterId: 'SUBMITTER_ID_HASH',
-          snapshotToken: 'SNAPSHOT_TOKEN_LEAF_VALUE',
+          snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
         },
       ],
     })
 
     // The admin-visible set is derived from the classification table:
     // nextStepRecipientEmails is read server-side by buildMrfMetadata, so it
-    // must still load; submitterId and snapshotToken are unread here.
+    // must still load; submitterId and snapshotTokens are unread here.
     const EXPECTED_ADMIN_STEP = {
       isApproval: true,
       submittedAt: '2026-07-22T00:00:00.000Z',
@@ -901,7 +901,7 @@ describe('Submission Model', () => {
           },
         })
       })
-      it('should project submittedSteps for multirespondent submissions, omitting the internal snapshotToken', async () => {
+      it('should project submittedSteps for multirespondent submissions, omitting the internal snapshotTokens', async () => {
         // Arrange
         const formId = new ObjectId()
         const submission = await MultirespondentSubmission.create({
@@ -922,7 +922,7 @@ describe('Submission Model', () => {
               status: WorkflowStatus.APPROVED,
               nextStepRecipientEmails: ['next@example.com'],
               submitterId: 'SUBMITTER_ID_HASH',
-              snapshotToken: 'SNAPSHOT_TOKEN_LEAF_VALUE',
+              snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
             },
           ],
         })

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -545,8 +545,10 @@ const submittedStepSchema = new Schema(
       type: String,
       enum: [WorkflowStatus.APPROVED, WorkflowStatus.REJECTED],
     },
-    snapshotToken: {
-      type: String,
+    snapshotTokens: {
+      v4: {
+        type: String,
+      },
     },
   },
   { _id: false },

--- a/apps/backend/src/app/modules/status-tracker/__tests__/status-tracker.controller.spec.ts
+++ b/apps/backend/src/app/modules/status-tracker/__tests__/status-tracker.controller.spec.ts
@@ -18,7 +18,7 @@ const getStatusTrackerSubmissionData = handleGetStatusTracker[
 describe('status-tracker.controller', () => {
   afterEach(() => jest.restoreAllMocks())
 
-  it('omits the internal snapshotToken and respondent emails from the response body', async () => {
+  it('omits the internal snapshotTokens and respondent emails from the response body', async () => {
     // Arrange: a real (unsaved) mongoose document, so the controller sees the
     // subdocument shape it sees in production.
     const submission = new MultirespondentSubmission({
@@ -38,7 +38,7 @@ describe('status-tracker.controller', () => {
           status: WorkflowStatus.APPROVED,
           nextStepRecipientEmails: ['next@example.com'],
           submitterId: 'SUBMITTER_ID_HASH',
-          snapshotToken: 'SNAPSHOT_TOKEN_LEAF_VALUE',
+          snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
         },
       ],
     })

--- a/apps/backend/src/app/modules/submission/__tests__/submitted-step-visibility.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submitted-step-visibility.spec.ts
@@ -17,11 +17,11 @@ const fullApprovalStep = {
   status: WorkflowStatus.APPROVED,
   nextStepRecipientEmails: ['next@example.com'],
   submitterId: 'SUBMITTER_ID_HASH',
-  snapshotToken: 'SNAPSHOT_TOKEN_LEAF_VALUE',
+  snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
 } satisfies SubmittedStep
 
 describe('projectSubmittedStepForWebhook', () => {
-  it('drops snapshotToken but keeps the fields webhook consumers receive today', () => {
+  it('drops snapshotTokens but keeps the fields webhook consumers receive today', () => {
     const out = projectSubmittedStepForWebhook(fullApprovalStep)
 
     expect(out).toEqual({
@@ -45,7 +45,7 @@ describe('projecting a mongoose subdocument', () => {
       status: String,
       nextStepRecipientEmails: [String],
       submitterId: String,
-      snapshotToken: String,
+      snapshotTokens: { v4: String },
     },
     { _id: false },
   )
@@ -73,7 +73,7 @@ describe('projecting a mongoose subdocument', () => {
 })
 
 describe('projectSubmittedStepForPublic', () => {
-  it('drops snapshotToken and respondent emails from the public response', () => {
+  it('drops snapshotTokens and respondent emails from the public response', () => {
     const out = projectSubmittedStepForPublic(fullApprovalStep)
 
     expect(out).toEqual({

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -3871,7 +3871,7 @@ describe('multirespondent-submission.service', () => {
           {
             isApproval: false,
             submittedAt: new Date().toISOString(),
-            snapshotToken: token,
+            snapshotTokens: token ? { v4: token } : undefined,
           },
         ],
         getWebhookView: jest.fn().mockResolvedValue(view),
@@ -3914,7 +3914,7 @@ describe('multirespondent-submission.service', () => {
       const saved = await getMultirespondentSubmissionModel(mongoose).findById(
         result._unsafeUnwrap().submission._id,
       )
-      expect(saved?.submittedSteps?.[0]?.snapshotToken).toBe('tok-create')
+      expect(saved?.submittedSteps?.[0]?.snapshotTokens?.v4).toBe('tok-create')
     })
 
     it('writes a v4 snapshot for the appended step and records the token on update', async () => {
@@ -3953,7 +3953,7 @@ describe('multirespondent-submission.service', () => {
       expect(snapshot.encryptedContent).toBe('v4-encrypted-content')
 
       const saved = await Model.findById(row._id)
-      expect(saved?.submittedSteps?.[1]?.snapshotToken).toBe('tok-update')
+      expect(saved?.submittedSteps?.[1]?.snapshotTokens?.v4).toBe('tok-update')
     })
 
     it('does not write a snapshot when the write-condition is false (mrfVersion 1)', async () => {
@@ -4217,7 +4217,9 @@ describe('multirespondent-submission.service', () => {
       expect(result.isOk()).toBe(true)
       const { submission: winner, snapshot: winnerSnapshot } =
         result._unsafeUnwrap()
-      expect(winner.submittedSteps?.[1]?.snapshotToken).toBe('winner-token')
+      expect(winner.submittedSteps?.[1]?.snapshotTokens?.v4).toBe(
+        'winner-token',
+      )
       // The winner's own object is what travels to reconstruction — the token
       // is recorded for the RETRY path, not consumed by the initial send.
       expect(winnerSnapshot?.submissionIndex).toBe(1)
@@ -4340,7 +4342,9 @@ describe('multirespondent-submission.service', () => {
 
       expect(resubmit.isOk()).toBe(true)
       const saved = await Model.findById(row._id)
-      expect(saved?.submittedSteps?.[1]?.snapshotToken).toBe('orphan-token-2')
+      expect(saved?.submittedSteps?.[1]?.snapshotTokens?.v4).toBe(
+        'orphan-token-2',
+      )
     })
 
     // ---- Regression / byte-identity ----

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -898,7 +898,7 @@ export const createMultiRespondentFormSubmission = ({
       const writeSnapshotIfNeeded: ResultAsync<undefined, SnapshotWriteError> =
         snapshot
           ? writeV4Snapshot(snapshot).map(({ token }) => {
-              submittedStepMeta.snapshotToken = token
+              submittedStepMeta.snapshotTokens = { v4: token }
               return undefined
             })
           : okAsync(undefined)
@@ -1523,7 +1523,7 @@ export const updateMultiRespondentFormSubmission = ({
       const writeSnapshotIfNeeded: ResultAsync<undefined, SnapshotWriteError> =
         snapshot
           ? writeV4Snapshot(snapshot).map(({ token }) => {
-              submittedStepMeta.snapshotToken = token
+              submittedStepMeta.snapshotTokens = { v4: token }
               return undefined
             })
           : okAsync(undefined)

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/initial-send-route-parity.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/initial-send-route-parity.spec.ts
@@ -153,7 +153,7 @@ describe('[GATE] v4 initial-send route parity', () => {
         {
           isApproval: false,
           submittedAt: new Date().toISOString(),
-          snapshotToken: 'tok-parity',
+          snapshotTokens: { v4: 'tok-parity' },
         },
       ],
     })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-reconstruction.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-reconstruction.spec.ts
@@ -20,7 +20,7 @@ const makeStoredStep = (index: number): SubmittedStep => ({
   status: WorkflowStatus.APPROVED,
   nextStepRecipientEmails: [`step-${index}@example.com`],
   submitterId: `SUBMITTER_ID_HASH_${index}`,
-  snapshotToken: `SNAPSHOT_TOKEN_LEAF_${index}`,
+  snapshotTokens: { v4: `SNAPSHOT_TOKEN_LEAF_${index}` },
 })
 
 const makeLiveData = (overrides: Partial<WebhookData> = {}): WebhookData => ({
@@ -205,7 +205,7 @@ describe('reconstructMrfWebhookData', () => {
     it.each([
       'stepTokenHash',
       'encryptedStepToken',
-      'snapshotToken',
+      'snapshotTokens',
       'SNAPSHOT_TOKEN_LEAF_0',
       'SNAPSHOT_TOKEN_LEAF_1',
       'SNAPSHOT_TOKEN_LEAF_2',

--- a/packages/shared/types/submission.ts
+++ b/packages/shared/types/submission.ts
@@ -97,6 +97,14 @@ export const ApprovalStatus = z.enum([
   WorkflowStatus.REJECTED,
 ])
 
+const SubmittedStepSnapshotTokens = z.object({
+  v4: z.string().optional(),
+})
+
+export type SubmittedStepSnapshotTokens = z.infer<
+  typeof SubmittedStepSnapshotTokens
+>
+
 const SubmittedNonApprovalStep = z.object({
   isApproval: z.literal(false),
   submittedAt: z.string().datetime({ precision: 3 }),
@@ -105,7 +113,7 @@ const SubmittedNonApprovalStep = z.object({
   // RATIONALE: per-attempt S3 snapshot key leaf recorded on the winning step
   // entry so the send path can point-read the frozen snapshot for THIS step;
   // never included in a webhook payload.
-  snapshotToken: z.string().optional(),
+  snapshotTokens: SubmittedStepSnapshotTokens.optional(),
 })
 
 export type SubmittedNonApprovalStep = z.infer<typeof SubmittedNonApprovalStep>
@@ -146,7 +154,7 @@ export const SUBMITTED_STEP_VISIBILITY = {
     admin: true,
   },
   submitterId: { webhook: true, public: true, admin: false },
-  snapshotToken: { webhook: false, public: false, admin: false },
+  snapshotTokens: { webhook: false, public: false, admin: false },
 } as const satisfies Record<
   SubmittedStepField,
   Record<SubmittedStepBoundary, boolean>


### PR DESCRIPTION
## Problem

Part of #9746 (S6), pulled forward out of it. Not closing an issue on its own.

#9803's **D7** replaces the single `snapshotToken` string on the winning `submittedSteps` entry with a per-format record. It was scheduled for S6 on the explicit grounds that *"it is a schema change, but it stays dormant until generic delivery exists either way, so there is no cost to waiting"* — the migration is free while `mrf-step-write-token` is dormant, because no production row carries a token.

**That reasoning expires the moment v4 snapshots are written for real.** Turning the flag on before D7 lands would strand rows on a field name S6 then has to rename — the exact dual-read/backfill that D7 says it avoids. So the deferral only held while nothing was stored, and this lands the shape ahead of any snapshot write.

## Solution

`snapshotToken: string` becomes `snapshotTokens: { v4?: string }`.

**Breaking Changes**
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
    - The field is written only when `mrfVersion === 2 && webhook.url && isRetryEnabled`, and `getMrfVersion` only returns `2` for a plumber URL when `mrf-step-write-token` is on. The flag is dormant, so no row carries the old field and the replacement is outright — no dual-read, no backfill, per D7.

**Improvements**:

- `packages/shared/types/submission.ts` — new exported `SubmittedStepSnapshotTokens` zod object. The map (rather than one token) is what makes the collision-retry path correct: the two create-if-absent PUTs for a step are independent, so the `v4` PUT can succeed on token A while the `v1` PUT collides and retries onto token B. One UUID cannot resolve both buckets, which is why #9744's shared-UUID contract was withdrawn.
- `SUBMITTED_STEP_VISIBILITY` gains `snapshotTokens: { webhook: false, public: false, admin: false }`, so D12's allow-list projection still drops it at all three boundaries. Because the table is `satisfies Record<SubmittedStepField, …>`, the rename could not silently skip classification — this is what #9803 meant by *"that is what the exhaustiveness check is for"*.
- `submission.server.model.ts` — `snapshotTokens` is a nested `Schema({ v4: String }, { _id: false })`, so the stored subdocument is a plain `{ v4: "…" }` with no mongoose `_id`.
- `multirespondent-submission.service.ts` — both write sites (create at :903, update at :1530) record `snapshotTokens = { v4: token }`, still inside the same `writeV4Snapshot(...).map()` before the step is appended and the row committed. The S3-first ordering and the "record before the subdocument cast" property are untouched.

Only `v4` exists here. The v1 form-key copy has no producer until S6, which adds the `v1` key — a purely additive optional field, unlike the rename this avoids.

### Scope

No reader changes: after D10 (#9811) the initial send reconstructs from the in-memory object, so per #9803 R1 there is **no production snapshot reader in S4** to update. The retry-path lookup is S5/S6's.

## Tests

No new tests — this is a shape change to a field whose behaviour is already covered. Existing suites were migrated to the map and all pass:

- `pnpm --filter formsg-backend test src/app/modules/submission/__tests__/submitted-step-visibility.spec.ts src/app/modules/submission/multirespondent-submission/webhook/__tests__/ src/app/modules/status-tracker/__tests__/status-tracker.controller.spec.ts` — 10 suites, 58 tests
- `pnpm --filter formsg-backend test src/app/models/__tests__/submission.server.model.spec.ts src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts` — 96 tests
- `pnpm --filter formsg-shared test` — 11 suites, 90 tests

Worth a reviewer's eye:

- `webhook-reconstruction.spec.ts`'s leak test now pins `'snapshotTokens'` as a forbidden substring, so the field is still provably absent from both the snapshot and live payloads.
- `submitted-step-visibility.spec.ts` covers the mongoose-subdocument case, confirming an object-valued field still projects to a plain object with no mongoose internals.
- The service spec's row builder writes `snapshotTokens: token ? { v4: token } : undefined` — the "no snapshot recorded" case stays a genuinely absent field rather than `{ v4: undefined }`, which is what the live-row routing branch keys on.

Types: backend `tsc --noEmit` sits at 110 errors, byte-identical to the pre-change baseline (all pre-existing, mostly mongoose typings in specs). `formsg-shared` typechecks clean. eslint and prettier clean.

## Deploy Notes

No new env vars, scripts, or dependencies. No migration — see Breaking Changes above.

**Follow-up, not in this PR:** #9745 (line 39) and #9746 (amendment 3) both still instruct the implementer to ship against the single `snapshotToken`, which now names a field that does not exist. Those notes need amending before S5 is picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
