### PR TITLE
feat: enforce scheduled form closure (3/8)

### DIFF
--- a/apps/backend/src/app/modules/form/__tests__/form.service.spec.ts
+++ b/apps/backend/src/app/modules/form/__tests__/form.service.spec.ts
@@ -1000,6 +1000,74 @@ describe('FormService', () => {
       expect(actual._unsafeUnwrap()).toEqual(true)
     })
 
+    it('should return PrivateFormError when a public form is past its scheduled expiry', async () => {
+      const form = {
+        _id: new ObjectId(),
+        status: FormStatus.Public,
+        closeAt: new Date(Date.now() - 60 * 1000),
+        inactiveMessage: 'test inactive message',
+      } as unknown as IPopulatedForm
+
+      const actual = FormService.isFormPublic(form)
+
+      expect(actual._unsafeUnwrapErr()).toEqual(
+        new PrivateFormError(form.inactiveMessage, form.title),
+      )
+    })
+
+    it('should return PrivateFormError when the expiry is exactly now', async () => {
+      // The deadline is inclusive: 2359 means closed at 2359.
+      const now = new Date()
+      jest.useFakeTimers().setSystemTime(now)
+      const form = {
+        _id: new ObjectId(),
+        status: FormStatus.Public,
+        closeAt: now,
+        inactiveMessage: 'test inactive message',
+      } as unknown as IPopulatedForm
+
+      const actual = FormService.isFormPublic(form)
+
+      jest.useRealTimers()
+      expect(actual.isErr()).toEqual(true)
+    })
+
+    it('should return true when a public form has a future expiry', async () => {
+      const form = {
+        _id: new ObjectId(),
+        status: FormStatus.Public,
+        closeAt: new Date(Date.now() + 60 * 60 * 1000),
+      } as unknown as IPopulatedForm
+
+      const actual = FormService.isFormPublic(form)
+
+      expect(actual._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should return true when a public form has no expiry set', async () => {
+      const form = {
+        _id: new ObjectId(),
+        status: FormStatus.Public,
+        closeAt: null,
+      } as unknown as IPopulatedForm
+
+      const actual = FormService.isFormPublic(form)
+
+      expect(actual._unsafeUnwrap()).toEqual(true)
+    })
+
+    it('should still report a deleted form as deleted even when past its expiry', async () => {
+      const form = {
+        _id: new ObjectId(),
+        status: FormStatus.Archived,
+        closeAt: new Date(Date.now() - 60 * 1000),
+      } as unknown as IPopulatedForm
+
+      const actual = FormService.isFormPublic(form)
+
+      expect(actual._unsafeUnwrapErr()).toEqual(new FormDeletedError())
+    })
+
     it('should return FormDeletedError when form has been deleted', async () => {
       // Arrange
       const form = {

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -2186,6 +2186,105 @@ describe('admin-form.service', () => {
         expect(actualResult.isErr()).toBeFalse()
       })
     })
+
+    describe('clearing a lapsed closeAt on manual reopen', () => {
+      const AN_HOUR_AGO = new Date(Date.now() - 60 * 60 * 1000)
+      const IN_AN_HOUR = new Date(Date.now() + 60 * 60 * 1000)
+
+      const formWithCloseAt = (closeAt: Date | null) =>
+        jest.mocked({
+          _id: new ObjectId(),
+          status: FormStatus.Private,
+          responseMode: FormResponseMode.Email,
+          closeAt,
+        } as unknown as IPopulatedForm)
+
+      it('should clear closeAt when reopening a form whose expiry has lapsed', async () => {
+        const form = formWithCloseAt(AN_HOUR_AGO)
+
+        await AdminFormService.updateFormSettings(form, {
+          status: FormStatus.Public,
+        })
+
+        expect(EMAIL_UPDATE_SPY).toHaveBeenCalledWith(
+          form._id,
+          { status: FormStatus.Public, closeAt: null },
+          expect.anything(),
+        )
+      })
+
+      it('should keep a future closeAt when reopening, so a pre-scheduled expiry survives', async () => {
+        const form = formWithCloseAt(IN_AN_HOUR)
+
+        await AdminFormService.updateFormSettings(form, {
+          status: FormStatus.Public,
+        })
+
+        expect(EMAIL_UPDATE_SPY).toHaveBeenCalledWith(
+          form._id,
+          { status: FormStatus.Public },
+          expect.anything(),
+        )
+      })
+
+      it('should not touch closeAt when the form has none', async () => {
+        const form = formWithCloseAt(null)
+
+        await AdminFormService.updateFormSettings(form, {
+          status: FormStatus.Public,
+        })
+
+        expect(EMAIL_UPDATE_SPY).toHaveBeenCalledWith(
+          form._id,
+          { status: FormStatus.Public },
+          expect.anything(),
+        )
+      })
+
+      it('should respect a closeAt supplied in the same request over clearing it', async () => {
+        const form = formWithCloseAt(AN_HOUR_AGO)
+        const rescheduled = IN_AN_HOUR.toISOString() as never
+
+        await AdminFormService.updateFormSettings(form, {
+          status: FormStatus.Public,
+          closeAt: rescheduled,
+        })
+
+        expect(EMAIL_UPDATE_SPY).toHaveBeenCalledWith(
+          form._id,
+          { status: FormStatus.Public, closeAt: rescheduled },
+          expect.anything(),
+        )
+      })
+
+      it('should not clear closeAt when closing a form rather than reopening it', async () => {
+        const form = formWithCloseAt(AN_HOUR_AGO)
+
+        await AdminFormService.updateFormSettings(form, {
+          status: FormStatus.Private,
+        })
+
+        expect(EMAIL_UPDATE_SPY).toHaveBeenCalledWith(
+          form._id,
+          { status: FormStatus.Private },
+          expect.anything(),
+        )
+      })
+
+      it('should not clear closeAt when the update does not touch status', async () => {
+        const form = formWithCloseAt(AN_HOUR_AGO)
+
+        await AdminFormService.updateFormSettings(form, {
+          title: 'a new title',
+        })
+
+        expect(EMAIL_UPDATE_SPY).toHaveBeenCalledWith(
+          form._id,
+          { title: 'a new title' },
+          expect.anything(),
+        )
+      })
+    })
   })
 
   describe('updateFormField', () => {

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -2061,6 +2061,27 @@ export const deleteFormWorkflowStep = (
 }
 
 /**
+ * Clears a lapsed closeAt when an admin manually reopens a form, so the sweep
+ * does not immediately close it again. A future closeAt, or one supplied in the
+ * same request, is left alone.
+ */
+const withExpiredCloseAtCleared = (
+  originalForm: IPopulatedForm,
+  body: SettingsUpdateDto,
+): SettingsUpdateDto => {
+  const isReopening = body.status === FormStatus.Public
+  const isReschedulingInSameRequest = body.closeAt !== undefined
+  const hasLapsedCloseAt =
+    !!originalForm.closeAt && new Date(originalForm.closeAt) <= new Date()
+
+  if (!isReopening || isReschedulingInSameRequest || !hasLapsedCloseAt) {
+    return body
+  }
+
+  return { ...body, closeAt: null }
+}
+
+/**
  * Updates form settings.
  * @param originalForm The original form to update settings for
  * @param body the subset of form settings to update
@@ -2143,7 +2164,9 @@ export const updateFormSettings = (
     }
   }
 
-  const dotifiedSettingsToUpdate = dotifyObject(body)
+  const dotifiedSettingsToUpdate = dotifyObject(
+    withExpiredCloseAtCleared(originalForm, body),
+  )
   const ModelToUse = getFormModelByResponseMode(originalForm.responseMode)
 
   return ResultAsync.fromPromise(

--- a/apps/backend/src/app/modules/form/form.service.ts
+++ b/apps/backend/src/app/modules/form/form.service.ts
@@ -209,13 +209,23 @@ export const retrieveFormById = (
   })
 }
 
+const hasPassedCloseAt = (form: IPopulatedForm): boolean =>
+  !!form.closeAt && new Date(form.closeAt) <= new Date()
+
 /**
  * Method to ensure given form is available to the public.
+ *
+ * The closeAt check is what enforces a deadline; the sweep only lags behind it.
+ * Unlike the submission limit check this does not deactivate the form, which
+ * would drop it from the sweep's `status: Public` query and leave the admin
+ * unnotified.
+ *
  * @param form the form to check
  * @returns ok(true) if form is public
  * @returns err(ApplicationError) if form has an invalid state
  * @returns err(FormDeletedError) if form has been deleted
- * @returns err(PrivateFormError) if form is private, the message will be the form inactive message
+ * @returns err(PrivateFormError) if form is private or past its scheduled
+ * expiry; the message will be the form inactive message
  */
 export const isFormPublic = (
   form: IPopulatedForm,
@@ -225,7 +235,9 @@ export const isFormPublic = (
   }
   switch (form.status) {
     case FormStatus.Public:
-      return ok(true)
+      return hasPassedCloseAt(form)
+        ? err(new PrivateFormError(form.inactiveMessage, form.title))
+        : ok(true)
     case FormStatus.Archived:
       return err(new FormDeletedError())
     case FormStatus.Private:

--- a/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.ensures.spec.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.ensures.spec.ts
@@ -1,0 +1,83 @@
+import { FormStatus } from 'formsg-shared/types'
+
+import { IPopulatedForm } from 'src/types'
+
+import { ensurePublicForm } from '../encrypt-submission.ensures'
+
+const createMockRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn().mockReturnThis(),
+})
+
+const createMockContext = (form: Partial<IPopulatedForm>) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  req: {} as any,
+  res: createMockRes(),
+  logMeta: { action: 'test' },
+  form: {
+    title: 'a form',
+    inactiveMessage: 'This form is not available.',
+    ...form,
+  } as IPopulatedForm,
+})
+
+describe('Encrypt Submission Ensures', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  describe('ensurePublicForm', () => {
+    it('should reject a submission to a form past its scheduled expiry', async () => {
+      const next = jest.fn()
+      const ctx = createMockContext({
+        status: FormStatus.Public,
+        closeAt: new Date(Date.now() - 60 * 1000),
+      } as unknown as Partial<IPopulatedForm>)
+
+      await ensurePublicForm(ctx as never, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(ctx.res.status).toHaveBeenCalledWith(404)
+      // NOTE: pre-existing behaviour for any closed form on this path: the
+      // generic "taken down" copy, not the form's inactiveMessage.
+      expect(ctx.res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageKey: 'features.publicForm.errors.takenDown',
+        }),
+      )
+    })
+
+    it('should allow a submission when the expiry is still in the future', async () => {
+      const next = jest.fn()
+      const ctx = createMockContext({
+        status: FormStatus.Public,
+        closeAt: new Date(Date.now() + 60 * 60 * 1000),
+      } as unknown as Partial<IPopulatedForm>)
+
+      await ensurePublicForm(ctx as never, next)
+
+      expect(next).toHaveBeenCalled()
+      expect(ctx.res.status).not.toHaveBeenCalled()
+    })
+
+    it('should allow a submission when no expiry is set', async () => {
+      const next = jest.fn()
+      const ctx = createMockContext({
+        status: FormStatus.Public,
+        closeAt: null,
+      } as unknown as Partial<IPopulatedForm>)
+
+      await ensurePublicForm(ctx as never, next)
+
+      expect(next).toHaveBeenCalled()
+    })
+
+    it('should reject a submission to a form closed the ordinary way', async () => {
+      const next = jest.fn()
+      const ctx = createMockContext({ status: FormStatus.Private })
+
+      await ensurePublicForm(ctx as never, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(ctx.res.status).toHaveBeenCalledWith(404)
+    })
+  })
+})

