### PR TITLE
feat(mrf): non-plumber v3 delivery behind its own flag (mrf-webhooks-v3-generic)

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -553,7 +553,7 @@ describe('Submission Model', () => {
               encryptedContent: MOCK_ENCRYPTED_CONTENT,
               encryptedSubmissionSecretKey: 'test secret key',
               verifiedContent: undefined,
-              version: 1,
+              version: 3,
               created: submission.created,
               paymentContent: {},
               workflowContent: {

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -37,6 +37,10 @@ import {
 } from '../../types'
 import { getPaymentWebhookEventObject } from '../modules/payments/payment.service.utils'
 import { MultirespondentSubmissionContent } from '../modules/submission/multirespondent-submission/multirespondent-submission.types'
+import {
+  contentFormatToWebhookVersion,
+  mrfVersionToContentFormat,
+} from '../modules/submission/multirespondent-submission/webhook/webhook-payload-policy'
 import { buildMrfMetadata } from '../modules/submission/submission.utils'
 import {
   buildAdminSubmittedStepsMongoProjection,
@@ -645,7 +649,9 @@ MultirespondentSubmissionSchema.methods.getWebhookView = async function (
     encryptedContent: this.encryptedContent,
     encryptedSubmissionSecretKey: this.encryptedSubmissionSecretKey,
     verifiedContent: this.verifiedContent,
-    version: this.version,
+    version: contentFormatToWebhookVersion(
+      mrfVersionToContentFormat(this.mrfVersion),
+    ),
     created: this.created,
     attachmentDownloadUrls: attachmentRecords,
     paymentContent,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -53,6 +53,7 @@ import {
 } from '../multirespondent-submission.controller'
 import * as MultiRespondentSubmissionService from '../multirespondent-submission.service'
 import * as MultirespondentSubmissionUtils from '../multirespondent-submission.utils'
+import { SnapshotWriteError } from '../webhook/submission-snapshot.errors'
 
 jest.mock('src/app/modules/datadog/datadog.utils')
 
@@ -109,9 +110,9 @@ describe('multirespondent-submision.controller', () => {
       .mockReturnValue(ok(mockMrfForm))
 
     MockMultiRespondentSubmissionService.createMultiRespondentFormSubmission =
-      jest.fn().mockReturnValue(okAsync(mockMrfSubmission))
+      jest.fn().mockReturnValue(okAsync({ submission: mockMrfSubmission }))
     MockMultiRespondentSubmissionService.updateMultiRespondentFormSubmission =
-      jest.fn().mockReturnValue(okAsync(mockMrfSubmission))
+      jest.fn().mockReturnValue(okAsync({ submission: mockMrfSubmission }))
     MockMultiRespondentSubmissionService.performMultiRespondentPostSubmissionCreateActions =
       jest.fn().mockReturnValue(okAsync(true))
     MockMultiRespondentSubmissionService.performMultiRespondentPostSubmissionUpdateActions =
@@ -445,6 +446,49 @@ describe('multirespondent-submision.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(500)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: submissionSaveError.message,
+      })
+    })
+
+    it('returns 500 when the snapshot write fails', async () => {
+      // Arrange
+      MockMultiRespondentSubmissionService.createMultiRespondentFormSubmission =
+        jest.fn().mockReturnValue(errAsync(new SnapshotWriteError()))
+
+      const mockReq = expressHandler.mockRequest({
+        params: {
+          formId: mockFormId,
+          submissionId: mockSubmissionId,
+        },
+        body: {} as any,
+      })
+      const mockSubmitMrfReq = merge(mockReq, {
+        formsg: {
+          formDef: {
+            _id: mockFormId,
+            authType: FormAuthType.NIL,
+            getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+          },
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {},
+            workflowStep: 0,
+          },
+        } as any,
+      })
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await submitMultirespondentFormForTest(mockSubmitMrfReq, mockRes)
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: new SnapshotWriteError().message,
       })
     })
 
@@ -834,6 +878,67 @@ describe('multirespondent-submision.controller', () => {
         message: submissionSaveError.message,
         submissionId: mockSubmissionId,
       })
+    })
+
+    it('returns 500 when the snapshot write fails', async () => {
+      // Arrange
+      MockMultiRespondentSubmissionService.updateMultiRespondentFormSubmission =
+        jest.fn().mockReturnValue(errAsync(new SnapshotWriteError()))
+      const mockReq = expressHandler.mockRequest({
+        params: {
+          formId: mockFormId,
+          submissionId: mockSubmissionId,
+        },
+        body: {} as any,
+      })
+      const mockSubmitMrfReq = merge(mockReq, {
+        formsg: {
+          formDef: {
+            _id: mockFormId,
+            authType: FormAuthType.NIL,
+            getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+          },
+          snapshottedFormDef: {
+            _id: mockFormId,
+            form_fields: [],
+            form_logics: [],
+            workflow: [],
+            emails: [],
+            stepOneEmailNotificationFieldId: '',
+            stepsToNotify: [],
+            hasRespondentCopy: false,
+            title: 'Mock snapshotted form def',
+            webhook: {
+              url: 'https://plumber.gov.sg/webhook',
+              isRetryEnabled: true,
+            },
+          } as SnapshottedFormDef,
+          encryptedPayload: {
+            encryptedContent: 'encryptedContent',
+            version: 1,
+            submissionPublicKey: 'submissionPublicKey',
+            encryptedSubmissionSecretKey: 'encryptedSubmissionSecretKey',
+            responses: {},
+            workflowStep: 1,
+          },
+        } as any,
+      })
+      const mockRes = expressHandler.mockResponse()
+
+      // Act
+      await updateMultirespondentSubmissionForTest(mockSubmitMrfReq, mockRes)
+
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(
+        StatusCodes.INTERNAL_SERVER_ERROR,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        message: new SnapshotWriteError().message,
+      })
+      // The post-submission actions must not fire for an aborted save.
+      expect(
+        MockMultiRespondentSubmissionService.performMultiRespondentPostSubmissionUpdateActions,
+      ).not.toHaveBeenCalled()
     })
 
     it('returns 404 not found when submission id not found', async () => {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -52,7 +52,15 @@ jest.mock('@opengovsg/formsg-sdk/adapters', () => ({
   isFieldResponsesV4: jest.fn(),
 }))
 jest.mock('src/app/utils/logic-adaptor')
-jest.mock('../multirespondent-submission.utils')
+jest.mock('../multirespondent-submission.utils', () => {
+  const actual = jest.requireActual(
+    '../multirespondent-submission.utils',
+  ) as typeof import('../multirespondent-submission.utils')
+  return {
+    ...actual,
+    validateMrfFieldResponses: jest.fn(),
+  }
+})
 jest.mock('src/app/config/formsg-sdk', () => ({
   __esModule: true,
   default: {
@@ -947,7 +955,7 @@ describe('Multirespondent Submission Middleware', () => {
       mockDecrypt.mockReturnValue({ responses: MOCK_RESPONSES })
     })
 
-    it('should encrypt responses as V3 and set mrfVersion to 1 when form has a webhook url', async () => {
+    it('should encrypt responses as V4 and set mrfVersion to 2 when the form has a generic webhook url', async () => {
       jest.mocked(adaptV4ToV3).mockReturnValue({
         field1: { fieldType: BasicField.ShortText, answer: 'hello' },
       } as any)
@@ -958,8 +966,8 @@ describe('Multirespondent Submission Middleware', () => {
 
       await encryptSubmission(mockReq, mockRes as any, mockNext)
 
-      expect(jest.mocked(adaptV4ToV3)).toHaveBeenCalledWith(MOCK_RESPONSES)
-      expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(1)
+      expect(jest.mocked(adaptV4ToV3)).not.toHaveBeenCalled()
+      expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(2)
       expect(mockNext).toHaveBeenCalled()
     })
 
@@ -1042,6 +1050,162 @@ describe('Multirespondent Submission Middleware', () => {
           return mockReq.formsg.encryptedPayload.stepToken as string
         }
         expect(await run()).not.toBe(await run())
+      })
+    })
+
+    describe('mrf version gate', () => {
+      const PLUMBER_URL = 'https://plumber.gov.sg/webhooks/abc'
+      const ZAPIER_URL = 'https://hooks.zapier.com/hooks/catch/123/abc'
+      const GENERIC_URL = 'https://example.com/hook'
+      const V3_ADAPTED = {
+        field1: { fieldType: BasicField.ShortText, answer: 'hello' },
+      }
+
+      const runGate = async ({
+        webhookUrl,
+        webhookFormat,
+        flags = [],
+      }: {
+        webhookUrl?: string
+        webhookFormat?: 'v1' | 'v4'
+        flags?: string[]
+      }) => {
+        jest.mocked(adaptV4ToV3).mockClear()
+        jest.mocked(adaptV4ToV3).mockReturnValue(V3_ADAPTED as any)
+        jest.mocked(formsgSdk.cryptoV3.encrypt).mockClear()
+        const mockReq = createMockEncryptReq(false)
+        if (webhookUrl) {
+          mockReq.formsg.formDef = {
+            ...MOCK_FORM_BASE,
+            webhook: { url: webhookUrl, isRetryEnabled: false, webhookFormat },
+          }
+        }
+        mockReq.growthbook.isOn = jest.fn((flag: string) =>
+          flags.includes(flag),
+        )
+        await encryptSubmission(mockReq, createMockRes() as any, jest.fn())
+        return mockReq
+      }
+
+      const expectEncryptedAs = (
+        mockReq: Awaited<ReturnType<typeof runGate>>,
+        expected: 1 | 2,
+      ) => {
+        expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(expected)
+        if (expected === 2) {
+          // V4: encrypt the in-process responses as-is; do not downgrade.
+          expect(jest.mocked(adaptV4ToV3)).not.toHaveBeenCalled()
+          expect(jest.mocked(formsgSdk.cryptoV3.encrypt)).toHaveBeenCalledWith(
+            MOCK_RESPONSES,
+            MOCK_FORM_PUBLIC_KEY,
+          )
+        } else {
+          // V3: downgrade via adaptV4ToV3, then encrypt the adapted shape.
+          expect(jest.mocked(adaptV4ToV3)).toHaveBeenCalledWith(MOCK_RESPONSES)
+          expect(jest.mocked(formsgSdk.cryptoV3.encrypt)).toHaveBeenCalledWith(
+            V3_ADAPTED,
+            MOCK_FORM_PUBLIC_KEY,
+          )
+        }
+      }
+
+      describe('URL → consumer class via getWebhookType', () => {
+        it('classifies plumber.gov.sg as plumber (V4 when write-guard on)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: PLUMBER_URL,
+              flags: [featureFlags.mrfStepWriteToken],
+            }),
+            2,
+          )
+        })
+
+        it('classifies example.com as generic (V4 regardless of the flags)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: GENERIC_URL,
+              flags: [featureFlags.mrfStepWriteToken],
+            }),
+            2,
+          )
+          expectEncryptedAs(await runGate({ webhookUrl: GENERIC_URL }), 2)
+        })
+
+        it('classifies hooks.zapier.com as generic (V4 regardless of the flags)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: ZAPIER_URL,
+              flags: [featureFlags.mrfStepWriteToken],
+            }),
+            2,
+          )
+          expectEncryptedAs(await runGate({ webhookUrl: ZAPIER_URL }), 2)
+        })
+
+        it('no webhook URL is treated as none (V4)', async () => {
+          expectEncryptedAs(await runGate({ flags: [] }), 2)
+        })
+      })
+
+      describe('ignored inputs that never reach getMrfVersion', () => {
+        it('does not treat enableMrfWebhooks as a substitute for mrfStepWriteToken on plumber', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: PLUMBER_URL,
+              flags: [featureFlags.enableMrfWebhooks],
+            }),
+            1,
+          )
+        })
+
+        it('ignores webhookFormat on plumber (v1 + write-guard still V4)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: PLUMBER_URL,
+              webhookFormat: 'v1',
+              flags: [featureFlags.mrfStepWriteToken],
+            }),
+            2,
+          )
+        })
+
+        it('ignores webhookFormat and enableMrfWebhooks on generic (V4 either way)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: GENERIC_URL,
+              webhookFormat: 'v1',
+              flags: [featureFlags.enableMrfWebhooks],
+            }),
+            2,
+          )
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: GENERIC_URL,
+              webhookFormat: 'v4',
+              flags: [],
+            }),
+            2,
+          )
+        })
+
+        it('ignores webhookFormat and enableMrfWebhooks on zapier (V4 either way)', async () => {
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: ZAPIER_URL,
+              webhookFormat: 'v1',
+              flags: [featureFlags.enableMrfWebhooks],
+            }),
+            2,
+          )
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: ZAPIER_URL,
+              webhookFormat: 'v4',
+              flags: [],
+            }),
+            2,
+          )
+        })
       })
     })
   })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -955,7 +955,7 @@ describe('Multirespondent Submission Middleware', () => {
       mockDecrypt.mockReturnValue({ responses: MOCK_RESPONSES })
     })
 
