### PR TITLE
feat(mrf): widen the row content-version gate by consumer class

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -52,7 +52,15 @@ jest.mock('@opengovsg/formsg-sdk/adapters', () => ({
   isFieldResponsesV4: jest.fn(),
 }))
 jest.mock('src/app/utils/logic-adaptor')
-jest.mock('../multirespondent-submission.utils')
+jest.mock('../multirespondent-submission.utils', () => {
+  const actual = jest.requireActual(
+    '../multirespondent-submission.utils',
+  ) as typeof import('../multirespondent-submission.utils')
+  return {
+    ...actual,
+    validateMrfFieldResponses: jest.fn(),
+  }
+})
 jest.mock('src/app/config/formsg-sdk', () => ({
   __esModule: true,
   default: {
@@ -947,7 +955,7 @@ describe('Multirespondent Submission Middleware', () => {
       mockDecrypt.mockReturnValue({ responses: MOCK_RESPONSES })
     })
 
-    it('should encrypt responses as V3 and set mrfVersion to 1 when form has a webhook url', async () => {
+    it('should encrypt responses as V4 and set mrfVersion to 2 when the form has a generic webhook url', async () => {
       jest.mocked(adaptV4ToV3).mockReturnValue({
         field1: { fieldType: BasicField.ShortText, answer: 'hello' },
       } as any)
@@ -958,8 +966,8 @@ describe('Multirespondent Submission Middleware', () => {
 
       await encryptSubmission(mockReq, mockRes as any, mockNext)
 
-      expect(jest.mocked(adaptV4ToV3)).toHaveBeenCalledWith(MOCK_RESPONSES)
-      expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(1)
+      expect(jest.mocked(adaptV4ToV3)).not.toHaveBeenCalled()
+      expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(2)
       expect(mockNext).toHaveBeenCalled()
     })
 
@@ -1042,6 +1050,162 @@ describe('Multirespondent Submission Middleware', () => {
           return mockReq.formsg.encryptedPayload.stepToken as string
         }
         expect(await run()).not.toBe(await run())
+      })
+    })
+
+    describe('mrf version gate', () => {
+      const PLUMBER_URL = 'https://plumber.gov.sg/webhooks/abc'
+      const ZAPIER_URL = 'https://hooks.zapier.com/hooks/catch/123/abc'
+      const GENERIC_URL = 'https://example.com/hook'
+      const V3_ADAPTED = {
+        field1: { fieldType: BasicField.ShortText, answer: 'hello' },
+      }
+
+      const runGate = async ({
+        webhookUrl,
+        webhookFormat,
+        flags = [],
+      }: {
+        webhookUrl?: string
+        webhookFormat?: 'v1' | 'v4'
+        flags?: string[]
+      }) => {
+        jest.mocked(adaptV4ToV3).mockClear()
+        jest.mocked(adaptV4ToV3).mockReturnValue(V3_ADAPTED as any)
+        jest.mocked(formsgSdk.cryptoV3.encrypt).mockClear()
+        const mockReq = createMockEncryptReq(false)
+        if (webhookUrl) {
+          mockReq.formsg.formDef = {
+            ...MOCK_FORM_BASE,
+            webhook: { url: webhookUrl, isRetryEnabled: false, webhookFormat },
+          }
+        }
+        mockReq.growthbook.isOn = jest.fn((flag: string) =>
+          flags.includes(flag),
+        )
+        await encryptSubmission(mockReq, createMockRes() as any, jest.fn())
+        return mockReq
+      }
+
+      const expectEncryptedAs = (
+        mockReq: Awaited<ReturnType<typeof runGate>>,
+        expected: 1 | 2,
+      ) => {
+        expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(expected)
+        if (expected === 2) {
+          // V4: encrypt the in-process responses as-is; do not downgrade.
+          expect(jest.mocked(adaptV4ToV3)).not.toHaveBeenCalled()
+          expect(jest.mocked(formsgSdk.cryptoV3.encrypt)).toHaveBeenCalledWith(
+            MOCK_RESPONSES,
+            MOCK_FORM_PUBLIC_KEY,
+          )
+        } else {
+          // V3: downgrade via adaptV4ToV3, then encrypt the adapted shape.
+          expect(jest.mocked(adaptV4ToV3)).toHaveBeenCalledWith(MOCK_RESPONSES)
+          expect(jest.mocked(formsgSdk.cryptoV3.encrypt)).toHaveBeenCalledWith(
+            V3_ADAPTED,
+            MOCK_FORM_PUBLIC_KEY,
+          )
+        }
+      }
+
+      describe('URL → consumer class via getWebhookType', () => {
+        it('classifies plumber.gov.sg as plumber (V4 when write-guard on)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: PLUMBER_URL,
+              flags: [featureFlags.mrfStepWriteToken],
+            }),
+            2,
+          )
+        })
+
+        it('classifies example.com as generic (V4 regardless of the flags)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: GENERIC_URL,
+              flags: [featureFlags.mrfStepWriteToken],
+            }),
+            2,
+          )
+          expectEncryptedAs(await runGate({ webhookUrl: GENERIC_URL }), 2)
+        })
+
+        it('classifies hooks.zapier.com as generic (V4 regardless of the flags)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: ZAPIER_URL,
+              flags: [featureFlags.mrfStepWriteToken],
+            }),
+            2,
+          )
+          expectEncryptedAs(await runGate({ webhookUrl: ZAPIER_URL }), 2)
+        })
+
+        it('no webhook URL is treated as none (V4)', async () => {
+          expectEncryptedAs(await runGate({ flags: [] }), 2)
+        })
+      })
+
+      describe('ignored inputs that never reach getMrfVersion', () => {
+        it('does not treat enableMrfWebhooks as a substitute for mrfStepWriteToken on plumber', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: PLUMBER_URL,
+              flags: [featureFlags.enableMrfWebhooks],
+            }),
+            1,
+          )
+        })
+
+        it('ignores webhookFormat on plumber (v1 + write-guard still V4)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: PLUMBER_URL,
+              webhookFormat: 'v1',
+              flags: [featureFlags.mrfStepWriteToken],
+            }),
+            2,
+          )
+        })
+
+        it('ignores webhookFormat and enableMrfWebhooks on generic (V4 either way)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: GENERIC_URL,
+              webhookFormat: 'v1',
+              flags: [featureFlags.enableMrfWebhooks],
+            }),
+            2,
+          )
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: GENERIC_URL,
+              webhookFormat: 'v4',
+              flags: [],
+            }),
+            2,
+          )
+        })
+
+        it('ignores webhookFormat and enableMrfWebhooks on zapier (V4 either way)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: ZAPIER_URL,
+              webhookFormat: 'v1',
+              flags: [featureFlags.enableMrfWebhooks],
+            }),
+            2,
+          )
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: ZAPIER_URL,
+              webhookFormat: 'v4',
+              flags: [],
+            }),
+            2,
+          )
+        })
       })
     })
   })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -42,7 +42,9 @@ import {
   createMultirespondentSubmissionDto,
   createPublicMultirespondentSubmissionDto,
   extractRespondentCopyEmailDatas,
+  getMrfVersion,
   getQuestionAnswerPairsForMultipleFields,
+  MrfVersion,
   retrieveWorkflowStepEmailAddresses,
   validateMrfFieldResponses,
 } from '../multirespondent-submission.utils'
