### PR TITLE
feat(workflow): completion email card, read-only (2/3)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
@@ -1,5 +1,7 @@
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { Meta, StoryFn } from '@storybook/react'
 
+import { featureFlags } from 'formsg-shared/constants'
 import {
   AttachmentSize,
   BasicField,
@@ -8,11 +10,17 @@ import {
 import {
   AdminFormDto,
   FormResponseMode,
+  FormStatus,
   FormWorkflowStepDto,
+  MultirespondentFormSettings,
   WorkflowType,
 } from 'formsg-shared/types/form'
 
-import { createFormBuilderMocks } from '~/mocks/msw/handlers/admin-form'
+import {
+  createFormBuilderMocks,
+  getAdminFormSettings,
+  patchAdminFormSettings,
+} from '~/mocks/msw/handlers/admin-form'
 
 import { StoryRouter, viewports } from '~utils/storybook'
 
@@ -238,6 +246,10 @@ const FORM_WITH_WORKFLOW: Partial<AdminFormDto> = {
   workflow: [workflow_step_1, workflow_step_2],
 }
 
+const redesignOn = new GrowthBook({
+  features: { [featureFlags.workflowBuilderRedesign]: { defaultValue: true } },
+})
+
 const Template: StoryFn = () => <CreatePageWorkflowTab />
 export const NoWorkflow = Template.bind({})
 
@@ -366,6 +378,37 @@ Step2InvalidConditionalRecipientSelected.parameters = {
         ],
       }),
     },
