### PR TITLE
fix(frontend): reload once on chunk preload failure

### DIFF
--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -16,7 +16,7 @@ import { AppHelmet } from './AppHelmet'
 import { AppRouter } from './AppRouter'
 
 // Create a client
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 60 * 1000, // 60 seconds,

--- a/apps/frontend/src/app/chunkPreloadError.test.ts
+++ b/apps/frontend/src/app/chunkPreloadError.test.ts
@@ -1,0 +1,199 @@
+import { QueryClient } from 'react-query'
+import { datadogLogs } from '@datadog/browser-logs'
+
+import {
+  isPublicFormPathname,
+  registerChunkPreloadErrorHandler,
+} from './chunkPreloadError'
+
+vi.mock('@datadog/browser-logs', () => ({
+  datadogLogs: { logger: { error: vi.fn() } },
+}))
+
+const MOCK_FORM_ID = '61540ece3d4a6e50ac0cc6ff'
+
+const mockLoggerError = datadogLogs.logger.error as unknown as ReturnType<
+  typeof vi.fn
+>
+
+const mockReload = vi.fn()
+
+const setPathname = (pathname: string) => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { pathname, reload: mockReload },
+  })
+}
+
+/** Dispatches a preload error at the registered handler, returning the event. */
+const dispatchPreloadError = () => {
+  const event = new Event('vite:preloadError', {
+    cancelable: true,
+  }) as VitePreloadErrorEvent
+  event.payload = new Error(
+    'Failed to fetch dynamically imported module: /assets/index-abc.js',
+  )
+  window.dispatchEvent(event)
+  return event
+}
+
+describe('chunkPreloadError', () => {
+  let queryClient: QueryClient
+  let unregister: (() => void) | undefined
+
+  /**
+   * Registers exactly one handler for the current test. The unregister call in
+   * afterEach is load-bearing: listeners are added to the jsdom window shared by
+   * every test in this file, so leaking one leaves a handler holding a stale
+   * queryClient that reloads in later tests.
+   */
+  const register = () => {
+    unregister = registerChunkPreloadErrorHandler(queryClient)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.sessionStorage.clear()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-13T00:00:00Z'))
+    setPathname('/dashboard')
+    queryClient = new QueryClient()
+  })
+
+  afterEach(() => {
+    unregister?.()
+    unregister = undefined
+    vi.useRealTimers()
+  })
+
+  describe('isPublicFormPathname', () => {
+    it('should match a bare public form route', () => {
+      expect(isPublicFormPathname(`/${MOCK_FORM_ID}`)).toBe(true)
+    })
+
+    it('should match a public form subroute', () => {
+      expect(isPublicFormPathname(`/${MOCK_FORM_ID}/payment/abc`)).toBe(true)
+    })
+
+    it('should not match admin routes containing a form id', () => {
+      expect(isPublicFormPathname(`/admin/form/${MOCK_FORM_ID}`)).toBe(false)
+    })
+
+    it('should not match non-form routes', () => {
+      expect(isPublicFormPathname('/dashboard')).toBe(false)
+      expect(isPublicFormPathname('/')).toBe(false)
+    })
+  })
+
+  describe('registerChunkPreloadErrorHandler', () => {
+    it('should reload and suppress the rethrow on first failure', () => {
+      register()
+
+      const event = dispatchPreloadError()
+
+      expect(mockReload).toHaveBeenCalledTimes(1)
+      expect(event.defaultPrevented).toBe(true)
+    })
+
+    it('should not reload again within the repeat window', () => {
+      register()
+
+      dispatchPreloadError()
+      expect(mockReload).toHaveBeenCalledTimes(1)
+
+      // The guard is the sessionStorage marker, which survives the reload, so
+      // dispatching again exercises the same path a fresh page load would.
+      vi.advanceTimersByTime(5_000)
+      const event = dispatchPreloadError()
+
+      expect(mockReload).toHaveBeenCalledTimes(1)
+      expect(event.defaultPrevented).toBe(false)
+      expect(mockLoggerError).toHaveBeenLastCalledWith(
+        'Chunk preload failed',
+        expect.objectContaining({
+          meta: expect.objectContaining({ isRepeat: true, willReload: false }),
+        }),
+      )
+    })
+
+    it('should reload again once the repeat window has passed', () => {
+      register()
+
+      dispatchPreloadError()
+      vi.advanceTimersByTime(30_000)
+      dispatchPreloadError()
+
+      expect(mockReload).toHaveBeenCalledTimes(2)
+    })
+
+    it('should not reload while a mutation is in flight', () => {
+      vi.spyOn(queryClient, 'isMutating').mockReturnValue(1)
+      register()
+
+      const event = dispatchPreloadError()
+
+      expect(mockReload).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
+      expect(mockLoggerError).toHaveBeenLastCalledWith(
+        'Chunk preload failed',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            hasInFlightMutation: true,
+            willReload: false,
+          }),
+        }),
+      )
+    })
+
+    it('should not reload on a public form route', () => {
+      setPathname(`/${MOCK_FORM_ID}`)
+      register()
+
+      const event = dispatchPreloadError()
+
+      expect(mockReload).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
+      expect(mockLoggerError).toHaveBeenLastCalledWith(
+        'Chunk preload failed',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            mayHaveUnsavedInput: true,
+            willReload: false,
+          }),
+        }),
+      )
+    })
+
+    it('should stop handling once unregistered', () => {
+      register()
+      unregister?.()
+      unregister = undefined
+
+      const event = dispatchPreloadError()
+
+      expect(mockReload).not.toHaveBeenCalled()
+      expect(mockLoggerError).not.toHaveBeenCalled()
+      expect(event.defaultPrevented).toBe(false)
+    })
+
+    it('should log the failure even when it does not reload', () => {
+      setPathname(`/${MOCK_FORM_ID}`)
+      register()
+
+      dispatchPreloadError()
+
+      expect(mockLoggerError).toHaveBeenCalledTimes(1)
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Chunk preload failed',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            error: expect.objectContaining({
+              message:
+                'Failed to fetch dynamically imported module: /assets/index-abc.js',
+            }),
+          }),
+        }),
+      )
+    })
+  })
+})

