### PR TITLE
feat(workflow): completion email card, editable (3/3)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/SaveActionGroup.tsx
+++ b/apps/frontend/src/features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition/SaveActionGroup.tsx
@@ -13,6 +13,11 @@ export interface SaveActionGroupProps {
   submitButtonLabel?: string
   isLoading: boolean
   ariaLabelName: string
+  /**
+   * Disables submit on its own, leaving cancel usable. For a card that is shown
+   * read-only rather than hidden, so it can still be closed.
+   */
+  isSubmitDisabled?: boolean
 }
 
 export const SaveActionGroup = ({
@@ -22,6 +27,7 @@ export const SaveActionGroup = ({
   handleSubmit,
   isLoading,
   ariaLabelName,
+  isSubmitDisabled,
 }: SaveActionGroupProps): JSX.Element => {
   const { t } = useTranslation()
   const isMobile = useIsMobile()
@@ -52,7 +58,7 @@ export const SaveActionGroup = ({
         w="100%"
       >
         <Button
-          isDisabled={isLoading}
+          isDisabled={isLoading || isSubmitDisabled}
           onClick={handleSubmit}
           isFullWidth={isMobile}
         >

--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
@@ -13,6 +13,7 @@ type AdminWorkflowStore = {
   pendingSwitchTo: CreateOrEditData | null
   requestSwitchTo: (stepNumber: number) => void
   requestSwitchToEmailCard: () => void
+  requestSwitchToCreating: () => void
   cancelPendingSwitch: () => void
   completeSave: () => void
 }
@@ -59,6 +60,9 @@ export const requestSwitchToSelector = (state: AdminWorkflowStore) =>
 export const requestSwitchToEmailCardSelector = (state: AdminWorkflowStore) =>
   state.requestSwitchToEmailCard
 
+export const requestSwitchToCreatingSelector = (state: AdminWorkflowStore) =>
+  state.requestSwitchToCreating
+
 export const cancelPendingSwitchSelector = (state: AdminWorkflowStore) =>
   state.cancelPendingSwitch
 
@@ -100,6 +104,10 @@ export const useAdminWorkflowStore = create<AdminWorkflowStore>()(
     requestSwitchToEmailCard: () =>
       set({
         pendingSwitchTo: { state: AdminEditWorkflowState.EditingEmailCard },
+      }),
+    requestSwitchToCreating: () =>
+      set({
+        pendingSwitchTo: { state: AdminEditWorkflowState.CreatingStep },
       }),
     cancelPendingSwitch: () => set({ pendingSwitchTo: null }),
     // Hand over to a pending switch, or collapse when there is none: a null

--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
@@ -1,19 +1,18 @@
 import create from 'zustand'
 import { devtools } from 'zustand/middleware'
 
-import { AdminEditWorkflowState } from './types'
+import { AdminEditWorkflowState, CreateOrEditData } from './types'
 
 type AdminWorkflowStore = {
   setToCreating: () => void
   setToEditing: (stepNumber: number) => void
+  setToEditingEmailCard: () => void
   setToInactive: () => void
   reset: () => void
-  createOrEditData:
-    | { state: AdminEditWorkflowState.CreatingStep }
-    | { state: AdminEditWorkflowState.EditingStep; stepNumber: number }
-    | null
-  pendingSwitchTo: number | null
-  requestSwitchTo: (target: number) => void
+  createOrEditData: CreateOrEditData | null
+  pendingSwitchTo: CreateOrEditData | null
+  requestSwitchTo: (stepNumber: number) => void
+  requestSwitchToEmailCard: () => void
   cancelPendingSwitch: () => void
   completeSave: () => void
 }
@@ -42,6 +41,12 @@ export const setToCreatingSelector = (state: AdminWorkflowStore) =>
 export const setToEditingSelector = (state: AdminWorkflowStore) =>
   state.setToEditing
 
+export const isEditingEmailCardSelector = (state: AdminWorkflowStore) =>
+  state.createOrEditData?.state === AdminEditWorkflowState.EditingEmailCard
+
+export const setToEditingEmailCardSelector = (state: AdminWorkflowStore) =>
+  state.setToEditingEmailCard
+
 export const setToInactiveSelector = (state: AdminWorkflowStore) =>
   state.setToInactive
 
@@ -50,6 +55,9 @@ export const pendingSwitchToSelector = (state: AdminWorkflowStore) =>
 
 export const requestSwitchToSelector = (state: AdminWorkflowStore) =>
   state.requestSwitchTo
+
+export const requestSwitchToEmailCardSelector = (state: AdminWorkflowStore) =>
+  state.requestSwitchToEmailCard
 
 export const cancelPendingSwitchSelector = (state: AdminWorkflowStore) =>
   state.cancelPendingSwitch
@@ -74,24 +82,29 @@ export const useAdminWorkflowStore = create<AdminWorkflowStore>()(
           stepNumber,
         },
       }),
+    setToEditingEmailCard: () =>
+      set({
+        createOrEditData: {
+          state: AdminEditWorkflowState.EditingEmailCard,
+        },
+      }),
     setToInactive: () => set({ createOrEditData: null }),
     reset: () => set(INITIAL_STATE),
-    requestSwitchTo: (target) => set({ pendingSwitchTo: target }),
+    requestSwitchTo: (stepNumber) =>
+      set({
+        pendingSwitchTo: {
+          state: AdminEditWorkflowState.EditingStep,
+          stepNumber,
+        },
+      }),
+    requestSwitchToEmailCard: () =>
+      set({
+        pendingSwitchTo: { state: AdminEditWorkflowState.EditingEmailCard },
+      }),
     cancelPendingSwitch: () => set({ pendingSwitchTo: null }),
-    // Complete a pending switch if one was requested, else collapse the card.
-    completeSave: () => {
-      const pending = get().pendingSwitchTo
-      if (pending !== null) {
-        set({
-          createOrEditData: {
-            state: AdminEditWorkflowState.EditingStep,
-            stepNumber: pending,
-          },
-          pendingSwitchTo: null,
-        })
-      } else {
-        set({ createOrEditData: null })
-      }
-    },
+    // Hand over to a pending switch, or collapse when there is none: a null
+    // pending target is exactly the collapsed state.
+    completeSave: () =>
+      set({ createOrEditData: get().pendingSwitchTo, pendingSwitchTo: null }),
   })),
 )

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { Box, Divider, Stack, Text } from '@chakra-ui/react'
 import { isEqual, uniq } from 'lodash'