--- a/apps/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormPage.tsx
@@ -6,6 +6,7 @@ import { fillMinHeightCss } from '~utils/fillHeightCss'
 import FloatingToolbar from './components/FloatingToolBar'
 import { FormBanner } from './components/FormBanner'
 import FormEndPage from './components/FormEndPage'
+import { FormExpiryBanner } from './components/FormExpiryBanner'
 import FormFields from './components/FormFields'
 import { FormSectionsProvider } from './components/FormFields/FormSectionsContext'
 import { FormFooter } from './components/FormFooter'
@@ -40,6 +41,7 @@ export const PublicFormPage = (): JSX.Element => {
       <FormSectionsProvider>
         <Flex direction="column" css={fillMinHeightCss}>
           <FormBanner />
+          <FormExpiryBanner />
           <PublicFormLogo />
           <FormStartPage />
           <LanguageControl />

--- a/apps/frontend/src/features/public-form/components/FormExpiryBanner.stories.tsx
+++ b/apps/frontend/src/features/public-form/components/FormExpiryBanner.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta, StoryFn } from '@storybook/react'
+
+import { DateString } from 'formsg-shared/types'
+import { PublicFormDto } from 'formsg-shared/types/form'
+
+import { PublicFormContext } from '../PublicFormContext'
+
+import { FormExpiryBanner } from './FormExpiryBanner'
+
+const withCloseAt = (closeAt: string | null) => {
+  const value = {
+    form: { closeAt } as unknown as PublicFormDto,
+  } as unknown as React.ContextType<typeof PublicFormContext>
+
+  const Decorated: StoryFn = () => (
+    <PublicFormContext.Provider value={value}>
+      <FormExpiryBanner />
+    </PublicFormContext.Provider>
+  )
+  return Decorated
+}
+
+export default {
+  title: 'Features/PublicForm/FormExpiryBanner',
+  component: FormExpiryBanner,
+  parameters: {
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+  },
+} as Meta
+
+/** 2359 SGT on 31 Dec 2026, stored as UTC. Should read as 11.59pm (SGT). */
+export const EndOfYearDeadline = withCloseAt(
+  '2026-12-31T15:59:00.000Z' as DateString,
+)
+
+/** Midday deadline, to check the am/pm rendering. */
+export const MiddayDeadline = withCloseAt(
+  '2026-12-31T04:00:00.000Z' as DateString,
+)
+
+/** No expiry set — the banner renders nothing at all. */
+export const NoExpiry = withCloseAt(null)
+
+/** A deadline that has already passed: the banner hides itself. */
+export const LapsedDeadline = withCloseAt(
+  '2020-01-01T00:00:00.000Z' as DateString,
+)

