### PR TITLE
refactor(admin-form): map backend errors to i18n message keys

### DIFF
--- a/apps/backend/src/app/loaders/express/__tests__/error-handler.spec.ts
+++ b/apps/backend/src/app/loaders/express/__tests__/error-handler.spec.ts
@@ -1,3 +1,4 @@
+import { celebrate, Joi, Segments } from 'celebrate'
 import express from 'express'
 import supertest, { Session } from 'supertest-session'
 
@@ -30,6 +31,46 @@ describe('error-handler.loader', () => {
       // Assert
       expect(response.status).toEqual(400)
       expect(response.text).toContain('"message":"Expected \':\'')
+    })
+  })
+
+  describe('Celebrate errors', () => {
+    const app = express()
+    app
+      .use(express.json())
+      .post(
+        '/',
+        celebrate({
+          [Segments.BODY]: Joi.object({
+            buttonLink: Joi.string()
+              .uri({ scheme: ['http', 'https'] })
+              .message('Please enter a valid HTTP or HTTPS URI'),
+          }),
+        }),
+        (_req, res) => res.sendStatus(200),
+      )
+      .use(errorHandlerMiddlewares())
+
+    beforeEach(() => {
+      request = supertest(app)
+    })
+
+    it('adds i18n metadata while retaining the Celebrate payload', async () => {
+      const response = await request
+        .post('/')
+        .send({ buttonLink: 'not-a-url' })
+        .type('json')
+
+      expect(response.status).toEqual(400)
+      expect(response.body).toMatchObject({
+        message: 'Please enter a valid HTTP or HTTPS URI',
+        messageKey: 'features.adminForm.backendErrors.endPage.invalidUrl',
+        validation: {
+          body: {
+            message: 'Please enter a valid HTTP or HTTPS URI',
+          },
+        },
+      })
     })
   })
 })