@@ -102,12 +102,16 @@ export const ActiveCompletionEmailCard = ({
     )
   }, cancelPendingSwitch)
 
-  // Matches Settings: the placeholder is a hint for an empty field, so it goes
-  // away once there are recipients.
+  // The placeholder is a hint for an empty field, so it goes away once there
+  // are recipients. Subscribed rather than read with getValues: this card
+  // commits on Save, so nothing else re-renders it when a tag is added or
+  // removed. Settings gets away with getValues only because it saves on blur.
+  const otherParties = useWatch({
+    control,
+    name: OTHER_PARTIES_EMAIL_INPUT_NAME,
+  })
   const otherPartiesPlaceholder =
-    (getValues(OTHER_PARTIES_EMAIL_INPUT_NAME)?.length ?? 0) > 0
-      ? undefined
-      : 'me@example.com'
+    (otherParties?.length ?? 0) > 0 ? undefined : 'me@example.com'
 
   // Dedupes on blur but does not submit: this card commits only on Save.
   const handleOtherPartiesBlur = () => {

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useLayoutEffect, useRef } from 'react'
+import { useForm } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { Divider, Stack } from '@chakra-ui/react'
+import { isEqual, uniq } from 'lodash'
+import isEmail from 'validator/lib/isEmail'
+
+import { MultirespondentFormSettings } from 'formsg-shared/types/form'
+
+import InlineMessage from '~components/InlineMessage'
+
+import { SaveActionGroup } from '~features/admin-form/create/logic/components/LogicContent/EditLogicBlock/EditCondition'
+import {
+  MrfEmailRecipientsFieldGroup,
+  MrfEmailRecipientsFormData,
+  OTHER_PARTIES_EMAIL_INPUT_NAME,
+  STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME,
+  WORKFLOW_EMAIL_MULTISELECT_NAME,
+} from '~features/admin-form/settings/components/MrfEmailRecipientsFieldGroup'
+import { useMutateFormSettings } from '~features/admin-form/settings/mutations'
+
+import {
+  cancelPendingSwitchSelector,
+  completeSaveSelector,
+  pendingSwitchToSelector,
+  setToInactiveSelector,
+  useAdminWorkflowStore,
+} from '../../adminWorkflowStore'
+
+import { EditStepBlockContainer } from './EditStepBlock/EditStepBlockContainer'
+import { CompletionEmailLabel } from './CompletionEmailLabel'
+
+export interface ActiveCompletionEmailCardProps {
+  settings: MultirespondentFormSettings
+  /** True when the form is public: controls show, but read-only. */
+  isDisabled: boolean
+}
+
+/**
+ * Expanded completion email card. Save behaviour copies the step card rather
+ * than Settings: explicit Save, plus auto-save when another card is clicked.
+ * Deliberately no save-on-blur, so it cannot silently commit while the step
+ * cards beside it wait for a button.
+ */
+export const ActiveCompletionEmailCard = ({
+  settings,
+  isDisabled,
+}: ActiveCompletionEmailCardProps): JSX.Element => {
+  const { t } = useTranslation()
+  const setToInactive = useAdminWorkflowStore(setToInactiveSelector)
+  const pendingSwitchTo = useAdminWorkflowStore(pendingSwitchToSelector)
+  const completeSave = useAdminWorkflowStore(completeSaveSelector)
+  const cancelPendingSwitch = useAdminWorkflowStore(cancelPendingSwitchSelector)
+
+  const { stepsToNotify, emails, stepOneEmailNotificationFieldId } = settings
+  const { mutateMrfEmailNotifications } = useMutateFormSettings()
+  const isLoading = mutateMrfEmailNotifications.isLoading
+
+  const formMethods = useForm<MrfEmailRecipientsFormData>({
+    defaultValues: {
+      [WORKFLOW_EMAIL_MULTISELECT_NAME]: stepsToNotify,
+      [OTHER_PARTIES_EMAIL_INPUT_NAME]: emails,
+      [STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]:
+        stepOneEmailNotificationFieldId,
+    },
+  })
+  const { control, getValues, setValue } = formMethods
+
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+
+  useLayoutEffect(() => {
+    wrapperRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+  }, [])
+
+  // Must be read during render for the Proxy to track it. See EditStepBlock.
+  const { isDirty } = formMethods.formState
+
+  const handleSubmit = formMethods.handleSubmit((inputs) => {
+    const nextEmails = inputs[OTHER_PARTIES_EMAIL_INPUT_NAME]
+    const nextStepsToNotify = inputs[WORKFLOW_EMAIL_MULTISELECT_NAME]
+    const nextStepOneEmailNotificationFieldId =
+      inputs[STEP_1_RESPONDENT_NOTIFY_EMAIL_SINGLESELECT_NAME]
+
+    // Unchanged: skip the PATCH but still resolve any pending switch.
+    if (
+      isEqual(nextEmails, emails) &&
+      isEqual(nextStepsToNotify, stepsToNotify) &&
+      nextStepOneEmailNotificationFieldId === stepOneEmailNotificationFieldId
+    ) {
+      completeSave()
+      return
+    }
+
+    mutateMrfEmailNotifications.mutate(
+      {
+        emails: nextEmails,
+        stepsToNotify: nextStepsToNotify,
+        stepOneEmailNotificationFieldId: nextStepOneEmailNotificationFieldId,
+      },
+      // onError drops the pending switch so a failed save can't redirect a later one.
+      { onSuccess: completeSave, onError: cancelPendingSwitch },
+    )
+  }, cancelPendingSwitch)
+
+  // Matches Settings: the placeholder is a hint for an empty field, so it goes
+  // away once there are recipients.
+  const otherPartiesPlaceholder =
+    (getValues(OTHER_PARTIES_EMAIL_INPUT_NAME)?.length ?? 0) > 0
+      ? undefined
+      : 'me@example.com'
+
+  // Dedupes on blur but does not submit: this card commits only on Save.
+  const handleOtherPartiesBlur = () => {
+    const current = getValues(OTHER_PARTIES_EMAIL_INPUT_NAME) ?? []
+    const cleaned = uniq(current.filter((email) => isEmail(email)))
+    if (!isEqual(cleaned, current)) {
+      setValue(OTHER_PARTIES_EMAIL_INPUT_NAME, cleaned, { shouldDirty: true })
+    }
+  }
+
+  // Re-entry guard for the effect below, mirroring EditStepBlock: without it a
+  // second card click inside the pre-isLoading window double-saves.
+  const hasSubmittedForPendingSwitch = useRef(false)
+
+  // Auto-save when another card is clicked while this one is open.
+  useEffect(() => {
+    if (pendingSwitchTo === null) {
+      hasSubmittedForPendingSwitch.current = false
+      return
+    }
+
+    if (isLoading || hasSubmittedForPendingSwitch.current) return
+
+    // Read-only or untouched: nothing to save, so hand over immediately.
+    if (isDisabled || !isDirty) {
+      completeSave()
+      return
+    }
+
+    hasSubmittedForPendingSwitch.current = true
+    handleSubmit()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSwitchTo])
+
+  return (
+    <Stack
+      ref={wrapperRef}
+      py="2rem"
+      spacing="1.5rem"
+      borderRadius="4px"
+      bg="white"
+      border="1px solid"
+      borderColor="primary.500"
+      boxShadow="0 0 0 1px var(--chakra-colors-primary-500)"
+      transitionProperty="common"
+      transitionDuration="normal"
+    >
+      <EditStepBlockContainer>
+        <CompletionEmailLabel />
+      </EditStepBlockContainer>
+      <Divider />
+      {isDisabled ? (
+        <EditStepBlockContainer>
+          {/* Without this the card just shows dead controls. Reuses the
+          sentence Settings shows for the same situation. */}
+          <InlineMessage variant="info">
+            {t(
+              'features.adminForm.settings.emailNotifications.header.closeFormFirst',
+            )}
+          </InlineMessage>
+        </EditStepBlockContainer>
+      ) : null}
+      <EditStepBlockContainer>
+        <MrfEmailRecipientsFieldGroup
+          control={control}
+          isDisabled={isDisabled}
+          isHighContrast={false}
+          otherPartiesPlaceholder={otherPartiesPlaceholder}
+          onOtherPartiesBlur={handleOtherPartiesBlur}
+        />
+      </EditStepBlockContainer>
+      <Divider />
+      <SaveActionGroup
+        isLoading={isLoading}
+        isSubmitDisabled={isDisabled}
+        handleSubmit={handleSubmit}
+        handleCancel={setToInactive}
+        submitButtonLabel={undefined}
+        ariaLabelName="completion email"
+      />
+    </Stack>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Divider, Stack, Text } from '@chakra-ui/react'
+import { Box, Divider, Stack, Text } from '@chakra-ui/react'
 import { isEqual, uniq } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 
@@ -171,23 +171,31 @@ export const ActiveCompletionEmailCard = ({
         </EditStepBlockContainer>
       ) : null}
       <EditStepBlockContainer>
-        <MrfEmailRecipientsFieldGroup
-          control={control}
-          isDisabled={isDisabled}
-          isHighContrast={false}
-          otherPartiesPlaceholder={otherPartiesPlaceholder}
-          onOtherPartiesBlur={handleOtherPartiesBlur}
-          heading={
-            // Settings' own liner, in Settings' own treatment. The card only
-            // renders on a workflow with at least one step, so the
-            // no-workflow variant of this string is unreachable here.
-            <Text textStyle="body-1" textColor="secondary.700" mb="1.5rem">
-              {t(
-                'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientWorkflow',
-              )}
-            </Text>
-          }
-        />
+        {/* The field group carries Settings' own 1.5rem outer margins, which
+        double up against this card's Stack spacing and leave the controls
+        sitting 48px off the dividers where a step card's sit 24px. Cancelled
+        here rather than in the field group, which Settings also renders. The
+        Box is a flex item, so it establishes its own formatting context and
+        the child margins cannot collapse through it. */}
+        <Box my="-1.5rem">
+          <MrfEmailRecipientsFieldGroup
+            control={control}
+            isDisabled={isDisabled}
+            isHighContrast={false}
+            otherPartiesPlaceholder={otherPartiesPlaceholder}
+            onOtherPartiesBlur={handleOtherPartiesBlur}
+            heading={
+              // Settings' own liner, in Settings' own treatment. The card only
+              // renders on a workflow with at least one step, so the
+              // no-workflow variant of this string is unreachable here.
+              <Text textStyle="body-1" textColor="secondary.700" mb="1.5rem">
+                {t(
+                  'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientWorkflow',
+                )}
+              </Text>
+            }
+          />
+        </Box>
       </EditStepBlockContainer>
       <Divider />
       <SaveActionGroup

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
@@ -181,7 +181,10 @@ export const ActiveCompletionEmailCard = ({
           <MrfEmailRecipientsFieldGroup
             control={control}
             isDisabled={isDisabled}
-            isHighContrast={false}
+            // Matches Settings, which defaults this to true. The variant
+            // exists only to keep a disabled label dark rather than faded,
+            // and this card is read-only on a published form.
+            isHighContrast
             otherPartiesPlaceholder={otherPartiesPlaceholder}
             onOtherPartiesBlur={handleOtherPartiesBlur}
             heading={

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveCompletionEmailCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
-import { Divider, Stack } from '@chakra-ui/react'
+import { Divider, Stack, Text } from '@chakra-ui/react'
 import { isEqual, uniq } from 'lodash'
 import isEmail from 'validator/lib/isEmail'
 
@@ -177,6 +177,16 @@ export const ActiveCompletionEmailCard = ({
           isHighContrast={false}
           otherPartiesPlaceholder={otherPartiesPlaceholder}
           onOtherPartiesBlur={handleOtherPartiesBlur}
+          heading={
+            // Settings' own liner, in Settings' own treatment. The card only
+            // renders on a workflow with at least one step, so the
+            // no-workflow variant of this string is unreachable here.
+            <Text textStyle="body-1" textColor="secondary.700" mb="1.5rem">
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientWorkflow',
+              )}
+            </Text>
+          }
         />
       </EditStepBlockContainer>
       <Divider />

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { Meta, StoryFn } from '@storybook/react'
 
@@ -17,9 +18,15 @@ import {
 import {
   getAdminFormSettings,
   getAdminFormView,
+  patchAdminFormSettings,
 } from '~/mocks/msw/handlers/admin-form'
 
 import { StoryRouter } from '~utils/storybook'
+
+import {
+  setToEditingEmailCardSelector,
+  useAdminWorkflowStore,
+} from '../../adminWorkflowStore'
 
 import { CompletionEmailBlock } from './CompletionEmailBlock'
 
@@ -91,6 +98,7 @@ const mocks = (
       ...settingsOverrides,
     },
   }),
+  patchAdminFormSettings({ mode: FormResponseMode.Multirespondent }),
 ]
 
 const NOTHING_CONFIGURED = {
@@ -120,6 +128,15 @@ export default {
 } as Meta
 
 const Template: StoryFn = () => <CompletionEmailBlock />
+
+/** Opens the card, for the stories that document its expanded state. */
+const OpenedTemplate: StoryFn = () => {
+  const setToEditingEmailCard = useAdminWorkflowStore(
+    setToEditingEmailCardSelector,
+  )
+  useEffect(() => setToEditingEmailCard(), [setToEditingEmailCard])
+  return <CompletionEmailBlock />
+}
 
 export const InactiveEmpty = Template.bind({})
 InactiveEmpty.storyName = 'Inactive, nothing configured'
@@ -153,6 +170,31 @@ Loading.parameters = {
     description: {
       story:
         'The form resolves before its settings, so the divider, card frame and label are already in place while the recipient list is still on its way. Only the list is skeletoned.',
+    },
+  },
+}
+
+export const Active = OpenedTemplate.bind({})
+Active.parameters = {
+  msw: { handlers: mocks(FULLY_CONFIGURED) },
+  docs: {
+    description: {
+      story:
+        'Expanded card. Commits on Save only, unlike Settings, which saves on blur.',
+    },
+  },
+}
+
+export const ActiveOnPublicForm = OpenedTemplate.bind({})
+ActiveOnPublicForm.storyName = 'Active, form is public'
+ActiveOnPublicForm.parameters = {
+  msw: {
+    handlers: mocks({ ...FULLY_CONFIGURED, status: FormStatus.Public }),
+  },
+  docs: {
+    description: {
+      story:
+        'Editing recipients on a live form is blocked in the frontend today, so the card opens read-only with Save disabled and Cancel still usable. This state has no design yet.',
     },
   },
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.stories.tsx
@@ -134,7 +134,12 @@ const OpenedTemplate: StoryFn = () => {
   const setToEditingEmailCard = useAdminWorkflowStore(
     setToEditingEmailCardSelector,
   )
-  useEffect(() => setToEditingEmailCard(), [setToEditingEmailCard])
+  // Resets on unmount, so switching between the Active and Inactive stories
+  // does not leak an open card into the next one.
+  useEffect(() => {
+    setToEditingEmailCard()
+    return () => useAdminWorkflowStore.getState().reset()
+  }, [setToEditingEmailCard])
   return <CompletionEmailBlock />
 }
 

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
@@ -108,4 +108,41 @@ describe('completion email seam', () => {
     ).toBeInTheDocument()
     expect(screen.queryByText(DIVIDER)).not.toBeInTheDocument()
   })
+  // Add step used to call setToCreating directly, which unmounted the open card
+  // and dropped its edits with no save and no warning. It now goes through the
+  // same pending-switch mechanism as clicking another card.
+  it('saves pending edits before Add step opens the new step form', async () => {
+    await act(async () => {
+      render(<WithWorkflowRedesignOn />)
+    })
+
+    const card = await screen.findByRole(
+      'button',
+      { name: /completion email/i },
+      { timeout: 10000 },
+    )
+    await act(async () => {
+      fireEvent.click(card)
+    })
+
+    const tagInput = await screen.findByRole('textbox', {}, { timeout: 10000 })
+    await act(async () => {
+      fireEvent.change(tagInput, {
+        target: { value: 'newperson@example.gov.sg' },
+      })
+    })
+    await act(async () => {
+      fireEvent.keyDown(tagInput, { key: 'Enter', code: 'Enter' })
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /add step/i }))
+    })
+
+    // The toast is the observable proof the edit was saved rather than dropped
+    // on the way to the new step form.
+    expect(
+      await screen.findByText(/emails successfully updated/i),
+    ).toBeInTheDocument()
+  })
 })

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
@@ -15,8 +15,16 @@ const DIVIDER = /end of workflow/i
 
 describe('completion email seam', () => {
   // jsdom does not implement scrollIntoView, which the expanded card calls.
+  // It has to be assigned rather than spied, because vi.spyOn needs the
+  // property to already exist. Deleted afterwards so the global does not leak
+  // into other suites.
   beforeAll(() => {
     Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterAll(() => {
+    delete (Element.prototype as Partial<Pick<Element, 'scrollIntoView'>>)
+      .scrollIntoView
   })
 
   afterEach(() => useAdminWorkflowStore.getState().reset())

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.test.tsx
@@ -1,14 +1,26 @@
 import { composeStories } from '@storybook/react'
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
+import { useAdminWorkflowStore } from '../../adminWorkflowStore'
 import * as pageStories from '../../CreatePageWorkflowTab.stories'
+import { AdminEditWorkflowState } from '../../types'
+
+import * as cardStories from './CompletionEmailBlock.stories'
 
 const { WithWorkflow, WithWorkflowRedesignOn } = composeStories(pageStories)
+const { Active } = composeStories(cardStories)
 
 const SETTINGS_LINK = /email notifications/i
 const DIVIDER = /end of workflow/i
 
 describe('completion email seam', () => {
+  // jsdom does not implement scrollIntoView, which the expanded card calls.
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => useAdminWorkflowStore.getState().reset())
+
   // The flag-off path must stay exactly as it was: an inline message pointing
   // at Settings, with no trace of the new card.
   it('keeps the Settings inline message when the redesign flag is off', async () => {
@@ -31,5 +43,47 @@ describe('completion email seam', () => {
     expect(
       screen.queryByRole('link', { name: SETTINGS_LINK }),
     ).not.toBeInTheDocument()
+  })
+
+  // Save-before-switch is the one path that can lose an admin's edits, and it
+  // already shipped a data-loss bug once (#9849), so it is worth rendering for.
+  it('saves pending edits before handing over to another card', async () => {
+    await act(async () => {
+      render(<Active />)
+    })
+
+    // fireEvent rather than userEvent: the tag input manages its own roving
+    // tabindex, which userEvent's focus handling does not drive in jsdom.
+    const tagInput = await screen.findByRole('textbox', {}, { timeout: 10000 })
+    await act(async () => {
+      fireEvent.change(tagInput, {
+        target: { value: 'newperson@example.gov.sg' },
+      })
+    })
+    await act(async () => {
+      fireEvent.keyDown(tagInput, { key: 'Enter', code: 'Enter' })
+    })
+    expect(
+      await screen.findByText('newperson@example.gov.sg'),
+    ).toBeInTheDocument()
+
+    // Stands in for clicking a step card, which is what sets a pending switch.
+    await act(async () => {
+      useAdminWorkflowStore.getState().requestSwitchTo(0)
+    })
+
+    // The success toast is the observable proof that the edit was saved, not
+    // merely dropped on the way to the next card.
+    expect(
+      await screen.findByText(/emails successfully updated/i),
+    ).toBeInTheDocument()
+
+    // And only then does the switch complete.
+    await waitFor(() =>
+      expect(useAdminWorkflowStore.getState().createOrEditData).toEqual({
+        state: AdminEditWorkflowState.EditingStep,
+        stepNumber: 0,
+      }),
+    )
   })
 })

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/CompletionEmailBlock.tsx
@@ -2,14 +2,23 @@ import { Stack } from '@chakra-ui/react'
 
 import {
   FormResponseMode,
+  FormStatus,
   MultirespondentFormSettings,
 } from 'formsg-shared/types/form'
 
 import { useAdminFormSettings } from '~features/admin-form/settings/queries'
 
+import {
+  createOrEditDataSelector,
+  isEditingEmailCardSelector,
+  requestSwitchToEmailCardSelector,
+  setToEditingEmailCardSelector,
+  useAdminWorkflowStore,
+} from '../../adminWorkflowStore'
 import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
 
 import { getCompletionEmailRecipients } from './utils/getCompletionEmailRecipients'
+import { ActiveCompletionEmailCard } from './ActiveCompletionEmailCard'
 import { EndOfWorkflowDivider } from './EndOfWorkflowDivider'
 import { InactiveCompletionEmailCard } from './InactiveCompletionEmailCard'
 
@@ -25,12 +34,34 @@ export const CompletionEmailBlock = (): JSX.Element | null => {
   const { data: settings } = useAdminFormSettings()
   const { formWorkflow, emailFormFields } = useAdminFormWorkflow()
 
+  const isEditing = useAdminWorkflowStore(isEditingEmailCardSelector)
+  const stateData = useAdminWorkflowStore(createOrEditDataSelector)
+  const setToEditingEmailCard = useAdminWorkflowStore(
+    setToEditingEmailCardSelector,
+  )
+  const requestSwitchToEmailCard = useAdminWorkflowStore(
+    requestSwitchToEmailCardSelector,
+  )
+
   // Not an MRF form, so the card does not apply at all. Unreachable from the
   // workflow tab, which only exists on MRF forms, but it narrows the union.
   if (settings && settings.responseMode !== FormResponseMode.Multirespondent) {
     return null
   }
   const mrfSettings: MultirespondentFormSettings | undefined = settings
+
+  const handleClick = () => {
+    if (stateData) {
+      // Another card is open: auto-save it and switch here.
+      requestSwitchToEmailCard()
+      return
+    }
+    setToEditingEmailCard()
+  }
+
+  // Editing on a live form is blocked in the frontend today, so the card opens
+  // read-only rather than being hidden. Removing this is a separate change.
+  const isDisabled = mrfSettings?.status === FormStatus.Public
 
   // Settings are a separate query from the form, so they can arrive after the
   // steps. Null recipients tell the card to hold its frame and skeleton the
@@ -56,7 +87,19 @@ export const CompletionEmailBlock = (): JSX.Element | null => {
     // path stays untouched.
     <Stack spacing="1.5rem" pb={{ base: '1rem', md: '3rem' }}>
       <EndOfWorkflowDivider />
-      <InactiveCompletionEmailCard recipients={recipients} />
+      {/* The expanded card needs settings in hand, so until they arrive the
+      collapsed card holds the space and skeletons its list. */}
+      {isEditing && mrfSettings ? (
+        <ActiveCompletionEmailCard
+          settings={mrfSettings}
+          isDisabled={isDisabled}
+        />
+      ) : (
+        <InactiveCompletionEmailCard
+          recipients={recipients}
+          onClick={handleClick}
+        />
+      )}
     </Stack>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next'
-import { Box, Flex, Skeleton, Stack, Text } from '@chakra-ui/react'
+import { BiPencil } from 'react-icons/bi'
+import { Box, chakra, Flex, Icon, Skeleton, Stack, Text } from '@chakra-ui/react'
 
 import { LogicBadge } from '~features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/LogicBadge'
 
@@ -20,17 +21,19 @@ export interface InactiveCompletionEmailCardProps {
    * skeletons forever.
    */
   recipients: CompletionEmailRecipients | null
+  onClick: () => void
 }
 
 /**
  * Collapsed completion email card: a summary of who gets notified, or an
  * instruction to pick someone when nothing is configured yet.
  *
- * Read-only for now. Chrome matches InactiveStepBlock's resting state; the
- * click target, hover affordance and pencil arrive with the editable card.
+ * Chrome matches InactiveStepBlock exactly, including the pencil being a
+ * hover-only affordance rather than a control of its own.
  */
 export const InactiveCompletionEmailCard = ({
   recipients,
+  onClick,
 }: InactiveCompletionEmailCardProps): JSX.Element => {
   const { t } = useTranslation()
 
@@ -65,64 +68,87 @@ export const InactiveCompletionEmailCard = ({
     : []
 
   return (
-    <Box
-      w="100%"
-      borderRadius="4px"
-      bg="white"
-      border="1px solid"
-      borderColor="neutral.300"
-      transitionProperty="common"
-      transitionDuration="normal"
-    >
-      <Stack spacing="1.5rem" p={{ base: '1.5rem', md: '2rem' }}>
-        <CompletionEmailLabel />
+    <Box pos="relative" role="group">
+      <chakra.button
+        type="button"
+        w="100%"
+        textAlign="start"
+        borderRadius="4px"
+        bg="white"
+        border="1px solid"
+        borderColor="neutral.300"
+        transitionProperty="common"
+        transitionDuration="normal"
+        cursor="pointer"
+        _groupHover={{ borderColor: 'primary.500', bg: 'primary.100' }}
+        onClick={onClick}
+      >
+        <Stack spacing="1.5rem" p={{ base: '1.5rem', md: '2rem' }}>
+          <CompletionEmailLabel />
 
-        {!recipients ? (
-          // Settings arrive after the form, so the card holds its frame and
-          // label rather than the whole block appearing late. Sized bars rather
-          // than a <Skeleton isLoaded> wrapper because the loaded content has
-          // two different shapes, and neither is honest to size a placeholder
-          // against.
-          <Stack spacing="0.25rem">
-            <Skeleton h="1.5rem" w="60%" />
-            <Skeleton h="1.5rem" w="40%" />
-          </Stack>
-        ) : recipients.isEmpty ? (
-          // Reuses the Settings instruction rather than an absence message:
-          // this is the state every new form starts in, so it should tell the
-          // admin what to do next.
-          <Text color="secondary.400">
-            {t(
-              'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientWorkflow',
-            )}
-          </Text>
-        ) : (
-          <Stack spacing="1.5rem">
-            {groups.map(({ id, label, values }) => (
-              // Bare Stack, so the label-to-chips gap is Chakra's 0.5rem
-              // default, the same as InactiveStepBlock's respondent block.
-              <Stack key={id}>
-                <Text textStyle="subhead-3">{label}</Text>
-                {/* Chip row copied from InactiveStepBlock's respondent badges
-                    rather than approximated, so both cards lay recipients out
-                    identically. Values are unique within a group: emails are
-                    deduplicated in the helper, step labels carry their step
-                    number, and step 1 is a single value. */}
-                <Flex
-                  flexDir={{ base: 'column', md: 'row' }}
-                  gap={{ base: '0.5rem', md: '1rem' }}
-                  rowGap={{ md: '0.5rem' }}
-                  wrap="wrap"
-                >
-                  {values.map((value) => (
-                    <LogicBadge key={value}>{value}</LogicBadge>
-                  ))}
-                </Flex>
-              </Stack>
-            ))}
-          </Stack>
-        )}
-      </Stack>
+          {!recipients ? (
+            // Settings arrive after the form, so the card holds its frame and
+            // label rather than the whole block appearing late. Sized bars
+            // rather than a <Skeleton isLoaded> wrapper because the loaded
+            // content has two different shapes, and neither is honest to size a
+            // placeholder against.
+            <Stack spacing="0.25rem">
+              <Skeleton h="1.5rem" w="60%" />
+              <Skeleton h="1.5rem" w="40%" />
+            </Stack>
+          ) : recipients.isEmpty ? (
+            // Reuses the Settings instruction rather than an absence message:
+            // this is the state every new form starts in, so it should tell the
+            // admin what to do next.
+            <Text color="secondary.400">
+              {t(
+                'features.adminForm.settings.emailNotifications.section.mrf.selectRecipientWorkflow',
+              )}
+            </Text>
+          ) : (
+            <Stack spacing="1.5rem">
+              {groups.map(({ id, label, values }) => (
+                // Bare Stack, so the label-to-chips gap is Chakra's 0.5rem
+                // default, the same as InactiveStepBlock's respondent block.
+                <Stack key={id}>
+                  <Text textStyle="subhead-3">{label}</Text>
+                  {/* Chip row copied from InactiveStepBlock's respondent badges
+                      rather than approximated, so both cards lay recipients out
+                      identically. Values are unique within a group: emails are
+                      deduplicated in the helper, step labels carry their step
+                      number, and step 1 is a single value. */}
+                  <Flex
+                    flexDir={{ base: 'column', md: 'row' }}
+                    gap={{ base: '0.5rem', md: '1rem' }}
+                    rowGap={{ md: '0.5rem' }}
+                    wrap="wrap"
+                  >
+                    {values.map((value) => (
+                      <LogicBadge key={value}>{value}</LogicBadge>
+                    ))}
+                  </Flex>
+                </Stack>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      </chakra.button>
+      {/* The whole card is the button, so the pencil is a visual affordance
+      only: no click target, no tab stop, hidden from AT. It reacts to hover on
+      the card via the wrapper's role="group". */}
+      <Icon
+        as={BiPencil}
+        aria-hidden
+        pointerEvents="none"
+        top={{ base: '0.5rem', md: '2rem' }}
+        right={{ base: '0.5rem', md: '2rem' }}
+        pos="absolute"
+        fontSize="1.5rem"
+        color="neutral.500"
+        transitionProperty="common"
+        transitionDuration="normal"
+        _groupHover={{ color: 'primary.500' }}
+      />
     </Box>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/InactiveCompletionEmailCard.tsx
@@ -1,6 +1,14 @@
 import { useTranslation } from 'react-i18next'
 import { BiPencil } from 'react-icons/bi'
-import { Box, chakra, Flex, Icon, Skeleton, Stack, Text } from '@chakra-ui/react'
+import {
+  Box,
+  chakra,
+  Flex,
+  Icon,
+  Skeleton,
+  Stack,
+  Text,
+} from '@chakra-ui/react'
 
 import { LogicBadge } from '~features/admin-form/create/logic/components/LogicContent/InactiveLogicBlock/LogicBadge'
 

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/NewStepBlock/NewStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/NewStepBlock/NewStepBlock.tsx
@@ -9,7 +9,9 @@ import Button from '~components/Button'
 import {
   cancelPendingSwitchSelector,
   completeSaveSelector,
+  createOrEditDataSelector,
   isCreatingStateSelector,
+  requestSwitchToCreatingSelector,
   setToCreatingSelector,
   useAdminWorkflowStore,
 } from '../../../adminWorkflowStore'
@@ -21,13 +23,34 @@ export const NewStepBlock = () => {
   const { t } = useTranslation()
   const { formWorkflow } = useAdminFormWorkflow()
   const { createStepMutation } = useWorkflowMutations()
-  const { isCreatingState, setToCreating, completeSave, cancelPendingSwitch } =
-    useAdminWorkflowStore((state) => ({
-      isCreatingState: isCreatingStateSelector(state),
-      setToCreating: setToCreatingSelector(state),
-      completeSave: completeSaveSelector(state),
-      cancelPendingSwitch: cancelPendingSwitchSelector(state),
-    }))
+  const {
+    isCreatingState,
+    stateData,
+    setToCreating,
+    requestSwitchToCreating,
+    completeSave,
+    cancelPendingSwitch,
+  } = useAdminWorkflowStore((state) => ({
+    isCreatingState: isCreatingStateSelector(state),
+    stateData: createOrEditDataSelector(state),
+    setToCreating: setToCreatingSelector(state),
+    requestSwitchToCreating: requestSwitchToCreatingSelector(state),
+    completeSave: completeSaveSelector(state),
+    cancelPendingSwitch: cancelPendingSwitchSelector(state),
+  }))
+
+  // Another card is open: hand it a pending switch so it saves first, the same
+  // way clicking a step card or the email card does. Calling setToCreating
+  // straight away unmounts that card and drops its edits with no save and no
+  // warning.
+  const handleAddStep = () => {
+    if (stateData) {
+      requestSwitchToCreating()
+      return
+    }
+    setToCreating()
+  }
+
   const handleSubmit = useCallback(
     (step: FormWorkflowStep) =>
       createStepMutation.mutate(step, {
@@ -51,7 +74,7 @@ export const NewStepBlock = () => {
       )}
     />
   ) : (
-    <Button onClick={setToCreating} variant="outline" leftIcon={<BiPlus />}>
+    <Button onClick={handleAddStep} variant="outline" leftIcon={<BiPlus />}>
       {t('features.adminForm.sidebar.workflow.approvals.addStep')}
     </Button>
   )

--- a/apps/frontend/src/features/admin-form/create/workflow/types.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/types.ts
@@ -9,7 +9,18 @@ import {
 export enum AdminEditWorkflowState {
   CreatingStep,
   EditingStep,
+  EditingEmailCard,
 }
+
+/**
+ * Which card is open. Also what an in-flight save is handing over to, so that
+ * "the open card" and "the card we are switching to" are the same shape and
+ * need no translation between them.
+ */
+export type CreateOrEditData =
+  | { state: AdminEditWorkflowState.CreatingStep }
+  | { state: AdminEditWorkflowState.EditingStep; stepNumber: number }
+  | { state: AdminEditWorkflowState.EditingEmailCard }
 
 export type EditStepInputs = FormWorkflowStep & {
   _id: string


### PR DESCRIPTION
## Problem

The card added in #9873 shows who gets the completion email but cannot be changed. Admins still have to leave the workflow builder for Settings to edit it, which is the round trip FRM-2495 exists to remove.

Stacked on #9873 — please review/merge that first. Base retargets to `develop` once it lands.

Closes FRM-2495.

## Solution

Makes the card open and save in place, behaving like a step card rather than like Settings.

Save is explicit, with an auto-save when the admin clicks another card. Deliberately no save-on-blur, so the card cannot silently commit while the step cards beside it wait for a button. Settings keeps its blur-save unchanged. There is no Delete: unlike a step, this card is a permanent fixture.

### Sharing the open-card slot

The card takes a third variant of `createOrEditData` rather than tracking "is the email card open" separately, so only one card can be open at a time by construction: with the email card open, `editDataSelector` narrows to `EditingStep` and every step card renders inactive on its own.

This also collapses the two encodings of "which card" into one. `pendingSwitchTo` now holds the same shape as `createOrEditData`, so `completeSave` is a single `set()` with no translation step, and a null pending target is exactly the collapsed state.

> [!IMPORTANT]
> `AdminEditWorkflowState` is only ever compared for equality, never switched on exhaustively, so a new member compiles cleanly while every existing check silently ignores it. The compiler cannot catch a missed consumer. Checked by hand: `WorkflowBlockFactory`, `InactiveStepBlock`, `NewStepBlock`, `EmptyWorkflow` and `DeleteStepModal` are all correct unchanged.

### Published forms

Editing recipients on a live form is blocked in the frontend today. The card still opens, with the fields read-only and Save disabled, carrying the same sentence Settings shows in that situation so the dead controls are explained. Cancel stays usable. Unblocking live editing is a separate change; when it lands, this stops forcing `isDisabled`.

## Alternatives considered

- **Matching Settings' save-on-blur instead of the step card.** Rejected. A card with a Save button that also commits on tab-out is incoherent, and it would behave differently from the step cards directly above it.
- **Separate store state for the email card instead of a third union variant.** Rejected. Separate state permits two cards being open at once and would need the exclusion maintained by hand; the union makes it impossible.
- **Not letting the card open at all on a published form.** Considered and rejected. Expanding it does repeat information the collapsed card already shows, but being able to open it and see the fields, with a reason why they are inactive, was preferred to a card that silently refuses to open.
- **Extracting the auto-save-on-switch protocol into a hook.** Deferred. `EditStepBlock` and `EditLogicBlock` already had a copy each before this PR, so this is the third. Extracting it only helps if all three adopt it, and the other two are files this stack must not touch. Doing it for this card alone would leave two copies plus a hook.
- **Not reusing `SaveActionGroup`.** Rejected. It gains one optional `isSubmitDisabled` so Save can be disabled while Cancel stays usable; the prop is optional and every existing caller is unchanged.

## Known gaps (not addressed here)

- **Clicking "Add step" while the card is open discards unsaved edits**, with no save and no warning. `NewStepBlock` calls `setToCreating` directly rather than going through the pending-switch mechanism, so the auto-save never fires. Step cards already behave this way, so this is a parity gap rather than a regression, but it is the same shape as the data loss #9849 fixed. Whether "Add step" should save or discard is a product call, and fixing it changes step card behaviour too.
- **The read-only state on a published form has no design.** It is in a story so it can be looked at.
- The card carries its own copy of the card chrome (border, radius, hover, pencil), which the step and logic cards also each have. Extracting it was deliberately deferred; it edits the step card, which this stack must not touch.
- The collapsed card reads four `settings.emailNotifications.*` keys, the only place under `create/**` that does. That is what keeps the two surfaces' wording identical, but it means a Settings copy edit also rewrites the card.

## Screenshots

| State | Before | After |
| --- | --- | --- |
| Collapsed card | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/after-card-summary.png" /> | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/after-card-with-pencil.png" /> |
| Expanded card | n/a — could not be opened | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/after-card-expanded.png" /> |
| Expanded on a published form | n/a | <img width="500" src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2495-completion-email-card/after-card-published-form.png" /> |

In the first row the Before is the read-only card from #9873; the After adds the pencil and makes the whole card a button. Hover state is not shown because Storybook has no pseudo-state addon.

## Breaking Changes

No - backwards compatible. No API or schema changes, and it stays behind `useIsWorkflowBuilderRedesign`.

## Tests

Automated: save-before-switch is covered by a rendered test, asserting on the success toast so it proves the edit was saved rather than merely that a request went out.

**TC1: open, edit, save**

- [ ] Hovering the card highlights it and tints the pencil; clicking anywhere on it opens it
- [ ] Tab skips the pencil — focus lands on the card, and Enter or Space opens it
- [ ] Change recipients, click Save changes: a success toast appears and the collapsed card shows the new list
- [ ] Settings → Email notifications shows the same change

**TC2: cancel discards**

- [ ] Open the card, change recipients, click Cancel: the card collapses and the old list is still shown
- [ ] Settings shows no change

**TC3: only one card open at a time**

- [ ] With a step card open, click the email card: the step saves and the email card opens
- [ ] With the email card open, click a step card: the email card saves and the step opens
- [ ] Never are two cards open at once

**TC4: switching without changes fires no save**

- [ ] Open the email card, change nothing, click a step card: the step opens and no PATCH is sent

**TC5: published form is read-only but openable**

- [ ] Publish the form, open the card: fields are inactive, Save is disabled, Cancel works, and the "close your form to new responses" message shows
- [ ] Close the form to new responses: the fields become editable again

**TC6: known gap, confirm it behaves as described**

- [ ] Open the card, change recipients, click Add step: the edits are discarded without a save. Confirm this matches what an open step card already does in the same situation
