### PR TITLE
feat(mrf): replay the failed step's snapshot on webhook retry

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/retry-fidelity.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/retry-fidelity.spec.ts
@@ -1,0 +1,480 @@
+// A delayed retry must redeliver the step submission that failed, not whatever
+// the live row has since been mutated into. These gates pin that the retry
+// payload matches the initial send for the SAME step even after the row has
+// advanced, and that what it delivers is decided by the queue message alone.
+//
+// Equality is asserted modulo attachment presigned URLs, which `sendWebhook`
+// mints fresh per send, so byte-equality cannot hold on a fixture with
+// attachments. The URL keys and their S3 targets are still compared.
+import dbHandler from '__tests__/unit/backend/helpers/jest-db'
+import axios, { AxiosResponse } from 'axios'
+import { ObjectId } from 'bson'
+import { MULTIRESPONDENT_FORM_SUBMISSION_VERSION } from 'formsg-shared/constants'
+import {
+  SubmissionType,
+  SubmittedStepSnapshotTokens,
+  WorkflowType,
+} from 'formsg-shared/types'
+import { omit } from 'lodash'
+import mongoose from 'mongoose'
+import { errAsync, okAsync } from 'neverthrow'
+
+import { getMultirespondentSubmissionModel } from 'src/app/models/submission.server.model'
+import * as WebhookValidationModule from 'src/app/modules/webhook/webhook.validation'
+import { IMultirespondentSubmissionSchema, WebhookView } from 'src/types'
+import { WebhookData } from 'src/types/submission'
+
+import { sendWebhook } from '../../../../webhook/webhook.service'
+import {
+  SnapshotAccessDeniedError,
+  SnapshotDataIntegrityError,
+  SnapshotFormatNotRecordedError,
+  SnapshotReadError,
+} from '../submission-snapshot.errors'
+import { buildV4Snapshot } from '../submission-snapshot.producer'
+import { SubmissionSnapshotV4 } from '../submission-snapshot.schema'
+import * as SnapshotStore from '../submission-snapshot.store'
+import { getWebhookPayloadPolicy } from '../webhook-payload-policy'
+import { reconstructMrfWebhookData } from '../webhook-reconstruction'
+import { resolveSnapshotRetryView } from '../webhook-retry-view'
+
+jest.mock('axios')
+const MockAxios = jest.mocked(axios)
+
+jest.mock('src/app/modules/webhook/webhook.validation')
+const MockWebhookValidation = jest.mocked(WebhookValidationModule)
+
+jest.mock('../submission-snapshot.store')
+const MockSnapshotStore = jest.mocked(SnapshotStore)
+
+const MOCK_WEBHOOK_URL = 'https://plumber.gov.sg/webhooks/retry'
+
+const MOCK_AXIOS_RESPONSE = {
+  data: { result: 'ok' },
+  status: 200,
+  statusText: 'success',
+  headers: {},
+  config: {},
+} as AxiosResponse
+
+const MultirespondentSubmissionModel =
+  getMultirespondentSubmissionModel(mongoose)
+
+const formId = new ObjectId()
+const fieldId = new ObjectId().toHexString()
+const attachmentFieldId = new ObjectId().toHexString()
+
+const STEP_1 = {
+  encryptedContent: 'step-1-encrypted-content',
+  verifiedContent: 'step-1-verified-content',
+  attachmentMetadata: {
+    [attachmentFieldId]: `${formId.toHexString()}/step-1-attachment`,
+  },
+  token: 'tok-step-1',
+}
+const STEP_2 = {
+  encryptedContent: 'step-2-encrypted-content',
+  verifiedContent: 'step-2-verified-content',
+  attachmentMetadata: {
+    [attachmentFieldId]: `${formId.toHexString()}/step-2-attachment`,
+  },
+  token: 'tok-step-2',
+}
+const ENCRYPTED_SUBMISSION_SECRET_KEY = 'wrapped-read-key-v4'
+
+const staticStep = (emails: string[]) => ({
+  _id: new ObjectId().toHexString(),
+  workflow_type: WorkflowType.Static,
+  emails,
+  edit: [fieldId],
+})
+
+/**
+ * Reduces each presigned URL to its path, so an attachment going missing or
+ * pointing somewhere else still fails the comparison.
+ */
+const comparablePayload = (data: WebhookData): unknown => {
+  if (data.attachmentDownloadUrls === undefined) {
+    return { ...data }
+  }
+  return {
+    ...data,
+    attachmentDownloadUrls: Object.fromEntries(
+      Object.entries(data.attachmentDownloadUrls).map(([key, url]) => [
+        key,
+        new URL(url).pathname,
+      ]),
+    ),
+  }
+}
+
+const capturePostedPayload = async (
+  view: WebhookView,
+): Promise<WebhookData> => {
+  MockAxios.post.mockClear()
+  MockAxios.post.mockResolvedValue(MOCK_AXIOS_RESPONSE)
+
+  const result = await sendWebhook(view, MOCK_WEBHOOK_URL)
+  expect(result.isOk()).toBe(true)
+
+  return (MockAxios.post.mock.calls[0][1] as WebhookView).data
+}
+
+describe('[GATE] v4 per-step retry fidelity', () => {
+  beforeAll(async () => {
+    await dbHandler.connect()
+  })
+  afterEach(async () => {
+    await dbHandler.clearDatabase()
+    jest.clearAllMocks()
+  })
+  afterAll(async () => await dbHandler.closeDatabase())
+
+  beforeEach(() => {
+    MockWebhookValidation.validateWebhookUrl.mockResolvedValue(undefined)
+  })
+
+  /**
+   * A row sitting at the given step, with a submittedSteps entry per step
+   * submission so far. `workflowSteps` lets a loop-back workflow repeat a step
+   * number while submittedSteps keeps growing.
+   */
+  const createRowAtStep = async ({
+    latest,
+    workflowStep,
+    tokens,
+  }: {
+    latest: typeof STEP_1
+    workflowStep: number
+    tokens: string[]
+  }): Promise<IMultirespondentSubmissionSchema> =>
+    await MultirespondentSubmissionModel.create({
+      form: formId,
+      submissionType: SubmissionType.Multirespondent,
+      form_fields: [],
+      form_logics: [],
+      workflow: [staticStep([]), staticStep(['next@example.com'])],
+      submissionPublicKey: 'submission-public-key',
+      encryptedSubmissionSecretKey: ENCRYPTED_SUBMISSION_SECRET_KEY,
+      encryptedContent: latest.encryptedContent,
+      verifiedContent: latest.verifiedContent,
+      attachmentMetadata: new Map(Object.entries(latest.attachmentMetadata)),
+      version: MULTIRESPONDENT_FORM_SUBMISSION_VERSION,
+      workflowStep,
+      mrfVersion: 2,
+      submittedSteps: tokens.map((token, index) => ({
+        isApproval: false,
+        submittedAt: new Date(Date.UTC(2026, 6, 22, index)).toISOString(),
+        snapshotTokens: { v4: token },
+      })),
+    })
+
+  const snapshotFor = ({
+    submission,
+    step,
+    submissionIndex,
+    workflowStep,
+  }: {
+    submission: IMultirespondentSubmissionSchema
+    step: typeof STEP_1
+    submissionIndex: number
+    workflowStep: number
+  }): SubmissionSnapshotV4 =>
+    buildV4Snapshot({
+      formId: formId.toHexString(),
+      submissionId: String(submission._id),
+      submissionIndex,
+      workflowStep,
+      encryptedContent: step.encryptedContent,
+      encryptedSubmissionSecretKey: ENCRYPTED_SUBMISSION_SECRET_KEY,
+      verifiedContent: step.verifiedContent,
+      attachmentMetadata: step.attachmentMetadata,
+      createdAt: submission.submittedSteps?.[submissionIndex]
+        ?.submittedAt as string,
+    })
+
+  /** The payload the initial send delivered for that step. */
+  const initialSendPayload = async ({
+    submission,
+    snapshot,
+    submissionIndex,
+  }: {
+    submission: IMultirespondentSubmissionSchema
+    snapshot: SubmissionSnapshotV4
+    submissionIndex: number
+  }): Promise<WebhookData> => {
+    const liveView = await submission.getWebhookView()
+    return capturePostedPayload({
+      data: reconstructMrfWebhookData({
+        liveData: liveView.data,
+        snapshot,
+        submissionIndex,
+        policy: getWebhookPayloadPolicy({
+          webhookType: 'plumber',
+          isStepWriteTokenEnabled: true,
+          submissionIndex,
+          submittedStepsLength: submission.submittedSteps?.length ?? 0,
+        }),
+      })._unsafeUnwrap(),
+    })
+  }
+
+  /** The payload a retry of that step delivers, resolved from the message. */
+  const retryPayload = async ({
+    submission,
+    submissionIndex,
+    contentFormat = 'v4',
+  }: {
+    submission: IMultirespondentSubmissionSchema
+    submissionIndex: number
+    contentFormat?: 'v1' | 'v4'
+  }): Promise<WebhookData> => {
+    const liveView = await submission.getWebhookView()
+    const view = await resolveSnapshotRetryView({
+      liveView,
+      submissionId: String(submission._id),
+      snapshotRef: { submissionIndex, contentFormat },
+      webhookType: 'plumber',
+      submittedStepSnapshotTokens: (submission.submittedSteps ?? []).map(
+        (step) => step.snapshotTokens,
+      ),
+    })
+
+    return capturePostedPayload(view._unsafeUnwrap())
+  }
+
+  it('redelivers the step submission that failed, not a newly submitted latest step', async () => {
+    const submission = await createRowAtStep({
+      latest: STEP_1,
+      workflowStep: 0,
+      tokens: [STEP_1.token],
+    })
+    const step1Snapshot = snapshotFor({
+      submission,
+      step: STEP_1,
+      submissionIndex: 0,
+      workflowStep: 0,
+    })
+    const initial = await initialSendPayload({
+      submission,
+      snapshot: step1Snapshot,
+      submissionIndex: 0,
+    })
+
+    // The row advances: step 2 overwrites the content and attachment map.
+    submission.encryptedContent = STEP_2.encryptedContent
+    submission.verifiedContent = STEP_2.verifiedContent
+    submission.attachmentMetadata = new Map(
+      Object.entries(STEP_2.attachmentMetadata),
+    )
+    submission.workflowStep = 1
+    submission.submittedSteps?.push({
+      isApproval: false,
+      submittedAt: new Date(Date.UTC(2026, 6, 22, 1)).toISOString(),
+      snapshotTokens: { v4: STEP_2.token },
+    })
+    await submission.save()
+
+    MockSnapshotStore.readV4Snapshot.mockReturnValue(okAsync(step1Snapshot))
+
+    const retried = await retryPayload({ submission, submissionIndex: 0 })
+
+    expect(comparablePayload(retried)).toEqual(comparablePayload(initial))
+    expect(retried.encryptedContent).toBe(STEP_1.encryptedContent)
+    // Omits later steps from the submittedSteps, so the retry is identical to what was sent.
+    expect(retried.workflowContent?.submittedSteps).toHaveLength(1)
+  })
+
+  it("presigns the retried step's own attachments, not the latest step's", async () => {
+    const submission = await createRowAtStep({
+      latest: STEP_2,
+      workflowStep: 1,
+      tokens: [STEP_1.token, STEP_2.token],
+    })
+    MockSnapshotStore.readV4Snapshot.mockReturnValue(
+      okAsync(
+        snapshotFor({
+          submission,
+          step: STEP_1,
+          submissionIndex: 0,
+          workflowStep: 0,
+        }),
+      ),
+    )
+
+    const retried = await retryPayload({ submission, submissionIndex: 0 })
+
+    const presignedPaths = Object.values(
+      retried.attachmentDownloadUrls ?? {},
+    ).map((url) => new URL(url).pathname)
+    expect(presignedPaths).toHaveLength(1)
+    expect(presignedPaths[0]).toContain('step-1-attachment')
+    expect(presignedPaths[0]).not.toContain('step-2-attachment')
+  })
+
+  it('resolves a loop-back retry by submission index, not by the repeated workflow step', async () => {
+    // Step 0 is submitted, then step 1, then the workflow loops back to step 0:
+    // `workflowStep` repeats while `submissionIndex` keeps counting.
+    const submission = await createRowAtStep({
+      latest: STEP_2,
+      workflowStep: 0,
+      tokens: [STEP_1.token, 'tok-step-2', 'tok-loop-back'],
+    })
+    const loopBackSnapshot = snapshotFor({
+      submission,
+      step: STEP_2,
+      submissionIndex: 2,
+      workflowStep: 0,
+    })
+    MockSnapshotStore.readV4Snapshot.mockReturnValue(okAsync(loopBackSnapshot))
+
+    const retried = await retryPayload({ submission, submissionIndex: 2 })
+
+    expect(MockSnapshotStore.readV4Snapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ submissionIndex: 2, token: 'tok-loop-back' }),
+    )
+    expect(retried.encryptedContent).toBe(STEP_2.encryptedContent)
+    // All three step submissions are in scope for the third one, and the first
+    // step's snapshot is untouched by the loop-back.
+    expect(
+      (retried.workflowContent as { submittedSteps: unknown[] }).submittedSteps,
+    ).toHaveLength(3)
+  })
+
+  it('delivers the content format from the retry queue message, not from the live row', async () => {
+    const submission = await createRowAtStep({
+      latest: STEP_1,
+      workflowStep: 0,
+      tokens: [STEP_1.token],
+    })
+    const step1Snapshot = snapshotFor({
+      submission,
+      step: STEP_1,
+      submissionIndex: 0,
+      workflowStep: 0,
+    })
+    MockSnapshotStore.readV4Snapshot.mockReturnValue(okAsync(step1Snapshot))
+
+    const liveView = await submission.getWebhookView()
+    const v1LiveView: WebhookView = {
+      data: omit(
+        { ...liveView.data, version: 1 },
+        'encryptedSubmissionSecretKey',
+      ) as WebhookData,
+    }
+
+    const result = await resolveSnapshotRetryView({
+      liveView: v1LiveView,
+      submissionId: String(submission._id),
+      snapshotRef: { submissionIndex: 0, contentFormat: 'v4' },
+      webhookType: 'plumber',
+      submittedStepSnapshotTokens: (submission.submittedSteps ?? []).map(
+        (step) => step.snapshotTokens,
+      ),
+    })
+
+    const retried = await capturePostedPayload(result._unsafeUnwrap())
+    expect(retried.version).toBe(4)
+    expect(retried.encryptedSubmissionSecretKey).toBe(
+      ENCRYPTED_SUBMISSION_SECRET_KEY,
+    )
+  })
+
+  it.each([
+    [
+      'the retry asks for v4 but the step has no v4 snapshot token',
+      {} as SubmittedStepSnapshotTokens,
+      'v4' as const,
+    ],
+    [
+      'the retry asks for v1, a format that is never snapshotted',
+      { v1: 'tok-v1' } as SubmittedStepSnapshotTokens,
+      'v1' as const,
+    ],
+  ])(
+    'fails loud without reading the store when %s',
+    async (_case, recordedTokens, contentFormat) => {
+      const submission = await createRowAtStep({
+        latest: STEP_1,
+        workflowStep: 0,
+        tokens: [STEP_1.token],
+      })
+
+      const liveView = await submission.getWebhookView()
+      const result = await resolveSnapshotRetryView({
+        liveView,
+        submissionId: String(submission._id),
+        snapshotRef: { submissionIndex: 0, contentFormat },
+        webhookType: 'plumber',
+        submittedStepSnapshotTokens: [recordedTokens],
+      })
+
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(
+        SnapshotFormatNotRecordedError,
+      )
+      expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+    },
+  )
+
+  it('fails loud when the stored snapshot is not in the format it was recorded under', async () => {
+    const submission = await createRowAtStep({
+      latest: STEP_1,
+      workflowStep: 0,
+      tokens: [STEP_1.token],
+    })
+    const v4Snapshot = snapshotFor({
+      submission,
+      step: STEP_1,
+      submissionIndex: 0,
+      workflowStep: 0,
+    })
+    MockSnapshotStore.readV4Snapshot.mockReturnValue(
+      okAsync({
+        ...omit(v4Snapshot, 'encryptedSubmissionSecretKey'),
+        contentFormat: 'v1' as const,
+      }),
+    )
+
+    const liveView = await submission.getWebhookView()
+    const result = await resolveSnapshotRetryView({
+      liveView,
+      submissionId: String(submission._id),
+      snapshotRef: { submissionIndex: 0, contentFormat: 'v4' },
+      webhookType: 'plumber',
+      submittedStepSnapshotTokens: (submission.submittedSteps ?? []).map(
+        (step) => step.snapshotTokens,
+      ),
+    })
+
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(SnapshotDataIntegrityError)
+  })
+
+  it.each([
+    ['missing or malformed', new SnapshotDataIntegrityError()],
+    ['transient', new SnapshotReadError()],
+    ['denied', new SnapshotAccessDeniedError()],
+  ])(
+    'surfaces a %s snapshot read as itself, never falling back to the live row',
+    async (_case, storeError) => {
+      const submission = await createRowAtStep({
+        latest: STEP_2,
+        workflowStep: 1,
+        tokens: [STEP_1.token, STEP_2.token],
+      })
+      MockSnapshotStore.readV4Snapshot.mockReturnValue(errAsync(storeError))
+
+      const liveView = await submission.getWebhookView()
+      const result = await resolveSnapshotRetryView({
+        liveView,
+        submissionId: String(submission._id),
+        snapshotRef: { submissionIndex: 0, contentFormat: 'v4' },
+        webhookType: 'plumber',
+        submittedStepSnapshotTokens: (submission.submittedSteps ?? []).map(
+          (step) => step.snapshotTokens,
+        ),
+      })
+
+      expect(result._unsafeUnwrapErr()).toBe(storeError)
+    },
+  )
+})

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-retry-view.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/webhook-retry-view.ts
@@ -1,0 +1,112 @@
+import { SubmittedStepSnapshotTokens } from 'formsg-shared/types'
+import { errAsync, ResultAsync } from 'neverthrow'
+
+import { WebhookView } from '../../../../../types'
+import { SnapshotRef } from '../../../webhook/webhook.types'
+
+import {
+  SnapshotAccessDeniedError,
+  SnapshotDataIntegrityError,
+  SnapshotFormatNotRecordedError,
+  SnapshotReadError,
+} from './submission-snapshot.errors'
+import { readV4Snapshot } from './submission-snapshot.store'
+import {
+  getKeyPermissionsPolicy,
+  WebhookConsumerType,
+  WebhookPayloadPolicy,
+} from './webhook-payload-policy'
+import { reconstructMrfWebhookData } from './webhook-reconstruction'
+
+export type SnapshotRetryError =
+  | SnapshotDataIntegrityError
+  | SnapshotReadError
+  | SnapshotAccessDeniedError
+  | SnapshotFormatNotRecordedError
+
+interface GetRecordedPayloadPolicyInput {
+  snapshotRef: SnapshotRef
+  webhookType: WebhookConsumerType
+  submittedStepsLength: number
+}
+
+export const getRecordedPayloadPolicy = ({
+  snapshotRef,
+  webhookType,
+  submittedStepsLength,
+}: GetRecordedPayloadPolicyInput): WebhookPayloadPolicy => {
+  const { contentFormat, submissionIndex } = snapshotRef
+  const keyPermissionsPolicy = getKeyPermissionsPolicy({
+    webhookType,
+    submissionIndex,
+    submittedStepsLength,
+    contentFormat,
+  })
+  return {
+    contentFormat,
+    ...keyPermissionsPolicy,
+  }
+}
+
+/**
+ * Rebuilds the webhook payload a retry must deliver from the provided
+ * snapshot reference.
+ */
+export const resolveSnapshotRetryView = ({
+  liveView,
+  submissionId,
+  snapshotRef,
+  submittedStepSnapshotTokens,
+  webhookType,
+}: {
+  liveView: WebhookView
+  submissionId: string
+  snapshotRef: SnapshotRef
+  submittedStepSnapshotTokens?: (SubmittedStepSnapshotTokens | undefined)[]
+  webhookType: WebhookConsumerType
+}): ResultAsync<WebhookView, SnapshotRetryError> => {
+  const meta = { submissionId, snapshotRef }
+  const { submissionIndex, contentFormat } = snapshotRef
+  const { workflowContent } = liveView.data
+  const submittedStepsLength = workflowContent?.submittedSteps?.length ?? 0
+
+  // RATIONALE: Only `v4` exists today, so a message naming `v1`
+  // resolves to not recorded until future backward compatibility to
+  // widens the row schema to carry the v1 copy.
+  if (contentFormat === 'v1') {
+    return errAsync(new SnapshotFormatNotRecordedError(undefined, meta))
+  }
+  const recordedTokensForSubmissionIndex =
+    submittedStepSnapshotTokens?.[submissionIndex]
+  const token = recordedTokensForSubmissionIndex?.[contentFormat]
+  if (!token) {
+    return errAsync(new SnapshotFormatNotRecordedError(undefined, meta))
+  }
+
+  return readV4Snapshot({
+    formId: liveView.data.formId,
+    submissionId,
+    submissionIndex,
+    token,
+  }).andThen((snapshot) => {
+    if (snapshot.contentFormat !== contentFormat) {
+      return errAsync(
+        new SnapshotDataIntegrityError(
+          'Stored snapshot is not in the content format it was recorded under',
+          { ...meta, storedContentFormat: snapshot.contentFormat },
+        ),
+      )
+    }
+
+    return reconstructMrfWebhookData({
+      liveData: liveView.data,
+      snapshot,
+      submissionIndex,
+      policy: getRecordedPayloadPolicy({
+        snapshotRef,
+        webhookType,
+        submittedStepsLength,
+      }),
+    }).map((data) => ({ data }))
+  })
+}

