### PR TITLE
chore(frontend): log chunk preload failures to Datadog

### DIFF
--- a/apps/frontend/src/app/chunkPreloadError.test.ts
+++ b/apps/frontend/src/app/chunkPreloadError.test.ts
@@ -1,0 +1,110 @@
+import { datadogLogs } from '@datadog/browser-logs'
+
+import {
+  isPublicFormPathname,
+  registerChunkPreloadErrorListener,
+} from './chunkPreloadError'
+
+vi.mock('@datadog/browser-logs', () => ({
+  datadogLogs: { logger: { error: vi.fn() } },
+}))
+
+const MOCK_FORM_ID = '61540ece3d4a6e50ac0cc6ff'
+
+const mockLoggerError = datadogLogs.logger.error as unknown as ReturnType<
+  typeof vi.fn
+>
+
+const setPathname = (pathname: string) => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { pathname },
+  })
+}
+
+/** Dispatches a preload error at the registered handler, returning the event. */
+const dispatchPreloadError = () => {
+  const event = new Event('vite:preloadError', {
+    cancelable: true,
+  }) as VitePreloadErrorEvent
+  event.payload = new Error(
+    'Failed to fetch dynamically imported module: /assets/index-abc.js',
+  )
+  window.dispatchEvent(event)
+  return event
+}
+
+describe('chunkPreloadError', () => {
+  let unregister: (() => void) | undefined
+
+  /**
+   * Registers exactly one handler for the current test. The unregister call in
+   * afterEach is load-bearing: listeners are added to the jsdom window shared by
+   * every test in this file, so leaking one leaves a handler that logs during
+   * later tests.
+   */
+  const register = () => {
+    unregister = registerChunkPreloadErrorListener()
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setPathname('/dashboard')
+  })
+
+  afterEach(() => {
+    unregister?.()
+    unregister = undefined
+  })
+
+  describe('isPublicFormPathname', () => {
+    it('should match a bare public form route', () => {
+      expect(isPublicFormPathname(`/${MOCK_FORM_ID}`)).toBe(true)
+    })
+
+    it('should match a public form subroute', () => {
+      expect(isPublicFormPathname(`/${MOCK_FORM_ID}/payment/abc`)).toBe(true)
+    })
+
+    it('should not match admin routes containing a form id', () => {
+      expect(isPublicFormPathname(`/admin/form/${MOCK_FORM_ID}`)).toBe(false)
+    })
+
+    it('should not match non-form routes', () => {
+      expect(isPublicFormPathname('/dashboard')).toBe(false)
+      expect(isPublicFormPathname('/')).toBe(false)
+    })
+  })
+
+  describe('registerChunkPreloadErrorListener', () => {
+    it('should log the failure with the pathname and error', () => {
+      register()
+
+      dispatchPreloadError()
+
+      expect(mockLoggerError).toHaveBeenCalledTimes(1)
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        'Chunk preload failed',
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            pathname: '/dashboard',
+            error: expect.objectContaining({
+              message:
+                'Failed to fetch dynamically imported module: /assets/index-abc.js',
+            }),
+          }),
+        }),
+      )
+    })
+
+    // Vite rethrows unless the event is cancelled. Observing must not change
+    // what the app does with the failure.
+    it('should not suppress the rethrow', () => {
+      register()
+
+      const event = dispatchPreloadError()
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+  })
+})

--- a/apps/frontend/src/app/chunkPreloadError.ts
+++ b/apps/frontend/src/app/chunkPreloadError.ts
@@ -1,0 +1,42 @@
+import { datadogLogs } from '@datadog/browser-logs'
+
+/**
+ * Public form respondent routes, i.e. `/:formId` where formId is a 24-char hex
+ * ObjectId, optionally with a subroute. Mirrors the backend's
+ * `/:formId([a-fA-F0-9]{24})` in frontend.routes.ts. Logged because a
+ * respondent-facing failure is more severe than an admin one, and because any
+ * future recovery must treat the two differently.
+ */
+const PUBLIC_FORM_PATHNAME_REGEX = /^\/[a-fA-F0-9]{24}(\/|$)/
+
+export const isPublicFormPathname = (pathname: string): boolean =>
+  PUBLIC_FORM_PATHNAME_REGEX.test(pathname)
+
+/**
+ * Registers the `vite:preloadError` reporter.
+ *
+ * @returns a function that unregisters the handler. Unused in the app, where
+ * the handler lives for the lifetime of the page; tests need it so listeners do
+ * not accumulate on the shared jsdom window.
+ */
+export const registerChunkPreloadErrorListener = (): (() => void) => {
+  const handlePreloadError = (event: VitePreloadErrorEvent) => {
+    datadogLogs.logger.error('Chunk preload failed', {
+      meta: {
+        action: 'handlePreloadError',
+        pathname: window.location.pathname,
+        version: import.meta.env.VITE_APP_VERSION,
+        isPublicForm: isPublicFormPathname(window.location.pathname),
+        error: {
+          message: event.payload?.message,
+          stack: event.payload?.stack,
+        },
+      },
+    })
+  }
+
+  window.addEventListener('vite:preloadError', handlePreloadError)
+
+  return () =>
+    window.removeEventListener('vite:preloadError', handlePreloadError)
+}

--- a/apps/frontend/src/index.tsx
+++ b/apps/frontend/src/index.tsx
@@ -6,12 +6,15 @@ import * as React from 'react'
 import { createRoot } from 'react-dom/client'
 
 import { App } from './app/App'
+import { registerChunkPreloadErrorListener } from './app/chunkPreloadError'
 import * as dayjs from './utils/dayjs'
 import { env } from './env'
 
 if (import.meta.env.MODE === 'test') {
   import('./mocks/msw/browser').then(({ worker }) => worker.start())
 }
+
+registerChunkPreloadErrorListener()
 
 // Init Google Analytics
 declare global {


### PR DESCRIPTION
## Problem

A lazy route chunk that fails to load leaves the app blank, and we have no telemetry for it today — so we cannot tell whether it is actually happening, how often, or to whom.

## What this does

Registers a `vite:preloadError` listener that logs to Datadog and does nothing else.

Deliberately observe-only:

- It does **not** call `preventDefault()`, so Vite still rethrows and existing error reporting is unchanged.
- No reload, no retry. Recovery is a separate decision, taken once the logs say whether it is warranted.

Logged fields: `pathname`, `isPublicForm`, app `version`, and the error message/stack.

`isPublicForm` as any future recovery would have to treat the two differently (a reload would discard a half-filled form).

## Notes for the reviewer

- `registerChunkPreloadErrorLogger` returns an unregister function. The app never calls it — the handler lives as long as the page — but tests need it so listeners do not accumulate on the shared jsdom window.
- The public form pathname regex mirrors the backend's `/:formId([a-fA-F0-9]{24})` in `frontend.routes.ts`.

## Tests

`apps/frontend/src/app/chunkPreloadError.test.ts` — 8 tests, passing. Covers the pathname matcher, the logged payload, the public form flag, that the rethrow is not suppressed, and that unregistering stops handling.