-    it('should encrypt responses as V4 and set mrfVersion to 2 when the form has a generic webhook url', async () => {
+    it('should encrypt responses as V3 and set mrfVersion to 1 when the form has a generic webhook url', async () => {
       jest.mocked(adaptV4ToV3).mockReturnValue({
         field1: { fieldType: BasicField.ShortText, answer: 'hello' },
       } as any)
@@ -966,8 +966,9 @@ describe('Multirespondent Submission Middleware', () => {
 
       await encryptSubmission(mockReq, mockRes as any, mockNext)
 
-      expect(jest.mocked(adaptV4ToV3)).not.toHaveBeenCalled()
-      expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(2)
+      // Generic consumers are v3-only, so the row is downgraded and stored V3.
+      expect(jest.mocked(adaptV4ToV3)).toHaveBeenCalled()
+      expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(1)
       expect(mockNext).toHaveBeenCalled()
     })
 
@@ -1120,26 +1121,26 @@ describe('Multirespondent Submission Middleware', () => {
           )
         })
 
-        it('classifies example.com as generic (V4 regardless of the flags)', async () => {
+        it('classifies example.com as generic (V3 regardless of the flags)', async () => {
           expectEncryptedAs(
             await runGate({
               webhookUrl: GENERIC_URL,
               flags: [featureFlags.mrfStepWriteToken],
             }),
-            2,
+            1,
           )
-          expectEncryptedAs(await runGate({ webhookUrl: GENERIC_URL }), 2)
+          expectEncryptedAs(await runGate({ webhookUrl: GENERIC_URL }), 1)
         })
 
-        it('classifies hooks.zapier.com as generic (V4 regardless of the flags)', async () => {
+        it('classifies hooks.zapier.com as generic (V3 regardless of the flags)', async () => {
           expectEncryptedAs(
             await runGate({
               webhookUrl: ZAPIER_URL,
               flags: [featureFlags.mrfStepWriteToken],
             }),
-            2,
+            1,
           )
-          expectEncryptedAs(await runGate({ webhookUrl: ZAPIER_URL }), 2)
+          expectEncryptedAs(await runGate({ webhookUrl: ZAPIER_URL }), 1)
         })
 
         it('no webhook URL is treated as none (V4)', async () => {
@@ -1169,14 +1170,14 @@ describe('Multirespondent Submission Middleware', () => {
           )
         })
 
-        it('ignores webhookFormat and enableMrfWebhooks on generic (V4 either way)', async () => {
+        it('ignores webhookFormat and enableMrfWebhooks on generic (V3 either way)', async () => {
           expectEncryptedAs(
             await runGate({
               webhookUrl: GENERIC_URL,
               webhookFormat: 'v1',
               flags: [featureFlags.enableMrfWebhooks],
             }),
-            2,
+            1,
           )
           expectEncryptedAs(
             await runGate({
@@ -1184,18 +1185,18 @@ describe('Multirespondent Submission Middleware', () => {
               webhookFormat: 'v4',
               flags: [],
             }),
-            2,
+            1,
           )
         })
 
-        it('ignores webhookFormat and enableMrfWebhooks on zapier (V4 either way)', async () => {
+        it('ignores webhookFormat and enableMrfWebhooks on zapier (V3 either way)', async () => {
           expectEncryptedAs(
             await runGate({
               webhookUrl: ZAPIER_URL,
               webhookFormat: 'v1',
               flags: [featureFlags.enableMrfWebhooks],
             }),
-            2,
+            1,
           )
           expectEncryptedAs(
             await runGate({
@@ -1203,6 +1204,44 @@ describe('Multirespondent Submission Middleware', () => {
               webhookFormat: 'v4',
               flags: [],
             }),
+            1,
+          )
+        })
+
+        it('ignores the mrf-webhooks-v3-generic delivery flag at storage time (generic stores V3 either way)', async () => {
+          // The delivery flag must not influence the stored version: storage
+          // is unconditional V3 for non-plumber so the wire invariant holds
+          // across flag flips mid-workflow.
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: GENERIC_URL,
+              flags: [featureFlags.mrfWebhooksV3Generic],
+            }),
+            1,
+          )
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: GENERIC_URL,
+              flags: [
+                featureFlags.mrfWebhooksV3Generic,
+                featureFlags.mrfStepWriteToken,
+              ],
+            }),
+            1,
+          )
+          // ...and it must not gate plumber's or the no-webhook V4 storage.
+          expectEncryptedAs(
+            await runGate({
+              webhookUrl: PLUMBER_URL,
+              flags: [
+                featureFlags.mrfWebhooksV3Generic,
+                featureFlags.mrfStepWriteToken,
+              ],
+            }),
+            2,
+          )
+          expectEncryptedAs(
+            await runGate({ flags: [featureFlags.mrfWebhooksV3Generic] }),
             2,
           )
         })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -3767,9 +3767,11 @@ describe('multirespondent-submission.service', () => {
     const growthbookWithFlags = ({
       enableMrfWebhooks = false,
       mrfStepWriteToken = false,
+      mrfWebhooksV3Generic = false,
     }: {
       enableMrfWebhooks?: boolean
       mrfStepWriteToken?: boolean
+      mrfWebhooksV3Generic?: boolean
     }) =>
       ({
         isOn: jest.fn((flag: string) =>
@@ -3777,7 +3779,9 @@ describe('multirespondent-submission.service', () => {
             ? enableMrfWebhooks
             : flag === featureFlags.mrfStepWriteToken
               ? mrfStepWriteToken
-              : false,
+              : flag === featureFlags.mrfWebhooksV3Generic
+                ? mrfWebhooksV3Generic
+                : false,
         ),
         getFeatureValue: jest.fn((_flag: string, def: unknown) => def),
       }) as any
@@ -3983,15 +3987,18 @@ describe('multirespondent-submission.service', () => {
       expect(MockSnapshotStore.writeV4Snapshot).not.toHaveBeenCalled()
     })
 
+    // A generic V4 row (only reachable when the row was encrypted while the
+    // form had no/other webhook config) is never delivered to a v3-only
+    // consumer, so it never snapshots — no flag combination changes that.
     it.each`
-      label                          | enableMrfWebhooks | mrfStepWriteToken | expectWritten
-      ${'no flags'}                  | ${false}          | ${false}          | ${false}
-      ${'enable-mrf-webhooks only'}  | ${true}           | ${false}          | ${false}
-      ${'mrf-step-write-token only'} | ${false}          | ${true}           | ${false}
-      ${'both flags'}                | ${true}           | ${true}           | ${true}
+      label                             | mrfWebhooksV3Generic | mrfStepWriteToken
+      ${'no flags'}                     | ${false}             | ${false}
+      ${'mrf-webhooks-v3-generic only'} | ${true}              | ${false}
+      ${'mrf-step-write-token only'}    | ${false}             | ${true}
+      ${'both flags'}                   | ${true}              | ${true}
     `(
-      'generic V4 create snapshot write ($label) -> written=$expectWritten',
-      async ({ enableMrfWebhooks, mrfStepWriteToken, expectWritten }) => {
+      'generic V4 create never snapshots ($label)',
+      async ({ mrfWebhooksV3Generic, mrfStepWriteToken }) => {
         const result = await createMultiRespondentFormSubmission({
           form: buildV4Form({
             webhook: { url: GENERIC_URL, isRetryEnabled: true } as any,
@@ -3999,15 +4006,13 @@ describe('multirespondent-submission.service', () => {
           encryptedPayload: buildV4Payload(),
           logMeta: { action: 'test' },
           growthbook: growthbookWithFlags({
-            enableMrfWebhooks,
+            mrfWebhooksV3Generic,
             mrfStepWriteToken,
           }),
         })
 
         expect(result.isOk()).toBe(true)
-        expect(MockSnapshotStore.writeV4Snapshot).toHaveBeenCalledTimes(
-          expectWritten ? 1 : 0,
-        )
+        expect(MockSnapshotStore.writeV4Snapshot).not.toHaveBeenCalled()
       },
     )
 
@@ -4036,7 +4041,7 @@ describe('multirespondent-submission.service', () => {
         }),
         encryptedPayload: buildV4Payload({ workflowStep: 1 }),
         logMeta: { action: 'test' },
-        growthbook: growthbookWithFlags({ enableMrfWebhooks: true }),
+        growthbook: growthbookWithFlags({ mrfWebhooksV3Generic: true }),
       })
 
       expect(result.isOk()).toBe(true)
@@ -4131,33 +4136,35 @@ describe('multirespondent-submission.service', () => {
     // ---- Send gate table ----
 
     it.each`
-      label                          | url            | enableMrfWebhooks | mrfStepWriteToken | expectSent
-      ${'plumber, no flags'}         | ${PLUMBER_URL} | ${false}          | ${false}          | ${true}
-      ${'plumber, webhooks only'}    | ${PLUMBER_URL} | ${true}           | ${false}          | ${true}
-      ${'plumber, write-token only'} | ${PLUMBER_URL} | ${false}          | ${true}           | ${true}
-      ${'plumber, both'}             | ${PLUMBER_URL} | ${true}           | ${true}           | ${true}
-      ${'generic, no flags'}         | ${GENERIC_URL} | ${false}          | ${false}          | ${false}
-      ${'generic, webhooks only'}    | ${GENERIC_URL} | ${true}           | ${false}          | ${false}
-      ${'generic, write-token only'} | ${GENERIC_URL} | ${false}          | ${true}           | ${false}
-      ${'generic, both'}             | ${GENERIC_URL} | ${true}           | ${true}           | ${true}
-      ${'zapier, webhooks only'}     | ${ZAPIER_URL}  | ${true}           | ${false}          | ${false}
-      ${'zapier, both'}              | ${ZAPIER_URL}  | ${true}           | ${true}           | ${true}
+      label                                 | url            | mrfVersion | mrfWebhooksV3Generic | expectSent
+      ${'plumber V3, flag off'}             | ${PLUMBER_URL} | ${1}       | ${false}             | ${true}
+      ${'plumber V3, flag on'}              | ${PLUMBER_URL} | ${1}       | ${true}              | ${true}
+      ${'plumber V4, flag off'}             | ${PLUMBER_URL} | ${2}       | ${false}             | ${true}
+      ${'plumber V4, flag on'}              | ${PLUMBER_URL} | ${2}       | ${true}              | ${true}
+      ${'generic V3, flag off'}             | ${GENERIC_URL} | ${1}       | ${false}             | ${false}
+      ${'generic V3, flag on'}              | ${GENERIC_URL} | ${1}       | ${true}              | ${true}
+      ${'generic V4 never delivered (off)'} | ${GENERIC_URL} | ${2}       | ${false}             | ${false}
+      ${'generic V4 never delivered (on)'}  | ${GENERIC_URL} | ${2}       | ${true}              | ${false}
+      ${'zapier V3, flag off'}              | ${ZAPIER_URL}  | ${1}       | ${false}             | ${false}
+      ${'zapier V3, flag on'}               | ${ZAPIER_URL}  | ${1}       | ${true}              | ${true}
+      ${'zapier V4 never delivered (on)'}   | ${ZAPIER_URL}  | ${2}       | ${true}              | ${false}
     `(
       'send gate: $label -> sent=$expectSent',
-      async ({ url, enableMrfWebhooks, mrfStepWriteToken, expectSent }) => {
+      async ({ url, mrfVersion, mrfWebhooksV3Generic, expectSent }) => {
         const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
-        const submission = buildSubmissionWithToken(undefined)
+        const submission = buildSubmissionWithToken(
+          undefined,
+          buildLiveWebhookView(),
+          mrfVersion,
+        )
 
         await performMultiRespondentPostSubmissionCreateActions({
           submission,
           submissionId: submission._id.toString(),
           form: buildV4Form({ webhook: { url, isRetryEnabled: true } as any }),
-          encryptedPayload: buildV4Payload(),
+          encryptedPayload: buildV4Payload({ mrfVersion }),
           logMeta: {} as any,
-          growthbook: growthbookWithFlags({
-            enableMrfWebhooks,
-            mrfStepWriteToken,
-          }),
+          growthbook: growthbookWithFlags({ mrfWebhooksV3Generic }),
         })
         await flushPromises()
 
@@ -4165,52 +4172,46 @@ describe('multirespondent-submission.service', () => {
       },
     )
 
-    // ---- Generic never takes the legacy raw-getWebhookView path ----
+    // ---- Generic is v3-only end to end ----
 
-    it.each([
-      ['with a snapshot', true],
-      ['without a snapshot', false],
-    ])(
-      'routes a generic V4 send through reconstruction, never the legacy live-row path (%s)',
-      async (_label, withSnapshot) => {
-        const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
-        const submission = buildSubmissionWithToken(
-          withSnapshot ? 'tok-generic' : undefined,
-        )
+    it('sends a generic V3 row down the legacy live-row path (well-formed v3, no reconstruction)', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      const submission = buildSubmissionWithToken(
+        undefined,
+        buildLiveWebhookView(),
+        1,
+      )
 
-        await performMultiRespondentPostSubmissionCreateActions({
-          submission,
-          snapshot: withSnapshot ? buildSnapshot() : undefined,
-          submissionId: submission._id.toString(),
-          form: buildV4Form({
-            webhook: { url: GENERIC_URL, isRetryEnabled: true } as any,
-          }),
-          encryptedPayload: buildV4Payload(),
-          logMeta: {} as any,
-          growthbook: growthbookWithFlags({
-            enableMrfWebhooks: true,
-            mrfStepWriteToken: true,
-          }),
-        })
-        await flushPromises()
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        submissionId: submission._id.toString(),
+        form: buildV4Form({
+          webhook: { url: GENERIC_URL, isRetryEnabled: true } as any,
+        }),
+        encryptedPayload: buildV4Payload({ mrfVersion: 1 }),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({ mrfWebhooksV3Generic: true }),
+      })
+      await flushPromises()
 
-        expect(sendSpy).toHaveBeenCalledTimes(1)
-        // The legacy branch is identified by the absent 4th argument.
-        expect(sendSpy.mock.calls[0][3]).toBeDefined()
-      },
-    )
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      // The legacy v3 branch is identified by the absent 4th argument: the
+      // webhook module derives the view (and version 3) from the live row.
+      expect(sendSpy.mock.calls[0][3]).toBeUndefined()
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+    })
 
-    // ---- Generic never receives the step token (write credential) ----
+    // ---- Generic never receives a v4-shaped payload (or a step token) ----
 
     it.each`
-      enableMrfWebhooks | mrfStepWriteToken
-      ${false}          | ${false}
-      ${true}           | ${false}
-      ${false}          | ${true}
-      ${true}           | ${true}
+      mrfWebhooksV3Generic | mrfStepWriteToken
+      ${false}             | ${false}
+      ${true}              | ${false}
+      ${false}             | ${true}
+      ${true}              | ${true}
     `(
-      'never sends encryptedStepToken to a generic consumer (webhooks=$enableMrfWebhooks, writeToken=$mrfStepWriteToken)',
-      async ({ enableMrfWebhooks, mrfStepWriteToken }) => {
+      'never sends a V4 row to a generic consumer (v3Generic=$mrfWebhooksV3Generic, writeToken=$mrfStepWriteToken)',
+      async ({ mrfWebhooksV3Generic, mrfStepWriteToken }) => {
         const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
 
         for (const url of [GENERIC_URL, ZAPIER_URL]) {
@@ -4226,20 +4227,17 @@ describe('multirespondent-submission.service', () => {
             encryptedPayload: buildV4Payload(),
             logMeta: {} as any,
             growthbook: growthbookWithFlags({
-              enableMrfWebhooks,
+              mrfWebhooksV3Generic,
               mrfStepWriteToken,
             }),
           })
         }
         await flushPromises()
 
-        for (const call of sendSpy.mock.calls) {
-          expect(
-            (call[3]?.data as Record<string, unknown> | undefined)?.[
-              'encryptedStepToken'
-            ],
-          ).toBeUndefined()
-        }
+        // The rows above are V4 (mrfVersion 2): a v3-only consumer must not
+        // receive them under any flag combination, which also means the step
+        // token (a write credential) can never leak to it.
+        expect(sendSpy).not.toHaveBeenCalled()
       },
     )
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -1,5 +1,6 @@
 import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
+import { featureFlags } from 'formsg-shared/constants'
 import {
   BasicField,
   FieldResponsesV3,
@@ -15,12 +16,15 @@ import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 
 import { getMultirespondentSubmissionModel } from 'src/app/models/submission.server.model'
+import { WebhookFactory } from 'src/app/modules/webhook/webhook.factory'
+import { webhookStatsdClient } from 'src/app/modules/webhook/webhook.statsd-client'
 import { AutoreplyPdfGenerationError } from 'src/app/services/mail/mail.errors'
 import MailService from 'src/app/services/mail/mail.service'
 import * as MailUtils from 'src/app/services/mail/mail.utils'
 import {
   IMultirespondentSubmissionSchema,
   IPopulatedMultirespondentForm,
+  WebhookView,
 } from 'src/types'
 import { MultirespondentSubmissionDto, SnapshottedFormDef } from 'src/types/api'
 
@@ -42,9 +46,26 @@ import {
   updateMultiRespondentFormSubmission,
 } from '../multirespondent-submission.service'
 import * as stepToken from '../step-token'
+import {
+  SnapshotDataIntegrityError,
+  SnapshotWriteError,
+} from '../webhook/submission-snapshot.errors'
+import * as SnapshotStore from '../webhook/submission-snapshot.store'
 
 jest.mock('src/app/modules/datadog/datadog.utils')
 jest.mock('src/app/services/mail/mail.utils')
+
+// Mock only the S3 snapshot I/O so call order/args can be asserted and reads
+// can be steered; keep the real error classes (SnapshotWriteError etc.).
+jest.mock('../webhook/submission-snapshot.store', () => {
+  const actual = jest.requireActual('../webhook/submission-snapshot.store')
+  return {
+    ...actual,
+    writeV4Snapshot: jest.fn(),
+    readV4Snapshot: jest.fn(),
+  }
+})
+const MockSnapshotStore = jest.mocked(SnapshotStore)
 
 const mockFormId = new ObjectId().toHexString()
 const mockSubmissionId = new ObjectId().toHexString()
@@ -183,7 +204,7 @@ describe('multirespondent-submission.service', () => {
       )
       expect(saveProtoSpy).not.toHaveBeenCalled()
       expect(result.isOk()).toBe(true)
-      expect(result._unsafeUnwrap()).toEqual(mockSavedDoc)
+      expect(result._unsafeUnwrap().submission).toEqual(mockSavedDoc)
 
       saveIfSpy.mockRestore()
       saveProtoSpy.mockRestore()
@@ -221,7 +242,7 @@ describe('multirespondent-submission.service', () => {
       expect(saveIfSpy).not.toHaveBeenCalled()
       expect(saveProtoSpy).toHaveBeenCalled()
       expect(result.isOk()).toBe(true)
-      const savedSubmission = result._unsafeUnwrap()
+      const savedSubmission = result._unsafeUnwrap().submission
       expect(savedSubmission).toEqual(mockSavedSubmission)
 
       saveIfSpy.mockRestore()
@@ -3473,7 +3494,7 @@ describe('multirespondent-submission.service', () => {
 
       expect(result.isOk()).toBe(true)
       const saved = await getMultirespondentSubmissionModel(mongoose).findById(
-        result._unsafeUnwrap()._id,
+        result._unsafeUnwrap().submission._id,
       )
       expect(saved?.stepTokenHash).toBe(stepToken.hash(raw))
       expect(saved?.encryptedStepToken).toBe('wrapped-token-A')
@@ -3715,6 +3736,853 @@ describe('multirespondent-submission.service', () => {
       expect(sendSpy.mock.calls[0][0].responseUrl).toContain(
         `&token=${encodeURIComponent(raw)}`,
       )
+    })
+  })
+
+  describe('S4 MRF v4 webhook snapshot integration', () => {
+    const PLUMBER_URL = 'https://plumber.gov.sg/webhooks/x'
+    const GENERIC_URL = 'https://example.com/hook'
+    const ZAPIER_URL = 'https://hooks.zapier.com/hooks/catch/1/x'
+    const fieldId = new ObjectId().toHexString()
+    const stepId0 = new ObjectId().toHexString()
+    const stepId1 = new ObjectId().toHexString()
+
+    const twoStepWorkflow: FormWorkflowStepDto[] = [
+      {
+        _id: stepId0,
+        workflow_type: WorkflowType.Static,
+        emails: [],
+        edit: [fieldId],
+      },
+      {
+        _id: stepId1,
+        workflow_type: WorkflowType.Static,
+        emails: ['next@example.com'],
+        edit: [fieldId],
+      },
+    ]
+
+    const flushPromises = () => new Promise((resolve) => setImmediate(resolve))
+
+    const growthbookWithFlags = ({
+      enableMrfWebhooks = false,
+      mrfStepWriteToken = false,
+    }: {
+      enableMrfWebhooks?: boolean
+      mrfStepWriteToken?: boolean
+    }) =>
+      ({
+        isOn: jest.fn((flag: string) =>
+          flag === featureFlags.enableMrfWebhooks
+            ? enableMrfWebhooks
+            : flag === featureFlags.mrfStepWriteToken
+              ? mrfStepWriteToken
+              : false,
+        ),
+        getFeatureValue: jest.fn((_flag: string, def: unknown) => def),
+      }) as any
+
+    const buildV4Form = (
+      overrides: Partial<IPopulatedMultirespondentForm> = {},
+    ): IPopulatedMultirespondentForm =>
+      ({
+        _id: mockFormId,
+        authType: FormAuthType.NIL,
+        responseMode: FormResponseMode.Multirespondent,
+        title: 'Test form',
+        form_fields: [
+          { _id: fieldId, fieldType: BasicField.ShortText, title: 'Q1' },
+        ],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        isSingleSubmission: false,
+        webhook: { url: PLUMBER_URL, isRetryEnabled: true },
+        getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+        ...overrides,
+      }) as unknown as IPopulatedMultirespondentForm
+
+    const buildSnapshottedFormDef = (
+      overrides: Partial<SnapshottedFormDef> = {},
+    ): SnapshottedFormDef =>
+      ({
+        _id: mockFormId,
+        title: 'Test form',
+        form_fields: [
+          { _id: fieldId, fieldType: BasicField.ShortText, title: 'Q1' },
+        ],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        webhook: { url: PLUMBER_URL, isRetryEnabled: true },
+        ...overrides,
+      }) as unknown as SnapshottedFormDef
+
+    const buildV4Payload = (
+      overrides: Partial<MultirespondentSubmissionDto> = {},
+    ): MultirespondentSubmissionDto => ({
+      submissionPublicKey: 'submission-public-key',
+      encryptedSubmissionSecretKey: 'wrapped-read-key-v4',
+      encryptedContent: 'v4-encrypted-content',
+      verifiedContent: 'v4-verified-content',
+      submissionSecretKey: 'submission-secret-key',
+      version: 2,
+      workflowStep: 0,
+      responses: {
+        [fieldId]: {
+          fieldType: BasicField.ShortText,
+          answer: { value: 'answer' },
+          question: 'Q1',
+          provenance: {},
+        },
+      },
+      mrfVersion: 2,
+      ...overrides,
+    })
+
+    const buildSnapshot = (overrides: Record<string, unknown> = {}) =>
+      ({
+        _v: 1,
+        contentFormat: 'v4',
+        formId: mockFormId,
+        submissionId: 'snap-submission-id',
+        submissionIndex: 0,
+        workflowStep: 0,
+        encryptedContent: 'frozen-content',
+        encryptedSubmissionSecretKey: 'frozen-read-key',
+        verifiedContent: 'frozen-verified',
+        createdAt: new Date().toISOString(),
+        ...overrides,
+      }) as any
+
+    const buildLiveWebhookView = (): WebhookView =>
+      ({
+        data: {
+          formId: mockFormId,
+          submissionId: 'live-submission-id',
+          encryptedContent: 'live-content',
+          encryptedSubmissionSecretKey: 'live-read-key',
+          verifiedContent: 'live-verified',
+          version: 2,
+          created: new Date(),
+          attachmentDownloadUrls: {},
+          paymentContent: {},
+          workflowContent: {
+            workflow: twoStepWorkflow,
+            workflowStep: 0,
+            submittedSteps: [
+              { isApproval: false, submittedAt: new Date().toISOString() },
+            ],
+          },
+        },
+      }) as unknown as WebhookView
+
+    const buildSubmissionWithToken = (
+      token: string | undefined,
+      view: WebhookView = buildLiveWebhookView(),
+      mrfVersion = 2,
+    ): IMultirespondentSubmissionSchema =>
+      ({
+        _id: new ObjectId(),
+        mrfVersion,
+        submittedSteps: [
+          {
+            isApproval: false,
+            submittedAt: new Date().toISOString(),
+            snapshotTokens: token ? { v4: token } : undefined,
+          },
+        ],
+        getWebhookView: jest.fn().mockResolvedValue(view),
+      }) as unknown as IMultirespondentSubmissionSchema
+
+    beforeEach(() => {
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        okAsync({ token: 'default-token', key: 'default-key' }),
+      )
+      MockSnapshotStore.readV4Snapshot.mockReturnValue(okAsync(buildSnapshot()))
+      jest
+        .spyOn(webhookStatsdClient, 'increment')
+        .mockImplementation(() => undefined as any)
+      jest
+        .spyOn(WebhookFactory, 'sendInitialWebhook')
+        .mockReturnValue(okAsync(true))
+    })
+
+    // ---- Committed-step-has-a-readable-snapshot (write side) ----
+
+    it('writes a v4 snapshot matching the committed step and records the token on create', async () => {
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        okAsync({ token: 'tok-create', key: 'key-create' }),
+      )
+
+      const result = await createMultiRespondentFormSubmission({
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: { action: 'test' },
+      })
+
+      expect(result.isOk()).toBe(true)
+      expect(MockSnapshotStore.writeV4Snapshot).toHaveBeenCalledTimes(1)
+      const snapshot = MockSnapshotStore.writeV4Snapshot.mock.calls[0][0]
+      expect(snapshot.submissionIndex).toBe(0)
+      expect(snapshot.workflowStep).toBe(0)
+      expect(snapshot.encryptedContent).toBe('v4-encrypted-content')
+      expect(snapshot.encryptedSubmissionSecretKey).toBe('wrapped-read-key-v4')
+
+      const saved = await getMultirespondentSubmissionModel(mongoose).findById(
+        result._unsafeUnwrap().submission._id,
+      )
+      expect(saved?.submittedSteps?.[0]?.snapshotTokens?.v4).toBe('tok-create')
+    })
+
+    it('writes a v4 snapshot for the appended step and records the token on update', async () => {
+      const Model = getMultirespondentSubmissionModel(mongoose)
+      const row = await Model.create({
+        form: mockFormId,
+        submissionType: SubmissionType.Multirespondent,
+        form_fields: [],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        submissionPublicKey: 'pk',
+        encryptedSubmissionSecretKey: 'esk',
+        encryptedContent: 'ec',
+        version: 2,
+        workflowStep: 0,
+        submittedSteps: [
+          { isApproval: false, submittedAt: new Date().toISOString() },
+        ],
+      })
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        okAsync({ token: 'tok-update', key: 'key-update' }),
+      )
+
+      const result = await updateMultiRespondentFormSubmission({
+        submissionId: row._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: { action: 'test' },
+      })
+
+      expect(result.isOk()).toBe(true)
+      expect(MockSnapshotStore.writeV4Snapshot).toHaveBeenCalledTimes(1)
+      const snapshot = MockSnapshotStore.writeV4Snapshot.mock.calls[0][0]
+      expect(snapshot.submissionIndex).toBe(1)
+      expect(snapshot.workflowStep).toBe(1)
+      expect(snapshot.encryptedContent).toBe('v4-encrypted-content')
+
+      const saved = await Model.findById(row._id)
+      expect(saved?.submittedSteps?.[1]?.snapshotTokens?.v4).toBe('tok-update')
+    })
+
+    it('does not write a snapshot when the write-condition is false (mrfVersion 1)', async () => {
+      const result = await createMultiRespondentFormSubmission({
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload({ mrfVersion: 1 }),
+        logMeta: { action: 'test' },
+      })
+
+      expect(result.isOk()).toBe(true)
+      expect(MockSnapshotStore.writeV4Snapshot).not.toHaveBeenCalled()
+    })
+
+    it.each`
+      label                          | enableMrfWebhooks | mrfStepWriteToken | expectWritten
+      ${'no flags'}                  | ${false}          | ${false}          | ${false}
+      ${'enable-mrf-webhooks only'}  | ${true}           | ${false}          | ${false}
+      ${'mrf-step-write-token only'} | ${false}          | ${true}           | ${false}
+      ${'both flags'}                | ${true}           | ${true}           | ${true}
+    `(
+      'generic V4 create snapshot write ($label) -> written=$expectWritten',
+      async ({ enableMrfWebhooks, mrfStepWriteToken, expectWritten }) => {
+        const result = await createMultiRespondentFormSubmission({
+          form: buildV4Form({
+            webhook: { url: GENERIC_URL, isRetryEnabled: true } as any,
+          }),
+          encryptedPayload: buildV4Payload(),
+          logMeta: { action: 'test' },
+          growthbook: growthbookWithFlags({
+            enableMrfWebhooks,
+            mrfStepWriteToken,
+          }),
+        })
+
+        expect(result.isOk()).toBe(true)
+        expect(MockSnapshotStore.writeV4Snapshot).toHaveBeenCalledTimes(
+          expectWritten ? 1 : 0,
+        )
+      },
+    )
+
+    it('does not write a snapshot for a generic V4 row on update when the webhook would not be delivered', async () => {
+      const Model = getMultirespondentSubmissionModel(mongoose)
+      const row = await Model.create({
+        form: mockFormId,
+        submissionType: SubmissionType.Multirespondent,
+        form_fields: [],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        submissionPublicKey: 'pk',
+        encryptedSubmissionSecretKey: 'esk',
+        encryptedContent: 'ec',
+        version: 2,
+        workflowStep: 0,
+        submittedSteps: [
+          { isApproval: false, submittedAt: new Date().toISOString() },
+        ],
+      })
+
+      const result = await updateMultiRespondentFormSubmission({
+        submissionId: row._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef({
+          webhook: { url: GENERIC_URL, isRetryEnabled: true } as any,
+        }),
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: { action: 'test' },
+        growthbook: growthbookWithFlags({ enableMrfWebhooks: true }),
+      })
+
+      expect(result.isOk()).toBe(true)
+      expect(MockSnapshotStore.writeV4Snapshot).not.toHaveBeenCalled()
+    })
+
+    it('still writes a snapshot for a plumber V4 row with no flags on', async () => {
+      const result = await createMultiRespondentFormSubmission({
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: { action: 'test' },
+        growthbook: growthbookWithFlags({}),
+      })
+
+      expect(result.isOk()).toBe(true)
+      expect(MockSnapshotStore.writeV4Snapshot).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not write a snapshot when retries are disabled', async () => {
+      const result = await createMultiRespondentFormSubmission({
+        form: buildV4Form({
+          webhook: { url: PLUMBER_URL, isRetryEnabled: false } as any,
+        }),
+        encryptedPayload: buildV4Payload(),
+        logMeta: { action: 'test' },
+      })
+
+      expect(result.isOk()).toBe(true)
+      expect(MockSnapshotStore.writeV4Snapshot).not.toHaveBeenCalled()
+    })
+
+    it('aborts the save (fail-loud) when the snapshot write fails', async () => {
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        errAsync(new SnapshotWriteError()),
+      )
+      const saveSpy = jest.spyOn(
+        getMultirespondentSubmissionModel(mongoose).prototype,
+        'save',
+      )
+
+      const result = await createMultiRespondentFormSubmission({
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: { action: 'test' },
+      })
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(SnapshotWriteError)
+      expect(saveSpy).not.toHaveBeenCalled()
+      saveSpy.mockRestore()
+    })
+
+    it('does not commit the appended step when the snapshot write fails on update', async () => {
+      const Model = getMultirespondentSubmissionModel(mongoose)
+      const row = await Model.create({
+        form: mockFormId,
+        submissionType: SubmissionType.Multirespondent,
+        form_fields: [],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        submissionPublicKey: 'pk',
+        encryptedSubmissionSecretKey: 'esk',
+        encryptedContent: 'ec',
+        version: 2,
+        workflowStep: 0,
+        submittedSteps: [
+          { isApproval: false, submittedAt: new Date().toISOString() },
+        ],
+      })
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        errAsync(new SnapshotWriteError()),
+      )
+
+      const result = await updateMultiRespondentFormSubmission({
+        submissionId: row._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: { action: 'test' },
+      })
+
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(SnapshotWriteError)
+
+      // S3-first ordering: the row is untouched, so the respondent's retry
+      // starts from the same committed state.
+      const saved = await Model.findById(row._id)
+      expect(saved?.submittedSteps).toHaveLength(1)
+      expect(saved?.workflowStep).toBe(0)
+      expect(saved?.encryptedContent).toBe('ec')
+    })
+
+    // ---- Send gate table ----
+
+    it.each`
+      label                          | url            | enableMrfWebhooks | mrfStepWriteToken | expectSent
+      ${'plumber, no flags'}         | ${PLUMBER_URL} | ${false}          | ${false}          | ${true}
+      ${'plumber, webhooks only'}    | ${PLUMBER_URL} | ${true}           | ${false}          | ${true}
+      ${'plumber, write-token only'} | ${PLUMBER_URL} | ${false}          | ${true}           | ${true}
+      ${'plumber, both'}             | ${PLUMBER_URL} | ${true}           | ${true}           | ${true}
+      ${'generic, no flags'}         | ${GENERIC_URL} | ${false}          | ${false}          | ${false}
+      ${'generic, webhooks only'}    | ${GENERIC_URL} | ${true}           | ${false}          | ${false}
+      ${'generic, write-token only'} | ${GENERIC_URL} | ${false}          | ${true}           | ${false}
+      ${'generic, both'}             | ${GENERIC_URL} | ${true}           | ${true}           | ${true}
+      ${'zapier, webhooks only'}     | ${ZAPIER_URL}  | ${true}           | ${false}          | ${false}
+      ${'zapier, both'}              | ${ZAPIER_URL}  | ${true}           | ${true}           | ${true}
+    `(
+      'send gate: $label -> sent=$expectSent',
+      async ({ url, enableMrfWebhooks, mrfStepWriteToken, expectSent }) => {
+        const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+        const submission = buildSubmissionWithToken(undefined)
+
+        await performMultiRespondentPostSubmissionCreateActions({
+          submission,
+          submissionId: submission._id.toString(),
+          form: buildV4Form({ webhook: { url, isRetryEnabled: true } as any }),
+          encryptedPayload: buildV4Payload(),
+          logMeta: {} as any,
+          growthbook: growthbookWithFlags({
+            enableMrfWebhooks,
+            mrfStepWriteToken,
+          }),
+        })
+        await flushPromises()
+
+        expect(sendSpy).toHaveBeenCalledTimes(expectSent ? 1 : 0)
+      },
+    )
+
+    // ---- Generic never takes the legacy raw-getWebhookView path ----
+
+    it.each([
+      ['with a snapshot', true],
+      ['without a snapshot', false],
+    ])(
+      'routes a generic V4 send through reconstruction, never the legacy live-row path (%s)',
+      async (_label, withSnapshot) => {
+        const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+        const submission = buildSubmissionWithToken(
+          withSnapshot ? 'tok-generic' : undefined,
+        )
+
+        await performMultiRespondentPostSubmissionCreateActions({
+          submission,
+          snapshot: withSnapshot ? buildSnapshot() : undefined,
+          submissionId: submission._id.toString(),
+          form: buildV4Form({
+            webhook: { url: GENERIC_URL, isRetryEnabled: true } as any,
+          }),
+          encryptedPayload: buildV4Payload(),
+          logMeta: {} as any,
+          growthbook: growthbookWithFlags({
+            enableMrfWebhooks: true,
+            mrfStepWriteToken: true,
+          }),
+        })
+        await flushPromises()
+
+        expect(sendSpy).toHaveBeenCalledTimes(1)
+        // The legacy branch is identified by the absent 4th argument.
+        expect(sendSpy.mock.calls[0][3]).toBeDefined()
+      },
+    )
+
+    // ---- Generic never receives the step token (write credential) ----
+
+    it.each`
+      enableMrfWebhooks | mrfStepWriteToken
+      ${false}          | ${false}
+      ${true}           | ${false}
+      ${false}          | ${true}
+      ${true}           | ${true}
+    `(
+      'never sends encryptedStepToken to a generic consumer (webhooks=$enableMrfWebhooks, writeToken=$mrfStepWriteToken)',
+      async ({ enableMrfWebhooks, mrfStepWriteToken }) => {
+        const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+
+        for (const url of [GENERIC_URL, ZAPIER_URL]) {
+          const submission = buildSubmissionWithToken('tok-generic')
+
+          await performMultiRespondentPostSubmissionCreateActions({
+            submission,
+            snapshot: buildSnapshot(),
+            submissionId: submission._id.toString(),
+            form: buildV4Form({
+              webhook: { url, isRetryEnabled: true } as any,
+            }),
+            encryptedPayload: buildV4Payload(),
+            logMeta: {} as any,
+            growthbook: growthbookWithFlags({
+              enableMrfWebhooks,
+              mrfStepWriteToken,
+            }),
+          })
+        }
+        await flushPromises()
+
+        for (const call of sendSpy.mock.calls) {
+          expect(
+            (call[3]?.data as Record<string, unknown> | undefined)?.[
+              'encryptedStepToken'
+            ],
+          ).toBeUndefined()
+        }
+      },
+    )
+
+    // ---- D10: no S3 GET on the initial send ----
+
+    it('reconstructs from the in-memory snapshot, with the S3 read path stubbed to fail', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      // Any S3 GET on the initial send is a defect: stub the read path to fail
+      // so a surviving read-back would drop the webhook.
+      MockSnapshotStore.readV4Snapshot.mockReturnValue(
+        errAsync(new SnapshotDataIntegrityError('S3 GET must not be reached')),
+      )
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        okAsync({ token: 'tok-inmem', key: 'key-inmem' }),
+      )
+
+      const created = await createMultiRespondentFormSubmission({
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: { action: 'test' },
+      })
+      expect(created.isOk()).toBe(true)
+      const { submission, snapshot } = created._unsafeUnwrap()
+      expect(snapshot?.encryptedContent).toBe('v4-encrypted-content')
+
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        snapshot,
+        submissionId: submission._id.toString(),
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({
+          enableMrfWebhooks: true,
+          mrfStepWriteToken: true,
+        }),
+      })
+      await flushPromises()
+
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const view = sendSpy.mock.calls[0][3]
+      expect(view?.data.encryptedContent).toBe('v4-encrypted-content')
+      expect(view?.data.encryptedSubmissionSecretKey).toBe(
+        'wrapped-read-key-v4',
+      )
+    })
+
+    // ---- Reconstruction wired ----
+
+    it('passes a reconstructed pre-built view for a plumber v4 send', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      const submission = buildSubmissionWithToken('tok-A')
+
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        snapshot: buildSnapshot({
+          encryptedSubmissionSecretKey: 'frozen-read-key',
+        }),
+        submissionId: submission._id.toString(),
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({
+          enableMrfWebhooks: true,
+          mrfStepWriteToken: true,
+        }),
+      })
+      await flushPromises()
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      const view = sendSpy.mock.calls[0][3]
+      expect(view).toBeDefined()
+      expect(view?.data.version).toBe(4)
+      expect(view?.data.encryptedSubmissionSecretKey).toBe('frozen-read-key')
+      // frozen content wins over the live row.
+      expect(view?.data.encryptedContent).toBe('frozen-content')
+    })
+
+    it('takes the legacy path (no 4th arg) for a plumber V3 row', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      const submission = buildSubmissionWithToken(
+        undefined,
+        buildLiveWebhookView(),
+        1,
+      )
+
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        submissionId: submission._id.toString(),
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload({ mrfVersion: 1 }),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({}),
+      })
+      await flushPromises()
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy.mock.calls[0][3]).toBeUndefined()
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+    })
+
+    it('reconstructs the live row (not the legacy path) for a plumber V4 row with no snapshot', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      const liveView = buildLiveWebhookView()
+      const submission = buildSubmissionWithToken(undefined, liveView)
+
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        submissionId: submission._id.toString(),
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({
+          enableMrfWebhooks: true,
+          mrfStepWriteToken: true,
+        }),
+      })
+      await flushPromises()
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy.mock.calls[0][3]?.data).toEqual(liveView.data)
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+    })
+
+    // ---- D10: a recorded token never triggers a read on the initial send ----
+
+    it('ignores the recorded token on the initial send and never reads S3', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      // A token IS recorded on the row, yet the send must still not read S3 —
+      // the object it needs is already in hand.
+      const submission = buildSubmissionWithToken('tok-A')
+
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submission,
+        snapshot: buildSnapshot(),
+        submissionId: submission._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        currentStepNumber: 0,
+        encryptedPayload: buildV4Payload(),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({
+          enableMrfWebhooks: true,
+          mrfStepWriteToken: true,
+        }),
+      })
+      await flushPromises()
+
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy.mock.calls[0][3]?.data.encryptedContent).toBe(
+        'frozen-content',
+      )
+    })
+
+    // ---- Case A winner / 409 ----
+
+    it("records the winner token and hands the winner's own snapshot to reconstruction (Case A / 409 winner)", async () => {
+      const Model = getMultirespondentSubmissionModel(mongoose)
+      const row = await Model.create({
+        form: mockFormId,
+        submissionType: SubmissionType.Multirespondent,
+        form_fields: [],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        submissionPublicKey: 'pk',
+        encryptedSubmissionSecretKey: 'esk',
+        encryptedContent: 'ec',
+        version: 2,
+        workflowStep: 0,
+        submittedSteps: [
+          { isApproval: false, submittedAt: new Date().toISOString() },
+        ],
+      })
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        okAsync({ token: 'winner-token', key: 'winner-key' }),
+      )
+
+      const result = await updateMultiRespondentFormSubmission({
+        submissionId: row._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: { action: 'test' },
+      })
+      expect(result.isOk()).toBe(true)
+      const { submission: winner, snapshot: winnerSnapshot } =
+        result._unsafeUnwrap()
+      expect(winner.submittedSteps?.[1]?.snapshotTokens?.v4).toBe(
+        'winner-token',
+      )
+      // The winner's own object is what travels to reconstruction — the token
+      // is recorded for the RETRY path, not consumed by the initial send.
+      expect(winnerSnapshot?.submissionIndex).toBe(1)
+
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submission: winner,
+        snapshot: winnerSnapshot,
+        submissionId: winner._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        currentStepNumber: 1,
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({
+          enableMrfWebhooks: true,
+          mrfStepWriteToken: true,
+        }),
+      })
+      await flushPromises()
+
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy.mock.calls[0][3]?.data.encryptedContent).toBe(
+        'v4-encrypted-content',
+      )
+    })
+
+    it('surfaces a lost concurrent-write race as a 409 even after a successful snapshot write', async () => {
+      const Model = getMultirespondentSubmissionModel(mongoose)
+      const doc = await Model.create({
+        form: mockFormId,
+        submissionType: SubmissionType.Multirespondent,
+        form_fields: [],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        submissionPublicKey: 'pk',
+        encryptedSubmissionSecretKey: 'esk',
+        encryptedContent: 'ec',
+        version: 2,
+        workflowStep: 0,
+        submittedSteps: [
+          { isApproval: false, submittedAt: new Date().toISOString() },
+        ],
+      })
+      const versionError = new mongoose.Error.VersionError(
+        doc as any,
+        (doc as any).__v,
+        ['submittedSteps'],
+      )
+      const saveSpy = jest
+        .spyOn(Model.prototype, 'save')
+        .mockRejectedValueOnce(versionError)
+
+      const result = await updateMultiRespondentFormSubmission({
+        submissionId: doc._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: { action: 'test' },
+      })
+
+      expect(MockSnapshotStore.writeV4Snapshot).toHaveBeenCalledTimes(1)
+      expect(result.isErr()).toBe(true)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(DatabaseConflictError)
+      expect(mapRouteError(result._unsafeUnwrapErr()).statusCode).toBe(409)
+      saveSpy.mockRestore()
+    })
+
+    // ---- Case B/C benign orphan ----
+
+    it('leaves the snapshot as a benign orphan (no delete) when the save fails after a successful write, and a resubmit writes a NEW token', async () => {
+      const Model = getMultirespondentSubmissionModel(mongoose)
+      const row = await Model.create({
+        form: mockFormId,
+        submissionType: SubmissionType.Multirespondent,
+        form_fields: [],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        submissionPublicKey: 'pk',
+        encryptedSubmissionSecretKey: 'esk',
+        encryptedContent: 'ec',
+        version: 2,
+        workflowStep: 0,
+        submittedSteps: [
+          { isApproval: false, submittedAt: new Date().toISOString() },
+        ],
+      })
+      MockSnapshotStore.writeV4Snapshot.mockReturnValueOnce(
+        okAsync({ token: 'orphan-token-1', key: 'orphan-key-1' }),
+      )
+      const saveSpy = jest
+        .spyOn(Model.prototype, 'save')
+        .mockRejectedValueOnce(new Error('transient write failure'))
+
+      const failed = await updateMultiRespondentFormSubmission({
+        submissionId: row._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: { action: 'test' },
+      })
+
+      expect(failed.isErr()).toBe(true)
+      // The store exposes no delete/wipe primitive at all — an orphan is never
+      // reclaimed inline.
+      expect(
+        (SnapshotStore as Record<string, unknown>).deleteV4Snapshot,
+      ).toBeUndefined()
+      expect(
+        (SnapshotStore as Record<string, unknown>).removeV4Snapshot,
+      ).toBeUndefined()
+
+      saveSpy.mockRestore()
+
+      // Resubmit: a fresh write mints a NEW token, recorded on the row.
+      MockSnapshotStore.writeV4Snapshot.mockReturnValueOnce(
+        okAsync({ token: 'orphan-token-2', key: 'orphan-key-2' }),
+      )
+      const resubmit = await updateMultiRespondentFormSubmission({
+        submissionId: row._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: { action: 'test' },
+      })
+
+      expect(resubmit.isOk()).toBe(true)
+      const saved = await Model.findById(row._id)
+      expect(saved?.submittedSteps?.[1]?.snapshotTokens?.v4).toBe(
+        'orphan-token-2',
+      )
+    })
+
+    // ---- Regression / byte-identity ----
+
+    it('legacy plumber create (flag off, mrfVersion 1) sends via getWebhookView with no 4th arg and no snapshot', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      const submission = buildSubmissionWithToken(
+        undefined,
+        buildLiveWebhookView(),
+        1,
+      )
+
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        submissionId: submission._id.toString(),
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload({ mrfVersion: 1 }),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({}),
+      })
+      await flushPromises()
+
+      expect(sendSpy).toHaveBeenCalledTimes(1)
+      expect(sendSpy.mock.calls[0][3]).toBeUndefined()
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -1368,8 +1368,7 @@ describe('multirespondent-submission.utils', () => {
   })
 
   describe('getMrfVersion', () => {
-    type WebhookType = 'zapier' | 'plumber' | 'generic' | undefined
-
+    type WebhookType = Parameters<typeof getMrfVersion>[0]['webhookType']
     it.each<{
       name: string
       webhookType: WebhookType

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -1399,29 +1399,31 @@ describe('multirespondent-submission.utils', () => {
         isStepWriteTokenEnabled: false,
         expected: 1,
       },
+      // Non-plumber consumers are v3-only, so their rows always store V3 —
+      // the write-guard flag governs plumber's cutover, not theirs.
       {
-        name: 'generic, write-guard off => V4',
+        name: 'generic, write-guard off => V3',
         webhookType: 'generic',
         isStepWriteTokenEnabled: false,
-        expected: 2,
+        expected: 1,
       },
       {
-        name: 'generic, write-guard on => V4',
+        name: 'generic, write-guard on => V3',
         webhookType: 'generic',
         isStepWriteTokenEnabled: true,
-        expected: 2,
+        expected: 1,
       },
       {
-        name: 'zapier is treated as generic, write-guard off => V4',
+        name: 'zapier is treated as generic, write-guard off => V3',
         webhookType: 'zapier',
         isStepWriteTokenEnabled: false,
-        expected: 2,
+        expected: 1,
       },
       {
-        name: 'zapier is treated as generic, write-guard on => V4',
+        name: 'zapier is treated as generic, write-guard on => V3',
         webhookType: 'zapier',
         isStepWriteTokenEnabled: true,
-        expected: 2,
+        expected: 1,
       },
     ])('$name', ({ webhookType, isStepWriteTokenEnabled, expected }) => {
       expect(getMrfVersion({ webhookType, isStepWriteTokenEnabled })).toBe(

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.utils.spec.ts
@@ -42,7 +42,9 @@ import {
   createMultirespondentSubmissionDto,
   createPublicMultirespondentSubmissionDto,
   extractRespondentCopyEmailDatas,
+  getMrfVersion,
   getQuestionAnswerPairsForMultipleFields,
+  MrfVersion,
   retrieveWorkflowStepEmailAddresses,
   validateMrfFieldResponses,
 } from '../multirespondent-submission.utils'
@@ -1362,6 +1364,70 @@ describe('multirespondent-submission.utils', () => {
         }),
       )
       expect(result[2]).not.toHaveProperty('fieldType')
+    })
+  })
+
+  describe('getMrfVersion', () => {
+    type WebhookType = 'zapier' | 'plumber' | 'generic' | undefined
+
+    it.each<{
+      name: string
+      webhookType: WebhookType
+      isStepWriteTokenEnabled: boolean
+      expected: MrfVersion
+    }>([
+      {
+        name: 'no webhook, write-guard off => V4',
+        webhookType: undefined,
+        isStepWriteTokenEnabled: false,
+        expected: 2,
+      },
+      {
+        name: 'no webhook, write-guard on => V4',
+        webhookType: undefined,
+        isStepWriteTokenEnabled: true,
+        expected: 2,
+      },
+      {
+        name: 'plumber, write-guard on => V4',
+        webhookType: 'plumber',
+        isStepWriteTokenEnabled: true,
+        expected: 2,
+      },
+      {
+        name: 'plumber, write-guard off => V3',
+        webhookType: 'plumber',
+        isStepWriteTokenEnabled: false,
+        expected: 1,
+      },
+      {
+        name: 'generic, write-guard off => V4',
+        webhookType: 'generic',
+        isStepWriteTokenEnabled: false,
+        expected: 2,
+      },
+      {
+        name: 'generic, write-guard on => V4',
+        webhookType: 'generic',
+        isStepWriteTokenEnabled: true,
+        expected: 2,
+      },
+      {
+        name: 'zapier is treated as generic, write-guard off => V4',
+        webhookType: 'zapier',
+        isStepWriteTokenEnabled: false,
+        expected: 2,
+      },
+      {
+        name: 'zapier is treated as generic, write-guard on => V4',
+        webhookType: 'zapier',
+        isStepWriteTokenEnabled: true,
+        expected: 2,
+      },
+    ])('$name', ({ webhookType, isStepWriteTokenEnabled, expected }) => {
+      expect(getMrfVersion({ webhookType, isStepWriteTokenEnabled })).toBe(
+        expected,
+      )
     })
   })
 })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.controller.ts
