### PR TITLE
fix: prevent MRF checkbox answers without a value from crashing the app

### DIFF
--- a/apps/backend/src/app/utils/field-validation/field-validation.utils.ts
+++ b/apps/backend/src/app/utils/field-validation/field-validation.utils.ts
@@ -138,10 +138,15 @@ export const checkIsResponseChangedV4 = ({
       return a.value !== p.value || a.isOthersInput !== p.isOthersInput
     }
     case BasicField.Checkbox: {
-      const a = response.answer as CheckboxAnswerV4
-      const p = prevResponse.answer as CheckboxAnswerV4
-      const setsDiffer = !isEqual(new Set(a.value), new Set(p.value))
-      const othersDiffer = (a.othersInput ?? '') !== (p.othersInput ?? '')
+      // Optional-chain: malformed bodies can send a null answer or omit
+      // `value` entirely; treat as an empty selection rather than throwing.
+      const a = response.answer as CheckboxAnswerV4 | null
+      const p = prevResponse.answer as CheckboxAnswerV4 | null
+      const setsDiffer = !isEqual(
+        new Set(a?.value ?? []),
+        new Set(p?.value ?? []),
+      )
+      const othersDiffer = (a?.othersInput ?? '') !== (p?.othersInput ?? '')
       return setsDiffer || othersDiffer
     }
     case BasicField.Table:

--- a/apps/backend/src/app/utils/field-validation/index.ts
+++ b/apps/backend/src/app/utils/field-validation/index.ts
@@ -622,9 +622,12 @@ const isResponsePresentOnHiddenFieldV4 = ({
       return ok(a.value.trim() !== '')
     }
     case BasicField.Checkbox: {
-      const a = response.answer as CheckboxAnswerV4
+      // Optional-chain: malformed bodies can send a null answer or omit
+      // `value` entirely; treat as an empty selection rather than throwing.
+      const a = response.answer as CheckboxAnswerV4 | null
       return ok(
-        a.value.length > 0 || (!!a.othersInput && a.othersInput.trim() !== ''),
+        (a?.value?.length ?? 0) > 0 ||
+          (typeof a?.othersInput === 'string' && a.othersInput.trim() !== ''),
       )
     }
     case BasicField.Table: {
@@ -716,13 +719,13 @@ const isValidationRequiredV4 = ({
       return ok(requiredAndVisible || a.value.trim() !== '')
     }
     case BasicField.Checkbox: {
-      const a = response.answer as CheckboxAnswerV4
-      // Optional-chain: malformed bodies can omit `value` entirely; treat as
-      // an empty selection rather than throwing.
+      // Optional-chain: malformed bodies can send a null answer or omit
+      // `value` entirely; treat as an empty selection rather than throwing.
+      const a = response.answer as CheckboxAnswerV4 | null
       return ok(
         requiredAndVisible ||
-          (a.value?.length ?? 0) > 0 ||
-          (!!a.othersInput && a.othersInput.trim() !== ''),
+          (a?.value?.length ?? 0) > 0 ||
+          (typeof a?.othersInput === 'string' && a.othersInput.trim() !== ''),
       )
     }
     case BasicField.Table:

--- a/apps/backend/src/app/utils/field-validation/index.ts
+++ b/apps/backend/src/app/utils/field-validation/index.ts
@@ -717,9 +717,11 @@ const isValidationRequiredV4 = ({
     }
     case BasicField.Checkbox: {
       const a = response.answer as CheckboxAnswerV4
+      // Optional-chain: malformed bodies can omit `value` entirely; treat as
+      // an empty selection rather than throwing.
       return ok(
         requiredAndVisible ||
-          a.value.length > 0 ||
+          (a.value?.length ?? 0) > 0 ||
           (!!a.othersInput && a.othersInput.trim() !== ''),
       )
     }

--- a/apps/backend/src/app/utils/field-validation/validators/__tests__/checkbox-validation.spec.ts
+++ b/apps/backend/src/app/utils/field-validation/validators/__tests__/checkbox-validation.spec.ts
@@ -960,6 +960,25 @@ describe('Checkbox validation V4', () => {
       )
     })
 
+    it('should reject (not throw) on a hidden field', () => {
+      const formField = generateDefaultField(BasicField.Checkbox, {
+        fieldOptions,
+      })
+      const response = makeCheckboxResponseV4({ othersInput: 'other only' })
+      const validateResult = validateFieldV4({
+        formId,
+        formField,
+        response,
+        isVisible: false,
+      })
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldErrorV4(
+          'Attempted to submit response on a hidden field',
+        ),
+      )
+    })
+
     it('should treat an empty-object answer on an optional field as unanswered', () => {
       const formField = generateDefaultField(BasicField.Checkbox, {
         fieldOptions,
@@ -974,6 +993,76 @@ describe('Checkbox validation V4', () => {
       })
       expect(validateResult.isOk()).toBe(true)
       expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+  })
+
+  // Regression: the middleware only validates that `answer` is present
+  // (Joi.required()), so it can be null or a primitive, which used to throw
+  // on the `.value` dereference instead of returning err.
+  describe('answers that are null or not objects', () => {
+    it('should reject (not throw) a null answer on a required visible field', () => {
+      const formField = generateDefaultField(BasicField.Checkbox, {
+        fieldOptions,
+      })
+      const response = makeCheckboxResponseV4(null)
+      const validateResult = validateFieldV4({
+        formId,
+        formField,
+        response,
+        isVisible: true,
+      })
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldErrorV4('Invalid answer submitted'),
+      )
+    })
+
+    it('should treat a null answer on an optional visible field as unanswered', () => {
+      const formField = generateDefaultField(BasicField.Checkbox, {
+        fieldOptions,
+        required: false,
+      })
+      const response = makeCheckboxResponseV4(null)
+      const validateResult = validateFieldV4({
+        formId,
+        formField,
+        response,
+        isVisible: true,
+      })
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should treat a null answer on a hidden field as unanswered (not throw)', () => {
+      const formField = generateDefaultField(BasicField.Checkbox, {
+        fieldOptions,
+      })
+      const response = makeCheckboxResponseV4(null)
+      const validateResult = validateFieldV4({
+        formId,
+        formField,
+        response,
+        isVisible: false,
+      })
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should reject (not throw) a string answer on a required visible field', () => {
+      const formField = generateDefaultField(BasicField.Checkbox, {
+        fieldOptions,
+      })
+      const response = makeCheckboxResponseV4('not an object')
+      const validateResult = validateFieldV4({
+        formId,
+        formField,
+        response,
+        isVisible: true,
+      })
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldErrorV4('Invalid answer submitted'),
+      )
     })
   })
 

--- a/apps/backend/src/app/utils/field-validation/validators/__tests__/checkbox-validation.spec.ts
+++ b/apps/backend/src/app/utils/field-validation/validators/__tests__/checkbox-validation.spec.ts
@@ -8,8 +8,16 @@ import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from 'formsg-shared/constants'
 import { BasicField } from 'formsg-shared/types'
 import { mongo as mongodb } from 'mongoose'
 
-import { ValidateFieldError } from 'src/app/modules/submission/submission.errors'
-import { validateField, validateFieldV3 } from 'src/app/utils/field-validation'
+import {
+  ValidateFieldError,
+  ValidateFieldErrorV4,
+} from 'src/app/modules/submission/submission.errors'
+import {
+  validateField,
+  validateFieldV3,
+  validateFieldV4,
+} from 'src/app/utils/field-validation'
+import { ParsedClearFormFieldResponseV4 } from 'src/types/api'
 
 const { ObjectId } = mongodb
 
@@ -881,5 +889,113 @@ describe('Checkbox validation V3', () => {
         new ValidateFieldError('Invalid answer submitted'),
       )
     })
+  })
+})
+
+describe('Checkbox validation V4', () => {
+  const formId = new ObjectId().toHexString()
+  const fieldOptions = ['a', 'b', 'c']
+
+  const makeCheckboxResponseV4 = (
+    answer: unknown,
+  ): ParsedClearFormFieldResponseV4 =>
+    ({
+      fieldType: BasicField.Checkbox,
+      question: 'Checkbox',
+      answer,
+      provenance: {},
+    }) as ParsedClearFormFieldResponseV4
+
+  it('should allow a valid selection', () => {
+    const formField = generateDefaultField(BasicField.Checkbox, {
+      fieldOptions,
+    })
+    const response = makeCheckboxResponseV4({ value: ['a'] })
+    const validateResult = validateFieldV4({
+      formId,
+      formField,
+      response,
+      isVisible: true,
+    })
+    expect(validateResult.isOk()).toBe(true)
+    expect(validateResult._unsafeUnwrap()).toEqual(true)
+  })
+
+  // Regression: answers with no `value` key (e.g. othersInput set without any
+  // selection) used to throw `Cannot read properties of undefined (reading
+  // 'length')` instead of returning err, killing the process.
+  describe('answers with a missing value array', () => {
+    it('should reject (not throw) on an optional visible field', () => {
+      const formField = generateDefaultField(BasicField.Checkbox, {
+        fieldOptions,
+        required: false,
+      })
+      const response = makeCheckboxResponseV4({ othersInput: 'other only' })
+      const validateResult = validateFieldV4({
+        formId,
+        formField,
+        response,
+        isVisible: true,
+      })
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldErrorV4('Invalid answer submitted'),
+      )
+    })
+
+    it('should reject (not throw) on a required visible field', () => {
+      const formField = generateDefaultField(BasicField.Checkbox, {
+        fieldOptions,
+      })
+      const response = makeCheckboxResponseV4({ othersInput: 'other only' })
+      const validateResult = validateFieldV4({
+        formId,
+        formField,
+        response,
+        isVisible: true,
+      })
+      expect(validateResult.isErr()).toBe(true)
+      expect(validateResult._unsafeUnwrapErr()).toEqual(
+        new ValidateFieldErrorV4('Invalid answer submitted'),
+      )
+    })
+
+    it('should treat an empty-object answer on an optional field as unanswered', () => {
+      const formField = generateDefaultField(BasicField.Checkbox, {
+        fieldOptions,
+        required: false,
+      })
+      const response = makeCheckboxResponseV4({})
+      const validateResult = validateFieldV4({
+        formId,
+        formField,
+        response,
+        isVisible: true,
+      })
+      expect(validateResult.isOk()).toBe(true)
+      expect(validateResult._unsafeUnwrap()).toEqual(true)
+    })
+  })
+
+  it('should reject othersInput text without the Others sentinel selected', () => {
+    const formField = generateDefaultField(BasicField.Checkbox, {
+      fieldOptions,
+      required: false,
+      othersRadioButton: true,
+    })
+    const response = makeCheckboxResponseV4({
+      value: [],
+      othersInput: 'other only',
+    })
+    const validateResult = validateFieldV4({
+      formId,
+      formField,
+      response,
+      isVisible: true,
+    })
+    expect(validateResult.isErr()).toBe(true)
+    expect(validateResult._unsafeUnwrapErr()).toEqual(
+      new ValidateFieldErrorV4('Invalid answer submitted'),
+    )
   })
 })

