### PR TITLE
feat(security): pnpm defaults to harden against supply chain attacks

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+blockExoticSubdeps: true
+minimumReleaseAge: 4320 # 3 days
+trustPolicy: no-downgrade
 packages:
   - 'apps/*'
   - 'packages/*'


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
Supply chain attacks are frequent, with 4 major reports this year. 
Currently, the 2 practices we have directly on our pnpm settings are: 
- allow listing only specific postinstall scripts
- using a lockfile

## Solution
<!-- How did you solve the problem? -->
Apply defaults recommended by https://pnpm.io/supply-chain-security. 

note: 
- "minimumReleaseAge" is a sensible default, but malware can stay undetected for extended periods of time. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  