### PR TITLE
fix(workspace): make secret key download button responsive on mobile

### DIFF
--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/SaveSecretKeyContent.tsx
@@ -73,7 +73,7 @@ export const SaveSecretKeyContent = ({
   return (
     <>
       <ModalBody whiteSpace="pre-wrap">
-        <Container maxW="45rem" p={0}>
+        <Container maxW="42.5rem" p={0}>
           <Box
             bg="white"
             borderRadius="4px"
@@ -146,8 +146,11 @@ export const SaveSecretKeyContent = ({
                   {secretKey}
                 </Code>
               </Tooltip>
-              <ButtonGroup>
-                <Button onClick={handleDownloadKey}>
+              <ButtonGroup w={{ base: '100%', md: 'auto' }}>
+                <Button
+                  flex={{ base: 1, md: 'initial' }}
+                  onClick={handleDownloadKey}
+                >
                   {t('secretKey.download')}
                 </Button>
                 <IconButton


### PR DESCRIPTION
## Problem
On mobile viewports, the "Download key" button inside the Save Secret Key modal did not stretch or adapt to the container width, leaving an awkward empty space on the right next to the email action button.

Closes #9858

## Solution

**Breaking Changes** 
- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible  

**Bug Fixes**:
- Added responsive width `w={{ base: '100%', md: 'auto' }}` to `ButtonGroup` in `SaveSecretKeyContent`.
- Added `flex={{ base: 1, md: 'initial' }}` to the "Download key" button so it expands and fills the available horizontal space on mobile while retaining normal auto-width on desktop.

## Before & After Screenshots

**BEFORE**:
<img width="433" height="610" alt="image" src="https://github.com/user-attachments/assets/64a21edc-120d-46dc-b0ce-54b278cdde25" />


**AFTER**:
<img width="414" height="573" alt="image" src="https://github.com/user-attachments/assets/b2e103b9-311b-49be-b95b-4e44c93be923" />


## Tests
- Ran unit tests: `pnpm --filter formsg-frontend test SaveSecretKeyContent` (passed).
- Verified responsive layout across mobile and desktop breakpoints in Storybook (`SaveSecretKeyContent` story).
- Verified TypeScript compilation and build via `pnpm build:frontend`.

## Deploy Notes
None.
