### PR TITLE
feat(auth-wogad): accept a PKCE code verifier at /verify

### DIFF
--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -22,10 +22,6 @@ jest.mock('@azure/msal-node', () => {
   })
   const mockRemoveAccount = jest.fn()
 
-  // The controller narrows caught errors with `error instanceof AuthError`.
-  // Without this export the mock leaves AuthError undefined, and the catch
-  // block throws `Right-hand side of 'instanceof' is not an object` before it
-  // can log or respond.
   class MockAuthError extends Error {
     constructor(
       public errorCode?: string,
@@ -231,42 +227,6 @@ describe('AuthWogadController', () => {
         AuthWogadController.WOGAD_CSRF_TOKEN_COOKIE_NAME,
         AuthWogadController.WOGAD_AUTH_COOKIE_OPTIONS,
       )
-    })
-
-    // Guards the rolling-deploy window: a login started by an instance that
-    // predates PKCE has no verifier cookie and no code_challenge bound at the
-    // IdP, so the exchange must still be attempted rather than rejected here.
-    it('should still attempt the token exchange when the verifier cookie is absent', async () => {
-      // Arrange
-      const mockReq = expressHandler.mockRequest({
-        body: {
-          code: 'MOCK_AUTH_CODE',
-          csrfToken: csrfTokenA,
-        },
-        cookies: {
-          csrf_token: csrfTokenA,
-        },
-      })
-      const mockRes = expressHandler.mockResponse()
-      MockAuthService.validateEmailDomain = jest
-        .fn()
-        .mockReturnValue(okAsync(<AgencyDocument>{ _id: 'MOCK_AGENCY_ID' }))
-      MockUserService.retrieveUser = jest.fn().mockReturnValueOnce(
-        okAsync(<IPopulatedUser>{
-          _id: 'MOCK_USER_ID',
-        }),
-      )
-      // Act
-      await AuthWogadController.handleVerifyWithCodeForTest(
-        mockReq,
-        mockRes,
-        jest.fn(),
-      )
-      // Assert
-      expect(msalMocks.acquireTokenByCode).toHaveBeenCalledWith(
-        expect.objectContaining({ codeVerifier: undefined }),
-      )
-      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
     })
 
     it('should return 403 when csrf token mismatch', async () => {

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -22,7 +22,21 @@ jest.mock('@azure/msal-node', () => {
   })
   const mockRemoveAccount = jest.fn()
 
+  // The controller narrows caught errors with `error instanceof AuthError`.
+  // Without this export the mock leaves AuthError undefined, and the catch
+  // block throws `Right-hand side of 'instanceof' is not an object` before it
+  // can log or respond.
+  class MockAuthError extends Error {
+    constructor(
+      public errorCode?: string,
+      public errorMessage?: string,
+    ) {
+      super(errorMessage)
+    }
+  }
+
   return {
+    AuthError: MockAuthError,
     ConfidentialClientApplication: jest.fn().mockImplementation(() => ({
       getAuthCodeUrl: mockGetAuthCodeUrl,
       acquireTokenByCode: mockAcquireTokenByCode,

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -75,9 +75,9 @@ describe('AuthWogadController', () => {
       )
       // Assert
       expect(mockRes.cookie).toHaveBeenCalledWith(
-        'csrf_token',
+        AuthWogadController.WOGAD_CSRF_TOKEN_COOKIE_NAME,
         expect.stringMatching(/^[a-f0-9]{64}$/i),
-        expect.any(Object),
+        AuthWogadController.WOGAD_AUTH_COOKIE_OPTIONS,
       )
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -190,8 +190,12 @@ describe('AuthWogadController', () => {
       // Assert
       expect(mockRes.clearCookie).toHaveBeenCalledWith(
         AuthWogadController.WOGAD_CODE_VERIFIER_COOKIE_NAME,
+        AuthWogadController.WOGAD_AUTH_COOKIE_OPTIONS,
       )
-      expect(mockRes.clearCookie).toHaveBeenCalledWith('csrf_token')
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        AuthWogadController.WOGAD_CSRF_TOKEN_COOKIE_NAME,
+        AuthWogadController.WOGAD_AUTH_COOKIE_OPTIONS,
+      )
     })
 
     it('should clear both auth cookies when the token exchange fails', async () => {
@@ -221,8 +225,12 @@ describe('AuthWogadController', () => {
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.FORBIDDEN)
       expect(mockRes.clearCookie).toHaveBeenCalledWith(
         AuthWogadController.WOGAD_CODE_VERIFIER_COOKIE_NAME,
+        AuthWogadController.WOGAD_AUTH_COOKIE_OPTIONS,
       )
-      expect(mockRes.clearCookie).toHaveBeenCalledWith('csrf_token')
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        AuthWogadController.WOGAD_CSRF_TOKEN_COOKIE_NAME,
+        AuthWogadController.WOGAD_AUTH_COOKIE_OPTIONS,
+      )
     })
 
     // Guards the rolling-deploy window: a login started by an instance that

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -158,6 +158,66 @@ describe('AuthWogadController', () => {
       )
     })
 
+    it('should clear both auth cookies after a successful verification', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        body: {
+          code: 'MOCK_AUTH_CODE',
+          csrfToken: csrfTokenA,
+        },
+        cookies: {
+          csrf_token: csrfTokenA,
+          wogadCodeVerifier: MOCK_CODE_VERIFIER,
+        },
+      })
+      const mockRes = expressHandler.mockResponse()
+      MockAuthService.validateEmailDomain = jest
+        .fn()
+        .mockReturnValue(okAsync(<AgencyDocument>{ _id: 'MOCK_AGENCY_ID' }))
+      MockUserService.retrieveUser = jest.fn().mockReturnValueOnce(
+        okAsync(<IPopulatedUser>{
+          _id: 'MOCK_USER_ID',
+        }),
+      )
+      // Act
+      await AuthWogadController.handleVerifyWithCodeForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      // Assert
+      expect(mockRes.clearCookie).toHaveBeenCalledWith('wogadCodeVerifier')
+      expect(mockRes.clearCookie).toHaveBeenCalledWith('csrf_token')
+    })
+
+    it('should clear both auth cookies when the token exchange fails', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        body: {
+          code: 'MOCK_AUTH_CODE',
+          csrfToken: csrfTokenA,
+        },
+        cookies: {
+          csrf_token: csrfTokenA,
+          wogadCodeVerifier: MOCK_CODE_VERIFIER,
+        },
+      })
+      const mockRes = expressHandler.mockResponse()
+      msalMocks.acquireTokenByCode.mockRejectedValueOnce(
+        new Error('MOCK_TOKEN_FAILURE'),
+      )
+      // Act
+      await AuthWogadController.handleVerifyWithCodeForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      // Assert
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.FORBIDDEN)
+      expect(mockRes.clearCookie).toHaveBeenCalledWith('wogadCodeVerifier')
+      expect(mockRes.clearCookie).toHaveBeenCalledWith('csrf_token')
+    })
+
     it('should return 403 when csrf token mismatch', async () => {
       // Arrange
       const mockReq = expressHandler.mockRequest({

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -218,6 +218,42 @@ describe('AuthWogadController', () => {
       expect(mockRes.clearCookie).toHaveBeenCalledWith('csrf_token')
     })
 
+    // Guards the rolling-deploy window: a login started by an instance that
+    // predates PKCE has no verifier cookie and no code_challenge bound at the
+    // IdP, so the exchange must still be attempted rather than rejected here.
+    it('should still attempt the token exchange when the verifier cookie is absent', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        body: {
+          code: 'MOCK_AUTH_CODE',
+          csrfToken: csrfTokenA,
+        },
+        cookies: {
+          csrf_token: csrfTokenA,
+        },
+      })
+      const mockRes = expressHandler.mockResponse()
+      MockAuthService.validateEmailDomain = jest
+        .fn()
+        .mockReturnValue(okAsync(<AgencyDocument>{ _id: 'MOCK_AGENCY_ID' }))
+      MockUserService.retrieveUser = jest.fn().mockReturnValueOnce(
+        okAsync(<IPopulatedUser>{
+          _id: 'MOCK_USER_ID',
+        }),
+      )
+      // Act
+      await AuthWogadController.handleVerifyWithCodeForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      // Assert
+      expect(msalMocks.acquireTokenByCode).toHaveBeenCalledWith(
+        expect.objectContaining({ codeVerifier: undefined }),
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.OK)
+    })
+
     it('should return 403 when csrf token mismatch', async () => {
       // Arrange
       const mockReq = expressHandler.mockRequest({

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -39,6 +39,7 @@ jest.mock('@azure/msal-node', () => {
 })
 
 const MOCK_AUTH_URL = 'MOCK_AUTH_URL'
+const MOCK_CODE_VERIFIER = 'MOCK_CODE_VERIFIER'
 
 const msalMocks = jest.requireMock('@azure/msal-node').msalMocks
 
@@ -108,6 +109,39 @@ describe('AuthWogadController', () => {
       expect(mockRes.json).toHaveBeenCalledWith({
         _id: 'MOCK_USER_ID',
       })
+    })
+
+    it('should pass the code verifier from the cookie to the token request', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest({
+        body: {
+          code: 'MOCK_AUTH_CODE',
+          csrfToken: csrfTokenA,
+        },
+        cookies: {
+          csrf_token: csrfTokenA,
+          wogadCodeVerifier: MOCK_CODE_VERIFIER,
+        },
+      })
+      const mockRes = expressHandler.mockResponse()
+      MockAuthService.validateEmailDomain = jest
+        .fn()
+        .mockReturnValue(okAsync(<AgencyDocument>{ _id: 'MOCK_AGENCY_ID' }))
+      MockUserService.retrieveUser = jest.fn().mockReturnValueOnce(
+        okAsync(<IPopulatedUser>{
+          _id: 'MOCK_USER_ID',
+        }),
+      )
+      // Act
+      await AuthWogadController.handleVerifyWithCodeForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      // Assert
+      expect(msalMocks.acquireTokenByCode).toHaveBeenCalledWith(
+        expect.objectContaining({ codeVerifier: MOCK_CODE_VERIFIER }),
+      )
     })
 
     it('should return 403 when csrf token mismatch', async () => {

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -134,7 +134,8 @@ describe('AuthWogadController', () => {
         },
         cookies: {
           csrf_token: csrfTokenA,
-          wogadCodeVerifier: MOCK_CODE_VERIFIER,
+          [AuthWogadController.WOGAD_CODE_VERIFIER_COOKIE_NAME]:
+            MOCK_CODE_VERIFIER,
         },
       })
       const mockRes = expressHandler.mockResponse()
@@ -167,7 +168,8 @@ describe('AuthWogadController', () => {
         },
         cookies: {
           csrf_token: csrfTokenA,
-          wogadCodeVerifier: MOCK_CODE_VERIFIER,
+          [AuthWogadController.WOGAD_CODE_VERIFIER_COOKIE_NAME]:
+            MOCK_CODE_VERIFIER,
         },
       })
       const mockRes = expressHandler.mockResponse()
@@ -186,7 +188,9 @@ describe('AuthWogadController', () => {
         jest.fn(),
       )
       // Assert
-      expect(mockRes.clearCookie).toHaveBeenCalledWith('wogadCodeVerifier')
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        AuthWogadController.WOGAD_CODE_VERIFIER_COOKIE_NAME,
+      )
       expect(mockRes.clearCookie).toHaveBeenCalledWith('csrf_token')
     })
 
@@ -199,7 +203,8 @@ describe('AuthWogadController', () => {
         },
         cookies: {
           csrf_token: csrfTokenA,
-          wogadCodeVerifier: MOCK_CODE_VERIFIER,
+          [AuthWogadController.WOGAD_CODE_VERIFIER_COOKIE_NAME]:
+            MOCK_CODE_VERIFIER,
         },
       })
       const mockRes = expressHandler.mockResponse()
@@ -214,7 +219,9 @@ describe('AuthWogadController', () => {
       )
       // Assert
       expect(mockRes.status).toHaveBeenCalledWith(StatusCodes.FORBIDDEN)
-      expect(mockRes.clearCookie).toHaveBeenCalledWith('wogadCodeVerifier')
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        AuthWogadController.WOGAD_CODE_VERIFIER_COOKIE_NAME,
+      )
       expect(mockRes.clearCookie).toHaveBeenCalledWith('csrf_token')
     })
 

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
@@ -32,6 +32,11 @@ const ccaSingleton = isWogadConfigDefined
   : null
 const redirectUri = resolveAppUrl(`${wogad.redirectUri}`)
 
