### PR TITLE
feat: scheduled form closure sweep (4/8)

### DIFF
--- a/apps/backend/src/app/config/features/scheduled-closure-cron.config.ts
+++ b/apps/backend/src/app/config/features/scheduled-closure-cron.config.ts
@@ -1,0 +1,18 @@
+import convict, { Schema } from 'convict'
+
+export interface ScheduledClosureCron {
+  apiSecret: string
+}
+
+const cronScheduledClosureFeature: Schema<ScheduledClosureCron> = {
+  apiSecret: {
+    doc: 'Scheduled form closure cron API secret key, used by the sweep cronjob to call protected routes',
+    format: String,
+    default: '',
+    env: 'CRON_SCHEDULED_CLOSURE_API_SECRET',
+  },
+}
+
+export const cronScheduledClosureConfig = convict(cronScheduledClosureFeature)
+  .validate({ allowed: 'strict' })
+  .getProperties()

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -1677,6 +1677,22 @@ const compileFormModel = (db: Mongoose): IFormModel => {
     lastModified: -1,
   })
 
+  // Serves the scheduled closure sweep. Partial, because most forms have no
+  // closeAt and would only bloat the index.
+  //
+  // NOTE: `autoIndex` is off outside dev/test (see config.ts), so this does not
+  // create the index on a deployed database — it has to be created by hand in
+  // Atlas, in the background, before the feature carries real traffic.
+  FormSchema.index(
+    {
+      status: 1,
+      closeAt: 1,
+    },
+    {
+      partialFilterExpression: { closeAt: { $type: 'date' } },
+    },
+  )
+
   const FormModel = db.model<IFormSchema, IFormModel>(
     FORM_SCHEMA_ID,
     FormSchema,

--- a/apps/backend/src/app/modules/auth/auth.middlewares.ts
+++ b/apps/backend/src/app/modules/auth/auth.middlewares.ts
@@ -17,6 +17,7 @@ import { getUserByApiKey } from './auth.service'
 import {
   getUserIdFromSession,
   isCronPaymentAuthValid,
+  isCronScheduledClosureAuthValid,
   isUserInSession,
   mapRouteError,
   mapRoutePublicApiError,
@@ -124,6 +125,20 @@ export const withCronPaymentSecretAuthentication: ControllerHandler = (
   next,
 ) => {
   if (isCronPaymentAuthValid(req.headers)) {
+    return next()
+  }
+
+  return res
+    .status(StatusCodes.UNAUTHORIZED)
+    .json({ message: 'Request is unauthorized.' })
+}
+
+export const withCronScheduledClosureSecretAuthentication: ControllerHandler = (
+  req,
+  res,
+  next,
+) => {
+  if (isCronScheduledClosureAuthValid(req.headers)) {
     return next()
   }
 

--- a/apps/backend/src/app/modules/auth/auth.utils.ts
+++ b/apps/backend/src/app/modules/auth/auth.utils.ts
@@ -4,6 +4,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import { MapRouteError } from '../../../types/routing'
 import { cronPaymentConfig } from '../../config/features/payment-cron.config'
+import { cronScheduledClosureConfig } from '../../config/features/scheduled-closure-cron.config'
 import { createLoggerWithLabel } from '../../config/logger'
 import * as MailErrors from '../../services/mail/mail.errors'
 import { HashingError } from '../../utils/hash'
@@ -110,6 +111,16 @@ export const getUserIdFromSession = (
 
 export const isCronPaymentAuthValid = (header: IncomingHttpHeaders) => {
   return header['x-formsg-cron-payment-secret'] === cronPaymentConfig.apiSecret
+}
+
+export const isCronScheduledClosureAuthValid = (
+  header: IncomingHttpHeaders,
+) => {
+  const { apiSecret } = cronScheduledClosureConfig
+  // Fail closed: an unconfigured secret is the empty string, which an empty
+  // header value would otherwise match.
+  if (!apiSecret) return false
+  return header['x-formsg-cron-scheduled-closure-secret'] === apiSecret
 }
 
 export const isEmailInDomainWhitelist = (

--- a/apps/backend/src/app/modules/form/__tests__/form.scheduled-closure.service.spec.ts
+++ b/apps/backend/src/app/modules/form/__tests__/form.scheduled-closure.service.spec.ts
@@ -2,15 +2,23 @@ import dbHandler from '__tests__/unit/backend/helpers/jest-db'
 import { ObjectId } from 'bson'
 import { FormResponseMode, FormStatus } from 'formsg-shared/types'
 import mongoose from 'mongoose'
+import { errAsync, okAsync } from 'neverthrow'
 
 import getFormModel from 'src/app/models/form.server.model'
+import MailService from 'src/app/services/mail/mail.service'
 
+import { MailSendError } from '../../../services/mail/mail.errors'
 import { DatabaseError } from '../../core/core.errors'
 import * as FormService from '../form.service'
+
+jest.mock('src/app/services/mail/mail.service')
+const MockMailService = jest.mocked(MailService)
 
 const Form = getFormModel(mongoose)
 
 const MOCK_ADMIN_OBJ_ID = new ObjectId()
+// Matches the user seeded by dbHandler.insertFormCollectionReqs.
+const MOCK_ADMIN_EMAIL = 'test@test.gov.sg'
 
 const NOW = new Date('2026-08-20T12:00:00.000Z')
 const AN_HOUR_AGO = new Date('2026-08-20T11:00:00.000Z')
@@ -20,10 +28,12 @@ const createForm = async ({
   title,
   status,
   closeAt,
+  permissionList = [],
 }: {
   title: string
   status: FormStatus
   closeAt: Date | null
+  permissionList?: { email: string; write: boolean }[]
 }) =>
   Form.create({
     title,
@@ -32,6 +42,7 @@ const createForm = async ({
     emails: ['test@example.com'],
     status,
     closeAt,
+    permissionList,
   })
 
 describe('FormService.closeExpiredForms', () => {
@@ -61,7 +72,12 @@ describe('FormService.closeExpiredForms', () => {
 
     expect(actual.isOk()).toEqual(true)
     expect(actual._unsafeUnwrap()).toEqual([
-      { formId: String(form._id), title: 'expired', closeAt: AN_HOUR_AGO },
+      {
+        formId: String(form._id),
+        title: 'expired',
+        closeAt: AN_HOUR_AGO,
+        emailRecipients: [MOCK_ADMIN_EMAIL],
+      },
     ])
     await expect(
       Form.findById(form._id).then((f) => f?.status),
@@ -202,9 +218,11 @@ describe('FormService.closeExpiredForms', () => {
       () =>
         ({
           select: () => ({
-            limit: () => ({
-              lean: () => ({
-                exec: () => Promise.reject(new Error('boom')),
+            populate: () => ({
+              limit: () => ({
+                lean: () => ({
+                  exec: () => Promise.reject(new Error('boom')),
+                }),
               }),
             }),
           }),
@@ -215,5 +233,126 @@ describe('FormService.closeExpiredForms', () => {
 
     expect(actual.isErr()).toEqual(true)
     expect(actual._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+  })
+})
+
+describe('FormService.closeExpiredForms recipients', () => {
+  beforeAll(async () => {
+    await dbHandler.connect()
+    await dbHandler.insertFormCollectionReqs({ userId: MOCK_ADMIN_OBJ_ID })
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    await Form.deleteMany({})
+  })
+
+  afterAll(async () => {
+    await dbHandler.clearDatabase()
+    await dbHandler.closeDatabase()
+  })
+
+  it('should include the admin and every collaborator', async () => {
+    await createForm({
+      title: 'expired with collaborators',
+      status: FormStatus.Public,
+      closeAt: AN_HOUR_AGO,
+      permissionList: [
+        { email: 'editor@test.gov.sg', write: true },
+        { email: 'viewer@test.gov.sg', write: false },
+      ],
+    })
+
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual._unsafeUnwrap()[0].emailRecipients).toEqual([
+      MOCK_ADMIN_EMAIL,
+      'editor@test.gov.sg',
+      'viewer@test.gov.sg',
+    ])
+  })
+})
+
+describe('FormService.notifyFormsClosed', () => {
+  const closedForm = {
+    formId: String(new ObjectId()),
+    title: 'expired form',
+    closeAt: AN_HOUR_AGO,
+    emailRecipients: ['admin@test.gov.sg'],
+  }
+
+  afterEach(() => jest.clearAllMocks())
+
+  it('should send one notification per closed form', async () => {
+    MockMailService.sendFormScheduledClosureNotification.mockReturnValue(
+      okAsync(true),
+    )
+    const second = { ...closedForm, formId: String(new ObjectId()) }
+
+    const actual = await FormService.notifyFormsClosed([closedForm, second])
+
+    expect(actual._unsafeUnwrap()).toEqual({ sentCount: 2, failedCount: 0 })
+    expect(
+      MockMailService.sendFormScheduledClosureNotification,
+    ).toHaveBeenCalledTimes(2)
+  })
+
+  it('should format the close instant in Singapore time', async () => {
+    MockMailService.sendFormScheduledClosureNotification.mockReturnValue(
+      okAsync(true),
+    )
+
+    // 11:00 UTC is 19:00 SGT on the same day.
+    await FormService.notifyFormsClosed([closedForm])
+
+    expect(
+      MockMailService.sendFormScheduledClosureNotification,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ closedAt: '20 Aug 2026, 19:00' }),
+    )
+  })
+
+  it('should count a failed send without rejecting', async () => {
+    MockMailService.sendFormScheduledClosureNotification.mockReturnValue(
+      errAsync(new MailSendError('nope')),
+    )
+
+    const actual = await FormService.notifyFormsClosed([closedForm])
+
+    expect(actual.isOk()).toEqual(true)
+    expect(actual._unsafeUnwrap()).toEqual({ sentCount: 0, failedCount: 1 })
+  })
+
+  it('should keep sending to other forms when one fails', async () => {
+    MockMailService.sendFormScheduledClosureNotification
+      .mockReturnValueOnce(errAsync(new MailSendError('nope')))
+      .mockReturnValueOnce(okAsync(true))
+
+    const actual = await FormService.notifyFormsClosed([
+      closedForm,
+      { ...closedForm, formId: String(new ObjectId()) },
+    ])
+
+    expect(actual._unsafeUnwrap()).toEqual({ sentCount: 1, failedCount: 1 })
+  })
+
+  it('should skip a form with no recipients rather than send to nobody', async () => {
+    const actual = await FormService.notifyFormsClosed([
+      { ...closedForm, emailRecipients: [] },
+    ])
+
+    expect(actual._unsafeUnwrap()).toEqual({ sentCount: 0, failedCount: 1 })
+    expect(
+      MockMailService.sendFormScheduledClosureNotification,
+    ).not.toHaveBeenCalled()
+  })
+
+  it('should do nothing when no forms were closed', async () => {
+    const actual = await FormService.notifyFormsClosed([])
+
+    expect(actual._unsafeUnwrap()).toEqual({ sentCount: 0, failedCount: 0 })
+    expect(
+      MockMailService.sendFormScheduledClosureNotification,
+    ).not.toHaveBeenCalled()
   })
 })

--- a/apps/backend/src/app/modules/form/__tests__/form.scheduled-closure.service.spec.ts
+++ b/apps/backend/src/app/modules/form/__tests__/form.scheduled-closure.service.spec.ts
@@ -1,0 +1,219 @@
+import dbHandler from '__tests__/unit/backend/helpers/jest-db'
+import { ObjectId } from 'bson'
+import { FormResponseMode, FormStatus } from 'formsg-shared/types'
+import mongoose from 'mongoose'
+
+import getFormModel from 'src/app/models/form.server.model'
+
+import { DatabaseError } from '../../core/core.errors'
+import * as FormService from '../form.service'
+
+const Form = getFormModel(mongoose)
+
+const MOCK_ADMIN_OBJ_ID = new ObjectId()
+
+const NOW = new Date('2026-08-20T12:00:00.000Z')
+const AN_HOUR_AGO = new Date('2026-08-20T11:00:00.000Z')
+const IN_AN_HOUR = new Date('2026-08-20T13:00:00.000Z')
+
+const createForm = async ({
+  title,
+  status,
+  closeAt,
+}: {
+  title: string
+  status: FormStatus
+  closeAt: Date | null
+}) =>
+  Form.create({
+    title,
+    admin: MOCK_ADMIN_OBJ_ID,
+    responseMode: FormResponseMode.Email,
+    emails: ['test@example.com'],
+    status,
+    closeAt,
+  })
+
+describe('FormService.closeExpiredForms', () => {
+  beforeAll(async () => {
+    await dbHandler.connect()
+    await dbHandler.insertFormCollectionReqs({ userId: MOCK_ADMIN_OBJ_ID })
+  })
+
+  afterEach(async () => {
+    jest.restoreAllMocks()
+    await Form.deleteMany({})
+  })
+
+  afterAll(async () => {
+    await dbHandler.clearDatabase()
+    await dbHandler.closeDatabase()
+  })
+
+  it('should close a public form whose closeAt has passed', async () => {
+    const form = await createForm({
+      title: 'expired',
+      status: FormStatus.Public,
+      closeAt: AN_HOUR_AGO,
+    })
+
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual.isOk()).toEqual(true)
+    expect(actual._unsafeUnwrap()).toEqual([
+      { formId: String(form._id), title: 'expired', closeAt: AN_HOUR_AGO },
+    ])
+    await expect(
+      Form.findById(form._id).then((f) => f?.status),
+    ).resolves.toEqual(FormStatus.Private)
+  })
+
+  it('should leave a public form whose closeAt is still in the future', async () => {
+    const form = await createForm({
+      title: 'not yet due',
+      status: FormStatus.Public,
+      closeAt: IN_AN_HOUR,
+    })
+
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual._unsafeUnwrap()).toEqual([])
+    await expect(
+      Form.findById(form._id).then((f) => f?.status),
+    ).resolves.toEqual(FormStatus.Public)
+  })
+
+  it('should leave a public form with no closeAt set', async () => {
+    const form = await createForm({
+      title: 'no schedule',
+      status: FormStatus.Public,
+      closeAt: null,
+    })
+
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual._unsafeUnwrap()).toEqual([])
+    await expect(
+      Form.findById(form._id).then((f) => f?.status),
+    ).resolves.toEqual(FormStatus.Public)
+  })
+
+  it('should not report an already-private expired form, so notifications are not resent', async () => {
+    await createForm({
+      title: 'already closed',
+      status: FormStatus.Private,
+      closeAt: AN_HOUR_AGO,
+    })
+
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual._unsafeUnwrap()).toEqual([])
+  })
+
+  it('should be idempotent across repeated sweeps', async () => {
+    await createForm({
+      title: 'expired',
+      status: FormStatus.Public,
+      closeAt: AN_HOUR_AGO,
+    })
+
+    const first = await FormService.closeExpiredForms(NOW)
+    const second = await FormService.closeExpiredForms(NOW)
+
+    expect(first._unsafeUnwrap()).toHaveLength(1)
+    expect(second._unsafeUnwrap()).toEqual([])
+  })
+
+  it('should close a form whose closeAt is exactly now', async () => {
+    // The deadline is inclusive: 2359 means closed at 2359, not at 2400.
+    const form = await createForm({
+      title: 'due exactly now',
+      status: FormStatus.Public,
+      closeAt: NOW,
+    })
+
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual._unsafeUnwrap()).toHaveLength(1)
+    await expect(
+      Form.findById(form._id).then((f) => f?.status),
+    ).resolves.toEqual(FormStatus.Private)
+  })
+
+  it('should close only the expired forms when several forms coexist', async () => {
+    const expired = await createForm({
+      title: 'expired',
+      status: FormStatus.Public,
+      closeAt: AN_HOUR_AGO,
+    })
+    const future = await createForm({
+      title: 'future',
+      status: FormStatus.Public,
+      closeAt: IN_AN_HOUR,
+    })
+    const unscheduled = await createForm({
+      title: 'unscheduled',
+      status: FormStatus.Public,
+      closeAt: null,
+    })
+
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual._unsafeUnwrap().map((f) => f.formId)).toEqual([
+      String(expired._id),
+    ])
+    await expect(
+      Form.findById(future._id).then((f) => f?.status),
+    ).resolves.toEqual(FormStatus.Public)
+    await expect(
+      Form.findById(unscheduled._id).then((f) => f?.status),
+    ).resolves.toEqual(FormStatus.Public)
+  })
+
+  it('should return an empty list when there is nothing to close', async () => {
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual.isOk()).toEqual(true)
+    expect(actual._unsafeUnwrap()).toEqual([])
+  })
+
+  it('should cap a single sweep at the batch limit', async () => {
+    // A small limit, rather than seeding 500+ documents for no extra coverage.
+    await Promise.all(
+      ['expired one', 'expired two', 'expired three'].map((title) =>
+        createForm({
+          title,
+          status: FormStatus.Public,
+          closeAt: AN_HOUR_AGO,
+        }),
+      ),
+    )
+
+    const actual = await FormService.closeExpiredForms(NOW, 2)
+
+    expect(actual._unsafeUnwrap()).toHaveLength(2)
+    await expect(
+      Form.countDocuments({ status: FormStatus.Public }),
+    ).resolves.toEqual(1)
+  })
+
+  it('should return a DatabaseError when the query fails', async () => {
+    jest.spyOn(Form, 'find').mockImplementationOnce(
+      () =>
+        ({
+          select: () => ({
+            limit: () => ({
+              lean: () => ({
+                exec: () => Promise.reject(new Error('boom')),
+              }),
+            }),
+          }),
+        }) as never,
+    )
+
+    const actual = await FormService.closeExpiredForms(NOW)
+
+    expect(actual.isErr()).toEqual(true)
+    expect(actual._unsafeUnwrapErr()).toBeInstanceOf(DatabaseError)
+  })
+})

--- a/apps/backend/src/app/modules/form/form.service.ts
+++ b/apps/backend/src/app/modules/form/form.service.ts
@@ -11,6 +11,7 @@ import {
   SubmissionType,
 } from 'formsg-shared/types'
 import { encryptString } from 'formsg-shared/utils/crypto'
+import moment from 'moment-timezone'
 import mongoose from 'mongoose'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 import { decodeBase64 } from 'tweetnacl-util'
@@ -24,6 +25,7 @@ import {
 } from '../../../types'
 import { smsConfig } from '../../config/features/sms.config'
 import { createLoggerWithLabel } from '../../config/logger'
+import { TIMEZONE } from '../../constants/timezone'
 import getFormModel, {
   getEmailFormModel,
   getEncryptedFormModel,
@@ -54,6 +56,7 @@ import {
   PrivateFormError,
 } from './form.errors'
 import {
+  getCollabEmailsWithPermission,
   getSubmissionType,
   hasVerifiableMobileFieldformFields,
 } from './form.utils'
@@ -255,6 +258,8 @@ export type ClosedExpiredForm = {
   formId: string
   title: string
   closeAt: Date
+  /** Admin plus collaborators. */
+  emailRecipients: string[]
 }
 
 /**
@@ -285,7 +290,8 @@ export const closeExpiredForms = (
       // the partial index's filter expression and is eligible to use it.
       closeAt: { $type: 'date', $lte: now },
     })
-      .select('_id title closeAt')
+      .select('_id title closeAt admin permissionList')
+      .populate({ path: 'admin', select: 'email' })
       .limit(limit)
       .lean()
       .exec(),
@@ -328,14 +334,76 @@ export const closeExpiredForms = (
         },
       })
 
-      return expiredForms.map((form) => ({
-        formId: String(form._id),
-        title: form.title,
-        // Declared as a wire-format DateString on the shared type but stored
-        // as a BSON date, so normalise instead of asserting either way.
-        closeAt: new Date(form.closeAt as unknown as string | Date),
-      }))
+      return expiredForms.map((form) => {
+        const adminEmail = (form.admin as unknown as { email?: string })?.email
+        return {
+          formId: String(form._id),
+          title: form.title,
+          // A wire-format DateString on the shared type, a BSON date here.
+          closeAt: new Date(form.closeAt as unknown as string | Date),
+          emailRecipients: adminEmail
+            ? [
+                adminEmail,
+                ...getCollabEmailsWithPermission(form.permissionList),
+              ]
+            : [],
+        }
+      })
     })
+  })
+}
+
+/**
+ * Notifies each form's admin and collaborators that their form has closed.
+ *
+ * Never rejects: the forms are already closed, so a failed send must not fail
+ * the sweep. At-most-once — a closed form no longer matches the sweep, so a
+ * failure here is logged and counted rather than retried.
+ *
+ * @param closedForms the forms closed by this sweep
+ * @returns ok with how many notifications were sent and how many failed
+ */
+export const notifyFormsClosed = (
+  closedForms: ClosedExpiredForm[],
+): ResultAsync<{ sentCount: number; failedCount: number }, never> => {
+  const sends = closedForms.map((form) => {
+    if (form.emailRecipients.length === 0) {
+      logger.warn({
+        message: 'Closed form has no notification recipients',
+        meta: {
+          action: 'notifyFormsClosed',
+          formId: form.formId,
+        },
+      })
+      return okAsync(false)
+    }
+
+    return MailService.sendFormScheduledClosureNotification({
+      emailRecipients: form.emailRecipients,
+      formTitle: form.title,
+      formId: form.formId,
+      closedAt: moment(form.closeAt).tz(TIMEZONE).format('D MMM YYYY, HH:mm'),
+    })
+      .map(() => true)
+      .orElse((error) => {
+        logger.error({
+          message: 'Failed to send scheduled closure notification',
+          meta: {
+            action: 'notifyFormsClosed',
+            formId: form.formId,
+          },
+          error,
+        })
+        return okAsync(false)
+      })
+  })
+
+  return ResultAsync.combine(sends).map((results) => {
+    const sentCount = results.filter(Boolean).length
+    return {
+      sentCount,
+      failedCount: results.length - sentCount,
+    }
   })
 }
 

--- a/apps/backend/src/app/modules/form/form.service.ts
+++ b/apps/backend/src/app/modules/form/form.service.ts
@@ -281,7 +281,9 @@ export const closeExpiredForms = (
     // notify their admins. An updateMany alone would only yield a count.
     FormModel.find({
       status: FormStatus.Public,
-      closeAt: { $ne: null, $lte: now },
+      // `$type: 'date'` rather than `$ne: null`, so the query provably matches
+      // the partial index's filter expression and is eligible to use it.
+      closeAt: { $type: 'date', $lte: now },
     })
       .select('_id title closeAt')
       .limit(limit)

--- a/apps/backend/src/app/modules/form/form.service.ts
+++ b/apps/backend/src/app/modules/form/form.service.ts
@@ -246,6 +246,98 @@ export const isFormPublic = (
 }
 
 /**
+ * Maximum number of forms closed in a single sweep. The remainder is picked up
+ * by the next run.
+ */
+export const CLOSE_EXPIRED_FORMS_BATCH_LIMIT = 500
+
+export type ClosedExpiredForm = {
+  formId: string
+  title: string
+  closeAt: Date
+}
+
+/**
+ * Closes every public form whose scheduled expiry has passed. Idempotent: a
+ * closed form no longer matches the query.
+ *
+ * @param now the instant to evaluate deadlines against
+ * @param limit maximum forms to close in this sweep
+ * @returns ok(closed forms) listing what this sweep closed, capped at the batch limit
+ * @returns err(PossibleDatabaseError) if the query or update failed
+ */
+export const closeExpiredForms = (
+  now: Date = new Date(),
+  limit: number = CLOSE_EXPIRED_FORMS_BATCH_LIMIT,
+): ResultAsync<ClosedExpiredForm[], PossibleDatabaseError> => {
+  const logMeta = {
+    action: 'closeExpiredForms',
+    now: now.toISOString(),
+    limit,
+  }
+
+  return ResultAsync.fromPromise(
+    // Read before updating, so the caller learns which forms closed and can
+    // notify their admins. An updateMany alone would only yield a count.
+    FormModel.find({
+      status: FormStatus.Public,
+      closeAt: { $ne: null, $lte: now },
+    })
+      .select('_id title closeAt')
+      .limit(limit)
+      .lean()
+      .exec(),
+    (error) => {
+      logger.error({
+        message: 'Error finding forms past their scheduled closure',
+        meta: logMeta,
+        error,
+      })
+      return transformMongoError(error)
+    },
+  ).andThen((expiredForms) => {
+    if (expiredForms.length === 0) return okAsync([])
+
+    const formIds = expiredForms.map((form) => form._id)
+
+    return ResultAsync.fromPromise(
+      // Re-assert `status` so a form reopened between the read and the write
+      // is left alone.
+      FormModel.updateMany(
+        { _id: { $in: formIds }, status: FormStatus.Public },
+        { $set: { status: FormStatus.Private } },
+      ).exec(),
+      (error) => {
+        logger.error({
+          message: 'Error closing forms past their scheduled closure',
+          meta: { ...logMeta, formIds },
+          error,
+        })
+        return transformMongoError(error)
+      },
+    ).map((result) => {
+      logger.info({
+        message: 'Closed forms past their scheduled closure',
+        meta: {
+          ...logMeta,
+          matchedCount: expiredForms.length,
+          modifiedCount: result.modifiedCount,
+          isBatchFull: expiredForms.length === limit,
+        },
+      })
+
+      return expiredForms.map((form) => ({
+        formId: String(form._id),
+        title: form.title,
+        // Declared as a wire-format DateString on the shared type but stored
+        // as a BSON date, so normalise instead of asserting either way.
+        closeAt: new Date(form.closeAt as unknown as string | Date),
+      }))
+    })
+  })
+}
+
+/**
  * Method to check whether a form has reached submission limits, and deactivate the form if necessary
  * @param form the form to check
  * @returns ok(form) if submission is allowed because the form has not reached limits

--- a/apps/backend/src/app/modules/form/scheduled-closure/scheduled-closure.controller.ts
+++ b/apps/backend/src/app/modules/form/scheduled-closure/scheduled-closure.controller.ts
@@ -1,0 +1,51 @@
+import { ErrorDto } from 'formsg-shared/types'
+import { StatusCodes } from 'http-status-codes'
+
+import { createLoggerWithLabel } from '../../../config/logger'
+import { ControllerHandler } from '../../core/core.types'
+import * as FormService from '../form.service'
+
+const logger = createLoggerWithLabel(module)
+
+export type CloseExpiredFormsDto = {
+  /** Number of forms this sweep closed. */
+  closedCount: number
+  /** Ids of the forms closed, for correlating against the cron job's logs. */
+  formIds: string[]
+  /** Whether the sweep filled its batch limit, so more forms may be due. */
+  hasMore: boolean
+}
+
+/**
+ * Handler for POST /cron/close-expired-forms
+ *
+ * Closes every public form whose scheduled expiry has passed. Driven by a
+ * periodic cron job because nothing else runs code at the close instant.
+ *
+ * @returns 200 with a report of what was closed
+ * @returns 500 if the sweep failed
+ */
+export const handleCloseExpiredForms: ControllerHandler<
+  never,
+  CloseExpiredFormsDto | ErrorDto
+> = (_req, res) => {
+  return FormService.closeExpiredForms()
+    .map((closedForms) => {
+      return res.status(StatusCodes.OK).json({
+        closedCount: closedForms.length,
+        formIds: closedForms.map((form) => form.formId),
+        hasMore:
+          closedForms.length === FormService.CLOSE_EXPIRED_FORMS_BATCH_LIMIT,
+      })
+    })
+    .mapErr((error) => {
+      logger.error({
+        message: 'Error running scheduled form closure sweep',
+        meta: { action: 'handleCloseExpiredForms' },
+        error,
+      })
+      return res
+        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+        .json({ message: error.message })
+    })
+}

--- a/apps/backend/src/app/modules/form/scheduled-closure/scheduled-closure.controller.ts
+++ b/apps/backend/src/app/modules/form/scheduled-closure/scheduled-closure.controller.ts
@@ -12,6 +12,10 @@ export type CloseExpiredFormsDto = {
   closedCount: number
   /** Ids of the forms closed, for correlating against the cron job's logs. */
   formIds: string[]
+  /** Notifications successfully sent to admins and collaborators. */
+  notifiedCount: number
+  /** Notifications that could not be sent. The closures still succeeded. */
+  notifyFailedCount: number
   /** Whether the sweep filled its batch limit, so more forms may be due. */
   hasMore: boolean
 }
@@ -19,21 +23,30 @@ export type CloseExpiredFormsDto = {
 /**
  * Handler for POST /cron/close-expired-forms
  *
- * Closes every public form whose scheduled expiry has passed. Driven by a
- * periodic cron job because nothing else runs code at the close instant.
+ * Closes every public form whose scheduled expiry has passed, then tells each
+ * form's admin and collaborators. Notification failures are reported but do not
+ * fail the request, since the forms are already closed.
  *
- * @returns 200 with a report of what was closed
- * @returns 500 if the sweep failed
+ * @returns 200 with a report of what was closed and notified
+ * @returns 500 if the sweep itself failed
  */
 export const handleCloseExpiredForms: ControllerHandler<
   never,
   CloseExpiredFormsDto | ErrorDto
 > = (_req, res) => {
   return FormService.closeExpiredForms()
-    .map((closedForms) => {
+    .andThen((closedForms) =>
+      FormService.notifyFormsClosed(closedForms).map((notified) => ({
+        closedForms,
+        notified,
+      })),
+    )
+    .map(({ closedForms, notified }) => {
       return res.status(StatusCodes.OK).json({
         closedCount: closedForms.length,
         formIds: closedForms.map((form) => form.formId),
+        notifiedCount: notified.sentCount,
+        notifyFailedCount: notified.failedCount,
         hasMore:
           closedForms.length === FormService.CLOSE_EXPIRED_FORMS_BATCH_LIMIT,
       })

--- a/apps/backend/src/app/routes/api/v3/cron/cron.routes.ts
+++ b/apps/backend/src/app/routes/api/v3/cron/cron.routes.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express'
+
+import { withCronScheduledClosureSecretAuthentication } from '../../../../modules/auth/auth.middlewares'
+import * as ScheduledClosureController from '../../../../modules/form/scheduled-closure/scheduled-closure.controller'
+
+/**
+ * Routes driven by scheduled jobs rather than by users. They sit outside
+ * /admin, whose router applies `withUserAuthentication` to everything beneath
+ * it: a cron caller has no user session, only a shared secret.
+ */
+export const CronRouter = Router()
+
+CronRouter.use(withCronScheduledClosureSecretAuthentication)
+
+/**
+ * Closes all public forms whose scheduled expiry has passed.
+ * @protected
+ * @route POST /cron/close-expired-forms
+ *
+ * @returns 200 with a report of which forms were closed
+ * @returns 401 if the shared secret is missing or wrong
+ * @returns 500 if the sweep failed
+ */
+CronRouter.post(
+  '/close-expired-forms',
+  ScheduledClosureController.handleCloseExpiredForms,
+)

--- a/apps/backend/src/app/routes/api/v3/cron/index.ts
+++ b/apps/backend/src/app/routes/api/v3/cron/index.ts
@@ -1,0 +1,1 @@
+export { CronRouter } from './cron.routes'

--- a/apps/backend/src/app/routes/api/v3/v3.routes.ts
+++ b/apps/backend/src/app/routes/api/v3/v3.routes.ts
@@ -6,6 +6,7 @@ import { AuthRouter } from './auth'
 import { BillingsRouter } from './billings'
 import { ClientRouter } from './client'
 import { CorppassOidcRouter } from './corppass'
+import { CronRouter } from './cron'
 import { FeatureFlagsRouter } from './feature-flags'
 import { PublicFormsRouter } from './forms'
 import { IntranetRouter } from './intranet'
@@ -31,3 +32,4 @@ V3Router.use('/payments', PaymentsRouter)
 V3Router.use('/feature-flags', FeatureFlagsRouter)
 V3Router.use('/intranet', IntranetRouter)
 V3Router.use('/status', StatusTrackerRouter)
+V3Router.use('/cron', CronRouter)

--- a/apps/backend/src/app/services/mail/mail.service.ts
+++ b/apps/backend/src/app/services/mail/mail.service.ts
@@ -33,6 +33,7 @@ import {
   WorkflowOutcome,
 } from '../../views/templates/EmailTemplate'
 import { FormDeactivatedNotification } from '../../views/templates/FormDeactivatedNotification'
+import { FormScheduledClosureNotification } from '../../views/templates/FormScheduledClosureNotification'
 import { SmsThresholdWarningNotification } from '../../views/templates/SmsThresholdWarningNotification'
 import { smsThreshold } from '../sms/sms.utils'
 
@@ -47,6 +48,7 @@ import {
   AutoreplySummaryRenderData,
   BounceNotificationHtmlData,
   FormDeactivatedNotificationHtmlData,
+  FormScheduledClosureNotificationHtmlData,
   IssueReportedNotificationData,
   MailOptions,
   MailServiceParams,
@@ -677,6 +679,81 @@ export class MailService {
         })
         return error
       })
+    })
+  }
+
+  /**
+   * Sends a notification that a form has closed by reaching its scheduled
+   * expiry date. Unlike sendFormDeactivatedNotification this needs no
+   * remediation, only confirmation.
+   *
+   * @param args the parameter object
+   * @param args.emailRecipients emails to send to
+   * @param args.formTitle title of form
+   * @param args.formId ID of form
+   * @param args.closedAt human-readable close instant, pre-formatted in SGT
+   */
+  sendFormScheduledClosureNotification = ({
+    emailRecipients,
+    formTitle,
+    formId,
+    closedAt,
+  }: {
+    emailRecipients: string[]
+    formTitle: string
+    formId: string
+    closedAt: string
+  }): ResultAsync<true, MailGenerationError | MailSendError> => {
+    const htmlData: FormScheduledClosureNotificationHtmlData = {
+      formTitle,
+      formLink: `${this.#appUrl}/${formId}`,
+      closedAt,
+      appName: this.#appName,
+    }
+
+    const generatedHtml = fromPromise(
+      render(FormScheduledClosureNotification(htmlData)),
+      (e) => {
+        logger.error({
+          message: 'Failed to render FormScheduledClosureNotification',
+          meta: {
+            action: 'sendFormScheduledClosureNotification',
+            error: e,
+          },
+        })
+
+        return new MailGenerationError(
+          'Error generating form scheduled closure notification email',
+        )
+      },
+    )
+
+    return generatedHtml.andThen((mailHtml) => {
+      const mail: MailOptions = {
+        to: emailRecipients,
+        from: this.#senderFromString,
+        subject: `Your form has closed: ${formTitle}`,
+        html: mailHtml,
+        headers: {
+          [EMAIL_HEADERS.emailType]: EmailType.WarningNotification,
+          [EMAIL_HEADERS.formId]: formId,
+        },
+      }
+
+      return this.#sendNodeMail(mail, { mailId: 'scheduled-closure' }).mapErr(
+        (error) => {
+          logger.error({
+            message: 'Error sending form scheduled closure notification email',
+            meta: {
+              action: 'sendFormScheduledClosureNotification',
+              formTitle,
+              formId,
+            },
+            error,
+          })
+          return error
+        },
+      )
     })
   }
 

--- a/apps/backend/src/app/services/mail/mail.types.ts
+++ b/apps/backend/src/app/services/mail/mail.types.ts
@@ -106,6 +106,14 @@ export type FormDeactivatedNotificationHtmlData = {
   appName: string
 }
 
+export type FormScheduledClosureNotificationHtmlData = {
+  formTitle: string
+  formLink: string
+  /** Human-readable close instant, pre-formatted in SGT by the caller. */
+  closedAt: string
+  appName: string
+}
+
 export type SmsThresholdWarningNotificationHtmlData =
   FormDeactivatedNotificationHtmlData & {
     smsThreshold: smsThreshold

--- a/apps/backend/src/app/views/templates/FormScheduledClosureNotification.tsx
+++ b/apps/backend/src/app/views/templates/FormScheduledClosureNotification.tsx
@@ -1,0 +1,31 @@
+import { Body, Head, Html, Text } from '@react-email/components'
+
+import { FormScheduledClosureNotificationHtmlData } from '../../services/mail/mail.types'
+
+export const FormScheduledClosureNotification = ({
+  formTitle,
+  formLink,
+  closedAt,
+  appName,
+}: FormScheduledClosureNotificationHtmlData): JSX.Element => {
+  return (
+    <Html>
+      <Head />
+      <Body>
+        <Text>Dear form admin(s),</Text>
+        <Text>
+          Your form <b>{formTitle}</b> (<a href={formLink}>{formLink}</a>) has
+          stopped accepting responses, as it reached the expiry date you set:{' '}
+          <b>{closedAt}</b>.
+        </Text>
+        <Text>
+          Your existing responses are unaffected and still available. If you
+          need to collect more responses, you can reopen the form and set a new
+          expiry date in its settings.
+        </Text>
+
+        <Text>The {appName} Support Team</Text>
+      </Body>
+    </Html>
+  )
+}

--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -114,6 +114,10 @@
           "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CRON_PAYMENT_API_SECRET"
         },
         {
+          "name": "CRON_SCHEDULED_CLOSURE_API_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CRON_SCHEDULED_CLOSURE_API_SECRET"
+        },
+        {
           "name": "SLACK_API_SECRET",
           "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SLACK_API_SECRET"
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,7 @@ services:
       - PAYMENT_LANDING_GUIDE_LINK
       # Cron secrets
       - CRON_PAYMENT_API_SECRET=secretKey
+      - CRON_SCHEDULED_CLOSURE_API_SECRET=secretKey
       # env vars for go integration
       - GOGOV_API_KEY
       # Bearer token API key format


### PR DESCRIPTION
## Problem

- After 3/8 nothing runs at the close instant, so a form nobody visits still reports itself open.
- The admin is never told the form closed, which the PRD requires. This is the server half; 5/8 invokes it.

## Solution

- `POST /api/v3/cron/close-expired-forms` closes every public form past its deadline and reports which.
- Each run caps at 500 forms and returns `hasMore`, so one sweep cannot become an unbounded update.
- A new `/cron` router carries its own shared-secret middleware, outside `/admin` and its session auth.
- The query says `$type: 'date'`, not `$ne: null`; the planner will not otherwise use the partial index.
- `notifyFormsClosed` never rejects — a mail failure would 500 a request that had already closed forms.
- The secret check fails closed when unset, unlike the payment cron's `===` against an empty default.

**Alternatives considered**

- Reusing `sendFormDeactivatedNotification` — skipped, it is SMS-threshold specific and tells the admin to contact support.
- A plain compound or `$exists` partial index — both work at ~45KB; `$type` holds only deadline-bearing forms, at ~20KB.
- Fixing the same auth bug in the payment cron — skipped, it deserves its own change and its own testing.

**Breaking changes:** none. The endpoint is new and unreachable without the secret; nothing calls it until 5/8.

**Deploy:** new `CRON_SCHEDULED_CLOSURE_API_SECRET`, separate from the payment secret. `autoIndex` is off outside dev, so build the index by hand in Atlas with `background: true`.

## Screenshots

Step 1. Created a new form, opened form to new responses, then set an expiry date.
<img width="1510" height="843" alt="Screenshot 2026-08-24 at 2 47 11 PM" src="https://github.com/user-attachments/assets/900a6ce4-c981-4892-8a2f-e39208bf4d27" />

Step 2. At the expiry date, hit the cron (this is done manually locally):
```
curl -X POST http://localhost:5001/api/v3/cron/close-expired-forms \
  -H "x-formsg-cron-scheduled-closure-secret: secretKey"
{"closedCount":1,"formIds":["6a8be80ebe9479d16560443e"],"notifiedCount":1,"notifyFailedCount":0,"hasMore":false}
```
Ensure that closedCount is 1

Step 3. Ensure that email has been sent.
<img width="1512" height="767" alt="Screenshot 2026-08-24 at 3 17 23 PM" src="https://github.com/user-attachments/assets/3112e6b6-4916-4093-91a4-1b5f9215fb2a" />

Step 4. Confirm that the form's status has been closed (PUBLIC back to PRIVATE) 
<img width="1511" height="764" alt="Screenshot 2026-08-24 at 3 19 58 PM" src="https://github.com/user-attachments/assets/87e58afa-7c71-4c0b-97d2-cf8de1fb9ecf" />
<img width="1510" height="838" alt="Screenshot 2026-08-24 at 3 20 40 PM" src="https://github.com/user-attachments/assets/c17ddee0-c15a-4a23-84b8-e5b7efe4cc1f" />

## Tests

**Automated**

- `form.scheduled-closure.service.spec.ts` — 17 tests: expired, future, unset and already-private forms.
- Also idempotency across repeated sweeps, the batch cap, collaborator recipients, SGT formatting and partial send failure.

**Manual**

- [ ] Backdate a public form, call the endpoint with the secret, and verify `closedCount: 1` and PRIVATE.
- [ ] Call again and verify `closedCount: 0`.
- [ ] Call with no header, a wrong secret, then an empty header value; verify 401 each time.
- [ ] Add a collaborator, run the sweep, and verify both recipients get the email in SGT.
- [ ] `explain("executionStats")` the sweep query and verify `IXSCAN`, not `COLLSCAN`.