@@ -129,6 +129,7 @@ const submitMultirespondentForm = async (
       form,
       encryptedPayload,
       logMeta,
+      growthbook: req.growthbook,
     })
 
   if (createMultiRespondentFormSubmissionResult.isErr()) {
@@ -138,7 +139,8 @@ const submitMultirespondentForm = async (
     return res.status(statusCode).json({ message: errorMessage })
   }
 
-  const submission = createMultiRespondentFormSubmissionResult.value
+  const { submission, snapshot } =
+    createMultiRespondentFormSubmissionResult.value
 
   // Send success back to client
   res.json({
@@ -150,6 +152,7 @@ const submitMultirespondentForm = async (
 
   await performMultiRespondentPostSubmissionCreateActions({
     submission,
+    snapshot,
     submissionId: submission._id.toString(),
     form,
     encryptedPayload,
@@ -220,6 +223,7 @@ const updateMultirespondentSubmission = async (
       snapshottedFormDef,
       encryptedPayload,
       logMeta,
+      growthbook: req.growthbook,
     })
 
   if (updateMultiRespondentFormSubmissionResult.isErr()) {
@@ -236,7 +240,8 @@ const updateMultirespondentSubmission = async (
     return res.status(statusCode).json({ message: errorMessage })
   }
 
-  const submission = updateMultiRespondentFormSubmissionResult.value
+  const { submission, snapshot } =
+    updateMultiRespondentFormSubmissionResult.value
 
   // Send success back to client
   res.json({
@@ -250,6 +255,7 @@ const updateMultirespondentSubmission = async (
 
   await performMultiRespondentPostSubmissionUpdateActions({
     submission,
+    snapshot,
     submissionId,
     snapshottedFormDef,
     currentStepNumber,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -54,6 +54,7 @@ import { getOidcService } from '../../spcp/spcp.oidc.service'
 import { createNdiResponsesV4FromRecord } from '../../spcp/spcp.util'
 import * as VerifiedContentService from '../../verified-content/verified-content.service'
 import { VerifiedContentV3 } from '../../verified-content/verified-content.types'
+import { getWebhookType } from '../../webhook/webhook.service'
 import { FormsgReqBodyExistsError } from '../encrypt-submission/encrypt-submission.errors'
 import { CreateFormsgAndRetrieveFormMiddlewareHandlerType } from '../encrypt-submission/encrypt-submission.types'
 import {
@@ -85,7 +86,10 @@ import {
   ProcessedMultirespondentSubmissionHandlerType,
   StrippedAttachmentResponseV4,
 } from './multirespondent-submission.types'
-import { validateMrfFieldResponses } from './multirespondent-submission.utils'
+import {
+  getMrfVersion,
+  validateMrfFieldResponses,
+} from './multirespondent-submission.utils'
 import * as stepToken from './step-token'
 
 const logger = createLoggerWithLabel(module)
@@ -848,15 +852,19 @@ export const encryptSubmission = async (
     req.formsg.unencryptedAttachments = unencryptedAttachments
   }
 
-  // Webhook compatibility: forms with webhooks have downstream consumers that
-  // parse the encrypted payload as V3-shaped (mrfVersion: 1). Convert back to
-  // V3 just for the encryption blob; in-process state (encryptedPayload.responses,
-  // emails, NDI handling) stays V4.
-  const hasWebhook = !!formDef.webhook?.url
-  const responsesToEncrypt = hasWebhook
-    ? adaptV4ToV3(strippedAttachmentResponses as unknown as FieldResponsesV4)
-    : strippedAttachmentResponses
-  const mrfVersion: 1 | 2 = hasWebhook ? 1 : 2
+  const isStepWriteTokenEnabled =
+    req.growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false
+
+  const webhookUrl = formDef.webhook?.url
+  const mrfVersion = getMrfVersion({
+    webhookType: webhookUrl ? getWebhookType(webhookUrl) : undefined,
+    isStepWriteTokenEnabled,
+  })
+  const useV4Encryption = mrfVersion === 2
+
+  const responsesToEncrypt = useV4Encryption
+    ? strippedAttachmentResponses
+    : adaptV4ToV3(strippedAttachmentResponses as unknown as FieldResponsesV4)
 
   const {
     encryptedContent,
@@ -896,8 +904,6 @@ export const encryptSubmission = async (
       req.body.version,
     )
 
-  const isStepWriteTokenEnabled =
-    req.growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false
   let mintedStepToken:
     | {
         stepToken: string
@@ -924,11 +930,6 @@ export const encryptSubmission = async (
     version: req.body.version,
     workflowStep: req.body.workflowStep,
     responses: responses as FieldResponsesV4,
-    /**
-     * MRF Version 2 = V4-encrypted responses (with provenance).
-     * MRF Version 1 = V3-encrypted responses (used when form has a webhook
-     * so existing webhook consumers can continue to parse V3 payloads).
-     */
     mrfVersion,
     ...mintedStepToken,
   }

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1,5 +1,6 @@
 import { GrowthBook } from '@growthbook/growthbook'
 import type { FieldResponsesV4 } from '@opengovsg/formsg-sdk'
+import { featureFlags } from 'formsg-shared/constants'
 import {
   BasicField,
   FormAuthType,
@@ -24,6 +25,7 @@ import {
   IMultirespondentSubmissionSchema,
   IPopulatedForm,
   IPopulatedMultirespondentForm,
+  WebhookView,
 } from '../../../../types'
 import {
   MultirespondentSubmissionDto,
@@ -46,6 +48,7 @@ import { DatabaseError, PossibleDatabaseError } from '../../core/core.errors'
 import { FormRespondentSingleSubmissionValidationError } from '../../form/form.errors'
 import { isFormMultirespondent } from '../../form/form.utils'
 import { WebhookFactory } from '../../webhook/webhook.factory'
+import { getWebhookType } from '../../webhook/webhook.service'
 import {
   AttachmentUploadError,
   ExpectedResponseNotFoundError,
@@ -66,6 +69,19 @@ import {
 } from '../submission.utils'
 import { reportSubmissionResponseTime } from '../submissions.statsd-client'
 
+import { SnapshotWriteError } from './webhook/submission-snapshot.errors'
+import { buildV4Snapshot } from './webhook/submission-snapshot.producer'
+import { SubmissionSnapshotV4 } from './webhook/submission-snapshot.schema'
+import { writeV4Snapshot } from './webhook/submission-snapshot.store'
+import {
+  getWebhookPayloadPolicy,
+  mrfVersionToContentFormat,
+} from './webhook/webhook-payload-policy'
+import { reconstructMrfWebhookData } from './webhook/webhook-reconstruction'
+import {
+  shouldSendMrfWebhook,
+  shouldWriteV4Snapshot,
+} from './webhook/webhook-send-eligibility'
 import { MultirespondentSubmissionContent } from './multirespondent-submission.types'
 import {
   buildMrfResponseJson,
@@ -85,6 +101,13 @@ const appUrl =
   process.env.NODE_ENV === Environment.Dev
     ? config.app.feAppUrl
     : config.app.appUrl
+
+export type SavedMultirespondentSubmission = {
+  submission: IMultirespondentSubmissionSchema & {
+    _id: mongoose.Types.ObjectId
+  }
+  snapshot?: SubmissionSnapshotV4
+}
 
 export const checkFormIsMultirespondent = (
   form: IPopulatedForm,
@@ -704,13 +727,15 @@ export const createMultiRespondentFormSubmission = ({
   form,
   encryptedPayload,
   logMeta,
+  growthbook,
 }: {
   form: IPopulatedMultirespondentForm
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
+  growthbook?: GrowthBook
 }): ResultAsync<
-  IMultirespondentSubmissionSchema & { _id: mongoose.Types.ObjectId },
-  AttachmentUploadError | SubmissionSaveError
+  SavedMultirespondentSubmission,
+  AttachmentUploadError | SubmissionSaveError | SnapshotWriteError
 > => {
   logMeta = {
     ...logMeta,
@@ -771,7 +796,14 @@ export const createMultiRespondentFormSubmission = ({
         submitterId: hashedSubmitterId,
       }
 
-      const submissionContent: MultirespondentSubmissionContent = {
+      // RATIONALE: Generate the submissionId up front so the S3 snapshot key can be built
+      // BEFORE the row is persisted (Snapshot saves to S3 first ordering).
+      const submissionObjectId = new mongoose.Types.ObjectId()
+
+      const submissionContent: MultirespondentSubmissionContent & {
+        _id: mongoose.Types.ObjectId
+      } = {
+        _id: submissionObjectId,
         form: form._id,
         authType: form.authType,
         myInfoFields: form.getUniqueMyInfoAttrs(),
@@ -790,6 +822,15 @@ export const createMultiRespondentFormSubmission = ({
         stepTokenHash,
         encryptedStepToken,
       }
+
+      const shouldWriteSnapshot = shouldWriteV4Snapshot({
+        mrfVersion,
+        webhook: form.webhook,
+        isMrfWebhooksEnabled:
+          growthbook?.isOn(featureFlags.enableMrfWebhooks) ?? false,
+        isStepWriteTokenEnabled:
+          growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false,
+      })
 
       const saveSubmission = async () => {
         if (form.isSingleSubmission && form.authType !== FormAuthType.NIL) {
@@ -826,25 +867,54 @@ export const createMultiRespondentFormSubmission = ({
         return submission.save()
       }
 
-      return ResultAsync.fromPromise(
-        saveSubmission().then((submission) => ({
-          submission,
-          responseMetadata,
-        })),
-        (error) => {
-          if (error instanceof FormRespondentSingleSubmissionValidationError) {
-            return error
-          }
-          logger.error({
-            message: 'Multirespondent submission save error',
-            meta: logMeta,
-            error,
+      const snapshot = shouldWriteSnapshot
+        ? buildV4Snapshot({
+            formId: String(form._id),
+            submissionId: String(submissionObjectId),
+            submissionIndex: 0,
+            workflowStep: 0,
+            encryptedContent,
+            encryptedSubmissionSecretKey,
+            verifiedContent,
+            attachmentMetadata: Object.fromEntries(
+              attachmentMetadata ?? new Map(),
+            ),
+            createdAt: submittedStepMeta.submittedAt,
           })
-          return new SubmissionSaveError()
-        },
+        : undefined
+
+      const writeSnapshotIfNeeded: ResultAsync<undefined, SnapshotWriteError> =
+        snapshot
+          ? writeV4Snapshot(snapshot).map(({ token }) => {
+              submittedStepMeta.snapshotTokens = { v4: token }
+              return undefined
+            })
+          : okAsync(undefined)
+
+      return writeSnapshotIfNeeded.andThen(() =>
+        ResultAsync.fromPromise(
+          saveSubmission().then((submission) => ({
+            submission,
+            responseMetadata,
+            snapshot,
+          })),
+          (error) => {
+            if (
+              error instanceof FormRespondentSingleSubmissionValidationError
+            ) {
+              return error
+            }
+            logger.error({
+              message: 'Multirespondent submission save error',
+              meta: logMeta,
+              error,
+            })
+            return new SubmissionSaveError()
+          },
+        ),
       )
     })
-    .map(({ submission, responseMetadata }) => {
+    .map(({ submission, responseMetadata, snapshot }) => {
       const submissionId = submission.id
       logger.info({
         message: 'Saved submission to MongoDB',
@@ -859,7 +929,7 @@ export const createMultiRespondentFormSubmission = ({
         })
       }
 
-      return submission
+      return { submission, snapshot }
     })
 }
 
@@ -1028,8 +1098,98 @@ const generatePdfAttachmentIfRequired = ({
   return pdfResult
 }
 
+const sendMrfInitialWebhookIfEligible = ({
+  submission,
+  snapshot,
+  webhookUrl,
+  isRetryEnabled,
+  growthbook,
+  logMeta,
+}: {
+  submission: IMultirespondentSubmissionSchema
+  snapshot?: SubmissionSnapshotV4
+  webhookUrl: string
+  isRetryEnabled: boolean
+  growthbook?: GrowthBook
+  logMeta: CustomLoggerParams['meta']
+}): void => {
+  const webhookType = getWebhookType(webhookUrl)
+  const isStepWriteTokenEnabled =
+    growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false
+
+  const shouldSend = shouldSendMrfWebhook({
+    webhookType,
+    isMrfWebhooksEnabled:
+      growthbook?.isOn(featureFlags.enableMrfWebhooks) ?? false,
+    isStepWriteTokenEnabled,
+  })
+  if (!shouldSend) {
+    return
+  }
+
+  logger.info({
+    message: 'Sending initial webhook for multirespondent submission',
+    meta: { ...logMeta, webhookType },
+  })
+
+  const submissionIndex = (submission.submittedSteps?.length ?? 1) - 1
+
+  // For V3 legacy, we load from the live row without a reconstructing from snapshot.
+  if (mrfVersionToContentFormat(submission.mrfVersion) === 'v3') {
+    WebhookFactory.sendInitialWebhook(
+      submission,
+      webhookUrl,
+      isRetryEnabled,
+    ).mapErr((error) => {
+      logger.error({
+        message: 'Multirespondent submission webhook error',
+        meta: logMeta,
+        error,
+      })
+    })
+    return
+  }
+
+  ResultAsync.fromPromise(
+    submission.getWebhookView(),
+    () => new DatabaseError(),
+  )
+    .andThen((liveView) => {
+      const policy = getWebhookPayloadPolicy({
+        webhookType: webhookType === 'plumber' ? 'plumber' : 'generic',
+        isStepWriteTokenEnabled,
+        submissionIndex,
+        submittedStepsLength: submission.submittedSteps?.length ?? 0,
+      })
+      return reconstructMrfWebhookData({
+        liveData: liveView.data,
+        snapshot,
+        // RATONALE: if snapshot does not exist, we use the live row.
+        submissionIndex: snapshot ? submissionIndex : undefined,
+        policy,
+      }).asyncAndThen((data) => {
+        const webhookView: WebhookView = { data }
+
+        return WebhookFactory.sendInitialWebhook(
+          submission,
+          webhookUrl,
+          isRetryEnabled,
+          webhookView,
+        ).map(() => undefined)
+      })
+    })
+    .mapErr((error) => {
+      logger.error({
+        message: 'Multirespondent submission webhook error',
+        meta: logMeta,
+        error,
+      })
+    })
+}
+
 export const performMultiRespondentPostSubmissionCreateActions = ({
   submission,
+  snapshot,
   submissionId,
   form,
   encryptedPayload,
@@ -1038,6 +1198,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   growthbook,
 }: {
   submission: IMultirespondentSubmissionSchema
+  snapshot?: SubmissionSnapshotV4
   submissionId: string
   form: IPopulatedMultirespondentForm
   encryptedPayload: MultirespondentSubmissionDto
@@ -1116,24 +1277,14 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
 
   const webhookUrl = form.webhook?.url
   if (webhookUrl) {
-    logger.info({
-      message: 'Sending initial webhook for multirespondent submission',
-      meta: logMeta,
-    })
-
-    WebhookFactory.sendInitialWebhook(
+    sendMrfInitialWebhookIfEligible({
       submission,
+      snapshot,
       webhookUrl,
-      !!form.webhook?.isRetryEnabled,
-    )
-      .andThen(() => okAsync(form))
-      .mapErr((error) => {
-        logger.error({
-          message: 'Multirespondent submission webhook error',
-          meta: logMeta,
-          error,
-        })
-      })
+      isRetryEnabled: !!form.webhook?.isRetryEnabled,
+      growthbook,
+      logMeta,
+    })
   }
 
   return sendNextStepEmail({
@@ -1183,17 +1334,20 @@ export const updateMultiRespondentFormSubmission = ({
   snapshottedFormDef,
   encryptedPayload,
   logMeta,
+  growthbook,
 }: {
   submissionId: string
   snapshottedFormDef: SnapshottedFormDef
   encryptedPayload: MultirespondentSubmissionDto
   logMeta: CustomLoggerParams['meta']
+  growthbook?: GrowthBook
 }): ResultAsync<
-  IMultirespondentSubmissionSchema & { _id: mongoose.Types.ObjectId },
+  SavedMultirespondentSubmission,
   | AttachmentUploadError
   | SubmissionSaveError
   | SubmissionNotFoundError
   | PossibleDatabaseError
+  | SnapshotWriteError
 > => {
   logMeta = {
     ...logMeta,
@@ -1296,10 +1450,8 @@ export const updateMultiRespondentFormSubmission = ({
             isApproval: false,
           } as SubmittedNonApprovalStep)
 
-      submission.submittedSteps = [
-        ...(submission.submittedSteps ?? []),
-        submittedStepMeta,
-      ]
+      const submissionIndex = submission.submittedSteps?.length ?? 0
+
       submission.responseMetadata = responseMetadata
       submission.submissionPublicKey = submissionPublicKey
       submission.encryptedSubmissionSecretKey = encryptedSubmissionSecretKey
@@ -1312,33 +1464,78 @@ export const updateMultiRespondentFormSubmission = ({
       submission.stepTokenHash = stepTokenHash
       submission.encryptedStepToken = encryptedStepToken
 
-      return ResultAsync.fromPromise(
-        submission.save().then(() => ({ submission, responseMetadata })),
-        (error) => {
-          if (error instanceof mongoose.Error.VersionError) {
-            return transformMongoError(error)
-          }
-          logger.error({
-            message: 'Multirespondent submission save error',
-            meta: logMeta,
-            error,
+      const shouldWriteSnapshot = shouldWriteV4Snapshot({
+        mrfVersion,
+        webhook: snapshottedFormDef.webhook,
+        isMrfWebhooksEnabled:
+          growthbook?.isOn(featureFlags.enableMrfWebhooks) ?? false,
+        isStepWriteTokenEnabled:
+          growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false,
+      })
+
+      const snapshot = shouldWriteSnapshot
+        ? buildV4Snapshot({
+            formId: String(snapshottedFormDef._id),
+            submissionId: String(submission._id),
+            submissionIndex,
+            workflowStep,
+            encryptedContent,
+            encryptedSubmissionSecretKey,
+            verifiedContent,
+            attachmentMetadata: Object.fromEntries(
+              attachmentMetadata ?? new Map(),
+            ),
+            createdAt: submittedStepMeta.submittedAt,
           })
-          return new SubmissionSaveError()
-        },
-      )
+        : undefined
+
+      const writeSnapshotIfNeeded: ResultAsync<undefined, SnapshotWriteError> =
+        snapshot
+          ? writeV4Snapshot(snapshot).map(({ token }) => {
+              submittedStepMeta.snapshotTokens = { v4: token }
+              return undefined
+            })
+          : okAsync(undefined)
+
+      return writeSnapshotIfNeeded.andThen(() => {
+        // NOTE: Append AFTER the token is recorded so the value survives mongoose's
+        // subdocument cast (which copies the plain object into the array).
+        submission.submittedSteps = [
+          ...(submission.submittedSteps ?? []),
+          submittedStepMeta,
+        ]
+
+        return ResultAsync.fromPromise(
+          submission
+            .save()
+            .then(() => ({ submission, responseMetadata, snapshot })),
+          (error) => {
+            if (error instanceof mongoose.Error.VersionError) {
+              return transformMongoError(error)
+            }
+            logger.error({
+              message: 'Multirespondent submission save error',
+              meta: logMeta,
+              error,
+            })
+            return new SubmissionSaveError()
+          },
+        )
+      })
     })
-    .map(({ submission, responseMetadata }) => {
+    .map(({ submission, responseMetadata, snapshot }) => {
       logger.info({
         message: 'Saved submission to MongoDB',
         meta: { ...logMeta, submissionId: submission.id, responseMetadata },
       })
 
-      return submission
+      return { submission, snapshot }
     })
 }
 
 export const performMultiRespondentPostSubmissionUpdateActions = ({
   submission,
+  snapshot,
   submissionId,
   snapshottedFormDef,
   currentStepNumber,
@@ -1348,6 +1545,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
   growthbook,
 }: {
   submission: IMultirespondentSubmissionSchema
+  snapshot?: SubmissionSnapshotV4
   submissionId: string
   snapshottedFormDef: SnapshottedFormDef
   currentStepNumber: number
@@ -1398,24 +1596,14 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
 
   const webhookUrl = snapshottedFormDef.webhook?.url
   if (webhookUrl) {
-    logger.info({
-      message: 'Sending update webhook for multirespondent submission',
-      meta: logMeta,
-    })
-
-    WebhookFactory.sendInitialWebhook(
+    sendMrfInitialWebhookIfEligible({
       submission,
+      snapshot,
       webhookUrl,
-      !!snapshottedFormDef.webhook?.isRetryEnabled,
-    )
-      .andThen(() => okAsync(undefined))
-      .mapErr((error) => {
-        logger.error({
-          message: 'Multirespondent submission webhook error',
-          meta: logMeta,
-          error,
-        })
-      })
+      isRetryEnabled: !!snapshottedFormDef.webhook?.isRetryEnabled,
+      growthbook,
+      logMeta,
+    })
   }
 
   const pdfResult = generatePdfAttachmentIfRequired({

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -826,10 +826,8 @@ export const createMultiRespondentFormSubmission = ({
       const shouldWriteSnapshot = shouldWriteV4Snapshot({
         mrfVersion,
         webhook: form.webhook,
-        isMrfWebhooksEnabled:
-          growthbook?.isOn(featureFlags.enableMrfWebhooks) ?? false,
-        isStepWriteTokenEnabled:
-          growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false,
+        isMrfWebhooksV3GenericEnabled:
+          growthbook?.isOn(featureFlags.mrfWebhooksV3Generic) ?? false,
       })
 
       const saveSubmission = async () => {
@@ -1119,9 +1117,9 @@ const sendMrfInitialWebhookIfEligible = ({
 
   const shouldSend = shouldSendMrfWebhook({
     webhookType,
-    isMrfWebhooksEnabled:
-      growthbook?.isOn(featureFlags.enableMrfWebhooks) ?? false,
-    isStepWriteTokenEnabled,
+    mrfVersion: submission.mrfVersion,
+    isMrfWebhooksV3GenericEnabled:
+      growthbook?.isOn(featureFlags.mrfWebhooksV3Generic) ?? false,
   })
   if (!shouldSend) {
     return
@@ -1467,10 +1465,8 @@ export const updateMultiRespondentFormSubmission = ({
       const shouldWriteSnapshot = shouldWriteV4Snapshot({
         mrfVersion,
         webhook: snapshottedFormDef.webhook,
-        isMrfWebhooksEnabled:
-          growthbook?.isOn(featureFlags.enableMrfWebhooks) ?? false,
-        isStepWriteTokenEnabled:
-          growthbook?.isOn(featureFlags.mrfStepWriteToken) ?? false,
+        isMrfWebhooksV3GenericEnabled:
+          growthbook?.isOn(featureFlags.mrfWebhooksV3Generic) ?? false,
       })
 
       const snapshot = shouldWriteSnapshot

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -686,6 +686,25 @@ export const getMrfCookieName = ({
   return `Mrf_${formId}_${previousSubmissionId}`
 }
 
+export type MrfVersion = 1 | 2
+
+export const getMrfVersion = ({
+  webhookType,
+  isStepWriteTokenEnabled,
+}: {
+  webhookType?: 'zapier' | 'plumber' | 'generic'
+  isStepWriteTokenEnabled: boolean
+}): MrfVersion => {
+  switch (webhookType) {
+    case 'plumber':
+      return isStepWriteTokenEnabled ? 2 : 1
+    case undefined:
+    case 'zapier':
+    case 'generic':
+      return 2
+  }
+}
+
 export const formatSubmittedStepTimestamp = ({
   submittedSteps,
   stepIndex,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -698,10 +698,20 @@ export const getMrfVersion = ({
 }): MrfVersion => {
   switch (webhookType) {
     case 'plumber':
+      // mrf-step-write-token doubles as plumber's v4 release flag: the wire
+      // version follows the stored mrfVersion, so storing V4 is what moves
+      // plumber to v4 payloads. Flag off => stored V3 => v3 wire (legacy).
       return isStepWriteTokenEnabled ? 2 : 1
-    case undefined:
     case 'zapier':
     case 'generic':
+      // Non-plumber consumers only ever understand v3 payloads, and the
+      // server cannot transcode encrypted content, so their rows are always
+      // stored V3 — unconditionally, so the invariant holds across flag
+      // flips mid-workflow (delivery is gated separately by
+      // mrf-webhooks-v3-generic at send time).
+      return 1
+    case undefined:
+      // No webhook consumer: store in the V4 target format.
       return 2
   }
 }

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -32,6 +32,7 @@ import { convertToSignaturePngDataUri } from '../../../utils/convert-vector-arra
 import { validateFieldV4 } from '../../../utils/field-validation'
 import { FieldIdSet } from '../../../utils/logic-adaptor'
 import { startsWithSPCPFieldTitle } from '../../spcp/spcp.util'
+import { WebhookType } from '../../webhook/webhook.service'
 import {
   InvalidWorkflowTypeError,
   ProcessingError,
@@ -692,7 +693,7 @@ export const getMrfVersion = ({
   webhookType,
   isStepWriteTokenEnabled,
 }: {
-  webhookType?: 'zapier' | 'plumber' | 'generic'
+  webhookType?: WebhookType
   isStepWriteTokenEnabled: boolean
 }): MrfVersion => {
   switch (webhookType) {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/initial-send-route-parity.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/initial-send-route-parity.spec.ts
@@ -1,0 +1,221 @@
+// Whether a step got a snapshot is a storage decision, so it must not change
+// what a consumer receives: a snapshot-backed send (reconstructed from the
+// frozen object) and a live-row send (legacy `getWebhookView`) must produce the
+// same wire payload for the same step.
+//
+// Equality is asserted modulo attachment presigned URLs, which `sendWebhook`
+// mints fresh per send, so byte-equality cannot hold on a fixture with
+// attachments. The URL keys and their S3 targets are still compared.
+import dbHandler from '__tests__/unit/backend/helpers/jest-db'
+import axios, { AxiosResponse } from 'axios'
+import { ObjectId } from 'bson'
+import { MULTIRESPONDENT_FORM_SUBMISSION_VERSION } from 'formsg-shared/constants'
+import { SubmissionType, WorkflowType } from 'formsg-shared/types'
+import mongoose from 'mongoose'
+
+import { getMultirespondentSubmissionModel } from 'src/app/models/submission.server.model'
+import * as WebhookValidationModule from 'src/app/modules/webhook/webhook.validation'
+import { IMultirespondentSubmissionSchema, WebhookView } from 'src/types'
+import { WebhookData } from 'src/types/submission'
+
+import { sendWebhook } from '../../../../webhook/webhook.service'
+import { buildV4Snapshot } from '../submission-snapshot.producer'
+import {
+  getWebhookPayloadPolicy,
+  WebhookConsumerType,
+} from '../webhook-payload-policy'
+import { reconstructMrfWebhookData } from '../webhook-reconstruction'
+
+jest.mock('axios')
+const MockAxios = jest.mocked(axios)
+
+jest.mock('src/app/modules/webhook/webhook.validation')
+const MockWebhookValidation = jest.mocked(WebhookValidationModule)
+
+const MOCK_WEBHOOK_URL = 'https://plumber.gov.sg/webhooks/parity'
+
+const MOCK_AXIOS_RESPONSE = {
+  data: { result: 'ok' },
+  status: 200,
+  statusText: 'success',
+  headers: {},
+  config: {},
+} as AxiosResponse
+
+const MultirespondentSubmissionModel =
+  getMultirespondentSubmissionModel(mongoose)
+
+const formId = new ObjectId()
+const fieldId = new ObjectId().toHexString()
+const attachmentFieldId = new ObjectId().toHexString()
+
+const ENCRYPTED_CONTENT = 'v4-encrypted-content'
+const ENCRYPTED_SUBMISSION_SECRET_KEY = 'wrapped-read-key-v4'
+const VERIFIED_CONTENT = 'v4-verified-content'
+const ATTACHMENT_METADATA = {
+  [attachmentFieldId]: `${formId.toHexString()}/attachment-object-key`,
+}
+
+const workflow = [
+  {
+    _id: new ObjectId().toHexString(),
+    workflow_type: WorkflowType.Static,
+    emails: [],
+    edit: [fieldId],
+  },
+  {
+    _id: new ObjectId().toHexString(),
+    workflow_type: WorkflowType.Static,
+    emails: ['next@example.com'],
+    edit: [fieldId],
+  },
+]
+
+/**
+ * Reduces each presigned URL to its path, so an attachment going missing or
+ * pointing somewhere else still fails the comparison. Preserves undefined when
+ * the field is absent so undefined vs {} remains a detectable shape mismatch.
+ */
+const comparablePayload = (data: WebhookData): unknown => {
+  if (data.attachmentDownloadUrls === undefined) {
+    return { ...data }
+  }
+  return {
+    ...data,
+    attachmentDownloadUrls: Object.fromEntries(
+      Object.entries(data.attachmentDownloadUrls).map(([key, url]) => [
+        key,
+        new URL(url).pathname,
+      ]),
+    ),
+  }
+}
+
+const capturePostedPayload = async (
+  submission: IMultirespondentSubmissionSchema,
+  view?: WebhookView,
+): Promise<WebhookData> => {
+  MockAxios.post.mockClear()
+  MockAxios.post.mockResolvedValue(MOCK_AXIOS_RESPONSE)
+
+  const liveView = view ?? (await submission.getWebhookView())
+  const result = await sendWebhook(liveView, MOCK_WEBHOOK_URL)
+  expect(result.isOk()).toBe(true)
+
+  return (MockAxios.post.mock.calls[0][1] as WebhookView).data
+}
+
+describe('[GATE] v4 initial-send route parity', () => {
+  beforeAll(async () => {
+    await dbHandler.connect()
+  })
+  afterEach(async () => {
+    await dbHandler.clearDatabase()
+    jest.clearAllMocks()
+  })
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  beforeEach(() => {
+    MockWebhookValidation.validateWebhookUrl.mockResolvedValue(undefined)
+  })
+
+  const createRow = async (): Promise<IMultirespondentSubmissionSchema> =>
+    await MultirespondentSubmissionModel.create({
+      form: formId,
+      submissionType: SubmissionType.Multirespondent,
+      form_fields: [],
+      form_logics: [],
+      workflow,
+      submissionPublicKey: 'submission-public-key',
+      encryptedSubmissionSecretKey: ENCRYPTED_SUBMISSION_SECRET_KEY,
+      encryptedContent: ENCRYPTED_CONTENT,
+      verifiedContent: VERIFIED_CONTENT,
+      attachmentMetadata: new Map(Object.entries(ATTACHMENT_METADATA)),
+      version: MULTIRESPONDENT_FORM_SUBMISSION_VERSION,
+      workflowStep: 0,
+      mrfVersion: 2,
+      submittedSteps: [
+        {
+          isApproval: false,
+          submittedAt: new Date().toISOString(),
+          snapshotTokens: { v4: 'tok-parity' },
+        },
+      ],
+    })
+
+  const bothRoutes = async (
+    webhookType: WebhookConsumerType = 'plumber',
+  ): Promise<{
+    snapshotBacked: WebhookData
+    liveRow: WebhookData
+  }> => {
+    const submission = await createRow()
+    const submissionIndex = (submission.submittedSteps?.length ?? 1) - 1
+
+    const snapshot = buildV4Snapshot({
+      formId: formId.toHexString(),
+      submissionId: String(submission._id),
+      submissionIndex,
+      workflowStep: submission.workflowStep,
+      encryptedContent: ENCRYPTED_CONTENT,
+      encryptedSubmissionSecretKey: ENCRYPTED_SUBMISSION_SECRET_KEY,
+      verifiedContent: VERIFIED_CONTENT,
+      attachmentMetadata: ATTACHMENT_METADATA,
+      createdAt: submission.submittedSteps?.[submissionIndex]
+        ?.submittedAt as string,
+    })
+    const liveView = await submission.getWebhookView()
+    const snapshotBacked = await capturePostedPayload(submission, {
+      data: reconstructMrfWebhookData({
+        liveData: liveView.data,
+        snapshot,
+        submissionIndex,
+        policy: getWebhookPayloadPolicy({
+          webhookType,
+          isStepWriteTokenEnabled: true,
+          submissionIndex,
+          submittedStepsLength: submission.submittedSteps?.length ?? 0,
+        }),
+      })._unsafeUnwrap(),
+    })
+
+    // Route B — no snapshot for this step, so the live-row view is sent.
+    const liveRow = await capturePostedPayload(submission)
+
+    return { snapshotBacked, liveRow }
+  }
+
+  it.each<WebhookConsumerType>(['plumber', 'generic'])(
+    'produces the same payload whether or not the step was snapshotted (%s)',
+    async (webhookType) => {
+      const { snapshotBacked, liveRow } = await bothRoutes(webhookType)
+
+      expect(comparablePayload(snapshotBacked)).toEqual(
+        comparablePayload(liveRow),
+      )
+    },
+  )
+
+  it.each<WebhookConsumerType>(['plumber', 'generic'])(
+    'derives the wire version from mrfVersion identically on both routes (%s)',
+    async (webhookType) => {
+      const { snapshotBacked, liveRow } = await bothRoutes(webhookType)
+
+      expect(snapshotBacked.version).toBe(4)
+      expect(liveRow.version).toBe(4)
+    },
+  )
+
+  it('ships the read key but never a step token, for either consumer class', async () => {
+    for (const webhookType of ['plumber', 'generic'] as WebhookConsumerType[]) {
+      const { snapshotBacked, liveRow } = await bothRoutes(webhookType)
+
+      for (const payload of [snapshotBacked, liveRow]) {
+        expect(payload.encryptedSubmissionSecretKey).toBeDefined()
+        expect(
+          (payload as unknown as Record<string, unknown>)['encryptedStepToken'],
+        ).toBeUndefined()
+      }
+    }
+  })
+})

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-send-eligibility.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-send-eligibility.spec.ts
@@ -12,95 +12,96 @@ const ZAPIER_URL = 'https://hooks.zapier.com/hooks/catch/1/x'
 describe('shouldSendMrfWebhook', () => {
   it.each<{
     webhookType: WebhookType
-    isMrfWebhooksEnabled: boolean
-    isStepWriteTokenEnabled: boolean
+    mrfVersion: number
+    isMrfWebhooksV3GenericEnabled: boolean
     expected: boolean
   }>([
+    // Plumber is always delivered; its wire cutover lives in getMrfVersion
+    // (mrf-step-write-token decides the stored version, wire follows).
     {
       webhookType: 'plumber',
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: false,
-      expected: true,
-    },
-    {
-      webhookType: 'plumber',
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: true,
+      mrfVersion: 1,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: true,
     },
     {
       webhookType: 'plumber',
-      isMrfWebhooksEnabled: true,
-      isStepWriteTokenEnabled: false,
+      mrfVersion: 1,
+      isMrfWebhooksV3GenericEnabled: true,
       expected: true,
     },
     {
       webhookType: 'plumber',
-      isMrfWebhooksEnabled: true,
-      isStepWriteTokenEnabled: true,
+      mrfVersion: 2,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: true,
     },
     {
+      webhookType: 'plumber',
+      mrfVersion: 2,
+      isMrfWebhooksV3GenericEnabled: true,
+      expected: true,
+    },
+    // Generic: v3-only, behind its own release flag.
+    {
       webhookType: 'generic',
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: false,
+      mrfVersion: 1,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: false,
     },
     {
       webhookType: 'generic',
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: true,
+      mrfVersion: 1,
+      isMrfWebhooksV3GenericEnabled: true,
+      expected: true,
+    },
+    // A V4 row (e.g. written while the form had no webhook URL) must never
+    // reach a v3 consumer, flag or no flag.
+    {
+      webhookType: 'generic',
+      mrfVersion: 2,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: false,
     },
     {
       webhookType: 'generic',
-      isMrfWebhooksEnabled: true,
-      isStepWriteTokenEnabled: false,
+      mrfVersion: 2,
+      isMrfWebhooksV3GenericEnabled: true,
+      expected: false,
+    },
+    // Zapier is treated as generic.
+    {
+      webhookType: 'zapier',
+      mrfVersion: 1,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: false,
     },
     {
-      webhookType: 'generic',
-      isMrfWebhooksEnabled: true,
-      isStepWriteTokenEnabled: true,
+      webhookType: 'zapier',
+      mrfVersion: 1,
+      isMrfWebhooksV3GenericEnabled: true,
       expected: true,
     },
     {
       webhookType: 'zapier',
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: false,
+      mrfVersion: 2,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: false,
     },
     {
       webhookType: 'zapier',
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: true,
+      mrfVersion: 2,
+      isMrfWebhooksV3GenericEnabled: true,
       expected: false,
-    },
-    {
-      webhookType: 'zapier',
-      isMrfWebhooksEnabled: true,
-      isStepWriteTokenEnabled: false,
-      expected: false,
-    },
-    {
-      webhookType: 'zapier',
-      isMrfWebhooksEnabled: true,
-      isStepWriteTokenEnabled: true,
-      expected: true,
     },
   ])(
-    '$webhookType with enable-mrf-webhooks=$isMrfWebhooksEnabled, mrf-step-write-token=$isStepWriteTokenEnabled => $expected',
-    ({
-      webhookType,
-      isMrfWebhooksEnabled,
-      isStepWriteTokenEnabled,
-      expected,
-    }) => {
+    '$webhookType mrfVersion=$mrfVersion with mrf-webhooks-v3-generic=$isMrfWebhooksV3GenericEnabled => $expected',
+    ({ webhookType, mrfVersion, isMrfWebhooksV3GenericEnabled, expected }) => {
       expect(
         shouldSendMrfWebhook({
           webhookType,
-          isMrfWebhooksEnabled,
-          isStepWriteTokenEnabled,
+          mrfVersion,
+          isMrfWebhooksV3GenericEnabled,
         }),
       ).toBe(expected)
     },
@@ -108,109 +109,84 @@ describe('shouldSendMrfWebhook', () => {
 })
 
 describe('shouldWriteV4Snapshot', () => {
-  const bothFlagsOn = {
-    isMrfWebhooksEnabled: true,
-    isStepWriteTokenEnabled: true,
-  }
-
   it.each<{
     name: string
     mrfVersion: number
     webhook?: { url?: string; isRetryEnabled?: boolean }
-    isMrfWebhooksEnabled: boolean
-    isStepWriteTokenEnabled: boolean
+    isMrfWebhooksV3GenericEnabled: boolean
     expected: boolean
   }>([
     {
       name: 'a V3 row never snapshots',
       mrfVersion: 1,
       webhook: { url: PLUMBER_URL, isRetryEnabled: true },
-      ...bothFlagsOn,
+      isMrfWebhooksV3GenericEnabled: true,
       expected: false,
     },
     {
       name: 'no webhook url',
       mrfVersion: 2,
       webhook: undefined,
-      ...bothFlagsOn,
+      isMrfWebhooksV3GenericEnabled: true,
       expected: false,
     },
     {
       name: 'retries disabled',
       mrfVersion: 2,
       webhook: { url: PLUMBER_URL, isRetryEnabled: false },
-      ...bothFlagsOn,
+      isMrfWebhooksV3GenericEnabled: true,
       expected: false,
     },
     {
-      name: 'plumber needs no flags',
+      name: 'plumber V4 snapshots, no flags needed',
       mrfVersion: 2,
       webhook: { url: PLUMBER_URL, isRetryEnabled: true },
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: false,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: true,
     },
     {
-      name: 'generic with no flags is never delivered, so never snapshots',
+      name: 'generic V4 is never delivered, so never snapshots (flag off)',
       mrfVersion: 2,
       webhook: { url: GENERIC_URL, isRetryEnabled: true },
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: false,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: false,
     },
     {
-      name: 'generic with only enable-mrf-webhooks is not delivered',
+      name: 'generic V4 is never delivered, so never snapshots (flag on)',
       mrfVersion: 2,
       webhook: { url: GENERIC_URL, isRetryEnabled: true },
-      isMrfWebhooksEnabled: true,
-      isStepWriteTokenEnabled: false,
+      isMrfWebhooksV3GenericEnabled: true,
       expected: false,
     },
     {
-      name: 'generic with only mrf-step-write-token is not delivered',
-      mrfVersion: 2,
-      webhook: { url: GENERIC_URL, isRetryEnabled: true },
-      isMrfWebhooksEnabled: false,
-      isStepWriteTokenEnabled: true,
-      expected: false,
-    },
-    {
-      name: 'generic with both flags snapshots',
-      mrfVersion: 2,
-      webhook: { url: GENERIC_URL, isRetryEnabled: true },
-      ...bothFlagsOn,
-      expected: true,
-    },
-    {
-      name: 'zapier with only enable-mrf-webhooks is not delivered',
+      name: 'zapier V4 is never delivered, so never snapshots (flag off)',
       mrfVersion: 2,
       webhook: { url: ZAPIER_URL, isRetryEnabled: true },
-      isMrfWebhooksEnabled: true,
-      isStepWriteTokenEnabled: false,
+      isMrfWebhooksV3GenericEnabled: false,
       expected: false,
     },
     {
-      name: 'zapier with both flags snapshots',
+      name: 'zapier V4 is never delivered, so never snapshots (flag on)',
       mrfVersion: 2,
       webhook: { url: ZAPIER_URL, isRetryEnabled: true },
-      ...bothFlagsOn,
-      expected: true,
+      isMrfWebhooksV3GenericEnabled: true,
+      expected: false,
+    },
+    {
+      name: 'a generic V3 row (the delivered non-plumber shape) never snapshots',
+      mrfVersion: 1,
+      webhook: { url: GENERIC_URL, isRetryEnabled: true },
+      isMrfWebhooksV3GenericEnabled: true,
+      expected: false,
     },
   ])(
     '$name',
-    ({
-      mrfVersion,
-      webhook,
-      isMrfWebhooksEnabled,
-      isStepWriteTokenEnabled,
-      expected,
-    }) => {
+    ({ mrfVersion, webhook, isMrfWebhooksV3GenericEnabled, expected }) => {
       expect(
         shouldWriteV4Snapshot({
           mrfVersion,
           webhook,
-          isMrfWebhooksEnabled,
-          isStepWriteTokenEnabled,
+          isMrfWebhooksV3GenericEnabled,
         }),
       ).toBe(expected)
     },

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-send-eligibility.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-send-eligibility.spec.ts
@@ -1,3 +1,5 @@
+import { WebhookType } from 'src/app/modules/webhook/webhook.service'
+
 import {
   shouldSendMrfWebhook,
   shouldWriteV4Snapshot,
@@ -9,7 +11,7 @@ const ZAPIER_URL = 'https://hooks.zapier.com/hooks/catch/1/x'
 
 describe('shouldSendMrfWebhook', () => {
   it.each<{
-    webhookType: 'plumber' | 'generic' | 'zapier'
+    webhookType: WebhookType
     isMrfWebhooksEnabled: boolean
     isStepWriteTokenEnabled: boolean
     expected: boolean

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-payload-policy.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-payload-policy.ts
@@ -1,6 +1,7 @@
 // 'v1' is unused: no policy input yields it, pending the S6 (#9746) rescope.
 export type WebhookContentFormat = 'v1' | 'v3' | 'v4'
 
+// This is not the same as WebhookType, this is the classes of webhook consumers (ie, internal or external)
 export type WebhookConsumerType = 'plumber' | 'generic'
 
 export interface WebhookPayloadPolicyInput {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-send-eligibility.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-send-eligibility.ts
@@ -1,40 +1,56 @@
 import { getWebhookType, WebhookType } from '../../../webhook/webhook.service'
 
+/**
+ * Decides whether an MRF webhook is delivered at all.
+ *
+ * Two independent release flags, one per consumer class:
+ * - Plumber is always delivered. Its v3→v4 wire cutover is governed by
+ *   `mrf-step-write-token` at storage time (see getMrfVersion): the wire
+ *   version follows the stored mrfVersion, so storage and wire are one
+ *   decision for plumber.
+ * - Non-plumber (generic/zapier) consumers are v3-only, gated by
+ *   `mrf-webhooks-v3-generic`. The `mrfVersion !== 2` guard encodes the
+ *   invariant that a v3 consumer can never receive v4-shaped bytes: the
+ *   server cannot transcode client-facing encrypted content, so a V4 row
+ *   (e.g. one written before a webhook URL was configured) is dropped
+ *   rather than delivered in the wrong format.
+ */
 export const shouldSendMrfWebhook = ({
   webhookType,
-  isMrfWebhooksEnabled,
-  isStepWriteTokenEnabled,
+  mrfVersion,
+  isMrfWebhooksV3GenericEnabled,
 }: {
   webhookType: WebhookType
-  isMrfWebhooksEnabled: boolean
-  isStepWriteTokenEnabled: boolean
+  mrfVersion: number
+  isMrfWebhooksV3GenericEnabled: boolean
 }): boolean => {
   switch (webhookType) {
     case 'plumber':
       return true
     case 'zapier':
     case 'generic':
-      return isMrfWebhooksEnabled && isStepWriteTokenEnabled
+      return isMrfWebhooksV3GenericEnabled && mrfVersion !== 2
   }
 }
 
 export const shouldWriteV4Snapshot = ({
   mrfVersion,
   webhook,
-  isMrfWebhooksEnabled,
-  isStepWriteTokenEnabled,
+  isMrfWebhooksV3GenericEnabled,
 }: {
   mrfVersion: number
   webhook?: { url?: string; isRetryEnabled?: boolean }
-  isMrfWebhooksEnabled: boolean
-  isStepWriteTokenEnabled: boolean
+  isMrfWebhooksV3GenericEnabled: boolean
 }): boolean => {
   const url = webhook?.url
   if (mrfVersion !== 2 || !url || !webhook?.isRetryEnabled) return false
 
+  // A snapshot is only useful if the (V4) webhook would actually be
+  // delivered. Non-plumber consumers never receive V4 payloads, so in
+  // practice only plumber V4 rows snapshot.
   return shouldSendMrfWebhook({
     webhookType: getWebhookType(url),
-    isMrfWebhooksEnabled,
-    isStepWriteTokenEnabled,
+    mrfVersion,
+    isMrfWebhooksV3GenericEnabled,
   })
 }

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-send-eligibility.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-send-eligibility.ts
@@ -1,11 +1,11 @@
-import { getWebhookType } from '../../../webhook/webhook.service'
+import { getWebhookType, WebhookType } from '../../../webhook/webhook.service'
 
 export const shouldSendMrfWebhook = ({
   webhookType,
   isMrfWebhooksEnabled,
   isStepWriteTokenEnabled,
 }: {
-  webhookType: 'zapier' | 'plumber' | 'generic'
+  webhookType: WebhookType
   isMrfWebhooksEnabled: boolean
   isStepWriteTokenEnabled: boolean
 }): boolean => {

--- a/apps/backend/src/app/modules/webhook/webhook.service.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.service.ts
@@ -226,7 +226,9 @@ export const sendWebhook = (
   })
 }
 
-export const getWebhookType = (webhookUrl: string) => {
+export type WebhookType = 'zapier' | 'plumber' | 'generic'
+
+export const getWebhookType = (webhookUrl: string): WebhookType => {
   const isZapier = /^https:\/\/hooks\.zapier\.com\//
   const isPlumber = /^https:\/\/plumber\.gov\.sg\/webhooks\//
   const webhookType = isZapier.test(webhookUrl)

--- a/apps/backend/src/app/modules/webhook/webhook.service.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.service.ts
@@ -252,6 +252,7 @@ export const createInitialWebhookSender =
     submission: IEncryptedSubmissionSchema | IMultirespondentSubmissionSchema,
     webhookUrl: string,
     isRetryEnabled: boolean,
+    webhookView?: WebhookView,
   ): ResultAsync<
     true,
     | WebhookValidationError
@@ -261,10 +262,17 @@ export const createInitialWebhookSender =
   > => {
     // Attempt to send webhook
 
-    return ResultAsync.fromPromise(
-      submission.getWebhookView(),
-      () => new DatabaseError(),
-    ).andThen((webhookView) =>
+    // RATIONALE: When a pre-built view is supplied (e.g. an MRF
+    // v4 snapshot-reconstructed payload) use it directly.
+    // Otherwise, derive it from the live row via getWebhookView (legacy path).
+    const webhookViewToUse = webhookView
+      ? okAsync(webhookView)
+      : ResultAsync.fromPromise(
+          submission.getWebhookView(),
+          () => new DatabaseError(),
+        )
+
+    return webhookViewToUse.andThen((webhookView) =>
       sendWebhook(webhookView, webhookUrl).andThen((webhookResponse) => {
         webhookStatsdClient.increment('sent', 1, 1, {
           responseCode: `${webhookResponse.response.status || null}`,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -12,6 +12,11 @@ export const featureFlags = {
   enableIntranetSgidLogin: 'enable-intranet-sgid-login' as const,
   enableMrfWebhooks: 'enable-mrf-webhooks' as const,
   mrfStepWriteToken: 'mrf-step-write-token' as const,
+  // Delivery flag for non-plumber (generic/zapier) MRF webhook consumers,
+  // which only ever receive v3-format payloads. Plumber's v4 release is
+  // governed separately by mrf-step-write-token (storage and wire format are
+  // one decision, since the wire version follows the stored mrfVersion).
+  mrfWebhooksV3Generic: 'mrf-webhooks-v3-generic' as const,
   useFormsgEsrvcId: 'use-formsg-esrvcid' as const,
   lambdaPdfGeneration: 'lambda-pdf-generation' as const,
   enableSaveDraftButtonHeader: 'enable-save-draft-button-header' as const,

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -104,6 +104,7 @@ export type FormSupportedLanguages = {
 export type FormWebhook = {
   url: string
   isRetryEnabled: boolean
+  webhookFormat?: 'v1' | 'v4'
 }
 
 export enum FormResponseMode {


### PR DESCRIPTION
Stacked on #9822 (`feat/9744-mrf-v4-minimal-e2e`).

## Problem

As #9822 leaves the stack, non-plumber (generic/zapier) MRF webhook consumers are in a bad spot:

1. **Silent delivery loss.** With flags off they are never delivered — before this stack, develop delivered MRF webhooks unconditionally whenever a webhook URL existed.
2. **Wrong wire format when enabled.** #9821 stores non-plumber rows as V4 (`mrfVersion: 2`), and the wire version follows the stored `mrfVersion` (#9820). So the only way to turn non-plumber delivery back on (`enable-mrf-webhooks` + `mrf-step-write-token`) would ship **v4-shaped bytes** to consumers that only understand v3. In a mid-stack deploy window they would already have received V4-shaped payloads.
3. **No independent rollout.** The generic gate was coupled to `mrf-step-write-token`, conflating plumber's storage/wire rollout with non-plumber delivery.

## Solution

Give each consumer class its own release flag, and make the wire invariant structural:

- **New flag `mrf-webhooks-v3-generic`** (`featureFlags.mrfWebhooksV3Generic`) gates non-plumber delivery. Flag on → generic/zapier receive well-formed **v3** payloads via the legacy live-row path (initial send and queued retries both derive from the stored V3 row). Flag off → not delivered (unchanged from #9822).
- **Non-plumber rows always store V3.** `getMrfVersion` now returns `1` for generic/zapier unconditionally. Payload format follows from the stored `mrfVersion` (the server encrypts in `encryptSubmission` and cannot transcode afterwards), so storing V3 is what makes the v3 wire possible. Making it unconditional — rather than flag-conditioned — means the invariant holds across flag flips mid-workflow. Rows for forms with **no** webhook URL keep storing V4.
- **`shouldSendMrfWebhook` is now `mrfVersion`-aware.** A V4 row (e.g. created while the form had no webhook URL, then a generic URL was added mid-workflow... or a mid-stack-deploy legacy row) is **dropped, never delivered v4-shaped** to a v3-only consumer, flag or no flag.
- **Plumber's v4 flag is `mrf-step-write-token` (existing).** For plumber, storage format and wire format are a single decision (wire follows `mrfVersion`), so the storage flag *is* the wire flag; a second flag would be a redundant knob that could only introduce impossible states. Flag off → plumber stores V3 and receives v3 (pre-stack behaviour, still delivered). Documented on the flag registry and in `getMrfVersion`.
- `enable-mrf-webhooks` no longer participates in MRF send/snapshot gating (it remains in use by the admin settings frontend).

### Flag matrix

| Consumer | `mrf-step-write-token` | `mrf-webhooks-v3-generic` | Stored `mrfVersion` | Delivered? | Wire version |
|---|---|---|---|---|---|
| plumber | off | – | 1 (V3) | yes | 3 |
| plumber | on | – | 2 (V4) | yes | 4 |
| generic/zapier | – | off | 1 (V3) | no | – |
| generic/zapier | – | on | 1 (V3) | yes | 3 |
| generic/zapier (legacy V4 row¹) | – | on **or** off | 2 (V4) | **no** | – |
| none (no webhook URL) | – | – | 2 (V4) | – | – |

¹ A V4 row can meet a generic consumer only if the row was encrypted under different webhook config (mid-stack deploy window rows, or a generic URL added mid-workflow before the next step re-encrypts). Such steps are dropped rather than delivered in the wrong format; the next submitted step re-stores the row as V3 and delivery resumes.

Snapshot writes compose off the same eligibility function and now reduce to plumber V4 rows only (non-plumber v3 retries use the pre-existing v3 queue machinery and need no S3 snapshot).

## Rollout notes

- The two flags are fully independent; either order works:
  - **Non-plumber v3 restore:** flip `mrf-webhooks-v3-generic` on. Storage is already unconditionally V3 for these consumers from deploy time, so the first flip cleanly resumes v3 delivery. New workflow steps after the flip deliver immediately; steps submitted *while the flag was off* are not retro-delivered (same semantics as #9822's gate).
  - **Plumber v4:** flip `mrf-step-write-token` (unchanged from #9821/#9822 semantics — also enables step-token minting/write-guard).
- Mid-workflow flips are safe in both directions: `encryptSubmission` re-derives `mrfVersion` per step and the update path overwrites the row, so the row converges to the current decision on the next step; the send gate drops (never mis-formats) any row still in the wrong shape.
- S5 retry work: non-plumber v3 rows ride the existing v3 retry queue untouched. The v4 snapshot/retry path (S5) stays plumber-only, which shrinks the S5 surface.

## Limitations / open questions

- **Storage regression for non-plumber forms:** their rows no longer participate in the V4 storage rollout at all (previously #9821 stored them V4). This is deliberate — v3 wire requires v3 storage — but it means these forms only migrate to V4 storage when a future release gives generic consumers a v4 contract (S6 rescope, `webhookFormat` on `FormWebhook` is the inert hook for that).
- Steps submitted while `mrf-webhooks-v3-generic` was off are permanently undelivered (no backfill). Fine for a release flag; worth confirming with the team.
- The legacy-V4-row drop (footnote ¹) trades a one-step delivery gap for format correctness. Alternative (deliver v4 anyway) was rejected: v3 consumers cannot decrypt v4 content.

## Test evidence

- `apps/backend` — all 13 multirespondent-submission suites green: **277 passed** (includes the `[GATE] v4 initial-send route-parity` spec, untouched and green).
- Decision tables rewritten/extended:
  - `webhook-send-eligibility.spec.ts`: full consumer × `mrfVersion` × flag matrix for `shouldSendMrfWebhook` + `shouldWriteV4Snapshot`.
  - `multirespondent-submission.utils.spec.ts`: `getMrfVersion` table (generic/zapier → V3 regardless of flags).
  - `multirespondent-submission.middleware.spec.ts`: storage gate — generic/zapier encrypt V3 either way; new test that the delivery flag never influences storage.
  - `multirespondent-submission.service.spec.ts`: send-gate table (plumber/generic/zapier × mrfVersion × flag), generic V3 legacy-path routing, "never sends a V4 row to a generic consumer" invariant (subsumes the step-token leak check), generic V4 never snapshots.
- `tsc --noEmit` clean on `apps/backend`; eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
