### PR TITLE
refactor(mrf): ready the payload policy and reconstruction for replay

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1168,12 +1168,19 @@ const sendMrfInitialWebhookIfEligible = ({
         submissionIndex,
         submittedStepsLength: submission.submittedSteps?.length ?? 0,
       })
+      const snapshotDetails = snapshot
+        ? {
+            snapshot,
+            submissionIndex,
+          }
+        : {
+            snapshot: undefined,
+            submissionIndex: undefined,
+          }
       return reconstructMrfWebhookData({
         liveData: liveView.data,
-        snapshot,
-        // RATONALE: if snapshot does not exist, we use the live row.
-        submissionIndex: snapshot ? submissionIndex : undefined,
         policy,
+        ...snapshotDetails,
       }).asyncAndThen((data) => {
         const webhookView: WebhookView = { data }
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-reconstruction.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/webhook-reconstruction.spec.ts
@@ -1,10 +1,10 @@
 import { SubmittedStep, WorkflowStatus } from 'formsg-shared/types'
+import { omit } from 'lodash'
 
 import { projectSubmittedStepForWebhook } from 'src/app/modules/submission/submitted-step-visibility'
 import { WorkflowWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
 import { WebhookData } from 'src/types/submission'
 
-import { SnapshotDataIntegrityError } from '../submission-snapshot.errors'
 import { WebhookPayloadPolicy } from '../webhook-payload-policy'
 import { reconstructMrfWebhookData } from '../webhook-reconstruction'
 
@@ -72,6 +72,8 @@ describe('reconstructMrfWebhookData', () => {
 
       const output = reconstructMrfWebhookData({
         liveData,
+        snapshot: undefined,
+        submissionIndex: undefined,
         policy: PLUMBER_LATEST,
       })._unsafeUnwrap()
 
@@ -82,21 +84,6 @@ describe('reconstructMrfWebhookData', () => {
   })
 
   describe('with submissionIndex (snapshot path)', () => {
-    it('returns a SnapshotDataIntegrityError when the snapshot is missing (fails loud, never falls back to liveData)', () => {
-      const liveData = makeLiveData()
-
-      const result = reconstructMrfWebhookData({
-        liveData,
-        submissionIndex: 1,
-        snapshot: undefined,
-        policy: PLUMBER_LATEST,
-      })
-
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
-        SnapshotDataIntegrityError,
-      )
-    })
-
     it('derives version from the FROZEN snapshot content shape (v4 => 4), overriding liveData.version', () => {
       const output = reconstructMrfWebhookData({
         liveData: makeLiveData({ version: 1 }),
@@ -168,8 +155,10 @@ describe('reconstructMrfWebhookData', () => {
     })
 
     it('emits no attachment urls when the snapshot froze none, even if the live row has some', () => {
-      const snapshotWithoutAttachments = { ...makeV4Snapshot() }
-      delete snapshotWithoutAttachments.attachmentMetadata
+      const snapshotWithoutAttachments = omit(
+        makeV4Snapshot(),
+        'attachmentMetadata',
+      )
 
       const output = reconstructMrfWebhookData({
         liveData: makeLiveData({
@@ -200,17 +189,6 @@ describe('reconstructMrfWebhookData', () => {
       expect(workflowContent.workflow).toEqual([{ _id: 'step-def' }])
       // workflowStep taken from the snapshot.
       expect(workflowContent.workflowStep).toBe(1)
-    })
-
-    it('handles a plain-object liveData.workflowContent gracefully', () => {
-      const result = reconstructMrfWebhookData({
-        liveData: makeLiveData({ workflowContent: {} }),
-        snapshot: makeV4Snapshot(),
-        submissionIndex: 1,
-        policy: PLUMBER_LATEST,
-      })
-
-      expect(result.isOk()).toBe(true)
     })
   })
 
@@ -259,6 +237,8 @@ describe('reconstructMrfWebhookData', () => {
       const livePath = JSON.stringify(
         reconstructMrfWebhookData({
           liveData: makeLiveData(),
+          snapshot: undefined,
+          submissionIndex: undefined,
           policy: PLUMBER_LATEST,
         })._unsafeUnwrap(),
       )

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-payload-policy.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-payload-policy.ts
@@ -11,10 +11,31 @@ export interface WebhookPayloadPolicyInput {
   submittedStepsLength: number
 }
 
-export interface WebhookPayloadPolicy {
-  contentFormat: WebhookContentFormat
+export interface KeyPermissionsPolicy {
   includeEncryptedSubmissionSecretKey: boolean
   includeEncryptedStepToken: boolean
+}
+export interface WebhookPayloadPolicy extends KeyPermissionsPolicy {
+  contentFormat: WebhookContentFormat
+}
+
+export const getKeyPermissionsPolicy = ({
+  webhookType,
+  submissionIndex,
+  submittedStepsLength,
+  contentFormat,
+}: {
+  webhookType: WebhookConsumerType
+  submissionIndex: number
+  submittedStepsLength: number
+  contentFormat: WebhookContentFormat
+}): Omit<WebhookPayloadPolicy, 'contentFormat'> => {
+  const isLatestStep = submissionIndex === submittedStepsLength - 1
+  return {
+    includeEncryptedSubmissionSecretKey: contentFormat === 'v4',
+    includeEncryptedStepToken:
+      contentFormat === 'v4' && webhookType === 'plumber' && isLatestStep,
+  }
 }
 
 export const getWebhookPayloadPolicy = ({
@@ -27,17 +48,16 @@ export const getWebhookPayloadPolicy = ({
     ? 'v4'
     : 'v3'
 
-  const includeEncryptedSubmissionSecretKey = contentFormat === 'v4'
-
-  const includeEncryptedStepToken =
-    contentFormat === 'v4' &&
-    webhookType === 'plumber' &&
-    submissionIndex === submittedStepsLength - 1
+  const keyPermissionsPolicy = getKeyPermissionsPolicy({
+    webhookType,
+    submissionIndex,
+    submittedStepsLength,
+    contentFormat,
+  })
 
   return {
     contentFormat,
-    includeEncryptedSubmissionSecretKey,
-    includeEncryptedStepToken,
+    ...keyPermissionsPolicy,
   }
 }
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-reconstruction.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-reconstruction.ts
@@ -1,6 +1,5 @@
-import { err, ok, Result } from 'neverthrow'
+import { ok, Result } from 'neverthrow'
 
-import { WorkflowWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
 import { WebhookData } from 'src/types/submission'
 
 import { SnapshotDataIntegrityError } from './submission-snapshot.errors'
@@ -10,40 +9,32 @@ import {
   WebhookPayloadPolicy,
 } from './webhook-payload-policy'
 
-export const reconstructMrfWebhookData = (input: {
+interface ReconstructMrfWebhookDataInputBase {
   liveData: WebhookData
-  snapshot?: SubmissionSnapshot
-  submissionIndex?: number
   policy: WebhookPayloadPolicy
-}): Result<WebhookData, SnapshotDataIntegrityError> => {
+}
+
+interface ReconstructMrfWebhookDataInputWithoutSnapshot extends ReconstructMrfWebhookDataInputBase {
+  snapshot: undefined
+  submissionIndex: undefined
+}
+
+interface ReconstructMrfWebhookDataInputWithSnapshot extends ReconstructMrfWebhookDataInputBase {
+  snapshot: SubmissionSnapshot
+  submissionIndex: number
+}
+
+type ReconstructMrfWebhookDataInput =
+  | ReconstructMrfWebhookDataInputWithSnapshot
+  | ReconstructMrfWebhookDataInputWithoutSnapshot
+
+export const reconstructMrfWebhookData = (
+  input: ReconstructMrfWebhookDataInput,
+): Result<WebhookData, SnapshotDataIntegrityError> => {
   const { liveData, snapshot, submissionIndex, policy } = input
 
-  if (submissionIndex === undefined) {
+  if (snapshot === undefined) {
     return ok(liveData)
-  }
-
-  if (!snapshot) {
-    return err(
-      new SnapshotDataIntegrityError(
-        'Snapshot missing on the snapshot reconstruction path',
-        { submissionId: liveData.submissionId, submissionIndex },
-      ),
-    )
-  }
-
-  const liveWorkflow = (liveData.workflowContent ??
-    {}) as Partial<WorkflowWebhookEventObject>
-  const workflowContent: WebhookData['workflowContent'] = {
-    ...liveWorkflow,
-    workflowStep: snapshot.workflowStep,
-    ...(Array.isArray(liveWorkflow.submittedSteps)
-      ? {
-          submittedSteps: liveWorkflow.submittedSteps.slice(
-            0,
-            submissionIndex + 1,
-          ),
-        }
-      : {}),
   }
 
   const reconstructed: WebhookData = {
@@ -54,7 +45,23 @@ export const reconstructMrfWebhookData = (input: {
     encryptedContent: snapshot.encryptedContent,
     verifiedContent: snapshot.verifiedContent,
     version: contentFormatToWebhookVersion(snapshot.contentFormat),
-    workflowContent,
+  }
+
+  const liveWorkflow = liveData.workflowContent
+
+  if (liveWorkflow !== undefined) {
+    reconstructed.workflowContent = {
+      ...liveWorkflow,
+      workflowStep: snapshot.workflowStep,
+      ...(Array.isArray(liveWorkflow.submittedSteps)
+        ? {
+            submittedSteps: liveWorkflow.submittedSteps.slice(
+              0,
+              submissionIndex + 1,
+            ),
+          }
+        : {}),
+    }
   }
 
   if (liveData.paymentContent !== undefined) {

--- a/apps/backend/src/types/submission.ts
+++ b/apps/backend/src/types/submission.ts
@@ -34,7 +34,7 @@ export interface WebhookData {
   created: IEncryptedSubmissionSchema['created']
   attachmentDownloadUrls: Record<string, string>
   paymentContent?: PaymentWebhookEventObject | object
-  workflowContent?: WorkflowWebhookEventObject | object
+  workflowContent?: WorkflowWebhookEventObject
   encryptedSubmissionSecretKey?: string
 }
 


### PR DESCRIPTION
## Problem

A webhook retry must rebuild the payload the initial send delivered. Two pieces of the send path prevent that. The payload policy always derives the content version itself, from the form and the feature flag as they read at that moment, so a retry that called it would follow a later change rather than the recorded one. And reconstruction takes an optional snapshot together with an optional submission index, so a caller can ask for the snapshot path without a snapshot, and the function answers that with a runtime error.

Part of #9745.

## Solution

Two refactors that prepare the send path for replay. Neither changes what an initial send delivers.

`getKeyPermissionsPolicy` now decides which keys a payload may carry, and takes the content version as an input instead of deriving it. `getWebhookPayloadPolicy` keeps its signature and its behaviour: it derives the content version, then delegates. The retry path can call the first one directly with the version recorded at enqueue time.

`reconstructMrfWebhookData` takes a union of two total shapes — a snapshot with its submission index, or neither. The caller states which path it is on, the unusable combination no longer compiles, and the runtime integrity error that guarded it is gone.

**Alternatives considered**

- We could have left `WebhookData.workflowContent` as `WorkflowWebhookEventObject | object` and kept casting at each use, which is what the code did. We narrowed the type instead, because the union makes every field access unsafe and reconstruction must read `submittedSteps`.

**Breaking Changes**

No - backwards compatible. One nuance for the reviewer: reconstruction now copies the workflow content only when the live row has it, in place of synthesising one from an empty object. An MRF row always has it.

## Tests

**TC1: An MRF step webhook still delivers as it does today**

- [ ] Submit a step on a V4 MRF form with a plumber webhook URL, `mrf-step-write-token` on.
- [ ] The payload carries the same `version`, `encryptedSubmissionSecretKey` and `encryptedStepToken` fields as before this change.
- [ ] Repeat on a V3 form: the payload is unchanged, and carries neither key field.