--- a/apps/backend/src/app/loaders/express/__tests__/error-handler.spec.ts
+++ b/apps/backend/src/app/loaders/express/__tests__/error-handler.spec.ts
@@ -46,6 +46,7 @@ describe('error-handler.loader', () => {
         '/',
         celebrate({
           [Segments.BODY]: Joi.object({
+            name: Joi.string().required(),
             buttonLink: attachAdminFormErrorI18n(
               Joi.string()
                 .uri({ scheme: ['http', 'https'] })
@@ -65,7 +66,7 @@ describe('error-handler.loader', () => {
     it('adds i18n metadata while retaining the Celebrate payload', async () => {
       const response = await request
         .post('/')
-        .send({ buttonLink: 'not-a-url' })
+        .send({ name: 'Form name', buttonLink: 'not-a-url' })
         .type('json')
 
       expect(response.status).toEqual(400)
@@ -75,6 +76,27 @@ describe('error-handler.loader', () => {
         validation: {
           body: {
             message: 'Please enter a valid HTTP or HTTPS URI',
+          },
+        },
+      })
+    })
+
+    it('retains the vanilla Celebrate payload without i18n metadata', async () => {
+      const response = await request
+        .post('/')
+        .send({ buttonLink: 'https://example.com' })
+        .type('json')
+
+      expect(response.status).toEqual(400)
+      expect(response.body).toEqual({
+        statusCode: 400,
+        error: 'Bad Request',
+        message: 'Validation failed',
+        validation: {
+          body: {
+            source: 'body',
+            keys: ['name'],
+            message: '"name" is required',
           },
         },
       })

--- a/apps/backend/src/app/loaders/express/__tests__/error-handler.spec.ts
+++ b/apps/backend/src/app/loaders/express/__tests__/error-handler.spec.ts
@@ -2,6 +2,10 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import express from 'express'
 import supertest, { Session } from 'supertest-session'
 
+import {
+  adminFormErrorKey,
+  attachAdminFormErrorI18n,
+} from '../../../modules/form/admin-form/admin-form.i18n'
 import { errorHandlerMiddlewares } from '../error-handler'
 import parserMiddlewares from '../parser'
 
@@ -42,9 +46,12 @@ describe('error-handler.loader', () => {
         '/',
         celebrate({
           [Segments.BODY]: Joi.object({
-            buttonLink: Joi.string()
-              .uri({ scheme: ['http', 'https'] })
-              .message('Please enter a valid HTTP or HTTPS URI'),
+            buttonLink: attachAdminFormErrorI18n(
+              Joi.string()
+                .uri({ scheme: ['http', 'https'] })
+                .message('Please enter a valid HTTP or HTTPS URI'),
+              adminFormErrorKey('endPage.invalidUrl'),
+            ),
           }),
         }),
         (_req, res) => res.sendStatus(200),

--- a/apps/backend/src/app/loaders/express/error-handler.ts
+++ b/apps/backend/src/app/loaders/express/error-handler.ts
@@ -1,8 +1,9 @@
 import axios from 'axios'
-import { errors, isCelebrateError } from 'celebrate'
+import { CelebrateError, isCelebrateError } from 'celebrate'
 import { ErrorRequestHandler, RequestHandler } from 'express'
 import { HttpError, isHttpError } from 'http-errors'
-import { StatusCodes } from 'http-status-codes'
+import { getReasonPhrase, StatusCodes } from 'http-status-codes'
+import escape from 'lodash/escape'
 import get from 'lodash/get'
 import { types } from 'util'
 
@@ -15,7 +16,35 @@ import {
 import { createReqMeta } from '../../utils/request'
 
 const logger = createLoggerWithLabel(module)
-const celebrateErrorHandler = errors()
+
+const buildCelebrateErrorResponse = (error: CelebrateError) => {
+  const i18nError = [...error.details.values()]
+    .flatMap((validationError) => validationError.details)
+    .map((detail) => {
+      const { messageKey, messageParams } = getCelebrateErrorI18n(detail)
+      return buildAdminFormErrorDto(detail.message, messageKey, messageParams)
+    })
+    .find((detail) => detail.messageKey)
+
+  const validation = Object.fromEntries(
+    [...error.details.entries()].map(([segment, joiError]) => [
+      segment,
+      {
+        source: segment,
+        keys: joiError.details.map((detail) => escape(detail.path.join('.'))),
+        message: joiError.message,
+      },
+    ]),
+  )
+
+  return {
+    statusCode: StatusCodes.BAD_REQUEST,
+    error: getReasonPhrase(StatusCodes.BAD_REQUEST),
+    message: error.message,
+    validation,
+    ...i18nError,
+  }
+}
 
 const isBodyParserError = (
   err: unknown,
@@ -112,24 +141,9 @@ export const genericErrorHandlerMiddleware: ErrorRequestHandler = (
         },
         error: err,
       })
-      const i18nError = [...err.details.values()]
-        .flatMap((validationError) => validationError.details)
-        .map((detail) => {
-          const { messageKey, messageParams } = getCelebrateErrorI18n(detail)
-          return buildAdminFormErrorDto(
-            detail.message,
-            messageKey,
-            messageParams,
-          )
-        })
-        .find((detail) => detail.messageKey)
-
-      if (i18nError) {
-        const originalJson = res.json.bind(res)
-        res.json = (body) => originalJson({ ...body, ...i18nError })
-      }
-
-      return celebrateErrorHandler(err, req, res, next)
+      return res
+        .status(StatusCodes.BAD_REQUEST)
+        .json(buildCelebrateErrorResponse(err))
     }
 
     if (isBodyParserError(err)) {

--- a/apps/backend/src/app/loaders/express/error-handler.ts
+++ b/apps/backend/src/app/loaders/express/error-handler.ts
@@ -8,7 +8,10 @@ import { types } from 'util'
 
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
-import { buildAdminFormErrorDto } from '../../modules/form/admin-form/admin-form.i18n'
+import {
+  buildAdminFormErrorDto,
+  getCelebrateErrorI18n,
+} from '../../modules/form/admin-form/admin-form.i18n'
 import { createReqMeta } from '../../utils/request'
 
 const logger = createLoggerWithLabel(module)
@@ -110,7 +113,15 @@ export const genericErrorHandlerMiddleware: ErrorRequestHandler = (
         error: err,
       })
       const i18nError = [...err.details.values()]
-        .map((detail) => buildAdminFormErrorDto(detail.message))
+        .flatMap((validationError) => validationError.details)
+        .map((detail) => {
+          const { messageKey, messageParams } = getCelebrateErrorI18n(detail)
+          return buildAdminFormErrorDto(
+            detail.message,
+            messageKey,
+            messageParams,
+          )
+        })
         .find((detail) => detail.messageKey)
 
       if (i18nError) {

--- a/apps/backend/src/app/loaders/express/error-handler.ts
+++ b/apps/backend/src/app/loaders/express/error-handler.ts
@@ -8,6 +8,7 @@ import { types } from 'util'
 
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
+import { buildAdminFormErrorDto } from '../../modules/form/admin-form/admin-form.i18n'
 import { createReqMeta } from '../../utils/request'
 
 const logger = createLoggerWithLabel(module)
@@ -108,6 +109,15 @@ export const genericErrorHandlerMiddleware: ErrorRequestHandler = (
         },
         error: err,
       })
+      const i18nError = [...err.details.values()]
+        .map((detail) => buildAdminFormErrorDto(detail.message))
+        .find((detail) => detail.messageKey)
+
+      if (i18nError) {
+        const originalJson = res.json.bind(res)
+        res.json = (body) => originalJson({ ...body, ...i18nError })
+      }
+
       return celebrateErrorHandler(err, req, res, next)
     }
 

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -4217,6 +4217,7 @@ describe('admin-form.controller', () => {
       // Should return specific message.
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Form must be public to be copied',
+        messageKey: 'features.adminForm.backendErrors.template.mustBePublic',
       })
       expect(MockUserService.getPopulatedUserById).toHaveBeenCalledWith(
         MOCK_USER_ID,
@@ -6741,6 +6742,7 @@ describe('admin-form.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(404)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Field to modify not found',
+        messageKey: 'features.adminForm.backendErrors.fields.notFound',
       })
       expect(MockAdminFormService.updateFormField).toHaveBeenCalledWith(
         MOCK_FORM,
@@ -7389,6 +7391,7 @@ describe('admin-form.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(404)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Field to modify not found',
+        messageKey: 'features.adminForm.backendErrors.fields.notFound',
       })
       expect(MockAdminFormService.duplicateFormField).toHaveBeenCalledWith(
         MOCK_FORM,
@@ -7675,6 +7678,7 @@ describe('admin-form.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(404)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Field to modify not found',
+        messageKey: 'features.adminForm.backendErrors.fields.notFound',
       })
       expect(MockAdminFormService.reorderFormField).toHaveBeenCalledWith(
         MOCK_FORM,
@@ -8349,6 +8353,7 @@ describe('admin-form.controller', () => {
       expect(mockRes.status).toHaveBeenCalledWith(404)
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Field to modify not found',
+        messageKey: 'features.adminForm.backendErrors.fields.notFound',
       })
       expect(MockAdminFormService.deleteFormField).toHaveBeenCalledWith(
         MOCK_FORM,

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.i18n.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.i18n.spec.ts
@@ -1,0 +1,32 @@
+import {
+  buildAdminFormErrorDto,
+  getAdminFormErrorI18n,
+} from '../admin-form.i18n'
+
+describe('admin-form.i18n', () => {
+  it('adds the matching i18n key while retaining fallback text', () => {
+    const message = 'Field to modify not found'
+
+    expect(buildAdminFormErrorDto(message)).toEqual({
+      message,
+      messageKey: 'features.adminForm.backendErrors.fields.notFound',
+    })
+  })
+
+  it('extracts the whitelist file-size interpolation parameter', () => {
+    expect(
+      buildAdminFormErrorDto(
+        'You have exceeded the file size limit, please upload a file below 250 kB.',
+      ),
+    ).toEqual({
+      message:
+        'You have exceeded the file size limit, please upload a file below 250 kB.',
+      messageKey: 'features.adminForm.backendErrors.whitelist.fileTooLarge',
+      messageParams: { limitKb: 250 },
+    })
+  })
+
+  it('does not add a key to messages outside the catalogued admin errors', () => {
+    expect(getAdminFormErrorI18n('Uncatalogued error')).toEqual({})
+  })
+})

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.i18n.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.i18n.spec.ts
@@ -1,22 +1,30 @@
+import { Joi } from 'celebrate'
+
 import {
+  adminFormErrorKey,
+  attachAdminFormErrorI18n,
   buildAdminFormErrorDto,
-  getAdminFormErrorI18n,
+  getCelebrateErrorI18n,
 } from '../admin-form.i18n'
 
 describe('admin-form.i18n', () => {
-  it('adds the matching i18n key while retaining fallback text', () => {
+  it('retains an explicitly supplied i18n key and fallback text', () => {
     const message = 'Field to modify not found'
 
-    expect(buildAdminFormErrorDto(message)).toEqual({
+    expect(
+      buildAdminFormErrorDto(message, adminFormErrorKey('fields.notFound')),
+    ).toEqual({
       message,
       messageKey: 'features.adminForm.backendErrors.fields.notFound',
     })
   })
 
-  it('extracts the whitelist file-size interpolation parameter', () => {
+  it('retains explicitly supplied interpolation parameters', () => {
     expect(
       buildAdminFormErrorDto(
         'You have exceeded the file size limit, please upload a file below 250 kB.',
+        adminFormErrorKey('whitelist.fileTooLarge'),
+        { limitKb: 250 },
       ),
     ).toEqual({
       message:
@@ -26,7 +34,15 @@ describe('admin-form.i18n', () => {
     })
   })
 
-  it('does not add a key to messages outside the catalogued admin errors', () => {
-    expect(getAdminFormErrorI18n('Uncatalogued error')).toEqual({})
+  it('reads i18n metadata attached directly to a Joi validation error', () => {
+    const schema = attachAdminFormErrorI18n(
+      Joi.string().uri().message('Please enter a valid URI'),
+      adminFormErrorKey('endPage.invalidUrl'),
+    )
+    const detail = schema.validate('not-a-url').error?.details[0]
+
+    expect(detail && getCelebrateErrorI18n(detail)).toEqual({
+      messageKey: 'features.adminForm.backendErrors.endPage.invalidUrl',
+    })
   })
 })

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
@@ -16,6 +16,7 @@ import {
   createFormFieldsUsingTextPrompt,
   createFormFieldsUsingVisionPrompt,
 } from './admin-form.assistance.service'
+import { buildAdminFormErrorDto } from './admin-form.i18n'
 import { PermissionLevel } from './admin-form.types'
 import { mapRouteError } from './admin-form.utils'
 
@@ -94,7 +95,7 @@ const _handleTextPrompt: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -183,7 +184,7 @@ const _handleVisionPrompt: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.assistance.controller.ts
@@ -16,7 +16,11 @@ import {
   createFormFieldsUsingTextPrompt,
   createFormFieldsUsingVisionPrompt,
 } from './admin-form.assistance.service'
-import { buildAdminFormErrorDto } from './admin-form.i18n'
+import {
+  adminFormErrorKey,
+  attachAdminFormErrorI18n,
+  buildAdminFormErrorDto,
+} from './admin-form.i18n'
 import { PermissionLevel } from './admin-form.types'
 import { mapRouteError } from './admin-form.utils'
 
@@ -24,10 +28,13 @@ const logger = createLoggerWithLabel(module)
 
 const handleTextPromptValidator = celebrate({
   [Segments.PARAMS]: {
-    formId: Joi.string()
-      .required()
-      .pattern(/^[a-fA-F0-9]{24}$/)
-      .message('Your form ID is invalid.'),
+    formId: attachAdminFormErrorI18n(
+      Joi.string()
+        .required()
+        .pattern(/^[a-fA-F0-9]{24}$/)
+        .message('Your form ID is invalid.'),
+      adminFormErrorKey('whitelist.invalidFormId'),
+    ),
   },
   [Segments.BODY]: {
     prompt: Joi.string().required().max(MFB_TEXT_PROMPT_MAX_CHAR),
@@ -94,8 +101,10 @@ const _handleTextPrompt: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -106,10 +115,13 @@ export const handleTextPrompt = [
 
 const handleVisionPromptValidator = celebrate({
   [Segments.PARAMS]: {
-    formId: Joi.string()
-      .required()
-      .pattern(/^[a-fA-F0-9]{24}$/)
-      .message('Your form ID is invalid.'),
+    formId: attachAdminFormErrorI18n(
+      Joi.string()
+        .required()
+        .pattern(/^[a-fA-F0-9]{24}$/)
+        .message('Your form ID is invalid.'),
+      adminFormErrorKey('whitelist.invalidFormId'),
+    ),
   },
   [Segments.BODY]: {
     imageDataUrls: Joi.array()
@@ -183,8 +195,11 @@ const _handleVisionPrompt: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -82,6 +82,7 @@ import * as FormService from '../form.service'
 import { getSubmissionType } from '../form.utils'
 
 import { EditFieldError, GoGovServerError } from './admin-form.errors'
+import { buildAdminFormErrorDto } from './admin-form.i18n'
 import {
   createWorkflowStepValidator,
   getWebhookSettingsValidator,
@@ -278,7 +279,7 @@ export const handleListDashboardForms: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -323,7 +324,7 @@ export const handleGetAdminForm: ControllerHandler<{ formId: string }> = (
         })
 
         const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -371,7 +372,7 @@ export const handleGetFormCollaborators: ControllerHandler<
         })
 
         const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -421,7 +422,7 @@ export const handlePreviewAdminForm: ControllerHandler<{ formId: string }> = (
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -484,7 +485,7 @@ export const createPresignedPostUrlForImages: ControllerHandler<
         })
 
         const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -552,7 +553,7 @@ export const createPresignedPostUrlForLogos: ControllerHandler<
         })
 
         const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -620,7 +621,7 @@ export const countFormSubmissions: ControllerHandler<
       error: formResult.error,
     })
     const { errorMessage, statusCode } = mapRouteError(formResult.error)
-    return res.status(statusCode).json({ message: errorMessage })
+    return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
   }
 
   // Step 3: Has permissions, continue to retrieve submission counts.
@@ -646,7 +647,7 @@ export const countFormSubmissions: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -701,7 +702,7 @@ export const handleCountFormFeedback: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -751,7 +752,7 @@ export const handleStreamFormFeedback: ControllerHandler<{
     const { errorMessage, statusCode } = mapRouteError(
       hasReadPermissionResult.error,
     )
-    return res.status(statusCode).json({ message: errorMessage })
+    return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
   }
 
   // No errors, start stream.
@@ -764,9 +765,9 @@ export const handleStreamFormFeedback: ControllerHandler<{
         meta: logMeta,
         error,
       })
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: 'Error retrieving from database.',
-      })
+      return res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json(buildAdminFormErrorDto('Error retrieving from database.'))
     })
     .pipe(JSONStream.stringify())
     .on('error', (error) => {
@@ -775,9 +776,9 @@ export const handleStreamFormFeedback: ControllerHandler<{
         meta: logMeta,
         error,
       })
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: 'Error converting feedback to JSON',
-      })
+      return res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json(buildAdminFormErrorDto('Error converting feedback to JSON'))
     })
     .pipe(res.type('json'))
     .on('error', (error) => {
@@ -840,7 +841,7 @@ export const handleGetFormFeedback: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -905,7 +906,7 @@ export const handleArchiveForm: ControllerHandler<{ formId: string }> = async (
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1000,7 +1001,7 @@ export const duplicateAdminForm: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1061,7 +1062,7 @@ export const handleGetTemplateForm: ControllerHandler<
             formTitle: error.formTitle,
           })
         }
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1128,11 +1129,11 @@ export const copyTemplateForm: ControllerHandler<
 
         // Specialized error response for PrivateFormError.
         if (error instanceof PrivateFormError) {
-          return res.status(statusCode).json({
-            message: 'Form must be public to be copied',
-          })
+          return res
+            .status(statusCode)
+            .json(buildAdminFormErrorDto('Form must be public to be copied'))
         }
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1183,7 +1184,7 @@ export const transferAllFormsOwnership: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1246,7 +1247,7 @@ export const transferFormOwnership: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1313,7 +1314,7 @@ export const createForm: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1390,7 +1391,7 @@ export const handleUpdateForm: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -1443,7 +1444,7 @@ export const handleDuplicateFormField: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -1483,7 +1484,7 @@ export const _handleUpdateSettings: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -1560,7 +1561,7 @@ export const _handleUpdateWebhookSettings: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -1624,7 +1625,7 @@ export const _handleCreateWorkflowStep: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1677,7 +1678,7 @@ const _handleUpdateWorkflowStep: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -1727,7 +1728,7 @@ export const handleDeleteWorkflowStep: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1795,7 +1796,7 @@ const _handleUpdateWhitelistSetting: ControllerHandler<
       error,
     })
     const { errorMessage, statusCode } = mapRouteError(error)
-    return res.status(statusCode).json({ message: errorMessage })
+    return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
   }
 
   const form = formResult.value
@@ -1828,9 +1829,9 @@ const _handleUpdateWhitelistSetting: ControllerHandler<
       message: 'Form does not have a public key',
       meta: logMeta,
     })
-    return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-      message: 'Form does not have a public key',
-    })
+    return res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json(buildAdminFormErrorDto('Form does not have a public key'))
   }
   const formPublicKey = form.publicKey
   const encryptedWhitelistSubmitterIdsContent = upperCaseWhitelistedSubmitterIds
@@ -1856,7 +1857,7 @@ const _handleUpdateWhitelistSetting: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -1917,7 +1918,7 @@ export const _handleUpdateFormField: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -1961,7 +1962,7 @@ export const handleGetSettings: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -2006,7 +2007,7 @@ export const handleGetWhitelistSetting: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -2068,7 +2069,7 @@ export const _handleGetWebhookSettings: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -2144,7 +2145,7 @@ export const submitEncryptPreview: ControllerHandler<
     })
     .mapErr((error) => {
       const { errorMessage, statusCode } = mapSubmissionError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -2244,7 +2245,7 @@ const _handleUpdateOptionsToRecipientsMap: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -2320,7 +2321,7 @@ export const _handleCreateFormField: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2377,7 +2378,7 @@ export const _handleCreateLogic: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2494,7 +2495,7 @@ export const handleDeleteLogic: ControllerHandler<{
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2582,7 +2583,7 @@ export const _handleReorderFormField: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2652,7 +2653,7 @@ export const _handleUpdateLogic: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2723,7 +2724,7 @@ export const handleDeleteFormField: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2775,7 +2776,7 @@ export const handleDeleteFormFields: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2829,7 +2830,7 @@ export const _handleUpdateEndPage: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2925,7 +2926,7 @@ export const handleGetFormField: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -2981,7 +2982,7 @@ export const _handleUpdateCollaborators: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -3063,7 +3064,7 @@ export const handleRemoveSelfFromCollaborators: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -3118,7 +3119,7 @@ export const _handleUpdateStartPage: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -3209,7 +3210,7 @@ export const handleGetGoLinkSuffix: ControllerHandler<{ formId: string }> = (
             error,
           })
         }
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -3277,7 +3278,7 @@ export const handleSetGoLinkSuffix: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -3317,7 +3318,7 @@ export const handleConvertEmailToStorageMode: ControllerHandler<
     })
     .mapErr((error) => {
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -3363,7 +3364,7 @@ export const handleGetSmsCountForFormAdmin: ControllerHandler<
           error,
         })
         const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -82,7 +82,12 @@ import * as FormService from '../form.service'
 import { getSubmissionType } from '../form.utils'
 
 import { EditFieldError, GoGovServerError } from './admin-form.errors'
-import { buildAdminFormErrorDto } from './admin-form.i18n'
+import {
+  adminFormErrorKey,
+  attachAdminFormErrorI18n,
+  attachAdminFormErrorI18nByCode,
+  buildAdminFormErrorDto,
+} from './admin-form.i18n'
 import {
   createWorkflowStepValidator,
   getWebhookSettingsValidator,
@@ -278,8 +283,10 @@ export const handleListDashboardForms: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -323,8 +330,11 @@ export const handleGetAdminForm: ControllerHandler<{ formId: string }> = (
           error,
         })
 
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { statusCode, errorMessage, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -371,8 +381,11 @@ export const handleGetFormCollaborators: ControllerHandler<
           error,
         })
 
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { statusCode, errorMessage, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -421,8 +434,11 @@ export const handlePreviewAdminForm: ControllerHandler<{ formId: string }> = (
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -484,8 +500,11 @@ export const createPresignedPostUrlForImages: ControllerHandler<
           error,
         })
 
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { statusCode, errorMessage, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -552,8 +571,11 @@ export const createPresignedPostUrlForLogos: ControllerHandler<
           error,
         })
 
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { statusCode, errorMessage, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -620,8 +642,12 @@ export const countFormSubmissions: ControllerHandler<
       meta: logMeta,
       error: formResult.error,
     })
