### PR TITLE
feat(mrf): derive the wire webhook version from the content format

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -553,7 +553,7 @@ describe('Submission Model', () => {
               encryptedContent: MOCK_ENCRYPTED_CONTENT,
               encryptedSubmissionSecretKey: 'test secret key',
               verifiedContent: undefined,
-              version: 1,
+              version: 3,
               created: submission.created,
               paymentContent: {},
               workflowContent: {

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -37,6 +37,10 @@ import {
 } from '../../types'
 import { getPaymentWebhookEventObject } from '../modules/payments/payment.service.utils'
 import { MultirespondentSubmissionContent } from '../modules/submission/multirespondent-submission/multirespondent-submission.types'
+import {
+  contentFormatToWebhookVersion,
+  mrfVersionToContentFormat,
+} from '../modules/submission/multirespondent-submission/webhook/webhook-payload-policy'
 import { buildMrfMetadata } from '../modules/submission/submission.utils'
 import {
   buildAdminSubmittedStepsMongoProjection,
@@ -645,7 +649,9 @@ MultirespondentSubmissionSchema.methods.getWebhookView = async function (
     encryptedContent: this.encryptedContent,
     encryptedSubmissionSecretKey: this.encryptedSubmissionSecretKey,
     verifiedContent: this.verifiedContent,
-    version: this.version,
+    version: contentFormatToWebhookVersion(
+      mrfVersionToContentFormat(this.mrfVersion),
+    ),
     created: this.created,
     attachmentDownloadUrls: attachmentRecords,
     paymentContent,


### PR DESCRIPTION
## Problem

`getWebhookView` sends the row's own `version` field — the front end's `MULTIRESPONDENT_FORM_SUBMISSION_VERSION`, most recently bumped 3 → 4 by #9782. That describes **the submission format the client posted**, not the shape of the bytes in `encryptedContent`, which is what a consumer actually branches on.

Reconstruction (#PR3) derives `version` from the frozen content shape. Without this change the same plumber form would report a different `version` depending on whether a snapshot happened to exist — the one place initial-send and retry must not diverge.

## Solution

Point `getWebhookView` at the same mapping reconstruction uses, so `version` describes `encryptedContent` on **both** routes:

| row | content format | wire `version` |
|---|---|---|
| `mrfVersion 2` (V4 native) | `v4` | **4** |
| `mrfVersion 1` (V3 downgrade via `adaptV4ToV3`) | `v3` | **3** |
| generic v1 form-key copy (later slice) | `v1` | **2.1** |

Two files. Isolated into its own PR precisely because it is the only change in this stack that is **live with all flags off** — it can be signed off, merged, or reverted independently of the dormant v4 machinery around it.

## Breaking Changes

**Yes — one deliberate wire change, live on merge.**

A plumber MRF webhook with `mrf-step-write-token` OFF now reports `version: 3` where develop reports `4`. The bytes in `encryptedContent` are unchanged and are V3-shaped in both cases; develop's `4` came from the front-end row field and described the wrong thing.

**Plumber is the only MRF consumer receiving webhooks today, so that is the full blast radius.** This needs calling out to the plumber team before merge if they branch on `version`.

## Tests

This is the one change in the stack that is live with all flags off, so it is worth exercising directly. **Needs plumber sign-off before merge.**

**TC1: A V3 row now reports `version: 3`**

- [x] `mrf-step-write-token` OFF. Advance a step on an MRF form with a plumber webhook URL (row stores `mrfVersion 1`).
- [x] Delivered payload is byte-identical to develop **except** `data.version`, which is now `3` instead of `4`.
- [x] `encryptedContent` still decrypts to the same V3-shaped responses — confirm the bytes did not move.

**TC2: A V4 row still reports `version: 4`**

- [x] Advance a step on a form whose row stores `mrfVersion 2` and capture the delivered body.
- [x] `data.version` is `4` — same value as develop, now derived from the content format rather than the row field.

**TC3: Non-MRF and no-webhook paths are untouched**

- [x] Submit to a regular encrypt-mode form with a webhook → `data.version` unchanged from develop.
- [x] Advance a step on an MRF form with no webhook URL → nothing is delivered, submission succeeds.

## Payload content format

Exactly one field moves: `data.version`. Every other field is byte-identical to develop, and the `encryptedContent` bytes do not move.

| row | content of `encryptedContent` | develop `version` | this PR `version` |
|---|---|---|---|
| `mrfVersion 2` (V4 native) | V4 responses, encrypted to the submission public key | `4` (row field) | **`4`** — same value, now derived from the content |
| `mrfVersion 1` (V3 downgrade via `adaptV4ToV3`) | V3-shaped responses, same crypto | `4` (row field — wrong) | **`3`** |
| generic v1 form-key copy (later slice) | responses encrypted to the **form** key | n/a | **`2.1`** |

The develop value is `MULTIRESPONDENT_FORM_SUBMISSION_VERSION` — the format the *client posted*, bumped 3 → 4 by #9782 regardless of what the row actually stores. So a V3 row advertised `4` while carrying V3-shaped responses.

**Delivered body for the changed case** (plumber, `mrf-step-write-token` OFF — the live-on-merge case):

```json
{
  "data": {
    "formId": "66c0f0…",
    "submissionId": "66c0f1…",
    "created": "2026-08-03T04:15:22.180Z",
    "version": 3,
    "encryptedContent": "<unchanged bytes: V3-shaped responses>",
    "encryptedSubmissionSecretKey": "<unchanged>",
    "verifiedContent": "<unchanged>",
    "attachmentDownloadUrls": { "<fieldId>": "<presigned GET url>" },
    "paymentContent": {},
    "workflowContent": {
      "workflow": [ /* unchanged */ ],
      "workflowStep": 0,
      "submittedSteps": [ /* unchanged */ ]
    }
  }
}
```

Diff against develop for this payload: `"version": 4` → `"version": 3`. Nothing else.

---

Part of PRD #9740, extracted from #9777. Stacked on #PR3. **Do not merge before plumber sign-off.**


