### PR TITLE
feat(growthbook): add adminEmail attribute for formid-json targeting

### DIFF
--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.service.ts
@@ -244,10 +244,11 @@ export const performEncryptPostSubmissionActions = ({
       ).andThen(() => okAsync(form))
     })
     .andThen((form) => {
-      // Add formId to growthbook attributes to allow for targeting in growthbook feature flags
+      // Add formId and adminEmail to growthbook attributes to allow for targeting in growthbook feature flags
       void growthbook?.setAttributes({
         ...growthbook?.getAttributes(),
         formId: form._id.toString(),
+        adminEmail: form.admin.email,
       })
       const respondentCopyEmailData: AutoReplyMailData[] = respondentEmails
         ? respondentEmails?.map((val) => {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -888,6 +888,7 @@ describe('Multirespondent Submission Middleware', () => {
     const MOCK_FORM_BASE = {
       _id: MOCK_FORM_ID,
       publicKey: MOCK_FORM_PUBLIC_KEY,
+      admin: { email: 'admin@example.com' },
       form_fields: [
         { _id: 'field1', fieldType: BasicField.ShortText, title: 'Field 1' },
       ],
@@ -969,6 +970,12 @@ describe('Multirespondent Submission Middleware', () => {
       expect(jest.mocked(adaptV4ToV3)).not.toHaveBeenCalled()
       expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(2)
       expect(mockNext).toHaveBeenCalled()
+      expect(mockReq.growthbook.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          formId: MOCK_FORM_ID,
+          adminEmail: 'admin@example.com',
+        }),
+      )
     })
 
     it('should return 500 and not call next() when decryptFromSubmissionKey returns falsy', async () => {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -804,6 +804,7 @@ export const encryptSubmission = async (
   void req.growthbook?.setAttributes({
     ...req.growthbook.getAttributes(),
     formId: req.params.formId,
+    adminEmail: req.formsg.formDef.admin.email,
   })
 
   const formDef = req.formsg.formDef


### PR DESCRIPTION
## Problem

The `formid-json` GrowthBook feature flag (which controls whether the Form ID is embedded in the submission response JSON) can currently only be targeted by `formId`. That is the only attribute the backend feeds to GrowthBook in the code paths that evaluate the flag, so it is impossible to write an exception/rollout rule keyed on the form's admin.

We want to be able to target the `formid-json` flag (and other flags evaluated in these paths) by **admin email** in addition to `formId`.

## Solution

Set `adminEmail` as a GrowthBook attribute alongside the existing `formId` attribute in the two submission paths that evaluate `formid-json`:

- **Encrypt submissions** — `performEncryptPostSubmissionActions` in `encrypt-submission.service.ts`. The `form` here comes from `retrieveFullFormById` (`IPopulatedForm`), so `form.admin.email` is populated.
- **Multirespondent submissions** — the `encryptSubmission` middleware in `multirespondent-submission.middleware.ts`. `req.formsg.formDef` is an `IPopulatedMultirespondentForm`, so `admin.email` is populated; the surrounding code already dereferences `req.formsg.formDef` non-optionally.

**Breaking Changes**
- No — this is backwards compatible. It only adds an extra attribute to the GrowthBook context; existing `formId`-based targeting is unchanged.