### PR TITLE
feat: force refresh modal when backend crosses a major version

### DIFF
--- a/apps/backend/src/app/modules/frontend/frontend.service.ts
+++ b/apps/backend/src/app/modules/frontend/frontend.service.ts
@@ -1,5 +1,7 @@
 import { GrowthBook } from '@growthbook/growthbook'
 import { ClientEnvVars, FrontendRuntimeEnv } from 'formsg-shared/types/core'
+import { readFileSync } from 'fs'
+import path from 'path'
 
 import config from '../../config/config'
 import { captchaConfig } from '../../config/features/captcha.config'
@@ -11,6 +13,24 @@ import {
 import { paymentConfig } from '../../config/features/payment.config'
 import { spcpMyInfoConfig } from '../../config/features/spcp-myinfo.config'
 import { turnstileConfig } from '../../config/features/turnstile.config'
+
+// Version of the deployed backend, read once at startup from the backend's
+// own package.json. Resolved relative to cwd (apps/backend), matching how the
+// controller resolves the frontend dist; present in both dev and the
+// production image (see Dockerfile.production). The frontend compares this
+// against the version baked into its bundle to detect stale bundles after a
+// deploy.
+const readAppVersion = (): string => {
+  try {
+    const { version } = JSON.parse(
+      readFileSync(path.resolve('package.json'), { encoding: 'utf8' }),
+    ) as { version?: string }
+    return version ?? ''
+  } catch {
+    return ''
+  }
+}
+export const appVersion = readAppVersion()
 
 export const getFrontendRuntimeEnv = (
   growthbook?: GrowthBook,
@@ -54,6 +74,9 @@ export const getEnvScriptHtml = ({
 
 export const getClientEnvVars = (): ClientEnvVars => {
   return {
+    // Used by the frontend to detect when its loaded bundle is a breaking
+    // (major) version behind the deployed backend, and prompt a refresh.
+    appVersion,
     isGeneralMaintenance: config.isGeneralMaintenance,
     isLoginBanner: config.isLoginBanner,
     siteBannerContent: config.siteBannerContent,

--- a/apps/frontend/src/app/PrivateElement.tsx
+++ b/apps/frontend/src/app/PrivateElement.tsx
@@ -3,6 +3,8 @@ import { Navigate, NavigateProps, useLocation } from 'react-router-dom'
 import { useAuth } from '~contexts/AuthContext'
 import { LOGIN_ROUTE } from '~constants/routes'
 
+import { ForceRefreshModal } from '~features/version-check/ForceRefreshModal'
+
 interface PrivateElementProps {
   /**
    * Route to redirect to when user is not authenticated. Defaults to
@@ -21,7 +23,12 @@ export const PrivateElement = ({
   const { isAuthenticated } = useAuth()
 
   return isAuthenticated ? (
-    element
+    <>
+      {element}
+      {/* Mounted on authenticated admin routes only: forcing a refresh must
+      never interrupt an in-progress public form submission. */}
+      <ForceRefreshModal />
+    </>
   ) : (
     <Navigate replace to={redirectTo} state={{ from: location }} />
   )

--- a/apps/frontend/src/features/version-check/ForceRefreshModal.stories.tsx
+++ b/apps/frontend/src/features/version-check/ForceRefreshModal.stories.tsx
@@ -1,0 +1,50 @@
+import { Meta, StoryFn } from '@storybook/react'
+import { http, HttpResponse } from 'msw'
+
+import { ClientEnvVars } from 'formsg-shared/types/core'
+
+import { fullScreenDecorator } from '~utils/storybook'
+
+import { ForceRefreshModal } from './ForceRefreshModal'
+
+const mockEnvWithVersion = (appVersion: string) => [
+  http.get<never, never, Partial<ClientEnvVars>>('/api/v3/client/env', () =>
+    HttpResponse.json({ appVersion }),
+  ),
+]
+
+export default {
+  title: 'Features/VersionCheck/ForceRefreshModal',
+  component: ForceRefreshModal,
+  decorators: [fullScreenDecorator],
+  parameters: {
+    layout: 'fullscreen',
+    // Prevent flaky tests due to modal animating in.
+    chromatic: { pauseAnimationAtEnd: true },
+  },
+} as Meta<typeof ForceRefreshModal>
+
+const Template: StoryFn<typeof ForceRefreshModal> = (args) => (
+  <ForceRefreshModal {...args} />
+)
+
+/** Backend has crossed a major version boundary: modal is shown. */
+export const BreakingChange = Template.bind({})
+BreakingChange.args = { clientVersion: '9.6.1-develop-abc12345' }
+BreakingChange.parameters = {
+  msw: { handlers: { env: mockEnvWithVersion('10.0.0') } },
+}
+
+/** Backend is newer but within the same major: nothing is rendered. */
+export const NonBreakingChange = Template.bind({})
+NonBreakingChange.args = { clientVersion: '9.6.1' }
+NonBreakingChange.parameters = {
+  msw: { handlers: { env: mockEnvWithVersion('9.7.0') } },
+}
+
+/** Local dev / unknown bundle version: nothing is rendered. */
+export const UnknownClientVersion = Template.bind({})
+UnknownClientVersion.args = { clientVersion: '' }
+UnknownClientVersion.parameters = {
+  msw: { handlers: { env: mockEnvWithVersion('10.0.0') } },
+}

--- a/apps/frontend/src/features/version-check/ForceRefreshModal.test.tsx
+++ b/apps/frontend/src/features/version-check/ForceRefreshModal.test.tsx
@@ -1,0 +1,66 @@
+import { composeStories } from '@storybook/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import i18n from '~/i18n/setupI18nTests'
+
+import * as stories from './ForceRefreshModal.stories'
+
+const { BreakingChange, NonBreakingChange, UnknownClientVersion } =
+  composeStories(stories)
+
+// i18next's untyped `t` returns `TFunctionResult`; coerce for testing-library
+// matchers.
+const tr = (key: string): string => String(i18n.t(key))
+
+describe('ForceRefreshModal', () => {
+  it('should show a non-dismissible modal when the backend is a breaking version away', async () => {
+    // Arrange
+    const onRefresh = vi.fn()
+    render(<BreakingChange onRefresh={onRefresh} />)
+
+    // Assert: modal appears once the version query resolves.
+    const refreshButton = await screen.findByRole('button', {
+      name: tr('features.app.forceRefreshModal.refreshButton'),
+    })
+    expect(
+      screen.getByText(tr('features.app.forceRefreshModal.title')),
+    ).toBeInTheDocument()
+    // No close button is rendered.
+    expect(screen.queryByRole('button', { name: /close/i })).toBeNull()
+
+    // Act: escape does not dismiss the modal.
+    await userEvent.keyboard('{Escape}')
+    expect(
+      screen.getByText(tr('features.app.forceRefreshModal.title')),
+    ).toBeInTheDocument()
+
+    // Act: clicking refresh triggers the reload handler.
+    await userEvent.click(refreshButton)
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('should render nothing for a non-breaking newer backend version', async () => {
+    // Arrange
+    render(<NonBreakingChange />)
+
+    // Assert: query resolves without the modal ever appearing.
+    await waitFor(() =>
+      expect(
+        screen.queryByText(tr('features.app.forceRefreshModal.title')),
+      ).toBeNull(),
+    )
+  })
+
+  it('should render nothing when the bundle version is unknown (local dev)', async () => {
+    // Arrange
+    render(<UnknownClientVersion />)
+
+    // Assert
+    await waitFor(() =>
+      expect(
+        screen.queryByText(tr('features.app.forceRefreshModal.title')),
+      ).toBeNull(),
+    )
+  })
+})

--- a/apps/frontend/src/features/version-check/ForceRefreshModal.tsx
+++ b/apps/frontend/src/features/version-check/ForceRefreshModal.tsx
@@ -1,0 +1,79 @@
+import { useTranslation } from 'react-i18next'
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from '@chakra-ui/react'
+
+import { isBreakingVersionChange } from 'formsg-shared/utils/version'
+
+import { useIsMobile } from '~hooks/useIsMobile'
+import Button from '~components/Button'
+
+import { getBundleVersion, useServerAppVersion } from './queries'
+
+export interface ForceRefreshModalProps {
+  /**
+   * Version of the loaded frontend bundle. Injectable for tests and stories;
+   * defaults to the version baked in at build time.
+   */
+  clientVersion?: string
+  /**
+   * Called when the user clicks the refresh button. Injectable for tests;
+   * defaults to a full page reload, which fetches the new bundle.
+   */
+  onRefresh?: () => void
+}
+
+/**
+ * Non-dismissible modal shown when the deployed backend is a breaking
+ * (major) version away from the loaded frontend bundle. The only way out is
+ * to refresh, which loads the bundle matching the current backend.
+ *
+ * Mounted only on authenticated admin routes (see PrivateElement) so an
+ * in-progress public form submission is never interrupted.
+ */
+export const ForceRefreshModal = ({
+  clientVersion = getBundleVersion(),
+  onRefresh = () => window.location.reload(),
+}: ForceRefreshModalProps): JSX.Element | null => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'features.app.forceRefreshModal',
+  })
+  const isMobile = useIsMobile()
+  const serverVersion = useServerAppVersion()
+
+  const isOpen = isBreakingVersionChange(clientVersion, serverVersion)
+  if (!isOpen) return null
+
+  return (
+    <Modal
+      isOpen
+      // Modal is intentionally not dismissible: the loaded bundle can no
+      // longer be assumed compatible with the deployed backend.
+      onClose={() => undefined}
+      closeOnOverlayClick={false}
+      closeOnEsc={false}
+      size={isMobile ? 'mobile' : undefined}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{t('title')}</ModalHeader>
+        <ModalBody>
+          <Text textStyle="body-2" color="secondary.500">
+            {t('body')}
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button isFullWidth={isMobile} onClick={onRefresh}>
+            {t('refreshButton')}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/frontend/src/features/version-check/queries.ts
+++ b/apps/frontend/src/features/version-check/queries.ts
@@ -1,0 +1,39 @@
+import { useQuery } from 'react-query'
+
+import { getClientEnvVars } from '~features/env/EnvService'
+
+const versionCheckKeys = {
+  base: ['version-check'] as const,
+}
+
+/**
+ * How often to poll the backend for its deployed version. Deploys are
+ * infrequent relative to this, and the env endpoint is a cheap static
+ * payload, so a modest interval keeps detection latency low without
+ * meaningful load.
+ */
+export const VERSION_CHECK_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
+
+/**
+ * Version string baked into the frontend bundle at build time
+ * (see Dockerfile.production and vite.config.ts). Empty in local dev,
+ * in which case version comparisons are skipped entirely.
+ */
+export const getBundleVersion = (): string =>
+  import.meta.env.VITE_APP_VERSION ?? ''
+
+/**
+ * Polls the backend's env endpoint for the currently deployed backend
+ * version. Also refetches on window focus so long-lived background tabs
+ * catch up as soon as the user returns.
+ * @returns the deployed backend version, or `undefined` while loading or if
+ * the backend predates the `appVersion` field.
+ */
+export const useServerAppVersion = (): string | undefined => {
+  const { data } = useQuery(versionCheckKeys.base, getClientEnvVars, {
+    refetchInterval: VERSION_CHECK_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+  })
+  return data?.appVersion
+}

--- a/apps/frontend/src/i18n/locales/features/app/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/app/en-sg.ts
@@ -23,4 +23,9 @@ export const enSG: App = {
       transferAllForms: 'Transfer all forms',
     },
   },
+  forceRefreshModal: {
+    title: 'Form has been updated',
+    body: 'A new version of Form has been released, and the page you have open is no longer compatible. Refresh the page to continue.',
+    refreshButton: 'Refresh',
+  },
 }

--- a/apps/frontend/src/i18n/locales/features/app/index.ts
+++ b/apps/frontend/src/i18n/locales/features/app/index.ts
@@ -23,4 +23,9 @@ export interface App {
       transferAllForms: string
     }
   }
+  forceRefreshModal: {
+    title: string
+    body: string
+    refreshButton: string
+  }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -199,6 +199,10 @@
       "require": "./dist/utils/verified-content.js",
       "default": "./utils/verified-content.ts"
     },
+    "./utils/version": {
+      "require": "./dist/utils/version.js",
+      "default": "./utils/version.ts"
+    },
     "./modules/logic": {
       "require": "./dist/modules/logic/index.js",
       "default": "./modules/logic/index.ts"

--- a/packages/shared/types/core.ts
+++ b/packages/shared/types/core.ts
@@ -27,6 +27,10 @@ export interface PrivateFormErrorDto extends ErrorDto {
 
 // List of env vars expected from the server that client uses
 export type ClientEnvVars = {
+  // Version of the currently deployed backend (from its package.json).
+  // Optional so older backends that predate this field keep typechecking;
+  // consumers must treat absence as "unknown" and skip version comparisons.
+  appVersion?: string
   isGeneralMaintenance: string
   isLoginBanner: string
   siteBannerContent: string

--- a/packages/shared/utils/__tests__/version.spec.ts
+++ b/packages/shared/utils/__tests__/version.spec.ts
@@ -1,0 +1,64 @@
+import { isBreakingVersionChange, parseMajorVersion } from '../version'
+
+describe('parseMajorVersion', () => {
+  it('should parse a clean semver string', () => {
+    expect(parseMajorVersion('9.6.1')).toEqual(9)
+    expect(parseMajorVersion('10.0.0')).toEqual(10)
+  })
+
+  it('should parse CI-style version strings with build suffixes', () => {
+    // CI builds APP_VERSION as `<package.json version>-<branch>-<short sha>`.
+    expect(parseMajorVersion('9.6.1-develop-abc12345')).toEqual(9)
+    expect(parseMajorVersion('10.0.0-release-al2023-deadbeef')).toEqual(10)
+  })
+
+  it('should parse versions with a leading v', () => {
+    expect(parseMajorVersion('v9.6.1')).toEqual(9)
+  })
+
+  it('should tolerate surrounding whitespace', () => {
+    expect(parseMajorVersion(' 9.6.1 ')).toEqual(9)
+  })
+
+  it('should return null for missing or empty versions', () => {
+    expect(parseMajorVersion('')).toBeNull()
+    expect(parseMajorVersion(null)).toBeNull()
+    expect(parseMajorVersion(undefined)).toBeNull()
+  })
+
+  it('should return null for non-semver strings', () => {
+    expect(parseMajorVersion('develop')).toBeNull()
+    expect(parseMajorVersion('9.6')).toBeNull()
+    expect(parseMajorVersion('abc-9.6.1')).toBeNull()
+  })
+})
+
+describe('isBreakingVersionChange', () => {
+  it('should return false when versions share the same major', () => {
+    expect(isBreakingVersionChange('9.6.1', '9.6.1')).toEqual(false)
+    expect(isBreakingVersionChange('9.6.1', '9.7.0')).toEqual(false)
+    expect(isBreakingVersionChange('9.6.1', '9.6.2')).toEqual(false)
+    expect(isBreakingVersionChange('9.6.1-develop-abc12345', '9.7.0')).toEqual(
+      false,
+    )
+  })
+
+  it('should return true when the server major is ahead of the client', () => {
+    expect(isBreakingVersionChange('9.6.1', '10.0.0')).toEqual(true)
+    expect(isBreakingVersionChange('9.6.1-develop-abc12345', '10.0.0')).toEqual(
+      true,
+    )
+  })
+
+  it('should return true when the server major is behind the client (rollback)', () => {
+    expect(isBreakingVersionChange('10.0.0', '9.6.1')).toEqual(true)
+  })
+
+  it('should fail open when either version is unknown', () => {
+    expect(isBreakingVersionChange('', '10.0.0')).toEqual(false)
+    expect(isBreakingVersionChange(undefined, '10.0.0')).toEqual(false)
+    expect(isBreakingVersionChange('9.6.1', '')).toEqual(false)
+    expect(isBreakingVersionChange('9.6.1', undefined)).toEqual(false)
+    expect(isBreakingVersionChange('develop', '10.0.0')).toEqual(false)
+  })
+})

--- a/packages/shared/utils/version.ts
+++ b/packages/shared/utils/version.ts
@@ -1,0 +1,45 @@
+/**
+ * Utilities for comparing the version of the loaded frontend bundle against
+ * the version reported by the deployed backend.
+ *
+ * Deployed version strings are not always clean semver — CI builds versions
+ * like `9.6.1-develop-abc12345` (package.json version + branch + short sha) —
+ * so parsing only relies on the leading `major.minor.patch` prefix.
+ */
+const SEMVER_PREFIX_REGEX = /^v?(\d+)\.(\d+)\.(\d+)/
+
+/**
+ * Extracts the major version number from a version string.
+ * @returns the major version, or `null` if the string does not start with a
+ * `major.minor.patch` prefix (e.g. empty string in local dev builds).
+ */
+export const parseMajorVersion = (
+  version: string | null | undefined,
+): number | null => {
+  if (!version) return null
+  const match = SEMVER_PREFIX_REGEX.exec(version.trim())
+  if (!match) return null
+  return Number(match[1])
+}
+
+/**
+ * Whether the frontend bundle and the deployed backend differ by a breaking
+ * change, i.e. their semver major versions differ.
+ *
+ * A mismatch in either direction is breaking: refreshing always loads the
+ * bundle the current backend serves, so both a backend upgrade past a major
+ * boundary and a backend rollback across one are fixed by a refresh.
+ *
+ * Returns `false` when either version cannot be parsed (e.g. local dev where
+ * the bundle version is not injected) so the check fails open — no refresh
+ * prompt is ever shown on unknown versions.
+ */
+export const isBreakingVersionChange = (
+  clientVersion: string | null | undefined,
+  serverVersion: string | null | undefined,
+): boolean => {
+  const clientMajor = parseMajorVersion(clientVersion)
+  const serverMajor = parseMajorVersion(serverVersion)
+  if (clientMajor === null || serverMajor === null) return false
+  return clientMajor !== serverMajor
+}


### PR DESCRIPTION
## Problem

Admins keep FormSG tabs open for days. After a deploy, those tabs keep running the old frontend bundle; if the deploy crossed a breaking-change boundary, the stale bundle can silently misbehave against the new backend until the user happens to refresh.

## Solution

- **Backend reports its version.** `GET /api/v3/client/env` (the existing client-bootstrap endpoint) now includes `appVersion`, read once at startup from the backend's own `package.json` — the same file the `chore: bump version` release flow bumps in lockstep with the frontend. The `ClientEnvVars` field is optional so older backends keep typechecking.
- **Frontend knows its bundle version.** `VITE_APP_VERSION` is already baked into the bundle at build time (Dockerfile.production / deploy-ecs.yml, e.g. `9.6.1-develop-abc12345`); parsing keys off the leading `major.minor.patch` prefix only.
- **Polling.** A dedicated react-query hook polls `/client/env` every 5 minutes and refetches on window focus, so long-lived background tabs catch up as soon as the user returns.
- **Comparison rule.** Breaking = semver **major mismatch** (either direction — a rollback across a major also leaves the bundle incompatible, and a refresh fixes both cases). Comparison fails open when either version is unknown, so local dev and old backends can never trigger the modal.
- **Modal.** Non-dismissible (no close button, no overlay/esc close) with a single **Refresh** button calling `window.location.reload()`. Mounted via `PrivateElement`, so it renders on authenticated admin routes only — a forced refresh must never destroy an in-progress public form submission; respondents pick up the new bundle on their next page load, and cross-major breakage mid-submission surfaces through existing submission error paths.

### Alternatives considered

- **New `/client/version` endpoint**: rejected — more surface area for one string; the env endpoint is already the channel for what the backend tells the client about itself.
- **`window.__ENV__` inline script**: rejected — snapshotted at page load, so it can never observe a *newer* backend without the very refresh we're trying to prompt.
- **Backend-driven `minimumSupportedVersion` field**: rejected — cleaner in theory, but it adds an operational step a human must remember on every breaking release; semver majors already encode the signal and are bumped mechanically by the release flow.
- **Prompt on any newer version**: rejected — minor/patch deploys ship several times a week; nagging on every deploy trains admins to ignore the modal.
- **Threading the version through convict config**: rejected — convict is for operator-tunable env vars; a build-artifact constant does not belong there.

## Tests

- `packages/shared/utils/__tests__/version.spec.ts` — 10 unit tests for prefix parsing (CI-style suffixes, leading `v`, whitespace, unparseable) and the breaking-change rule (same-major, ahead, rollback, fail-open).
- `apps/frontend/src/features/version-check/ForceRefreshModal.test.tsx` — storybook-composed component tests: modal shows on major mismatch, has no close button, ignores Escape, fires the refresh handler; renders nothing for non-breaking versions and unknown bundle versions.
- Typecheck clean: frontend `tsc --noEmit`, backend `tsc --noEmit -p tsconfig.build.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)