### PR TITLE
feat: scheduled form closure admin ui (2/8)

### DIFF
--- a/apps/frontend/src/features/admin-form/settings/SettingsGeneralPage.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsGeneralPage.stories.tsx
@@ -1,0 +1,101 @@
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { featureFlags } from 'formsg-shared/constants'
+import { DateString } from 'formsg-shared/types'
+import { FormResponseMode, FormSettings } from 'formsg-shared/types/form'
+
+import {
+  getAdminFormSettings,
+  patchAdminFormSettings,
+} from '~/mocks/msw/handlers/admin-form'
+
+import { getMobileViewParameters, StoryRouter } from '~utils/storybook'
+
+import { SettingsGeneralPage } from './SettingsGeneralPage'
+
+const buildMswRoutes = ({
+  overrides,
+  delay,
+}: {
+  overrides?: Partial<FormSettings>
+  delay?: number | 'infinite'
+} = {}) => [
+  getAdminFormSettings({ overrides, delay }),
+  patchAdminFormSettings({ overrides }),
+]
+
+const scheduledClosureOn = new GrowthBook({
+  features: { [featureFlags.scheduledFormClosure]: { defaultValue: true } },
+})
+
+export default {
+  title: 'Pages/AdminFormPage/Settings/General',
+  component: SettingsGeneralPage,
+  decorators: [
+    StoryRouter({ initialEntries: ['/12345'], path: '/:formId' }),
+    (Story) => (
+      <GrowthBookProvider growthbook={scheduledClosureOn}>
+        <Story />
+      </GrowthBookProvider>
+    ),
+  ],
+  parameters: {
+    // Required so skeleton "animation" does not hide content.
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+    msw: {
+      handlers: {
+        default: buildMswRoutes({
+          overrides: { responseMode: FormResponseMode.Encrypt },
+        }),
+      },
+    },
+  },
+} as Meta
+
+const Template: StoryFn = () => <SettingsGeneralPage />
+
+/** Expiry toggle off — the date picker is hidden until the admin opts in. */
+export const NoScheduledClosure = Template.bind({})
+
+/** Expiry toggle on, showing the date picker pre-filled with a close date. */
+export const WithScheduledClosure = Template.bind({})
+WithScheduledClosure.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Encrypt,
+          closeAt: '2026-12-31T15:59:59.999Z' as DateString,
+        },
+      }),
+    },
+  },
+}
+
+/** Both auto-close triggers set, to check they read as independent. */
+export const WithResponseLimitAndScheduledClosure = Template.bind({})
+WithResponseLimitAndScheduledClosure.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        overrides: {
+          responseMode: FormResponseMode.Encrypt,
+          submissionLimit: 1000,
+          closeAt: '2026-12-31T15:59:59.999Z' as DateString,
+        },
+      }),
+    },
+  },
+}
+
+export const Loading = Template.bind({})
+Loading.parameters = {
+  msw: { handlers: { default: buildMswRoutes({ delay: 'infinite' }) } },
+}
+
+export const Mobile = Template.bind({})
+Mobile.parameters = {
+  ...WithScheduledClosure.parameters,
+  ...getMobileViewParameters(),
+}

--- a/apps/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
+++ b/apps/frontend/src/features/admin-form/settings/SettingsGeneralPage.tsx
@@ -3,6 +3,7 @@ import { Divider, Stack } from '@chakra-ui/react'
 import { FormCaptchaToggle } from './components/FormCaptchaToggle'
 import { FormCustomisationSection } from './components/FormCustomisationSection'
 import { FormDetailsSection } from './components/FormDetailsSection'
+import { FormExpiryToggle } from './components/FormExpiryToggle'
 import { FormIssueNotificationToggle } from './components/FormIssueNotificationToggle'
 import { FormLimitToggle } from './components/FormLimitToggle'
 import FormSaveDraftToggle from './components/FormSaveDraftToggle'
@@ -16,6 +17,7 @@ export const SettingsGeneralPage = (): JSX.Element => {
         <GeneralTabHeader />
         <FormStatusToggle />
         <FormLimitToggle />
+        <FormExpiryToggle />
         <FormCustomisationSection />
       </>
       <FormSaveDraftToggle />

--- a/apps/frontend/src/features/admin-form/settings/SettingsService.ts
+++ b/apps/frontend/src/features/admin-form/settings/SettingsService.ts
@@ -77,6 +77,13 @@ export const updateFormLimit: UpdateFormFn<'submissionLimit'> = async (
   return updateFormSettings(formId, { submissionLimit: newLimit })
 }
 
+export const updateFormCloseAt: UpdateFormFn<'closeAt'> = async (
+  formId,
+  newCloseAt,
+) => {
+  return updateFormSettings(formId, { closeAt: newCloseAt })
+}
+
 export const updateFormHasMultiLang: UpdateFormFn<'hasMultiLang'> = async (
   formId,
   newHasMultiLang,

--- a/apps/frontend/src/features/admin-form/settings/components/FormExpiryToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormExpiryToggle.tsx
@@ -32,7 +32,6 @@ const toCloseAt = (date: Date, timeOfDay: string) => {
   }).toISOString() as DateString
 }
 