+  },
+}
+
+// Paired with WithWorkflow to show the completion email seam in both flag
+// states: off keeps the inline message pointing at Settings, on replaces it
+// with the editable card.
+export const WithWorkflowRedesignOn = Template.bind({})
+WithWorkflowRedesignOn.decorators = [
+  (Story: StoryFn) => (
+    <GrowthBookProvider growthbook={redesignOn}>
+      <Story />
+    </GrowthBookProvider>
+  ),
+]
+WithWorkflowRedesignOn.parameters = {
+  msw: {
+    handlers: [
+      ...buildMswRoutes(FORM_WITH_WORKFLOW),
+      getAdminFormSettings({
+        mode: FormResponseMode.Multirespondent,
+        overrides: {
+          // The shared mock form is Public by default, which renders the MRF
+          // email controls read-only.
+          status: FormStatus.Private,
+          emails: ['admin@example.gov.sg'],
+          stepsToNotify: [workflow_step_2._id],
+          stepOneEmailNotificationFieldId: form_field_5._id,
+        } satisfies Partial<MultirespondentFormSettings>,
+      }),
+      patchAdminFormSettings({ mode: FormResponseMode.Multirespondent }),
+    ],
   },
 }
 

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
@@ -1,5 +1,6 @@
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { Meta, StoryFn } from '@storybook/react'
+import { http, HttpResponse } from 'msw'
 
 import { featureFlags } from 'formsg-shared/constants'
 import {
@@ -153,6 +154,27 @@ Loading.parameters = {
     description: {
       story:
         'The form resolves before its settings, so the divider, card frame and label are already in place while the recipient list is still on its way. Only the list is skeletoned.',
+    },
+  },
+}
+
+export const SettingsError = Template.bind({})
+SettingsError.storyName = 'Settings request failed'
+SettingsError.parameters = {
+  // Overridden inline rather than by teaching the shared settings handler about
+  // failures, which every other story would then carry.
+  msw: {
+    handlers: [
+      mocks(NOTHING_CONFIGURED)[0],
+      http.get('/api/v3/admin/forms/:formId/settings', () =>
+        HttpResponse.json({ message: 'Forbidden' }, { status: 403 }),
+      ),
+    ],
+  },
+  docs: {
+    description: {
+      story:
+        'With no recipients to summarise the card would skeleton indefinitely, since a failed request and one still in flight both leave the data undefined. Falls back to the message the flag-off path shows, so the admin still gets a working link to Settings.',
     },
   },
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
@@ -70,7 +70,10 @@ const redesignOn = new GrowthBook({
   features: { [featureFlags.workflowBuilderRedesign]: { defaultValue: true } },
 })
 
-const mocks = (settingsOverrides: Partial<MultirespondentFormSettings>) => [
+const mocks = (
+  settingsOverrides: Partial<MultirespondentFormSettings>,
+  settingsDelay: number | 'infinite' = 0,
+) => [
   getAdminFormView({
     mode: FormResponseMode.Multirespondent,
     overrides: {
@@ -80,6 +83,7 @@ const mocks = (settingsOverrides: Partial<MultirespondentFormSettings>) => [
   }),
   getAdminFormSettings({
     mode: FormResponseMode.Multirespondent,
+    delay: settingsDelay,
     overrides: {
       // The shared mock form is Public by default, which would render every
       // story read-only. Editable stories must say so explicitly.
@@ -137,6 +141,18 @@ InactiveConfigured.parameters = {
     description: {
       story:
         'Summarises all three recipient groups. Notified steps read in workflow order, not the order the ids happen to be stored in.',
+    },
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.storyName = 'Loading, settings not yet arrived'
+Loading.parameters = {
+  msw: { handlers: mocks(FULLY_CONFIGURED, 'infinite') },
+  docs: {
+    description: {
+      story:
+        'The form resolves before its settings, so the divider, card frame and label are already in place while the recipient list is still on its way. Only the list is skeletoned.',
     },
   },
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
@@ -1,0 +1,142 @@
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { featureFlags } from 'formsg-shared/constants'
+import {
+  BasicField,
+  FormFieldDto,
+  FormResponseMode,
+  FormWorkflowStepDto,
+  WorkflowType,
+} from 'formsg-shared/types'
+import {
+  FormStatus,
+  MultirespondentFormSettings,
+} from 'formsg-shared/types/form'
+
+import {
+  getAdminFormSettings,
+  getAdminFormView,
+} from '~/mocks/msw/handlers/admin-form'
+
+import { StoryRouter } from '~utils/storybook'
+
+import { CompletionEmailBlock } from './CompletionEmailBlock'
+
+const emailField: FormFieldDto = {
+  title: 'Your email',
+  description: '',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.Email,
+  _id: '617a262d4fa0850013d1568f',
+  autoReplyOptions: {
+    hasAutoReply: false,
+    autoReplySubject: '',
+    autoReplySender: '',
+    autoReplyMessage: '',
+    includeFormSummary: false,
+  },
+  isVerifiable: false,
+  hasAllowedEmailDomains: false,
+  allowedEmailDomains: [],
+}
+
+const yesNoField: FormFieldDto = {
+  title: 'Approve time off?',
+  description: '',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.YesNo,
+  _id: '620115cf3bc125001349f9c3',
+}
+
+const step1: FormWorkflowStepDto = {
+  _id: '61e6857c9c794b0012f1c6f8',
+  workflow_type: WorkflowType.Static,
+  emails: [],
+  edit: [emailField._id],
+}
+
+const step2: FormWorkflowStepDto = {
+  _id: '61e6857c9c794b0012f1c6f9',
+  workflow_type: WorkflowType.Static,
+  emails: ['approver@example.gov.sg'],
+  edit: [yesNoField._id],
+  step_name: 'Approver',
+}
+
+const redesignOn = new GrowthBook({
+  features: { [featureFlags.workflowBuilderRedesign]: { defaultValue: true } },
+})
+
+const mocks = (settingsOverrides: Partial<MultirespondentFormSettings>) => [
+  getAdminFormView({
+    mode: FormResponseMode.Multirespondent,
+    overrides: {
+      form_fields: [emailField, yesNoField],
+      workflow: [step1, step2],
+    },
+  }),
+  getAdminFormSettings({
+    mode: FormResponseMode.Multirespondent,
+    overrides: {
+      // The shared mock form is Public by default, which would render every
+      // story read-only. Editable stories must say so explicitly.
+      status: FormStatus.Private,
+      ...settingsOverrides,
+    },
+  }),
+]
+
+const NOTHING_CONFIGURED = {
+  emails: [],
+  stepsToNotify: [],
+  stepOneEmailNotificationFieldId: '',
+}
+
+const FULLY_CONFIGURED = {
+  emails: ['admin@example.gov.sg', 'records@example.gov.sg'],
+  stepsToNotify: [step2._id],
+  stepOneEmailNotificationFieldId: emailField._id,
+}
+
+export default {
+  component: CompletionEmailBlock,
+  title:
+    'Features/AdminForm/create/workflow/components/WorkflowContent/CompletionEmailBlock',
+  decorators: [
+    StoryRouter({ initialEntries: ['/12345'], path: '/:formId' }),
+    (Story: StoryFn) => (
+      <GrowthBookProvider growthbook={redesignOn}>
+        <Story />
+      </GrowthBookProvider>
+    ),
+  ],
+} as Meta
+
+const Template: StoryFn = () => <CompletionEmailBlock />
+
+export const InactiveEmpty = Template.bind({})
+InactiveEmpty.storyName = 'Inactive, nothing configured'
+InactiveEmpty.parameters = {
+  msw: { handlers: mocks(NOTHING_CONFIGURED) },
+  docs: {
+    description: {
+      story:
+        'The state every new MRF form starts in, since the recipient fields all default to empty. Shows the Settings instruction rather than an absence message.',
+    },
+  },
+}
+
+export const InactiveConfigured = Template.bind({})
+InactiveConfigured.storyName = 'Inactive, recipients configured'
+InactiveConfigured.parameters = {
+  msw: { handlers: mocks(FULLY_CONFIGURED) },
+  docs: {
+    description: {
+      story:
+        'Summarises all three recipient groups. Notified steps read in workflow order, not the order the ids happen to be stored in.',
+    },
+  },
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
@@ -1,0 +1,35 @@
+import { composeStories } from '@storybook/react'
+import { act, render, screen } from '@testing-library/react'
+
+import * as pageStories from '../../CreatePageWorkflowTab.stories'
+
+const { WithWorkflow, WithWorkflowRedesignOn } = composeStories(pageStories)
+
+const SETTINGS_LINK = /email notifications/i
+const DIVIDER = /end of workflow/i
+
+describe('completion email seam', () => {
+  // The flag-off path must stay exactly as it was: an inline message pointing
+  // at Settings, with no trace of the new card.
+  it('keeps the Settings inline message when the redesign flag is off', async () => {
+    await act(async () => {
+      render(<WithWorkflow />)
+    })
+
+    expect(
+      await screen.findByRole('link', { name: SETTINGS_LINK }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(DIVIDER)).not.toBeInTheDocument()
+  })
+
+  it('replaces the inline message with the card when the flag is on', async () => {
+    await act(async () => {
+      render(<WithWorkflowRedesignOn />)
+    })
+
+    expect(await screen.findByText(DIVIDER)).toBeInTheDocument()
+    expect(
+      screen.queryByRole('link', { name: SETTINGS_LINK }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
@@ -3,7 +3,10 @@ import { act, render, screen } from '@testing-library/react'
 
 import * as pageStories from '../../CreatePageWorkflowTab.stories'
 
+import * as blockStories from './CompletionEmailBlock.stories'
+
 const { WithWorkflow, WithWorkflowRedesignOn } = composeStories(pageStories)
+const { SettingsError } = composeStories(blockStories)
 
 const SETTINGS_LINK = /email notifications/i
 const DIVIDER = /end of workflow/i
@@ -31,5 +34,18 @@ describe('completion email seam', () => {
     expect(
       screen.queryByRole('link', { name: SETTINGS_LINK }),
     ).not.toBeInTheDocument()
+  })
+  // A failed settings request leaves `data` undefined, exactly as one still in
+  // flight does, so the card would otherwise skeleton with no error and no
+  // retry. The fallback keeps a working route to Settings.
+  it('falls back to the Settings message when the settings request fails', async () => {
+    await act(async () => {
+      render(<SettingsError />)
+    })
+
+    expect(
+      await screen.findByRole('link', { name: SETTINGS_LINK }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(DIVIDER)).not.toBeInTheDocument()
   })
 })

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
@@ -33,9 +33,10 @@ export const CompletionEmailBlock = (): JSX.Element | null => {
   const mrfSettings: MultirespondentFormSettings | undefined = settings
 
   // Settings are a separate query from the form, so they can arrive after the
-  // steps. Undefined recipients tell the card to hold its frame and skeleton
-  // the list, rather than the whole block appearing a beat late.
-  // StatusTrackerToggle, which reads the same query on this tab, does the same.
+  // steps. Null recipients tell the card to hold its frame and skeleton the
+  // list, rather than the whole block appearing a beat late. StatusTrackerToggle
+  // reads the same query on this tab and also skeletons rather than returning
+  // null, though it wraps its whole control instead of holding a frame.
   const recipients = mrfSettings
     ? getCompletionEmailRecipients({
         emails: mrfSettings.emails,
@@ -46,7 +47,7 @@ export const CompletionEmailBlock = (): JSX.Element | null => {
         workflowSteps: formWorkflow ?? [],
         emailFormFields,
       })
-    : undefined
+    : null
 
   return (
     <Stack spacing="1.5rem">

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
@@ -50,7 +50,11 @@ export const CompletionEmailBlock = (): JSX.Element | null => {
     : null
 
   return (
-    <Stack spacing="1.5rem">
+    // Measured: only 16px sits below this card today, from the tab's own
+    // `md: '1rem'` padding. These add to that for 64px on desktop and 48px on
+    // mobile. On this Stack rather than a shared container so the flag-off
+    // path stays untouched.
+    <Stack spacing="1.5rem" pb={{ base: '1rem', md: '3rem' }}>
       <EndOfWorkflowDivider />
       <InactiveCompletionEmailCard recipients={recipients} />
     </Stack>

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
@@ -1,0 +1,51 @@
+import { Stack } from '@chakra-ui/react'
+
+import {
+  FormResponseMode,
+  MultirespondentFormSettings,
+} from 'formsg-shared/types/form'
+
+import { useAdminFormSettings } from '~features/admin-form/settings/queries'
+
+import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
+
+import { getCompletionEmailRecipients } from './utils/getCompletionEmailRecipients'
+import { EndOfWorkflowDivider } from './EndOfWorkflowDivider'
+import { InactiveCompletionEmailCard } from './InactiveCompletionEmailCard'
+
+/**
+ * The completion email as a card at the end of the workflow, replacing the
+ * inline message that used to point admins at Settings.
+ *
+ * Rendered only when the redesign flag is on and the workflow has at least one
+ * step; both conditions are the caller's, inherited from where the inline
+ * message used to sit.
+ */
+export const CompletionEmailBlock = (): JSX.Element | null => {
+  const { data: settings } = useAdminFormSettings()
+  const { formWorkflow, emailFormFields } = useAdminFormWorkflow()
+
+  // Settings load separately from the form, so the card waits rather than
+  // rendering with no recipients and then filling in.
+  if (!settings || settings.responseMode !== FormResponseMode.Multirespondent) {
+    return null
+  }
+  const mrfSettings: MultirespondentFormSettings = settings
+
+  const recipients = getCompletionEmailRecipients({
+    emails: mrfSettings.emails,
+    // Defaults to '' in the model, but the settings type still has it optional.
+    stepOneEmailNotificationFieldId:
+      mrfSettings.stepOneEmailNotificationFieldId ?? '',
+    stepsToNotify: mrfSettings.stepsToNotify,
+    workflowSteps: formWorkflow ?? [],
+    emailFormFields,
+  })
+
+  return (
+    <Stack spacing="1.5rem">
+      <EndOfWorkflowDivider />
+      <InactiveCompletionEmailCard recipients={recipients} />
+    </Stack>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
@@ -25,22 +25,28 @@ export const CompletionEmailBlock = (): JSX.Element | null => {
   const { data: settings } = useAdminFormSettings()
   const { formWorkflow, emailFormFields } = useAdminFormWorkflow()
 
-  // Settings load separately from the form, so the card waits rather than
-  // rendering with no recipients and then filling in.
-  if (!settings || settings.responseMode !== FormResponseMode.Multirespondent) {
+  // Not an MRF form, so the card does not apply at all. Unreachable from the
+  // workflow tab, which only exists on MRF forms, but it narrows the union.
+  if (settings && settings.responseMode !== FormResponseMode.Multirespondent) {
     return null
   }
-  const mrfSettings: MultirespondentFormSettings = settings
+  const mrfSettings: MultirespondentFormSettings | undefined = settings
 
-  const recipients = getCompletionEmailRecipients({
-    emails: mrfSettings.emails,
-    // Defaults to '' in the model, but the settings type still has it optional.
-    stepOneEmailNotificationFieldId:
-      mrfSettings.stepOneEmailNotificationFieldId ?? '',
-    stepsToNotify: mrfSettings.stepsToNotify,
-    workflowSteps: formWorkflow ?? [],
-    emailFormFields,
-  })
+  // Settings are a separate query from the form, so they can arrive after the
+  // steps. Undefined recipients tell the card to hold its frame and skeleton
+  // the list, rather than the whole block appearing a beat late.
+  // StatusTrackerToggle, which reads the same query on this tab, does the same.
+  const recipients = mrfSettings
+    ? getCompletionEmailRecipients({
+        emails: mrfSettings.emails,
+        // Defaults to '' in the model, but the settings type has it optional.
+        stepOneEmailNotificationFieldId:
+          mrfSettings.stepOneEmailNotificationFieldId ?? '',
+        stepsToNotify: mrfSettings.stepsToNotify,
+        workflowSteps: formWorkflow ?? [],
+        emailFormFields,
+      })
+    : undefined
 
   return (
     <Stack spacing="1.5rem">

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
@@ -12,6 +12,7 @@ import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
 import { getCompletionEmailRecipients } from './utils/getCompletionEmailRecipients'
 import { EndOfWorkflowDivider } from './EndOfWorkflowDivider'
 import { InactiveCompletionEmailCard } from './InactiveCompletionEmailCard'
+import { WorkflowCompletionMessageBlock } from './WorkflowCompletionMessageBlock'
 
 /**
  * The completion email as a card at the end of the workflow, replacing the
@@ -22,7 +23,7 @@ import { InactiveCompletionEmailCard } from './InactiveCompletionEmailCard'
  * message used to sit.
  */
 export const CompletionEmailBlock = (): JSX.Element | null => {
-  const { data: settings } = useAdminFormSettings()
+  const { data: settings, isError } = useAdminFormSettings()
   const { formWorkflow, emailFormFields } = useAdminFormWorkflow()
 
   // Not an MRF form, so the card does not apply at all. Unreachable from the
@@ -48,6 +49,19 @@ export const CompletionEmailBlock = (): JSX.Element | null => {
         emailFormFields,
       })
     : null
+
+  // Settings failed rather than merely arrived late. `data` is undefined for
+  // both a request in flight and a failed one, so without this the card reads
+  // the failure as loading and skeletons indefinitely, with no error and no
+  // retry. Falls back to the message the flag-off path shows, which keeps a
+  // working link to Settings and needs no new copy.
+  //
+  // Gated on `recipients` too, not `isError` alone: react-query keeps the last
+  // successful `data` when a refetch fails, and a stale summary is more use
+  // than the fallback.
+  if (!recipients && isError) {
+    return <WorkflowCompletionMessageBlock />
+  }
 
   return (
     // Measured: only 16px sits below this card today, from the tab's own

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailLabel.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailLabel.tsx
@@ -16,9 +16,13 @@ export const CompletionEmailLabel = (): JSX.Element => {
       alignItems="center"
       textStyle="subhead-3"
     >
+      {/* Measured against StepLabel's number box, which renders 44.51 x 42px:
+      42px tall from 0.5rem padding + subhead-3's 1.5rem line box + 1px borders,
+      and glyph-driven in width. Padding here would size to the icon instead
+      (54 x 38px), so the box is set square to that measured height. */}
       <Flex
-        py="0.5rem"
-        px="1rem"
+        boxSize="2.625rem"
+        flexShrink={0}
         borderWidth="1px"
         borderColor="secondary.300"
         borderRadius="4px"

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailLabel.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailLabel.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from 'react-i18next'
+import { BiEnvelope } from 'react-icons/bi'
+import { Flex, Icon, Stack, Text } from '@chakra-ui/react'
+
+/**
+ * Header for the completion email card. Mirrors StepLabel's shape so the card
+ * sits in the same rhythm as the step cards above it, with an envelope in place
+ * of the step number.
+ */
+export const CompletionEmailLabel = (): JSX.Element => {
+  const { t } = useTranslation()
+  return (
+    <Stack
+      direction="row"
+      spacing="1.5rem"
+      alignItems="center"
+      textStyle="subhead-3"
+    >
+      <Flex
+        py="0.5rem"
+        px="1rem"
+        borderWidth="1px"
+        borderColor="secondary.300"
+        borderRadius="4px"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Icon as={BiEnvelope} aria-hidden fontSize="1.25rem" />
+      </Flex>
+      <Flex direction="row">
+        <Text>
+          {t('features.adminForm.sidebar.workflow.completionEmail.title')}
+        </Text>
+      </Flex>
+    </Stack>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EndOfWorkflowDivider.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EndOfWorkflowDivider.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from 'react-i18next'
+import { Divider, Flex, Text } from '@chakra-ui/react'
+
+/**
+ * Labelled boundary between the last workflow step and the completion email
+ * card. Without it the card reads as one more step rather than as what happens
+ * after the workflow ends.
+ */
+export const EndOfWorkflowDivider = (): JSX.Element => {
+  const { t } = useTranslation()
+  return (
+    <Flex align="center" gap="1rem">
+      <Divider borderColor="secondary.200" borderBottomWidth="2px" />
+      <Text
+        textStyle="caption-1"
+        color="secondary.400"
+        whiteSpace="nowrap"
+        letterSpacing="0.08em"
+      >
+        {t('features.adminForm.sidebar.workflow.completionEmail.divider')}
+      </Text>
+      <Divider borderColor="secondary.200" borderBottomWidth="2px" />
+    </Flex>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EndOfWorkflowDivider.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EndOfWorkflowDivider.tsx
@@ -11,12 +11,13 @@ export const EndOfWorkflowDivider = (): JSX.Element => {
   return (
     <Flex align="center" gap="1rem">
       <Divider borderColor="secondary.200" borderBottomWidth="2px" />
-      <Text
-        textStyle="caption-1"
-        color="secondary.400"
-        whiteSpace="nowrap"
-        letterSpacing="0.08em"
-      >
+      {/* subhead-3 to match the step card headers this sits between; it also
+      carries letterSpacing 0.08em, so no hand-written prop.
+
+      Colour stays recessed toward the rules rather than matching them: the
+      rules' own secondary.200 measures 1.33:1 on this background, against the
+      4.5:1 AA needs for 14px/600 text. secondary.400 is 4.60:1. */}
+      <Text textStyle="subhead-3" color="secondary.400" whiteSpace="nowrap">
         {t('features.adminForm.sidebar.workflow.completionEmail.divider')}
       </Text>
       <Divider borderColor="secondary.200" borderBottomWidth="2px" />

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from 'react-i18next'
-import { Box, Skeleton, Stack, Text } from '@chakra-ui/react'
+import { Box, Flex, Skeleton, Stack, Text } from '@chakra-ui/react'
+
+import { LogicBadge } from '~features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/LogicBadge'
 
 import {
   formatEmailFieldLabel,
@@ -97,14 +99,25 @@ export const InactiveCompletionEmailCard = ({
         ) : (
           <Stack spacing="1.5rem">
             {groups.map(({ id, label, values }) => (
-              <Stack key={id} spacing="0.25rem">
+              // Bare Stack, so the label-to-chips gap is Chakra's 0.5rem
+              // default, the same as InactiveStepBlock's respondent block.
+              <Stack key={id}>
                 <Text textStyle="subhead-3">{label}</Text>
-                {/* Values are unique within a group: emails are deduplicated in
-                    the helper, step labels carry their step number, and step 1
-                    is a single value. */}
-                {values.map((value) => (
-                  <Text key={value}>{value}</Text>
-                ))}
+                {/* Chip row copied from InactiveStepBlock's respondent badges
+                    rather than approximated, so both cards lay recipients out
+                    identically. Values are unique within a group: emails are
+                    deduplicated in the helper, step labels carry their step
+                    number, and step 1 is a single value. */}
+                <Flex
+                  flexDir={{ base: 'column', md: 'row' }}
+                  gap={{ base: '0.5rem', md: '1rem' }}
+                  rowGap={{ md: '0.5rem' }}
+                  wrap="wrap"
+                >
+                  {values.map((value) => (
+                    <LogicBadge key={value}>{value}</LogicBadge>
+                  ))}
+                </Flex>
               </Stack>
             ))}
           </Stack>

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -1,6 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import { Box, Skeleton, Stack, Text } from '@chakra-ui/react'
 
+import {
+  formatEmailFieldLabel,
+  formatNotifiedStepLabel,
+} from './utils/completionEmailLabels'
 import { CompletionEmailRecipients } from './utils/getCompletionEmailRecipients'
 import { CompletionEmailLabel } from './CompletionEmailLabel'
 
@@ -45,20 +49,14 @@ export const InactiveCompletionEmailCard = ({
           id: 'step1',
           label: t(`${PREFIX}.step1.label`),
           values: recipients.stepOneField
-            ? [
-                recipients.stepOneField.questionNumber
-                  ? `${recipients.stepOneField.questionNumber}. ${recipients.stepOneField.title}`
-                  : recipients.stepOneField.title,
-              ]
+            ? [formatEmailFieldLabel(recipients.stepOneField)]
             : [],
         },
         {
           id: 'stepN',
           label: t(`${PREFIX}.stepN.label.overallRedesign`),
-          values: recipients.notifiedSteps.map(
-            ({ stepNumber, stepName }) =>
-              t(`${PREFIX}.stepN.label.each`, { stepNumber }) +
-              (stepName ? ` (${stepName})` : ''),
+          values: recipients.notifiedSteps.map((step) =>
+            formatNotifiedStepLabel(t, step),
           ),
         },
       ].filter(({ values }) => values.length > 0)

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import { Box, Stack, Text } from '@chakra-ui/react'
+import { Box, Skeleton, Stack, Text } from '@chakra-ui/react'
 
 import { CompletionEmailRecipients } from './utils/getCompletionEmailRecipients'
 import { CompletionEmailLabel } from './CompletionEmailLabel'
@@ -8,7 +8,8 @@ const PREFIX =
   'features.adminForm.settings.emailNotifications.section.mrf.respondents'
 
 export interface InactiveCompletionEmailCardProps {
-  recipients: CompletionEmailRecipients
+  /** Undefined while the settings query is still in flight. */
+  recipients?: CompletionEmailRecipients
 }
 
 /**
@@ -22,7 +23,6 @@ export const InactiveCompletionEmailCard = ({
   recipients,
 }: InactiveCompletionEmailCardProps): JSX.Element => {
   const { t } = useTranslation()
-  const { otherParties, stepOneField, notifiedSteps, isEmpty } = recipients
 
   // One group per control in the expanded card, same order, same labels, so the
   // two views cannot describe the same settings differently. Every label is
@@ -30,29 +30,35 @@ export const InactiveCompletionEmailCard = ({
   //
   // Keyed on `id` rather than `label`: labels are translated, so they are not
   // ours to guarantee unique.
-  const groups = [
-    { id: 'others', label: t(`${PREFIX}.others.label`), values: otherParties },
-    {
-      id: 'step1',
-      label: t(`${PREFIX}.step1.label`),
-      values: stepOneField
-        ? [
-            stepOneField.questionNumber
-              ? `${stepOneField.questionNumber}. ${stepOneField.title}`
-              : stepOneField.title,
-          ]
-        : [],
-    },
-    {
-      id: 'stepN',
-      label: t(`${PREFIX}.stepN.label.overallRedesign`),
-      values: notifiedSteps.map(
-        ({ stepNumber, stepName }) =>
-          t(`${PREFIX}.stepN.label.each`, { stepNumber }) +
-          (stepName ? ` (${stepName})` : ''),
-      ),
-    },
-  ].filter(({ values }) => values.length > 0)
+  const groups = recipients
+    ? [
+        {
+          id: 'others',
+          label: t(`${PREFIX}.others.label`),
+          values: recipients.otherParties,
+        },
+        {
+          id: 'step1',
+          label: t(`${PREFIX}.step1.label`),
+          values: recipients.stepOneField
+            ? [
+                recipients.stepOneField.questionNumber
+                  ? `${recipients.stepOneField.questionNumber}. ${recipients.stepOneField.title}`
+                  : recipients.stepOneField.title,
+              ]
+            : [],
+        },
+        {
+          id: 'stepN',
+          label: t(`${PREFIX}.stepN.label.overallRedesign`),
+          values: recipients.notifiedSteps.map(
+            ({ stepNumber, stepName }) =>
+              t(`${PREFIX}.stepN.label.each`, { stepNumber }) +
+              (stepName ? ` (${stepName})` : ''),
+          ),
+        },
+      ].filter(({ values }) => values.length > 0)
+    : []
 
   return (
     <Box
@@ -67,7 +73,17 @@ export const InactiveCompletionEmailCard = ({
       <Stack spacing="1.5rem" p={{ base: '1.5rem', md: '2rem' }}>
         <CompletionEmailLabel />
 
-        {isEmpty ? (
+        {!recipients ? (
+          // Settings arrive after the form, so the card holds its frame and
+          // label rather than the whole block appearing late. Sized bars rather
+          // than a <Skeleton isLoaded> wrapper because the loaded content has
+          // two different shapes, and neither is honest to size a placeholder
+          // against.
+          <Stack spacing="0.25rem">
+            <Skeleton h="1.5rem" w="60%" />
+            <Skeleton h="1.5rem" w="40%" />
+          </Stack>
+        ) : recipients.isEmpty ? (
           // Reuses the Settings instruction rather than an absence message:
           // this is the state every new form starts in, so it should tell the
           // admin what to do next.

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -8,8 +8,12 @@ const PREFIX =
   'features.adminForm.settings.emailNotifications.section.mrf.respondents'
 
 export interface InactiveCompletionEmailCardProps {
-  /** Undefined while the settings query is still in flight. */
-  recipients?: CompletionEmailRecipients
+  /**
+   * Null while the settings query is still in flight. Required rather than
+   * optional so that omitting it is a type error instead of a card that
+   * skeletons forever.
+   */
+  recipients: CompletionEmailRecipients | null
 }
 
 /**
@@ -97,10 +101,11 @@ export const InactiveCompletionEmailCard = ({
             {groups.map(({ id, label, values }) => (
               <Stack key={id} spacing="0.25rem">
                 <Text textStyle="subhead-3">{label}</Text>
-                {/* Emails are deduplicated on entry but not in storage, so the
-                    index keeps the key unique for data written before that. */}
-                {values.map((value, index) => (
-                  <Text key={`${value}-${index}`}>{value}</Text>
+                {/* Values are unique within a group: emails are deduplicated in
+                    the helper, step labels carry their step number, and step 1
+                    is a single value. */}
+                {values.map((value) => (
+                  <Text key={value}>{value}</Text>
                 ))}
               </Stack>
             ))}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -27,9 +27,13 @@ export const InactiveCompletionEmailCard = ({
   // One group per control in the expanded card, same order, same labels, so the
   // two views cannot describe the same settings differently. Every label is
   // Settings' own string; none of this copy is new.
+  //
+  // Keyed on `id` rather than `label`: labels are translated, so they are not
+  // ours to guarantee unique.
   const groups = [
-    { label: t(`${PREFIX}.others.label`), values: otherParties },
+    { id: 'others', label: t(`${PREFIX}.others.label`), values: otherParties },
     {
+      id: 'step1',
       label: t(`${PREFIX}.step1.label`),
       values: stepOneField
         ? [
@@ -40,6 +44,7 @@ export const InactiveCompletionEmailCard = ({
         : [],
     },
     {
+      id: 'stepN',
       label: t(`${PREFIX}.stepN.label.overallRedesign`),
       values: notifiedSteps.map(
         ({ stepNumber, stepName }) =>
@@ -73,11 +78,13 @@ export const InactiveCompletionEmailCard = ({
           </Text>
         ) : (
           <Stack spacing="1.5rem">
-            {groups.map(({ label, values }) => (
-              <Stack key={label} spacing="0.25rem">
+            {groups.map(({ id, label, values }) => (
+              <Stack key={id} spacing="0.25rem">
                 <Text textStyle="subhead-3">{label}</Text>
-                {values.map((value) => (
-                  <Text key={value}>{value}</Text>
+                {/* Emails are deduplicated on entry but not in storage, so the
+                    index keeps the key unique for data written before that. */}
+                {values.map((value, index) => (
+                  <Text key={`${value}-${index}`}>{value}</Text>
                 ))}
               </Stack>
             ))}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -18,6 +18,9 @@ export interface InactiveCompletionEmailCardProps {
    * Null while the settings query is still in flight. Required rather than
    * optional so that omitting it is a type error instead of a card that
    * skeletons forever.
+   *
+   * A failed query is not this component's to represent: the caller renders the
+   * flag-off message instead of the card, so null here only ever means loading.
    */
   recipients: CompletionEmailRecipients | null
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -1,0 +1,89 @@
+import { useTranslation } from 'react-i18next'
+import { Box, Stack, Text } from '@chakra-ui/react'
+
+import { CompletionEmailRecipients } from './utils/getCompletionEmailRecipients'
+import { CompletionEmailLabel } from './CompletionEmailLabel'
+
+const PREFIX =
+  'features.adminForm.settings.emailNotifications.section.mrf.respondents'
+
+export interface InactiveCompletionEmailCardProps {
+  recipients: CompletionEmailRecipients
+}
+
+/**
+ * Collapsed completion email card: a summary of who gets notified, or an
+ * instruction to pick someone when nothing is configured yet.
+ *
+ * Read-only for now. Chrome matches InactiveStepBlock's resting state; the
+ * click target, hover affordance and pencil arrive with the editable card.
+ */
+export const InactiveCompletionEmailCard = ({
+  recipients,
+}: InactiveCompletionEmailCardProps): JSX.Element => {
+  const { t } = useTranslation()
+  const { otherParties, stepOneField, notifiedSteps, isEmpty } = recipients
+
+  // One group per control in the expanded card, same order, same labels, so the
+  // two views cannot describe the same settings differently. Every label is
+  // Settings' own string; none of this copy is new.
+  const groups = [
+    { label: t(`${PREFIX}.others.label`), values: otherParties },
+    {
+      label: t(`${PREFIX}.step1.label`),
+      values: stepOneField
+        ? [
+            stepOneField.questionNumber
+              ? `${stepOneField.questionNumber}. ${stepOneField.title}`
+              : stepOneField.title,
+          ]
+        : [],
+    },
+    {
+      label: t(`${PREFIX}.stepN.label.overallRedesign`),
+      values: notifiedSteps.map(
+        ({ stepNumber, stepName }) =>
+          t(`${PREFIX}.stepN.label.each`, { stepNumber }) +
+          (stepName ? ` (${stepName})` : ''),
+      ),
+    },
+  ].filter(({ values }) => values.length > 0)
+
+  return (
+    <Box
+      w="100%"
+      borderRadius="4px"
+      bg="white"
+      border="1px solid"
+      borderColor="neutral.300"
+      transitionProperty="common"
+      transitionDuration="normal"
+    >
+      <Stack spacing="1.5rem" p={{ base: '1.5rem', md: '2rem' }}>
+        <CompletionEmailLabel />
+
+        {isEmpty ? (
+          // Reuses the Settings instruction rather than an absence message:
+          // this is the state every new form starts in, so it should tell the
+          // admin what to do next.
+          <Text color="secondary.400">
+            {t(
+              'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientWorkflow',
+            )}
+          </Text>
+        ) : (
+          <Stack spacing="1.5rem">
+            {groups.map(({ label, values }) => (
+              <Stack key={label} spacing="0.25rem">
+                <Text textStyle="subhead-3">{label}</Text>
+                {values.map((value) => (
+                  <Text key={value}>{value}</Text>
+                ))}
+              </Stack>
+            ))}
+          </Stack>
+        )}
+      </Stack>
+    </Box>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowCompletionMessageBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowCompletionMessageBlock.tsx
@@ -4,19 +4,16 @@ import { Link, Text } from '@chakra-ui/react'
 
 import InlineMessage from '~components/InlineMessage'
 
-import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
-
 export const WorkflowCompletionMessageBlock = (): JSX.Element => {
   const { t } = useTranslation()
-  const isRedesign = useIsWorkflowBuilderRedesign()
-  const { prefix, prefixRedesign, link, suffix } = t(
+  const { prefix, link, suffix } = t(
     'features.adminForm.sidebar.workflow.approvals.complete',
     { returnObjects: true },
   )
   return (
     <InlineMessage variant="info">
       <Text>
-        {isRedesign ? prefixRedesign : prefix}{' '}
+        {prefix}{' '}
         <Link as={ReactLink} to={'settings/email-notifications'}>
           {link}
         </Link>

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -5,13 +5,16 @@ import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
 import { StatusTrackerToggle } from '~features/admin-form/settings/components/EmailNotificationsSection/StatusTrackerToggle'
 
 import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
+import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
 
+import { CompletionEmailBlock } from './CompletionEmailBlock'
 import { NewStepBlock } from './NewStepBlock'
 import { WorkflowBlockFactory } from './WorkflowBlockFactory'
 import { WorkflowCompletionMessageBlock } from './WorkflowCompletionMessageBlock'
 
 export const WorkflowContent = (): JSX.Element | null => {
   const { formWorkflow, isLoading } = useAdminFormWorkflow()
+  const isRedesign = useIsWorkflowBuilderRedesign()
 
   if (isLoading) return null
   return (
@@ -38,7 +41,13 @@ export const WorkflowContent = (): JSX.Element | null => {
         ))}
         <NewStepBlock />
       </Stack>
-      {formWorkflow?.length ? <WorkflowCompletionMessageBlock /> : null}
+      {formWorkflow?.length ? (
+        isRedesign ? (
+          <CompletionEmailBlock />
+        ) : (
+          <WorkflowCompletionMessageBlock />
+        )
+      ) : null}
     </Stack>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/completionEmailLabels.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/completionEmailLabels.test.ts
@@ -1,0 +1,34 @@
+import { TFunction } from 'i18next'
+
+import {
+  formatEmailFieldLabel,
+  formatNotifiedStepLabel,
+} from './completionEmailLabels'
+
+// Stands in for i18n so the composition is testable without a provider.
+const t = ((_key: string, { stepNumber }: { stepNumber: number }) =>
+  `Step ${stepNumber}`) as unknown as TFunction
+
+describe('formatEmailFieldLabel', () => {
+  it('should prefix the question number when the field has one', () => {
+    expect(
+      formatEmailFieldLabel({ questionNumber: 2, title: 'Your email' }),
+    ).toBe('2. Your email')
+  })
+
+  it('should fall back to the bare title when there is no question number', () => {
+    expect(formatEmailFieldLabel({ title: 'Your email' })).toBe('Your email')
+  })
+})
+
+describe('formatNotifiedStepLabel', () => {
+  it('should append the step name in brackets when the step is named', () => {
+    expect(
+      formatNotifiedStepLabel(t, { stepNumber: 2, stepName: 'Approver' }),
+    ).toBe('Step 2 (Approver)')
+  })
+
+  it('should return the step alone when it is unnamed', () => {
+    expect(formatNotifiedStepLabel(t, { stepNumber: 3 })).toBe('Step 3')
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/completionEmailLabels.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/completionEmailLabels.ts
@@ -1,0 +1,33 @@
+import { TFunction } from 'i18next'
+
+/**
+ * The two composed labels the completion email views show for a recipient.
+ *
+ * Kept here rather than at each call site because the card's summary and
+ * Settings' controls have to describe the same setting the same way, and only
+ * one implementation can enforce that. Separate from
+ * getCompletionEmailRecipients so that module stays free of i18n.
+ */
+
+const STEP_N_EACH_KEY =
+  'features.adminForm.settings.emailNotifications.section.mrf.respondents.stepN.label.each'
+
+/**
+ * An email field, as "2. Your email". Falls back to the bare title when the
+ * field has no question number, which Settings' own option list does not guard
+ * against.
+ */
+export const formatEmailFieldLabel = ({
+  questionNumber,
+  title,
+}: {
+  questionNumber?: number
+  title: string
+}): string => (questionNumber ? `${questionNumber}. ${title}` : title)
+
+/** A notified step, as "Step 2", or "Step 2 (Approver)" when it is named. */
+export const formatNotifiedStepLabel = (
+  t: TFunction,
+  { stepNumber, stepName }: { stepNumber: number; stepName?: string },
+): string =>
+  t(STEP_N_EACH_KEY, { stepNumber }) + (stepName ? ` (${stepName})` : '')

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/getCompletionEmailRecipients.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/getCompletionEmailRecipients.test.ts
@@ -71,6 +71,19 @@ describe('getCompletionEmailRecipients', () => {
     ).toEqual(['zoe@example.gov.sg', 'amir@example.gov.sg'])
   })
 
+  it('should drop duplicate other parties, keeping the first occurrence', () => {
+    expect(
+      getCompletionEmailRecipients({
+        ...EMPTY,
+        emails: [
+          'zoe@example.gov.sg',
+          'amir@example.gov.sg',
+          'zoe@example.gov.sg',
+        ],
+      }).otherParties,
+    ).toEqual(['zoe@example.gov.sg', 'amir@example.gov.sg'])
+  })
+
   it('should resolve the step 1 field to its question number and title', () => {
     expect(
       getCompletionEmailRecipients({

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/getCompletionEmailRecipients.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/getCompletionEmailRecipients.test.ts
@@ -1,0 +1,97 @@
+import { getCompletionEmailRecipients } from './getCompletionEmailRecipients'
+
+const EMPTY = {
+  emails: [],
+  stepOneEmailNotificationFieldId: '',
+  stepsToNotify: [],
+  workflowSteps: [],
+  emailFormFields: [],
+}
+
+// Step 2 is the only named one, so the tests can tell naming from numbering.
+const WORKFLOW_STEPS = [
+  { _id: 'step1' },
+  { _id: 'step2', step_name: 'Approver' },
+  { _id: 'step3' },
+]
+
+const EMAIL_FIELDS = [{ _id: 'fieldA', questionNumber: 2, title: 'Your email' }]
+
+describe('getCompletionEmailRecipients', () => {
+  it('should report empty when nothing is configured', () => {
+    expect(getCompletionEmailRecipients(EMPTY)).toEqual({
+      otherParties: [],
+      stepOneField: null,
+      notifiedSteps: [],
+      isEmpty: true,
+    })
+  })
+
+  it('should not report empty when any one group is configured', () => {
+    const configured = [
+      { ...EMPTY, emails: ['a@example.gov.sg'] },
+      {
+        ...EMPTY,
+        stepOneEmailNotificationFieldId: 'fieldA',
+        emailFormFields: EMAIL_FIELDS,
+      },
+      { ...EMPTY, stepsToNotify: ['step2'], workflowSteps: WORKFLOW_STEPS },
+    ]
+
+    configured.forEach((input) =>
+      expect(getCompletionEmailRecipients(input).isEmpty).toBe(false),
+    )
+  })
+
+  it('should report empty when the only configured values no longer resolve', () => {
+    // A deleted field and a deleted step leave nothing to show, so the card
+    // must fall back to its empty state rather than render blank groups.
+    const result = getCompletionEmailRecipients({
+      ...EMPTY,
+      stepOneEmailNotificationFieldId: 'deletedField',
+      stepsToNotify: ['deletedStep'],
+      workflowSteps: WORKFLOW_STEPS,
+      emailFormFields: EMAIL_FIELDS,
+    })
+
+    expect(result).toEqual({
+      otherParties: [],
+      stepOneField: null,
+      notifiedSteps: [],
+      isEmpty: true,
+    })
+  })
+
+  it('should keep other parties in stored order and drop empty entries', () => {
+    expect(
+      getCompletionEmailRecipients({
+        ...EMPTY,
+        emails: ['zoe@example.gov.sg', '', 'amir@example.gov.sg'],
+      }).otherParties,
+    ).toEqual(['zoe@example.gov.sg', 'amir@example.gov.sg'])
+  })
+
+  it('should resolve the step 1 field to its question number and title', () => {
+    expect(
+      getCompletionEmailRecipients({
+        ...EMPTY,
+        stepOneEmailNotificationFieldId: 'fieldA',
+        emailFormFields: EMAIL_FIELDS,
+      }).stepOneField,
+    ).toEqual({ questionNumber: 2, title: 'Your email' })
+  })
+
+  it('should read notified steps in workflow order, carrying any step name', () => {
+    expect(
+      getCompletionEmailRecipients({
+        ...EMPTY,
+        // Deliberately out of order, and including a since-deleted step.
+        stepsToNotify: ['step3', 'deletedStep', 'step2'],
+        workflowSteps: WORKFLOW_STEPS,
+      }).notifiedSteps,
+    ).toEqual([
+      { stepNumber: 2, stepName: 'Approver' },
+      { stepNumber: 3, stepName: undefined },
+    ])
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/getCompletionEmailRecipients.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/getCompletionEmailRecipients.ts
@@ -33,7 +33,10 @@ export const getCompletionEmailRecipients = ({
   workflowSteps,
   emailFormFields,
 }: CompletionEmailRecipientsInput): CompletionEmailRecipients => {
-  const otherParties = emails.filter(Boolean)
+  // Compacted and deduplicated: the tag input blocks repeats on entry, but
+  // nothing dedupes what is already stored, and an admin should not be shown
+  // the same address twice.
+  const otherParties = [...new Set(emails.filter(Boolean))]
 
   // A field or step since deleted resolves away rather than showing a dangling
   // id. Settings drops them from its options for the same reason.

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/getCompletionEmailRecipients.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/utils/getCompletionEmailRecipients.ts
@@ -1,0 +1,66 @@
+/**
+ * What the collapsed completion email card displays, derived from the stored MRF
+ * email notification settings. Free of i18n so that the id resolution and the
+ * empty-state rule are testable without rendering.
+ */
+
+export interface CompletionEmailRecipientsInput {
+  emails: string[]
+  /** '' when unset. */
+  stepOneEmailNotificationFieldId: string
+  stepsToNotify: string[]
+  workflowSteps: readonly { _id: string; step_name?: string }[]
+  emailFormFields: readonly {
+    _id: string
+    questionNumber?: number
+    title: string
+  }[]
+}
+
+export interface CompletionEmailRecipients {
+  otherParties: string[]
+  stepOneField: { questionNumber?: number; title: string } | null
+  /** 1-based step numbers, as admins see them, in workflow order. */
+  notifiedSteps: { stepNumber: number; stepName?: string }[]
+  /** True when nothing is configured, which is where every new form starts. */
+  isEmpty: boolean
+}
+
+export const getCompletionEmailRecipients = ({
+  emails,
+  stepOneEmailNotificationFieldId,
+  stepsToNotify,
+  workflowSteps,
+  emailFormFields,
+}: CompletionEmailRecipientsInput): CompletionEmailRecipients => {
+  const otherParties = emails.filter(Boolean)
+
+  // A field or step since deleted resolves away rather than showing a dangling
+  // id. Settings drops them from its options for the same reason.
+  const matchedField = stepOneEmailNotificationFieldId
+    ? emailFormFields.find(
+        (field) => field._id === stepOneEmailNotificationFieldId,
+      )
+    : undefined
+  const stepOneField = matchedField
+    ? { questionNumber: matchedField.questionNumber, title: matchedField.title }
+    : null
+
+  // Walk the workflow, not stepsToNotify, so the summary reads in the same
+  // order as the steps above it.
+  const notifiedStepIds = new Set(stepsToNotify)
+  const notifiedSteps = workflowSteps
+    .map((step, index) => ({ step, stepNumber: index + 1 }))
+    .filter(({ step }) => notifiedStepIds.has(step._id))
+    .map(({ step, stepNumber }) => ({ stepNumber, stepName: step.step_name }))
+
+  return {
+    otherParties,
+    stepOneField,
+    notifiedSteps,
+    isEmpty:
+      otherParties.length === 0 &&
+      stepOneField === null &&
+      notifiedSteps.length === 0,
+  }
+}

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -175,4 +175,8 @@ export const enSG: Workflow = {
   stepName: {
     label: 'Step name',
   },
+  completionEmail: {
+    title: 'Completion email',
+    divider: 'END OF WORKFLOW',
+  },
 }

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -147,4 +147,8 @@ export interface Workflow {
   stepName: {
     label: string
   }
+  completionEmail: {
+    title: string
+    divider: string
+  }
 }


### PR DESCRIPTION
## Problem

At the end of the workflow builder tab, admins get an info box telling them that completion emails exist and sending them to Settings to configure it. They cannot see who is currently notified without leaving the page, and on a form they did not set up themselves they have no way to tell whether anyone is notified at all.

Stacked on #9872 — please review/merge that first. Base retargets to `develop` once it lands.

Part of FRM-2495.

## Solution

Replaces that info box with a card that summarises who actually gets notified when the workflow finishes. Read-only in this PR; the card becomes clickable and editable in #9874, so that the save and card-switching logic can be reviewed on its own.

The seam is the conditional the info box already sat behind, so flag-off returns it untouched, the "at least one step" gate comes for free rather than being restated, and the card being non-draggable and always last falls out of its position outside the Stack that holds the steps.

The card shows one group per control in the expanded card, in the same order and with the same labels, so the two views cannot describe the same settings in different words. Only two strings are new — the card title and the divider label. Everything else is reused from Settings.

### Empty state

The empty state is the common case, not an edge case: all three recipient fields default to empty, so it is what every admin sees after adding their first step. It therefore reuses Settings' "Select who to notify when the workflow is complete" instruction rather than an absence message, because the useful thing to say is what to do next.

### Feature flagging

Everything is behind `useIsWorkflowBuilderRedesign`. Flag-off is asserted, not assumed — see Tests.

## Alternatives considered

- **A new conditional in `WorkflowContent` rather than reusing the info box's.** Rejected. Reusing it is what makes flag-off provably untouched and inherits the step-count gate for free.
- **"No recipients added yet" for the empty state.** Rejected in favour of Settings' existing instruction. Since the empty state is the first thing every admin sees, an instruction is more use than a statement of absence, and it needs no new copy.
- **Formatting the recipient summary inside the derivation.** Rejected. The helper stays free of i18n and returns numbers and names, which puts the two rules worth testing — a deleted field or step resolving away, and steps reading in workflow order — under test without rendering anything.
- **Naming the divider and the card the same thing.** Rejected. The divider says END OF WORKFLOW and the card says Completion email, so the two do not repeat. This does mean the card title differs from the design mocks, which show END-OF-WORKFLOW EMAIL.

## Screenshots

| State | Before | After |
| --- | --- | --- |
| Workflow tab, bottom of the page | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/before-workflow-tab.png" /> | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/after-workflow-tab.png" /> |
| Card, nothing configured yet | n/a | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/after-card-empty.png" /> |
| Card, recipients configured | n/a | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/after-card-summary.png" /> |
| Card, settings still loading | n/a | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/after-card-loading.png" /> |

> [!NOTE]
> In the first row, the status tracker toggle at the top renders as a grey skeleton in the Before shot and as a real toggle in the After shot. That is because the flag-off story has no settings mock attached, not because anything about it changed. Compare the bottom of the two pages. That skeleton is unrelated to the loading row above, which is the card's own deliberate placeholder while the settings request is still in flight.

## Breaking Changes

No - backwards compatible. No API or schema changes, and the flag is off by default, so nothing changes for admins until it is turned on.

## Tests

Automated: the flag seam is asserted both ways, and the recipient derivation is unit tested (deleted fields and steps resolving away, step ordering, the empty-state rule).

**TC1: flag off changes nothing**

- [ ] With the flag off, the workflow tab still shows the info box linking to Settings
- [ ] No divider and no card appear anywhere on the tab

**TC2: flag on replaces the info box**

- [ ] With the flag on, the info box is gone and an END OF WORKFLOW divider plus a Completion email card appear below Add step
- [ ] The card is last on the page and cannot be dragged

**TC3: the card matches Settings**

- [ ] Configure recipients in Settings → Email notifications, return to the workflow tab, and the card lists the same people under the same headings, in the same order as Settings
- [ ] Notified steps are listed in workflow order

**TC4: empty and short-workflow states**

- [ ] On a new MRF form, add one step: the card appears showing "Select who to notify when the workflow is complete"
- [ ] With one step, the card shows no "people who fill in a workflow step" group
- [ ] With no steps at all, no card and no divider appear

**TC5: stale references disappear rather than dangle**

- [ ] Pick a Step 1 email field in Settings, then delete that field from the form: the card stops listing it instead of showing a blank entry
- [ ] Notify a step in Settings, then delete that step: same