--- a/apps/frontend/src/app/chunkPreloadError.ts
+++ b/apps/frontend/src/app/chunkPreloadError.ts
@@ -1,0 +1,103 @@
+import { QueryClient } from 'react-query'
+import { datadogLogs } from '@datadog/browser-logs'
+
+/**
+ * Recovers from failed lazy-route chunk loads by reloading once.
+ *
+ * Vite fires `vite:preloadError` when a dynamic `import()` cannot be fetched.
+ * The two causes we see in production are:
+ *
+ * 1. A tab left open across a deploy requests a hash that is no longer on the
+ *    container's disk. `catchNonExistentStaticRoutesMiddleware` already covers
+ *    this by falling back to the S3 static assets bucket.
+ * 2. Cloudflare issues a `cf-mitigated` challenge for the chunk request itself.
+ *    The interstitial comes back as HTML, so the browser rejects the module and
+ *    the app whites out. We handle challenges for API calls in the ApiService
+ *    interceptor, but a `<script>` or dynamic `import()` is a plain browser
+ *    fetch that axios never sees — so nothing catches this today. A reload
+ *    carries the challenge clearance and generally recovers.
+ *
+ * Reloading is the only client-side recovery available for (2), but it is
+ * destructive: it cancels in-flight requests and discards unsaved form state.
+ * The guards below keep it to cases where there is nothing to lose.
+ */
+
+const RELOAD_MARKER_KEY = 'chunkPreloadErrorReloadedAt'
+
+/** A reload inside this window means the reload did not fix it — stop trying. */
+const REPEAT_WINDOW_MS = 10_000
+
+/**
+ * Public form respondent routes, i.e. `/:formId` where formId is a 24-char hex
+ * ObjectId, optionally with a subroute. Mirrors the backend's
+ * `/:formId([a-fA-F0-9]{24})` in frontend.routes.ts.
+ */
+const PUBLIC_FORM_PATHNAME_REGEX = /^\/[a-fA-F0-9]{24}(\/|$)/
+
+export const isPublicFormPathname = (pathname: string): boolean =>
+  PUBLIC_FORM_PATHNAME_REGEX.test(pathname)
+
+/**
+ * Registers the `vite:preloadError` recovery handler.
+ *
+ * @param queryClient used to detect in-flight mutations, which must never be
+ * reloaded over — the server may already have persisted the write.
+ * @returns a function that unregisters the handler. Unused in the app, where
+ * the handler lives for the lifetime of the page; tests need it so listeners do
+ * not accumulate on the shared jsdom window.
+ */
+export const registerChunkPreloadErrorHandler = (
+  queryClient: QueryClient,
+): (() => void) => {
+  const handlePreloadError = (event: VitePreloadErrorEvent) => {
+    const lastReloadedAt = Number(
+      window.sessionStorage.getItem(RELOAD_MARKER_KEY) ?? 0,
+    )
+    const isRepeat = Date.now() - lastReloadedAt < REPEAT_WINDOW_MS
+
+    // A pending mutation may already have reached the server. Reloading would
+    // cancel the response client-side only, leaving the respondent without a
+    // confirmation for a submission that did in fact succeed — and liable to
+    // resubmit, or to be locked out by single-submission validation.
+    const hasInFlightMutation = queryClient.isMutating() > 0
+
+    // Defensive: no chunk on the public form is lazy today, so this cannot
+    // currently fire there. Guarding anyway so that lazily loading a field
+    // component later does not silently start discarding half-filled forms.
+    const mayHaveUnsavedInput = isPublicFormPathname(window.location.pathname)
+
+    const willReload = !isRepeat && !hasInFlightMutation && !mayHaveUnsavedInput
+
+    datadogLogs.logger.error('Chunk preload failed', {
+      meta: {
+        action: 'registerChunkPreloadErrorHandler',
+        pathname: window.location.pathname,
+        version: import.meta.env.VITE_APP_VERSION,
+        // `isRepeat` distinguishes the causes above: a stale chunk recovers on
+        // the first reload, so repeats point at a challenge or a genuinely
+        // absent asset. Correlate with the backend's "Static asset not found in
+        // S3" log to separate those two.
+        isRepeat,
+        hasInFlightMutation,
+        mayHaveUnsavedInput,
+        willReload,
+        error: {
+          message: event.payload?.message,
+          stack: event.payload?.stack,
+        },
+      },
+    })
+
+    if (!willReload) return
+
+    // Suppress Vite's rethrow — the reload supersedes it.
+    event.preventDefault()
+    window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(Date.now()))
+    window.location.reload()
+  }
+
+  window.addEventListener('vite:preloadError', handlePreloadError)
+
+  return () =>
+    window.removeEventListener('vite:preloadError', handlePreloadError)
+}

