### PR TITLE
feat(auth-wogad): issue an S256 PKCE challenge at /authUrl

### DIFF
--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -64,9 +64,10 @@ describe('AuthWogadController', () => {
   ) =>
     jest
       .mocked(mockRes.cookie)
-      .mock.calls.find(([name]) => name === 'wogadCodeVerifier') as unknown as
-      | [string, string, Record<string, unknown>]
-      | undefined
+      .mock.calls.find(
+        ([name]) =>
+          name === AuthWogadController.WOGAD_CODE_VERIFIER_COOKIE_NAME,
+      ) as unknown as [string, string, Record<string, unknown>] | undefined
 
   describe('generateAuthUrl', () => {
     it('should include csrf token in response cookie', async () => {

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.spec.ts
@@ -1,4 +1,5 @@
 import expressHandler from '__tests__/unit/backend/helpers/jest-express'
+import crypto from 'crypto'
 import { StatusCodes } from 'http-status-codes'
 import { errAsync, okAsync } from 'neverthrow'
 
@@ -58,6 +59,15 @@ describe('AuthWogadController', () => {
     jest.clearAllMocks()
   })
 
+  const getVerifierCookieCall = (
+    mockRes: ReturnType<typeof expressHandler.mockResponse>,
+  ) =>
+    jest
+      .mocked(mockRes.cookie)
+      .mock.calls.find(([name]) => name === 'wogadCodeVerifier') as unknown as
+      | [string, string, Record<string, unknown>]
+      | undefined
+
   describe('generateAuthUrl', () => {
     it('should include csrf token in response cookie', async () => {
       // Arrange
@@ -80,6 +90,81 @@ describe('AuthWogadController', () => {
         authUrl: MOCK_AUTH_URL,
         csrfToken: expect.stringMatching(/^[a-f0-9]{64}$/i),
       })
+    })
+
+    it('should send an S256 challenge derived from the stored verifier', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest()
+      const mockRes = expressHandler.mockResponse()
+      // Act
+      await AuthWogadController.generateAuthUrlForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      // Assert
+      const verifier = getVerifierCookieCall(mockRes)?.[1]
+      const [authCodeUrlParams] = jest.mocked(msalMocks.getAuthCodeUrl).mock
+        .calls[0] as unknown as [Record<string, unknown>]
+
+      // The challenge must actually be SHA256(verifier), not merely present -
+      // an unrelated pair would sail past a presence check and fail only at
+      // the IdP, in production.
+      expect(authCodeUrlParams.codeChallenge).toBe(
+        crypto
+          .createHash('sha256')
+          .update(verifier as string)
+          .digest('base64url'),
+      )
+      expect(authCodeUrlParams.codeChallengeMethod).toBe('S256')
+    })
+
+    it('should store the code verifier in a session-scoped httpOnly cookie', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest()
+      const mockRes = expressHandler.mockResponse()
+      // Act
+      await AuthWogadController.generateAuthUrlForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      // Assert
+      const verifierCookieCall = getVerifierCookieCall(mockRes)
+      expect(verifierCookieCall).toBeDefined()
+
+      const [, value, options] = verifierCookieCall as [
+        string,
+        string,
+        Record<string, unknown>,
+      ]
+      // 32 octets base64url-encoded, per RFC 7636 section 4.1.
+      expect(value).toMatch(/^[A-Za-z0-9_-]{43}$/)
+      expect(options).toMatchObject({ httpOnly: true })
+      // A lifetime shorter than the user's journey through the IdP would strand
+      // a valid auth code with no verifier, so this stays a session cookie.
+      expect(options).not.toHaveProperty('maxAge')
+      expect(options).not.toHaveProperty('expires')
+    })
+
+    it('should never return the code verifier in the response body', async () => {
+      // Arrange
+      const mockReq = expressHandler.mockRequest()
+      const mockRes = expressHandler.mockResponse()
+      // Act
+      await AuthWogadController.generateAuthUrlForTest(
+        mockReq,
+        mockRes,
+        jest.fn(),
+      )
+      // Assert
+      // Asserted against the serialised payload rather than a named key: the
+      // verifier reaching the browser defeats PKCE regardless of what it is
+      // called, so renaming a field must not be able to slip past this.
+      const verifier = getVerifierCookieCall(mockRes)?.[1]
+      const [payload] = jest.mocked(mockRes.json).mock.calls[0]
+      expect(verifier).toBeDefined()
+      expect(JSON.stringify(payload)).not.toContain(verifier)
     })
   })
 

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
@@ -46,12 +46,6 @@ export const WOGAD_AUTH_COOKIE_OPTIONS = {
 
 /**
  * Generates an RFC 7636 S256 PKCE pair.
- *
- * Hand-rolled rather than taken from MSAL: @azure/msal-node v5 no longer
- * exports CryptoProvider from its public surface, and its `exports` map blocks
- * deep imports. This construction is the one RFC 7636 section 4.1 recommends -
- * 32 random octets, base64url-encoded - which also carries more entropy than
- * MSAL's own generator did.
  */
 const generatePkcePair = () => {
   const codeVerifier = crypto.randomBytes(32).toString('base64url')
@@ -75,8 +69,9 @@ const validateWogadConfig: ControllerHandler = (_req, res, next) => {
  * Generates the WOG AD Authorization URL.
  *
  * Flow:
- * 1. After receiving the auth URL, the browser redirects to WOG AD with the csrf token in the state and completes the authentication challenge.
- * 2. Then, WOG AD will redirect the browser to the registered redirect URI with the code and the same csrf token the browser passed in its initial request.
+ * 1. Before generating the auth URL, the backend will generate a CSRF token and a PKCE verifier and challenge pair. It issues the challenge to the authorization endpoint.
+ * 2. After receiving the auth URL, the browser redirects to WOG AD with the csrf token in the state and completes the authentication challenge.d
+ * 3. Then, WOG AD will redirect the browser to the registered redirect URI with the code and the same csrf token the browser passed in its initial request.
  */
 const _generateAuthUrl: ControllerHandler<
   unknown,
@@ -109,10 +104,6 @@ const _generateAuthUrl: ControllerHandler<
 
   res.cookie(WOGAD_CSRF_TOKEN_COOKIE_NAME, csrfToken, WOGAD_AUTH_COOKIE_OPTIONS)
 
-  // Deliberately a session cookie. The verifier has to outlive the user's whole
-  // journey through the IdP, including MFA; any fixed lifetime shorter than that
-  // strands a valid auth code with no verifier and turns a slow login into a
-  // hard failure (AADSTS501481). It is cleared explicitly at /verify instead.
   res.cookie(
     WOGAD_CODE_VERIFIER_COOKIE_NAME,
     codeVerifier,

--- a/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
+++ b/apps/backend/src/app/modules/auth/wogad/auth-wogad.controller.ts
@@ -44,6 +44,24 @@ export const WOGAD_AUTH_COOKIE_OPTIONS = {
   path: '/',
 }
 
+/**
+ * Generates an RFC 7636 S256 PKCE pair.
+ *
+ * Hand-rolled rather than taken from MSAL: @azure/msal-node v5 no longer
+ * exports CryptoProvider from its public surface, and its `exports` map blocks
+ * deep imports. This construction is the one RFC 7636 section 4.1 recommends -
+ * 32 random octets, base64url-encoded - which also carries more entropy than
+ * MSAL's own generator did.
+ */
+const generatePkcePair = () => {
+  const codeVerifier = crypto.randomBytes(32).toString('base64url')
+  const codeChallenge = crypto
+    .createHash('sha256')
+    .update(codeVerifier)
+    .digest('base64url')
+  return { codeVerifier, codeChallenge }
+}
+
 const validateWogadConfig: ControllerHandler = (_req, res, next) => {
   if (!isWogadConfigDefined || !ccaSingleton) {
     return res.status(StatusCodes.METHOD_NOT_ALLOWED).json({
@@ -79,13 +97,27 @@ const _generateAuthUrl: ControllerHandler<
 
   const csrfToken = crypto.randomBytes(32).toString('hex')
 
+  const { codeVerifier, codeChallenge } = generatePkcePair()
+
   const authCodeUrlParams: AuthorizationUrlRequest = {
     state: csrfToken,
     scopes: ['openid', 'email'],
     redirectUri,
+    codeChallenge,
+    codeChallengeMethod: 'S256',
   }
 
   res.cookie(WOGAD_CSRF_TOKEN_COOKIE_NAME, csrfToken, WOGAD_AUTH_COOKIE_OPTIONS)
+
+  // Deliberately a session cookie. The verifier has to outlive the user's whole
+  // journey through the IdP, including MFA; any fixed lifetime shorter than that
+  // strands a valid auth code with no verifier and turns a slow login into a
+  // hard failure (AADSTS501481). It is cleared explicitly at /verify instead.
+  res.cookie(
+    WOGAD_CODE_VERIFIER_COOKIE_NAME,
+    codeVerifier,
+    WOGAD_AUTH_COOKIE_OPTIONS,
+  )
 
   const authUrl = await ccaSingleton.getAuthCodeUrl(authCodeUrlParams)
 


### PR DESCRIPTION
## Problem

This is the second of two steps that add PKCE to the WOG AD admin login, and the one that switches it on. The first step taught `/verify` to forward a code verifier. Until this ships, nothing produces one, so an authorization code that leaks from a URL is still redeemable by whoever finds it.

## Solution

`/authUrl` now creates a PKCE pair. It sends the S256 challenge to WOG AD and keeps the verifier in an `httpOnly` cookie. WOG AD ties the challenge to the code it issues and, at `/verify`, refuses to hand over a token unless the verifier hashes to that challenge.

The split between the two values is what does the work. The challenge travels in a URL, where referrers, browser history and access logs can all see it, and that is fine because it is a one-way hash. The verifier travels only in a cookie that the page's own JavaScript cannot read, and it is never put in a response body. A code lifted from any URL channel therefore cannot be redeemed.

The verifier cookie has no fixed lifetime, on purpose. It has to outlast the admin's whole trip through WOG AD, including MFA. Any shorter limit would strand a valid code with no verifier and turn a slow sign-in into a hard failure.

### Deploy ordering

**Do not release this until the first pull request is fully rolled out.** From here on, every authorization code is issued against a challenge. Any instance still running the older `/verify` code will send token requests with no verifier, and WOG AD will refuse them with `AADSTS501481`.

**Breaking Changes**

No - backwards compatible for anyone already running the first step. See Deploy ordering above.

## Tests

**TC1: An admin can still sign in**

- [x] Sign in through WOG AD as a whitelisted admin.
- [x] Confirm you reach the dashboard.
- [x] In devtools, confirm a `wogadCodeVerifier` cookie is set, is marked `HttpOnly`, and has no expiry date.
- [x] Confirm both `wogadCodeVerifier` and `csrf_token` are gone after `/verify` finishes.

**TC2: The verifier never reaches the page**

- [x] Open devtools and start the WOG AD sign-in.
- [x] In the `/authUrl` response body, confirm only `authUrl` and `csrfToken` appear, and no verifier.
- [ ] In the console, run `document.cookie` and confirm `wogadCodeVerifier` is not listed.
- [ ] In the WOG AD redirect URL, confirm `code_challenge` and `code_challenge_method=S256` are present.

**TC3: A slow sign-in still succeeds**

- [x] Start the WOG AD sign-in and leave the WOG AD page open for more than 15 minutes before you finish MFA.
- [x] Confirm you still reach the dashboard, and do not get a 403.

**TC4: A tampered verifier is refused**

- [ ] Start the WOG AD sign-in and complete it.
- [ ] Before `/verify` runs, edit the `wogadCodeVerifier` cookie value in devtools.
- [ ] Confirm the login fails, and the server log records the WOG AD rejection.
