### PR TITLE
feat(mrf): send-time payload policy, reconstruction, and gates (M4 + M3)

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-payload-policy.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-payload-policy.spec.ts
@@ -1,0 +1,151 @@
+import {
+  contentFormatToWebhookVersion,
+  getWebhookPayloadPolicy,
+  mrfVersionToContentFormat,
+  WebhookConsumerType,
+  WebhookContentFormat,
+  WebhookPayloadPolicyInput,
+} from '../webhook-payload-policy'
+
+describe('getWebhookPayloadPolicy', () => {
+  it.each<{
+    name: string
+    webhookType: WebhookConsumerType
+    isStepWriteTokenEnabled: boolean
+    latest: boolean
+    expected: {
+      contentFormat: WebhookContentFormat
+      includeEncryptedSubmissionSecretKey: boolean
+      includeEncryptedStepToken: boolean
+    }
+  }>([
+    {
+      name: 'plumber, write-token on, latest step',
+      webhookType: 'plumber',
+      isStepWriteTokenEnabled: true,
+      latest: true,
+      expected: {
+        contentFormat: 'v4',
+        includeEncryptedSubmissionSecretKey: true,
+        includeEncryptedStepToken: true,
+      },
+    },
+    {
+      name: 'plumber, write-token on, non-latest step',
+      webhookType: 'plumber',
+      isStepWriteTokenEnabled: true,
+      latest: false,
+      expected: {
+        contentFormat: 'v4',
+        includeEncryptedSubmissionSecretKey: true,
+        includeEncryptedStepToken: false,
+      },
+    },
+    {
+      name: 'plumber, write-token off, latest step (V3 downgrade)',
+      webhookType: 'plumber',
+      isStepWriteTokenEnabled: false,
+      latest: true,
+      expected: {
+        contentFormat: 'v3',
+        includeEncryptedSubmissionSecretKey: false,
+        includeEncryptedStepToken: false,
+      },
+    },
+    {
+      name: 'generic, write-token on, latest step',
+      webhookType: 'generic',
+      isStepWriteTokenEnabled: true,
+      latest: true,
+      expected: {
+        contentFormat: 'v4',
+        includeEncryptedSubmissionSecretKey: true,
+        includeEncryptedStepToken: false,
+      },
+    },
+    {
+      name: 'generic, write-token off, latest step (fail-safe)',
+      webhookType: 'generic',
+      isStepWriteTokenEnabled: false,
+      latest: true,
+      expected: {
+        contentFormat: 'v3',
+        includeEncryptedSubmissionSecretKey: false,
+        includeEncryptedStepToken: false,
+      },
+    },
+    {
+      name: 'generic, write-token off, non-latest step (fail-safe)',
+      webhookType: 'generic',
+      isStepWriteTokenEnabled: false,
+      latest: false,
+      expected: {
+        contentFormat: 'v3',
+        includeEncryptedSubmissionSecretKey: false,
+        includeEncryptedStepToken: false,
+      },
+    },
+    {
+      name: 'generic, write-token on, non-latest step',
+      webhookType: 'generic',
+      isStepWriteTokenEnabled: true,
+      latest: false,
+      expected: {
+        contentFormat: 'v4',
+        includeEncryptedSubmissionSecretKey: true,
+        includeEncryptedStepToken: false,
+      },
+    },
+  ])(
+    'returns the correct policy for $name',
+    ({ webhookType, isStepWriteTokenEnabled, latest, expected }) => {
+      const submittedStepsLength = 3
+      const input: WebhookPayloadPolicyInput = {
+        webhookType,
+        isStepWriteTokenEnabled,
+        submittedStepsLength,
+        submissionIndex: latest ? submittedStepsLength - 1 : 0,
+      }
+      expect(getWebhookPayloadPolicy(input)).toEqual(expected)
+    },
+  )
+
+  it('never includes the step token for a generic consumer, whatever the flags or step', () => {
+    for (const isStepWriteTokenEnabled of [true, false]) {
+      for (const submissionIndex of [0, 1, 2]) {
+        expect(
+          getWebhookPayloadPolicy({
+            webhookType: 'generic',
+            isStepWriteTokenEnabled,
+            submissionIndex,
+            submittedStepsLength: 3,
+          }).includeEncryptedStepToken,
+        ).toBe(false)
+      }
+    }
+  })
+})
+
+describe('contentFormatToWebhookVersion', () => {
+  it('maps v4 to submission version 4', () => {
+    expect(contentFormatToWebhookVersion('v4')).toBe(4)
+  })
+
+  it('maps v3 to submission version 3', () => {
+    expect(contentFormatToWebhookVersion('v3')).toBe(3)
+  })
+
+  it('maps v1 to submission version 2.1', () => {
+    expect(contentFormatToWebhookVersion('v1')).toBe(2.1)
+  })
+})
+
+describe('mrfVersionToContentFormat', () => {
+  it('maps mrfVersion 2 to v4 (native v4 encryption)', () => {
+    expect(mrfVersionToContentFormat(2)).toBe('v4')
+  })
+
+  it('maps mrfVersion 1 to v3 (downgraded via adaptV4ToV3)', () => {
+    expect(mrfVersionToContentFormat(1)).toBe('v3')
+  })
+})

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-reconstruction.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-reconstruction.spec.ts
@@ -1,0 +1,270 @@
+import { SubmittedStep, WorkflowStatus } from 'formsg-shared/types'
+
+import { projectSubmittedStepForWebhook } from 'src/app/modules/submission/submitted-step-visibility'
+import { WorkflowWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
+import { WebhookData } from 'src/types/submission'
+
+import { SnapshotDataIntegrityError } from '../submission-snapshot.errors'
+import { WebhookPayloadPolicy } from '../webhook-payload-policy'
+import { reconstructMrfWebhookData } from '../webhook-reconstruction'
+
+/**
+ * The real step-subdocument shape with EVERY field populated, including the
+ * internal ones.
+ *
+ * RATIONALE: Allows internal field leak to be detected by tests.
+ */
+const makeStoredStep = (index: number): SubmittedStep => ({
+  isApproval: true,
+  submittedAt: `2026-07-2${index}T00:00:00.000Z`,
+  status: WorkflowStatus.APPROVED,
+  nextStepRecipientEmails: [`step-${index}@example.com`],
+  submitterId: `SUBMITTER_ID_HASH_${index}`,
+  snapshotTokens: { v4: `SNAPSHOT_TOKEN_LEAF_${index}` },
+})
+
+const makeLiveData = (overrides: Partial<WebhookData> = {}): WebhookData => ({
+  formId: 'form-1',
+  submissionId: 'sub-1',
+  encryptedContent: 'LIVE_ROW_ENCRYPTED_CONTENT',
+  verifiedContent: 'LIVE_ROW_VERIFIED_CONTENT',
+  version: 1,
+  created: new Date('2026-07-22T00:00:00.000Z'),
+  attachmentDownloadUrls: { 'field-9': 'https://example.com/attachment' },
+  workflowContent: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    workflow: [{ _id: 'step-def' }] as any,
+    workflowStep: 2,
+    submittedSteps: [0, 1, 2].map((index) =>
+      projectSubmittedStepForWebhook(makeStoredStep(index)),
+    ),
+  },
+  encryptedSubmissionSecretKey: 'LIVE_ROW_KEY',
+  ...overrides,
+})
+
+const makeV4Snapshot = () =>
+  ({
+    _v: 1 as const,
+    contentFormat: 'v4' as const,
+    formId: 'form-1',
+    submissionId: 'sub-1',
+    submissionIndex: 1,
+    workflowStep: 1,
+    encryptedContent: 'FROZEN_ENCRYPTED_CONTENT',
+    encryptedSubmissionSecretKey: 'FROZEN_KEY',
+    verifiedContent: 'FROZEN_VERIFIED_CONTENT',
+    attachmentMetadata: { 'field-1': 'form-1/FROZEN_ATTACHMENT_OBJECT_KEY' },
+    createdAt: '2026-07-22T00:00:00.000Z',
+  }) as const
+
+const PLUMBER_LATEST: WebhookPayloadPolicy = {
+  contentFormat: 'v4',
+  includeEncryptedSubmissionSecretKey: true,
+  includeEncryptedStepToken: true,
+}
+
+describe('reconstructMrfWebhookData', () => {
+  describe('without submissionIndex (legacy / no-snapshot path)', () => {
+    it('returns liveData unchanged and does not mutate it', () => {
+      const liveData = makeLiveData()
+      const frozen = JSON.parse(JSON.stringify(liveData))
+
+      const output = reconstructMrfWebhookData({
+        liveData,
+        policy: PLUMBER_LATEST,
+      })._unsafeUnwrap()
+
+      expect(output).toEqual(liveData)
+      // liveData itself was not mutated.
+      expect(JSON.parse(JSON.stringify(liveData))).toEqual(frozen)
+    })
+  })
+
+  describe('with submissionIndex (snapshot path)', () => {
+    it('returns a SnapshotDataIntegrityError when the snapshot is missing (fails loud, never falls back to liveData)', () => {
+      const liveData = makeLiveData()
+
+      const result = reconstructMrfWebhookData({
+        liveData,
+        submissionIndex: 1,
+        snapshot: undefined,
+        policy: PLUMBER_LATEST,
+      })
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        SnapshotDataIntegrityError,
+      )
+    })
+
+    it('derives version from the FROZEN snapshot content shape (v4 => 4), overriding liveData.version', () => {
+      const output = reconstructMrfWebhookData({
+        liveData: makeLiveData({ version: 1 }),
+        snapshot: makeV4Snapshot(),
+        submissionIndex: 1,
+        policy: PLUMBER_LATEST,
+      })._unsafeUnwrap()
+
+      expect(output.version).toBe(4)
+    })
+
+    it('sources encryptedSubmissionSecretKey from the FROZEN snapshot, not the live row', () => {
+      const output = reconstructMrfWebhookData({
+        liveData: makeLiveData({
+          encryptedSubmissionSecretKey: 'LIVE_ROW_KEY',
+        }),
+        snapshot: makeV4Snapshot(),
+        submissionIndex: 1,
+        policy: {
+          ...PLUMBER_LATEST,
+          includeEncryptedSubmissionSecretKey: true,
+        },
+      })._unsafeUnwrap()
+
+      expect(output.encryptedSubmissionSecretKey).toBe('FROZEN_KEY')
+    })
+
+    it('omits encryptedSubmissionSecretKey entirely when the policy excludes it', () => {
+      const output = reconstructMrfWebhookData({
+        liveData: makeLiveData(),
+        snapshot: makeV4Snapshot(),
+        submissionIndex: 1,
+        policy: {
+          ...PLUMBER_LATEST,
+          includeEncryptedSubmissionSecretKey: false,
+        },
+      })._unsafeUnwrap()
+
+      expect('encryptedSubmissionSecretKey' in output).toBe(false)
+    })
+
+    it('freezes encryptedContent and verifiedContent from the snapshot', () => {
+      const output = reconstructMrfWebhookData({
+        liveData: makeLiveData(),
+        snapshot: makeV4Snapshot(),
+        submissionIndex: 1,
+        policy: PLUMBER_LATEST,
+      })._unsafeUnwrap()
+
+      expect(output.encryptedContent).toBe('FROZEN_ENCRYPTED_CONTENT')
+      expect(output.verifiedContent).toBe('FROZEN_VERIFIED_CONTENT')
+    })
+
+    it('sources attachmentDownloadUrls from the FROZEN snapshot, not the live row', () => {
+      const output = reconstructMrfWebhookData({
+        liveData: makeLiveData({
+          attachmentDownloadUrls: {
+            'field-9': 'form-1/LIVE_ROW_ATTACHMENT_OBJECT_KEY',
+          },
+        }),
+        snapshot: makeV4Snapshot(),
+        submissionIndex: 1,
+        policy: PLUMBER_LATEST,
+      })._unsafeUnwrap()
+
+      expect(output.attachmentDownloadUrls).toEqual({
+        'field-1': 'form-1/FROZEN_ATTACHMENT_OBJECT_KEY',
+      })
+    })
+
+    it('emits no attachment urls when the snapshot froze none, even if the live row has some', () => {
+      const snapshotWithoutAttachments = { ...makeV4Snapshot() }
+      delete snapshotWithoutAttachments.attachmentMetadata
+
+      const output = reconstructMrfWebhookData({
+        liveData: makeLiveData({
+          attachmentDownloadUrls: {
+            'field-9': 'form-1/LIVE_ROW_ATTACHMENT_OBJECT_KEY',
+          },
+        }),
+        snapshot: snapshotWithoutAttachments,
+        submissionIndex: 1,
+        policy: PLUMBER_LATEST,
+      })._unsafeUnwrap()
+
+      expect(output.attachmentDownloadUrls).toEqual({})
+    })
+
+    it('reconstructs submittedSteps as the prefix up to and including this step', () => {
+      const output = reconstructMrfWebhookData({
+        liveData: makeLiveData(), // 3 submittedSteps
+        snapshot: makeV4Snapshot(),
+        submissionIndex: 1,
+        policy: PLUMBER_LATEST,
+      })._unsafeUnwrap()
+
+      const workflowContent =
+        output.workflowContent as WorkflowWebhookEventObject
+      expect(workflowContent.submittedSteps).toHaveLength(2)
+      // workflow definition preserved from the live row.
+      expect(workflowContent.workflow).toEqual([{ _id: 'step-def' }])
+      // workflowStep taken from the snapshot.
+      expect(workflowContent.workflowStep).toBe(1)
+    })
+
+    it('handles a plain-object liveData.workflowContent gracefully', () => {
+      const result = reconstructMrfWebhookData({
+        liveData: makeLiveData({ workflowContent: {} }),
+        snapshot: makeV4Snapshot(),
+        submissionIndex: 1,
+        policy: PLUMBER_LATEST,
+      })
+
+      expect(result.isOk()).toBe(true)
+    })
+  })
+
+  describe('byte-identity (initial send vs retry)', () => {
+    it('produces deep-equal output across repeated calls and a store round-trip', () => {
+      const liveData = makeLiveData()
+      const snapshot = makeV4Snapshot()
+
+      const first = reconstructMrfWebhookData({
+        liveData,
+        snapshot,
+        submissionIndex: 1,
+        policy: PLUMBER_LATEST,
+      })._unsafeUnwrap()
+
+      // Simulate a store write/read round-trip of the snapshot (JSON bytes).
+      const roundTrippedSnapshot = JSON.parse(JSON.stringify(snapshot))
+      const second = reconstructMrfWebhookData({
+        liveData,
+        snapshot: roundTrippedSnapshot,
+        submissionIndex: 1,
+        policy: PLUMBER_LATEST,
+      })._unsafeUnwrap()
+
+      expect(second).toEqual(first)
+    })
+  })
+
+  describe('secrecy — no step-token fields ever leak', () => {
+    it.each([
+      'stepTokenHash',
+      'encryptedStepToken',
+      'snapshotTokens',
+      'SNAPSHOT_TOKEN_LEAF_0',
+      'SNAPSHOT_TOKEN_LEAF_1',
+      'SNAPSHOT_TOKEN_LEAF_2',
+    ])('never emits %s on the snapshot path or the live path', (forbidden) => {
+      const snapshotPath = JSON.stringify(
+        reconstructMrfWebhookData({
+          liveData: makeLiveData(),
+          snapshot: makeV4Snapshot(),
+          submissionIndex: 1,
+          policy: PLUMBER_LATEST,
+        })._unsafeUnwrap(),
+      )
+      const livePath = JSON.stringify(
+        reconstructMrfWebhookData({
+          liveData: makeLiveData(),
+          policy: PLUMBER_LATEST,
+        })._unsafeUnwrap(),
+      )
+
+      expect(snapshotPath).not.toContain(forbidden)
+      expect(livePath).not.toContain(forbidden)
+    })
+  })
+})

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-send-eligibility.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-send-eligibility.spec.ts
@@ -1,0 +1,216 @@
+import {
+  shouldSendMrfWebhook,
+  shouldWriteV4Snapshot,
+} from '../webhook-send-eligibility'
+
+const PLUMBER_URL = 'https://plumber.gov.sg/webhooks/x'
+const GENERIC_URL = 'https://example.com/hook'
+const ZAPIER_URL = 'https://hooks.zapier.com/hooks/catch/1/x'
+
+describe('shouldSendMrfWebhook', () => {
+  it.each<{
+    webhookType: 'plumber' | 'generic' | 'zapier'
+    isMrfWebhooksEnabled: boolean
+    isStepWriteTokenEnabled: boolean
+    expected: boolean
+  }>([
+    {
+      webhookType: 'plumber',
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: false,
+      expected: true,
+    },
+    {
+      webhookType: 'plumber',
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: true,
+      expected: true,
+    },
+    {
+      webhookType: 'plumber',
+      isMrfWebhooksEnabled: true,
+      isStepWriteTokenEnabled: false,
+      expected: true,
+    },
+    {
+      webhookType: 'plumber',
+      isMrfWebhooksEnabled: true,
+      isStepWriteTokenEnabled: true,
+      expected: true,
+    },
+    {
+      webhookType: 'generic',
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: false,
+      expected: false,
+    },
+    {
+      webhookType: 'generic',
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: true,
+      expected: false,
+    },
+    {
+      webhookType: 'generic',
+      isMrfWebhooksEnabled: true,
+      isStepWriteTokenEnabled: false,
+      expected: false,
+    },
+    {
+      webhookType: 'generic',
+      isMrfWebhooksEnabled: true,
+      isStepWriteTokenEnabled: true,
+      expected: true,
+    },
+    {
+      webhookType: 'zapier',
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: false,
+      expected: false,
+    },
+    {
+      webhookType: 'zapier',
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: true,
+      expected: false,
+    },
+    {
+      webhookType: 'zapier',
+      isMrfWebhooksEnabled: true,
+      isStepWriteTokenEnabled: false,
+      expected: false,
+    },
+    {
+      webhookType: 'zapier',
+      isMrfWebhooksEnabled: true,
+      isStepWriteTokenEnabled: true,
+      expected: true,
+    },
+  ])(
+    '$webhookType with enable-mrf-webhooks=$isMrfWebhooksEnabled, mrf-step-write-token=$isStepWriteTokenEnabled => $expected',
+    ({
+      webhookType,
+      isMrfWebhooksEnabled,
+      isStepWriteTokenEnabled,
+      expected,
+    }) => {
+      expect(
+        shouldSendMrfWebhook({
+          webhookType,
+          isMrfWebhooksEnabled,
+          isStepWriteTokenEnabled,
+        }),
+      ).toBe(expected)
+    },
+  )
+})
+
+describe('shouldWriteV4Snapshot', () => {
+  const bothFlagsOn = {
+    isMrfWebhooksEnabled: true,
+    isStepWriteTokenEnabled: true,
+  }
+
+  it.each<{
+    name: string
+    mrfVersion: number
+    webhook?: { url?: string; isRetryEnabled?: boolean }
+    isMrfWebhooksEnabled: boolean
+    isStepWriteTokenEnabled: boolean
+    expected: boolean
+  }>([
+    {
+      name: 'a V3 row never snapshots',
+      mrfVersion: 1,
+      webhook: { url: PLUMBER_URL, isRetryEnabled: true },
+      ...bothFlagsOn,
+      expected: false,
+    },
+    {
+      name: 'no webhook url',
+      mrfVersion: 2,
+      webhook: undefined,
+      ...bothFlagsOn,
+      expected: false,
+    },
+    {
+      name: 'retries disabled',
+      mrfVersion: 2,
+      webhook: { url: PLUMBER_URL, isRetryEnabled: false },
+      ...bothFlagsOn,
+      expected: false,
+    },
+    {
+      name: 'plumber needs no flags',
+      mrfVersion: 2,
+      webhook: { url: PLUMBER_URL, isRetryEnabled: true },
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: false,
+      expected: true,
+    },
+    {
+      name: 'generic with no flags is never delivered, so never snapshots',
+      mrfVersion: 2,
+      webhook: { url: GENERIC_URL, isRetryEnabled: true },
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: false,
+      expected: false,
+    },
+    {
+      name: 'generic with only enable-mrf-webhooks is not delivered',
+      mrfVersion: 2,
+      webhook: { url: GENERIC_URL, isRetryEnabled: true },
+      isMrfWebhooksEnabled: true,
+      isStepWriteTokenEnabled: false,
+      expected: false,
+    },
+    {
+      name: 'generic with only mrf-step-write-token is not delivered',
+      mrfVersion: 2,
+      webhook: { url: GENERIC_URL, isRetryEnabled: true },
+      isMrfWebhooksEnabled: false,
+      isStepWriteTokenEnabled: true,
+      expected: false,
+    },
+    {
+      name: 'generic with both flags snapshots',
+      mrfVersion: 2,
+      webhook: { url: GENERIC_URL, isRetryEnabled: true },
+      ...bothFlagsOn,
+      expected: true,
+    },
+    {
+      name: 'zapier with only enable-mrf-webhooks is not delivered',
+      mrfVersion: 2,
+      webhook: { url: ZAPIER_URL, isRetryEnabled: true },
+      isMrfWebhooksEnabled: true,
+      isStepWriteTokenEnabled: false,
+      expected: false,
+    },
+    {
+      name: 'zapier with both flags snapshots',
+      mrfVersion: 2,
+      webhook: { url: ZAPIER_URL, isRetryEnabled: true },
+      ...bothFlagsOn,
+      expected: true,
+    },
+  ])(
+    '$name',
+    ({
+      mrfVersion,
+      webhook,
+      isMrfWebhooksEnabled,
+      isStepWriteTokenEnabled,
+      expected,
+    }) => {
+      expect(
+        shouldWriteV4Snapshot({
+          mrfVersion,
+          webhook,
+          isMrfWebhooksEnabled,
+          isStepWriteTokenEnabled,
+        }),
+      ).toBe(expected)
+    },
+  )
+})

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-payload-policy.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-payload-policy.ts
@@ -1,0 +1,60 @@
+// 'v1' is unused: no policy input yields it, pending the S6 (#9746) rescope.
+export type WebhookContentFormat = 'v1' | 'v3' | 'v4'
+
+export type WebhookConsumerType = 'plumber' | 'generic'
+
+export interface WebhookPayloadPolicyInput {
+  webhookType: WebhookConsumerType
+  isStepWriteTokenEnabled: boolean
+  submissionIndex: number
+  submittedStepsLength: number
+}
+
+export interface WebhookPayloadPolicy {
+  contentFormat: WebhookContentFormat
+  includeEncryptedSubmissionSecretKey: boolean
+  includeEncryptedStepToken: boolean
+}
+
+export const getWebhookPayloadPolicy = ({
+  webhookType,
+  isStepWriteTokenEnabled,
+  submissionIndex,
+  submittedStepsLength,
+}: WebhookPayloadPolicyInput): WebhookPayloadPolicy => {
+  const contentFormat: WebhookContentFormat = isStepWriteTokenEnabled
+    ? 'v4'
+    : 'v3'
+
+  const includeEncryptedSubmissionSecretKey = contentFormat === 'v4'
+
+  const includeEncryptedStepToken =
+    contentFormat === 'v4' &&
+    webhookType === 'plumber' &&
+    submissionIndex === submittedStepsLength - 1
+
+  return {
+    contentFormat,
+    includeEncryptedSubmissionSecretKey,
+    includeEncryptedStepToken,
+  }
+}
+
+export type WebhookVersion = 2.1 | 3 | 4
+
+export const contentFormatToWebhookVersion = (
+  shape: WebhookContentFormat,
+): WebhookVersion => {
+  switch (shape) {
+    case 'v4':
+      return 4
+    case 'v3':
+      return 3
+    case 'v1':
+      return 2.1
+  }
+}
+
+export const mrfVersionToContentFormat = (
+  mrfVersion: number,
+): WebhookContentFormat => (mrfVersion === 2 ? 'v4' : 'v3')

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-reconstruction.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-reconstruction.ts
@@ -34,7 +34,7 @@ export const reconstructMrfWebhookData = (input: {
   const liveWorkflow = (liveData.workflowContent ??
     {}) as Partial<WorkflowWebhookEventObject>
   const workflowContent: WebhookData['workflowContent'] = {
-    ...(liveData.workflowContent as object),
+    ...liveWorkflow,
     workflowStep: snapshot.workflowStep,
     ...(Array.isArray(liveWorkflow.submittedSteps)
       ? {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-reconstruction.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-reconstruction.ts
@@ -1,0 +1,73 @@
+import { err, ok, Result } from 'neverthrow'
+
+import { WorkflowWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
+import { WebhookData } from 'src/types/submission'
+
+import { SnapshotDataIntegrityError } from './submission-snapshot.errors'
+import { SubmissionSnapshot } from './submission-snapshot.schema'
+import {
+  contentFormatToWebhookVersion,
+  WebhookPayloadPolicy,
+} from './webhook-payload-policy'
+
+export const reconstructMrfWebhookData = (input: {
+  liveData: WebhookData
+  snapshot?: SubmissionSnapshot
+  submissionIndex?: number
+  policy: WebhookPayloadPolicy
+}): Result<WebhookData, SnapshotDataIntegrityError> => {
+  const { liveData, snapshot, submissionIndex, policy } = input
+
+  if (submissionIndex === undefined) {
+    return ok(liveData)
+  }
+
+  if (!snapshot) {
+    return err(
+      new SnapshotDataIntegrityError(
+        'Snapshot missing on the snapshot reconstruction path',
+        { submissionId: liveData.submissionId, submissionIndex },
+      ),
+    )
+  }
+
+  const liveWorkflow = (liveData.workflowContent ??
+    {}) as Partial<WorkflowWebhookEventObject>
+  const workflowContent: WebhookData['workflowContent'] = {
+    ...(liveData.workflowContent as object),
+    workflowStep: snapshot.workflowStep,
+    ...(Array.isArray(liveWorkflow.submittedSteps)
+      ? {
+          submittedSteps: liveWorkflow.submittedSteps.slice(
+            0,
+            submissionIndex + 1,
+          ),
+        }
+      : {}),
+  }
+
+  const reconstructed: WebhookData = {
+    formId: liveData.formId,
+    submissionId: liveData.submissionId,
+    created: liveData.created,
+    attachmentDownloadUrls: snapshot.attachmentMetadata ?? {},
+    encryptedContent: snapshot.encryptedContent,
+    verifiedContent: snapshot.verifiedContent,
+    version: contentFormatToWebhookVersion(snapshot.contentFormat),
+    workflowContent,
+  }
+
+  if (liveData.paymentContent !== undefined) {
+    reconstructed.paymentContent = liveData.paymentContent
+  }
+
+  if (
+    policy.includeEncryptedSubmissionSecretKey &&
+    snapshot.contentFormat === 'v4'
+  ) {
+    reconstructed.encryptedSubmissionSecretKey =
+      snapshot.encryptedSubmissionSecretKey
+  }
+
+  return ok(reconstructed)
+}

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-send-eligibility.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-send-eligibility.ts
@@ -1,0 +1,40 @@
+import { getWebhookType } from '../../../webhook/webhook.service'
+
+export const shouldSendMrfWebhook = ({
+  webhookType,
+  isMrfWebhooksEnabled,
+  isStepWriteTokenEnabled,
+}: {
+  webhookType: 'zapier' | 'plumber' | 'generic'
+  isMrfWebhooksEnabled: boolean
+  isStepWriteTokenEnabled: boolean
+}): boolean => {
+  switch (webhookType) {
+    case 'plumber':
+      return true
+    case 'zapier':
+    case 'generic':
+      return isMrfWebhooksEnabled && isStepWriteTokenEnabled
+  }
+}
+
+export const shouldWriteV4Snapshot = ({
+  mrfVersion,
+  webhook,
+  isMrfWebhooksEnabled,
+  isStepWriteTokenEnabled,
+}: {
+  mrfVersion: number
+  webhook?: { url?: string; isRetryEnabled?: boolean }
+  isMrfWebhooksEnabled: boolean
+  isStepWriteTokenEnabled: boolean
+}): boolean => {
+  const url = webhook?.url
+  if (mrfVersion !== 2 || !url || !webhook?.isRetryEnabled) return false
+
+  return shouldSendMrfWebhook({
+    webhookType: getWebhookType(url),
+    isMrfWebhooksEnabled,
+    isStepWriteTokenEnabled,
+  })
+}


### PR DESCRIPTION
## Problem

Deciding what an MRF webhook payload looks like currently has nowhere to live. The shape depends on the flag and the consumer (whether the native envelope and the read credential go out, and whether step-token fields do), and the payload must be reconstructable from a frozen snapshot so that an initial send and a later retry are byte-identical.

This PR adds those decisions as three pure, independently-tested modules. All dormant — no caller yet.

## Solution

**Payload policy (M4).** The single place any decision branches on the consumer URL: content shape, whether the wrapped submission secret key is included as a read credential, and whether step-token fields are included. One reviewable table instead of scattered conditionals at the send site. It is also the single source of truth for the wire `version` (`contentFormatToWebhookVersion`: `v4→4`, `v3→3`, `v1→2.1`).

**Reconstruction (M3).** `(liveRow, snapshot?) → WebhookData`. This one function is what makes initial-send and retry byte-identical, so it is deliberately the only place they could diverge — and it does not.

- Given a `submissionIndex`, the snapshot **must** exist. Missing or corrupt fails loud; there is no live-row fallback, because falling back would ship the latest step's bytes under an earlier step's identity.
- Content, `verifiedContent`, `version`, `attachmentDownloadUrls` and the read credential all come from the **frozen** snapshot, never the live row. Absent snapshot `attachmentMetadata` is pinned to `{}` for the same reason.
- Without a `submissionIndex` it returns today's live-row payload unchanged — this is what keeps the flag-off path byte-for-byte identical.

**Send + snapshot-write gates.** `shouldSendMrfWebhook` (plumber always delivered to; generic/zapier — zapier is in the generic group — require **both** `enable-mrf-webhooks` **and** `mrf-step-write-token`, both default off) and `shouldWriteV4Snapshot` (the same send eligibility plus the row being V4, so we never write an object no send could read). Extracted as pure functions so their decision tables are unit-enumerable rather than inlined in the service.

## Breaking Changes

No. Three new modules, no call sites.

## Tests

Three new modules with no call sites, fully covered by unit specs. The only thing worth checking by hand is that nothing was accidentally wired up.

**TC1: No behavioural change from this branch**

- [x] With both flags `enable-mrf-webhooks` and `mrf-step-write-token` off , submit and advance a step on an MRF form with a plumber webhook URL.
- [x] Webhook is delivered with today's payload, and no S3 snapshot object is written.

## Payload content format

The policy's whole job is to decide this, so here is the full table it encodes. Note `contentFormat` is keyed on the **flag**, not on the consumer class — so a send-eligible generic consumer receives the same native envelope plumber does. The only consumer-class branch is the step-token field.

| consumer | `mrf-step-write-token` | step | `contentFormat` | `encryptedSubmissionSecretKey` | step-token fields | wire `version` |
|---|---|---|---|---|---|---|
| plumber | OFF | any | `v3` | ✅ (from the live row — see note) | ❌ | 3 |
| plumber | ON | latest | `v4` | ✅ | ✅ (computed; see below) | 4 |
| plumber | ON | earlier (retry) | `v4` | ✅ | ❌ | 4 |
| generic / zapier | ON (+ `enable-mrf-webhooks` ON) | any | `v4` | ✅ | ❌ | 4 |
| generic / zapier | OFF, **or** `enable-mrf-webhooks` OFF | any | — | *not delivered* (`shouldSendMrfWebhook` false) | | |

**On generic consumers receiving `encryptedSubmissionSecretKey`.** Intentional: a generic/zapier send requires `mrf-step-write-token` on, which is the same condition that makes the format `v4`. So the credential is never reachable without the operator enabling it, and it needs no per-consumer gate — only the step-token field has one.

**Note on the read credential for `v3`.** `includeEncryptedSubmissionSecretKey` is `false` there, but the delivered payload still carries `encryptedSubmissionSecretKey` — `getWebhookView` emits it unconditionally for MRF, and the flag-off path ships the live row. The policy flag governs only whether reconstruction copies the key **from a snapshot**; it never strips a field the live row already has. That is also why the `snapshot.contentFormat === 'v4'` half of the condition is belt-and-braces: no snapshot has `contentFormat: 'v3'` (the schema admits only `v4` and `v1`), so the `v3` arm is unreachable. Withholding the key from a V3 consumer would be a wire change, and this stack deliberately makes none outside #9820.

`includeEncryptedStepToken` is computed but **not yet read**: reconstruction never writes a step-token field, so no payload in this stack carries one. Delivering it is S11 (#9751), one atomic flip with write-guard enforcement.

### Reconstruction output, field by field

`reconstructMrfWebhookData({ liveData, snapshot, submissionIndex, policy })`:

| payload field | with a `submissionIndex` (snapshot route) | without one (flag-off / no-snapshot route) |
|---|---|---|
| `formId`, `submissionId`, `created` | live row | live row |
| `encryptedContent` | **snapshot** | live row |
| `verifiedContent` | **snapshot** | live row |
| `encryptedSubmissionSecretKey` | **snapshot**, only if policy includes it and `contentFormat === 'v4'` | live row (as `getWebhookView` emits it today) |
| `attachmentDownloadUrls` | **snapshot** `attachmentMetadata`, or `{}` when absent — presigned at send | live row |
| `version` | from **snapshot** `contentFormat` | live row (`getWebhookView`, see #9820) |
| `workflowContent.workflow` | live row | live row |
| `workflowContent.workflowStep` | **snapshot** | live row |
| `workflowContent.submittedSteps` | live row, truncated to `submissionIndex + 1` | live row, full |
| `paymentContent` | live row, only when defined | live row |

**Delivered body** (the `v4` row of the table above; POSTed with an `X-FormSG-Signature` header):

```json
{
  "data": {
    "formId": "66c0f0…",
    "submissionId": "66c0f1…",
    "created": "2026-08-03T04:15:22.180Z",
    "version": 4,
    "encryptedContent": "<V4 responses, encrypted to the submission public key>",
    "encryptedSubmissionSecretKey": "<submission secret key, wrapped to the form public key>",
    "verifiedContent": "<native verifiedContent, omitted when absent>",
    "attachmentDownloadUrls": { "<fieldId>": "<presigned GET url, 1h>" },
    "paymentContent": {},
    "workflowContent": {
      "workflow": [ /* FormWorkflowDto */ ],
      "workflowStep": 0,
      "submittedSteps": [
        {
          "isApproval": false,
          "submittedAt": "2026-08-03T04:15:22.180Z",
          "nextStepRecipientEmails": ["next@agency.gov.sg"],
          "submitterId": "S1234567D"
        }
      ]
    }
  }
}
```

The `v3` row is the same envelope with `version: 3`, `encryptedContent` holding **V3-shaped** responses (`adaptV4ToV3` before encryption), and `submittedSteps` untruncated. In both cases the ciphertext is `cryptoV3.encrypt` to the submission public key — the V3/V4 difference is the response schema *inside* the ciphertext, not the crypto. `snapshotTokens` never appears (#9817).

---

Part of PRD #9740, extracted from #9777. Stacked on #PR2.







