### PR TITLE
feat(mrf): enqueue a snapshot-naming retry where a snapshot exists

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.service.spec.ts
@@ -4319,6 +4319,104 @@ describe('multirespondent-submission.service', () => {
       expect(view?.data.encryptedContent).toBe('frozen-content')
     })
 
+    it('passes snapshotRef so a retry reconstructs from the frozen snapshot', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      const submission = buildSubmissionWithToken('tok-A')
+
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        snapshot: buildSnapshot(),
+        submissionId: submission._id.toString(),
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({
+          enableMrfWebhooks: true,
+          mrfStepWriteToken: true,
+        }),
+      })
+      await flushPromises()
+
+      expect(sendSpy.mock.calls[0][4]).toEqual({
+        submissionIndex: (submission.submittedSteps?.length ?? 1) - 1,
+        contentFormat: 'v4',
+      })
+    })
+
+    it('omits snapshotRef when no snapshot was frozen so a retry uses the live row', async () => {
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      const submission = buildSubmissionWithToken(
+        undefined,
+        buildLiveWebhookView(),
+      )
+
+      await performMultiRespondentPostSubmissionCreateActions({
+        submission,
+        submissionId: submission._id.toString(),
+        form: buildV4Form(),
+        encryptedPayload: buildV4Payload(),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({
+          enableMrfWebhooks: true,
+          mrfStepWriteToken: true,
+        }),
+      })
+      await flushPromises()
+
+      expect(sendSpy.mock.calls[0][4]).toBeUndefined()
+    })
+
+    it('passes snapshotRef for the current sending step to send as initialWebhook, not the previous step', async () => {
+      const Model = getMultirespondentSubmissionModel(mongoose)
+      const row = await Model.create({
+        form: mockFormId,
+        submissionType: SubmissionType.Multirespondent,
+        form_fields: [],
+        form_logics: [],
+        workflow: twoStepWorkflow,
+        submissionPublicKey: 'pk',
+        encryptedSubmissionSecretKey: 'esk',
+        encryptedContent: 'ec',
+        version: 2,
+        workflowStep: 0,
+        submittedSteps: [
+          { isApproval: false, submittedAt: new Date().toISOString() },
+        ],
+      })
+      MockSnapshotStore.writeV4Snapshot.mockReturnValue(
+        okAsync({ token: 'tok-step-2', key: 'key-step-2' }),
+      )
+
+      const updated = await updateMultiRespondentFormSubmission({
+        submissionId: row._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: { action: 'test' },
+      })
+      const { submission, snapshot } = updated._unsafeUnwrap()
+
+      const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
+      await performMultiRespondentPostSubmissionUpdateActions({
+        submission,
+        snapshot,
+        submissionId: submission._id.toString(),
+        snapshottedFormDef: buildSnapshottedFormDef(),
+        currentStepNumber: 1,
+        encryptedPayload: buildV4Payload({ workflowStep: 1 }),
+        logMeta: {} as any,
+        growthbook: growthbookWithFlags({
+          enableMrfWebhooks: true,
+          mrfStepWriteToken: true,
+        }),
+      })
+      await flushPromises()
+
+      expect(sendSpy.mock.calls[0][4]).toEqual({
+        submissionIndex: 1,
+        contentFormat: 'v4',
+      })
+    })
+
     it('takes the legacy path (no 4th arg) for a plumber V3 row', async () => {
       const sendSpy = jest.mocked(WebhookFactory.sendInitialWebhook)
       const submission = buildSubmissionWithToken(

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -1184,11 +1184,19 @@ const sendMrfInitialWebhookIfEligible = ({
       }).asyncAndThen((data) => {
         const webhookView: WebhookView = { data }
 
+        const snapshotRef = snapshot
+          ? {
+              submissionIndex,
+              contentFormat: snapshot.contentFormat,
+            }
+          : undefined
+
         return WebhookFactory.sendInitialWebhook(
           submission,
           webhookUrl,
           isRetryEnabled,
           webhookView,
+          snapshotRef,
         ).map(() => undefined)
       })
     })

--- a/apps/backend/src/app/modules/webhook/__tests__/webhook.service.spec.ts
+++ b/apps/backend/src/app/modules/webhook/__tests__/webhook.service.spec.ts
@@ -473,8 +473,37 @@ describe('webhook.service', () => {
       expect(result._unsafeUnwrap()).toBe(true)
       expect(MockWebhookQueueMessage.fromSubmissionId).toHaveBeenCalledWith(
         String(testSubmission._id),
+        // No snapshot for this step, so the retry names none and falls back to
+        // the live row.
+        undefined,
       )
       expect(MOCK_PRODUCER.sendMessage).toHaveBeenCalledWith(mockQueueMessage)
+    })
+
+    it('should enqueue a retry naming the step submission when that step froze a snapshot', async () => {
+      const mockQueueMessage =
+        'mockQueueMessage' as unknown as WebhookQueueMessage
+      MockWebhookQueueMessage.fromSubmissionId.mockReturnValueOnce(
+        ok(mockQueueMessage),
+      )
+      MockAxios.post.mockResolvedValue(MOCK_AXIOS_FAILURE_RESPONSE)
+      const MOCK_PRODUCER = generateMockProducer()
+
+      const result = await WebhookService.createInitialWebhookSender(
+        MOCK_PRODUCER,
+      )(
+        testSubmission,
+        MOCK_WEBHOOK_URL,
+        /* isRetryEnabled= */ true,
+        /* webhookView= */ undefined,
+        /* snapshotRef= */ { submissionIndex: 1, contentFormat: 'v4' },
+      )
+
+      expect(result._unsafeUnwrap()).toBe(true)
+      expect(MockWebhookQueueMessage.fromSubmissionId).toHaveBeenCalledWith(
+        String(testSubmission._id),
+        { submissionIndex: 1, contentFormat: 'v4' },
+      )
     })
   })
 })

