### PR TITLE
fix(workflow,logic): guard auto-save effect against double submit

### DIFF
--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
@@ -137,16 +137,28 @@ export const EditLogicBlock = ({
   const completeSave = useAdminLogicStore(completeSaveSelector)
   const isCreatingState = useAdminLogicStore(isCreatingStateSelector)
 
+  // Guards the auto-save effect against re-entry: the mutation's isLoading
+  // only flips true on the render after mutate() is called, and handleSubmit's
+  // validation is promise-based, so a second card click landing in that window
+  // would pass the isLoading check and submit again (double-saving an existing
+  // block, or creating a new block twice). Set synchronously before submitting;
+  // cleared when the pending switch resolves (pendingSwitchTo returns to null
+  // on cancel, or this card unmounts on success).
+  const hasSubmittedForPendingSwitch = useRef(false)
+
   // Auto-save when another logic block is clicked while this one is open.
   // InactiveLogicBlock sets pendingSwitchTo; this effect is dormant until it
   // does. Shared by both the edit (ActiveLogicBlock) and create (NewLogicBlock)
   // paths.
   useEffect(() => {
-    if (pendingSwitchTo === null) return
+    if (pendingSwitchTo === null) {
+      hasSubmittedForPendingSwitch.current = false
+      return
+    }
 
     // A save is already in flight; its onSuccess completes the switch.
     // Submitting again would double-save and collapse the target.
-    if (isLoading) return
+    if (isLoading || hasSubmittedForPendingSwitch.current) return
 
     // A new block has nothing persisted yet, so it must always run validation
     // (like the Add logic button): an incomplete new block blocks the switch.
@@ -157,6 +169,7 @@ export const EditLogicBlock = ({
       return
     }
 
+    hasSubmittedForPendingSwitch.current = true
     handleSubmit()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingSwitchTo])

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -163,14 +163,26 @@ export const EditStepBlock = ({
     onSubmit(step)
   }, cancelPendingSwitch)
 
+  // Guards the auto-save effect against re-entry: the mutation's isLoading
+  // only flips true on the render after mutate() is called, and handleSubmit's
+  // validation is promise-based, so a second card click landing in that window
+  // would pass the isLoading check and submit again (double-saving an existing
+  // step, or creating a new step twice). Set synchronously before submitting;
+  // cleared when the pending switch resolves (pendingSwitchTo returns to null
+  // on cancel, or this card unmounts on success).
+  const hasSubmittedForPendingSwitch = useRef(false)
+
   // Auto-save when another step is clicked while this one is open.
   // InactiveStepBlock sets pendingSwitchTo; this effect is dormant until it does.
   useEffect(() => {
-    if (pendingSwitchTo === null) return
+    if (pendingSwitchTo === null) {
+      hasSubmittedForPendingSwitch.current = false
+      return
+    }
 
     // A save is already in flight; its onSuccess completes the switch.
     // Submitting again would double-save and collapse the target.
-    if (isLoading) return
+    if (isLoading || hasSubmittedForPendingSwitch.current) return
 
     // A new step has nothing persisted yet, so it must always run validation
     // (like the Add step button): an incomplete new step blocks the switch. An
@@ -181,6 +193,7 @@ export const EditStepBlock = ({
       return
     }
 
+    hasSubmittedForPendingSwitch.current = true
     handleSubmit()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingSwitchTo])


### PR DESCRIPTION
## Problem

Found in review of #9781 / #9786. The auto-save-on-switch effect guards on the save mutation's `isLoading`, but react-query only flips `isLoading` on the render **after** `mutate()` is called, and react-hook-form's `handleSubmit` validation is promise-based. A second card click landing in that window re-enters the effect with `isLoading` still `false` and `isDirty` still `true`, so it submits again:

- for an existing card, a duplicate (harmless but wasteful) update;
- for a **new** step/logic block in creating state, a duplicate create — i.e. the step or logic rule is created twice.

This is exactly the scenario of #9781's TC6 ("rapid switching doesn't double-save"), which is only covered manually.

## Solution

Add a `hasSubmittedForPendingSwitch` ref in both `EditStepBlock` and `EditLogicBlock`, set synchronously immediately before `handleSubmit()` so there is no window, and cleared when the pending switch resolves:

- **cancel path** (validation failure, save error, unbuildable step): `cancelPendingSwitch` resets `pendingSwitchTo` to `null`, the effect fires and clears the ref, so a subsequent click can submit again;
- **success path**: `completeSave` switches cards and this component unmounts, taking the ref with it.

No behaviour change outside the race window; all other guards (`isLoading`, untouched-card short-circuit, new-block always-validate) are unchanged.

## Tests

- [ ] TC6 from #9781: open a dirty card, rapidly click two different cards — exactly one save request fires and the last-clicked card opens
- [ ] Rapid double-click from a valid **new** step/logic block to an existing card — exactly one create request fires (no duplicate step/rule)
- [ ] Blocked switch (invalid card) followed by another card click still re-attempts the save

## Notes

Targets `feat/clickable-cards-logic` (tip of the #9781 → #9786 stack) so the stack can be released with the guard included. Frontend typecheck and eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)