-    const { errorMessage, statusCode } = mapRouteError(formResult.error)
-    return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+    const { errorMessage, statusCode, errorMessageKey } = mapRouteError(
+      formResult.error,
+    )
+    return res
+      .status(statusCode)
+      .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
   }
 
   // Step 3: Has permissions, continue to retrieve submission counts.
@@ -646,8 +672,10 @@ export const countFormSubmissions: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -701,8 +729,11 @@ export const handleCountFormFeedback: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -749,10 +780,12 @@ export const handleStreamFormFeedback: ControllerHandler<{
       meta: logMeta,
       error: hasReadPermissionResult.error,
     })
-    const { errorMessage, statusCode } = mapRouteError(
+    const { errorMessage, statusCode, errorMessageKey } = mapRouteError(
       hasReadPermissionResult.error,
     )
-    return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+    return res
+      .status(statusCode)
+      .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
   }
 
   // No errors, start stream.
@@ -767,7 +800,12 @@ export const handleStreamFormFeedback: ControllerHandler<{
       })
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .json(buildAdminFormErrorDto('Error retrieving from database.'))
+        .json(
+          buildAdminFormErrorDto(
+            'Error retrieving from database.',
+            adminFormErrorKey('exports.databaseRetrieval'),
+          ),
+        )
     })
     .pipe(JSONStream.stringify())
     .on('error', (error) => {
@@ -778,7 +816,12 @@ export const handleStreamFormFeedback: ControllerHandler<{
       })
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .json(buildAdminFormErrorDto('Error converting feedback to JSON'))
+        .json(
+          buildAdminFormErrorDto(
+            'Error converting feedback to JSON',
+            adminFormErrorKey('exports.feedback.jsonConversion'),
+          ),
+        )
     })
     .pipe(res.type('json'))
     .on('error', (error) => {
@@ -840,8 +883,10 @@ export const handleGetFormFeedback: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -905,8 +950,11 @@ export const handleArchiveForm: ControllerHandler<{ formId: string }> = async (
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1000,8 +1048,11 @@ export const duplicateAdminForm: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1050,7 +1101,8 @@ export const handleGetTemplateForm: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
 
         // Specialized error response for PrivateFormError.
         if (error instanceof PrivateFormError) {
@@ -1062,7 +1114,9 @@ export const handleGetTemplateForm: ControllerHandler<
             formTitle: error.formTitle,
           })
         }
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1125,15 +1179,23 @@ export const copyTemplateForm: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
 
         // Specialized error response for PrivateFormError.
         if (error instanceof PrivateFormError) {
           return res
             .status(statusCode)
-            .json(buildAdminFormErrorDto('Form must be public to be copied'))
+            .json(
+              buildAdminFormErrorDto(
+                'Form must be public to be copied',
+                adminFormErrorKey('template.mustBePublic'),
+              ),
+            )
         }
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1183,8 +1245,11 @@ export const transferAllFormsOwnership: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1246,8 +1311,11 @@ export const transferFormOwnership: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1313,8 +1381,11 @@ export const createForm: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1390,8 +1461,10 @@ export const handleUpdateForm: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -1443,8 +1516,10 @@ export const handleDuplicateFormField: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -1483,8 +1558,10 @@ export const _handleUpdateSettings: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -1560,8 +1637,10 @@ export const _handleUpdateWebhookSettings: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -1624,8 +1703,11 @@ export const _handleCreateWorkflowStep: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1677,8 +1759,10 @@ const _handleUpdateWorkflowStep: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -1727,8 +1811,11 @@ export const handleDeleteWorkflowStep: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1737,21 +1824,41 @@ const LIMIT_IN_KB = 250
 const STRING_MAX_LENGTH = LIMIT_IN_KB * KB
 const _handleUpdateWhitelistSettingValidator = celebrate({
   [Segments.PARAMS]: Joi.object({
-    formId: Joi.string()
-      .required()
-      .pattern(/^[a-fA-F0-9]{24}$/)
-      .message('Your form ID is invalid.'),
+    formId: attachAdminFormErrorI18n(
+      Joi.string()
+        .required()
+        .pattern(/^[a-fA-F0-9]{24}$/)
+        .message('Your form ID is invalid.'),
+      adminFormErrorKey('whitelist.invalidFormId'),
+    ),
   }),
   [Segments.BODY]: Joi.object({
-    whitelistCsvString: Joi.string()
-      .allow(null) // for removal of whitelist
-      .max(STRING_MAX_LENGTH)
-      .pattern(/^[a-zA-Z0-9,\r\n]+$/)
-      .messages({
-        'string.empty': 'Your csv is empty.',
-        'string.pattern.base': 'Your csv has one or more invalid characters.',
-        'string.max': `You have exceeded the file size limit, please upload a file below ${LIMIT_IN_KB} kB.`,
-      }),
+    whitelistCsvString: attachAdminFormErrorI18nByCode(
+      Joi.string()
+        .allow(null) // for removal of whitelist
+        .max(STRING_MAX_LENGTH)
+        .pattern(/^[a-zA-Z0-9,\r\n]+$/)
+        .messages({
+          'string.empty': 'Your csv is empty.',
+          'string.pattern.base': 'Your csv has one or more invalid characters.',
+          'string.max': `You have exceeded the file size limit, please upload a file below ${LIMIT_IN_KB} kB.`,
+        }),
+      (code) => {
+        switch (code) {
+          case 'string.empty':
+            return { messageKey: adminFormErrorKey('whitelist.emptyCsv') }
+          case 'string.pattern.base':
+            return {
+              messageKey: adminFormErrorKey('whitelist.invalidCharacters'),
+            }
+          case 'string.max':
+            return {
+              messageKey: adminFormErrorKey('whitelist.fileTooLarge'),
+              messageParams: { limitKb: LIMIT_IN_KB },
+            }
+        }
+      },
+    ),
   }),
 })
 
@@ -1795,8 +1902,10 @@ const _handleUpdateWhitelistSetting: ControllerHandler<
       meta: logMeta,
       error,
     })