--- a/apps/backend/src/app/modules/webhook/webhook.service.ts
+++ b/apps/backend/src/app/modules/webhook/webhook.service.ts
@@ -31,6 +31,7 @@ import {
 import { WebhookQueueMessage } from './webhook.message'
 import { WebhookProducer } from './webhook.producer'
 import { webhookStatsdClient } from './webhook.statsd-client'
+import { SnapshotRef } from './webhook.types'
 import { formatWebhookResponse, isSuccessfulResponse } from './webhook.utils'
 import { validateWebhookUrl } from './webhook.validation'
 
@@ -256,6 +257,7 @@ export const createInitialWebhookSender =
     webhookUrl: string,
     isRetryEnabled: boolean,
     webhookView?: WebhookView,
+    snapshotRef?: SnapshotRef,
   ): ResultAsync<
     true,
     | WebhookValidationError
@@ -297,6 +299,7 @@ export const createInitialWebhookSender =
             // Webhook failed and retries enabled, so create initial message and enqueue
             return WebhookQueueMessage.fromSubmissionId(
               String(submission._id),
+              snapshotRef,
             ).asyncAndThen((queueMessage) => producer.sendMessage(queueMessage))
           },
         )


### PR DESCRIPTION
## Problem

Everything needed to replay the failed step on a webhook retry is in place below this slice, but nothing uses it: no send path names the snapshot it just froze, so every enqueued retry still says "read the live row". Until a sender names the step, a retry of step 1 that fires after step 2 commits still delivers step 2's payload under step 1's identity.

Closes #9745.

## Solution

This slice turns the replay on.

The MRF send path already knows whether it froze a snapshot for the step it is sending, and at which submission index and content version. It now passes that as the `snapshotRef` to `sendInitialWebhook`, which hands it to the queue message. What the retry delivers is therefore fixed at enqueue time, by the code that made the initial send.

The reference is passed only when a snapshot was frozen. A row without one — a V3 form, or either MRF webhook flag off — enqueues the same live row message as before, so the flag-off path is untouched and a rollout that never writes snapshots never emits the new message version. The index named is the step being sent, not the row's latest, so a send that races ahead of the row still names its own step.

**Breaking Changes**

No - backwards compatible on the wire, and retries already in flight keep delivering. A version 1 message read by an instance running older code — during the rolling deploy, or after a rollback — parses, drops the `snapshotRef` and delivers from the live row, so the worst case in either direction is today's behaviour.

What to watch instead is the disposition change. A retry whose snapshot is missing, or whose recorded content version does not match, is now deleted and never delivered, where before it would have delivered the live row. That is the intended fix — delivering the wrong step is worse than delivering nothing — but it means error codes `100239` and `100242` are the signal to follow after this deploys.

## Tests

Needs the V4 bucket provisioned (#9753) and the retry queue running. Start from a 3-step MRF form with a plumber webhook URL, `mrf-step-write-token` and webhook retries on, and a webhook endpoint that fails so a retry is enqueued.

**TC1: A retry redelivers the step that failed, not the latest one**

- [x] Submit step 1 with attachment A. Let the initial webhook fail.
- [x] Submit step 2 with attachment B, so the row advances before the retry fires.
- [x] When the retry lands, its `encryptedContent` is step 1's and `workflowContent.submittedSteps` has length 1.
- [x] Its `attachmentDownloadUrls` presigns A's S3 key, not B's.
- [x] Apart from freshly minted presigned URL values, the payload matches step 1's initial send field for field.

**TC2: A loop-back workflow resolves by submission index**

- [ ] On a workflow that returns to an earlier step, let the loop-back step's webhook fail.
- [ ] The retry delivers the loop-back submission's content, not the first visit to that same `workflowStep`.

**TC3: The delivered shape survives a mid-flight change**

- [ ] After the initial send fails but before the retry fires, change the form's `webhookFormat` and flip `mrf-step-write-token`.
- [ ] The retry still delivers the shape recorded at enqueue: the same `version`, with `encryptedSubmissionSecretKey` present or absent exactly as on the initial send.

**TC4: Messages already in flight survive the deploy**

- [ ] Enqueue a message by hand with `_v: 0` and no `snapshotRef`.
- [ ] It delivers from the live row, and the snapshot store is not read.

**TC5: The path stays inert with the flags off**

- [ ] With `mrf-step-write-token` and `enable-mrf-webhooks` both off, fill and advance the form with a failing webhook.
- [ ] No snapshot is written, the enqueued message is `_v: 0`, and the retry delivers today's V3 payload from the live row.