--- a/apps/backend/src/app/utils/field-validation/validators/checkboxValidator.ts
+++ b/apps/backend/src/app/utils/field-validation/validators/checkboxValidator.ts
@@ -358,14 +358,15 @@ const isCheckboxFieldTypeV4: ResponseValidator<
 }
 
 /**
- * The answer is a blind cast from an unvalidated request body, so `value` may
- * be missing or not an array. Reject the shape before any validator
- * dereferences it.
+ * The answer is a blind cast from an unvalidated request body, so it may be
+ * null or a primitive, and `value` may be missing or not an array. Reject the
+ * shape before any validator dereferences it.
  */
 const isCheckboxAnswerShapeV4: ResponseValidator<CheckboxResponseV4> = (
   response,
 ) => {
-  return Array.isArray(response.answer.value)
+  const answer = response.answer as CheckboxAnswerV4 | null
+  return Array.isArray(answer?.value)
     ? right(response)
     : left(`CheckboxValidatorV4:\t answer value is not an array`)
 }

--- a/apps/backend/src/app/utils/field-validation/validators/checkboxValidator.ts
+++ b/apps/backend/src/app/utils/field-validation/validators/checkboxValidator.ts
@@ -357,6 +357,19 @@ const isCheckboxFieldTypeV4: ResponseValidator<
   return right(response as CheckboxResponseV4)
 }
 