--- a/apps/backend/src/app/modules/webhook/__tests__/webhook.consumer.spec.ts
+++ b/apps/backend/src/app/modules/webhook/__tests__/webhook.consumer.spec.ts
@@ -7,8 +7,17 @@ import mongoose from 'mongoose'
 import { errAsync, okAsync } from 'neverthrow'
 
 import getSubmissionModel from 'src/app/models/submission.server.model'
+import {
+  SnapshotAccessDeniedError,
+  SnapshotDataIntegrityError,
+  SnapshotFormatNotRecordedError,
+  SnapshotReadError,
+} from 'src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.errors'
+import { SubmissionSnapshotV4 } from 'src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.schema'
+import * as SnapshotStore from 'src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store'
 import { SubmissionWebhookInfo } from 'src/types'
 
+import { QUEUE_MESSAGE_SNAPSHOT_VERSION } from '../webhook.constants'
 import { createWebhookQueueHandler } from '../webhook.consumer'
 import { WebhookPushToQueueError } from '../webhook.errors'
 import { WebhookProducer } from '../webhook.producer'
@@ -17,6 +26,11 @@ import { WebhookQueueMessageObject } from '../webhook.types'
 
 jest.mock('../webhook.service')
 const MockWebhookService = jest.mocked(WebhookService)