-/** Whole days before today are unselectable; time-of-day is checked separately. */
 const isPastDay = (date: Date): boolean => isBefore(endOfDay(date), new Date())
 
 interface FormExpiryBlockProps {
@@ -53,10 +52,19 @@ const FormExpiryBlock = ({
   const save = useCallback(
     (nextDate: Date, nextTimeOfDay: string) => {
       const nextCloseAt = toCloseAt(nextDate, nextTimeOfDay)
+
+      // isPastDay only rejects whole days, so today can still be in the past.
+      if (isBefore(new Date(nextCloseAt), new Date())) {
+        return setError(
+          t('features.adminForm.settings.general.expiry.dateInThePast'),
+        )
+      }
+
+      setError(undefined)
       if (nextCloseAt === initialCloseAt) return
       return mutateFormCloseAt.mutate(nextCloseAt)
     },
-    [initialCloseAt, mutateFormCloseAt],
+    [initialCloseAt, mutateFormCloseAt, t],
   )
 
   const handleDateChange = useCallback(

--- a/apps/frontend/src/features/admin-form/settings/components/FormExpiryToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormExpiryToggle.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Box, FormControl, Skeleton } from '@chakra-ui/react'
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
+import { addDays, endOfDay, isBefore, isValid } from 'date-fns'
+
+import { featureFlags } from 'formsg-shared/constants'
+import { DateString } from 'formsg-shared/types'
+
+import { DatePicker } from '~components/DatePicker'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Toggle from '~components/Toggle'
+
+import { useMutateFormSettings } from '../mutations'
+import { useAdminFormSettings } from '../queries'
+
+const DEFAULT_EXPIRY_DAYS_FROM_NOW = 7
+
+/**
+ * The picker is date-only for now, so a selected date means "closes at the end
+ * of that day" — which is what admins ask for ("close at 2359 on the deadline").
+ * Once the Time field lands this becomes an admin-chosen time of day.
+ *
+ * NOTE: this resolves end-of-day in the browser's timezone. Admins are in SGT so
+ * it is correct in practice, but normalising to Asia/Singapore belongs on the
+ * server, where the close instant is actually enforced.
+ */
+const toCloseAt = (date: Date) => endOfDay(date).toISOString() as DateString
+
+const isPast = (date: Date): boolean => isBefore(endOfDay(date), new Date())
+
+interface FormExpiryBlockProps {
+  initialCloseAt: DateString
+}
+
+const FormExpiryBlock = ({
+  initialCloseAt,
+}: FormExpiryBlockProps): JSX.Element => {
+  const { t } = useTranslation()
+  const [error, setError] = useState<string>()
+  const { mutateFormCloseAt } = useMutateFormSettings()
+
+  const value = useMemo(() => new Date(initialCloseAt), [initialCloseAt])
+
+  const handleChange = useCallback(
+    (nextDate: Date | null) => {
+      // Clearing the date is the toggle's job, not the picker's.
+      if (!nextDate) return
+
+      if (!isValid(nextDate) || isPast(nextDate)) {
+        return setError(
+          t('features.adminForm.settings.general.expiry.dateInThePast'),
+        )
+      }
+
+      setError(undefined)
+      const nextCloseAt = toCloseAt(nextDate)
+      if (nextCloseAt === initialCloseAt) return
+
+      return mutateFormCloseAt.mutate(nextCloseAt)
+    },
+    [initialCloseAt, mutateFormCloseAt, t],
+  )
+
+  return (
+    <FormControl mt="2rem" isInvalid={!!error}>
+      <FormLabel
+        isRequired
+        description={t(
+          'features.adminForm.settings.general.expiry.input.description',
+        )}
+      >
+        {t('features.adminForm.settings.general.expiry.input.label')}
+      </FormLabel>
+      <Box maxW="16rem">
+        <DatePicker
+          value={value}
+          onChange={handleChange}
+          isDateUnavailable={isPast}
+        />
+      </Box>
+      <FormErrorMessage>{error}</FormErrorMessage>
+    </FormControl>
+  )
+}
+
+export const FormExpiryToggle = (): JSX.Element => {
+  const { t } = useTranslation()
+  const { data: settings, isLoading: isLoadingSettings } =
+    useAdminFormSettings()
+
+  // TODO(FRM-2376): Remove this check once scheduled closure is stable.
+  const isTest = import.meta.env.STORYBOOK_NODE_ENV === 'test'
+  const isEnabled = useFeatureIsOn(featureFlags.scheduledFormClosure) || isTest
+
+  const { mutateFormCloseAt } = useMutateFormSettings()
+
+  const isScheduled = useMemo(() => !!settings?.closeAt, [settings])
+
+  const handleToggleExpiry = useCallback(() => {
+    if (!settings || isLoadingSettings || mutateFormCloseAt.isLoading) return
+
+    if (settings.closeAt) {
+      return mutateFormCloseAt.mutate(null)
+    }
+
+    return mutateFormCloseAt.mutate(
+      toCloseAt(addDays(new Date(), DEFAULT_EXPIRY_DAYS_FROM_NOW)),
+    )
+  }, [isLoadingSettings, mutateFormCloseAt, settings])
+
+  return isEnabled ? (
+    <Skeleton isLoaded={!isLoadingSettings && !!settings} mt="2rem">
+      <Toggle
+        isLoading={mutateFormCloseAt.isLoading}
+        isChecked={isScheduled}
+        label={t('features.adminForm.settings.general.expiry.label')}
+        onChange={() => handleToggleExpiry()}
+      />
+      {settings?.closeAt && (
+        <FormExpiryBlock initialCloseAt={settings.closeAt} />
+      )}
+    </Skeleton>
+  ) : (
+    <></>
+  )
+}

--- a/apps/frontend/src/features/admin-form/settings/components/FormExpiryToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormExpiryToggle.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Box, FormControl, Skeleton } from '@chakra-ui/react'
+import { Box, FormControl, Skeleton, Stack } from '@chakra-ui/react'
 import { useFeatureIsOn } from '@growthbook/growthbook-react'
-import { addDays, endOfDay, isBefore, isValid } from 'date-fns'
+import { addDays, endOfDay, format, isBefore, isValid, set } from 'date-fns'
 
 import { featureFlags } from 'formsg-shared/constants'
 import { DateString } from 'formsg-shared/types'
@@ -15,20 +15,25 @@ import Toggle from '~components/Toggle'
 import { useMutateFormSettings } from '../mutations'
 import { useAdminFormSettings } from '../queries'
 
+import { isValidTimeOfDay, TimeInput } from './TimeInput'
+
 const DEFAULT_EXPIRY_DAYS_FROM_NOW = 7
 
-/**
- * The picker is date-only for now, so a selected date means "closes at the end
- * of that day" — which is what admins ask for ("close at 2359 on the deadline").
- * Once the Time field lands this becomes an admin-chosen time of day.
- *
- * NOTE: this resolves end-of-day in the browser's timezone. Admins are in SGT so
- * it is correct in practice, but normalising to Asia/Singapore belongs on the
- * server, where the close instant is actually enforced.
- */
-const toCloseAt = (date: Date) => endOfDay(date).toISOString() as DateString
+const DEFAULT_EXPIRY_TIME = '23:59'
 
-const isPast = (date: Date): boolean => isBefore(endOfDay(date), new Date())
+// NOTE: resolves in the browser's timezone, not Asia/Singapore.
+const toCloseAt = (date: Date, timeOfDay: string) => {
+  const [hours, minutes] = timeOfDay.split(':').map(Number)
+  return set(date, {
+    hours,
+    minutes,
+    seconds: 0,
+    milliseconds: 0,
+  }).toISOString() as DateString
+}
+
+/** Whole days before today are unselectable; time-of-day is checked separately. */
+const isPastDay = (date: Date): boolean => isBefore(endOfDay(date), new Date())
 
 interface FormExpiryBlockProps {
   initialCloseAt: DateString
@@ -41,27 +46,47 @@ const FormExpiryBlock = ({
   const [error, setError] = useState<string>()
   const { mutateFormCloseAt } = useMutateFormSettings()
 
-  const value = useMemo(() => new Date(initialCloseAt), [initialCloseAt])
+  const closeAtDate = useMemo(() => new Date(initialCloseAt), [initialCloseAt])
 
-  const handleChange = useCallback(
+  const [timeOfDay, setTimeOfDay] = useState(() => format(closeAtDate, 'HH:mm'))
+
+  const save = useCallback(
+    (nextDate: Date, nextTimeOfDay: string) => {
+      const nextCloseAt = toCloseAt(nextDate, nextTimeOfDay)
+      if (nextCloseAt === initialCloseAt) return
+      return mutateFormCloseAt.mutate(nextCloseAt)
+    },
+    [initialCloseAt, mutateFormCloseAt],
+  )
+
+  const handleDateChange = useCallback(
     (nextDate: Date | null) => {
       // Clearing the date is the toggle's job, not the picker's.
       if (!nextDate) return
 
-      if (!isValid(nextDate) || isPast(nextDate)) {
+      if (!isValid(nextDate) || isPastDay(nextDate)) {
         return setError(
           t('features.adminForm.settings.general.expiry.dateInThePast'),
         )
       }
 
       setError(undefined)
-      const nextCloseAt = toCloseAt(nextDate)
-      if (nextCloseAt === initialCloseAt) return
-
-      return mutateFormCloseAt.mutate(nextCloseAt)
+      return save(nextDate, timeOfDay)
     },
-    [initialCloseAt, mutateFormCloseAt, t],
+    [save, t, timeOfDay],
   )
+
+  const handleTimeBlur = useCallback(() => {
+    if (!isValidTimeOfDay(timeOfDay)) {
+      setTimeOfDay(format(closeAtDate, 'HH:mm'))
+      return setError(
+        t('features.adminForm.settings.general.expiry.invalidTime'),
+      )
+    }
+
+    setError(undefined)
+    return save(closeAtDate, timeOfDay)
+  }, [closeAtDate, save, t, timeOfDay])
 
   return (
     <FormControl mt="2rem" isInvalid={!!error}>
@@ -73,13 +98,25 @@ const FormExpiryBlock = ({
       >
         {t('features.adminForm.settings.general.expiry.input.label')}
       </FormLabel>
-      <Box maxW="16rem">
-        <DatePicker
-          value={value}
-          onChange={handleChange}
-          isDateUnavailable={isPast}
-        />
-      </Box>
+      <Stack direction={{ base: 'column', md: 'row' }} spacing="1rem">
+        <Box maxW="16rem" flex={1}>
+          <DatePicker
+            value={closeAtDate}
+            onChange={handleDateChange}
+            isDateUnavailable={isPastDay}
+          />
+        </Box>
+        <Box maxW="8rem">
+          <TimeInput
+            value={timeOfDay}
+            onChange={setTimeOfDay}
+            onBlur={handleTimeBlur}
+            aria-label={t(
+              'features.adminForm.settings.general.expiry.input.timeLabel',
+            )}
+          />
+        </Box>
+      </Stack>
       <FormErrorMessage>{error}</FormErrorMessage>
     </FormControl>
   )
@@ -106,7 +143,10 @@ export const FormExpiryToggle = (): JSX.Element => {
     }
 
     return mutateFormCloseAt.mutate(
-      toCloseAt(addDays(new Date(), DEFAULT_EXPIRY_DAYS_FROM_NOW)),
+      toCloseAt(
+        addDays(new Date(), DEFAULT_EXPIRY_DAYS_FROM_NOW),
+        DEFAULT_EXPIRY_TIME,
+      ),
     )
   }, [isLoadingSettings, mutateFormCloseAt, settings])
 

--- a/apps/frontend/src/features/admin-form/settings/components/FormExpiryToggle.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/FormExpiryToggle.tsx
@@ -70,6 +70,14 @@ const FormExpiryBlock = ({
         )
       }
 
+      // date-fns coerces a partial time rather than rejecting it, so "09:3"
+      // would silently persist 09:03.
+      if (!isValidTimeOfDay(timeOfDay)) {
+        return setError(
+          t('features.adminForm.settings.general.expiry.invalidTime'),
+        )
+      }
+
       setError(undefined)
       return save(nextDate, timeOfDay)
     },
@@ -104,6 +112,9 @@ const FormExpiryBlock = ({
             value={closeAtDate}
             onChange={handleDateChange}
             isDateUnavailable={isPastDay}
+            // Both inputs derive from the last saved closeAt, so an edit made
+            // mid-save would compute from a stale base.
+            isDisabled={mutateFormCloseAt.isLoading}
           />
         </Box>
         <Box maxW="8rem">
@@ -111,6 +122,7 @@ const FormExpiryBlock = ({
             value={timeOfDay}
             onChange={setTimeOfDay}
             onBlur={handleTimeBlur}
+            isDisabled={mutateFormCloseAt.isLoading}
             aria-label={t(
               'features.adminForm.settings.general.expiry.input.timeLabel',
             )}
@@ -122,7 +134,7 @@ const FormExpiryBlock = ({
   )
 }
 
-export const FormExpiryToggle = (): JSX.Element => {
+export const FormExpiryToggle = (): JSX.Element | null => {
   const { t } = useTranslation()
   const { data: settings, isLoading: isLoadingSettings } =
     useAdminFormSettings()
@@ -162,7 +174,5 @@ export const FormExpiryToggle = (): JSX.Element => {
         <FormExpiryBlock initialCloseAt={settings.closeAt} />
       )}
     </Skeleton>
-  ) : (
-    <></>
-  )
+  ) : null
 }

--- a/apps/frontend/src/features/admin-form/settings/components/TimeInput.stories.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/TimeInput.stories.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { Box, FormControl, Stack, Text } from '@chakra-ui/react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+
+import { isValidTimeOfDay, TimeInput } from './TimeInput'
+
+/** TEMPORARY — see the note in TimeInput.tsx. */
+export default {
+  title: 'Features/AdminForm/Settings/TimeInput',
+  component: TimeInput,
+  parameters: {
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+  },
+} as Meta
+
+/** Live input: type into it to see the mask insert the colon at HH|MM. */
+const InteractiveTemplate: StoryFn = () => {
+  const [value, setValue] = useState('')
+  const [touched, setTouched] = useState(false)
+
+  const isInvalid = touched && !isValidTimeOfDay(value)
+
+  return (
+    <Box maxW="20rem">
+      <FormControl isInvalid={isInvalid}>
+        <FormLabel description="Type digits only — the colon is inserted for you.">
+          Expiry time (24-hour)
+        </FormLabel>
+        <TimeInput
+          value={value}
+          onChange={setValue}
+          onBlur={() => setTouched(true)}
+        />
+        <FormErrorMessage>
+          Enter a 24-hour time between 00:00 and 23:59
+        </FormErrorMessage>
+      </FormControl>
+      <Text mt="1rem" textStyle="caption-1" color="secondary.400">
+        Parsed value: <code>{value || '(empty)'}</code> —{' '}
+        {isValidTimeOfDay(value) ? 'valid' : 'not yet valid'}
+      </Text>
+    </Box>
+  )
+}
+
+export const Interactive = InteractiveTemplate.bind({})
+
+/** Static states, side by side, for a quick visual scan. */
+const StatesTemplate: StoryFn = () => (
+  <Stack spacing="1.5rem" maxW="20rem">
+    <FormControl>
+      <FormLabel>Empty</FormLabel>
+      <TimeInput value="" onChange={() => undefined} />
+    </FormControl>
+
+    <FormControl>
+      <FormLabel>Valid — end of day</FormLabel>
+      <TimeInput value="23:59" onChange={() => undefined} />
+    </FormControl>
+
+    <FormControl>
+      <FormLabel>Valid — midnight</FormLabel>
+      <TimeInput value="00:00" onChange={() => undefined} />
+    </FormControl>
+
+    <FormControl>
+      <FormLabel>Partially typed</FormLabel>
+      <TimeInput value="09:3" onChange={() => undefined} />
+    </FormControl>
+
+    <FormControl isInvalid>
+      <FormLabel>Invalid — hour out of range</FormLabel>
+      <TimeInput value="25:00" onChange={() => undefined} />
+      <FormErrorMessage>
+        Enter a 24-hour time between 00:00 and 23:59
+      </FormErrorMessage>
+    </FormControl>
+
+    <FormControl isInvalid>
+      <FormLabel>Invalid — minute out of range</FormLabel>
+      <TimeInput value="12:75" onChange={() => undefined} />
+      <FormErrorMessage>
+        Enter a 24-hour time between 00:00 and 23:59
+      </FormErrorMessage>
+    </FormControl>
+
+    <FormControl isDisabled>
+      <FormLabel>Disabled</FormLabel>
+      <TimeInput value="18:00" onChange={() => undefined} isDisabled />
+    </FormControl>
+  </Stack>
+)
+
+export const States = StatesTemplate.bind({})

--- a/apps/frontend/src/features/admin-form/settings/components/TimeInput.test.ts
+++ b/apps/frontend/src/features/admin-form/settings/components/TimeInput.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { isValidTimeOfDay } from './TimeInput'
+
+describe('isValidTimeOfDay', () => {
+  it.each(['00:00', '09:30', '13:05', '23:59'])('should accept %s', (v) => {
+    expect(isValidTimeOfDay(v)).toBe(true)
+  })
+
+  it.each([
+    ['', 'empty'],
+    ['0', 'single digit'],
+    ['09', 'hours only'],
+    ['09:', 'trailing colon'],
+    ['09:3', 'one minute digit — would silently save 09:03'],
+    ['1430', 'unmasked digits'],
+    ['24:00', 'hour out of range'],
+    ['23:60', 'minute out of range'],
+    ['99:99', 'both out of range'],
+    ['9:30', 'unpadded hour'],
+    ['ab:cd', 'letters'],
+  ])('should reject %j (%s)', (v) => {
+    expect(isValidTimeOfDay(v)).toBe(false)
+  })
+})

--- a/apps/frontend/src/features/admin-form/settings/components/TimeInput.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/TimeInput.tsx
@@ -1,0 +1,70 @@
+import { ChangeEventHandler, useCallback } from 'react'
+import { forwardRef } from '@chakra-ui/react'
+
+import Input, { InputProps } from '~components/Input'
+
+/**
+ * TEMPORARY — NOT THE FINAL TIME FIELD.
+ *
+ * A plain masked text input for a 24-hour time of day, built only to unblock the
+ * scheduled form closure prototype while the real Time field is still being
+ * designed. When that lands (as a `BasicField.Time` with a proper picker and its
+ * own shared component), this file should be deleted outright rather than grown
+ * into the real thing — it deliberately has no dropdown, no locale handling, no
+ * seconds, and no AM/PM.
+ *
+ * Scope of what it does do: accepts `HH:MM` in 24-hour time, masks input to
+ * digits, and reports validity to its parent. Validation of *when* the time is
+ * (in the past, etc.) is the caller's job.
+ */
+
+/** Matches a 24-hour time of day: 00:00 through 23:59. */
+export const TIME_OF_DAY_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/
+
+export const isValidTimeOfDay = (value: string): boolean =>
+  TIME_OF_DAY_REGEX.test(value)
+
+/**
+ * Masks raw keystrokes into a partial `HH:MM` string. Keeps only digits so the
+ * colon is positional rather than something the admin has to type, and caps at
+ * four digits so overtyping a complete time is a no-op instead of silently
+ * shifting the value.
+ */
+const maskTimeInput = (raw: string): string => {
+  const digits = raw.replace(/\D/g, '').slice(0, 4)
+  if (digits.length <= 2) return digits
+  return `${digits.slice(0, 2)}:${digits.slice(2)}`
+}
+
+export interface TimeInputProps extends Omit<
+  InputProps,
+  'value' | 'onChange' | 'type'
+> {
+  /** Current value, as a partial or complete `HH:MM` string. */
+  value: string
+  /** Fired with the masked value on every keystroke. */
+  onChange: (value: string) => void
+}
+
+export const TimeInput = forwardRef<TimeInputProps, 'input'>(
+  ({ value, onChange, ...props }, ref) => {
+    const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+      (e) => onChange(maskTimeInput(e.target.value)),
+      [onChange],
+    )
+
+    return (
+      <Input
+        ref={ref}
+        value={value}
+        onChange={handleChange}
+        placeholder="HH:MM"
+        inputMode="numeric"
+        // 5 for HH:MM. The mask already enforces this; maxLength is belt and
+        // braces for paste.
+        maxLength={5}
+        {...props}
+      />
+    )
+  },
+)

--- a/apps/frontend/src/features/admin-form/settings/components/TimeInput.tsx
+++ b/apps/frontend/src/features/admin-form/settings/components/TimeInput.tsx
@@ -4,32 +4,21 @@ import { forwardRef } from '@chakra-ui/react'
 import Input, { InputProps } from '~components/Input'
 
 /**
- * TEMPORARY — NOT THE FINAL TIME FIELD.
- *
- * A plain masked text input for a 24-hour time of day, built only to unblock the
- * scheduled form closure prototype while the real Time field is still being
- * designed. When that lands (as a `BasicField.Time` with a proper picker and its
- * own shared component), this file should be deleted outright rather than grown
- * into the real thing — it deliberately has no dropdown, no locale handling, no
- * seconds, and no AM/PM.
- *
- * Scope of what it does do: accepts `HH:MM` in 24-hour time, masks input to
- * digits, and reports validity to its parent. Validation of *when* the time is
- * (in the past, etc.) is the caller's job.
+ * TEMPORARY: a masked text input for a 24-hour time of day, to unblock
+ * scheduled form closure until the real Time field lands. Delete it then.
  */
 
-/** Matches a 24-hour time of day: 00:00 through 23:59. */
+/**
+ * Matches 00:00 through 23:59. The lowercase `hh:mm` shown to admins is a
+ * placeholder, not a date-fns format string — date-fns `hh` is the 12-hour
+ * clock, so format strings reading this value must stay `HH:mm`.
+ */
 export const TIME_OF_DAY_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/
 
 export const isValidTimeOfDay = (value: string): boolean =>
   TIME_OF_DAY_REGEX.test(value)
 
-/**
- * Masks raw keystrokes into a partial `HH:MM` string. Keeps only digits so the
- * colon is positional rather than something the admin has to type, and caps at
- * four digits so overtyping a complete time is a no-op instead of silently
- * shifting the value.
- */
+// Keeps only digits, so the colon is positional rather than typed.
 const maskTimeInput = (raw: string): string => {
   const digits = raw.replace(/\D/g, '').slice(0, 4)
   if (digits.length <= 2) return digits
@@ -40,9 +29,8 @@ export interface TimeInputProps extends Omit<
   InputProps,
   'value' | 'onChange' | 'type'
 > {
-  /** Current value, as a partial or complete `HH:MM` string. */
+  /** A partial or complete `hh:mm` string. */
   value: string
-  /** Fired with the masked value on every keystroke. */
   onChange: (value: string) => void
 }
 
@@ -58,10 +46,8 @@ export const TimeInput = forwardRef<TimeInputProps, 'input'>(
         ref={ref}
         value={value}
         onChange={handleChange}
-        placeholder="HH:MM"
+        placeholder="hh:mm"
         inputMode="numeric"
-        // 5 for HH:MM. The mask already enforces this; maxLength is belt and
-        // braces for paste.
         maxLength={5}
         {...props}
       />

--- a/apps/frontend/src/features/admin-form/settings/mutations.ts
+++ b/apps/frontend/src/features/admin-form/settings/mutations.ts
@@ -183,7 +183,7 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         const toastStatusMessage = newData.closeAt
           ? t('features.adminForm.settings.general.expiry.toast.success', {
-              closeAt: format(new Date(newData.closeAt), 'd MMM yyyy'),
+              closeAt: format(new Date(newData.closeAt), 'd MMM yyyy, HH:mm'),
             })
           : t('features.adminForm.settings.general.expiry.toast.successRemoved')
         handleSuccess({ newData, toastDescription: toastStatusMessage })

--- a/apps/frontend/src/features/admin-form/settings/mutations.ts
+++ b/apps/frontend/src/features/admin-form/settings/mutations.ts
@@ -2,7 +2,9 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQueryClient } from 'react-query'
 import { useParams } from 'react-router-dom'
+import { format } from 'date-fns'
 
+import { DateString } from 'formsg-shared/types'
 import {
   FormAuthType,
   FormResponseMode,
@@ -32,6 +34,7 @@ import {
   updateBusinessInfo,
   updateFormAuthType,
   updateFormCaptcha,
+  updateFormCloseAt,
   updateFormEmails,
   updateFormEsrvcId,
   updateFormHasMultiLang,
@@ -168,6 +171,21 @@ export const useMutateFormSettings = () => {
               submissionLimit: formatOrdinal(newData.submissionLimit),
             })
           : t('features.adminForm.settings.general.limit.toast.successRemoved')
+        handleSuccess({ newData, toastDescription: toastStatusMessage })
+      },
+      onError: handleError,
+    },
+  )
+
+  const mutateFormCloseAt = useMutation(
+    (nextCloseAt: DateString | null) => updateFormCloseAt(formId, nextCloseAt),
+    {
+      onSuccess: (newData) => {
+        const toastStatusMessage = newData.closeAt
+          ? t('features.adminForm.settings.general.expiry.toast.success', {
+              closeAt: format(new Date(newData.closeAt), 'd MMM yyyy'),
+            })
+          : t('features.adminForm.settings.general.expiry.toast.successRemoved')
         handleSuccess({ newData, toastDescription: toastStatusMessage })
       },
       onError: handleError,
@@ -592,6 +610,7 @@ export const useMutateFormSettings = () => {
     mutateFormWebhookUrl,
     mutateFormStatus,
     mutateFormLimit,
+    mutateFormCloseAt,
     mutateFormHasMultiLang,
     mutateFormSupportedLanguages,
     mutateFormInactiveMessage,

--- a/apps/frontend/src/features/admin-form/settings/mutations.ts
+++ b/apps/frontend/src/features/admin-form/settings/mutations.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation, useQueryClient } from 'react-query'
 import { useParams } from 'react-router-dom'
-import { format } from 'date-fns'
+import { formatInTimeZone } from 'date-fns-tz'
 
 import { DateString } from 'formsg-shared/types'
 import {
@@ -183,7 +183,12 @@ export const useMutateFormSettings = () => {
       onSuccess: (newData) => {
         const toastStatusMessage = newData.closeAt
           ? t('features.adminForm.settings.general.expiry.toast.success', {
-              closeAt: format(new Date(newData.closeAt), 'd MMM yyyy, HH:mm'),
+              // Rendered in SGT, matching the banner respondents see.
+              closeAt: formatInTimeZone(
+                new Date(newData.closeAt),
+                'Asia/Singapore',
+                "d MMM yyyy, HH:mm '(SGT)'",
+              ),
             })
           : t('features.adminForm.settings.general.expiry.toast.successRemoved')
         handleSuccess({ newData, toastDescription: toastStatusMessage })

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -39,15 +39,17 @@ export const enSG = {
   expiry: {
     label: 'Schedule an expiry date',
     input: {
-      label: 'Expiry date',
+      label: 'Expiry date and time',
+      timeLabel: 'Expiry time (24-hour, HH:MM)',
       description:
-        'Your form will automatically close at the end of the selected date.',
+        'Your form will automatically close at the selected date and time.',
     },
     toast: {
       success: 'Your form will now automatically close on {closeAt}.',
       successRemoved: 'The expiry date on your form is removed.',
     },
     dateInThePast: 'Expiry date must be in the future',
+    invalidTime: 'Enter a 24-hour time between 00:00 and 23:59',
   },
   customisation: {
     closedFormMessage: 'Set message for closed form',

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -40,7 +40,7 @@ export const enSG = {
     label: 'Schedule an expiry date',
     input: {
       label: 'Expiry date and time',
-      timeLabel: 'Expiry time (24-hour, HH:MM)',
+      timeLabel: 'Expiry time (24-hour, hh:mm)',
       description:
         'Your form will automatically close at the selected date and time.',
     },

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/en-sg.ts
@@ -36,6 +36,19 @@ export const enSG = {
     limitLessThanCurrent:
       'Submission limit must be greater than current submission count ({currentResponseCount})',
   },
+  expiry: {
+    label: 'Schedule an expiry date',
+    input: {
+      label: 'Expiry date',
+      description:
+        'Your form will automatically close at the end of the selected date.',
+    },
+    toast: {
+      success: 'Your form will now automatically close on {closeAt}.',
+      successRemoved: 'The expiry date on your form is removed.',
+    },
+    dateInThePast: 'Expiry date must be in the future',
+  },
   customisation: {
     closedFormMessage: 'Set message for closed form',
   },

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
@@ -37,6 +37,7 @@ export interface General extends HasTitle {
     label: string
     input: {
       label: string
+      timeLabel: string
       description: string
     }
     toast: {
@@ -44,6 +45,7 @@ export interface General extends HasTitle {
       successRemoved: string
     }
     dateInThePast: string
+    invalidTime: string
   }
   customisation: {
     closedFormMessage: string

--- a/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/settings/general/index.ts
@@ -33,6 +33,18 @@ export interface General extends HasTitle {
     }
     limitLessThanCurrent: string
   }
+  expiry: {
+    label: string
+    input: {
+      label: string
+      description: string
+    }
+    toast: {
+      success: string
+      successRemoved: string
+    }
+    dateInThePast: string
+  }
   customisation: {
     closedFormMessage: string
   }

--- a/apps/frontend/src/mocks/msw/handlers/admin-form/form.ts
+++ b/apps/frontend/src/mocks/msw/handlers/admin-form/form.ts
@@ -929,6 +929,7 @@ export const createMockForm = (
         inactiveMessage:
           'If you require further assistance, please contact the agency that gave you the form link.',
         submissionLimit: null,
+        closeAt: null,
         form_fields: [],
         form_logics: [],
         payments_channel: { channel: PaymentChannel.Unconnected },


### PR DESCRIPTION
## Problem

- 1/8 added a `closeAt` field that nothing sets. Admins need a way to set it.
- Nothing enforces the deadline until 3/8, so at this point the date saves and displays only.

## Solution

- `FormExpiryToggle` adds "Schedule an expiry date" to Settings → General, after the response limit.
- Switching it on prefills seven days out at 2359; writing null would flip the toggle straight back off.
- The date input reuses `~components/DatePicker`, with past dates unselectable.
- `TimeInput` masks `hh:mm` and checks validity on blur, so partial input is not rewritten mid-keystroke.
- Unparseable time reverts to the last saved value, so the field never shows a time other than the deadline.
- The whole surface sits behind the `scheduled-form-closure` flag.

**Alternatives considered**

- Nesting the toggle inside the response limit — skipped, a close date would then need a response limit.
- Growing `TimeInput` into the real Time field — skipped, `BasicField` has no `Time` member; delete this when one ships.

**Breaking changes:** none. Everything is behind a flag that is off by default.

**Deploy:** create the `scheduled-form-closure` flag in GrowthBook per environment. It is off by default.

## Screenshots

**BEFORE**:
<img width="740" height="334" alt="Screenshot 2026-08-25 at 11 27 35 AM" src="https://github.com/user-attachments/assets/aafd4700-704d-4e31-8e63-9ed83aa147df" />


**AFTER**:
<img width="768" height="521" alt="Screenshot 2026-08-25 at 11 27 18 AM" src="https://github.com/user-attachments/assets/0d31d2a1-bc5d-410c-8dc4-95b1b5e2b8a4" />

## Tests

**Automated**

- Storybook `Pages/AdminFormPage/Settings/General` — four states, including both triggers set at once.
- Storybook `Features/AdminForm/Settings/TimeInput` — interactive, plus valid, partial, invalid and disabled.

**Manual**

- [ ] Switch the toggle on; verify it prefills seven days out at 23:59 with a success toast.
- [ ] Type `1430` and verify `14:30`; type `9999`, blur, and verify an error plus a revert.
- [ ] Set an expiry with no response limit, then set both, and verify neither interferes.
- [ ] Turn the flag off and verify the toggle is not rendered.