+/**
+ * The answer is a blind cast from an unvalidated request body, so `value` may
+ * be missing or not an array. Reject the shape before any validator
+ * dereferences it.
+ */
+const isCheckboxAnswerShapeV4: ResponseValidator<CheckboxResponseV4> = (
+  response,
+) => {
+  return Array.isArray(response.answer.value)
+    ? right(response)
+    : left(`CheckboxValidatorV4:\t answer value is not an array`)
+}
+
 const isCheckboxAnswerOrOthersInputEmptyV4: ResponseValidator<
   CheckboxResponseV4
 > = (response) => {
@@ -454,6 +467,7 @@ export const constructCheckboxValidatorV4: ResponseValidatorConstructor<
 > = (checkboxField) =>
   flow(
     isCheckboxFieldTypeV4,
+    chain(isCheckboxAnswerShapeV4),
     chain(isCheckboxAnswerOrOthersInputEmptyV4),
     chain(makeMinOptionsValidatorV4(checkboxField)),
     chain(makeMaxOptionsValidatorV4(checkboxField)),

--- a/apps/frontend/src/features/public-form/utils/createSubmission.test.ts
+++ b/apps/frontend/src/features/public-form/utils/createSubmission.test.ts
@@ -102,18 +102,26 @@ describe('createResponsesV4', () => {
     })
   })
 