+
+jest.mock(
+  'src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store',
+)
+const MockSnapshotStore = jest.mocked(SnapshotStore)
 
 const SubmissionModel = getSubmissionModel(mongoose)
 
@@ -62,6 +76,51 @@ const MOCK_WEBHOOK_INFO = {
     },
   },
 } as SubmissionWebhookInfo
+
+const MOCK_FORM_ID = new ObjectId().toHexString()
+
+/**
+ * An MRF row that has advanced past the step a retry is redelivering: its
+ * content is the LATEST step's, so anything the retry ships from the live row
+ * is immediately visible.
+ */
+const MOCK_MRF_WEBHOOK_INFO: SubmissionWebhookInfo = {
+  isRetryEnabled: true,
+  webhookUrl: 'https://plumber.gov.sg/webhooks/retry',
+  webhookView: {
+    data: {
+      formId: MOCK_FORM_ID,
+      submissionId: VALID_MESSAGE_BODY.submissionId,
+      encryptedContent: 'latest-step-encrypted-content',
+      verifiedContent: 'latest-step-verified-content',
+      version: 4,
+      created: new Date('2026-07-22T00:00:00.000Z'),
+      attachmentDownloadUrls: {},
+      paymentContent: {},
+      workflowContent: {
+        workflow: [],
+        workflowStep: 1,
+        submittedSteps: [
+          { isApproval: false, submittedAt: '2026-07-22T00:00:00.000Z' },
+          { isApproval: false, submittedAt: '2026-07-22T01:00:00.000Z' },
+        ],
+      },
+    },
+  },
+  submittedStepSnapshotTokens: [{ v4: 'tok-step-0' }, { v4: 'tok-step-1' }],
+}
+
+const MOCK_SNAPSHOT: SubmissionSnapshotV4 = {
+  _v: 1,
+  contentFormat: 'v4',
+  formId: MOCK_FORM_ID,
+  submissionId: VALID_MESSAGE_BODY.submissionId,
+  submissionIndex: 0,
+  workflowStep: 0,
+  encryptedContent: 'frozen-step-0-encrypted-content',
+  encryptedSubmissionSecretKey: 'wrapped-read-key',
+  createdAt: '2026-07-22T00:00:00.000Z',
+}
 
 describe('webhook.consumer', () => {
   beforeAll(async () => await dbHandler.connect())
@@ -282,6 +341,118 @@ describe('webhook.consumer', () => {
         MOCK_WEBHOOK_FAILURE_RESPONSE,
       )
       expect(FAILURE_PRODUCER.sendMessage).toHaveBeenCalled()
+    })
+
+    describe('snapshot replay', () => {
+      const SNAPSHOT_MESSAGE_BODY: WebhookQueueMessageObject = {
+        submissionId: VALID_MESSAGE_BODY.submissionId,
+        snapshotRef: {
+          submissionIndex: 0,
+          contentFormat: 'v4',
+        },
+        previousAttempts: [Date.now()],
+        nextAttempt: Date.now(),
+        _v: QUEUE_MESSAGE_SNAPSHOT_VERSION,
+      }
+      const SNAPSHOT_SQS_MESSAGE: Message = {
+        Body: JSON.stringify(SNAPSHOT_MESSAGE_BODY),
+      }
+
+      beforeEach(() => {
+        jest
+          .spyOn(SubmissionModel, 'retrieveWebhookInfoById')
+          .mockResolvedValue(MOCK_MRF_WEBHOOK_INFO)
+        MockWebhookService.sendWebhook.mockReturnValue(
+          okAsync(MOCK_WEBHOOK_SUCCESS_RESPONSE),
+        )
+      })
+
+      it('should redeliver the frozen step submission, not the live row, for a snapshot message', async () => {
+        MockSnapshotStore.readV4Snapshot.mockReturnValue(okAsync(MOCK_SNAPSHOT))
+
+        await expect(
+          createWebhookQueueHandler(SUCCESS_PRODUCER)(SNAPSHOT_SQS_MESSAGE),
+        ).toResolve()
+
+        expect(MockSnapshotStore.readV4Snapshot).toHaveBeenCalledWith(
+          expect.objectContaining({
+            submissionIndex: 0,
+            token: 'tok-step-0',
+          }),
+        )
+        const [sentView] = MockWebhookService.sendWebhook.mock.calls[0]
+        expect(sentView.data.encryptedContent).toBe(
+          MOCK_SNAPSHOT.encryptedContent,
+        )
+      })
+
+      it('should redeliver from the live row for an in-flight legacy message', async () => {
+        await expect(
+          createWebhookQueueHandler(SUCCESS_PRODUCER)(VALID_SQS_MESSAGE),
+        ).toResolve()
+
+        expect(MockSnapshotStore.readV4Snapshot).not.toHaveBeenCalled()
+        expect(MockWebhookService.sendWebhook).toHaveBeenCalledWith(
+          MOCK_MRF_WEBHOOK_INFO.webhookView,
+          MOCK_MRF_WEBHOOK_INFO.webhookUrl,
+        )
+      })
+
+      it.each([
+        ['a data-integrity failure', new SnapshotDataIntegrityError()],
+        [
+          'a produce/deliver disagreement',
+          new SnapshotFormatNotRecordedError(),
+        ],
+      ])(
+        'should delete the message without attempting the webhook on %s',
+        async (_case, storeError) => {
+          MockSnapshotStore.readV4Snapshot.mockReturnValue(errAsync(storeError))
+
+          await expect(
+            createWebhookQueueHandler(SUCCESS_PRODUCER)(SNAPSHOT_SQS_MESSAGE),
+          ).toResolve()
+
+          expect(MockWebhookService.sendWebhook).not.toHaveBeenCalled()
+          expect(SUCCESS_PRODUCER.sendMessage).not.toHaveBeenCalled()
+        },
+      )
+
+      it.each([
+        ['a transient read failure', new SnapshotReadError()],
+        ['a denied read', new SnapshotAccessDeniedError()],
+      ])(
+        'should leave the message for redelivery, with no webhook attempt burned, on %s',
+        async (_case, storeError) => {
+          MockSnapshotStore.readV4Snapshot.mockReturnValue(errAsync(storeError))
+
+          await expect(
+            createWebhookQueueHandler(SUCCESS_PRODUCER)(SNAPSHOT_SQS_MESSAGE),
+          ).toReject()
+
+          expect(MockWebhookService.sendWebhook).not.toHaveBeenCalled()
+          expect(MockWebhookService.saveWebhookRecord).not.toHaveBeenCalled()
+          expect(SUCCESS_PRODUCER.sendMessage).not.toHaveBeenCalled()
+        },
+      )
+
+      it('should carry the named step submission into the requeued message when the retry fails', async () => {
+        MockSnapshotStore.readV4Snapshot.mockReturnValue(okAsync(MOCK_SNAPSHOT))
+        MockWebhookService.sendWebhook.mockReturnValue(
+          okAsync(MOCK_WEBHOOK_FAILURE_RESPONSE),
+        )
+
+        await expect(
+          createWebhookQueueHandler(SUCCESS_PRODUCER)(SNAPSHOT_SQS_MESSAGE),
+        ).toResolve()
+
+        const [requeued] = (SUCCESS_PRODUCER.sendMessage as jest.Mock).mock
+          .calls[0]
+        expect(requeued.snapshotRef).toEqual({
+          submissionIndex: 0,
+          contentFormat: 'v4',
+        })
+      })
     })
   })
 })

