### PR TITLE
fix(config): add socket timeout to lambda invoke clients

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -34,6 +34,7 @@
     "@opengovsg/sgid-client": "^2.2.0",
     "@react-email/components": "^0.0.26",
     "@react-email/render": "^1.0.5",
+    "@smithy/node-http-handler": "^4.9.13",
     "@smithy/util-stream": "^3.3.4",
     "@stablelib/base64": "^1.0.1",
     "JSONStream": "^1.3.5",

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -1,6 +1,7 @@
 import { Lambda } from '@aws-sdk/client-lambda'
 import { S3Client } from '@aws-sdk/client-s3'
 import { defaultProvider } from '@aws-sdk/credential-provider-node'
+import { NodeHttpHandler } from '@smithy/node-http-handler'
 import convict from 'convict'
 import { SessionOptions } from 'express-session'
 import { merge } from 'lodash'
@@ -96,6 +97,15 @@ const hasR2Buckets = Object.values(s3BucketUrlVars).some((url) =>
 // Shared across configureAws() and AWS clients below so that credentials are resolved once only and reused
 const credentialsProvider = defaultProvider()
 
+// AWS SDK v2 defaulted to a 120s socket timeout on every request. AWS SDK v3's
+// NodeHttpHandler has no timeout by default (requestTimeout: 0), so a hung/stalled
+// synchronous Lambda invocation would otherwise block the calling request forever.
+// This restores an explicit ceiling for the synchronous lambdas we invoke inline
+// on the request path.
+const lambdaRequestHandler = new NodeHttpHandler({
+  requestTimeout: 120_000,
+})
+
 const s3 = new S3Client({
   region: basicVars.awsConfig.region,
   // Unset and use default if not in development mode
@@ -112,6 +122,7 @@ const s3 = new S3Client({
 const guarddutyLambda = new Lambda({
   region: basicVars.awsConfig.region,
   credentials: credentialsProvider,
+  requestHandler: lambdaRequestHandler,
   // For dev mode or where specified, endpoint is set to point to the separate docker container running the lambda function.
   // host.docker.internal is a special DNS name which resolves to the internal IP address used by the host.
   // Reference: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
@@ -127,6 +138,7 @@ const guarddutyLambda = new Lambda({
 const pdfGeneratorLambda = new Lambda({
   region: basicVars.awsConfig.region,
   credentials: credentialsProvider,
+  requestHandler: lambdaRequestHandler,
   // For dev mode or where specified, endpoint is set to point to the separate docker container running the lambda function.
   // host.docker.internal is a special DNS name which resolves to the internal IP address used by the host.
   // Reference: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host

--- a/apps/backend/src/app/config/config.ts
+++ b/apps/backend/src/app/config/config.ts
@@ -97,13 +97,16 @@ const hasR2Buckets = Object.values(s3BucketUrlVars).some((url) =>
 // Shared across configureAws() and AWS clients below so that credentials are resolved once only and reused
 const credentialsProvider = defaultProvider()
 
-// AWS SDK v2 defaulted to a 120s socket timeout on every request. AWS SDK v3's
-// NodeHttpHandler has no timeout by default (requestTimeout: 0), so a hung/stalled
-// synchronous Lambda invocation would otherwise block the calling request forever.
-// This restores an explicit ceiling for the synchronous lambdas we invoke inline
-// on the request path.
+// NodeHttpHandler has no socket timeout by default, so a hung/stalled synchronous
+// Lambda invocation (e.g. a half-open connection where no data ever arrives) would
+// otherwise leave the calling request pending forever. socketTimeout mirrors the
+// inactivity-based timeout AWS SDK v2 used to apply by default.
+// Both guarddutyLambda and pdfGeneratorLambda have a configured function timeout of
+// 300s (services/virus-scanner-guardduty/serverless.yml, services/pdf-gen-sparticuz/template.yaml),
+// so this is set comfortably above that so it only fires on a genuine hang, never on
+// a legitimate slow-but-successful invocation.
 const lambdaRequestHandler = new NodeHttpHandler({
-  requestTimeout: 120_000,
+  socketTimeout: 310_000,
 })
 
 const s3 = new S3Client({
@@ -123,6 +126,12 @@ const guarddutyLambda = new Lambda({
   region: basicVars.awsConfig.region,
   credentials: credentialsProvider,
   requestHandler: lambdaRequestHandler,
+  // On a clean scan, the lambda moves the file to the clean bucket under a new key
+  // and deletes the quarantined original, then returns that new key in the response.
+  // That's a one-shot, non-idempotent side effect: if the SDK retried a slow-but-
+  // successful invocation, the retry would find the source file already gone and
+  // surface a false failure, silently dropping the correct response. Disable retries.
+  maxAttempts: 1,
   // For dev mode or where specified, endpoint is set to point to the separate docker container running the lambda function.
   // host.docker.internal is a special DNS name which resolves to the internal IP address used by the host.
   // Reference: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host
@@ -139,6 +148,9 @@ const pdfGeneratorLambda = new Lambda({
   region: basicVars.awsConfig.region,
   credentials: credentialsProvider,
   requestHandler: lambdaRequestHandler,
+  // Kept consistent with guarddutyLambda; a retry here would just be wasted compute
+  // rather than a correctness issue, since PDF generation has no side effects.
+  maxAttempts: 1,
   // For dev mode or where specified, endpoint is set to point to the separate docker container running the lambda function.
   // host.docker.internal is a special DNS name which resolves to the internal IP address used by the host.
   // Reference: https://docs.docker.com/desktop/networking/#i-want-to-connect-from-a-container-to-a-service-on-the-host

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       '@react-email/render':
         specifier: ^1.0.5
         version: 1.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@smithy/node-http-handler':
+        specifier: ^4.9.13
+        version: 4.9.13
       '@smithy/util-stream':
         specifier: ^3.3.4
         version: 3.3.4


### PR DESCRIPTION
## Summary
- `guarddutyLambda` and `pdfGeneratorLambda` (`apps/backend/src/app/config/config.ts`) are invoked synchronously, inline on the request path (submission virus-scan check, PDF generation for form responses), with no timeout configured anywhere and no per-call `AbortSignal`.
- `NodeHttpHandler` (the SDK v3 HTTP layer) has no socket timeout by default, so a genuine hang -- e.g. a half-open TCP connection where no data ever arrives in either direction -- leaves the calling backend request pending indefinitely. The ALB may eventually return a 504 to the end user (default idle timeout), but that doesn't cancel anything server-side: the dangling promise, open socket, and retained closures stay alive on the Node process for as long as the hang lasts, since there's no `req.on('close')`/`AbortController` wiring anywhere in this call path.
- Fix: a shared `NodeHttpHandler({ socketTimeout: 310_000 })` passed as `requestHandler` to both `Lambda` clients. `socketTimeout` is the inactivity-based timer that matches how AWS SDK v2's `httpOptions.timeout` used to work (`requestTimeout` is a different, stricter total-deadline concept in the v3 handler, and additionally requires `throwOnRequestTimeout: true` to actually reject rather than just log a warning). 310s is sized above both lambdas' configured 300s function timeout (`services/virus-scanner-guardduty/serverless.yml:75`, `services/pdf-gen-sparticuz/template.yaml:13`), so it only fires on a genuine hang, never on a legitimate slow-but-successful invocation.
- Also pinned `maxAttempts: 1` on both clients. Neither currently overrides the SDK v3 default (`maxAttempts: 3`), and a socket timeout is classified as a retryable error. For `guarddutyLambda` specifically, a retry after a slow-but-successful invocation is actively harmful, not just wasteful: on a clean scan the lambda moves the file to the clean bucket under a new random key and deletes the quarantined original (`services/virus-scanner-guardduty/src/index.ts:119-166`), so a retry would find the source object already gone and surface a false "file not found" failure, silently dropping the correct response.

## Test plan
- [x] `tsc --noEmit` on `apps/backend` shows no new errors introduced by this change
- [x] `eslint` clean on the changed file
- [ ] Manual verification against a deliberately hung lambda endpoint (e.g. a stub that accepts the connection but never responds) confirms `invoke()` now rejects after ~310s instead of hanging, and does not retry

Generated with Claude Code