-  it('normalizes untouched checkbox value `false` to an empty selection', () => {
+  it('omits a checkbox with no selection even when othersInput has text', () => {
     const formFields = [mockField(CHECKBOX_ID, BasicField.Checkbox)]
-    const formInputs = {
-      [CHECKBOX_ID]: { value: false, othersInput: 'other only' },
-    } as unknown as FormFieldValues
 
-    const responses = createResponsesV4(formFields, formInputs, [])
-
-    expect(responses[CHECKBOX_ID].answer).toEqual({
-      value: [],
-      othersInput: 'other only',
-    })
+    // othersInput text is only submitted when the Others sentinel is
+    // selected, so every no-selection state is unanswered: `false` (untouched
+    // group artifact), `undefined` (othersInput set without a group change
+    // event) and an emptied-out selection.
+    const noSelectionInputs = [
+      { value: false, othersInput: 'other only' },
+      { othersInput: 'other only' },
+      { value: [], othersInput: 'other only' },
+    ]
+    for (const input of noSelectionInputs) {
+      const responses = createResponsesV4(
+        formFields,
+        { [CHECKBOX_ID]: input } as unknown as FormFieldValues,
+        [],
+      )
+      expect(responses).toEqual({})
+    }
   })
 
   it('keys table rows by generated rowId with rowNum ordering', () => {

--- a/apps/frontend/src/features/public-form/utils/createSubmission.ts
+++ b/apps/frontend/src/features/public-form/utils/createSubmission.ts
@@ -554,16 +554,16 @@ export const createResponsesV4 = (
         const input = formInputs[ff._id] as
           | FormFieldValue<typeof ff.fieldType>
           | undefined
-        if (
-          (!input?.value || input?.value.length === 0) &&
-          !input?.othersInput
-        ) {
-          break
-        }
+        // `false` is a react-hook-form artifact of untouched checkbox groups,
+        // and `undefined` occurs when othersInput is set without the group
+        // ever firing a change event. Either way nothing is selected — and
+        // othersInput text is only submitted when the Others sentinel is
+        // selected — so the field is unanswered and must be omitted. Sending
+        // `value: undefined` would JSON-serialize to an answer with no
+        // `value` key at all, which the BE rejects.
+        if (!input?.value || input.value.length === 0) break
         returnedInputs[ff._id] = toWireResponseV4(ff.fieldType, {
-          // `false` is a react-hook-form artifact of untouched checkboxes;
-          // normalize to an empty selection for the wire.
-          value: input.value === false ? [] : input.value,
+          value: input.value,
           ...(input.othersInput !== undefined && {
             othersInput: input.othersInput,
           }),


### PR DESCRIPTION
## Problem

A multirespondent submission containing a checkbox answer with **no `value` key** (e.g. `{"answer": {"othersInput": "text"}}`) throws `TypeError: Cannot read properties of undefined (reading 'length')` in `isValidationRequiredV4`. The throw escapes the neverthrow chain as an unhandled promise rejection and **kills the entire ECS task**, taking down every in-flight request on it. Observed in prod on 2026-08-05: a single respondent retrying their submission killed 3 tasks in 40 seconds.

Root cause chain:
1. In the public form, react-hook-form can hold checkbox state `{ othersInput: 'text', value: undefined }` — `othersInput` set without the checkbox group ever firing a change event (the typing→auto-check affordance normally prevents this, but it is best-effort, and defaultValues paths such as restored drafts bypass change events entirely).
2. The V4 wire builder included the response whenever `othersInput` was non-empty and passed `value: undefined` through, which JSON-serializes to an answer with no `value` key at all.
3. The backend body schema only checks `answer: Joi.required()` (no shape), and the V4 validators blind-cast `response.answer`, so the malformed shape reaches an unguarded `a.value.length`.

A related non-crashing variant: check Others → type → uncheck yields `{ value: [], othersInput: 'text' }`, which the V4 backend rejects with the generic "There is something wrong with your form submission" banner — confusing, since the greyed-out-Others UI implies the text simply won't be submitted.

## Solution

Enforce the invariant that **`othersInput` text is only meaningful when the Others sentinel is in `value`** — so a checkbox with no selection is unanswered, full stop:

- **FE** (`createResponsesV4`): omit the checkbox response entirely whenever nothing is selected (`value` is `undefined`, `false`, or `[]`), regardless of `othersInput` text. The crash shape and the confusing-400 shape both become unproducible by the client.
- **BE** (`isValidationRequiredV4`): optional-chain the `a.value.length` dereference (the exact line from the prod stack trace) so a missing `value` is treated as an empty selection instead of throwing.
- **BE** (`constructCheckboxValidatorV4`): new `isCheckboxAnswerShapeV4` guard at the head of the chain rejects any answer whose `value` is not an array with a clean `ValidateFieldErrorV4` (400) — the endpoint is public, so stale cached bundles and scripted clients that bypass the FE fix must fail safely rather than kill the process.

**Breaking Changes**
- No — this PR is backwards compatible. One behavioral note: a respondent who types Others text and then unchecks all options previously got a 400 on submit; the field is now submitted as unanswered (matching the UI, which greys out the Others input and implies the text will not be submitted). Required checkboxes are unaffected — FE required-validation still blocks submission before this code runs.

## Tests

TC1: Others text with nothing selected no longer crashes (prod repro)
- [x] Create an MRF form with an **optional** checkbox field that has Others enabled, plus one other editable field
- [x] As respondent 1, check Others, type text into the Others input, then uncheck Others (leaving the text visible but no boxes checked)
- [x] Fill the other field and submit
- [x] Verify that the submission succeeds (no error banner, no 5xx)
- [x] Verify in the admin responses view that the checkbox field is empty/unanswered

TC2: Normal Others flow is unaffected
- [x] On the same form, check Others and type text, then submit
- [x] Verify that the stored response contains the Others answer text

TC3: Regular selections are unaffected
- [x] Select one or more regular options (no Others) and submit
- [x] Verify that the stored response contains the selected options
- [x] Repeat with a **required** checkbox and nothing selected; verify the FE blocks submission with a field error

TC4: Malformed body from a non-FE client fails safely
- [ ] POST to `/api/v3/forms/:formId/submissions/multirespondent` with a checkbox response of `{"fieldType": "checkbox", "answer": {"othersInput": "x"}}` (no `value` key)
- [ ] Verify that the API responds 400 with the standard submission-validation message
- [ ] Verify that the app process stays alive (no ECS task restart, no `TypeError ... reading 'length'` in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)