-    const { errorMessage, statusCode } = mapRouteError(error)
-    return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+    const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+    return res
+      .status(statusCode)
+      .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
   }
 
   const form = formResult.value
@@ -1831,7 +1940,12 @@ const _handleUpdateWhitelistSetting: ControllerHandler<
     })
     return res
       .status(StatusCodes.INTERNAL_SERVER_ERROR)
-      .json(buildAdminFormErrorDto('Form does not have a public key'))
+      .json(
+        buildAdminFormErrorDto(
+          'Form does not have a public key',
+          adminFormErrorKey('whitelist.missingPublicKey'),
+        ),
+      )
   }
   const formPublicKey = form.publicKey
   const encryptedWhitelistSubmitterIdsContent = upperCaseWhitelistedSubmitterIds
@@ -1856,8 +1970,10 @@ const _handleUpdateWhitelistSetting: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -1917,8 +2033,11 @@ export const _handleUpdateFormField: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -1961,8 +2080,10 @@ export const handleGetSettings: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -2006,8 +2127,10 @@ export const handleGetWhitelistSetting: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -2068,8 +2191,10 @@ export const _handleGetWebhookSettings: ControllerHandler<
         meta: logMeta,
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -2145,7 +2270,7 @@ export const submitEncryptPreview: ControllerHandler<
     })
     .mapErr((error) => {
       const { errorMessage, statusCode } = mapSubmissionError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      return res.status(statusCode).json({ message: errorMessage })
     })
 }
 