@@ -1373,6 +1375,70 @@ describe('multirespondent-submission.utils', () => {
         }),
       )
       expect(result[3]).not.toHaveProperty('fieldType')
+    })
+  })
+
+  describe('getMrfVersion', () => {
+    type WebhookType = 'zapier' | 'plumber' | 'generic' | undefined
+
+    it.each<{
+      name: string
+      webhookType: WebhookType
+      isStepWriteTokenEnabled: boolean
+      expected: MrfVersion
+    }>([
+      {
+        name: 'no webhook, write-guard off => V4',
+        webhookType: undefined,
+        isStepWriteTokenEnabled: false,
+        expected: 2,
+      },
+      {
+        name: 'no webhook, write-guard on => V4',
+        webhookType: undefined,
+        isStepWriteTokenEnabled: true,
+        expected: 2,
+      },
+      {
+        name: 'plumber, write-guard on => V4',
+        webhookType: 'plumber',
+        isStepWriteTokenEnabled: true,
+        expected: 2,
+      },
+      {
+        name: 'plumber, write-guard off => V3',
+        webhookType: 'plumber',
+        isStepWriteTokenEnabled: false,
+        expected: 1,
+      },
+      {
+        name: 'generic, write-guard off => V4',
+        webhookType: 'generic',
+        isStepWriteTokenEnabled: false,
+        expected: 2,
+      },
+      {
+        name: 'generic, write-guard on => V4',
+        webhookType: 'generic',
+        isStepWriteTokenEnabled: true,
+        expected: 2,
+      },
+      {
+        name: 'zapier is treated as generic, write-guard off => V4',
+        webhookType: 'zapier',
+        isStepWriteTokenEnabled: false,
+        expected: 2,
+      },
+      {
+        name: 'zapier is treated as generic, write-guard on => V4',
+        webhookType: 'zapier',
+        isStepWriteTokenEnabled: true,
+        expected: 2,
+      },
+    ])('$name', ({ webhookType, isStepWriteTokenEnabled, expected }) => {
+      expect(getMrfVersion({ webhookType, isStepWriteTokenEnabled })).toBe(
+        expected,
+      )
     })
   })
 })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -1379,8 +1379,7 @@ describe('multirespondent-submission.utils', () => {
   })
 
   describe('getMrfVersion', () => {
-    type WebhookType = 'zapier' | 'plumber' | 'generic' | undefined
-
+    type WebhookType = Parameters<typeof getMrfVersion>[0]['webhookType']
     it.each<{
       name: string
       webhookType: WebhookType

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -54,6 +54,7 @@ import { getOidcService } from '../../spcp/spcp.oidc.service'
 import { createNdiResponsesV4FromRecord } from '../../spcp/spcp.util'
 import * as VerifiedContentService from '../../verified-content/verified-content.service'
 import { VerifiedContentV3 } from '../../verified-content/verified-content.types'
+import { getWebhookType } from '../../webhook/webhook.service'
 import { FormsgReqBodyExistsError } from '../encrypt-submission/encrypt-submission.errors'
 import { CreateFormsgAndRetrieveFormMiddlewareHandlerType } from '../encrypt-submission/encrypt-submission.types'
 import {
@@ -85,7 +86,10 @@ import {
   ProcessedMultirespondentSubmissionHandlerType,
   StrippedAttachmentResponseV4,
 } from './multirespondent-submission.types'
-import { validateMrfFieldResponses } from './multirespondent-submission.utils'
+import {
+  getMrfVersion,
+  validateMrfFieldResponses,
+} from './multirespondent-submission.utils'
 import * as stepToken from './step-token'
 
 const logger = createLoggerWithLabel(module)
@@ -848,15 +852,19 @@ export const encryptSubmission = async (
     req.formsg.unencryptedAttachments = unencryptedAttachments
   }
 
-  // Webhook compatibility: forms with webhooks have downstream consumers that
-  // parse the encrypted payload as V3-shaped (mrfVersion: 1). Convert back to
-  // V3 just for the encryption blob; in-process state (encryptedPayload.responses,
-  // emails, NDI handling) stays V4.
-  const hasWebhook = !!formDef.webhook?.url
-  const responsesToEncrypt = hasWebhook
-    ? adaptV4ToV3(strippedAttachmentResponses as unknown as FieldResponsesV4)
-    : strippedAttachmentResponses
-  const mrfVersion: 1 | 2 = hasWebhook ? 1 : 2
+  const isStepWriteTokenEnabled =
+    req.growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false
+
+  const webhookUrl = formDef.webhook?.url
+  const mrfVersion = getMrfVersion({
+    webhookType: webhookUrl ? getWebhookType(webhookUrl) : undefined,
+    isStepWriteTokenEnabled,
+  })
+  const useV4Encryption = mrfVersion === 2
+
+  const responsesToEncrypt = useV4Encryption
+    ? strippedAttachmentResponses
+    : adaptV4ToV3(strippedAttachmentResponses as unknown as FieldResponsesV4)
 
   const {
     encryptedContent,
@@ -896,8 +904,6 @@ export const encryptSubmission = async (
       req.body.version,
     )
 
-  const isStepWriteTokenEnabled =
-    req.growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false
   let mintedStepToken:
     | {
         stepToken: string
@@ -924,11 +930,6 @@ export const encryptSubmission = async (
     version: req.body.version,
     workflowStep: req.body.workflowStep,
     responses: responses as FieldResponsesV4,
-    /**
-     * MRF Version 2 = V4-encrypted responses (with provenance).
-     * MRF Version 1 = V3-encrypted responses (used when form has a webhook
-     * so existing webhook consumers can continue to parse V3 payloads).
-     */
     mrfVersion,
     ...mintedStepToken,
   }

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -32,6 +32,7 @@ import { convertToSignaturePngDataUri } from '../../../utils/convert-vector-arra
 import { validateFieldV4 } from '../../../utils/field-validation'
 import { FieldIdSet } from '../../../utils/logic-adaptor'
 import { startsWithSPCPFieldTitle } from '../../spcp/spcp.util'
+import { WebhookType } from '../../webhook/webhook.service'
 import {
   InvalidWorkflowTypeError,
   ProcessingError,
@@ -695,7 +696,7 @@ export const getMrfVersion = ({
   webhookType,
   isStepWriteTokenEnabled,
 }: {
-  webhookType?: 'zapier' | 'plumber' | 'generic'
+  webhookType?: WebhookType
   isStepWriteTokenEnabled: boolean
 }): MrfVersion => {
   switch (webhookType) {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -689,6 +689,25 @@ export const getMrfCookieName = ({
   return `Mrf_${formId}_${previousSubmissionId}`
 }
 
+export type MrfVersion = 1 | 2
+
+export const getMrfVersion = ({
+  webhookType,
+  isStepWriteTokenEnabled,
+}: {
+  webhookType?: 'zapier' | 'plumber' | 'generic'
+  isStepWriteTokenEnabled: boolean
+}): MrfVersion => {
+  switch (webhookType) {
+    case 'plumber':
+      return isStepWriteTokenEnabled ? 2 : 1
+    case undefined:
+    case 'zapier':
+    case 'generic':
+      return 2
+  }
+}
+
 export const formatSubmittedStepTimestamp = ({
   submittedSteps,
   stepIndex,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-send-eligibility.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-send-eligibility.spec.ts
@@ -1,3 +1,5 @@
+import { WebhookType } from 'src/app/modules/webhook/webhook.service'
+
 import {
   shouldSendMrfWebhook,
   shouldWriteV4Snapshot,
@@ -9,7 +11,7 @@ const ZAPIER_URL = 'https://hooks.zapier.com/hooks/catch/1/x'
 
 describe('shouldSendMrfWebhook', () => {
   it.each<{
-    webhookType: 'plumber' | 'generic' | 'zapier'
+    webhookType: WebhookType
     isMrfWebhooksEnabled: boolean
     isStepWriteTokenEnabled: boolean
     expected: boolean

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-payload-policy.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-payload-policy.ts
@@ -1,6 +1,7 @@
 // 'v1' is unused: no policy input yields it, pending the S6 (#9746) rescope.
 export type WebhookContentFormat = 'v1' | 'v3' | 'v4'
 
+// This is not the same as WebhookType, this is the classes of webhook consumers (ie, internal or external)
 export type WebhookConsumerType = 'plumber' | 'generic'
 
 export interface WebhookPayloadPolicyInput {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-send-eligibility.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-send-eligibility.ts
@@ -1,11 +1,11 @@
-import { getWebhookType } from '../../../webhook/webhook.service'
+import { getWebhookType, WebhookType } from '../../../webhook/webhook.service'
 
 export const shouldSendMrfWebhook = ({
   webhookType,
   isMrfWebhooksEnabled,
   isStepWriteTokenEnabled,
 }: {
-  webhookType: 'zapier' | 'plumber' | 'generic'
+  webhookType: WebhookType
   isMrfWebhooksEnabled: boolean
   isStepWriteTokenEnabled: boolean
 }): boolean => {

--- a/apps/backend/src/app/modules/webhook/webhook.service.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.service.ts
@@ -226,7 +226,9 @@ export const sendWebhook = (
   })
 }
 
-export const getWebhookType = (webhookUrl: string) => {
+export type WebhookType = 'zapier' | 'plumber' | 'generic'
+
+export const getWebhookType = (webhookUrl: string): WebhookType => {
   const isZapier = /^https:\/\/hooks\.zapier\.com\//
   const isPlumber = /^https:\/\/plumber\.gov\.sg\/webhooks\//
   const webhookType = isZapier.test(webhookUrl)

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -104,6 +104,7 @@ export type FormSupportedLanguages = {
 export type FormWebhook = {
   url: string
   isRetryEnabled: boolean
+  webhookFormat?: 'v1' | 'v4'
 }
 
 export enum FormResponseMode {


### PR DESCRIPTION
## Problem

The row content-version gate is an inline `hasWebhook ? 1 : 2` inside `encryptSubmission`: untestable on its own, and keyed on mere URL **presence**. The v4 rollout needs it keyed on consumer **class** (plumber vs generic vs none) and on the `mrf-step-write-token` flag.

## Solution

Extract it as a pure `getMrfVersion({ webhookType, isStepWriteTokenEnabled })` so its decision table is unit-enumerable, and widen it:

| consumer | `mrf-step-write-token` | stored |
|---|---|---|
| no webhook | either | V4 (`mrfVersion 2`) — unchanged from develop |
| plumber | ON | **V4 — the new arm** |
| plumber | OFF | V3 (`1`) — unchanged, today's downgrade |
| generic / zapier | either | V4 (`2`) |

This is a **storage** decision — what the row holds — and deliberately **not** an input to whether a webhook is delivered. `enable-mrf-webhooks` is not a parameter here at all (PRD #9803 R7); delivery is gated separately by the send-eligibility function from #PR3.

Note the direction of the adapt: the pipeline is V4-native in-process, and V3 is produced by adapting **down** for consumers that cannot parse V4. This PR only widens which consumer classes keep the native shape.

`webhookFormat` lands on the shared `FormWebhook` type as the field a later slice keys generic's opt-in on. Nothing in production reads it — the specs here pin that `getMrfVersion` **ignores** it, so a form carrying the field cannot change shape until that slice arrives with the v1 fallback that makes it safe.

## Breaking Changes

No wire change. This moves what the **row** stores for generic/zapier and for plumber-with-the-flag-on. Four things read the row — the admin decrypt path, the respondent's next-step read, the snapshot writer, and transitively the webhook — and all handle both `mrfVersion` values today. Forward-only: existing `mrfVersion 1` rows stay readable, no backfill.

With `mrf-step-write-token` off, plumber reduces to develop's behaviour exactly.

## Tests

This changes what the **row** stores, so most checks are "read the row back, then read it through every consumer of it".

**TC1: Plumber with the flag on stores V4 (the new arm)**

- [x] `mrf-step-write-token` ON. Submit a step on an MRF form with a plumber webhook URL.
- [x] Row stores `mrfVersion: 2`, and the delivered payload is the V4 shape.

**TC2: Plumber with the flag off is develop's behaviour exactly**

- [x] `mrf-step-write-token` OFF. Submit the same step.
- [x] Row stores `mrfVersion: 1`, delivered payload is V3-shaped as today.

**TC3: Forms with no webhook are unaffected either way**

- [x] Submit on an MRF form with no webhook URL, with the flag ON and then OFF.
- [x] Row stores `mrfVersion: 2` in both cases.

**TC4: Mixed-version rows all still read**

- [x] On a form holding a mix of `mrfVersion 1` and `mrfVersion 2` rows, open the admin results table, open individual submissions, and export the CSV.
- [x] Every row decrypts and renders; the export contains both.

**TC5: A respondent can still advance a V4 row**

- [x] With the flag ON, complete step 1 and then open the next-step link as the next respondent.
- [x] Previous answers load correctly and the step can be submitted.

## Payload content format

This PR decides what the **row** stores, which in turn fixes what a consumer receives. Stored shape → wire shape, per case:

| consumer | `mrf-step-write-token` | stored `mrfVersion` | `encryptedContent` holds | wire `version` | read credential |
|---|---|---|---|---|---|
| no webhook | either | 2 (V4) | V4 responses | — nothing delivered | — |
| plumber | ON | **2 (V4)** — the new arm | V4 responses | 4 | `encryptedSubmissionSecretKey` |
| plumber | OFF | 1 (V3) | V3-shaped responses (`adaptV4ToV3`) | 3 | `encryptedSubmissionSecretKey` |
| generic / zapier | ON | 2 (V4) | V4 responses | 4 | `encryptedSubmissionSecretKey` |
| generic / zapier | OFF | 2 (V4) | V4 responses | — not delivered (`enable-mrf-webhooks` + flag gate) | — |

Only the plumber-flag-ON row is new. Generic/zapier already stored V4 on develop; what changes for them is delivery, gated elsewhere (#9819).

The crypto is identical in both arms — `cryptoV3.encrypt(responses, formPublicKey)`, content under the submission public key with the submission secret key wrapped to the form key. The V3/V4 difference is purely the response schema **inside** the ciphertext:

```jsonc
// V4 (mrfVersion 2) — structured answer + per-response metadata
{
  "<fieldId>": {
    "fieldType": "textfield",
    "answer": { "value": "Alice" },
    "question": "Name",
    "provenance": { "submittedAt": "2026-08-03T04:15:22.180Z", "stepNumber": 0 },
    "previousAnswers": [ /* … */ ],
    "myInfo": { /* … */ }
  }
}

// V3 (mrfVersion 1) — adaptV4ToV3: answer flattened, metadata dropped
{ "<fieldId>": { "fieldType": "textfield", "answer": "Alice" } }
```

Both are records keyed by field id. `adaptV4ToV3` flattens each answer to its V3 form (`{value}` → string, `radiobutton` → `{value}`/`{othersInput}`, and so on) and drops `question`, `provenance`, `previousAnswers` and `myInfo` — so a V3 consumer cannot see who answered what on which step. That metadata is the reason plumber wants V4.

`webhookFormat` on `FormWebhook` is inert: `getMrfVersion` ignores it (pinned by spec), so setting it changes no stored or delivered shape until the v1 slice lands.

---

Part of PRD #9740, extracted from #9777. Stacked on #PR4.