+/**
+ * Name of the cookie holding the PKCE code verifier for the WOG AD flow.
+ */
+export const WOGAD_CODE_VERIFIER_COOKIE_NAME = 'wogadCodeVerifier'
+
 const validateWogadConfig: ControllerHandler = (_req, res, next) => {
   if (!isWogadConfigDefined || !ccaSingleton) {
     return res.status(StatusCodes.METHOD_NOT_ALLOWED).json({
@@ -137,11 +142,13 @@ const _handleVerifyWithCode: ControllerHandler<
   }
 
   const code = req.body['code']
+  const codeVerifier = req.cookies[WOGAD_CODE_VERIFIER_COOKIE_NAME]
 
   const tokenRequest = {
     code,
     scopes: ['openid', 'email'],
     redirectUri,
+    codeVerifier,
   }
 
   let account: AccountInfo | null

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
@@ -144,6 +144,12 @@ const _handleVerifyWithCode: ControllerHandler<
   const code = req.body['code']
   const codeVerifier = req.cookies[WOGAD_CODE_VERIFIER_COOKIE_NAME]
 
+  // Both cookies are single-use and scoped to this one login attempt. Clear
+  // them before the exchange so that every exit path below - success or
+  // failure - leaves nothing behind for a subsequent attempt to pick up.
+  res.clearCookie(WOGAD_CODE_VERIFIER_COOKIE_NAME)
+  res.clearCookie('csrf_token')
+
   const tokenRequest = {
     code,
     scopes: ['openid', 'email'],

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
@@ -1,6 +1,7 @@
 import {
   AccountInfo,
   AuthError,
+  AuthorizationCodeRequest,
   AuthorizationUrlRequest,
   ConfidentialClientApplication,
 } from '@azure/msal-node'
@@ -32,10 +33,16 @@ const ccaSingleton = isWogadConfigDefined
   : null
 const redirectUri = resolveAppUrl(`${wogad.redirectUri}`)
 
-/**
- * Name of the cookie holding the PKCE code verifier for the WOG AD flow.
- */
 export const WOGAD_CODE_VERIFIER_COOKIE_NAME = 'wogadCodeVerifier'
+export const WOGAD_CSRF_TOKEN_COOKIE_NAME = 'csrf_token'
+
+// RATIONALE: Shared with both res.cookie and res.clearCookie to ensure cookies match when cleared.
+export const WOGAD_AUTH_COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: !config.isDevOrTest,
+  sameSite: !config.isDevOrTest ? ('strict' as const) : undefined,
+  path: '/',
+}
 
 const validateWogadConfig: ControllerHandler = (_req, res, next) => {
   if (!isWogadConfigDefined || !ccaSingleton) {
@@ -78,11 +85,7 @@ const _generateAuthUrl: ControllerHandler<
     redirectUri,
   }
 
-  res.cookie('csrf_token', csrfToken, {
-    httpOnly: true,
-    secure: !config.isDevOrTest,
-    sameSite: !config.isDevOrTest ? 'strict' : undefined,
-  })
+  res.cookie(WOGAD_CSRF_TOKEN_COOKIE_NAME, csrfToken, WOGAD_AUTH_COOKIE_OPTIONS)
 
   const authUrl = await ccaSingleton.getAuthCodeUrl(authCodeUrlParams)
 
@@ -103,12 +106,13 @@ export const generateAuthUrl = [
  * 1. This endpoint is called after the browser is redirected to the redirect URI with the code and csrf token.
  * 2. Then, it will send over the code and csrf token to the backend.
  * 3. The backend will verify the csrf token matches before using the code to retrieve the access token.
- * 4. This access token will also include the additional metadata such as admin's email in the same HTTPS response payload.
+ * 4. The code verifier is included in the request, to verify the code is generated from the same browser which has the cookie.
+ * 5. This access token will also include the additional metadata such as admin's email in the same HTTPS response payload.
  * (Hence, no validation of signature is needed.)
- * 5. Once the access token is retrieved, we will perform checks on whitelist access.
- * 6. Then, we can modify the session to include the user's id and persist this session in the store as active.
- * 7. Also, we include a grant source to indicate that the user logged in via WOG AD. This is useful during logout.
- * 8. At this point, the user is logged in and can access the protected routes using FormSG's session mechanism.
+ * 6. Once the access token is retrieved, we will perform checks on whitelist access.
+ * 7. Then, we can modify the session to include the user's id and persist this session in the store as active.
+ * 8. Also, we include a grant source to indicate that the user logged in via WOG AD. This is useful during logout.
+ * 9. At this point, the user is logged in and can access the protected routes using FormSG's session mechanism.
  */
 const _handleVerifyWithCode: ControllerHandler<
   unknown,
@@ -128,7 +132,7 @@ const _handleVerifyWithCode: ControllerHandler<
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR)
   }
 
-  const csrfTokenFromCookie = req.cookies['csrf_token']
+  const csrfTokenFromCookie = req.cookies[WOGAD_CSRF_TOKEN_COOKIE_NAME]
   const csrfTokenFromBody = req.body['csrfToken']
 
   if (!csrfTokenFromCookie || csrfTokenFromCookie !== csrfTokenFromBody) {
@@ -144,13 +148,12 @@ const _handleVerifyWithCode: ControllerHandler<
   const code = req.body['code']
   const codeVerifier = req.cookies[WOGAD_CODE_VERIFIER_COOKIE_NAME]
 
-  // Both cookies are single-use and scoped to this one login attempt. Clear
-  // them before the exchange so that every exit path below - success or
-  // failure - leaves nothing behind for a subsequent attempt to pick up.
-  res.clearCookie(WOGAD_CODE_VERIFIER_COOKIE_NAME)
-  res.clearCookie('csrf_token')
+  // RATIONALE: Both cookies are single-use and scoped to this one login attempt. Clear
+  // before the exchange to prevent reuse, regardless of success or failure.
+  res.clearCookie(WOGAD_CODE_VERIFIER_COOKIE_NAME, WOGAD_AUTH_COOKIE_OPTIONS)
+  res.clearCookie(WOGAD_CSRF_TOKEN_COOKIE_NAME, WOGAD_AUTH_COOKIE_OPTIONS)
 
-  const tokenRequest = {
+  const tokenRequest: AuthorizationCodeRequest = {
     code,
     scopes: ['openid', 'email'],
     redirectUri,


### PR DESCRIPTION
## Problem

Our WOG AD admin login ties an authorization code to a browser with one control only: the `csrf_token` double-submit. That stops a forged login, where an attacker makes someone sign in as the attacker. It does not stop the reverse. If a person gets hold of a code that WOG AD issued for an admin, they can post it to our own `/verify` endpoint. FormSG holds the client secret, so FormSG redeems the code and puts that admin's identity into the attacker's session.

Codes travel in URLs, so they leak through referrer headers, browser history, and proxy or CDN access logs. PKCE closes this gap. This pull request is the first of two steps and changes nothing an admin can see.

## Solution

<img width="1672" height="1822" alt="image" src="https://github.com/user-attachments/assets/bf83f9da-624d-4d4d-b09f-823e4a0f61f3" />

`/verify` now reads a `wogadCodeVerifier` cookie and passes it to the token request. It also clears both single-use login cookies before the exchange, so no exit path can leave one behind for a later attempt to pick up.

Nothing sets that cookie yet. `/authUrl` starts to issue a challenge in the follow-up pull request. This release therefore does nothing on its own, and that is deliberate. Every running instance must be able to handle a verifier before any instance starts to issue challenges. If we did it the other way round, a new instance would issue a challenge while an old instance still served `/verify`, the token request would arrive with no verifier, and WOG AD would refuse it with `AADSTS501481`.

**Alternatives considered**

- We considered a 403 when the verifier cookie is missing. It gives a clearer error on our side, but it breaks every login that was already in flight when the deploy started, and it buys no security. Once `/authUrl` issues a challenge, WOG AD refuses any redemption without a matching verifier, so the real enforcement is there, not here.
- We considered one release for both halves. It is simpler, but admins who are part-way through login during the rollout would get a 403 and have to try again. This is a login path, so that turns into support tickets.
- We considered a `WOGAD_PKCE_ENABLED` setting in SSM so we could ship once and switch on later. Our config is read at boot, so the switch still needs a restart. Same two steps, plus a setting to remove afterwards.

**Breaking Changes**

No - backwards compatible. This release is inert until the follow-up ships.

## Tests

**TC1: WOG AD login is unchanged**

- [x] Sign in through WOG AD as a whitelisted admin.
- [x] Confirm you reach the dashboard as before.
- [x] In devtools, confirm no `wogadCodeVerifier` cookie appears at any point. This release does not create one.
- [x] Confirm `csrf_token` is gone from the browser after `/verify` finishes.

**TC2: A refused login still cleans up**

- [x] Sign in through WOG AD as an admin whose email is not whitelisted.
- [x] Confirm you see the login failure.
- [x] Confirm `csrf_token` is gone from the browser.