@@ -2244,8 +2369,10 @@ const _handleUpdateOptionsToRecipientsMap: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -2320,8 +2447,11 @@ export const _handleCreateFormField: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2377,8 +2507,11 @@ export const _handleCreateLogic: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2494,8 +2627,11 @@ export const handleDeleteLogic: ControllerHandler<{
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2582,8 +2718,11 @@ export const _handleReorderFormField: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2652,8 +2791,11 @@ export const _handleUpdateLogic: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2723,8 +2865,11 @@ export const handleDeleteFormField: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2775,8 +2920,11 @@ export const handleDeleteFormFields: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2829,8 +2977,11 @@ export const _handleUpdateEndPage: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2843,10 +2994,13 @@ export const handleUpdateEndPage = [
     [Segments.BODY]: Joi.object({
       title: Joi.string(),
       paragraph: Joi.string().allow(''),
-      buttonLink: Joi.string()
-        .uri({ scheme: ['http', 'https'] })
-        .allow('')
-        .message('Please enter a valid HTTP or HTTPS URI'),
+      buttonLink: attachAdminFormErrorI18n(
+        Joi.string()
+          .uri({ scheme: ['http', 'https'] })
+          .allow('')
+          .message('Please enter a valid HTTP or HTTPS URI'),
+        adminFormErrorKey('endPage.invalidUrl'),
+      ),
       buttonText: Joi.string().allow(''),
       // TODO(#1895): Remove when deprecated `buttons` key is removed from all forms in the database
       titleTranslations: Joi.array()
@@ -2925,8 +3079,11 @@ export const handleGetFormField: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -2981,8 +3138,11 @@ export const _handleUpdateCollaborators: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -3063,8 +3223,11 @@ export const handleRemoveSelfFromCollaborators: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -3118,8 +3281,11 @@ export const _handleUpdateStartPage: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -3196,7 +3362,8 @@ export const handleGetGoLinkSuffix: ControllerHandler<{ formId: string }> = (
       })
       .map((goLinkSuffix) => res.status(StatusCodes.OK).json(goLinkSuffix))
       .mapErr((error) => {
-        const { errorMessage, statusCode } = mapRouteError(error)
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
         // Don't log 404 errors as they are expected for most forms
         if (statusCode !== StatusCodes.NOT_FOUND) {
           logger.error({
@@ -3210,7 +3377,9 @@ export const handleGetGoLinkSuffix: ControllerHandler<{ formId: string }> = (
             error,
           })
         }
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -3277,8 +3446,11 @@ export const handleSetGoLinkSuffix: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -3317,8 +3489,10 @@ export const handleConvertEmailToStorageMode: ControllerHandler<
       return res.sendStatus(StatusCodes.OK)
     })
     .mapErr((error) => {
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -3363,8 +3537,11 @@ export const handleGetSmsCountForFormAdmin: ControllerHandler<
           meta: logMeta,
           error,
         })
-        const { statusCode, errorMessage } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { statusCode, errorMessage, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.errors.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.errors.ts
@@ -4,10 +4,22 @@ import {
 } from 'formsg-shared/constants'
 
 import { ApplicationError, ErrorCodes } from '../../core/core.errors'
+import { InvalidPaymentAmountError } from '../../payments/payments.errors'
+
+import { adminFormErrorKey } from './admin-form.i18n'
 
 export class InvalidFileTypeError extends ApplicationError {
-  constructor(message = 'Unsupported file type') {
-    super(message, undefined, ErrorCodes.ADMIN_FORM_INVALID_FILE_TYPE)
+  readonly messageKey?: string
+
+  constructor(message?: string) {
+    super(
+      message ?? 'Unsupported file type',
+      undefined,
+      ErrorCodes.ADMIN_FORM_INVALID_FILE_TYPE,
+    )
+    if (message === undefined) {
+      this.messageKey = adminFormErrorKey('assets.unsupportedFileType')
+    }
   }
 }
 
@@ -18,8 +30,31 @@ export class EditFieldError extends ApplicationError {
 }
 
 export class FieldNotFoundError extends ApplicationError {
-  constructor(message = 'Field to modify not found') {
-    super(message, undefined, ErrorCodes.ADMIN_FORM_FIELD_NOT_FOUND)
+  readonly messageKey?: string
+
+  constructor(message?: string) {
+    super(
+      message ?? 'Field to modify not found',
+      undefined,
+      ErrorCodes.ADMIN_FORM_FIELD_NOT_FOUND,
+    )
+    if (message === undefined) {
+      this.messageKey = adminFormErrorKey('fields.notFound')
+    }
+  }
+}
+
+export class AdminFormInvalidPaymentAmountError extends InvalidPaymentAmountError {
+  readonly messageKey = adminFormErrorKey('payments.invalidAmount')
+}
+
+export class PaymentProductAmountLimitExceededError extends InvalidPaymentAmountError {
+  readonly messageKey = adminFormErrorKey('payments.productAmountLimitExceeded')
+
+  constructor(
+    message = 'Item and Quantity exceeded limit. Either lower your quantity or lower payment amount.',
+  ) {
+    super(message)
   }
 }
 

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.i18n.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.i18n.ts
@@ -1,0 +1,59 @@
+import { ErrorDto, I18nMessageParams } from 'formsg-shared/types'
+
+const ADMIN_FORM_BACKEND_ERROR_KEY_PREFIX =
+  'features.adminForm.backendErrors' as const
+
+const errorKey = (suffix: string) =>
+  `${ADMIN_FORM_BACKEND_ERROR_KEY_PREFIX}.${suffix}`
+
+const ADMIN_FORM_ERROR_KEYS: Record<string, string> = {
+  'Error converting feedback to JSON': errorKey(
+    'exports.feedback.jsonConversion',
+  ),
+  'Error converting issue to JSON.': errorKey('exports.issue.jsonConversion'),
+  'Error retrieving from database.': errorKey('exports.databaseRetrieval'),
+  'Field to modify not found': errorKey('fields.notFound'),
+  'Form does not have a public key': errorKey('whitelist.missingPublicKey'),
+  'Form must be public to be copied': errorKey('template.mustBePublic'),
+  'Invalid payment amount': errorKey('payments.invalidAmount'),
+  'Item and Quantity exceeded limit. Either lower your quantity or lower payment amount.':
+    errorKey('payments.productAmountLimitExceeded'),
+  'Please enter a valid HTTP or HTTPS URI': errorKey('endPage.invalidUrl'),
+  'Something went wrong. Please try creating fields again.': errorKey(
+    'fields.createFailed',
+  ),
+  'Unsupported file type': errorKey('assets.unsupportedFileType'),
+  'Your csv has one or more invalid characters.': errorKey(
+    'whitelist.invalidCharacters',
+  ),
+  'Your csv is empty.': errorKey('whitelist.emptyCsv'),
+  'Your form ID is invalid.': errorKey('whitelist.invalidFormId'),
+}
+
+const FILE_SIZE_LIMIT_PATTERN =
+  /^You have exceeded the file size limit, please upload a file below (\d+) kB\.$/
+
+export const getAdminFormErrorI18n = (
+  message: string,
+): Pick<ErrorDto, 'messageKey' | 'messageParams'> => {
+  const messageKey = ADMIN_FORM_ERROR_KEYS[message]
+  if (messageKey) return { messageKey }
+
+  const fileSizeMatch = message.match(FILE_SIZE_LIMIT_PATTERN)
+  if (fileSizeMatch) {
+    const messageParams: I18nMessageParams = {
+      limitKb: Number(fileSizeMatch[1]),
+    }
+    return {
+      messageKey: errorKey('whitelist.fileTooLarge'),
+      messageParams,
+    }
+  }
+
+  return {}
+}
+
+export const buildAdminFormErrorDto = (message: string): ErrorDto => ({
+  message,
+  ...getAdminFormErrorI18n(message),
+})

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.i18n.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.i18n.ts
@@ -1,59 +1,68 @@
+import { Joi } from 'celebrate'
 import { ErrorDto, I18nMessageParams } from 'formsg-shared/types'
 
 const ADMIN_FORM_BACKEND_ERROR_KEY_PREFIX =
   'features.adminForm.backendErrors' as const
 
-const errorKey = (suffix: string) =>
+export const adminFormErrorKey = (suffix: string) =>
   `${ADMIN_FORM_BACKEND_ERROR_KEY_PREFIX}.${suffix}`
 
-const ADMIN_FORM_ERROR_KEYS: Record<string, string> = {
-  'Error converting feedback to JSON': errorKey(
-    'exports.feedback.jsonConversion',
-  ),
-  'Error converting issue to JSON.': errorKey('exports.issue.jsonConversion'),
-  'Error retrieving from database.': errorKey('exports.databaseRetrieval'),
-  'Field to modify not found': errorKey('fields.notFound'),
-  'Form does not have a public key': errorKey('whitelist.missingPublicKey'),
-  'Form must be public to be copied': errorKey('template.mustBePublic'),
-  'Invalid payment amount': errorKey('payments.invalidAmount'),
-  'Item and Quantity exceeded limit. Either lower your quantity or lower payment amount.':
-    errorKey('payments.productAmountLimitExceeded'),
-  'Please enter a valid HTTP or HTTPS URI': errorKey('endPage.invalidUrl'),
-  'Something went wrong. Please try creating fields again.': errorKey(
-    'fields.createFailed',
-  ),
-  'Unsupported file type': errorKey('assets.unsupportedFileType'),
-  'Your csv has one or more invalid characters.': errorKey(
-    'whitelist.invalidCharacters',
-  ),
-  'Your csv is empty.': errorKey('whitelist.emptyCsv'),
-  'Your form ID is invalid.': errorKey('whitelist.invalidFormId'),
-}
-
-const FILE_SIZE_LIMIT_PATTERN =
-  /^You have exceeded the file size limit, please upload a file below (\d+) kB\.$/
-
-export const getAdminFormErrorI18n = (
+export const buildAdminFormErrorDto = (
   message: string,
-): Pick<ErrorDto, 'messageKey' | 'messageParams'> => {
-  const messageKey = ADMIN_FORM_ERROR_KEYS[message]
-  if (messageKey) return { messageKey }
+  messageKey?: string,
+  messageParams?: I18nMessageParams,
+): ErrorDto => ({
+  message,
+  ...(messageKey ? { messageKey } : {}),
+  ...(messageParams ? { messageParams } : {}),
+})
 
-  const fileSizeMatch = message.match(FILE_SIZE_LIMIT_PATTERN)
-  if (fileSizeMatch) {
-    const messageParams: I18nMessageParams = {
-      limitKb: Number(fileSizeMatch[1]),
-    }
-    return {
-      messageKey: errorKey('whitelist.fileTooLarge'),
-      messageParams,
-    }
-  }
-
-  return {}
+type JoiErrorReportWithI18n = Joi.ErrorReport & {
+  code: string
+  local: Record<string, unknown>
 }
 
-export const buildAdminFormErrorDto = (message: string): ErrorDto => ({
-  message,
-  ...getAdminFormErrorI18n(message),
-})
+type ErrorI18n = Pick<ErrorDto, 'messageKey' | 'messageParams'>
+
+export const attachAdminFormErrorI18nByCode = <T extends Joi.Schema>(
+  schema: T,
+  getI18n: (code: string) => ErrorI18n | undefined,
+): T => {
+  const attachI18n = ((errors: Joi.ErrorReport[]) => {
+    errors.forEach((error) => {
+      const report = error as JoiErrorReportWithI18n
+      const i18n = getI18n(report.code)
+      if (i18n?.messageKey) report.local.messageKey = i18n.messageKey
+      if (i18n?.messageParams) {
+        report.local.messageParams = i18n.messageParams
+      }
+    })
+    return errors
+  }) as unknown as Joi.ValidationErrorFunction
+
+  return schema.error(attachI18n) as T
+}
+
+export const attachAdminFormErrorI18n = <T extends Joi.Schema>(
+  schema: T,
+  messageKey: string,
+  messageParams?: I18nMessageParams,
+): T =>
+  attachAdminFormErrorI18nByCode(schema, () => ({
+    messageKey,
+    messageParams,
+  }))
+
+export const getCelebrateErrorI18n = (
+  detail: Joi.ValidationErrorItem,
+): Pick<ErrorDto, 'messageKey' | 'messageParams'> => {
+  const messageKey = detail.context?.messageKey
+  const messageParams = detail.context?.messageParams
+
+  return {
+    ...(typeof messageKey === 'string' ? { messageKey } : {}),
+    ...(typeof messageParams === 'object' && messageParams !== null
+      ? { messageParams: messageParams as I18nMessageParams }
+      : {}),
+  }
+}

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.issue.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.issue.controller.ts
@@ -14,6 +14,7 @@ import { ControllerHandler } from '../../core/core.types'
 import * as IssueService from '../../issue/issue.service'
 import * as UserService from '../../user/user.service'
 
+import { buildAdminFormErrorDto } from './admin-form.i18n'
 import { PermissionLevel } from './admin-form.types'
 import { mapRouteError } from './admin-form.utils'
 
@@ -61,7 +62,7 @@ export const handleGetFormIssues: ControllerHandler<
         error,
       })
       const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json({ message: errorMessage })
+      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
     })
 }
 
@@ -110,7 +111,7 @@ export const handleStreamFormIssues: ControllerHandler<
     const { errorMessage, statusCode } = mapRouteError(
       hasReadPermissionResult.error,
     )
-    return res.status(statusCode).json({ message: errorMessage })
+    return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
   }
 
   // No errors, start stream.
@@ -123,9 +124,9 @@ export const handleStreamFormIssues: ControllerHandler<
         meta: logMeta,
         error,
       })
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: 'Error retrieving from database.',
-      })
+      return res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json(buildAdminFormErrorDto('Error retrieving from database.'))
     })
     .pipe(JSONStream.stringify())
     .on('error', (error) => {
@@ -134,9 +135,9 @@ export const handleStreamFormIssues: ControllerHandler<
         meta: logMeta,
         error,
       })
