### PR TITLE
feat(webhook): version the retry queue message to name its step

### DIFF
--- a/apps/backend/src/app/modules/webhook/__tests__/webhook.message.spec.ts
+++ b/apps/backend/src/app/modules/webhook/__tests__/webhook.message.spec.ts
@@ -1,8 +1,10 @@
 import { ObjectId } from 'bson'
+import { omit } from 'lodash'
 
 import {
   DUE_TIME_TOLERANCE_SECONDS,
-  QUEUE_MESSAGE_VERSION,
+  QUEUE_MESSAGE_LIVE_ROW_VERSION,
+  QUEUE_MESSAGE_SNAPSHOT_VERSION,
   RETRY_INTERVALS,
 } from '../webhook.constants'
 import {
@@ -18,7 +20,18 @@ describe('WebhookQueueMessage', () => {
     submissionId: new ObjectId().toHexString(),
     previousAttempts: [Date.now()],
     nextAttempt: Date.now(),
-    _v: 0,
+    _v: QUEUE_MESSAGE_LIVE_ROW_VERSION,
+  }
+
+  const VALID_SNAPSHOT_MESSAGE: WebhookQueueMessageObject = {
+    submissionId: new ObjectId().toHexString(),
+    snapshotRef: {
+      submissionIndex: 1,
+      contentFormat: 'v4',
+    },
+    previousAttempts: [Date.now()],
+    nextAttempt: Date.now(),
+    _v: QUEUE_MESSAGE_SNAPSHOT_VERSION,
   }
 
   beforeEach(() => {
@@ -64,6 +77,59 @@ describe('WebhookQueueMessage', () => {
 
       expect(result._unsafeUnwrap().message).toEqual(VALID_MESSAGE)
     })
+
+    it('should parse a legacy message enqueued before the snapshot retry path shipped', () => {
+      const result = WebhookQueueMessage.deserialise(
+        JSON.stringify(VALID_MESSAGE),
+      )
+
+      const message = result._unsafeUnwrap()
+      expect(message.message._v).toBe(QUEUE_MESSAGE_LIVE_ROW_VERSION)
+      expect(message.snapshotRef).toBeUndefined()
+    })
+
+    it('should parse a snapshot message carrying its submission index and content format', () => {
+      const result = WebhookQueueMessage.deserialise(
+        JSON.stringify(VALID_SNAPSHOT_MESSAGE),
+      )
+
+      const message = result._unsafeUnwrap()
+      expect(message.message).toEqual(VALID_SNAPSHOT_MESSAGE)
+      expect(message.snapshotRef).toEqual({
+        submissionIndex: 1,
+        contentFormat: 'v4',
+      })
+    })
+
+    it.each([
+      'snapshotRef',
+      'snapshotRef.submissionIndex',
+      'snapshotRef.contentFormat',
+    ] as const)(
+      'should return WebhookQueueMessageParsingError when a snapshot message omits %s',
+      (field) => {
+        const result = WebhookQueueMessage.deserialise(
+          JSON.stringify(omit(VALID_SNAPSHOT_MESSAGE, field)),
+        )
+
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+          WebhookQueueMessageParsingError,
+        )
+      },
+    )
+
+    it('should fail loud on an unknown message version rather than defaulting to a path', () => {
+      const result = WebhookQueueMessage.deserialise(
+        JSON.stringify({
+          ...VALID_SNAPSHOT_MESSAGE,
+          _v: QUEUE_MESSAGE_SNAPSHOT_VERSION + 1,
+        }),
+      )
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        WebhookQueueMessageParsingError,
+      )
+    })
   })
 
   describe('fromSubmissionId', () => {
@@ -83,7 +149,26 @@ describe('WebhookQueueMessage', () => {
         submissionId,
         previousAttempts: [MOCK_NOW],
         nextAttempt: expect.any(Number),
-        _v: QUEUE_MESSAGE_VERSION,
+        _v: QUEUE_MESSAGE_LIVE_ROW_VERSION,
+      })
+    })
+
+    it('should name the step submission and content format when a snapshot was recorded', () => {
+      const submissionId = new ObjectId().toHexString()
+      const result = WebhookQueueMessage.fromSubmissionId(submissionId, {
+        submissionIndex: 2,
+        contentFormat: 'v4',
+      })
+
+      expect(result._unsafeUnwrap().message).toEqual({
+        submissionId,
+        previousAttempts: [MOCK_NOW],
+        nextAttempt: expect.any(Number),
+        _v: QUEUE_MESSAGE_SNAPSHOT_VERSION,
+        snapshotRef: {
+          submissionIndex: 2,
+          contentFormat: 'v4',
+        },
       })
     })
   })
