### PR TITLE
fix(workflow,logic): auto-save on card switch discards edits

### DIFF
--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
@@ -137,6 +137,11 @@ export const EditLogicBlock = ({
   const completeSave = useAdminLogicStore(completeSaveSelector)
   const isCreatingState = useAdminLogicStore(isCreatingStateSelector)
 
+  // Read during render, not inside the effect below: RHF's formState is a Proxy
+  // that only tracks a flag once something reads it while rendering. Read only
+  // from the effect it stays false, and edits were discarded on switch.
+  const { isDirty } = formMethods.formState
+
   // Guards the auto-save effect against re-entry: the mutation's isLoading
   // only flips true on the render after mutate() is called, and handleSubmit's
   // validation is promise-based, so a second card click landing in that window
@@ -164,7 +169,7 @@ export const EditLogicBlock = ({
     // (like the Add logic button): an incomplete new block blocks the switch.
     // An existing block that wasn't touched can switch directly without a
     // redundant save.
-    if (!isCreatingState && !formMethods.formState.isDirty) {
+    if (!isCreatingState && !isDirty) {
       completeSave()
       return
     }

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
@@ -138,8 +138,9 @@ export const EditLogicBlock = ({
   const isCreatingState = useAdminLogicStore(isCreatingStateSelector)
 
   // Read during render, not inside the effect below: RHF's formState is a Proxy
-  // that only tracks a flag once something reads it while rendering. Read only
-  // from the effect it stays false, and edits were discarded on switch.
+  // that only tracks a flag once something reads it while rendering. Read for
+  // the first time inside the effect, it stays false, and edits were discarded
+  // on switch.
   const { isDirty } = formMethods.formState
 
   // Guards the auto-save effect against re-entry: the mutation's isLoading

--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditLogicBlock.tsx
@@ -137,10 +137,9 @@ export const EditLogicBlock = ({
   const completeSave = useAdminLogicStore(completeSaveSelector)
   const isCreatingState = useAdminLogicStore(isCreatingStateSelector)
 
-  // Read during render, not inside the effect below: RHF's formState is a Proxy
-  // that only tracks a flag once something reads it while rendering. Read for
-  // the first time inside the effect, it stays false, and edits were discarded
-  // on switch.
+  // RATIONALE: Returned formState is wrapped with a Proxy to improve
+  // render performance, we must ead it before a render in order to enable
+  // the state update.
   const { isDirty } = formMethods.formState
 
   // Guards the auto-save effect against re-entry: the mutation's isLoading

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -150,8 +150,9 @@ export const EditStepBlock = ({
   const isFirstStep = isFirstStepByStepNumber(stepNumber)
 
   // Read during render, not inside the effect below: RHF's formState is a Proxy
-  // that only tracks a flag once something reads it while rendering. Read only
-  // from the effect it stays false, and edits were discarded on switch.
+  // that only tracks a flag once something reads it while rendering. Read for
+  // the first time inside the effect, it stays false, and edits were discarded
+  // on switch.
   const { isDirty } = formMethods.formState
 
   // Shared by the Save button and the auto-save-on-switch effect. An invalid

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -149,6 +149,11 @@ export const EditStepBlock = ({
 
   const isFirstStep = isFirstStepByStepNumber(stepNumber)
 
+  // Read during render, not inside the effect below: RHF's formState is a Proxy
+  // that only tracks a flag once something reads it while rendering. Read only
+  // from the effect it stays false, and edits were discarded on switch.
+  const { isDirty } = formMethods.formState
+
   // Shared by the Save button and the auto-save-on-switch effect. An invalid
   // submit cancels any pending switch so the card stays open; the Save-button
   // path never has a pending switch, so that cancel is a no-op there.
@@ -188,7 +193,7 @@ export const EditStepBlock = ({
     // (like the Add step button): an incomplete new step blocks the switch. An
     // existing step that wasn't touched can switch directly without a
     // redundant save.
-    if (!isCreatingState && !formMethods.formState.isDirty) {
+    if (!isCreatingState && !isDirty) {
       completeSave()
       return
     }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -149,10 +149,9 @@ export const EditStepBlock = ({
 
   const isFirstStep = isFirstStepByStepNumber(stepNumber)
 
-  // Read during render, not inside the effect below: RHF's formState is a Proxy
-  // that only tracks a flag once something reads it while rendering. Read for
-  // the first time inside the effect, it stays false, and edits were discarded
-  // on switch.
+  // RATIONALE: Returned formState is wrapped with a Proxy to improve
+  // render performance, we must ead it before a render in order to enable
+  // the state update.
   const { isDirty } = formMethods.formState
 
   // Shared by the Save button and the auto-save-on-switch effect. An invalid


### PR DESCRIPTION
## Problem

Editing a step or logic block that **already exists**, then clicking another card, silently discards the edits. No error is shown. Found while rebasing an approval-reframe branch onto the click-to-edit work.

Not behind a flag: `editable-cards-mrf-logic` was dropped in `8caec073a`, and `InactiveStepBlock`'s `onClick` is unconditional. Limited so far only by recency — #9781 and #9786 merged today.

## Cause

The auto-save effect decides whether to save by reading `formState.isDirty`. RHF's `formState` is a Proxy that only starts tracking a flag once something reads it **during render** — that read is the subscription. Both components read `isDirty` only inside the effect, which runs after render, so nothing ever subscribed and the value stayed at its initial `false`. The effect took the "nothing changed" branch and switched without saving.

New blocks were unaffected because `isCreatingState` short-circuits before reaching `isDirty`. That's why this went unnoticed: the natural thing to test is creating a step and clicking away, and that path works.

Verified empirically with a throwaway harness reproducing the component shape (parent `useForm`, children destructuring `formState: { errors }`, a `Controller`-driven edit, an effect keyed on a pending-switch prop):

| Render-time subscription | `isDirty` seen by effect | Edit landed? |
|---|---|---|
| No (before) | `false` | `value === 'edited'` |
| Yes (after) | `true` | `value === 'edited'` |

The right-hand column is the control, proving the edit registered in both arms.

## Solution

Read `isDirty` during render so RHF subscribes, and use that variable in the effect. Two lines, one per component.

Dependency array stays `[pendingSwitchTo]`: the edit re-renders once subscribed, and the card click re-renders again, so the effect always closes over a current value. Adding `isDirty` to the deps would re-run the effect mid-switch on every keystroke, leaning entirely on `hasSubmittedForPendingSwitch` to prevent double submits.

## Tests

- [ ] Save a step so it exists → reopen it → change the step name → click another card → reopen: the change is still there
- [ ] Same for a logic block
- [ ] Control: brand-new unsaved step, edit, click another card → still saves (this already worked)
- [ ] Untouched existing step → click another card → switches with no save request (the short-circuit still short-circuits)
- [ ] #9838 regression: rapid double-click from a dirty new step → exactly one create request

## Notes

- **No automated test.** The bug is a render-time subscription with no seam to unit-test. A real component test via `composeStories` hits the `workflow_type` double-registration quirk the stories file already documents, and grew several times larger than the two-line fix. Left as the manual TCs above.
- **Relation to #9838.** That PR fixed a real double-submit race on the new-block path and is untouched here. The two are complementary: it stops a duplicate save on new blocks, this makes existing blocks save at all.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