-      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-        message: 'Error converting issue to JSON.',
-      })
+      return res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json(buildAdminFormErrorDto('Error converting issue to JSON.'))
     })
     .pipe(res.type('json'))
     .on('error', (error) => {

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.issue.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.issue.controller.ts
@@ -14,7 +14,7 @@ import { ControllerHandler } from '../../core/core.types'
 import * as IssueService from '../../issue/issue.service'
 import * as UserService from '../../user/user.service'
 
-import { buildAdminFormErrorDto } from './admin-form.i18n'
+import { adminFormErrorKey, buildAdminFormErrorDto } from './admin-form.i18n'
 import { PermissionLevel } from './admin-form.types'
 import { mapRouteError } from './admin-form.utils'
 
@@ -61,8 +61,10 @@ export const handleGetFormIssues: ControllerHandler<
         },
         error,
       })
-      const { errorMessage, statusCode } = mapRouteError(error)
-      return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+      const { errorMessage, statusCode, errorMessageKey } = mapRouteError(error)
+      return res
+        .status(statusCode)
+        .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
     })
 }
 
@@ -108,10 +110,12 @@ export const handleStreamFormIssues: ControllerHandler<
       meta: logMeta,
       error: hasReadPermissionResult.error,
     })
-    const { errorMessage, statusCode } = mapRouteError(
+    const { errorMessage, statusCode, errorMessageKey } = mapRouteError(
       hasReadPermissionResult.error,
     )
-    return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+    return res
+      .status(statusCode)
+      .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
   }
 
   // No errors, start stream.
