### PR TITLE
refactor(mrf-email): extract the MRF completion email field group (1/3)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useAdminFormWorkflow.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useAdminFormWorkflow.ts
@@ -18,8 +18,15 @@ import { augmentWithMyInfo } from '~features/myinfo/utils'
 export const useAdminFormWorkflow = () => {
   const { data: form, isLoading } = useAdminForm()
 
-  const augmentedFormFields = augmentFieldWithQuestionNo(
-    form?.form_fields.map(augmentWithMyInfo) ?? [],
+  // Memoised on form_fields. Without this the array identity changes on every
+  // render, so the four useMemos below never hit and every consumer redoes a
+  // keyBy plus three filters over every field in the form.
+  const augmentedFormFields = useMemo(
+    () =>
+      augmentFieldWithQuestionNo(
+        form?.form_fields.map(augmentWithMyInfo) ?? [],
+      ),
+    [form?.form_fields],
   )
 
   const idToFieldMap = useMemo(

--- a/apps/frontend/src/features/admin-form/settings/components/MrfEmailRecipientsFieldGroup.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfEmailRecipientsFieldGroup.tsx
@@ -1,0 +1,231 @@
+import { ReactNode } from 'react'
+import {
+  Control,
+  Controller,
+  RegisterOptions,
+  useFormState,
+} from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { Box, FormControl, FormErrorMessage, Skeleton } from '@chakra-ui/react'
+import { get, isEmpty, noop } from 'lodash'
+import isEmail from 'validator/lib/isEmail'
+
+import { useOptionalAdminEmailValidationRules } from '~utils/formValidation'
+import { MultiSelect, SingleSelect } from '~components/Dropdown'
+import FormLabel from '~components/FormControl/FormLabel'
+import { TagInput } from '~components/TagInput'
+
+import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
+import { useAdminFormWorkflow } from '~features/admin-form/create/workflow/hooks/useAdminFormWorkflow'
+import { useIsWorkflowBuilderRedesign } from '~features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign'
+
+export const WORKFLOW_EMAIL_MULTISELECT_NAME = 'email-multi-select'
+export const STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME =
+  'step-1-notify-single-select'
+export const OTHER_PARTIES_EMAIL_INPUT_NAME = 'other-parties-email-input'
+
+export interface MrfEmailRecipientsFormData {
+  [WORKFLOW_EMAIL_MULTISELECT_NAME]: string[]
+  [OTHER_PARTIES_EMAIL_INPUT_NAME]: string[]
+  [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]: string
+}
+
+export interface MrfEmailRecipientsFieldGroupProps {
+  control: Control<MrfEmailRecipientsFormData>
+  isDisabled: boolean
+  isHighContrast: boolean
+  /** Sits above the first control, sharing its wrapper. */
+  heading?: ReactNode
+  otherPartiesPlaceholder?: string
+  /** Settings dedupes then submits here; the card only dedupes. */
+  onOtherPartiesBlur: () => void
+  /** Settings submits here; the card passes nothing. */
+  onSelectBlur?: () => void
+}
+
+/**
+ * The three MRF completion email recipient controls, without any form or
+ * mutation of their own. Shared by Settings > Email notifications and the
+ * completion email card on the workflow tab, so the two cannot drift.
+ *
+ * Save behaviour is injected rather than baked in: the two consumers commit at
+ * different moments. Everything else, including which controls appear at which
+ * workflow step count, is identical by construction.
+ */
+export const MrfEmailRecipientsFieldGroup = ({
+  control,
+  isDisabled,
+  isHighContrast,
+  heading,
+  otherPartiesPlaceholder,
+  onOtherPartiesBlur,
+  onSelectBlur,
+}: MrfEmailRecipientsFieldGroupProps): JSX.Element => {
+  const { t } = useTranslation()
+  // Subscribed here rather than taken as a prop: RHF's formState is a Proxy that
+  // only tracks what is read during render, so a consumer that forgot to read
+  // errors would silently pass stale ones.
+  const { errors } = useFormState({ control })
+  const isRedesign = useIsWorkflowBuilderRedesign()
+  const {
+    isLoading,
+    formWorkflow,
+    emailFormFields = [],
+  } = useAdminFormWorkflow()
+
+  const formWorkflowStepsWithStepNumber =
+    formWorkflow?.map((step, index) => ({
+      ...step,
+      stepNumber: index + 1,
+    })) ?? []
+
+  const workflowStepCount = formWorkflowStepsWithStepNumber.length
+
+  const emailFieldItems = emailFormFields.map(
+    ({ _id, questionNumber, title, fieldType }) => ({
+      label: `${questionNumber}. ${title}`,
+      value: _id,
+      icon: BASICFIELD_TO_DRAWER_META[fieldType].icon,
+    }),
+  )
+
+  const optionalAdminEmailValidationRules =
+    useOptionalAdminEmailValidationRules()
+
+  return (
+    <>
+      <Box my="1.5rem">
+        {heading}
+        <FormControl
+          isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
+          isDisabled={isDisabled}
+        >
+          <FormLabel
+            textColor="secondary.700"
+            mb="0.75rem"
+            tooltipVariant="info"
+            tooltipPlacement="top"
+            tooltipText={t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
+            )}
+            isHighContrast={isHighContrast}
+          >
+            {t(
+              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
+            )}
+          </FormLabel>
+          <Controller<MrfEmailRecipientsFormData>
+            name={OTHER_PARTIES_EMAIL_INPUT_NAME}
+            control={control}
+            rules={
+              optionalAdminEmailValidationRules as RegisterOptions<MrfEmailRecipientsFormData>
+            }
+            render={({ field }) => (
+              <TagInput
+                placeholder={isDisabled ? undefined : otherPartiesPlaceholder}
+                {...field}
+                value={field.value as string[]}
+                isDisabled={isDisabled}
+                onBlur={onOtherPartiesBlur}
+                tagValidation={isEmail}
+              />
+            )}
+          />
+          {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
+            <FormLabel.Description color="secondary.400" mt="0.5rem">
+              {t(
+                isRedesign
+                  ? 'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.descriptionRedesign'
+                  : 'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
+              )}
+            </FormLabel.Description>
+          ) : (
+            <FormErrorMessage>
+              {get(errors, `${OTHER_PARTIES_EMAIL_INPUT_NAME}.message`)}
+            </FormErrorMessage>
+          )}
+        </FormControl>
+      </Box>
+      <Box>
+        {workflowStepCount >= 1 && (
+          <Box>
+            <FormLabel mb="0.75rem" textColor="secondary.700">
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.label',
+              )}
+            </FormLabel>
+            <Skeleton isLoaded={!isLoading}>
+              <Controller
+                control={control}
+                name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
+                render={({
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  field: { value, onBlur, ...rest },
+                }) => (
+                  <SingleSelect
+                    isDisabled={isLoading || isDisabled}
+                    placeholder={t(
+                      'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.placeholder',
+                    )}
+                    items={emailFieldItems}
+                    onBlur={onSelectBlur}
+                    isClearable
+                    value={value}
+                    {...rest}
+                  />
+                )}
+              />
+            </Skeleton>
+          </Box>
+        )}
+        {workflowStepCount >= 2 && (
+          <Box my="1.5rem">
+            <FormLabel mb="0.75rem" textColor="secondary.700">
+              {t(
+                isRedesign
+                  ? 'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overallRedesign'
+                  : 'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
+              )}
+            </FormLabel>
+            <Skeleton isLoaded={!isLoading}>
+              <Controller
+                control={control}
+                name={WORKFLOW_EMAIL_MULTISELECT_NAME}
+                render={({
+                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                  field: { value: values = [], onChange, onBlur, ...rest },
+                }) => (
+                  <MultiSelect
+                    items={formWorkflowStepsWithStepNumber
+                      .filter((step) => step.stepNumber > 1)
+                      .map(({ step_name, stepNumber, _id: value }) => ({
+                        label:
+                          t(
+                            'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.each',
+                            { stepNumber },
+                          ) + (step_name ? ` (${step_name})` : ''),
+                        value,
+                      }))}
+                    values={values}
+                    onChange={onChange}
+                    onBlur={onSelectBlur ?? noop}
+                    placeholder={
+                      isDisabled
+                        ? null
+                        : t(
+                            'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.placeholder',
+                          )
+                    }
+                    isSelectedItemFullWidth
+                    isDisabled={isLoading || isDisabled}
+                    {...rest}
+                  />
+                )}
+              />
+            </Skeleton>
+          </Box>
+        )}
+      </Box>
+    </>
+  )
+}

