### PR TITLE
fix(tests): expect messageKey in MRF snapshot-write failure assertions

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.controller.spec.ts
@@ -501,9 +501,9 @@ describe('multirespondent-submision.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.INTERNAL_SERVER_ERROR,
       )
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message: new SnapshotWriteError().message,
-      })
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expectedSubmissionError('saveFailed', new SnapshotWriteError().message),
+      )
     })
 
     it('returns 200 ok when step has invalid workflow type', async () => {
@@ -949,9 +949,9 @@ describe('multirespondent-submision.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(
         StatusCodes.INTERNAL_SERVER_ERROR,
       )
-      expect(mockRes.json).toHaveBeenCalledWith({
-        message: new SnapshotWriteError().message,
-      })
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expectedSubmissionError('saveFailed', new SnapshotWriteError().message),
+      )
       // The post-submission actions must not fire for an aborted save.
       expect(
         MockMultiRespondentSubmissionService.performMultiRespondentPostSubmissionUpdateActions,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

PR #9664 added messageKey to mapRouteError responses, but the two snapshot-write tests from #9822 predate it and still expect message only.

## Solution
<!-- How did you solve the problem? -->

Resolved tests to match expected `messageKeys`

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
-  No - this PR is backwards compatible  