@@ -148,6 +233,18 @@ describe('WebhookQueueMessage', () => {
       expect(result.message.nextAttempt).toBeGreaterThan(
         VALID_MESSAGE.nextAttempt,
       )
+    })
+
+    it('should carry the named step submission and content format into the next attempt', () => {
+      const msg = new WebhookQueueMessage(VALID_SNAPSHOT_MESSAGE)
+
+      const result = msg.incrementAttempts()._unsafeUnwrap()
+
+      expect(result.snapshotRef).toEqual({
+        submissionIndex: 1,
+        contentFormat: 'v4',
+      })
+      expect(result.message._v).toBe(QUEUE_MESSAGE_SNAPSHOT_VERSION)
     })
 
     it('should return WebhookNoMoreRetriesError when retries have been exhausted', () => {

--- a/apps/backend/src/app/modules/webhook/__tests__/webhook.producer.spec.ts
+++ b/apps/backend/src/app/modules/webhook/__tests__/webhook.producer.spec.ts
@@ -2,10 +2,14 @@ import { ObjectId } from 'bson'
 import { addHours, addMinutes, subMinutes } from 'date-fns'
 import { Producer } from 'sqs-producer'
 
-import { MAX_DELAY_SECONDS } from '../webhook.constants'
+import {
+  MAX_DELAY_SECONDS,
+  QUEUE_MESSAGE_LIVE_ROW_VERSION,
+} from '../webhook.constants'
 import { WebhookPushToQueueError } from '../webhook.errors'
 import { WebhookQueueMessage } from '../webhook.message'
 import { WebhookProducer } from '../webhook.producer'
+import { WebhookQueueMessageObject } from '../webhook.types'
 
 jest.mock('sqs-producer')
 const MockSqsProducer = jest.mocked(Producer)
@@ -16,11 +20,11 @@ describe('WebhookProducer', () => {
 
   const MOCK_NOW = Date.now()
 
-  const MESSAGE_BODY = {
+  const MESSAGE_BODY: WebhookQueueMessageObject = {
     submissionId: new ObjectId().toHexString(),
     previousAttempts: [MOCK_NOW],
     nextAttempt: MOCK_NOW,
-    _v: 0,
+    _v: QUEUE_MESSAGE_LIVE_ROW_VERSION,
   }
 
   beforeAll(() => {

--- a/apps/backend/src/app/modules/webhook/webhook.constants.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.constants.ts
@@ -1,11 +1,17 @@
 import config from '../../config/config'
 
-import { RetryInterval } from './webhook.types'
+import type { RetryInterval } from './webhook.types'
 
 /**
- * Current version of queue message format.
+ * Version of the queue message format shipped before the snapshot retry path,
+ * which always sends the live row data for retries, even for earlier steps.
  */
-export const QUEUE_MESSAGE_VERSION = 0
+export const QUEUE_MESSAGE_LIVE_ROW_VERSION = 0
+
+/**
+ * Version of queue message format which sends the exact step's data for retries.
+ */
+export const QUEUE_MESSAGE_SNAPSHOT_VERSION = 1
 
 // Conversion to seconds
 const hours = (h: number) => h * 60 * 60

--- a/apps/backend/src/app/modules/webhook/webhook.message.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.message.ts
@@ -5,13 +5,15 @@ import { createLoggerWithLabel } from '../../config/logger'
 
 import {
   DUE_TIME_TOLERANCE_SECONDS,
-  QUEUE_MESSAGE_VERSION,
+  QUEUE_MESSAGE_LIVE_ROW_VERSION,
+  QUEUE_MESSAGE_SNAPSHOT_VERSION,
 } from './webhook.constants'
 import {
   WebhookNoMoreRetriesError,
   WebhookQueueMessageParsingError,
 } from './webhook.errors'
 import {
+  SnapshotRef,
   WebhookFailedQueueMessage,
   webhookMessageSchema,
   WebhookQueueMessageObject,
@@ -83,21 +85,38 @@ export class WebhookQueueMessage {
    * hence uses the current date as the time of the first
    * webhook attempt.
    * @param submissionId
+   * @param snapshotRef Used for fetching the snapshot to reconstruct
+   * the retry payload. Provided only when a snapshot was recorded
+   * for that step; otherwise the retry uses the live submission row.
    * @returns ok(encapsulated message) if retry policy exists
    * @returns err if the retry policy does not allow any retries
    */
   static fromSubmissionId(
     submissionId: string,
+    snapshotRef?: SnapshotRef,
   ): Result<WebhookQueueMessage, WebhookNoMoreRetriesError> {
     const initialAttempt = Date.now()
     return getNextAttempt(/* previousAttempts =*/ [initialAttempt]).map(
       (nextAttempt) =>
-        new WebhookQueueMessage({
-          submissionId,
-          previousAttempts: [initialAttempt],
-          nextAttempt,
-          _v: QUEUE_MESSAGE_VERSION,
-        }),
+        new WebhookQueueMessage(
+          snapshotRef
+            ? {
+                submissionId,
+                previousAttempts: [initialAttempt],
+                nextAttempt,
+                _v: QUEUE_MESSAGE_SNAPSHOT_VERSION,
+                snapshotRef: {
+                  submissionIndex: snapshotRef.submissionIndex,
+                  contentFormat: snapshotRef.contentFormat,
+                },
+              }
+            : {
+                submissionId,
+                previousAttempts: [initialAttempt],
+                nextAttempt,
+                _v: QUEUE_MESSAGE_LIVE_ROW_VERSION,
+              },
+        ),
     )
   }
 
@@ -139,10 +158,9 @@ export class WebhookQueueMessage {
     return getNextAttempt(updatedPreviousAttempts).map(
       (nextAttempt) =>
         new WebhookQueueMessage({
-          submissionId: this.message.submissionId,
+          ...this.message,
           previousAttempts: updatedPreviousAttempts,
           nextAttempt,
-          _v: QUEUE_MESSAGE_VERSION,
         }),
     )
   }
@@ -159,6 +177,7 @@ export class WebhookQueueMessage {
         this.nextAttempt,
       ].map(prettifyEpoch),
       _v: this.message._v,
+      snapshotRef: this.snapshotRef,
     }
   }
 
@@ -168,7 +187,14 @@ export class WebhookQueueMessage {
       previousAttempts: this.message.previousAttempts.map(prettifyEpoch),
       nextAttempt: prettifyEpoch(this.nextAttempt),
       _v: this.message._v,
+      snapshotRef: this.snapshotRef,
     }
+  }
+
+  get snapshotRef(): SnapshotRef | undefined {
+    return this.message._v === QUEUE_MESSAGE_SNAPSHOT_VERSION
+      ? this.message.snapshotRef
+      : undefined
   }
 
   get submissionId(): string {

--- a/apps/backend/src/app/modules/webhook/webhook.types.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.types.ts
@@ -3,6 +3,11 @@ import * as z from 'zod'
 
 import { IFormSchema, ISubmissionSchema, WebhookView } from '../../../types'
 
+import {
+  QUEUE_MESSAGE_LIVE_ROW_VERSION,
+  QUEUE_MESSAGE_SNAPSHOT_VERSION,
+} from './webhook.constants'
+
 export interface WebhookParams {
   webhookUrl: string
   submissionWebhookView: WebhookView
@@ -12,15 +17,45 @@ export interface WebhookParams {
   signature: string
 }
 
-/**
- * Schema for webhook queue message, which allows an object to be validated.
- */
-export const webhookMessageSchema = z.object({
+const webhookMessageBaseSchema = {
   submissionId: z.string().regex(/^[a-f\d]{24}$/i),
   previousAttempts: z.array(z.number()),
   nextAttempt: z.number(),
-  _v: z.number(),
+}
+
+/**
+ * Retry queue message for which uses live row data for reconstructing retry payload.
+ */
+const LiveRowQueueMessage = z.object({
+  ...webhookMessageBaseSchema,
+  _v: z.literal(QUEUE_MESSAGE_LIVE_ROW_VERSION),
 })
+
+/**
+ * Reference to the snapshot to be used for reconstructing retry payload.
+ */
+const SnapshotRef = z.object({
+  submissionIndex: z.number().int(),
+  contentFormat: z.enum(['v1', 'v4']),
+})
+export type SnapshotRef = z.infer<typeof SnapshotRef>
+
+/**
+ * Retry queue message for which uses snapshots for reconstructing retry payload.
+ */
+const SnapshotQueueMessage = z.object({
+  ...webhookMessageBaseSchema,
+  _v: z.literal(QUEUE_MESSAGE_SNAPSHOT_VERSION),
+  snapshotRef: SnapshotRef,
+})
+
+/**
+ * Schema for webhook retry queue message.
+ */
+export const webhookMessageSchema = z.discriminatedUnion('_v', [
+  SnapshotQueueMessage,
+  LiveRowQueueMessage,
+])
 
 /**
  * Shape of webhook queue message object.
@@ -36,6 +71,7 @@ export type WebhookQueueMessagePrettified = Omit<
 > & {
   previousAttempts: string[]
   nextAttempt: string
+  snapshotRef?: SnapshotRef
 }
 
 /**


### PR DESCRIPTION
## Problem

A retry queue message carries only a submission id, so the consumer decides what to deliver at delivery time. For a multirespondent form the row has moved on by then: a retry of step 1 that fires after step 2 commits delivers step 2's payload under step 1's identity. The form and its feature flags can also change in that window, so the retry can deliver a different shape than the initial send did.

Part of #9745.

## Solution

The message now states what to deliver, and that statement is fixed when the message is enqueued.

`webhookMessageSchema` becomes a union discriminated on `_v`. Version 0 is the shape already in flight and still means "read the live row", so retries that cross the deploy keep working. Version 1 adds a `snapshotRef` that names the `submissionIndex` to redeliver and the content version to redeliver it in. An unrecognised `_v` now fails to parse rather than being accepted as any number, so a message written by a future version is never guessed at.

`fromSubmissionId` emits version 1 only when it is given a `snapshotRef`. No caller supplies one yet, so every enqueued message stays version 0 and the consumer's behaviour is unchanged.

**Alternatives considered**

- `incrementAttempts` used to rebuild the message field by field at the current version. We changed it to spread the parsed message and override only the retry schedule, because rebuilding is exactly the defect this slice exists to prevent: a version 0 message would be silently promoted to version 1 with no `snapshotRef`, and a version 1 message would lose the step it names.

**Breaking Changes**

No - backwards compatible; nothing changes on the wire and in-flight version 0 messages still parse. Rollback is safe in both directions: the schema this replaces is a plain `z.object` with `_v: z.number()`, which accepts a version 1 message, drops the unrecognised `snapshotRef` and delivers from the live row. So an instance running older code — during a rolling deploy, or after a rollback — degrades to today's behaviour rather than failing to parse. Nothing emits version 1 until the top slice in any case.

## Tests

**TC1: A message already in flight still delivers**

- [ ] Enqueue a message by hand with `_v: 0` and no `snapshotRef`.
- [ ] It delivers from the live row, and the snapshot store is not read.

**TC2: A message from an unknown writer is refused**

- [ ] Enqueue a message by hand with `_v: 2`.
- [ ] It fails to parse and is disposed of as a parsing failure, rather than being treated as a live row message.