@@ -126,7 +130,12 @@ export const handleStreamFormIssues: ControllerHandler<
       })
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .json(buildAdminFormErrorDto('Error retrieving from database.'))
+        .json(
+          buildAdminFormErrorDto(
+            'Error retrieving from database.',
+            adminFormErrorKey('exports.databaseRetrieval'),
+          ),
+        )
     })
     .pipe(JSONStream.stringify())
     .on('error', (error) => {
@@ -137,7 +146,12 @@ export const handleStreamFormIssues: ControllerHandler<
       })
       return res
         .status(StatusCodes.INTERNAL_SERVER_ERROR)
-        .json(buildAdminFormErrorDto('Error converting issue to JSON.'))
+        .json(
+          buildAdminFormErrorDto(
+            'Error converting issue to JSON.',
+            adminFormErrorKey('exports.issue.jsonConversion'),
+          ),
+        )
     })
     .pipe(res.type('json'))
     .on('error', (error) => {

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -271,8 +271,11 @@ const _handleUpdatePayments: ControllerHandler<
           meta: logMeta,
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }
@@ -322,8 +325,11 @@ export const _handleUpdatePaymentsProduct: ControllerHandler<
           },
           error,
         })
-        const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
+        const { errorMessage, statusCode, errorMessageKey } =
+          mapRouteError(error)
+        return res
+          .status(statusCode)
+          .json(buildAdminFormErrorDto(errorMessage, errorMessageKey))
       })
   )
 }

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.payments.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.payments.controller.ts
@@ -31,6 +31,7 @@ import { getPopulatedUserById } from '../../user/user.service'
 import * as UserService from '../../user/user.service'
 
 import { PaymentChannelNotFoundError } from './admin-form.errors'
+import { buildAdminFormErrorDto } from './admin-form.i18n'
 import { JoiPaymentProduct } from './admin-form.payments.constants'
 import * as AdminFormPaymentService from './admin-form.payments.service'
 import { PermissionLevel } from './admin-form.types'
@@ -271,7 +272,7 @@ const _handleUpdatePayments: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }
@@ -322,7 +323,7 @@ export const _handleUpdatePaymentsProduct: ControllerHandler<
           error,
         })
         const { errorMessage, statusCode } = mapRouteError(error)
-        return res.status(statusCode).json({ message: errorMessage })
+        return res.status(statusCode).json(buildAdminFormErrorDto(errorMessage))
       })
   )
 }

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.payments.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.payments.service.ts
@@ -22,6 +22,11 @@ import {
 } from '../../payments/payments.errors'
 import { FormNotFoundError } from '../form.errors'
 
+import {
+  AdminFormInvalidPaymentAmountError,
+  PaymentProductAmountLimitExceededError,
+} from './admin-form.errors'
+
 const logger = createLoggerWithLabel(module)
 const EncryptedFormModel = getEncryptedFormModel(mongoose)
 
@@ -55,23 +60,23 @@ export const updatePayments = (
       amount_cents > paymentConfig.maxPaymentAmountCents ||
       amount_cents < paymentConfig.minPaymentAmountCents
     ) {
-      return errAsync(new InvalidPaymentAmountError())
+      return errAsync(new AdminFormInvalidPaymentAmountError())
     }
   }
 
   if (enabled && newPayments.payment_type === PaymentType.Variable) {
     const { min_amount, max_amount } = newPayments
     if (min_amount > max_amount) {
-      return errAsync(new InvalidPaymentAmountError())
+      return errAsync(new AdminFormInvalidPaymentAmountError())
     }
     const minAmountCents =
       newPayments.global_min_amount_override ||
       paymentConfig.minPaymentAmountCents
     if (min_amount < minAmountCents) {
-      return errAsync(new InvalidPaymentAmountError())
+      return errAsync(new AdminFormInvalidPaymentAmountError())
     }
     if (max_amount > paymentConfig.maxPaymentAmountCents) {
-      return errAsync(new InvalidPaymentAmountError())
+      return errAsync(new AdminFormInvalidPaymentAmountError())
     }
   }
 