--- a/apps/backend/src/app/modules/webhook/webhook.consumer.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.consumer.ts
@@ -3,12 +3,20 @@ import mongoose from 'mongoose'
 import { errAsync, okAsync, ResultAsync } from 'neverthrow'
 import { Consumer } from 'sqs-consumer'
 
-import { SubmissionWebhookInfo } from '../../../types'
+import { SubmissionWebhookInfo, WebhookView } from '../../../types'
 import config from '../../config/config'
 import { createLoggerWithLabel, CustomLoggerParams } from '../../config/logger'
 import getSubmissionModel from '../../models/submission.server.model'
 import { transformMongoError } from '../../utils/handle-mongo-error'
 import { PossibleDatabaseError } from '../core/core.errors'
+import {
+  SnapshotDataIntegrityError,
+  SnapshotFormatNotRecordedError,
+} from '../submission/multirespondent-submission/webhook/submission-snapshot.errors'
+import {
+  resolveSnapshotRetryView,
+  SnapshotRetryError,
+} from '../submission/multirespondent-submission/webhook/webhook-retry-view'
 import { SubmissionNotFoundError } from '../submission/submission.errors'
 
 import {
@@ -18,6 +26,7 @@ import {
 import { WebhookQueueMessage } from './webhook.message'
 import { WebhookProducer } from './webhook.producer'
 import * as WebhookService from './webhook.service'
+import { getWebhookType } from './webhook.service'
 import { isSuccessfulResponse } from './webhook.utils'
 
 const logger = createLoggerWithLabel(module)
@@ -148,24 +157,25 @@ export const createWebhookQueueHandler =
         )
 
       // Attempt webhook
-      return WebhookService.sendWebhook(
-        webhookInfo.webhookView,
-        webhookUrl,
-      ).andThen((webhookResponse) => {
-        // Save webhook response to database, but carry on even if it fails
-        void WebhookService.saveWebhookRecord(
-          webhookMessage.submissionId,
-          webhookResponse,
+      return resolveWebhookView(webhookMessage, webhookInfo)
+        .andThen((webhookView) =>
+          WebhookService.sendWebhook(webhookView, webhookUrl),
         )
+        .andThen((webhookResponse) => {
+          // Save webhook response to database, but carry on even if it fails
+          void WebhookService.saveWebhookRecord(
+            webhookMessage.submissionId,
+            webhookResponse,
+          )
 
-        // Webhook was successful, no further action required
-        if (isSuccessfulResponse(webhookResponse)) return okAsync(true)
+          // Webhook was successful, no further action required
+          if (isSuccessfulResponse(webhookResponse)) return okAsync(true)
 
-        // Requeue webhook for subsequent retry
-        return webhookMessage
-          .incrementAttempts()
-          .asyncAndThen((newMessage) => producer.sendMessage(newMessage))
-      })
+          // Requeue webhook for subsequent retry
+          return webhookMessage
+            .incrementAttempts()
+            .asyncAndThen((newMessage) => producer.sendMessage(newMessage))
+        })
     })
 
     if (retryResult.isOk()) return sqsMessage
