### PR TITLE
feat(workspace): rework form-origin question into two-question flow (FRM-2572)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ The underlying business activity or data-collection need a form serves (e.g. "pr
 _Avoid_: using "process" to mean the medium/format itself (e.g. "digital process" vs "paper process") — this is the exact confusion the origin question exists to resolve.
 
 **Existing process**:
-A **Process** for which the admin's agency was already collecting this data in some medium before creating this form (paper, email, spreadsheet, another FormSG form, another form builder, etc).
+A **Process** for which the admin's agency was already collecting this data in some medium before creating this form (paper, email, spreadsheet, an online form such as FormSG or another form builder, etc).
 
 **New process**:
 A **Process** for which the admin's agency was not collecting this data in any medium before creating this form.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,23 @@
+# FormSG
+
+FormSG lets government agencies build and publish forms. This glossary currently covers the form-creation domain, starting with the "form origin" question asked when a form is created.
+
+## Language
+
+**Process**:
+The underlying business activity or data-collection need a form serves (e.g. "processing leave applications"), independent of the medium used to run it.
+_Avoid_: using "process" to mean the medium/format itself (e.g. "digital process" vs "paper process") — this is the exact confusion the origin question exists to resolve.
+
+**Existing process**:
+A **Process** for which the admin's agency was already collecting this data in some medium before creating this form (paper, email, spreadsheet, another FormSG form, another form builder, etc).
+
+**New process**:
+A **Process** for which the admin's agency was not collecting this data in any medium before creating this form.
+
+**Form origin**:
+The record, on a form's metadata, of what **Process** and (if existing) what prior collection medium a form's data collection descends from. Stored as `metadata.formOrigins`.
+_Avoid_: conflating this with the collection medium alone — origin captures both the process-newness answer and the medium.
+
+## Flagged ambiguities
+
+- "process" was observed being interpreted by admins as the medium/format ("this is a new *digital* process") rather than the underlying activity — resolved: **Process** is activity-based, not medium-based. See v2.0 research observations.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ The underlying business activity or data-collection need a form serves (e.g. "pr
 _Avoid_: using "process" to mean the medium/format itself (e.g. "digital process" vs "paper process") — this is the exact confusion the origin question exists to resolve.
 
 **Existing process**:
-A **Process** for which the admin's agency was already collecting this data in some medium before creating this form (paper, email, spreadsheet, another FormSG form, another form builder, etc).
+A **Process** for which the admin's agency was already collecting this data in some medium before creating this form (another FormSG form, email, document, spreadsheet, paper, etc).
 
 **New process**:
 A **Process** for which the admin's agency was not collecting this data in any medium before creating this form.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ The underlying business activity or data-collection need a form serves (e.g. "pr
 _Avoid_: using "process" to mean the medium/format itself (e.g. "digital process" vs "paper process") — this is the exact confusion the origin question exists to resolve.
 
 **Existing process**:
-A **Process** for which the admin's agency was already collecting this data in some medium before creating this form (another FormSG form, email, document, spreadsheet, paper, etc).
+A **Process** for which the admin's agency was already collecting this data in some medium before creating this form (paper, email, spreadsheet, another FormSG form, another form builder, etc).
 
 **New process**:
 A **Process** for which the admin's agency was not collecting this data in any medium before creating this form.

--- a/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.cutover.test.tsx
+++ b/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.cutover.test.tsx
@@ -160,6 +160,34 @@ describe('UseTemplateWizardProvider — cutover behaviour', () => {
     expect(useStorageModeFormTemplateMutation.mutate).not.toHaveBeenCalled()
   })
 
+  it('submits only the new-process value when formOriginProcess is "new", discarding stale Q2 ticks', async () => {
+    setFlags({ cutover: true, paperTracking: true })
+    const { result } = renderHook(() =>
+      useUseTemplateWizardContext(MOCK_FORM_ID, vi.fn()),
+    )
+
+    act(() => {
+      result.current.formMethods.setValue('title', 'New title')
+      result.current.formMethods.setValue('formOriginProcess', 'new')
+      result.current.formMethods.setValue('formOrigins', {
+        value: [FormOrigin.DigitalSpreadsheet],
+      })
+    })
+    await act(async () => {
+      await result.current.handleCreateStorageModeOrMultirespondentForm()
+    })
+
+    expect(
+      useMultirespondentFormTemplateMutation.mutate.mock.calls[0][0],
+    ).toEqual(
+      expect.objectContaining({
+        metadata: {
+          formOrigins: { value: [FormOrigin.DigitalNew] },
+        },
+      }),
+    )
+  })
+
   it('re-asks origins and creates from template with them as metadata', async () => {
     setFlags({ cutover: true, paperTracking: true })
     const { result } = renderHook(() =>

--- a/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.cutover.test.tsx
+++ b/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.cutover.test.tsx
@@ -196,6 +196,7 @@ describe('UseTemplateWizardProvider — cutover behaviour', () => {
 
     act(() => {
       result.current.formMethods.setValue('title', 'New title')
+      result.current.formMethods.setValue('formOriginProcess', 'existing')
       result.current.formMethods.setValue('formOrigins', {
         value: [FormOrigin.DigitalSpreadsheet],
       })

--- a/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
+++ b/apps/frontend/src/features/admin-form/template/UseTemplateModal/UseTemplateWizardProvider.tsx
@@ -81,6 +81,7 @@ export const useUseTemplateWizardContext = (
     title,
     responseMode,
     emails,
+    formOriginProcess,
     formOrigins,
   }: CreateFormWizardInputProps) => {
     if (!formId) return
@@ -88,6 +89,7 @@ export const useUseTemplateWizardContext = (
     const metadata = buildFormClientMetadata({
       isPaperTrackingSetUpPageEnabled,
       isMrfCutoverEnabled,
+      formOriginProcess,
       formOrigins,
       formResponseMode: responseMode,
     })

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.stories.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.stories.tsx
@@ -66,16 +66,43 @@ const StoryOriginScreen = ({
 const Template: StoryFn = () => <StoryOriginScreen />
 export const Default = Template.bind({})
 
+export const NewProcessSelected: StoryFn = () => (
+  <StoryOriginScreen defaultValues={{ formOriginProcess: 'new' }} />
+)
+
+export const ExistingProcessSelected: StoryFn = () => (
+  <StoryOriginScreen defaultValues={{ formOriginProcess: 'existing' }} />
+)
+
 export const WithOtherSelected: StoryFn = () => (
   <StoryOriginScreen
     defaultValues={{
+      formOriginProcess: 'existing',
       formOrigins: { value: [CLIENT_CHECKBOX_OTHERS_INPUT_VALUE] },
     }}
   />
 )
 
-export const ValidationError: StoryFn = () => <StoryOriginScreen />
-ValidationError.play = async () => {
+export const Q1ValidationError: StoryFn = () => <StoryOriginScreen />
+Q1ValidationError.play = async () => {
+  await userEvent.click(
+    await screen.findByRole(
+      'button',
+      { name: /next step/i },
+      { timeout: 3000 },
+    ),
+  )
+  await expect(
+    await screen.findByText('Please select at least 1 option.', undefined, {
+      timeout: 3000,
+    }),
+  ).toBeInTheDocument()
+}
+
+export const Q2ValidationError: StoryFn = () => (
+  <StoryOriginScreen defaultValues={{ formOriginProcess: 'existing' }} />
+)
+Q2ValidationError.play = async () => {
   await userEvent.click(
     await screen.findByRole(
       'button',

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
@@ -29,8 +29,7 @@ vi.mock('react-i18next', () => {
     [`${P}.q2.options.digitalEmail`]: 'Emails',
     [`${P}.q2.options.digitalDocument`]: 'Documents (e.g. PDF, Word)',
     [`${P}.q2.options.digitalSpreadsheet`]: 'Spreadsheets (e.g. Excel, Sheets)',
-    [`${P}.q2.options.digitalFormsg`]: 'Another FormSG form',
-    [`${P}.q2.options.digitalFormbuilder`]: 'Other form builders',
+    [`${P}.q2.options.digitalFormbuilder`]: 'An online form (e.g. FormSG)',
     [`${P}.q2.options.others`]: 'Other',
     [`${P}.otherInputLabel`]: 'Other source',
     [`${P}.errors.q1Required`]: 'Please select an option.',
@@ -169,22 +168,23 @@ describe('CreateFormOriginScreen', () => {
     )
   })
 
-  it('offers "Another FormSG form" as its own option, distinct from "Other form builders"', async () => {
+  it('offers "An online form (e.g. FormSG)" as a medium option', async () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
 
     await selectExisting(user)
-    expect(screen.getByLabelText('Another FormSG form')).toBeInTheDocument()
-    expect(screen.getByLabelText('Other form builders')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('An online form (e.g. FormSG)'),
+    ).toBeInTheDocument()
 
-    await user.click(screen.getByLabelText('Another FormSG form'))
+    await user.click(screen.getByLabelText('An online form (e.g. FormSG)'))
     await clickNext(user)
 
     await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1))
     expect(onCreate.mock.calls[0][0]).toEqual(
       expect.objectContaining({
         formOrigins: expect.objectContaining({
-          value: [FormOrigin.DigitalFormsg],
+          value: [FormOrigin.DigitalFormBuilder],
         }),
       }),
     )

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
@@ -30,8 +30,10 @@ vi.mock('react-i18next', () => {
     [`${P}.q2.options.digitalDocument`]: 'Documents (e.g. PDF, Word)',
     [`${P}.q2.options.digitalSpreadsheet`]: 'Spreadsheets (e.g. Excel, Sheets)',
     [`${P}.q2.options.digitalFormsg`]: 'Another FormSG form',
+    [`${P}.q2.options.digitalFormbuilder`]: 'Other form builders',
     [`${P}.q2.options.others`]: 'Other',
     [`${P}.otherInputLabel`]: 'Other source',
+    [`${P}.errors.q1Required`]: 'Please select an option.',
     [`${P}.errors.atLeastOne`]: 'Please select at least 1 option.',
     [`${P}.errors.otherRequired`]:
       'Please specify a value for the "others" option',
@@ -126,7 +128,7 @@ describe('CreateFormOriginScreen', () => {
     await clickNext(user)
 
     expect(
-      await screen.findByText('Please select at least 1 option.'),
+      await screen.findByText('Please select an option.'),
     ).toBeInTheDocument()
     expect(onCreate).not.toHaveBeenCalled()
   })
@@ -167,12 +169,13 @@ describe('CreateFormOriginScreen', () => {
     )
   })
 
-  it('offers "Another FormSG form" as its own option', async () => {
+  it('offers "Another FormSG form" as its own option, distinct from "Other form builders"', async () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
 
     await selectExisting(user)
     expect(screen.getByLabelText('Another FormSG form')).toBeInTheDocument()
+    expect(screen.getByLabelText('Other form builders')).toBeInTheDocument()
 
     await user.click(screen.getByLabelText('Another FormSG form'))
     await clickNext(user)

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
@@ -30,7 +30,6 @@ vi.mock('react-i18next', () => {
     [`${P}.q2.options.digitalDocument`]: 'Documents (e.g. PDF, Word)',
     [`${P}.q2.options.digitalSpreadsheet`]: 'Spreadsheets (e.g. Excel, Sheets)',
     [`${P}.q2.options.digitalFormsg`]: 'Another FormSG form',
-    [`${P}.q2.options.digitalFormbuilder`]: 'Other form builders',
     [`${P}.q2.options.others`]: 'Other',
     [`${P}.otherInputLabel`]: 'Other source',
     [`${P}.errors.atLeastOne`]: 'Please select at least 1 option.',
@@ -168,13 +167,12 @@ describe('CreateFormOriginScreen', () => {
     )
   })
 
-  it('offers "Another FormSG form" as its own option, distinct from "Other form builders"', async () => {
+  it('offers "Another FormSG form" as its own option', async () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
 
     await selectExisting(user)
     expect(screen.getByLabelText('Another FormSG form')).toBeInTheDocument()
-    expect(screen.getByLabelText('Other form builders')).toBeInTheDocument()
 
     await user.click(screen.getByLabelText('Another FormSG form'))
     await clickNext(user)

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
@@ -29,7 +29,8 @@ vi.mock('react-i18next', () => {
     [`${P}.q2.options.digitalEmail`]: 'Emails',
     [`${P}.q2.options.digitalDocument`]: 'Documents (e.g. PDF, Word)',
     [`${P}.q2.options.digitalSpreadsheet`]: 'Spreadsheets (e.g. Excel, Sheets)',
-    [`${P}.q2.options.digitalFormbuilder`]: 'An online form (e.g. FormSG)',
+    [`${P}.q2.options.digitalFormbuilder`]:
+      'Online form builders (e.g. FormSG)',
     [`${P}.q2.options.others`]: 'Other',
     [`${P}.otherInputLabel`]: 'Other source',
     [`${P}.errors.q1Required`]: 'Please select an option.',
@@ -168,16 +169,18 @@ describe('CreateFormOriginScreen', () => {
     )
   })
 
-  it('offers "An online form (e.g. FormSG)" as a medium option', async () => {
+  it('offers "Online form builders (e.g. FormSG)" as a medium option', async () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
 
     await selectExisting(user)
     expect(
-      screen.getByLabelText('An online form (e.g. FormSG)'),
+      screen.getByLabelText('Online form builders (e.g. FormSG)'),
     ).toBeInTheDocument()
 
-    await user.click(screen.getByLabelText('An online form (e.g. FormSG)'))
+    await user.click(
+      screen.getByLabelText('Online form builders (e.g. FormSG)'),
+    )
     await clickNext(user)
 
     await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1))

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.test.tsx
@@ -20,14 +20,18 @@ import { CreateFormOriginScreen } from './CreateFormOriginScreen'
 vi.mock('react-i18next', () => {
   const P = 'features.workspace.modals.forms.create.origin'
   const translations: Record<string, string> = {
-    [`${P}.question`]: 'How is this data being collected today?',
-    [`${P}.options.paper`]: 'Paper form',
-    [`${P}.options.digitalNew`]: "This data isn't collected",
-    [`${P}.options.digitalEmail`]: 'Emails',
-    [`${P}.options.digitalDocument`]: 'Documents (e.g. PDF, Word)',
-    [`${P}.options.digitalSpreadsheet`]: 'Spreadsheets (e.g. Excel, Sheets)',
-    [`${P}.options.digitalFormbuilder`]: 'Other form builders',
-    [`${P}.options.others`]: 'Other',
+    [`${P}.topicSentence`]: 'Tell us about your process',
+    [`${P}.q1.label`]: 'Is this form based on a new or existing process?',
+    [`${P}.q1.options.new`]: 'New',
+    [`${P}.q1.options.existing`]: 'Existing',
+    [`${P}.q2.label`]: 'How is this data being collected today?',
+    [`${P}.q2.options.paper`]: 'Paper form',
+    [`${P}.q2.options.digitalEmail`]: 'Emails',
+    [`${P}.q2.options.digitalDocument`]: 'Documents (e.g. PDF, Word)',
+    [`${P}.q2.options.digitalSpreadsheet`]: 'Spreadsheets (e.g. Excel, Sheets)',
+    [`${P}.q2.options.digitalFormsg`]: 'Another FormSG form',
+    [`${P}.q2.options.digitalFormbuilder`]: 'Other form builders',
+    [`${P}.q2.options.others`]: 'Other',
     [`${P}.otherInputLabel`]: 'Other source',
     [`${P}.errors.atLeastOne`]: 'Please select at least 1 option.',
     [`${P}.errors.otherRequired`]:
@@ -91,7 +95,31 @@ const clickNext = async (user: ReturnType<typeof userEvent.setup>) => {
   await user.click(screen.getByRole('button', { name: /next step/i }))
 }
 
+const selectExisting = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('radio', { name: 'Existing' }))
+}
+
 describe('CreateFormOriginScreen', () => {
+  it('renders the topic sentence as the header and Q1 as a radio with New/Existing, with Q2 absent', () => {
+    renderOriginScreen()
+
+    expect(screen.getByText('Tell us about your process')).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'New' })).toBeInTheDocument()
+    expect(screen.getByRole('radio', { name: 'Existing' })).toBeInTheDocument()
+    expect(screen.queryByLabelText('Paper form')).not.toBeInTheDocument()
+  })
+
+  it('keeps Q2 hidden when Q1 = New is actively selected, and shows it when Q1 = Existing is selected', async () => {
+    const user = userEvent.setup()
+    renderOriginScreen()
+
+    await user.click(screen.getByRole('radio', { name: 'New' }))
+    expect(screen.queryByLabelText('Paper form')).not.toBeInTheDocument()
+
+    await selectExisting(user)
+    expect(screen.getByLabelText('Paper form')).toBeInTheDocument()
+  })
+
   it('blocks submission and shows an error when no origin is selected', async () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
@@ -104,10 +132,25 @@ describe('CreateFormOriginScreen', () => {
     expect(onCreate).not.toHaveBeenCalled()
   })
 
+  it("shows only Q2's error (not Q1's) when Q1 = Existing but Q2 is left empty", async () => {
+    const user = userEvent.setup()
+    const { onCreate } = renderOriginScreen()
+
+    await selectExisting(user)
+    await clickNext(user)
+
+    const errors = await screen.findAllByText(
+      'Please select at least 1 option.',
+    )
+    expect(errors).toHaveLength(1)
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+
   it('creates the form with the selected origins when at least one is chosen', async () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
 
+    await selectExisting(user)
     await user.click(screen.getByLabelText('Paper form'))
     await user.click(screen.getByLabelText('Spreadsheets (e.g. Excel, Sheets)'))
     await clickNext(user)
@@ -125,10 +168,59 @@ describe('CreateFormOriginScreen', () => {
     )
   })
 
+  it('offers "Another FormSG form" as its own option, distinct from "Other form builders"', async () => {
+    const user = userEvent.setup()
+    const { onCreate } = renderOriginScreen()
+
+    await selectExisting(user)
+    expect(screen.getByLabelText('Another FormSG form')).toBeInTheDocument()
+    expect(screen.getByLabelText('Other form builders')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('Another FormSG form'))
+    await clickNext(user)
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1))
+    expect(onCreate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        formOrigins: expect.objectContaining({
+          value: [FormOrigin.DigitalFormsg],
+        }),
+      }),
+    )
+  })
+
+  it('creates the form when Q1 = New is selected, without requiring an answer to Q2', async () => {
+    const user = userEvent.setup()
+    const { onCreate } = renderOriginScreen()
+
+    await user.click(screen.getByRole('radio', { name: 'New' }))
+    await clickNext(user)
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledTimes(1))
+    expect(onCreate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ formOriginProcess: 'new' }),
+    )
+  })
+
+  it('restores previously ticked Q2 options after switching to New and back to Existing', async () => {
+    const user = userEvent.setup()
+    renderOriginScreen()
+
+    await selectExisting(user)
+    await user.click(screen.getByLabelText('Paper form'))
+
+    await user.click(screen.getByRole('radio', { name: 'New' }))
+    expect(screen.queryByLabelText('Paper form')).not.toBeInTheDocument()
+
+    await selectExisting(user)
+    expect(screen.getByLabelText('Paper form')).toBeChecked()
+  })
+
   it('requires the free-text detail when "Other" is selected', async () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
 
+    await selectExisting(user)
     await user.click(screen.getByLabelText('Other'))
     await clickNext(user)
 
@@ -142,6 +234,7 @@ describe('CreateFormOriginScreen', () => {
     const user = userEvent.setup()
     renderOriginScreen()
 
+    await selectExisting(user)
     await user.click(screen.getByLabelText('Other'))
     await user.type(screen.getByLabelText('Other source'), 'Carrier pigeon')
 
@@ -154,6 +247,7 @@ describe('CreateFormOriginScreen', () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
 
+    await selectExisting(user)
     await user.click(screen.getByLabelText('Other'))
     const input = screen.getByLabelText('Other source')
     await user.click(input)
@@ -172,6 +266,7 @@ describe('CreateFormOriginScreen', () => {
     const user = userEvent.setup()
     const { onCreate } = renderOriginScreen()
 
+    await selectExisting(user)
     await user.click(screen.getByLabelText('Other'))
     await user.type(screen.getByLabelText('Other source'), 'Carrier pigeon')
     await clickNext(user)

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.tsx
@@ -15,14 +15,16 @@ import {
 
 import {
   CLIENT_CHECKBOX_OTHERS_INPUT_VALUE,
-  FORM_ORIGIN_OPTIONS,
+  FORM_ORIGIN_MEDIUM_OPTIONS,
   FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH,
 } from 'formsg-shared/constants'
 
 import Button from '~components/Button'
 import Checkbox from '~components/Checkbox'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
 import Input from '~components/Input'
+import Radio from '~components/Radio'
 
 import { useCreateFormWizard } from '../CreateFormWizardContext'
 
@@ -47,6 +49,7 @@ export const CreateFormOriginScreen = ({
     formState: { errors },
   } = formMethods
 
+  const formOriginProcess = watch('formOriginProcess')
   const formOrigins = watch('formOrigins')
   const isOthersSelected = (formOrigins?.value ?? []).includes(
     CLIENT_CHECKBOX_OTHERS_INPUT_VALUE,
@@ -57,87 +60,123 @@ export const CreateFormOriginScreen = ({
     <>
       <ModalHeader color="secondary.700">
         <Container maxW="45rem" p={0}>
-          {t(`${ORIGIN_I18N_PREFIX}.question`)}
+          {t(`${ORIGIN_I18N_PREFIX}.topicSentence`)}
         </Container>
       </ModalHeader>
       <ModalBody whiteSpace="pre-wrap">
         <Container maxW="45rem" p={0}>
           <FormControl
             isRequired
-            isInvalid={!!errors.formOrigins?.value}
-            mb="1rem"
+            isInvalid={!!errors.formOriginProcess}
+            mb="1.5rem"
           >
+            <FormLabel>{t(`${ORIGIN_I18N_PREFIX}.q1.label`)}</FormLabel>
             <Controller
-              name="formOrigins.value"
+              name="formOriginProcess"
               control={control}
-              defaultValue={[]}
               rules={{
-                validate: (value) =>
-                  (Array.isArray(value) && value.length > 0) ||
-                  t(`${ORIGIN_I18N_PREFIX}.errors.atLeastOne`),
+                required: t(`${ORIGIN_I18N_PREFIX}.errors.atLeastOne`),
               }}
               render={({ field: { value, onChange } }) => (
-                <CheckboxGroup value={value ?? []} onChange={onChange}>
+                <Radio.RadioGroup value={value ?? ''} onChange={onChange}>
                   <Stack spacing="0.5rem">
-                    {FORM_ORIGIN_OPTIONS.map((code) => (
-                      <Checkbox key={code} value={code}>
-                        {t(`${ORIGIN_I18N_PREFIX}.options.${code}`)}
-                      </Checkbox>
-                    ))}
-                    <>
-                      <Checkbox value={CLIENT_CHECKBOX_OTHERS_INPUT_VALUE}>
-                        {t(`${ORIGIN_I18N_PREFIX}.options.others`)}
-                      </Checkbox>
-                      {isOthersSelected && (
-                        <Box pl="2.25rem">
-                          <FormControl
-                            isRequired
-                            isInvalid={!!errors.formOrigins?.othersInput}
-                          >
-                            <Input
-                              aria-label={t(
-                                `${ORIGIN_I18N_PREFIX}.otherInputLabel`,
-                              )}
-                              {...register('formOrigins.othersInput', {
-                                validate: (detail) =>
-                                  !isOthersSelected ||
-                                  !!detail?.trim() ||
-                                  t(
-                                    `${ORIGIN_I18N_PREFIX}.errors.otherRequired`,
-                                  ),
-                                maxLength: {
-                                  value: FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH,
-                                  message: t(
-                                    `${ORIGIN_I18N_PREFIX}.errors.otherMaxLength`,
-                                    {
-                                      maxLength:
-                                        FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH,
-                                    },
-                                  ),
-                                },
-                              })}
-                            />
-                            <FormErrorMessage>
-                              {errors.formOrigins?.othersInput?.message}
-                            </FormErrorMessage>
-                            {!errors.formOrigins?.othersInput?.message &&
-                            otherDetailLength > 0 ? (
-                              <FormHelperText>
-                                {`(${otherDetailLength}/${FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH})`}
-                              </FormHelperText>
-                            ) : undefined}
-                          </FormControl>
-                        </Box>
-                      )}
-                    </>
+                    <Radio value="new">
+                      {t(`${ORIGIN_I18N_PREFIX}.q1.options.new`)}
+                    </Radio>
+                    <Radio value="existing">
+                      {t(`${ORIGIN_I18N_PREFIX}.q1.options.existing`)}
+                    </Radio>
                   </Stack>
-                </CheckboxGroup>
+                </Radio.RadioGroup>
               )}
             />
             <FormErrorMessage>
-              {errors.formOrigins?.value?.message}
+              {errors.formOriginProcess?.message}
             </FormErrorMessage>
           </FormControl>
+
+          <Controller
+            name="formOrigins.value"
+            control={control}
+            defaultValue={[]}
+            rules={{
+              validate: (value) =>
+                formOriginProcess !== 'existing' ||
+                (Array.isArray(value) && value.length > 0) ||
+                t(`${ORIGIN_I18N_PREFIX}.errors.atLeastOne`),
+            }}
+            render={({ field: { value, onChange } }) =>
+              formOriginProcess === 'existing' ? (
+                <FormControl
+                  isRequired
+                  isInvalid={!!errors.formOrigins?.value}
+                  mb="1rem"
+                >
+                  <FormLabel>{t(`${ORIGIN_I18N_PREFIX}.q2.label`)}</FormLabel>
+                  <CheckboxGroup value={value ?? []} onChange={onChange}>
+                    <Stack spacing="0.5rem">
+                      {FORM_ORIGIN_MEDIUM_OPTIONS.map((code) => (
+                        <Checkbox key={code} value={code}>
+                          {t(`${ORIGIN_I18N_PREFIX}.q2.options.${code}`)}
+                        </Checkbox>
+                      ))}
+                      <>
+                        <Checkbox value={CLIENT_CHECKBOX_OTHERS_INPUT_VALUE}>
+                          {t(`${ORIGIN_I18N_PREFIX}.q2.options.others`)}
+                        </Checkbox>
+                        {isOthersSelected && (
+                          <Box pl="2.25rem">
+                            <FormControl
+                              isRequired
+                              isInvalid={!!errors.formOrigins?.othersInput}
+                            >
+                              <Input
+                                aria-label={t(
+                                  `${ORIGIN_I18N_PREFIX}.otherInputLabel`,
+                                )}
+                                {...register('formOrigins.othersInput', {
+                                  validate: (detail) =>
+                                    !isOthersSelected ||
+                                    !!detail?.trim() ||
+                                    t(
+                                      `${ORIGIN_I18N_PREFIX}.errors.otherRequired`,
+                                    ),
+                                  maxLength: {
+                                    value: FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH,
+                                    message: t(
+                                      `${ORIGIN_I18N_PREFIX}.errors.otherMaxLength`,
+                                      {
+                                        maxLength:
+                                          FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH,
+                                      },
+                                    ),
+                                  },
+                                })}
+                              />
+                              <FormErrorMessage>
+                                {errors.formOrigins?.othersInput?.message}
+                              </FormErrorMessage>
+                              {!errors.formOrigins?.othersInput?.message &&
+                              otherDetailLength > 0 ? (
+                                <FormHelperText>
+                                  {`(${otherDetailLength}/${FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH})`}
+                                </FormHelperText>
+                              ) : undefined}
+                            </FormControl>
+                          </Box>
+                        )}
+                      </>
+                    </Stack>
+                  </CheckboxGroup>
+                  <FormErrorMessage>
+                    {errors.formOrigins?.value?.message}
+                  </FormErrorMessage>
+                </FormControl>
+              ) : (
+                <></>
+              )
+            }
+          />
 
           <Stack mt="2.5rem" spacing="0.75rem" align="center">
             <Button

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.tsx
@@ -75,7 +75,7 @@ export const CreateFormOriginScreen = ({
               name="formOriginProcess"
               control={control}
               rules={{
-                required: t(`${ORIGIN_I18N_PREFIX}.errors.atLeastOne`),
+                required: t(`${ORIGIN_I18N_PREFIX}.errors.q1Required`),
               }}
               render={({ field: { value, onChange } }) => (
                 <Radio.RadioGroup value={value ?? ''} onChange={onChange}>

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardContext.tsx
@@ -21,6 +21,8 @@ export enum CreateFormFlowStates {
   EmailModeCreation = 'emailModeCreation',
 }
 
+export type FormOriginProcessAnswer = 'new' | 'existing'
+
 export interface CreateFormWizardInputProps {
   title: string
   responseMode: FormResponseMode
@@ -28,6 +30,10 @@ export interface CreateFormWizardInputProps {
   emails?: string[]
   // Storage form props
   storageAck?: boolean
+  // Q1: whether the data collection is a new or existing process.
+  formOriginProcess?: FormOriginProcessAnswer
+  // Q2: mediums already used to collect this data today (only answered when
+  // formOriginProcess is 'existing').
   formOrigins?: CheckboxFieldResponsesV3
   // TODO: (Kill Email Mode) Remove this route after kill email mode is fully implemented.
   reason?: CheckboxFieldValues // for kill email mode

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.test.tsx
@@ -241,6 +241,32 @@ describe('useCreateFormWizardContext — paper-forms origin step', () => {
     )
   })
 
+  it('submits only the new-process value when formOriginProcess is "new", discarding stale Q2 ticks', async () => {
+    setFlags({ cutover: true, paperTracking: true })
+    const { result } = renderHook(() => useCreateFormWizardContext(vi.fn()))
+
+    act(() =>
+      result.current.formMethods.reset({
+        title: 'My form',
+        responseMode: FormResponseMode.Multirespondent,
+        formOriginProcess: 'new',
+        // Stale Q2 state left over from before the admin switched to "new".
+        formOrigins: { value: [FormOrigin.Paper] },
+      }),
+    )
+    await act(async () => {
+      await result.current.handleCreateStorageModeOrMultirespondentForm()
+    })
+
+    expect(mrfMutation.mutate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        metadata: {
+          formOrigins: { value: [FormOrigin.DigitalNew] },
+        },
+      }),
+    )
+  })
+
   it('exposes the "Next step" proceed label when paper tracking is enabled', () => {
     setFlags({ cutover: true, paperTracking: true })
     const { result } = renderHook(() => useCreateFormWizardContext(vi.fn()))

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.test.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.test.tsx
@@ -102,6 +102,7 @@ describe('useCreateFormWizardContext — paper-forms origin step', () => {
       result.current.formMethods.reset({
         title: 'My form',
         responseMode: FormResponseMode.Encrypt,
+        formOriginProcess: 'existing',
         formOrigins: {
           value: [FormOrigin.Paper, FormOrigin.DigitalSpreadsheet],
         },
@@ -131,6 +132,7 @@ describe('useCreateFormWizardContext — paper-forms origin step', () => {
       result.current.formMethods.reset({
         title: 'My form',
         responseMode: FormResponseMode.Multirespondent,
+        formOriginProcess: 'existing',
         formOrigins: {
           value: [FormOrigin.Paper, FormOrigin.DigitalSpreadsheet],
         },
@@ -160,6 +162,7 @@ describe('useCreateFormWizardContext — paper-forms origin step', () => {
       result.current.formMethods.reset({
         title: 'My form',
         responseMode: FormResponseMode.Multirespondent,
+        formOriginProcess: 'existing',
         formOrigins: {
           value: [CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
           othersInput: 'Carrier pigeon',
@@ -192,6 +195,7 @@ describe('useCreateFormWizardContext — paper-forms origin step', () => {
       result.current.formMethods.reset({
         title: 'My form',
         responseMode: FormResponseMode.Multirespondent,
+        formOriginProcess: 'existing',
         formOrigins: {
           value: [FormOrigin.Paper, CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
           othersInput: 'Carrier pigeon',

--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormWizardProvider.tsx
@@ -167,11 +167,13 @@ export const useCreateFormWizardContext = (
     title,
     responseMode,
     emails,
+    formOriginProcess,
     formOrigins,
   }: CreateFormWizardInputProps) => {
     const metadata = buildFormClientMetadata({
       isPaperTrackingSetUpPageEnabled,
       isMrfCutoverEnabled,
+      formOriginProcess,
       formOrigins,
       formResponseMode: responseMode,
     })

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.cutover.test.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.cutover.test.tsx
@@ -174,6 +174,34 @@ describe('DupeFormWizardProvider — cutover behaviour', () => {
     expect(dupeStorageModeFormMutation.mutate).not.toHaveBeenCalled()
   })
 
+  it('submits only the new-process value when formOriginProcess is "new", discarding stale Q2 ticks', async () => {
+    setFlags({ cutover: true, paperTracking: true })
+    const { result } = renderHook(() =>
+      useDupeFormWizardContext(vi.fn(), {
+        formIdToDuplicate: MOCK_FORM_ID as any,
+      }),
+    )
+
+    act(() => {
+      result.current.formMethods.setValue('title', 'New title')
+      result.current.formMethods.setValue('formOriginProcess', 'new')
+      result.current.formMethods.setValue('formOrigins', {
+        value: [FormOrigin.Paper],
+      })
+    })
+    await act(async () => {
+      await result.current.handleCreateStorageModeOrMultirespondentForm()
+    })
+
+    expect(dupeMultirespondentModeFormMutation.mutate.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        metadata: {
+          formOrigins: { value: [FormOrigin.DigitalNew] },
+        },
+      }),
+    )
+  })
+
   it('re-asks origins and duplicates with them as metadata', async () => {
     setFlags({ cutover: true, paperTracking: true })
     const { result } = renderHook(() =>

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.cutover.test.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.cutover.test.tsx
@@ -212,6 +212,7 @@ describe('DupeFormWizardProvider — cutover behaviour', () => {
 
     act(() => {
       result.current.formMethods.setValue('title', 'New title')
+      result.current.formMethods.setValue('formOriginProcess', 'existing')
       result.current.formMethods.setValue('formOrigins', {
         value: [FormOrigin.Paper, CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
         othersInput: 'Fax',

--- a/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
+++ b/apps/frontend/src/features/workspace/components/DuplicateFormModal/DupeFormWizardProvider.tsx
@@ -115,6 +115,7 @@ export const useDupeFormWizardContext = (
     title,
     responseMode,
     emails,
+    formOriginProcess,
     formOrigins,
   }: CreateFormWizardInputProps) => {
     if (!sourceFormId) {
@@ -124,6 +125,7 @@ export const useDupeFormWizardContext = (
     const metadata = buildFormClientMetadata({
       isPaperTrackingSetUpPageEnabled,
       isMrfCutoverEnabled,
+      formOriginProcess,
       formOrigins,
       formResponseMode: responseMode,
     })

--- a/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.test.ts
+++ b/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.test.ts
@@ -1,0 +1,125 @@
+import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from 'formsg-shared/constants'
+import { FormOrigin, FormResponseMode } from 'formsg-shared/types/form/form'
+
+import { buildFormClientMetadata } from './buildFormClientMetadata'
+
+describe('buildFormClientMetadata', () => {
+  it('produces only the new-process value when formOriginProcess is "new", ignoring any medium state', () => {
+    const metadata = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: false,
+      formOriginProcess: 'new',
+      formOrigins: { value: [FormOrigin.Paper, FormOrigin.DigitalEmail] },
+      formResponseMode: FormResponseMode.Multirespondent,
+    })
+
+    expect(metadata).toEqual({
+      formOrigins: { value: [FormOrigin.DigitalNew] },
+    })
+  })
+
+  it('produces exactly the selected medium when formOriginProcess is "existing" with one medium', () => {
+    const metadata = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: false,
+      formOriginProcess: 'existing',
+      formOrigins: { value: [FormOrigin.Paper] },
+      formResponseMode: FormResponseMode.Multirespondent,
+    })
+
+    expect(metadata).toEqual({
+      formOrigins: { value: [FormOrigin.Paper], othersInput: undefined },
+    })
+  })
+
+  it('produces all selected mediums when multiple are ticked, including the new FormSG option', () => {
+    const metadata = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: false,
+      formOriginProcess: 'existing',
+      formOrigins: {
+        value: [FormOrigin.Paper, FormOrigin.DigitalFormsg],
+      },
+      formResponseMode: FormResponseMode.Multirespondent,
+    })
+
+    expect(metadata).toEqual({
+      formOrigins: {
+        value: [FormOrigin.Paper, FormOrigin.DigitalFormsg],
+        othersInput: undefined,
+      },
+    })
+  })
+
+  it('includes the trimmed "other" detail when other is selected with text', () => {
+    const metadata = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: false,
+      formOriginProcess: 'existing',
+      formOrigins: {
+        value: [CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
+        othersInput: '  Carrier pigeon  ',
+      },
+      formResponseMode: FormResponseMode.Multirespondent,
+    })
+
+    expect(metadata).toEqual({
+      formOrigins: {
+        value: [CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
+        othersInput: 'Carrier pigeon',
+      },
+    })
+  })
+
+  it('omits the "other" detail when other is selected with a blank/whitespace-only detail', () => {
+    const metadata = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: false,
+      formOriginProcess: 'existing',
+      formOrigins: {
+        value: [CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
+        othersInput: '   ',
+      },
+      formResponseMode: FormResponseMode.Multirespondent,
+    })
+
+    expect(metadata).toEqual({
+      formOrigins: {
+        value: [CLIENT_CHECKBOX_OTHERS_INPUT_VALUE],
+        othersInput: undefined,
+      },
+    })
+  })
+
+  it('produces no formOrigins payload during the MRF-cutover escape hatch, regardless of Q1/Q2 state', () => {
+    const metadataForNewProcess = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: true,
+      formOriginProcess: 'new',
+      formOrigins: undefined,
+      formResponseMode: FormResponseMode.Encrypt,
+    })
+    const metadataForExistingProcess = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: true,
+      formOriginProcess: 'existing',
+      formOrigins: { value: [FormOrigin.Paper] },
+      formResponseMode: FormResponseMode.Encrypt,
+    })
+
+    expect(metadataForNewProcess).toBeUndefined()
+    expect(metadataForExistingProcess).toBeUndefined()
+  })
+
+  it('produces no formOrigins payload when formOriginProcess is unanswered', () => {
+    const metadata = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: false,
+      formOriginProcess: undefined,
+      formOrigins: undefined,
+      formResponseMode: FormResponseMode.Multirespondent,
+    })
+
+    expect(metadata).toBeUndefined()
+  })
+})

--- a/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.test.ts
+++ b/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.test.ts
@@ -32,20 +32,20 @@ describe('buildFormClientMetadata', () => {
     })
   })
 
-  it('produces all selected mediums when multiple are ticked, including the new FormSG option', () => {
+  it('produces all selected mediums when multiple are ticked', () => {
     const metadata = buildFormClientMetadata({
       isPaperTrackingSetUpPageEnabled: true,
       isMrfCutoverEnabled: false,
       formOriginProcess: 'existing',
       formOrigins: {
-        value: [FormOrigin.Paper, FormOrigin.DigitalFormsg],
+        value: [FormOrigin.Paper, FormOrigin.DigitalFormBuilder],
       },
       formResponseMode: FormResponseMode.Multirespondent,
     })
 
     expect(metadata).toEqual({
       formOrigins: {
-        value: [FormOrigin.Paper, FormOrigin.DigitalFormsg],
+        value: [FormOrigin.Paper, FormOrigin.DigitalFormBuilder],
         othersInput: undefined,
       },
     })

--- a/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.test.ts
+++ b/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.test.ts
@@ -122,4 +122,16 @@ describe('buildFormClientMetadata', () => {
 
     expect(metadata).toBeUndefined()
   })
+
+  it('ignores stale Q2 selections retained in wizard state when formOriginProcess is unanswered', () => {
+    const metadata = buildFormClientMetadata({
+      isPaperTrackingSetUpPageEnabled: true,
+      isMrfCutoverEnabled: false,
+      formOriginProcess: undefined,
+      formOrigins: { value: [FormOrigin.Paper] },
+      formResponseMode: FormResponseMode.Multirespondent,
+    })
+
+    expect(metadata).toBeUndefined()
+  })
 })

--- a/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.ts
+++ b/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.ts
@@ -1,24 +1,32 @@
 import { CLIENT_CHECKBOX_OTHERS_INPUT_VALUE } from 'formsg-shared/constants'
-import { FormMetadata, FormResponseMode } from 'formsg-shared/types'
+import { FormMetadata, FormOrigin, FormResponseMode } from 'formsg-shared/types'
 import { CheckboxFieldResponsesV3 } from 'formsg-shared/types/response-v3'
 
+import { FormOriginProcessAnswer } from '~features/workspace/components/CreateFormModal/CreateFormWizardContext'
+
 /**
- * Translates the frontend formOrigins state (for rendering) into the expected payload.
- * Required since for example, `othersInput` can be persisted in frontend state
- * but the `others` option is not selected in the frontend.
+ * Translates the wizard's Q1 (process) + Q2 (medium) state into the expected
+ * formOrigins payload. New process short-circuits to the new-process value
+ * alone, discarding any medium selections retained in Q2's UI state.
  * @param isPaperTrackingSetUpPageEnabled only defined if the paper tracking is enabled.
- * @param formOrigins frontend formOrigins state (for rendering)
+ * @param formOriginProcess Q1's raw answer.
+ * @param formOrigins Q2's frontend state (mediums + others detail, for rendering).
  * @returns the expected formOrigins payload for the backend
  */
 const buildFormOriginsPayload = (
   isPaperTrackingSetUpPageEnabled: boolean,
+  formOriginProcess: FormOriginProcessAnswer | undefined,
   formOrigins: CheckboxFieldResponsesV3 | undefined,
 ): CheckboxFieldResponsesV3 | undefined => {
-  if (
-    !isPaperTrackingSetUpPageEnabled ||
-    !formOrigins ||
-    formOrigins.value.length <= 0
-  ) {
+  if (!isPaperTrackingSetUpPageEnabled) {
+    return undefined
+  }
+
+  if (formOriginProcess === 'new') {
+    return { value: [FormOrigin.DigitalNew] }
+  }
+
+  if (!formOrigins || formOrigins.value.length <= 0) {
     return undefined
   }
 
@@ -36,18 +44,24 @@ const buildFormOriginsPayload = (
 export const buildFormClientMetadata = ({
   isPaperTrackingSetUpPageEnabled,
   isMrfCutoverEnabled,
+  formOriginProcess,
   formOrigins,
   formResponseMode,
 }: {
   isPaperTrackingSetUpPageEnabled: boolean
   isMrfCutoverEnabled: boolean
+  formOriginProcess: FormOriginProcessAnswer | undefined
   formOrigins: CheckboxFieldResponsesV3 | undefined
   formResponseMode: FormResponseMode
 }): Pick<FormMetadata, 'formOrigins'> | undefined => {
   const isEscapeHatchFlow =
     isMrfCutoverEnabled && formResponseMode === FormResponseMode.Encrypt
   const formOriginsPayload = !isEscapeHatchFlow
-    ? buildFormOriginsPayload(isPaperTrackingSetUpPageEnabled, formOrigins)
+    ? buildFormOriginsPayload(
+        isPaperTrackingSetUpPageEnabled,
+        formOriginProcess,
+        formOrigins,
+      )
     : undefined
 
   return formOriginsPayload

--- a/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.ts
+++ b/apps/frontend/src/features/workspace/utils/buildFormClientMetadata.ts
@@ -26,7 +26,11 @@ const buildFormOriginsPayload = (
     return { value: [FormOrigin.DigitalNew] }
   }
 
-  if (!formOrigins || formOrigins.value.length <= 0) {
+  if (
+    formOriginProcess !== 'existing' ||
+    !formOrigins ||
+    formOrigins.value.length <= 0
+  ) {
     return undefined
   }
 

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -88,12 +88,11 @@ export const enSG: CreateFormModal = {
     q2: {
       label: 'How is this data being collected today?',
       options: {
-        paper: 'Paper form',
+        digitalFormbuilder: 'An online form (e.g. FormSG)',
         digitalEmail: 'Emails',
         digitalDocument: 'Documents (e.g. PDF, Word)',
         digitalSpreadsheet: 'Spreadsheets (e.g. Excel, Sheets)',
-        digitalFormsg: 'Another FormSG form',
-        digitalFormbuilder: 'Other form builders',
+        paper: 'Paper form',
         others: 'Other',
       },
     },

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -88,16 +88,18 @@ export const enSG: CreateFormModal = {
     q2: {
       label: 'How is this data being collected today?',
       options: {
-        digitalFormsg: 'Another FormSG form',
+        paper: 'Paper form',
         digitalEmail: 'Emails',
         digitalDocument: 'Documents (e.g. PDF, Word)',
         digitalSpreadsheet: 'Spreadsheets (e.g. Excel, Sheets)',
-        paper: 'Paper form',
+        digitalFormsg: 'Another FormSG form',
+        digitalFormbuilder: 'Other form builders',
         others: 'Other',
       },
     },
     otherInputLabel: 'Other source',
     errors: {
+      q1Required: 'Please select an option.',
       atLeastOne: 'Please select at least 1 option.',
       otherRequired: 'Please specify a value for the "others" option',
       otherMaxLength: 'Please use {maxLength} characters or fewer.',

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -77,15 +77,25 @@ export const enSG: CreateFormModal = {
     suffix: '.',
   },
   origin: {
-    question: 'How is this data being collected today?',
-    options: {
-      paper: 'Paper form',
-      digitalNew: "This data isn't collected",
-      digitalEmail: 'Emails',
-      digitalDocument: 'Documents (e.g. PDF, Word)',
-      digitalSpreadsheet: 'Spreadsheets (e.g. Excel, Sheets)',
-      digitalFormbuilder: 'Other form builders',
-      others: 'Other',
+    topicSentence: 'Tell us about your process',
+    q1: {
+      label: 'Is this form based on a new or existing process?',
+      options: {
+        new: 'New',
+        existing: 'Existing',
+      },
+    },
+    q2: {
+      label: 'How is this data being collected today?',
+      options: {
+        paper: 'Paper form',
+        digitalEmail: 'Emails',
+        digitalDocument: 'Documents (e.g. PDF, Word)',
+        digitalSpreadsheet: 'Spreadsheets (e.g. Excel, Sheets)',
+        digitalFormsg: 'Another FormSG form',
+        digitalFormbuilder: 'Other form builders',
+        others: 'Other',
+      },
     },
     otherInputLabel: 'Other source',
     errors: {

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -88,12 +88,11 @@ export const enSG: CreateFormModal = {
     q2: {
       label: 'How is this data being collected today?',
       options: {
-        paper: 'Paper form',
+        digitalFormsg: 'Another FormSG form',
         digitalEmail: 'Emails',
         digitalDocument: 'Documents (e.g. PDF, Word)',
         digitalSpreadsheet: 'Spreadsheets (e.g. Excel, Sheets)',
-        digitalFormsg: 'Another FormSG form',
-        digitalFormbuilder: 'Other form builders',
+        paper: 'Paper form',
         others: 'Other',
       },
     },

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/en-sg.ts
@@ -88,7 +88,7 @@ export const enSG: CreateFormModal = {
     q2: {
       label: 'How is this data being collected today?',
       options: {
-        digitalFormbuilder: 'An online form (e.g. FormSG)',
+        digitalFormbuilder: 'Online form builders (e.g. FormSG)',
         digitalEmail: 'Emails',
         digitalDocument: 'Documents (e.g. PDF, Word)',
         digitalSpreadsheet: 'Spreadsheets (e.g. Excel, Sheets)',

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
@@ -68,15 +68,25 @@ export interface CreateFormModal {
     suffix: string
   }
   origin: {
-    question: string
-    options: {
-      paper: string
-      digitalNew: string
-      digitalEmail: string
-      digitalDocument: string
-      digitalSpreadsheet: string
-      digitalFormbuilder: string
-      others: string
+    topicSentence: string
+    q1: {
+      label: string
+      options: {
+        new: string
+        existing: string
+      }
+    }
+    q2: {
+      label: string
+      options: {
+        paper: string
+        digitalEmail: string
+        digitalDocument: string
+        digitalSpreadsheet: string
+        digitalFormsg: string
+        digitalFormbuilder: string
+        others: string
+      }
     }
     otherInputLabel: string
     errors: {

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
@@ -79,12 +79,11 @@ export interface CreateFormModal {
     q2: {
       label: string
       options: {
-        paper: string
+        digitalFormbuilder: string
         digitalEmail: string
         digitalDocument: string
         digitalSpreadsheet: string
-        digitalFormsg: string
-        digitalFormbuilder: string
+        paper: string
         others: string
       }
     }

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
@@ -79,12 +79,11 @@ export interface CreateFormModal {
     q2: {
       label: string
       options: {
-        paper: string
+        digitalFormsg: string
         digitalEmail: string
         digitalDocument: string
         digitalSpreadsheet: string
-        digitalFormsg: string
-        digitalFormbuilder: string
+        paper: string
         others: string
       }
     }

--- a/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
+++ b/apps/frontend/src/i18n/locales/features/workspace/modals/forms/create/index.ts
@@ -79,16 +79,18 @@ export interface CreateFormModal {
     q2: {
       label: string
       options: {
-        digitalFormsg: string
+        paper: string
         digitalEmail: string
         digitalDocument: string
         digitalSpreadsheet: string
-        paper: string
+        digitalFormsg: string
+        digitalFormbuilder: string
         others: string
       }
     }
     otherInputLabel: string
     errors: {
+      q1Required: string
       atLeastOne: string
       otherRequired: string
       otherMaxLength: string

--- a/docs/adr/0001-no-variant-logging-for-form-origin-v2.md
+++ b/docs/adr/0001-no-variant-logging-for-form-origin-v2.md
@@ -1,0 +1,7 @@
+# No per-form variant logging for the form-origin two-question redesign
+
+The form-origin redesign (splitting the single "how is this being filled today?" question into a process question and a medium question) needs to compare answer distributions from before and after the change. The obvious way to guarantee a clean comparison is to log, on each form, which UI version (old single-question vs new two-question) the admin saw — but we decided against adding that logging.
+
+Instead, the new two-question UI ships **directly inside the existing `enable-paper-tracking-set-up-page` flag** — no new flag is created for this redesign (v2.1 decision; v2.0 had originally planned a new flag layered on top, since abandoned). Whoever currently reaches the origin screen through that pre-existing flag sees the two-question version as soon as this change is deployed. Before/after comparison is done purely by each form's creation timestamp relative to the deploy — not by a stored variant marker, and not by a flag-flip timestamp (there is no new flag to flip).
+
+**Consequence**: if the deploy in practice isn't instantaneous for every admin (e.g. staggered rollout across instances, clients with stale cached bundles), forms created near the deploy boundary can't be reliably attributed to a version after the fact. This was accepted as a simplicity trade-off — do not add variant tracking on top of this without revisiting the decision, and do not assume answers near the deploy date are attributable to a single version.

--- a/packages/shared/constants/__tests__/form-origin.spec.ts
+++ b/packages/shared/constants/__tests__/form-origin.spec.ts
@@ -12,9 +12,12 @@ describe('FORM_ORIGIN_OPTIONS', () => {
     )
   })
 
-  it('places paper form last, after the digital mediums', () => {
-    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.Paper)).toBe(
-      FORM_ORIGIN_OPTIONS.length - 1,
+  it('places the "another FormSG form" option between spreadsheet and form-builder', () => {
+    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormsg)).toBe(
+      FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalSpreadsheet) + 1,
+    )
+    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormBuilder)).toBe(
+      FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormsg) + 1,
     )
   })
 })

--- a/packages/shared/constants/__tests__/form-origin.spec.ts
+++ b/packages/shared/constants/__tests__/form-origin.spec.ts
@@ -12,13 +12,14 @@ describe('FORM_ORIGIN_OPTIONS', () => {
     )
   })
 
-  it('places the "another FormSG form" option between spreadsheet and form-builder', () => {
-    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormsg)).toBe(
-      FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalSpreadsheet) + 1,
-    )
-    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormBuilder)).toBe(
-      FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormsg) + 1,
-    )
+  it('places form-builder first among the mediums, ahead of email/document/spreadsheet/paper', () => {
+    expect(FORM_ORIGIN_MEDIUM_OPTIONS).toEqual([
+      FormOrigin.DigitalFormBuilder,
+      FormOrigin.DigitalEmail,
+      FormOrigin.DigitalDocument,
+      FormOrigin.DigitalSpreadsheet,
+      FormOrigin.Paper,
+    ])
   })
 })
 

--- a/packages/shared/constants/__tests__/form-origin.spec.ts
+++ b/packages/shared/constants/__tests__/form-origin.spec.ts
@@ -12,12 +12,9 @@ describe('FORM_ORIGIN_OPTIONS', () => {
     )
   })
 
-  it('places the "another FormSG form" option between spreadsheet and form-builder', () => {
-    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormsg)).toBe(
-      FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalSpreadsheet) + 1,
-    )
-    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormBuilder)).toBe(
-      FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormsg) + 1,
+  it('places paper form last, after the digital mediums', () => {
+    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.Paper)).toBe(
+      FORM_ORIGIN_OPTIONS.length - 1,
     )
   })
 })

--- a/packages/shared/constants/__tests__/form-origin.spec.ts
+++ b/packages/shared/constants/__tests__/form-origin.spec.ts
@@ -1,10 +1,55 @@
 import { FormOrigin } from '../../types/form/form'
-import { FORM_ORIGIN_OPTIONS } from '../form-origin'
+import {
+  FORM_ORIGIN_MEDIUM_OPTIONS,
+  FORM_ORIGIN_OPTIONS,
+  isNewProcessFormOrigin,
+} from '../form-origin'
 
 describe('FORM_ORIGIN_OPTIONS', () => {
   it('lists every recognised origin code exactly once', () => {
     expect([...FORM_ORIGIN_OPTIONS].sort()).toEqual(
       [...Object.values(FormOrigin)].sort(),
     )
+  })
+
+  it('places the "another FormSG form" option between spreadsheet and form-builder', () => {
+    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormsg)).toBe(
+      FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalSpreadsheet) + 1,
+    )
+    expect(FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormBuilder)).toBe(
+      FORM_ORIGIN_OPTIONS.indexOf(FormOrigin.DigitalFormsg) + 1,
+    )
+  })
+})
+
+describe('FORM_ORIGIN_MEDIUM_OPTIONS', () => {
+  it('excludes exactly the new-process value and preserves the master ordering', () => {
+    expect(FORM_ORIGIN_MEDIUM_OPTIONS).toEqual(
+      FORM_ORIGIN_OPTIONS.filter((code) => code !== FormOrigin.DigitalNew),
+    )
+    expect(FORM_ORIGIN_MEDIUM_OPTIONS).not.toContain(FormOrigin.DigitalNew)
+  })
+})
+
+describe('isNewProcessFormOrigin', () => {
+  it('returns true when the value is solely the new-process code', () => {
+    expect(isNewProcessFormOrigin([FormOrigin.DigitalNew])).toBe(true)
+  })
+
+  it('returns false for an empty value', () => {
+    expect(isNewProcessFormOrigin([])).toBe(false)
+  })
+
+  it('returns false for medium-only values', () => {
+    expect(isNewProcessFormOrigin([FormOrigin.Paper])).toBe(false)
+    expect(
+      isNewProcessFormOrigin([FormOrigin.Paper, FormOrigin.DigitalEmail]),
+    ).toBe(false)
+  })
+
+  it('returns false for a value mixing the new-process code with a medium', () => {
+    expect(
+      isNewProcessFormOrigin([FormOrigin.DigitalNew, FormOrigin.Paper]),
+    ).toBe(false)
   })
 })

--- a/packages/shared/constants/form-origin.ts
+++ b/packages/shared/constants/form-origin.ts
@@ -14,5 +14,23 @@ export const FORM_ORIGIN_OPTIONS = [
   FormOrigin.DigitalEmail,
   FormOrigin.DigitalDocument,
   FormOrigin.DigitalSpreadsheet,
+  FormOrigin.DigitalFormsg,
   FormOrigin.DigitalFormBuilder,
 ] as const
+
+/**
+ * Medium options for the "how is this data being collected today?" question.
+ * Derived from FORM_ORIGIN_OPTIONS with the new-process value excluded, so
+ * the two lists can't drift apart when an option is added or renamed.
+ */
+export const FORM_ORIGIN_MEDIUM_OPTIONS = FORM_ORIGIN_OPTIONS.filter(
+  (code) => code !== FormOrigin.DigitalNew,
+)
+
+/**
+ * Whether a formOrigins.value array represents a "new process" answer, i.e.
+ * consists solely of the new-process code. Mixed values (legacy rows that
+ * combine DigitalNew with a real medium) are not treated as new-process.
+ */
+export const isNewProcessFormOrigin = (value: string[]): boolean =>
+  value.length === 1 && value[0] === FormOrigin.DigitalNew

--- a/packages/shared/constants/form-origin.ts
+++ b/packages/shared/constants/form-origin.ts
@@ -9,13 +9,12 @@ export const FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH = 200
  * rather than as an origin code.
  */
 export const FORM_ORIGIN_OPTIONS = [
-  FormOrigin.Paper,
   FormOrigin.DigitalNew,
+  FormOrigin.DigitalFormBuilder,
   FormOrigin.DigitalEmail,
   FormOrigin.DigitalDocument,
   FormOrigin.DigitalSpreadsheet,
-  FormOrigin.DigitalFormsg,
-  FormOrigin.DigitalFormBuilder,
+  FormOrigin.Paper,
 ] as const
 
 /**

--- a/packages/shared/constants/form-origin.ts
+++ b/packages/shared/constants/form-origin.ts
@@ -9,12 +9,13 @@ export const FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH = 200
  * rather than as an origin code.
  */
 export const FORM_ORIGIN_OPTIONS = [
+  FormOrigin.Paper,
   FormOrigin.DigitalNew,
-  FormOrigin.DigitalFormsg,
   FormOrigin.DigitalEmail,
   FormOrigin.DigitalDocument,
   FormOrigin.DigitalSpreadsheet,
-  FormOrigin.Paper,
+  FormOrigin.DigitalFormsg,
+  FormOrigin.DigitalFormBuilder,
 ] as const
 
 /**

--- a/packages/shared/constants/form-origin.ts
+++ b/packages/shared/constants/form-origin.ts
@@ -9,13 +9,12 @@ export const FORM_ORIGIN_OTHER_DETAIL_MAX_LENGTH = 200
  * rather than as an origin code.
  */
 export const FORM_ORIGIN_OPTIONS = [
-  FormOrigin.Paper,
   FormOrigin.DigitalNew,
+  FormOrigin.DigitalFormsg,
   FormOrigin.DigitalEmail,
   FormOrigin.DigitalDocument,
   FormOrigin.DigitalSpreadsheet,
-  FormOrigin.DigitalFormsg,
-  FormOrigin.DigitalFormBuilder,
+  FormOrigin.Paper,
 ] as const
 
 /**

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -120,7 +120,6 @@ export enum FormOrigin {
   DigitalDocument = 'digitalDocument',
   DigitalSpreadsheet = 'digitalSpreadsheet',
   DigitalFormsg = 'digitalFormsg',
-  DigitalFormBuilder = 'digitalFormbuilder',
 }
 
 export interface FormMetadata {

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -119,7 +119,6 @@ export enum FormOrigin {
   DigitalEmail = 'digitalEmail',
   DigitalDocument = 'digitalDocument',
   DigitalSpreadsheet = 'digitalSpreadsheet',
-  DigitalFormsg = 'digitalFormsg',
   DigitalFormBuilder = 'digitalFormbuilder',
 }
 

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -120,6 +120,7 @@ export enum FormOrigin {
   DigitalDocument = 'digitalDocument',
   DigitalSpreadsheet = 'digitalSpreadsheet',
   DigitalFormsg = 'digitalFormsg',
+  DigitalFormBuilder = 'digitalFormbuilder',
 }
 
 export interface FormMetadata {

--- a/packages/shared/types/form/form.ts
+++ b/packages/shared/types/form/form.ts
@@ -119,6 +119,7 @@ export enum FormOrigin {
   DigitalEmail = 'digitalEmail',
   DigitalDocument = 'digitalDocument',
   DigitalSpreadsheet = 'digitalSpreadsheet',
+  DigitalFormsg = 'digitalFormsg',
   DigitalFormBuilder = 'digitalFormbuilder',
 }
 


### PR DESCRIPTION
## Problem

When admins create a form, they're asked "How is this being filled in today?" and pick from a single checkbox list that conflates two different questions: whether the underlying process is new or already exists, and (if it exists) what medium currently collects it. Because "This is a new process" sits in that list next to options like "Paper form" and "Emails", admins conflate "new to me digitally" with "genuinely new" — someone digitizing a paper form often picks "new process" simply because the digital form is new, even though the underlying data collection has existed for years. This produces form-origin data that doesn't reflect reality, undermining Ops' ability to tell forms that digitize an existing process apart from forms that collect genuinely new data.

Closes #9853.

## Solution

Splits the single question into two, shown on the same screen. A topic sentence ("Tell us about your process") now sits in the header where the question used to be; Q1 asks whether this is a new or existing process (a plain "New"/"Existing" radio); Q2 — shown only when Q1 = "Existing" — asks how the data is collected today.

Q2's options are: Online form builders (e.g. FormSG), Emails, Documents (e.g. PDF, Word), Spreadsheets (e.g. Excel, Sheets), Paper form, Other. No `FormOrigin` enum member is added or removed from what's already live — the only content change is renaming the existing "Other form builders" option's display copy to "Online form builders (e.g. FormSG)", so it explicitly calls out FormSG as an example without needing a separate FormSG-specific value. (An earlier revision of this PR added a distinct `FormOrigin.DigitalFormsg` value so admins could name "another FormSG form" apart from other form builders — that's been dropped in favor of the simpler reworded option above, so Ops can no longer tell a FormSG-origin process apart from a generic form-builder one in `metadata.formOrigins` going forward.)

Toggling Q1 away from "Existing" and back preserves whatever was ticked in Q2, and the same holds across navigating back to the title screen and forward again.

Storage is unchanged — everything still lands in `metadata.formOrigins` in the same shape it always has, so there's no migration and no downstream consumer changes. This ships behind the existing paper-tracking flag only; there's no new flag and no gradual rollout — whoever already reaches this screen sees the two-question version as soon as this deploys (see `docs/adr/0001-no-variant-logging-for-form-origin-v2.md` for why no per-form variant is logged, and what that means for forms created right at the deploy boundary).

**Alternatives considered**

- We considered defining Q1's answer type (`FormOriginProcessAnswer`) directly in the payload-builder util where it's first used, but moved it into the wizard context instead, since it's really wizard state, not something the payload builder itself owns.
- We considered running a full visual regression pass against a design reference before opening this PR, but neither Figma nor a browser-automation tool was available while implementing this, so verification leaned on the RTL test suite and a shared mockup instead. The Storybook states are still updated with the new variants, so Chromatic picks up real regression coverage in CI from here.
- We considered adding a separate `FormOrigin.DigitalFormsg` value so "another FormSG form" could be tracked apart from other form builders in the stored data, but decided the simpler rename (folding FormSG back into the existing form-builder option as a named example) was preferable to introducing a new enum member for it.

**Breaking Changes**

No - backwards compatible, and no enum shape change at all in the final version of this PR. `metadata.formOrigins` keeps the same `{ value, othersInput }` shape. An earlier revision of this PR briefly removed `FormOrigin.DigitalFormBuilder` ("Other form builders") on the mistaken assumption it was new to this PR — it isn't, it's been live since #9576/#9579, so real forms already have it saved in `metadata.formOrigins`. That removal was reverted before merge; thanks to @ericyhliu for catching it in review. `FormOrigin.DigitalFormBuilder` itself is unchanged — only its front-end display copy was reworded.

## Tests

**TC1: Visual check on the create-form flow**

- [ ] Start a new form, reach the origin screen
- [ ] Confirm "Tell us about your process" appears as the screen header, with Q1 ("New" / "Existing") shown as radio buttons beneath it
- [ ] Select "Existing" and confirm Q2 appears with, in order: Online form builders (e.g. FormSG), Emails, Documents (e.g. PDF, Word), Spreadsheets (e.g. Excel, Sheets), Paper form, Other
- [ ] Select "Other" and confirm the free-text field appears with its character counter
- [ ] Submit with Q1 unanswered and confirm Q1 shows "Please select an option." (distinct from Q2's "Please select at least 1 option.")

**TC2: Selection-preserving behavior**

- [ ] On the origin screen, select "Existing" and tick a couple of mediums
- [ ] Switch to "New", then back to "Existing" — confirm the same mediums are still ticked
- [ ] Go back to the title screen, then forward again to the origin screen — confirm the selections are still there

**TC3: Duplicate and use-template parity**

- [ ] Duplicate an existing form and confirm the same two-question screen appears, for both a "new process" and an "existing process" answer
- [ ] Create a form from a template and confirm the same two-question screen appears, for both answers