@@ -138,11 +143,7 @@ export const updatePaymentsProduct = (
     const qtyModifier = product.multi_qty ? product.max_qty : 1
     const maximumSelectableQtyCost = qtyModifier * product.amount_cents
     if (maximumSelectableQtyCost > paymentConfig.maxPaymentAmountCents) {
-      return errAsync(
-        new InvalidPaymentAmountError(
-          'Item and Quantity exceeded limit. Either lower your quantity or lower payment amount.',
-        ),
-      )
+      return errAsync(new PaymentProductAmountLimitExceededError())
     }
   }
   return ResultAsync.fromPromise(

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.utils.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.utils.ts
@@ -46,6 +46,7 @@ import {
 import { UNICODE_ESCAPED_REGEX } from '../form.utils'
 
 import {
+  AdminFormInvalidPaymentAmountError,
   EditFieldError,
   FieldNotFoundError,
   GoGovAlreadyExistError,
@@ -60,7 +61,9 @@ import {
   ModelResponseInvalidSchemaFormatError,
   ModelResponseInvalidSyntaxError,
   PaymentChannelNotFoundError,
+  PaymentProductAmountLimitExceededError,
 } from './admin-form.errors'
+import { adminFormErrorKey } from './admin-form.i18n'
 import {
   AssertFormFn,
   EditFormFieldResult,
@@ -87,13 +90,23 @@ export const mapRouteError = (
         errorMessage: error.message,
       }
     case InvalidFileTypeError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+        errorMessageKey: error.messageKey,
+      }
     case CreatePresignedPostError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: error.message,
       }
-    case FormNotFoundError:
     case FieldNotFoundError:
+      return {
+        statusCode: StatusCodes.NOT_FOUND,
+        errorMessage: error.message,
+        errorMessageKey: error.messageKey,
+      }
+    case FormNotFoundError:
     case LogicNotFoundError:
       return {
         statusCode: StatusCodes.NOT_FOUND,
@@ -153,6 +166,18 @@ export const mapRouteError = (
         statusCode: StatusCodes.BAD_GATEWAY,
         errorMessage: coreErrorMessage ?? error.message,
       }
+    case AdminFormInvalidPaymentAmountError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+        errorMessageKey: error.messageKey,
+      }
+    case PaymentProductAmountLimitExceededError:
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        errorMessage: error.message,
+        errorMessageKey: error.messageKey,
+      }
     case InvalidPaymentAmountError:
       return {
         statusCode: StatusCodes.BAD_REQUEST,
@@ -203,6 +228,7 @@ export const mapRouteError = (
       return {
         statusCode: StatusCodes.BAD_REQUEST,
         errorMessage: 'Something went wrong. Please try creating fields again.',
+        errorMessageKey: adminFormErrorKey('fields.createFailed'),
       }
     default:
       logger.error({

--- a/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
+++ b/apps/backend/src/app/routes/api/v3/admin/forms/__tests__/admin-forms.form.routes.spec.ts
@@ -3150,14 +3150,18 @@ describe('admin-form.form.routes', () => {
 
       //Assert
       expect(response.status).toBe(400)
-      expect(response.body).toEqual(
-        buildCelebrateError({
-          body: {
-            key: 'buttonLink',
-            message: 'Please enter a valid HTTP or HTTPS URI',
+      expect(response.body).toEqual({
+        ...buildCelebrateError(
+          {
+            body: {
+              key: 'buttonLink',
+              message: 'Please enter a valid HTTP or HTTPS URI',
+            },
           },
-        }),
-      )
+          { message: 'Please enter a valid HTTP or HTTPS URI' },
+        ),
+        messageKey: 'features.adminForm.backendErrors.endPage.invalidUrl',
+      })
     })
   })
 

--- a/apps/frontend/src/i18n/locales/features/admin-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/en-sg.ts
@@ -15,6 +15,46 @@ import { enSG as template } from './template'
 import { enSG as toasts } from './toasts'
 
 export const enSG = {
+  backendErrors: {
+    exports: {
+      databaseRetrieval:
+        'There was a problem retrieving the export data. Please try again.',
+      feedback: {
+        jsonConversion:
+          'There was a problem preparing the feedback export. Please try again.',
+      },
+      issue: {
+        jsonConversion:
+          'There was a problem preparing the issue export. Please try again.',
+      },
+    },
+    fields: {
+      notFound: 'Field to modify not found',
+      createFailed: 'Something went wrong. Please try creating fields again.',
+    },
+    whitelist: {
+      missingPublicKey: 'Form does not have a public key',
+      fileTooLarge:
+        'You have exceeded the file size limit, please upload a file below {{limitKb}} kB.',
+      invalidCharacters: 'Your csv has one or more invalid characters.',
+      emptyCsv: 'Your csv is empty.',
+      invalidFormId: 'Your form ID is invalid.',
+    },
+    template: {
+      mustBePublic: 'Form must be public to be copied',
+    },
+    payments: {
+      invalidAmount: 'Invalid payment amount',
+      productAmountLimitExceeded:
+        'Item and Quantity exceeded limit. Either lower your quantity or lower payment amount.',
+    },
+    endPage: {
+      invalidUrl: 'Please enter a valid HTTP or HTTPS URI',
+    },
+    assets: {
+      unsupportedFileType: 'Unsupported file type',
+    },
+  },
   responses: {
     charts: responsesCharts,
     components: responsesComponents,

--- a/apps/frontend/src/services/ApiService.ts
+++ b/apps/frontend/src/services/ApiService.ts
@@ -95,16 +95,16 @@ export const transformAxiosError = (error: Error): ApiError => {
       if (typeof error.response.data === 'string') {
         return new HttpError(error.response.data, statusCode)
       }
-      // handle celebrate errors
+      const backendMessage = getTranslatedBackendMessage(error.response.data)
+      if (backendMessage) {
+        return new HttpError(backendMessage, statusCode)
+      }
+      // handle celebrate errors without an i18n-enabled top-level message
       if (error.response.data?.validation?.body?.message) {
         return new HttpError(
           error.response.data.validation.body.message,
           statusCode,
         )
-      }
-      const backendMessage = getTranslatedBackendMessage(error.response.data)
-      if (backendMessage) {
-        return new HttpError(backendMessage, statusCode)
       }
       if (error.response.statusText) {
         return new HttpError(error.response.statusText, statusCode)

--- a/apps/frontend/src/services/ApiService.ts
+++ b/apps/frontend/src/services/ApiService.ts
@@ -92,23 +92,32 @@ export const transformAxiosError = (error: Error): ApiError => {
       if (statusCode === StatusCodes.TOO_MANY_REQUESTS) {
         return new HttpError('Please try again later.', statusCode)
       }
-      if (typeof error.response.data === 'string') {
-        return new HttpError(error.response.data, statusCode)
+      const data = error.response.data
+
+      if (typeof data === 'string') {
+        return new HttpError(data, statusCode)
       }
-      const backendMessage = getTranslatedBackendMessage(error.response.data)
+      const backendMessage = getTranslatedBackendMessage(data)
+
+      // Prefer translated messages for i18n enabled Celebrate errors
+      if (typeof data?.messageKey === 'string' && backendMessage) {
+        return new HttpError(backendMessage, statusCode)
+      }
+
+      // Preserve specific message from vanilla Celebrate errors
+      if (data?.validation?.body?.message) {
+        return new HttpError(data.validation.body.message, statusCode)
+      }
+
+      // Fall back to the top-level message for ordinary backend errors
       if (backendMessage) {
         return new HttpError(backendMessage, statusCode)
       }
-      // handle celebrate errors without an i18n-enabled top-level message
-      if (error.response.data?.validation?.body?.message) {
-        return new HttpError(
-          error.response.data.validation.body.message,
-          statusCode,
-        )
-      }
+
       if (error.response.statusText) {
         return new HttpError(error.response.statusText, statusCode)
       }
+
       return new HttpError(`Error: ${statusCode}`, statusCode)
     } else if (error.request) {
       // TODO: Remove this logging once Network Error sources have been identified.


### PR DESCRIPTION
## Problem

Relates to Issue #9213

Admin form backend errors continued to rely on hardcoded English messages, so the frontend could not resolve localised strings for errors returned by admin form routes. Celebrate validation errors also prioritised the nested raw validation message over the new top-level translated error metadata.

## Solution

Added structured i18n metadata to catalogued admin form backend errors while preserving existing English messages as fallbacks.

**Breaking Changes**

- [ ] No — this PR is backwards compatible. Existing `message` values and Celebrate validation payloads are preserved; `messageKey` and `messageParams` are additive.

**Improvements**:

- Added a central admin form error catalogue mapping existing backend messages to `features.adminForm.backendErrors.*` translation keys
- Added `buildAdminFormErrorDto()` to consistently attach i18n metadata to admin form error responses
- Migrated admin form, assistance, payment, issue, export, whitelist, field, template, asset, and end-page errors to use the structured error DTO
- Added typed `limitKb` interpolation for whitelist file-size errors
- Added the corresponding `backendErrors` namespace to the `en-sg` admin form locale
- Added i18n metadata to recognised Celebrate validation errors while retaining the original Celebrate response payload
- Updated `ApiService` to resolve top-level translated backend errors before falling back to nested Celebrate validation messages
- Left uncatalogued backend errors unchanged so they continue using their legacy messages

## Before & After Screenshots

N/A , no UI Visual Changes

## Tests

**TC1: Admin form errors include message keys**

- Trigger a mapped admin form error, such as attempting to modify a missing field
- Confirm the response contains:
  - `message: "Field to modify not found"`
  - `messageKey: "features.adminForm.backendErrors.fields.notFound"`

**TC2: Frontend resolves translated admin form errors**

- Trigger any mapped admin form backend error
- Confirm the displayed error uses the corresponding `en-sg` translation instead of the raw fallback message

**TC3: Whitelist file-size interpolation**

- Upload a whitelist file exceeding the configured size limit
- Confirm the response contains:
  - `messageKey: "features.adminForm.backendErrors.whitelist.fileTooLarge"`
  - `messageParams.limitKb` with the extracted limit
- Confirm the frontend interpolates the limit into the translated message

**TC4: Celebrate errors resolve translations**

- Submit an invalid end-page URL
- Confirm the original Celebrate validation payload is retained
- Confirm the response also contains `messageKey: "features.adminForm.backendErrors.endPage.invalidUrl"`
- Confirm the frontend displays the translated top-level message

**TC5: Legacy fallback remains unchanged**

- Trigger an uncatalogued admin form backend error
- Confirm no `messageKey` is added and the frontend continues displaying the raw `message`

**TC6: Export and payment errors include message keys**

- Trigger a feedback or issue export failure and confirm the appropriate `exports.*` key is returned
- Trigger an invalid payment amount or product limit error and confirm the appropriate `payments.*` key is returned

## Deploy Notes

**New environment variables**: None

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None