--- a/apps/frontend/src/features/public-form/components/FormExpiryBanner.tsx
+++ b/apps/frontend/src/features/public-form/components/FormExpiryBanner.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { formatInTimeZone } from 'date-fns-tz'
+
+import { Banner } from '~components/Banner'
+
+import { usePublicFormContext } from '../PublicFormContext'
+
+// Deadlines are always Singapore time, and the respondent may not be.
+const SGT = 'Asia/Singapore'
+
+export const FormExpiryBanner = (): JSX.Element | null => {
+  const { t } = useTranslation()
+  const { form } = usePublicFormContext()
+
+  const closesAt = useMemo(() => {
+    if (!form?.closeAt) return null
+
+    const closeAt = new Date(form.closeAt)
+    // Only reachable in a tab left open across the deadline.
+    if (closeAt <= new Date()) return null
+
+    return formatInTimeZone(closeAt, SGT, "d MMM yyyy, h:mmaaa '(SGT)'")
+  }, [form?.closeAt])
+
+  if (!closesAt) return null
+
+  return (
+    <Banner variant="info">
+      {t('features.publicForm.expiry.banner', { closesAt })}
+    </Banner>
+  )
+}

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -4,6 +4,9 @@ import { enSG as table } from './table'
 import { PublicForm } from '.'
 
 export const enSG: PublicForm = {
+  expiry: {
+    banner: 'This form will stop accepting responses on {closesAt}.',
+  },
   backendErrors: {
     verification: {
       sessionExpired: 'Your session has expired, please refresh and try again.',

--- a/apps/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/index.ts
@@ -5,6 +5,9 @@ import { Table } from './table'
 export * from './en-sg'
 
 export interface PublicForm {
+  expiry: {
+    banner: string
+  }
   backendErrors: {
     verification: {
       sessionExpired: string

--- a/packages/shared/constants/form.ts
+++ b/packages/shared/constants/form.ts
@@ -1,6 +1,8 @@
 const PUBLIC_FORM_FIELDS = [
   'admin',
   'authType',
+  // Exposed so respondents see the deadline before they start filling the form
+  'closeAt',
   'isSubmitterIdCollectionEnabled',
   'isSingleSubmission',
   'endPage',


### PR DESCRIPTION
## Problem

- After 2/8 a deadline can be set but nothing honours it; the form accepts responses indefinitely.
- Respondents cannot tell a deadline exists until the form stops working.

## Solution

- `isFormPublic` enforces the deadline — already the single gate for `getFormIfPublic` and `ensurePublicForm`.
- An expired form returns the existing `PrivateFormError`, so respondents see the normal closed-form message.
- The check does not deactivate the form; that would hide it from the sweep's `status: PUBLIC` query.
- `updateFormSettings` clears a lapsed expiry on manual reopen, or the sweep re-closes the form within minutes.
- `FormExpiryBanner` names the closing instant, and `closeAt` joins `PUBLIC_FORM_FIELDS` so respondents receive it.
- The banner renders in SGT with the zone labelled, matching the deadline on the agency's own notice.

**Alternatives considered**

- Clearing `closeAt` on every reopen, as product asked — skipped, it would wipe a deadline set while still private.

**Breaking changes:** none. Forms without `closeAt` are unaffected; every new path is guarded on the field.

**Deploy:** the banner is English only. Malay, Tamil and Chinese fall back to English pending a real translator.

## Screenshots

This screen recording shows that the `closeAt` field is being persisted and survives refresh.

https://github.com/user-attachments/assets/ec4f27ee-e6d0-44fc-9138-66a19e726522

## Tests

**Automated**

- `form.service.spec.ts` — `isFormPublic` across expired, exactly-now, future, unset and archived-while-expired.
- `encrypt-submission.ensures.spec.ts` — the submit path consults it.
- `admin-form.service.spec.ts` — six branches of the reopen-clearing rule.
- Storybook `Features/PublicForm/FormExpiryBanner` — end-of-year, midday, no expiry and lapsed.

**Manual**

- [ ] Backdate `closeAt` leaving `status: PUBLIC`; verify the form shows closed and rejects a submission.
- [ ] Reopen a form with a lapsed deadline; verify `closeAt` clears and a future one survives.
