### PR TITLE
feat(mrf): classify submittedSteps sub-fields per egress boundary

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -8,6 +8,7 @@ import {
   PaymentType,
   SubmissionType,
   WebhookResponse,
+  WorkflowStatus,
   WorkflowType,
 } from 'formsg-shared/types'
 import { merge, omit, times } from 'lodash'
@@ -20,6 +21,7 @@ import getSubmissionModel, {
   getMultirespondentSubmissionModel,
 } from 'src/app/models/submission.server.model'
 import { buildMrfMetadata } from 'src/app/modules/submission/submission.utils'
+import { WorkflowWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
 
 import { ISubmissionSchema } from '../../../types'
 import getPaymentModel from '../payment.server.model'
@@ -772,6 +774,66 @@ describe('Submission Model', () => {
     })
   })
 
+  describe('Multirespondent admin queries', () => {
+    const MOCK_MRF_SUBMISSION = () => ({
+      form: MOCK_FORM_ID,
+      submissionType: SubmissionType.Multirespondent,
+      form_fields: [],
+      form_logics: [],
+      workflow: [],
+      submissionPublicKey: 'test public key',
+      encryptedSubmissionSecretKey: 'test secret key',
+      encryptedContent: MOCK_ENCRYPTED_CONTENT,
+      version: 1,
+      workflowStep: 1,
+      submittedSteps: [
+        {
+          isApproval: true,
+          submittedAt: '2026-07-22T00:00:00.000Z',
+          status: WorkflowStatus.APPROVED,
+          nextStepRecipientEmails: ['next@example.com'],
+          submitterId: 'SUBMITTER_ID_HASH',
+          snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
+        },
+      ],
+    })
+
+    const EXPECTED_ADMIN_STEP = {
+      isApproval: true,
+      submittedAt: '2026-07-22T00:00:00.000Z',
+      status: WorkflowStatus.APPROVED,
+      nextStepRecipientEmails: ['next@example.com'],
+    }
+
+    it('findEncryptedSubmissionById should not load unclassified step sub-fields', async () => {
+      const created = await MultirespondentSubmission.create(
+        MOCK_MRF_SUBMISSION(),
+      )
+
+      const actual =
+        await MultirespondentSubmission.findEncryptedSubmissionById(
+          String(MOCK_FORM_ID),
+          String(created._id),
+        )
+
+      expect(actual!.toObject().submittedSteps).toEqual([EXPECTED_ADMIN_STEP])
+    })
+
+    it('getSubmissionCursorByFormId should not load unclassified step sub-fields', async () => {
+      await MultirespondentSubmission.create(MOCK_MRF_SUBMISSION())
+
+      const cursor = MultirespondentSubmission.getSubmissionCursorByFormId(
+        String(MOCK_FORM_ID),
+        {},
+      )
+      const docs = []
+      for await (const doc of cursor) docs.push(doc)
+
+      expect(docs).toHaveLength(1)
+      expect(docs[0].submittedSteps).toEqual([EXPECTED_ADMIN_STEP])
+    })
+  })
+
   describe('Methods', () => {
     describe('getWebhookView', () => {
       it('should returnt non-null view with paymentContent when submission has paymentId', async () => {
@@ -834,6 +896,52 @@ describe('Submission Model', () => {
           },
         })
       })
+      it('should project submittedSteps for multirespondent submissions, omitting the internal snapshotTokens', async () => {
+        // Arrange
+        const formId = new ObjectId()
+        const submission = await MultirespondentSubmission.create({
+          form: formId,
+          submissionType: SubmissionType.Multirespondent,
+          form_fields: [],
+          form_logics: [],
+          workflow: [],
+          submissionPublicKey: 'test public key',
+          encryptedSubmissionSecretKey: 'test secret key',
+          encryptedContent: MOCK_ENCRYPTED_CONTENT,
+          version: 1,
+          workflowStep: 1,
+          submittedSteps: [
+            {
+              isApproval: true,
+              submittedAt: '2026-07-22T00:00:00.000Z',
+              status: WorkflowStatus.APPROVED,
+              nextStepRecipientEmails: ['next@example.com'],
+              submitterId: 'SUBMITTER_ID_HASH',
+              snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
+            },
+          ],
+        })
+
+        // Act
+        const actualWebhookView = await submission.getWebhookView()
+
+        // Assert
+        const { submittedSteps } = actualWebhookView!.data
+          .workflowContent as WorkflowWebhookEventObject
+        expect(submittedSteps).toEqual([
+          {
+            isApproval: true,
+            submittedAt: '2026-07-22T00:00:00.000Z',
+            status: WorkflowStatus.APPROVED,
+            nextStepRecipientEmails: ['next@example.com'],
+            submitterId: 'SUBMITTER_ID_HASH',
+          },
+        ])
+        expect(JSON.stringify(actualWebhookView)).not.toContain(
+          'SNAPSHOT_TOKEN_LEAF_VALUE',
+        )
+      })
+
       it('should return non-null view with encryptedSubmission type when submission has no verified content', async () => {
         // Arrange
         const formId = new ObjectId()

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -38,6 +38,10 @@ import {
 import { getPaymentWebhookEventObject } from '../modules/payments/payment.service.utils'
 import { MultirespondentSubmissionContent } from '../modules/submission/multirespondent-submission/multirespondent-submission.types'
 import { buildMrfMetadata } from '../modules/submission/submission.utils'
+import {
+  buildAdminSubmittedStepsMongoProjection,
+  projectSubmittedStepForWebhook,
+} from '../modules/submission/submitted-step-visibility'
 import { createQueryWithDateParam } from '../utils/date'
 
 import { FORM_SCHEMA_ID } from './form.server.model'
@@ -541,6 +545,11 @@ const submittedStepSchema = new Schema(
       type: String,
       enum: [WorkflowStatus.APPROVED, WorkflowStatus.REJECTED],
     },
+    snapshotTokens: {
+      v4: {
+        type: String,
+      },
+    },
   },
   { _id: false },
 )
@@ -643,7 +652,9 @@ MultirespondentSubmissionSchema.methods.getWebhookView = async function (
     workflowContent: {
       workflow: this.workflow,
       workflowStep: this.workflowStep,
-      submittedSteps: this.submittedSteps,
+      submittedSteps: (this.submittedSteps ?? []).map(
+        projectSubmittedStepForWebhook,
+      ),
     },
   }
 
@@ -834,7 +845,7 @@ MultirespondentSubmissionSchema.statics.getSubmissionCursorByFormId = function (
     form_logics: 1,
     workflow: 1,
     workflowStep: 1,
-    submittedSteps: 1,
+    ...buildAdminSubmittedStepsMongoProjection(),
     encryptedSubmissionSecretKey: 1,
     encryptedContent: 1,
     verifiedContent: 1,
@@ -886,7 +897,7 @@ MultirespondentSubmissionSchema.statics.findEncryptedSubmissionById = function (
       version: 1,
       workflowStep: 1,
       mrfVersion: 1,
-      submittedSteps: 1,
+      ...buildAdminSubmittedStepsMongoProjection(),
       encryptedStepToken: 1,
     })
     .exec()

--- a/apps/backend/src/app/modules/status-tracker/__tests__/status-tracker.controller.spec.ts
+++ b/apps/backend/src/app/modules/status-tracker/__tests__/status-tracker.controller.spec.ts
@@ -1,0 +1,72 @@
+import expressHandler from '__tests__/unit/backend/helpers/jest-express'
+import { ObjectId } from 'bson'
+import { StatusTrackerData, WorkflowStatus } from 'formsg-shared/types'
+import mongoose from 'mongoose'
+import { okAsync } from 'neverthrow'
+
+import { getMultirespondentSubmissionModel } from 'src/app/models/submission.server.model'
+import * as MultirespondentSubmissionService from 'src/app/modules/submission/multirespondent-submission/multirespondent-submission.service'
+
+import { handleGetStatusTracker } from '../status-tracker.controller'
+
+const MultirespondentSubmission = getMultirespondentSubmissionModel(mongoose)
+
+const getStatusTrackerSubmissionData = handleGetStatusTracker[
+  handleGetStatusTracker.length - 1
+] as (req: unknown, res: unknown) => Promise<unknown>
+
+describe('status-tracker.controller', () => {
+  afterEach(() => jest.restoreAllMocks())
+
+  it('omits the internal snapshotTokens and respondent emails from the response body', async () => {
+    // Arrange: a real (unsaved) mongoose document, so the controller sees the
+    // subdocument shape it sees in production.
+    const submission = new MultirespondentSubmission({
+      form: new ObjectId(),
+      form_fields: [],
+      form_logics: [],
+      workflow: [],
+      submissionPublicKey: 'public key',
+      encryptedSubmissionSecretKey: 'secret key',
+      encryptedContent: 'encrypted content',
+      version: 1,
+      workflowStep: 1,
+      submittedSteps: [
+        {
+          isApproval: true,
+          submittedAt: '2026-07-22T00:00:00.000Z',
+          status: WorkflowStatus.APPROVED,
+          nextStepRecipientEmails: ['next@example.com'],
+          submitterId: 'SUBMITTER_ID_HASH',
+          snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
+        },
+      ],
+    })
+
+    jest
+      .spyOn(MultirespondentSubmissionService, 'getMultirespondentSubmission')
+      .mockReturnValue(okAsync(submission))
+
+    const mockReq = expressHandler.mockRequest({
+      params: { submissionId: String(submission._id) },
+    })
+    const mockRes = expressHandler.mockResponse()
+
+    // Act
+    await getStatusTrackerSubmissionData(mockReq, mockRes)
+
+    // Assert
+    const body = mockRes.json.mock.calls[0][0] as StatusTrackerData
+    expect(body.submittedSteps).toEqual([
+      {
+        isApproval: true,
+        submittedAt: '2026-07-22T00:00:00.000Z',
+        status: WorkflowStatus.APPROVED,
+        submitterId: 'SUBMITTER_ID_HASH',
+      },
+    ])
+    const serialised = JSON.stringify(body)
+    expect(serialised).not.toContain('SNAPSHOT_TOKEN_LEAF_VALUE')
+    expect(serialised).not.toContain('next@example.com')
+  })
+})

--- a/apps/backend/src/app/modules/status-tracker/status-tracker.controller.ts
+++ b/apps/backend/src/app/modules/status-tracker/status-tracker.controller.ts
@@ -1,8 +1,8 @@
 import { celebrate, Joi, Segments } from 'celebrate'
 import {
+  PublicSubmittedStep,
   StatusTrackerData,
   StrippedFormWorkflowDto,
-  SubmittedStep,
 } from 'formsg-shared/types'
 import { stripWorkflowEmails } from 'formsg-shared/utils/strip-workflow-emails'
 import { StatusCodes } from 'http-status-codes'
@@ -13,6 +13,7 @@ import { createReqMeta } from '../../utils/request'
 import { ControllerHandler } from '../core/core.types'
 import { getMultirespondentSubmission } from '../submission/multirespondent-submission/multirespondent-submission.service'
 import { mapRouteError } from '../submission/submission.utils'
+import { projectSubmittedStepForPublic } from '../submission/submitted-step-visibility'
 
 const logger = createLoggerWithLabel(module)
 
@@ -39,12 +40,8 @@ const getStatusTrackerSubmissionData: ControllerHandler<
     .map((submissionData) => {
       // strip emails from submitted steps and workflow
       // drop mongoose internals to extract documentFields (e.g. submittedAt, etc.)
-      const strippedSubmittedSteps = submissionData
-        .toObject()
-        .submittedSteps?.map(
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          ({ nextStepRecipientEmails, ...rest }: SubmittedStep) => rest,
-        )
+      const strippedSubmittedSteps: PublicSubmittedStep[] | undefined =
+        submissionData.submittedSteps?.map(projectSubmittedStepForPublic)
 
       const strippedWorkflow: StrippedFormWorkflowDto = stripWorkflowEmails(
         submissionData.workflow,

--- a/apps/backend/src/app/modules/submission/__tests__/submitted-step-visibility.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submitted-step-visibility.spec.ts
@@ -1,0 +1,98 @@
+import { SubmittedStep, WorkflowStatus } from 'formsg-shared/types'
+import { model, Schema } from 'mongoose'
+
+import {
+  buildAdminSubmittedStepsMongoProjection,
+  projectSubmittedStepForPublic,
+  projectSubmittedStepForWebhook,
+} from '../submitted-step-visibility'
+
+/**
+ * A step subdocument with EVERY field populated, including the internal ones.
+ * Distinctive values so a leak is unmistakable in a stringified payload.
+ */
+const fullApprovalStep = {
+  isApproval: true as const,
+  submittedAt: '2026-07-22T00:00:00.000Z',
+  status: WorkflowStatus.APPROVED,
+  nextStepRecipientEmails: ['next@example.com'],
+  submitterId: 'SUBMITTER_ID_HASH',
+  snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
+} satisfies SubmittedStep
+
+describe('projectSubmittedStepForWebhook', () => {
+  it('drops snapshotTokens but keeps the fields webhook consumers receive today', () => {
+    const out = projectSubmittedStepForWebhook(fullApprovalStep)
+
+    expect(out).toEqual({
+      isApproval: true,
+      submittedAt: '2026-07-22T00:00:00.000Z',
+      status: WorkflowStatus.APPROVED,
+      nextStepRecipientEmails: ['next@example.com'],
+      submitterId: 'SUBMITTER_ID_HASH',
+    })
+    expect(JSON.stringify(out)).not.toContain('SNAPSHOT_TOKEN_LEAF_VALUE')
+  })
+})
+
+describe('projecting a mongoose subdocument', () => {
+  const StepSchema = new Schema<SubmittedStep>(
+    {
+      isApproval: Boolean,
+      submittedAt: String,
+      status: String,
+      nextStepRecipientEmails: [String],
+      submitterId: String,
+      snapshotTokens: { v4: String },
+    },
+    { _id: false },
+  )
+  const Holder = model(
+    'SubmittedStepHolder',
+    new Schema({ submittedSteps: [StepSchema] }),
+  )
+
+  it('returns a plain object carrying no mongoose internals', () => {
+    const holder = new Holder({ submittedSteps: [fullApprovalStep] })
+    const subdoc = holder.submittedSteps[0]
+
+    const out = projectSubmittedStepForWebhook(subdoc)
+
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype)
+    expect(out).toEqual({
+      isApproval: true,
+      submittedAt: '2026-07-22T00:00:00.000Z',
+      status: WorkflowStatus.APPROVED,
+      nextStepRecipientEmails: ['next@example.com'],
+      submitterId: 'SUBMITTER_ID_HASH',
+    })
+    expect(JSON.stringify(out)).not.toContain('SNAPSHOT_TOKEN_LEAF_VALUE')
+  })
+})
+
+describe('projectSubmittedStepForPublic', () => {
+  it('drops snapshotTokens and respondent emails from the public response', () => {
+    const out = projectSubmittedStepForPublic(fullApprovalStep)
+
+    expect(out).toEqual({
+      isApproval: true,
+      submittedAt: '2026-07-22T00:00:00.000Z',
+      status: WorkflowStatus.APPROVED,
+      submitterId: 'SUBMITTER_ID_HASH',
+    })
+    const serialised = JSON.stringify(out)
+    expect(serialised).not.toContain('SNAPSHOT_TOKEN_LEAF_VALUE')
+    expect(serialised).not.toContain('next@example.com')
+  })
+})
+
+describe('buildAdminSubmittedStepsMongoProjection', () => {
+  it('selects exactly the admin-visible sub-fields, so the rest never load', () => {
+    expect(buildAdminSubmittedStepsMongoProjection()).toEqual({
+      'submittedSteps.isApproval': 1,
+      'submittedSteps.submittedAt': 1,
+      'submittedSteps.status': 1,
+      'submittedSteps.nextStepRecipientEmails': 1,
+    })
+  })
+})

--- a/apps/backend/src/app/modules/submission/submitted-step-visibility.ts
+++ b/apps/backend/src/app/modules/submission/submitted-step-visibility.ts
@@ -1,0 +1,42 @@
+import {
+  PublicSubmittedStep,
+  SUBMITTED_STEP_VISIBILITY,
+  SubmittedStep,
+  SubmittedStepBoundary,
+  SubmittedStepField,
+  WebhookSubmittedStep,
+} from 'formsg-shared/types'
+
+const SUBMITTED_STEP_FIELDS = Object.keys(
+  SUBMITTED_STEP_VISIBILITY,
+) as SubmittedStepField[]
+
+const projectSubmittedStep = (
+  step: SubmittedStep,
+  boundary: SubmittedStepBoundary,
+): Record<string, unknown> => {
+  const projected: Record<string, unknown> = {}
+  for (const field of SUBMITTED_STEP_FIELDS) {
+    if (!SUBMITTED_STEP_VISIBILITY[field][boundary]) continue
+    const value = (step as Record<string, unknown>)[field]
+    if (value !== undefined) projected[field] = value
+  }
+  return projected
+}
+
+export const projectSubmittedStepForWebhook = (
+  step: SubmittedStep,
+): WebhookSubmittedStep =>
+  projectSubmittedStep(step, 'webhook') as WebhookSubmittedStep
+
+export const projectSubmittedStepForPublic = (
+  step: SubmittedStep,
+): PublicSubmittedStep =>
+  projectSubmittedStep(step, 'public') as PublicSubmittedStep
+
+export const buildAdminSubmittedStepsMongoProjection = (): Record<string, 1> =>
+  Object.fromEntries(
+    SUBMITTED_STEP_FIELDS.filter(
+      (field) => SUBMITTED_STEP_VISIBILITY[field].admin,
+    ).map((field) => [`submittedSteps.${field}`, 1] as const),
+  )

--- a/apps/backend/src/app/modules/webhook/webhook.types.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.types.ts
@@ -1,4 +1,4 @@
-import { FormWorkflowDto, SubmittedStep } from 'formsg-shared/types'
+import { FormWorkflowDto, WebhookSubmittedStep } from 'formsg-shared/types'
 import * as z from 'zod'
 
 import { IFormSchema, ISubmissionSchema, WebhookView } from '../../../types'
@@ -65,5 +65,5 @@ export type PaymentWebhookEventObject = {
 export type WorkflowWebhookEventObject = {
   workflow: FormWorkflowDto
   workflowStep: number
-  submittedSteps: SubmittedStep[]
+  submittedSteps: WebhookSubmittedStep[]
 }

--- a/packages/shared/types/submission.ts
+++ b/packages/shared/types/submission.ts
@@ -97,11 +97,20 @@ export const ApprovalStatus = z.enum([
   WorkflowStatus.REJECTED,
 ])
 
+const SubmittedStepSnapshotTokens = z.object({
+  v4: z.string().optional(),
+})
+
+export type SubmittedStepSnapshotTokens = z.infer<
+  typeof SubmittedStepSnapshotTokens
+>
+
 const SubmittedNonApprovalStep = z.object({
   isApproval: z.literal(false),
   submittedAt: z.string().datetime({ precision: 3 }),
   nextStepRecipientEmails: z.array(z.string()).optional(),
   submitterId: z.string().optional(),
+  snapshotTokens: SubmittedStepSnapshotTokens.optional(),
 })
 
 export type SubmittedNonApprovalStep = z.infer<typeof SubmittedNonApprovalStep>
@@ -119,6 +128,60 @@ export const SubmittedStep = z.discriminatedUnion('isApproval', [
 ])
 
 export type SubmittedStep = z.infer<typeof SubmittedStep>
+
+export type SubmittedStepField =
+  | keyof SubmittedNonApprovalStep
+  | keyof SubmittedApprovalStep
+
+/**
+ * The boundaries at which `submittedSteps` leaves the server.
+ * - `webhook`: the array shipped verbatim inside `workflowContent`.
+ * - `public`: unauthenticated responses reachable by submission id (eg, status tracking link).
+ * - `admin`: authenticated admin queries.
+ */
+export type SubmittedStepBoundary = 'webhook' | 'public' | 'admin'
+
+export const SUBMITTED_STEP_VISIBILITY = {
+  isApproval: { webhook: true, public: true, admin: true },
+  submittedAt: { webhook: true, public: true, admin: true },
+  status: { webhook: true, public: true, admin: true },
+  nextStepRecipientEmails: {
+    webhook: true,
+    public: false,
+    admin: true,
+  },
+  submitterId: { webhook: true, public: true, admin: false },
+  snapshotTokens: { webhook: false, public: false, admin: false },
+} as const satisfies Record<
+  SubmittedStepField,
+  Record<SubmittedStepBoundary, boolean>
+>
+
+type SubmittedStepVisibility = typeof SUBMITTED_STEP_VISIBILITY
+
+type VisibleFieldsAt<B extends SubmittedStepBoundary> = {
+  [K in keyof SubmittedStepVisibility]: SubmittedStepVisibility[K][B] extends true
+    ? K
+    : never
+}[keyof SubmittedStepVisibility]
+
+/**
+ * Distributes over the discriminated union so each member keeps only the fields
+ * it actually declares that are visible at boundary `B`.
+ */
+type ProjectSubmittedStep<
+  S,
+  B extends SubmittedStepBoundary,
+> = S extends unknown ? Pick<S, Extract<keyof S, VisibleFieldsAt<B>>> : never
+
+export type WebhookSubmittedStep = ProjectSubmittedStep<
+  SubmittedStep,
+  'webhook'
+>
+
+export type PublicSubmittedStep = ProjectSubmittedStep<SubmittedStep, 'public'>
+
+export type AdminSubmittedStep = ProjectSubmittedStep<SubmittedStep, 'admin'>
 
 export const MultirespondentSubmissionBase = SubmissionBase.extend({
   // Store the form fields and logic here, to use as reference for future
@@ -375,7 +438,7 @@ export type PaymentSubmissionData = {
 }
 
 export type StatusTrackerData = {
-  submittedSteps: SubmittedStep[] | undefined
+  submittedSteps: PublicSubmittedStep[] | undefined
   workflow: StrippedFormWorkflowDto
   responseId: string | undefined
   form: string


### PR DESCRIPTION
## Problem

`submittedSteps` is shipped verbatim at four egress points: the webhook view (`getWebhookView`), the unauthenticated public status tracker, and both admin Mongo queries (`getSubmissionCursorByFormId`, `findEncryptedSubmissionById`). Adding any server-internal sub-field therefore leaks it at all four by default.

That is about to matter: the MRF v4 webhook work (PRD #9740) records a per-attempt S3 snapshot token on each step, which must never reach a webhook consumer and certainly not the unauthenticated tracker.

## Solution

Replace the blanket pass-through with a single classification table, `SUBMITTED_STEP_VISIBILITY`, that states for every `submittedSteps` sub-field whether it may cross the `webhook`, `public` and `admin` boundaries. Every projection is derived from that table:

- `projectSubmittedStepForWebhook` — the array inside `workflowContent`
- `projectSubmittedStepForPublic` — the status tracker response
- `buildAdminSubmittedStepsMongoProjection()` — both admin queries

The derived types distribute over the `SubmittedStep` discriminated union, so a new sub-field is private until classified and **omitting a row from the table is a compile error**, not a silent leak.

Also lands `snapshotTokens: { v4?: string }` on the step schema, classified `false` at all three boundaries. It is written by a later PR in this stack; landing the shape first means flipping the flag later cannot strand rows on a field name that would then have to be renamed.

## Breaking Changes

No. No field any consumer sees today is withheld:

- `nextStepRecipientEmails` and `submitterId` are unchanged at the webhook boundary
- the status tracker keeps stripping exactly the emails it already stripped
- `nextStepRecipientEmails` still loads for admin queries because `buildMrfMetadata` reads it server-side
- `snapshotTokens` is new and unwritten, so withholding it withholds nothing

## Tests

Start from an MRF form with at least one completed step and a webhook URL configured.

**TC1: Public status tracker keeps stripping exactly what it stripped before**

- [x] Fetch the public status tracker for an MRF submission (unauthenticated).
- [x] `nextStepRecipientEmails` is absent; `isApproval`, `submittedAt`, `status` and `submitterId` are present.
- [x] No `snapshotTokens` field anywhere in the response.

**TC2: Webhook payload is unchanged**

- [x] Advance a step on an MRF form with a webhook URL and capture the delivered body.
- [x] `data.workflowContent.submittedSteps[]` is byte-identical to develop — `nextStepRecipientEmails` and `submitterId` both still present.
- [x] No `snapshotTokens` field on any step.

**TC3: Admin reads still have the fields they depend on**

- [x] Open the admin results table for the MRF form and export its responses as CSV.
- [x] The MRF metadata column renders (this is what proves `nextStepRecipientEmails` still loads server-side).
- [x] Open a single submission in the admin view → decrypts and renders as before.

## Payload content format

No payload *content* changes — what changes is which sub-fields of a `submittedSteps` entry are allowed past each boundary. One stored step, three projections, all derived from `SUBMITTED_STEP_VISIBILITY`.

**Stored step** (Mongo, `submittedSteps[i]`, approval step shown):

```json
{
  "isApproval": true,
  "status": "APPROVED",
  "submittedAt": "2026-08-03T04:15:22.180Z",
  "nextStepRecipientEmails": ["next.approver@agency.gov.sg"],
  "submitterId": "S1234567D",
  "snapshotTokens": { "v4": "6f1c2b8e-…" }
}
```

| sub-field | `webhook` | `public` | `admin` |
|---|---|---|---|
| `isApproval` | ✅ | ✅ | ✅ |
| `submittedAt` | ✅ | ✅ | ✅ |
| `status` | ✅ | ✅ | ✅ |
| `nextStepRecipientEmails` | ✅ | ❌ | ✅ (server-side only, for `buildMrfMetadata`) |
| `submitterId` | ✅ | ✅ | ❌ |
| `snapshotTokens` | ❌ | ❌ | ❌ |

**Webhook** — the array at `data.workflowContent.submittedSteps[]`, byte-identical to develop:

```json
{
  "isApproval": true,
  "status": "APPROVED",
  "submittedAt": "2026-08-03T04:15:22.180Z",
  "nextStepRecipientEmails": ["next.approver@agency.gov.sg"],
  "submitterId": "S1234567D"
}
```

**Public status tracker** — emails stripped, exactly as today:

```json
{
  "isApproval": true,
  "status": "APPROVED",
  "submittedAt": "2026-08-03T04:15:22.180Z",
  "submitterId": "S1234567D"
}
```

`snapshotTokens` is absent from all three by construction, which is the point: the field lands here so the PR that writes it (#9822) cannot leak it.

---

Part of PRD #9740 (MRF v4 Webhooks — Option A), extracted from #9777. First PR in the stack; independent of the rest — it is worth merging on its own merit as leak-prevention even if the v4 work stalls.


