### PR TITLE
fix: gate Form ID in admin notification JSON under formid-json feature flag

### DIFF
--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -297,6 +297,10 @@ export const performEncryptPostSubmissionActions = ({
           false,
         ) ?? false
 
+      // TODO (formid-json): remove when Form ID in response JSON is GA
+      const includeFormIdInResponseJson: boolean =
+        growthbook?.getFeatureValue(featureFlags.formIdJson, false) ?? false
+
       return pdfAttachmentResult.andThen((pdfAttachment) => {
         return ResultAsync.combine([
           MailService.sendSubmissionToAdmin({
@@ -318,6 +322,7 @@ export const performEncryptPostSubmissionActions = ({
               ? pdfAttachment
               : undefined,
             useStandardisedEmailTemplate,
+            includeFormIdInResponseJson,
           }).mapErr((error) => {
             logger.error({
               message:

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1,5 +1,6 @@
 import { GrowthBook } from '@growthbook/growthbook'
 import type { FieldResponsesV4 } from '@opengovsg/formsg-sdk'
+import { featureFlags } from 'formsg-shared/constants/feature-flags'
 import {
   BasicField,
   FormAuthType,
@@ -442,6 +443,7 @@ const sendMrfOutcomeEmails = ({
   isRejected = false,
   attachments,
   pdfResult,
+  growthbook,
 }: {
   currentStepNumber: number
   form: Pick<
@@ -466,6 +468,7 @@ const sendMrfOutcomeEmails = ({
     Mail.Attachment | undefined,
     AutoreplyPdfGenerationError
   >
+  growthbook?: GrowthBook
 }): ResultAsync<
   true,
   InvalidWorkflowTypeError | MailSendError | AutoreplyPdfGenerationError
@@ -519,10 +522,14 @@ const sendMrfOutcomeEmails = ({
           responses,
         })
 
+        // TODO (formid-json): remove when Form ID in response JSON is GA
+        const includeFormIdInResponseJson: boolean =
+          growthbook?.getFeatureValue(featureFlags.formIdJson, false) ?? false
+
         const responseJson = buildMrfResponseJson({
           formFields: form.form_fields,
           responses,
-          formId: String(form._id),
+          formId: includeFormIdInResponseJson ? String(form._id) : undefined,
           responseId: submissionId,
           timestamp: latestSubmissionTimestamp,
           delimiter: getFormDelimiter(form.metadata),
@@ -1167,6 +1174,7 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
         submissionId,
         attachments,
         pdfResult: sendMrfOutcomeEmailsPdfResult,
+        growthbook,
       })
     })
     .mapErr((error) => {
@@ -1486,6 +1494,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
       isRejected: true,
       attachments: attachments,
       pdfResult: sendMrfOutcomeEmailsPdfResult,
+      growthbook,
     }).mapErr((error) => {
       logger.error({
         message: 'Send mrf outcome email error',
@@ -1504,6 +1513,7 @@ export const performMultiRespondentPostSubmissionUpdateActions = ({
     isApproval: checkIsFormApproval(snapshottedFormDef),
     attachments: attachments,
     pdfResult: sendMrfOutcomeEmailsPdfResult,
+    growthbook,
   })
     .mapErr((error) => {
       logger.error({

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.utils.ts
@@ -564,13 +564,13 @@ export const buildMrfResponseJson = ({
 }: {
   formFields: FormFieldSchema[] | FormFieldDto[]
   responses: FieldResponsesV4
-  formId: string
+  formId?: string
   responseId: string
   timestamp: string
   delimiter?: string
 }): string => {
   const entries: { question: string; answer: string }[] = [
-    { question: 'Form ID', answer: formId },
+    ...(formId !== undefined ? [{ question: 'Form ID', answer: formId }] : []),
     { question: 'Response ID', answer: responseId },
     { question: 'Timestamp', answer: timestamp },
   ]

--- a/apps/backend/src/app/services/mail/__tests__/mail.service.spec.ts
+++ b/apps/backend/src/app/services/mail/__tests__/mail.service.spec.ts
@@ -388,6 +388,7 @@ describe('mail.service', () => {
         },
       ],
       formData: [],
+      includeFormIdInResponseJson: true,
     }
 
     const FORMATTED_SUBMISSION_TIME = moment(
@@ -396,7 +397,8 @@ describe('mail.service', () => {
       .tz('Asia/Singapore')
       .format('ddd, DD MMM YYYY hh:mm:ss A')
 
-    // Should include the metadata in the front, with the form ID first.
+    // Should include the metadata in the front, with the form ID first
+    // since includeFormIdInResponseJson is enabled in the mock params.
     const EXPECTED_JSON_DATA = [
       {
         question: 'Form ID',

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -771,6 +771,7 @@ export class MailService {
     formData,
     pdfAttachment,
     useStandardisedEmailTemplate,
+    includeFormIdInResponseJson,
   }: {
     replyToEmails?: string[]
     form: Pick<IFormHasEmailSchema, '_id' | 'title' | 'emails'>
@@ -783,6 +784,7 @@ export class MailService {
     }[]
     pdfAttachment?: Mail.Attachment
     useStandardisedEmailTemplate?: boolean
+    includeFormIdInResponseJson?: boolean
   }): ResultAsync<true, MailGenerationError | MailSendError> => {
     const logMeta = {
       action: 'sendSubmissionToAdmin',
@@ -828,10 +830,14 @@ export class MailService {
         // Surface the form ID first so admins feeding this JSON through an
         // automation can tell which form a response came from. Form ID is the
         // stable identifier automations should route on.
-        {
-          question: 'Form ID',
-          answer: formId,
-        },
+        ...(includeFormIdInResponseJson
+          ? [
+              {
+                question: 'Form ID',
+                answer: formId,
+              },
+            ]
+          : []),
         {
           question: 'Response ID',
           answer: refNo,

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -34,6 +34,7 @@ export const featureFlags = {
   sidebarNavLabels: 'enable-sidebar-nav-labels' as const,
   fiveStarAdminRating: '5star-admin-rating' as const,
   workflowBuilderRedesign: 'workflow-builder-redesign' as const,
+  formIdJson: 'formid-json' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {


### PR DESCRIPTION
## Problem

#9732 added a `{ "question": "Form ID", "answer": "<formId>" }` entry as the first element of the admin notification response JSON (storage-mode admin emails, and MRF workflow-completion/approval emails). This changed the shape of JSON that agencies may already be parsing through automations, and it shipped unconditionally — there is no way to roll it out gradually or roll it back without a deploy.

## Solution

Gate the Form ID entry behind a new GrowthBook feature flag `formid-json` (default **off**, preserving pre-#9732 output until enabled):

- **Shared constants**: added `formIdJson: 'formid-json'` to `featureFlags`.
- **Storage mode**: `encrypt-submission.service.ts` resolves the flag from GrowthBook and passes a new optional `includeFormIdInResponseJson` boolean to `MailService.sendSubmissionToAdmin`, mirroring the existing `useStandardisedEmailTemplate` threading pattern. The Form ID entry is only prepended when true.
- **MRF**: `sendMrfOutcomeEmails` now receives `growthbook` from its three call sites (already in scope in both post-submission create/update actions) and resolves the flag itself. `buildMrfResponseJson`'s `formId` param is now optional — the entry is only emitted when provided.

Existing unit tests now exercise the flag-on path (mock params opt in via `includeFormIdInResponseJson: true` / `formId` in `BASE_ARGS`); flag-off is the pre-#9732 behaviour those suites covered before.

**Breaking Changes**
- No — this PR is backwards compatible. With the flag off (default), admin notification JSON reverts to its pre-#9732 shape (`Response ID` first). Enabling `formid-json` in GrowthBook restores the Form ID-first behaviour.

## Tests

TC1: Storage-mode admin notification with flag OFF (default)
- [ ] Ensure `formid-json` is disabled in GrowthBook
- [ ] Submit a response to a storage-mode form with email notifications enabled
- [ ] Verify that the response JSON in the admin email starts with `Response ID` and contains no `Form ID` entry

TC2: Storage-mode admin notification with flag ON
- [ ] Enable `formid-json` in GrowthBook
- [ ] Submit a response to the same storage-mode form
- [ ] Verify that the response JSON's first entry is `{ "question": "Form ID", "answer": "<form id>" }`, followed by `Response ID` and `Timestamp`

TC3: MRF workflow-completion / approval email with flag OFF
- [ ] Ensure `formid-json` is disabled in GrowthBook
- [ ] Complete an MRF workflow (and separately an approval step) with outcome notifications configured
- [ ] Verify that the response JSON in the outcome email starts with `Response ID` and contains no `Form ID` entry

TC4: MRF workflow-completion / approval email with flag ON
- [ ] Enable `formid-json` in GrowthBook
- [ ] Complete the same MRF workflow
- [ ] Verify that the response JSON's first entry is `Form ID`, followed by `Response ID` and `Timestamp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)