--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -5,13 +5,17 @@ import './polyfills'
 import * as React from 'react'
 import { createRoot } from 'react-dom/client'
 
-import { App } from './app/App'
+import { App, queryClient } from './app/App'
+import { registerChunkPreloadErrorHandler } from './app/chunkPreloadError'
 import * as dayjs from './utils/dayjs'
 import { env } from './env'
 
 if (import.meta.env.MODE === 'test') {
   import('./mocks/msw/browser').then(({ worker }) => worker.start())
 }
+
+// Registered before render so it is listening before any lazy route resolves.
+registerChunkPreloadErrorHandler(queryClient)
 
 // Init Google Analytics
 declare global {


### PR DESCRIPTION
## Problem

A lazy route chunk that fails to load leaves the app blank — no error UI, nothing to click.

We already mitigate one cause. A tab left open across a deploy requests a hash that is no longer on the container's disk, and `catchNonExistentStaticRoutesMiddleware` falls back to the S3 static assets bucket (added in #5595, re-armed for the ECS pipeline by #8619 after the EB→ECS migration silently dropped the upload step for four months).

**That fallback only covers requests that reach Express.** When Cloudflare issues a `cf-mitigated` 403 for the chunk request itself, the interstitial comes back as HTML, the browser rejects the module script, and our origin is never consulted. We handle CF challenges for API calls in the `ApiService` interceptor — but a `<script>` tag or a dynamic `import()` is a plain browser fetch that axios never sees, so nothing catches it today.

For that cause, a client-side reload is the only recovery that exists.

## Solution

Register a `vite:preloadError` handler that logs to Datadog and then reloads once — guarded three ways, because reloading is destructive.

| Guard | Prevents |
|---|---|
| Not twice within 10s | Infinite reload loop when the reload doesn't fix it |
| Never over an in-flight mutation | Cancelling a write the server may already have persisted |
| Never on a public form route | Discarding a half-filled respondent form |

### Concerns raised in review, and why each does not apply

These were worked through before writing the code. Recording them so the next reader doesn't have to re-derive them — and because two of them are only *currently* safe.

**1. Could a reload cancel a submission that's mid-flight?**

Not from the form's own behaviour. The entire frontend has exactly 13 dynamic imports and all of them are top-level route chunks in `AppRouter.tsx`. Specifically:

- `src/features/public-form/**` contains zero `import()` calls and no workers — every field, validator and modal is already in the loaded chunk.
- The post-submit payment redirect (`PublicFormProvider.tsx:1190`, `:1257`) lands on `FormPaymentPage`, a **static** import (`AppRouter.tsx:57`).
- The non-payment success path just calls `setSubmissionData()` and re-renders in place — no navigation, no chunk.

So no dynamic import occurs between submit and response, and the event cannot fire there. The residual case is a user navigating to a *different* lazy route while a POST is in flight, which the `isMutating()` guard covers. That guard matters most on the admin side, where routes *are* lazy and admins navigate mid-save.

The damage model is why this is guarded rather than accepted: `reload()` cancels the XHR client-side only. The server may already have persisted the submission, so the respondent gets no confirmation for a write that succeeded, then resubmits (duplicate) or is locked out by single-submission validation. Strictly worse than the whiteout.

**2. Could it reload while a respondent is halfway through filling a form?**

Not today, and for a stronger reason than above: there is no pending *or future* chunk fetch while someone sits on `PublicFormPage`. No `.preload()` or prefetch calls exist anywhere in the codebase (verified — zero hits), and `@loadable/component` does not speculatively fetch, so no other route's chunk is being pulled in the background. Vite's `modulepreload` links resolve during initial page load, before the form renders. Nothing can fail ten minutes in.

Worth noting the corollary: public form answers live only in react-hook-form memory — there is no `localStorage` persistence in `src/features/public-form/**`. So in the one scenario where the event *could* fire on that page (a route navigation), the answers are already gone before the handler runs. The reload is not what costs the respondent anything.

**The route guard is kept anyway.** That safety property is an accident of current bundling, not a declared invariant. The day someone lazily loads a heavy field widget — a signature pad, an address map picker — half-filled forms start being discarded silently, with no test failing and nobody recalling this analysis. One line to make the accident explicit.

**3. Does this help with frontend/backend API contract skew?**

No, and it shouldn't be read as if it does. A stale client hitting a changed `/api/v3` produces no chunk failure, so the event never fires. Worth being explicit about what's uncovered there, since it's the same "stale client" family of problem:

- `App.tsx:23-28` disables react-query retries on 4xx, so a skew-induced 400 is terminal for that session — nothing self-heals.
- Request-shape skew surfaces the raw Joi message to the user, via `transformAxiosError` unwrapping `validation.body.message` (`ApiService.ts:55`).
- Response-shape skew (a renamed key) throws nothing at all — just `undefined` into render. No 4xx, no Datadog signal.

The defence for those is expand/contract discipline on the backend — additive request fields, no same-release renames — because during a rolling deploy both client versions are live by definition. Out of scope here.

### Alternatives considered

- **Server-side fix only** — impossible for the Cloudflare case: the request never reaches our origin.
- **Toast prompting a manual refresh instead of auto-reload** — rejected as the default, since a whiteout leaves no UI to render a toast into. It *is* effectively the behaviour on guarded routes, where the page still works.
- **`beforeunload` prompt** — rejected: asks the user to adjudicate something they have no information about.
- **Route guard alone, without `isMutating()`** — insufficient; the in-flight risk is not confined to public forms.

### Why it logs before deciding

`isRepeat` is the diagnostic we don't currently have. A stale chunk recovers on the first reload, so a repeat within the window means the reload didn't help — pointing at a Cloudflare challenge or a genuinely absent asset. Correlate against the backend's existing `Static asset not found in S3` log to separate those two. Right now a whiteout is indistinguishable from any other cause, and we've been guessing.

**Suggested follow-up:** check the `isRepeat` rate after a week. That's what tells us whether to invest in the Cloudflare side or whether it was stale chunks all along. Related: the S3 bucket's lifecycle policy is not in this repo, and if an expiration rule exists it silently defines the stale-tab grace period — worth confirming out of band.

## Tests

`apps/frontend/src/app/chunkPreloadError.test.ts` covers: reload + `preventDefault` on first failure; no second reload inside the repeat window; reload again after it passes; no reload while `isMutating()`; no reload on a public form route; no handling after unregister; and that it logs in every case including when it declines to reload. Plus `isPublicFormPathname` against public form routes, subroutes, and the admin route that also contains a form id.

**Note on `registerChunkPreloadErrorHandler` returning an unregister function.** The app never calls it — the handler lives as long as the page. It exists because listeners attach to the jsdom `window` shared by every test in the file, so a leaked registration leaves a handler holding a stale `queryClient` that reloads during later tests. The first CI run failed exactly this way (a logger asserted once was called 8 times, and a stale handler reloaded through the `isMutating` guard). `should stop handling once unregistered` is the regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
