### PR TITLE
fix(public-form): thread form colorScheme to issue feedback modal buttons

### DIFF
--- a/apps/frontend/src/features/public-form/components/FloatingToolBar/FloatingIssueFeedbackButton.tsx
+++ b/apps/frontend/src/features/public-form/components/FloatingToolBar/FloatingIssueFeedbackButton.tsx
@@ -41,6 +41,7 @@ export const FloatingIssueFeedbackButton = ({
         onClose={onClose}
         isPreview={isPreview}
         formId={formId}
+        colorScheme={colorScheme}
       />
     </>
   )

--- a/apps/frontend/src/features/public-form/components/FloatingToolBar/FormIssueFeedbackModal.stories.tsx
+++ b/apps/frontend/src/features/public-form/components/FloatingToolBar/FormIssueFeedbackModal.stories.tsx
@@ -41,18 +41,22 @@ const Template: StoryFn<FormIssueFeedbackProps> = (args) => {
 export const PublicView = Template.bind({})
 PublicView.args = {
   isPreview: false,
+  colorScheme: 'theme-red',
 }
+
 export const MobilePublicView = Template.bind({})
 MobilePublicView.parameters = {
   ...getMobileViewParameters(),
 }
 MobilePublicView.args = {
   isPreview: false,
+  colorScheme: 'theme-red',
 }
 
 export const AdminPreview = Template.bind({})
 AdminPreview.args = {
   isPreview: true,
+  colorScheme: 'theme-red',
 }
 
 export const MobileAdminPreView = Template.bind({})
@@ -61,4 +65,5 @@ MobileAdminPreView.parameters = {
 }
 MobileAdminPreView.args = {
   isPreview: true,
+  colorScheme: 'theme-red',
 }

--- a/apps/frontend/src/features/public-form/components/FloatingToolBar/FormIssueFeedbackModal.tsx
+++ b/apps/frontend/src/features/public-form/components/FloatingToolBar/FormIssueFeedbackModal.tsx
@@ -18,6 +18,7 @@ import isEmail from 'validator/lib/isEmail'
 
 import { BasicField, SubmitFormIssueBodyDto } from 'formsg-shared/types'
 
+import { ThemeColorScheme } from '~theme/foundations/colours'
 import { INVALID_EMAIL_ERROR, REQUIRED_ERROR } from '~constants/validation'
 import { useIsMobile } from '~hooks/useIsMobile'
 import { useToast } from '~hooks/useToast'
@@ -35,6 +36,7 @@ export interface FormIssueFeedbackProps {
   onClose: () => void
   isPreview: boolean
   formId: string
+  colorScheme?: ThemeColorScheme
 }
 
 export const FormIssueFeedbackModal = ({
@@ -42,6 +44,7 @@ export const FormIssueFeedbackModal = ({
   onClose,
   isPreview,
   formId,
+  colorScheme,
 }: FormIssueFeedbackProps): JSX.Element | null => {
   const { t } = useTranslation()
 
@@ -160,10 +163,19 @@ export const FormIssueFeedbackModal = ({
               justify="right"
               direction={{ base: 'column-reverse', md: 'row' }}
             >
-              <Button isFullWidth={isMobile} variant="clear" onClick={onClose}>
+              <Button
+                isFullWidth={isMobile}
+                variant="clear"
+                onClick={onClose}
+                colorScheme={colorScheme}
+              >
                 {t('features.common.cancel')}
               </Button>
-              <Button isFullWidth={isMobile} type="submit">
+              <Button
+                isFullWidth={isMobile}
+                type="submit"
+                colorScheme={colorScheme}
+              >
                 {t(
                   'features.publicForm.components.formIssueFeedbackModal.actions.submit',
                 )}


### PR DESCRIPTION
## Problem

Feedback button doesnt match the form theme colour, leading to design incosistencies.

<img width="1658" height="1226" alt="image" src="https://github.com/user-attachments/assets/f92111bf-51d7-4d71-8b40-ec8d03c3b425" />

## Solution

1. Pass the form's `colorScheme` down from `FloatingIssueFeedbackButton` into `FormIssueFeedbackModal`
2. Apply `colorScheme` to modal buttons
3. Update growthbook components to use different colour themes

**Breaking Changes**

No - backwards compatible. 

* `colorScheme` is an optional prop, omitting it falls back to existing behaviour
* no other component is using `FormIssueFeedbackModal`

## Screenshots

<img width="1909" height="931" alt="image" src="https://github.com/user-attachments/assets/d8f01c0a-eaae-498c-a911-69fbbf401fc2" />

<img width="1913" height="930" alt="image" src="https://github.com/user-attachments/assets/a2af5ec5-6d16-445e-b68d-04e69109cbfc" />

## Tests

**TC1: Modal buttons match the form's color scheme**

- [ ] Open a public form with a non-default colorScheme (e.g. `theme-red`) set in the admin builder.
- [ ] Click the floating "Report vulnerability" button to open the feedback modal.
- [ ] Confirm the Cancel and Submit buttons render in the form's colorScheme, not the default theme color.

**TC2: Admin preview and mobile views**

- [ ] Repeat TC1 from the admin preview and on a mobile viewport, confirming the Storybook `AdminPreview`/`MobilePublicView`/`MobileAdminPreView` states match.
