### PR TITLE
feat(save-draft): enable save draft by default on forms created from scratch and remove flag requirements

### DIFF
--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -1215,6 +1215,11 @@ describe('admin-form.service', () => {
   })
 
   describe('createForm', () => {
+    const withCreationDefaults = <T>(formParams: T) => ({
+      ...formParams,
+      isSaveDraftEnabled: true,
+    })
+
     it('should successfully create form', async () => {
       // Arrange
       const formParams: Parameters<typeof AdminFormService.createForm>[0] = {
@@ -1236,7 +1241,7 @@ describe('admin-form.service', () => {
 
       // Assert
       expect(actualResult._unsafeUnwrap()).toEqual(expectedForm)
-      expect(createSpy).toHaveBeenCalledWith(formParams)
+      expect(createSpy).toHaveBeenCalledWith(withCreationDefaults(formParams))
     })
 
     it('should return DatabaseValidationError on invalid form params whilst creating form', async () => {
@@ -1260,7 +1265,7 @@ describe('admin-form.service', () => {
       expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
         DatabaseValidationError,
       )
-      expect(createSpy).toHaveBeenCalledWith(formParams)
+      expect(createSpy).toHaveBeenCalledWith(withCreationDefaults(formParams))
     })
 
     it('should return DatabaseConflictError on mongoose version error', async () => {
@@ -1283,7 +1288,7 @@ describe('admin-form.service', () => {
       expect(actualResult._unsafeUnwrapErr()).toBeInstanceOf(
         DatabaseConflictError,
       )
-      expect(createSpy).toHaveBeenCalledWith(formParams)
+      expect(createSpy).toHaveBeenCalledWith(withCreationDefaults(formParams))
     })
 
     it('should return DatabasePayloadError on form size error', async () => {
@@ -1311,7 +1316,7 @@ describe('admin-form.service', () => {
           formatErrorRecoveryMessage(mockErrorString),
         ),
       )
-      expect(createSpy).toHaveBeenCalledWith(formParams)
+      expect(createSpy).toHaveBeenCalledWith(withCreationDefaults(formParams))
     })
 
     it('should return DatabaseError on database error whilst creating form', async () => {
@@ -1334,7 +1339,7 @@ describe('admin-form.service', () => {
       expect(actualResult._unsafeUnwrapErr()).toEqual(
         new DatabaseError(formatErrorRecoveryMessage(mockErrorString)),
       )
-      expect(createSpy).toHaveBeenCalledWith(formParams)
+      expect(createSpy).toHaveBeenCalledWith(withCreationDefaults(formParams))
     })
 
     // Creating into Workspace tests
@@ -1380,10 +1385,13 @@ describe('admin-form.service', () => {
       // Assert
       expect(actualResult._unsafeUnwrap()).toEqual(expectedForm)
       expect(createFormInWorkspaceTransactionSpy).toHaveBeenCalledWith(
-        formParams,
+        withCreationDefaults(formParams),
         mockWorkspaceId,
       )
-      expect(createSpy).toHaveBeenCalledWith([formParams], { session: null })
+      expect(createSpy).toHaveBeenCalledWith(
+        [withCreationDefaults(formParams)],
+        { session: null },
+      )
       expect(addFormIdsToWorkspaceSpy).toHaveBeenCalledWith({
         workspaceId: mockWorkspaceId,
         formIds: [expectedForm._id],
@@ -1425,10 +1433,13 @@ describe('admin-form.service', () => {
         new DatabaseError(formatErrorRecoveryMessage(mockErrorString)),
       )
       expect(createFormInWorkspaceTransactionSpy).toHaveBeenCalledWith(
-        formParams,
+        withCreationDefaults(formParams),
         mockWorkspaceId,
       )
-      expect(createSpy).toHaveBeenCalledWith([formParams], { session: null })
+      expect(createSpy).toHaveBeenCalledWith(
+        [withCreationDefaults(formParams)],
+        { session: null },
+      )
     })
 
     it('should return DatabaseError on database error whilst moving form into a workspace', async () => {
@@ -1473,10 +1484,13 @@ describe('admin-form.service', () => {
         new DatabaseError(formatErrorRecoveryMessage(mockErrorString)),
       )
       expect(createFormInWorkspaceTransactionSpy).toHaveBeenCalledWith(
-        formParams,
+        withCreationDefaults(formParams),
         mockWorkspaceId,
       )
-      expect(createSpy).toHaveBeenCalledWith([formParams], { session: null })
+      expect(createSpy).toHaveBeenCalledWith(
+        [withCreationDefaults(formParams)],
+        { session: null },
+      )
       expect(addFormIdsToWorkspaceSpy).toHaveBeenCalledWith({
         workspaceId: mockWorkspaceId,
         formIds: [expectedForm._id],

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -580,9 +580,13 @@ export const createForm = (
     }
   }
 
+  // Copied forms bypass createForm, so they keep inheriting their source's
+  // setting; the schema default stays false for forms predating the field.
+  const newFormParams = { ...formParams, isSaveDraftEnabled: true }
+
   if (workspaceId)
     return ResultAsync.fromPromise(
-      createFormInWorkspaceTransaction(formParams, workspaceId),
+      createFormInWorkspaceTransaction(newFormParams, workspaceId),
       (error) => {
         logger.error({
           message:
@@ -598,7 +602,7 @@ export const createForm = (
       },
     )
   return ResultAsync.fromPromise(
-    FormModel.create(formParams) as Promise<IFormDocument>,
+    FormModel.create(newFormParams) as Promise<IFormDocument>,
     (error) => {
       logger.error({
         message: 'Database error encountered when creating form',

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -494,7 +494,8 @@ type MultirespondentFormToCreate = Merge<
  * @returns err(Database*Error) on database errors
  */
 export const createForm = (
-  formParams: Merge<IForm, { admin: string }>,
+  // isSaveDraftEnabled omitted: creation decides it, not the caller.
+  formParams: Omit<Merge<IForm, { admin: string }>, 'isSaveDraftEnabled'>,
   workspaceId?: string,
 ): ResultAsync<
   IFormDocument,

--- a/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -231,6 +231,23 @@ describe('admin-form.form.routes', () => {
       )
     })
 
+    it('should offer save draft on a form created from scratch', async () => {
+      // Act
+      const response = await request.post('/admin/forms').send({
+        form: {
+          emails: defaultUser.email,
+          responseMode: FormResponseMode.Email,
+          title: 'new form gets save draft',
+        },
+      })
+
+      // Assert
+      expect(response.status).toEqual(200)
+      expect(response.body.isSaveDraftEnabled).toEqual(true)
+      const saved = await FormModel.findById(response.body._id)
+      expect(saved?.isSaveDraftEnabled).toEqual(true)
+    })
+
     it('should return 200 with newly created storage mode form', async () => {
       // Arrange
       const createStorageParams = {

--- a/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -1264,6 +1264,34 @@ describe('admin-form.form.routes', () => {
       )
     })
 
+    // Neither picking up the new-form default nor being reset by the copy.
+    it.each([true, false])(
+      "should inherit the source form's save draft setting of %s, rather than the new-form default",
+      async (isSaveDraftEnabled) => {
+        // Arrange
+        const formToDupe = await EmailFormModel.create({
+          title: `source form, save draft ${isSaveDraftEnabled}`,
+          emails: [defaultUser.email],
+          admin: defaultUser._id,
+          isSaveDraftEnabled,
+        })
+
+        // Act
+        const response = await request
+          .post(`/admin/forms/${formToDupe._id}/duplicate`)
+          .send({
+            responseMode: FormResponseMode.Email,
+            title: `duplicate, save draft ${isSaveDraftEnabled}`,
+            emails: [defaultUser.email],
+          })
+
+        // Assert
+        expect(response.status).toEqual(200)
+        const duplicated = await FormModel.findById(response.body._id)
+        expect(duplicated?.isSaveDraftEnabled).toEqual(isSaveDraftEnabled)
+      },
+    )
+
     it('should return 400 when body.emails is missing when duplicating to an email form', async () => {
       // Arrange
       const formToDupe = await EncryptFormModel.create({
@@ -1772,6 +1800,31 @@ describe('admin-form.form.routes', () => {
         String(templateForm._id),
       )
     })
+
+    // Template-started forms staying off is the accepted gap.
+    it.each([true, false])(
+      "should inherit the template's save draft setting of %s, rather than the new-form default",
+      async (isSaveDraftEnabled) => {
+        // Arrange
+        const templateForm = await createPublicTemplateForm()
+        await templateForm.updateOne({ isSaveDraftEnabled })
+
+        // Act
+        const response = await request
+          .post(`/admin/forms/${templateForm._id}/use-template`)
+          .send({
+            responseMode: FormResponseMode.Encrypt,
+            title: `form from template, save draft ${isSaveDraftEnabled}`,
+            publicKey: 'some random public key',
+            emails: [],
+          })
+
+        // Assert
+        expect(response.status).toEqual(200)
+        const started = await FormModel.findById(response.body._id)
+        expect(started?.isSaveDraftEnabled).toEqual(isSaveDraftEnabled)
+      },
+    )
 
     it('should return 400 when an unrecognised form origin code is provided', async () => {
       // Arrange

--- a/apps/frontend/src/features/public-form/components/FormStartPage/FormHeader.test.tsx
+++ b/apps/frontend/src/features/public-form/components/FormStartPage/FormHeader.test.tsx
@@ -1,0 +1,52 @@
+import { screen } from '@testing-library/react'
+
+import { render } from '~/test-utils'
+
+import {
+  PublicFormContext,
+  PublicFormContextProps,
+} from '~features/public-form/PublicFormContext'
+
+import { MiniHeader } from './FormHeader'
+
+const renderMiniHeader = ({
+  isSaveDraftEnabled,
+}: {
+  isSaveDraftEnabled: boolean
+}) =>
+  render(
+    <PublicFormContext.Provider
+      value={
+        {
+          formId: 'mock-form-id',
+          isSaveDraftEnabled,
+          onSaveDraft: vi.fn(),
+        } as unknown as PublicFormContextProps
+      }
+    >
+      <MiniHeader
+        isOpen
+        title="A long form"
+        titleBg="primary.500"
+        titleColor="white"
+      />
+    </PublicFormContext.Provider>,
+  )
+
+// The sticky header is aria-hidden, so the query must opt into hidden elements.
+const querySaveDraftButton = () =>
+  screen.queryByRole('button', { name: 'Save a draft', hidden: true })
+
+describe('MiniHeader', () => {
+  it('offers save draft when the form has save draft enabled', () => {
+    renderMiniHeader({ isSaveDraftEnabled: true })
+
+    expect(querySaveDraftButton()).toBeVisible()
+  })
+
+  it('does not offer save draft when the form has save draft disabled', () => {
+    renderMiniHeader({ isSaveDraftEnabled: false })
+
+    expect(querySaveDraftButton()).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
+++ b/apps/frontend/src/features/public-form/components/FormStartPage/FormHeader.tsx
@@ -12,9 +12,6 @@ import {
   useDisclosure,
 } from '@chakra-ui/react'
 import { datadogLogs } from '@datadog/browser-logs'
-import { useGrowthBook } from '@growthbook/growthbook-react'
-
-import { featureFlags } from 'formsg-shared/constants/feature-flags'
 
 import { BxMenuAltLeft } from '~assets/icons/BxMenuAltLeft'
 import { BxsTimeFive } from '~assets/icons/BxsTimeFive'
@@ -55,11 +52,6 @@ export const MiniHeader = ({
     formId,
   } = usePublicFormContext()
   const { t } = useTranslation()
-
-  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
-  const gb = useGrowthBook()
-  const enableFormHeaderSaveDraftButton =
-    gb?.isOn(featureFlags.enableSaveDraftButtonHeader) || isTest
 
   return (
     <Slide
@@ -102,7 +94,7 @@ export const MiniHeader = ({
                   t('features.publicForm.components.loadingTitle.title')}
               </Text>
             </Flex>
-            {isSaveDraftEnabled && enableFormHeaderSaveDraftButton && (
+            {isSaveDraftEnabled && (
               <FormHeaderSaveDraftButton
                 onSaveDraft={() => {
                   datadogLogs.logger.log(

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -14,7 +14,6 @@ export const featureFlags = {
   mrfStepWriteToken: 'mrf-step-write-token' as const,
   useFormsgEsrvcId: 'use-formsg-esrvcid' as const,
   lambdaPdfGeneration: 'lambda-pdf-generation' as const,
-  enableSaveDraftButtonHeader: 'enable-save-draft-button-header' as const,
   adminEmailPdf: 'admin-email-pdf' as const,
   ogpHeader: 'enable-ogp-header' as const,
   ogpAwareness: 'ogp-awareness' as const,


### PR DESCRIPTION
## Problem

Save draft protects a respondent's half-filled form, but it lives in Settings →
General and defaults to off, so an admin only finds it by going looking. Most
forms therefore don't offer it, and a respondent interrupted partway through a
long form loses their answers.

## Solution

- [PRD](https://app.notion.com/p/opengov/Save-draft-default-on-3b777dbba78880ec9dc0ffcf147a8610)
  · [Agent specs](https://app.notion.com/p/opengov/AI-agent-specs-48977dbba78883f7af6e01aef6e9c3cc)

A **new form** — one created from scratch — now comes out with save draft
already on. A **copied form** (duplicated, or started from a template) still
inherits its source's setting, so nothing about existing forms changes.

The PR also deletes the `enable-save-draft-button-header` GrowthBook flag. The
save draft button beside Submit was already ungated, but it sits at the bottom
of the form; the sticky-header button is the only affordance a respondent can
reach mid-fill — exactly the interrupted-halfway case. While the flag stayed,
GrowthBook rather than the form's own setting decided whether default-on meant
anything.

**Screenshots**

When a form is newly created, the save draft toggle is enabled.

<img width="712" height="110" alt="image" src="https://github.com/user-attachments/assets/51e1c780-b534-4a6b-afe8-95e768850d53" />

**Breaking Changes**

No — backwards compatible. No existing form document is read or written. Note
that rollback is asymmetric: reverting stops new forms getting the default, but
forms already created keep the persisted `true`, and nothing distinguishes them
from forms whose admin chose it.

**Alternatives considered**

- We considered flipping the schema default, which is the obvious place to
  express "the default", but it would have enabled save draft for every form
  created before Sep 2025 — the one outcome the PRD rules out.
- We considered flipping it anyway and backfilling `false` onto the old
  documents first, and skipped it: that's a write across every form document in
  the database to achieve what one line in `createForm` achieves with no
  migration.
- We considered writing the default from the frontend in the create-form
  request, but the endpoint's request body doesn't accept the field and there
  would be more than one client to keep honest.
- We looked at filling the default in only when absent
  (`isSaveDraftEnabled ?? true`) rather than always writing it. It makes no
  difference today, so we kept the unconditional write and instead omitted the
  field from `createForm`'s parameter type — a future caller that tries to pass
  it now gets a compile error rather than a silent override.

## Tests

**TC1: A newly created form offers save draft**

- [ ] Create a form from scratch (Storage mode)
- [ ] Open Settings → General and confirm the save draft toggle is already on,
      without saving anything
- [ ] Open the public form, confirm the Save draft button appears beside Submit
- [ ] Scroll down and confirm it also appears in the sticky header
- [ ] Repeat for Email mode and MRF

**TC2: Existing forms are untouched**

- [ ] Open a form created before this deploy that has save draft off
- [ ] Confirm the toggle is still off and the public form offers no Save draft

**TC3: A copied form inherits its source**

- [ ] Duplicate a form whose save draft is off; confirm the copy is off
- [ ] Duplicate a form whose save draft is on; confirm the copy is on
- [ ] Start a form from a template whose save draft is off; confirm it is off
      (template-started forms staying off is an accepted gap, decided
      deliberately)

**TC4: The toggle still works**

- [ ] On a form created after this change, switch save draft off, reload, and
      confirm it stays off
- [ ] Switch it back on and confirm the public form offers it again