--- a/apps/frontend/src/features/admin-form/settings/components/MrfEmailRecipientsFieldGroup.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfEmailRecipientsFieldGroup.tsx
@@ -65,7 +65,12 @@ export const MrfEmailRecipientsFieldGroup = ({
   // Subscribed here rather than taken as a prop: RHF's formState is a Proxy that
   // only tracks what is read during render, so a consumer that forgot to read
   // errors would silently pass stale ones.
-  const { errors } = useFormState({ control })
+  // Narrowed to the one field with validation rules; the two selects have none,
+  // so subscribing to them would only add re-renders.
+  const { errors } = useFormState({
+    control,
+    name: OTHER_PARTIES_EMAIL_INPUT_NAME,
+  })
   const isRedesign = useIsWorkflowBuilderRedesign()
   const {
     isLoading,

--- a/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/MrfFormEmailSection.tsx
@@ -1,47 +1,30 @@
 import { useCallback } from 'react'
-import { Controller, RegisterOptions, useForm } from 'react-hook-form'
+import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import {
-  Box,
-  FormControl,
-  FormErrorMessage,
-  Skeleton,
-  Text,
-} from '@chakra-ui/react'
-import { get, isEmpty, isEqual, uniq } from 'lodash'
+import { Box, Text } from '@chakra-ui/react'
+import { isEqual, uniq } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 
 import { MultirespondentFormSettings } from 'formsg-shared/types/form'
 
-import { useOptionalAdminEmailValidationRules } from '~utils/formValidation'
-import { MultiSelect, SingleSelect } from '~components/Dropdown'
-import FormLabel from '~components/FormControl/FormLabel'
-import { TagInput } from '~components/TagInput'
-
-import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants'
 import { useAdminFormWorkflow } from '~features/admin-form/create/workflow/hooks/useAdminFormWorkflow'
-import { useIsWorkflowBuilderRedesign } from '~features/admin-form/create/workflow/hooks/useIsWorkflowBuilderRedesign'
 import { useUser } from '~features/user/queries'
 
 import { useMutateFormSettings } from '../mutations'
 
 import { RespondentCopyToggle } from './EmailNotificationsSection/RespondentCopyToggle'
+import {
+  MrfEmailRecipientsFieldGroup,
+  MrfEmailRecipientsFormData,
+  OTHER_PARTIES_EMAIL_INPUT_NAME,
+  STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME,
+  WORKFLOW_EMAIL_MULTISELECT_NAME,
+} from './MrfEmailRecipientsFieldGroup'
 
 interface MrfEmailNotificationsFormProps {
   settings: MultirespondentFormSettings
   isDisabled: boolean
   isHighContrast: boolean
-}
-
-const WORKFLOW_EMAIL_MULTISELECT_NAME = 'email-multi-select'
-const STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME =
-  'step-1-notify-single-select'
-const OTHER_PARTIES_EMAIL_INPUT_NAME = 'other-parties-email-input'
-
-interface FormData {
-  [WORKFLOW_EMAIL_MULTISELECT_NAME]: string[]
-  [OTHER_PARTIES_EMAIL_INPUT_NAME]: string[]
-  [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]: string
 }
 
 const MrfEmailNotificationsForm = ({
@@ -50,32 +33,13 @@ const MrfEmailNotificationsForm = ({
   isHighContrast,
 }: MrfEmailNotificationsFormProps) => {
   const { t } = useTranslation()
-  const isRedesign = useIsWorkflowBuilderRedesign()
-  const {
-    isLoading,
-    formWorkflow,
-    emailFormFields = [],
-  } = useAdminFormWorkflow()
+  const { formWorkflow } = useAdminFormWorkflow()
 
   //TODO: (Respondent Copy): Remove isTest and user when respondent copy is out of beta
   const { user } = useUser()
   const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
 
-  const formWorkflowStepsWithStepNumber =
-    formWorkflow?.map((step, index) => ({
-      ...step,
-      stepNumber: index + 1,
-    })) ?? []
-
-  const workflowStepCount = formWorkflowStepsWithStepNumber.length
-
-  const emailFieldItems = emailFormFields.map(
-    ({ _id, questionNumber, title, fieldType }) => ({
-      label: `${questionNumber}. ${title}`,
-      value: _id,
-      icon: BASICFIELD_TO_DRAWER_META[fieldType].icon,
-    }),
-  )
+  const workflowStepCount = formWorkflow?.length ?? 0
 
   const filterInvalidEmails = useCallback((emails: string[]) => {
     if (!emails) return []
@@ -84,24 +48,15 @@ const MrfEmailNotificationsForm = ({
 
   const { stepsToNotify, emails, stepOneEmailNotificationFieldId } = settings
 
-  const {
-    handleSubmit,
-    control,
-    setValue,
-    getValues,
-    formState: { errors },
-  } = useForm<{
-    [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]: string
-    [WORKFLOW_EMAIL_MULTISELECT_NAME]: string[]
-    [OTHER_PARTIES_EMAIL_INPUT_NAME]: string[]
-  }>({
-    defaultValues: {
-      [WORKFLOW_EMAIL_MULTISELECT_NAME]: stepsToNotify,
-      [OTHER_PARTIES_EMAIL_INPUT_NAME]: emails,
-      [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]:
-        stepOneEmailNotificationFieldId,
-    },
-  })
+  const { handleSubmit, control, setValue, getValues } =
+    useForm<MrfEmailRecipientsFormData>({
+      defaultValues: {
+        [WORKFLOW_EMAIL_MULTISELECT_NAME]: stepsToNotify,
+        [OTHER_PARTIES_EMAIL_INPUT_NAME]: emails,
+        [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]:
+          stepOneEmailNotificationFieldId,
+      },
+    })
 
   const { mutateMrfEmailNotifications } = useMutateFormSettings()
 
@@ -128,7 +83,7 @@ const MrfEmailNotificationsForm = ({
     })
   }
 
-  const onSubmit = (formData: FormData) => {
+  const onSubmit = (formData: MrfEmailRecipientsFormData) => {
     const selectedSteps = formData[WORKFLOW_EMAIL_MULTISELECT_NAME]
     const selectedEmails = formData[OTHER_PARTIES_EMAIL_INPUT_NAME]
     const selectedStepOneEmailNotificationFieldId =
@@ -164,147 +119,21 @@ const MrfEmailNotificationsForm = ({
           'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientNoWorkflow',
         )
 
-  const optionalAdminEmailValidationRules =
-    useOptionalAdminEmailValidationRules()
-
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Box my="1.5rem">
-        <Text textStyle="body-1" textColor="secondary.700" mb="1.5rem">
-          {sectionText}
-        </Text>
-        <FormControl
-          isInvalid={!isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME])}
-          isDisabled={isDisabled}
-        >
-          <FormLabel
-            textColor="secondary.700"
-            mb="0.75rem"
-            tooltipVariant="info"
-            tooltipPlacement="top"
-            tooltipText={t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.tooltipText',
-            )}
-            isHighContrast={isHighContrast}
-          >
-            {t(
-              'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.label',
-            )}
-          </FormLabel>
-          <Controller<FormData>
-            name={OTHER_PARTIES_EMAIL_INPUT_NAME}
-            control={control}
-            rules={
-              optionalAdminEmailValidationRules as RegisterOptions<FormData>
-            }
-            render={({ field }) => (
-              <TagInput
-                placeholder={
-                  isDisabled ? undefined : otherPartiesEmailInputPlaceholder
-                }
-                {...field}
-                value={field.value as string[]}
-                isDisabled={isDisabled}
-                onBlur={handleOtherPartiesEmailInputBlur}
-                tagValidation={isEmail}
-              />
-            )}
-          />
-          {isEmpty(errors[OTHER_PARTIES_EMAIL_INPUT_NAME]) ? (
-            <FormLabel.Description color="secondary.400" mt="0.5rem">
-              {t(
-                isRedesign
-                  ? 'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.descriptionRedesign'
-                  : 'features.adminForm.settings.emailNotifications.section.mrf.respondents.others.description',
-              )}
-            </FormLabel.Description>
-          ) : (
-            <FormErrorMessage>
-              {get(errors, `${OTHER_PARTIES_EMAIL_INPUT_NAME}.message`)}
-            </FormErrorMessage>
-          )}
-        </FormControl>
-      </Box>
-      <Box>
-        {workflowStepCount >= 1 && (
-          <Box>
-            <FormLabel mb="0.75rem" textColor="secondary.700">
-              {t(
-                'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.label',
-              )}
-            </FormLabel>
-            <Skeleton isLoaded={!isLoading}>
-              <Controller
-                control={control}
-                name={STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME}
-                render={({
-                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                  field: { value, onBlur, ...rest },
-                }) => (
-                  <SingleSelect
-                    isDisabled={isLoading || isDisabled}
-                    placeholder={t(
-                      'features.adminForm.settings.emailNotifications.section.mrf.respondents.step1.placeholder',
-                    )}
-                    items={emailFieldItems}
-                    onBlur={handleSubmit(onSubmit)}
-                    isClearable
-                    value={value}
-                    {...rest}
-                  />
-                )}
-              />
-            </Skeleton>
-          </Box>
-        )}
-        {workflowStepCount >= 2 && (
-          <Box my="1.5rem">
-            <FormLabel mb="0.75rem" textColor="secondary.700">
-              {t(
-                isRedesign
-                  ? 'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overallRedesign'
-                  : 'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.overall',
-              )}
-            </FormLabel>
-            <Skeleton isLoaded={!isLoading}>
-              <Controller
-                control={control}
-                name={WORKFLOW_EMAIL_MULTISELECT_NAME}
-                render={({
-                  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                  field: { value: values = [], onChange, onBlur, ...rest },
-                }) => (
-                  <MultiSelect
-                    items={formWorkflowStepsWithStepNumber
-                      .filter((step) => step.stepNumber > 1)
-                      .map(({ step_name, stepNumber, _id: value }) => ({
-                        label:
-                          t(
-                            'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.each',
-                            { stepNumber },
-                          ) + (step_name ? ` (${step_name})` : ''),
-                        value,
-                      }))}
-                    values={values}
-                    onChange={onChange}
-                    onBlur={handleSubmit(onSubmit)}
-                    placeholder={
-                      isDisabled
-                        ? null
-                        : t(
-                            'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.placeholder',
-                          )
-                    }
-                    isSelectedItemFullWidth
-                    isDisabled={isLoading || isDisabled}
-                    {...rest}
-                  />
-                )}
-              />
-            </Skeleton>
-          </Box>
-        )}
-      </Box>
+      <MrfEmailRecipientsFieldGroup
+        control={control}
+        isDisabled={isDisabled}
+        isHighContrast={isHighContrast}
+        heading={
+          <Text textStyle="body-1" textColor="secondary.700" mb="1.5rem">
+            {sectionText}
+          </Text>
+        }
+        otherPartiesPlaceholder={otherPartiesEmailInputPlaceholder}
+        onOtherPartiesBlur={handleOtherPartiesEmailInputBlur}
+        onSelectBlur={handleSubmit(onSubmit)}
+      />
     </form>
   )
 }


### PR DESCRIPTION
## Problem

The three controls that pick who gets the MRF completion email live only in Settings → Email notifications. FRM-2495 needs the same three controls on the workflow builder tab, and rebuilding them there would let the two copies drift in wording, in validation, and in which controls appear at which workflow step count.

Groundwork for FRM-2495. No user-visible change.

## Solution

Lifts the three recipient controls out of `MrfFormEmailSection` into a `MrfEmailRecipientsFieldGroup` that both surfaces can render. Split into two commits: the first adds the group, the second points Settings at it.

Only the controls move. Everything that is Settings' own stays there — the form element, `useForm`, `onSubmit`, the mutation, the skip-if-unchanged guard and the email dedupe on blur.

Save behaviour is injected rather than baked in, because the two consumers commit at different moments: Settings submits on blur, and the card on the workflow tab will wait for a Save button. 

The group subscribes to form errors itself via `useFormState` instead of taking them as a prop. RHF's `formState` is a Proxy that only tracks what is read during render, so a consumer that forgot to read `errors` would silently pass stale ones.

## Alternatives considered

- **Duplicating the controls on the workflow tab.** Rejected. The two copies would drift, and the drift would be invisible: which controls appear depends on the workflow step count, and the Step 1 dropdown filters to email fields only. Both rules would have to be re-derived and kept in sync by hand.
- **Sharing via a hook, or a headless form model, instead of a component.** Rejected. The part that drifts is the JSX — labels, tooltips, the conditional rendering. A hook would still leave the markup duplicated in two places.
- **Moving the whole form, mutation included.** Rejected. That would force one save model on both surfaces, and they genuinely differ. Injecting the two blur callbacks is the smaller seam.
- **A neutral shared location instead of `settings/components/`.** Deferred. Settings is the honest home while the data is form settings, and `WorkflowContent` already imports `StatusTrackerToggle` from settings, so the import direction is established. Relocating it belongs with the wider card-chrome extraction, which is its own decision.

## Screenshots

None. This PR is a refactor with no visual change, and that is asserted rather than assumed — see Tests.

## Breaking Changes

No - backwards compatible. No API, schema or copy changes.

## Tests

Automated: none added; this is covered by the byte-identical verification below rather than by new unit tests.

Verified before opening: across the six existing MRF stories plus the email-mode story, the rendered DOM and the full-page screenshots are byte-identical before and after, and blur-to-save still fires exactly one PATCH to the same endpoint.

**TC1: MRF email notifications behave exactly as before**

- [ ] Settings → Email notifications on a private MRF form with 2+ steps shows all three controls
- [ ] Editing the "any email addresses you choose" field and clicking away saves, and a success toast appears
- [ ] Changing either dropdown and clicking away saves
- [ ] Entering an invalid address, then clicking away, drops it
- [ ] Entering the same address twice, then clicking away, keeps one

**TC2: fewer controls on shorter workflows**

- [ ] On an MRF form with one step, the "people who fill in a workflow step" dropdown is absent and the other two controls show
- [ ] On an MRF form with no steps, only the "any email addresses you choose" field shows, and the heading reads "…when a response has been submitted"

**TC3: nothing changed for other form types or states**

- [ ] Settings → Email notifications on an email-mode form is unchanged
- [ ] On a published MRF form the controls are still disabled, with the "close your form to new responses" message
- [ ] On a storage-mode form with payments connected, the payments message still shows