@@ -191,7 +201,19 @@ export const createWebhookQueueHandler =
       })
       return sqsMessage
     }
-    // Remaining cases are unexpected errors, move to DLQ
+    // Special handling for unrecoverable snapshot replay failures.
+    if (
+      retryResult.error instanceof SnapshotDataIntegrityError ||
+      retryResult.error instanceof SnapshotFormatNotRecordedError
+    ) {
+      logger.error({
+        message:
+          'Webhook retry could not replay the snapshotted step submission due to data integrity issues',
+        meta: logMeta,
+        error: retryResult.error,
+      })
+      return sqsMessage
+    }
     logger.error({
       message: 'Error while attempting to retry webhook',
       meta: logMeta,
@@ -201,6 +223,31 @@ export const createWebhookQueueHandler =
     // if redrive policy is exceeded
     return Promise.reject()
   }
+
+/**
+ * Decides what an webhook retry attempt payload includes,
+ * based on whether a snapshotRef exists.
+ */
+const resolveWebhookView = (
+  webhookMessage: WebhookQueueMessage,
+  webhookInfo: SubmissionWebhookInfo,
+): ResultAsync<WebhookView, SnapshotRetryError> => {
+  const snapshotRef = webhookMessage.snapshotRef
+  if (snapshotRef === undefined) {
+    return okAsync(webhookInfo.webhookView)
+  }
+
+  const webhookType =
+    getWebhookType(webhookInfo.webhookUrl) === 'plumber' ? 'plumber' : 'generic'
+
+  return resolveSnapshotRetryView({
+    liveView: webhookInfo.webhookView,
+    submissionId: webhookMessage.submissionId,
+    snapshotRef,
+    webhookType,
+    submittedStepSnapshotTokens: webhookInfo.submittedStepSnapshotTokens,
+  })
+}
 
 /**
  * Retrieves all relevant information to send webhook for a given submission.


### PR DESCRIPTION
## Problem

A delayed webhook retry rebuilds its payload from the live submission row, which for a multirespondent form every later step has changed in place. The retry therefore delivers the latest step's content under the failed step's identity. It also re-derives the wire shape at send time, so an admin who changes the form's `webhookFormat`, or an operator who flips a flag, between the initial send and the retry changes what the retry delivers.

Part of #9745.

## Solution

A retry now replays the snapshot that was frozen for the step submission that failed.

`resolveSnapshotRetryView` takes the `snapshotRef` the message carries and rebuilds the payload from that step's snapshot. It resolves the step by `submissionIndex`, which only ever increases, so a workflow that loops back to an earlier `workflowStep` still resolves the visit that failed. It derives the key permissions from the recorded content version, so nothing on this path consults the form, the row's latest step, or a feature flag. That is what makes an upgrade from a V1 to a V4 payload on retry structurally impossible: no generic consumer can be handed a submission secret key it was not entitled to at the initial send.

The consumer follows what the message says. A message carrying a `snapshotRef` replays that step; a message without one reads the live row as before. There is deliberately no fallback from the first to the second — falling back is the defect being fixed. The whole replay resolves before any HTTP call, so a snapshot that cannot be read burns no webhook attempt and leaves the retry schedule untouched.

### Disposing of a failed read

The response differs by cause, so the disposition does too:

| outcome | error | queue |
|---|---|---|
| missing, malformed or empty snapshot | `SnapshotDataIntegrityError` (100239) | deleted — another attempt cannot fix it |
| no snapshot recorded for the named content version | `SnapshotFormatNotRecordedError` (100242) | deleted — the sender and the store disagree |
| 5xx, throttling, timeout, networking | `SnapshotReadError` (100240) | left for redelivery |
| refused by the store | `SnapshotAccessDeniedError` (100241) | left for redelivery |

Nothing emits a `snapshotRef` yet, so none of this path is reachable in production until the slice above it merges.

**Alternatives considered**

- The error for a sender/store disagreement already had its own code and metric, but not its own disposition, so the default fall-through would have sent it to the dead-letter queue. We made it terminal instead: no later attempt makes a committed row grow a snapshot it never recorded, and dead-letter churn on an unfixable message is the same reason a data integrity failure is terminal. **This one is a judgement call and is worth a second opinion.**
- We considered falling back to the live row when a snapshot cannot be read, which is what a retry does today. We rejected it because that fallback is the defect this stack exists to remove; a loud failure is the correct outcome.

**Breaking Changes**

No - backwards compatible. Nothing changes on the wire, and the path added here is unreachable until a caller supplies a `snapshotRef`.

## Tests

The retry path is dormant on this slice, so each scenario needs a version 1 message enqueued by hand. Needs the V4 bucket provisioned (#9753) and the retry queue running.

**TC1: A retry redelivers the step that failed, not the latest one**

- [ ] On a 3-step MRF form, submit step 1 with attachment A, then step 2 with attachment B, so the row advances.
- [ ] Enqueue a version 1 message by hand naming step 1's `submissionIndex` and content version `v4`.
- [ ] The delivered `encryptedContent` is step 1's, and `workflowContent.submittedSteps` has length 1.
- [ ] `attachmentDownloadUrls` presigns A's S3 key, not B's.

**TC2: A missing snapshot fails loud and does not churn**

- [ ] Delete the snapshot object from the V4 bucket, then let the message fire.
- [ ] The log carries error code `100239`, the message is deleted rather than redelivered, and no webhook is sent from the live row.

**TC3: A refused read is retried, not discarded**

- [ ] Point the app at a bucket it cannot read, then let the message fire.
- [ ] The log carries error code `100241`, the message is redelivered, and the submission's recorded webhook attempts are unchanged.
