### PR TITLE
fix(snapshot-store): finish aws-sdk v3 migration for the S5 snapshot store

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
@@ -1,5 +1,4 @@
 import crypto from 'crypto'
-import { text } from 'stream/consumers'
 
 import { aws as AwsConfig } from 'src/app/config/config'
 
@@ -119,8 +118,7 @@ describe('writeV4Snapshot', () => {
     expect(params.IfNoneMatch).toBe('*')
     expect(params.ContentType).toBe('application/json')
     // Body round-trips through parse back to the input snapshot.
-    const body = await text(params.Body as ReadableStream)
-    expect(JSON.parse(body)).toEqual(snapshot)
+    expect(JSON.parse(params.Body as string)).toEqual(snapshot)
     expect(result._unsafeUnwrap().token).toBe('tok-1')
     expect(result._unsafeUnwrap().key).toBe(
       buildSnapshotKey({ ...COORDS, token: 'tok-1' }),

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
@@ -35,6 +35,12 @@ const makeSnapshot = (): SubmissionSnapshotV4 =>
     createdAt: '2026-07-22T00:00:00.000Z',
   })
 
+// Mirrors the shape of a v3 GetObjectCommandOutput Body (an SdkStream,
+// which is NOT a Buffer — it must be read via transformToString).
+const s3Body = (content: string) => ({
+  Body: { transformToString: () => Promise.resolve(content) },
+})
+
 // Mirrors the shape of aws-sdk v3 S3ServiceExceptions (`name` +
 // `$metadata.httpStatusCode`, not v2's `code`/`statusCode`).
 const s3Error = (name: string, httpStatusCode: number) => ({
@@ -191,9 +197,7 @@ describe('readV4Snapshot', () => {
     const snapshot = makeSnapshot()
     const getObject = jest
       .fn()
-      .mockReturnValue(
-        Promise.resolve({ Body: Buffer.from(JSON.stringify(snapshot)) }),
-      )
+      .mockReturnValue(Promise.resolve(s3Body(JSON.stringify(snapshot))))
     ;(AwsConfig.s3.send as jest.Mock) = getObject
 
     await readV4Snapshot({ ...COORDS, token: 'tok-1' })
@@ -207,9 +211,7 @@ describe('readV4Snapshot', () => {
     const snapshot = makeSnapshot()
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(
-        Promise.resolve({ Body: Buffer.from(JSON.stringify(snapshot)) }),
-      )
+      .mockReturnValue(Promise.resolve(s3Body(JSON.stringify(snapshot))))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -256,9 +258,7 @@ describe('readV4Snapshot', () => {
   it('should err the SAME SnapshotDataIntegrityError on a malformed stored body', async () => {
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(
-        Promise.resolve({ Body: Buffer.from('{ not valid json') }),
-      )
+      .mockReturnValue(Promise.resolve(s3Body('{ not valid json')))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -271,9 +271,7 @@ describe('readV4Snapshot', () => {
     const bad = { ...makeSnapshot(), _v: 2 }
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(
-        Promise.resolve({ Body: Buffer.from(JSON.stringify(bad)) }),
-      )
+      .mockReturnValue(Promise.resolve(s3Body(JSON.stringify(bad))))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
@@ -35,13 +35,11 @@ const makeSnapshot = (): SubmissionSnapshotV4 =>
     createdAt: '2026-07-22T00:00:00.000Z',
   })
 
-// Mirrors the shape of a v3 GetObjectCommandOutput Body (an SdkStream,
-// which is NOT a Buffer — it must be read via transformToString).
-const s3Body = (content: string) => ({
+const mockS3Body = (content: string) => ({
   Body: { transformToString: () => Promise.resolve(content) },
 })
 
-const s3Error = (name: string, httpStatusCode: number) =>
+const mockS3Error = (name: string, httpStatusCode: number) =>
   name === 'NoSuchKey'
     ? new NoSuchKey({
         message: 'No such key was found.',
@@ -135,7 +133,7 @@ describe('writeV4Snapshot', () => {
     // Arrange: first PUT collides (412), second succeeds.
     const snapshot = makeSnapshot()
     const putObject = putRejectsThen(
-      { reject: s3Error('PreconditionFailed', 412) },
+      { reject: mockS3Error('PreconditionFailed', 412) },
       { resolve: {} },
     )
     ;(AwsConfig.s3.send as jest.Mock) = putObject
@@ -161,7 +159,7 @@ describe('writeV4Snapshot', () => {
   it('should fail loud with SnapshotWriteError on a non-collision rejection (no retry)', async () => {
     const snapshot = makeSnapshot()
     const putObject = putRejectsThen({
-      reject: s3Error('AccessDenied', 403),
+      reject: mockS3Error('AccessDenied', 403),
     })
     ;(AwsConfig.s3.send as jest.Mock) = putObject
     mockTokens('tok-1')
@@ -178,7 +176,7 @@ describe('writeV4Snapshot', () => {
     // Persistent 412 on every fresh token — must stop and fail loud.
     const putObject = jest
       .fn()
-      .mockReturnValue(Promise.reject(s3Error('PreconditionFailed', 412)))
+      .mockReturnValue(Promise.reject(mockS3Error('PreconditionFailed', 412)))
     ;(AwsConfig.s3.send as jest.Mock) = putObject
     // Every attempt gets a distinct fresh token (tok-0, tok-1, ...).
     mockTokens()
@@ -201,7 +199,7 @@ describe('readV4Snapshot', () => {
     const snapshot = makeSnapshot()
     const getObject = jest
       .fn()
-      .mockReturnValue(Promise.resolve(s3Body(JSON.stringify(snapshot))))
+      .mockReturnValue(Promise.resolve(mockS3Body(JSON.stringify(snapshot))))
     ;(AwsConfig.s3.send as jest.Mock) = getObject
 
     await readV4Snapshot({ ...COORDS, token: 'tok-1' })
@@ -215,7 +213,7 @@ describe('readV4Snapshot', () => {
     const snapshot = makeSnapshot()
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(Promise.resolve(s3Body(JSON.stringify(snapshot))))
+      .mockReturnValue(Promise.resolve(mockS3Body(JSON.stringify(snapshot))))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -226,7 +224,7 @@ describe('readV4Snapshot', () => {
   it('should err SnapshotDataIntegrityError with NO fallback on a missing object (NoSuchKey/404)', async () => {
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(Promise.reject(s3Error('NoSuchKey', 404)))
+      .mockReturnValue(Promise.reject(mockS3Error('NoSuchKey', 404)))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -238,7 +236,7 @@ describe('readV4Snapshot', () => {
   it('should err SnapshotReadError, NOT an integrity error, on an operational S3 failure (AccessDenied)', async () => {
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(Promise.reject(s3Error('AccessDenied', 403)))
+      .mockReturnValue(Promise.reject(mockS3Error('AccessDenied', 403)))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -251,7 +249,7 @@ describe('readV4Snapshot', () => {
   it('should err SnapshotReadError on a throttled S3 read', async () => {
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(Promise.reject(s3Error('SlowDown', 503)))
+      .mockReturnValue(Promise.reject(mockS3Error('SlowDown', 503)))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -262,7 +260,7 @@ describe('readV4Snapshot', () => {
   it('should err the SAME SnapshotDataIntegrityError on a malformed stored body', async () => {
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(Promise.resolve(s3Body('{ not valid json')))
+      .mockReturnValue(Promise.resolve(mockS3Body('{ not valid json')))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -275,7 +273,7 @@ describe('readV4Snapshot', () => {
     const bad = { ...makeSnapshot(), _v: 2 }
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(Promise.resolve(s3Body(JSON.stringify(bad))))
+      .mockReturnValue(Promise.resolve(mockS3Body(JSON.stringify(bad))))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
@@ -1,3 +1,4 @@
+import { NoSuchKey, S3ServiceException } from '@aws-sdk/client-s3'
 import crypto from 'crypto'
 
 import { aws as AwsConfig } from 'src/app/config/config'
@@ -40,12 +41,17 @@ const s3Body = (content: string) => ({
   Body: { transformToString: () => Promise.resolve(content) },
 })
 
-// Mirrors the shape of aws-sdk v3 S3ServiceExceptions (`name` +
-// `$metadata.httpStatusCode`, not v2's `code`/`statusCode`).
-const s3Error = (name: string, httpStatusCode: number) => ({
-  name,
-  $metadata: { httpStatusCode },
-})
+const s3Error = (name: string, httpStatusCode: number) =>
+  name === 'NoSuchKey'
+    ? new NoSuchKey({
+        message: 'No such key was found.',
+        $metadata: { httpStatusCode },
+      })
+    : new S3ServiceException({
+        name,
+        $fault: 'client',
+        $metadata: { httpStatusCode },
+      })
 
 // Helper to make a resolved/rejected aws-sdk promise shape.
 const putResolves = () => jest.fn().mockReturnValue(Promise.resolve({}))

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/__tests__/submission-snapshot.store.spec.ts
@@ -35,6 +35,13 @@ const makeSnapshot = (): SubmissionSnapshotV4 =>
     createdAt: '2026-07-22T00:00:00.000Z',
   })
 
+// Mirrors the shape of aws-sdk v3 S3ServiceExceptions (`name` +
+// `$metadata.httpStatusCode`, not v2's `code`/`statusCode`).
+const s3Error = (name: string, httpStatusCode: number) => ({
+  name,
+  $metadata: { httpStatusCode },
+})
+
 // Helper to make a resolved/rejected aws-sdk promise shape.
 const putResolves = () => jest.fn().mockReturnValue(Promise.resolve({}))
 const putRejectsThen = (
@@ -118,7 +125,7 @@ describe('writeV4Snapshot', () => {
     // Arrange: first PUT collides (412), second succeeds.
     const snapshot = makeSnapshot()
     const putObject = putRejectsThen(
-      { reject: { code: 'PreconditionFailed', statusCode: 412 } },
+      { reject: s3Error('PreconditionFailed', 412) },
       { resolve: {} },
     )
     ;(AwsConfig.s3.send as jest.Mock) = putObject
@@ -144,7 +151,7 @@ describe('writeV4Snapshot', () => {
   it('should fail loud with SnapshotWriteError on a non-collision rejection (no retry)', async () => {
     const snapshot = makeSnapshot()
     const putObject = putRejectsThen({
-      reject: { code: 'AccessDenied', statusCode: 403 },
+      reject: s3Error('AccessDenied', 403),
     })
     ;(AwsConfig.s3.send as jest.Mock) = putObject
     mockTokens('tok-1')
@@ -161,9 +168,7 @@ describe('writeV4Snapshot', () => {
     // Persistent 412 on every fresh token — must stop and fail loud.
     const putObject = jest
       .fn()
-      .mockReturnValue(
-        Promise.reject({ code: 'PreconditionFailed', statusCode: 412 }),
-      )
+      .mockReturnValue(Promise.reject(s3Error('PreconditionFailed', 412)))
     ;(AwsConfig.s3.send as jest.Mock) = putObject
     // Every attempt gets a distinct fresh token (tok-0, tok-1, ...).
     mockTokens()
@@ -215,7 +220,7 @@ describe('readV4Snapshot', () => {
   it('should err SnapshotDataIntegrityError with NO fallback on a missing object (NoSuchKey/404)', async () => {
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(Promise.reject({ code: 'NoSuchKey', statusCode: 404 }))
+      .mockReturnValue(Promise.reject(s3Error('NoSuchKey', 404)))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -227,9 +232,7 @@ describe('readV4Snapshot', () => {
   it('should err SnapshotReadError, NOT an integrity error, on an operational S3 failure (AccessDenied)', async () => {
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(
-        Promise.reject({ code: 'AccessDenied', statusCode: 403 }),
-      )
+      .mockReturnValue(Promise.reject(s3Error('AccessDenied', 403)))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 
@@ -242,7 +245,7 @@ describe('readV4Snapshot', () => {
   it('should err SnapshotReadError on a throttled S3 read', async () => {
     ;(AwsConfig.s3.send as jest.Mock) = jest
       .fn()
-      .mockReturnValue(Promise.reject({ code: 'SlowDown', statusCode: 503 }))
+      .mockReturnValue(Promise.reject(s3Error('SlowDown', 503)))
 
     const result = await readV4Snapshot({ ...COORDS, token: 'tok-1' })
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store.ts
@@ -48,17 +48,25 @@ export const buildSnapshotKey = ({
  * (the key already exists), i.e. a token collision we should retry.
  */
 const isPreconditionFailed = (error: unknown): boolean => {
-  const s3Error = error as { code?: string; statusCode?: number } | null
+  const s3Error = error as {
+    name?: string
+    $metadata?: { httpStatusCode?: number }
+  } | null
   return (
     !!s3Error &&
-    (s3Error.code === 'PreconditionFailed' || s3Error.statusCode === 412)
+    (s3Error.name === 'PreconditionFailed' ||
+      s3Error.$metadata?.httpStatusCode === 412)
   )
 }
 
 const isNoSuchKey = (error: unknown): boolean => {
-  const s3Error = error as { code?: string; statusCode?: number } | null
+  const s3Error = error as {
+    name?: string
+    $metadata?: { httpStatusCode?: number }
+  } | null
   return (
-    !!s3Error && (s3Error.code === 'NoSuchKey' || s3Error.statusCode === 404)
+    !!s3Error &&
+    (s3Error.name === 'NoSuchKey' || s3Error.$metadata?.httpStatusCode === 404)
   )
 }
 

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store.ts
@@ -1,11 +1,10 @@
 import {
   GetObjectCommand,
   PutObjectCommand,
-  PutObjectRequest,
+  PutObjectCommandInput,
 } from '@aws-sdk/client-s3'
 import crypto from 'crypto'
 import { errAsync, ResultAsync } from 'neverthrow'
-import { Readable } from 'stream'
 
 import { aws as AwsConfig } from '../../../../config/config'
 import { createLoggerWithLabel } from '../../../../config/logger'
@@ -86,10 +85,10 @@ export const writeV4Snapshot = (
       token,
     })
 
-    const params: PutObjectRequest = {
+    const params: PutObjectCommandInput = {
       Bucket: AwsConfig.submissionHistoryV4S3Bucket,
       Key: key,
-      Body: Readable.from([body]),
+      Body: body,
       ContentType: 'application/json',
       // Create-if-absent: S3 returns 412 PreconditionFailed if the key exists.
       IfNoneMatch: '*',

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store.ts
@@ -1,7 +1,9 @@
 import {
   GetObjectCommand,
+  NoSuchKey,
   PutObjectCommand,
   PutObjectCommandInput,
+  S3ServiceException,
 } from '@aws-sdk/client-s3'
 import crypto from 'crypto'
 import { errAsync, ResultAsync } from 'neverthrow'
@@ -46,28 +48,12 @@ export const buildSnapshotKey = ({
  * Returns true if the S3 error signals a create-if-absent precondition failure
  * (the key already exists), i.e. a token collision we should retry.
  */
-const isPreconditionFailed = (error: unknown): boolean => {
-  const s3Error = error as {
-    name?: string
-    $metadata?: { httpStatusCode?: number }
-  } | null
-  return (
-    !!s3Error &&
-    (s3Error.name === 'PreconditionFailed' ||
-      s3Error.$metadata?.httpStatusCode === 412)
-  )
-}
+const isPreconditionFailed = (error: unknown): error is S3ServiceException =>
+  error instanceof S3ServiceException && error.name === 'PreconditionFailed'
 
-const isNoSuchKey = (error: unknown): boolean => {
-  const s3Error = error as {
-    name?: string
-    $metadata?: { httpStatusCode?: number }
-  } | null
-  return (
-    !!s3Error &&
-    (s3Error.name === 'NoSuchKey' || s3Error.$metadata?.httpStatusCode === 404)
-  )
-}
+const isNoSuchKey = (error: unknown): error is NoSuchKey | S3ServiceException =>
+  error instanceof NoSuchKey ||
+  (error instanceof S3ServiceException && error.name === 'NoSuchKey')
 
 export const writeV4Snapshot = (
   snapshot: SubmissionSnapshotV4,
@@ -111,7 +97,7 @@ export const writeV4Snapshot = (
                 submissionId: snapshot.submissionId,
                 submissionIndex: snapshot.submissionIndex,
               },
-              error: error as Error,
+              error,
             })
             return errAsync(
               new SnapshotWriteError(

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/webhook/submission-snapshot.store.ts
@@ -167,13 +167,15 @@ export const readV4Snapshot = ({
     (error) => error,
   )
     .andThen((data) => {
-      const body = data.Body?.toString()
-      if (body === undefined) {
+      if (data.Body === undefined) {
         return errAsync(
           new SnapshotDataIntegrityError('Submission snapshot body is empty'),
         )
       }
-      return parseSnapshot(body)
+      return ResultAsync.fromPromise(
+        data.Body.transformToString(),
+        (error) => error,
+      ).andThen(parseSnapshot)
     })
     .orElse((error) => {
       if (error instanceof SnapshotDataIntegrityError) {


### PR DESCRIPTION
## Context

While investigating the v9.10.1 regressions (IR-1322 / #9861), a review of the aws-sdk v3 migration (#9837) surfaced three more latent v3 bugs in the S5 submission snapshot store. All three share the failure pattern that let the presign bug ship: **tests mocked v2 shapes while prod gets v3 shapes**, so the suite stayed green.

None of these are user-facing today — `writeV4Snapshot` is live only behind flags and `readV4Snapshot` has no production caller yet — but they will bite the moment S5 webhook delivery lands, so they should ride along with (or land before) any re-release of #9837.

## Fixes (one commit each)

1. **v3 error shape matching** — `isPreconditionFailed`/`isNoSuchKey` checked v2's `error.code`/`error.statusCode`; v3 `S3ServiceException`s expose `error.name`/`error.$metadata.httpStatusCode`. Without this, a 412 token collision on `writeV4Snapshot` hard-fails as `SnapshotWriteError` instead of retrying with a fresh token, and `NoSuchKey` on read misclassifies as `SnapshotReadError` instead of `SnapshotDataIntegrityError`.
2. **GetObject Body read** — v3's `Body` is an `SdkStream`, not a Buffer; `.toString()` yields `"[object Object]"`, so every real read would fail `parseSnapshot`. Now read via `transformToString()`.
3. **PutObject Body** — v3 throws for a `Readable` of unknown length; the snapshot body is an in-memory JSON string, so pass it directly (typed via `PutObjectCommandInput`, whose `Body` accepts strings, rather than the wire-shaped `PutObjectRequest`).

Test mocks updated to v3 shapes (`name`/`$metadata.httpStatusCode` errors, `transformToString` bodies) so they exercise the same code paths prod does.

## Testing

- `pnpm test src/app/modules/submission/multirespondent-submission/webhook` — 7 suites, 79 tests pass
- `tsc --noEmit` — no errors in changed files (remaining errors pre-exist on develop)

## Not in scope

- The shipped presign regression is fixed separately in #9861.
- Staging verification of v3 default flexible checksums (CRC32/aws-chunked) against R2 endpoints is still worth doing before re-releasing #9837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)