### PR TITLE
fix(design-drawer): stop form title from autosaving before Save design

### DIFF
--- a/apps/frontend/src/features/admin-form/common/mutations.ts
+++ b/apps/frontend/src/features/admin-form/common/mutations.ts
@@ -485,6 +485,7 @@ export const usePreviewFormMutations = (formId: string) => {
   )
 
   const submitStorageModeFormMutation = useMutation(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
       return submitStorageModeFormPreview({ formId })
     },
@@ -498,6 +499,7 @@ export const usePreviewFormMutations = (formId: string) => {
   )
 
   const submitStorageModeFormFetchMutation = useMutation(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (args: Omit<SubmitStorageFormArgs, 'formId'>) => {
       return submitStorageModeFormPreviewWithFetch({ formId })
     },

--- a/apps/frontend/src/features/admin-form/common/mutations.ts
+++ b/apps/frontend/src/features/admin-form/common/mutations.ts
@@ -8,6 +8,7 @@ import {
   EndPageUpdateDto,
   FormPermission,
   FormPermissionsDto,
+  FormSettings,
   PaymentsProductUpdateDto,
   PaymentsUpdateDto,
   StartPageUpdateDto,
@@ -17,6 +18,7 @@ import { DASHBOARD_ROUTE } from '~constants/routes'
 import { useToast } from '~hooks/useToast'
 import { HttpError } from '~services/ApiService'
 
+import { updateFormTitle } from '~features/admin-form/settings/SettingsService'
 import {
   SubmitEmailFormArgs,
   SubmitStorageFormArgs,
@@ -390,6 +392,19 @@ export const useMutateFormPage = () => {
     },
   )
 
+  const titleMutation = useMutation<FormSettings, Error, string>(
+    (nextTitle: string) => updateFormTitle(formId, nextTitle),
+    {
+      onSuccess: (newData) => {
+        queryClient.setQueryData<AdminFormDto | undefined>(
+          adminFormKeys.id(formId),
+          (oldData) =>
+            oldData ? { ...oldData, title: newData.title } : undefined,
+        )
+      },
+    },
+  )
+
   const endPageMutation = useMutation(
     (endPage: EndPageUpdateDto) => updateFormEndPage(formId, endPage),
     {
@@ -455,6 +470,7 @@ export const useMutateFormPage = () => {
 
   return {
     startPageMutation,
+    titleMutation,
     endPageMutation,
     paymentsMutation,
     paymentsProductMutation,

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/StartPageView.tsx
@@ -94,6 +94,8 @@ export const StartPageView = () => {
     return form?.startPage
   }, [form?.startPage, startPageFromStore])
 
+  const previewTitle = startPageData?.title ?? form?.title
+
   // Color theme options and other design stuff, identical to public form
   const { logoImgSrc, ...formBannerLogoProps } = useFormBannerLogo({
     logoBucketUrl,
@@ -195,7 +197,7 @@ export const StartPageView = () => {
           {...formBannerLogoProps}
         />
         <FormHeader
-          title={form?.title}
+          title={previewTitle}
           showHeader
           loggedInId={
             form && form.authType !== FormAuthType.NIL

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.stories.tsx
@@ -39,11 +39,13 @@ export default {
   },
   args: {
     startPage: DEFAULT_START_PAGE,
+    title: 'Storybook form title',
   },
 } as Meta<StoryArgs>
 
 interface StoryArgs {
   startPage: FormStartPage
+  title: string
 }
 
 const Template: StoryFn<StoryArgs> = (args) => {

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawer.tsx
@@ -36,7 +36,6 @@ import Radio from '~components/Radio'
 
 import { useMutateFormPage } from '~features/admin-form/common/mutations'
 import { useCreatePageSidebar } from '~features/admin-form/create/common/CreatePageSidebarContext'
-import { FormDetailsSection } from '~features/admin-form/settings/components/FormDetailsSection'
 import { useEnv } from '~features/env/queries'
 import { getTitleBg } from '~features/public-form/components/FormStartPage/useFormHeader'
 
@@ -66,8 +65,11 @@ import {
   UploadImageInput,
 } from '../EditFieldDrawer/edit-fieldtype/EditImage/UploadImageInput'
 
+import { DesignFormTitleInput } from './DesignFormTitleInput'
+
 type DesignDrawerProps = {
   startPage: FormStartPage
+  title: string
 }
 
 export const DesignInput = (): JSX.Element | null => {
@@ -76,7 +78,7 @@ export const DesignInput = (): JSX.Element | null => {
   const { formId } = useParams()
   if (!formId) throw new Error('No formId provided')
 
-  const { startPageMutation } = useMutateFormPage()
+  const { startPageMutation, titleMutation } = useMutateFormPage()
   const { handleClose } = useCreatePageSidebar()
 
   const {
@@ -111,16 +113,21 @@ export const DesignInput = (): JSX.Element | null => {
 
   const {
     register,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, dirtyFields },
     control,
     handleSubmit,
     clearErrors,
     setError,
     setFocus,
+    reset,
   } = useForm<FormStartPageInput>({
     mode: 'onBlur',
     defaultValues: startPageData,
   })
+
+  const showDesignDrawerFormTitle = useFeatureIsOn(
+    featureFlags.designDrawerFormTitle,
+  )
 
   // Update dirty state of builder so confirmation modal can be shown
   useEffect(() => {
@@ -185,9 +192,39 @@ export const DesignInput = (): JSX.Element | null => {
 
   const handleCloseDrawer = useCallback(() => handleClose(false), [handleClose])
 
+  const handleSaveTitleThenClose = useCallback(
+    (title: string, originalStartPageData: FormStartPageInput) => {
+      if (!showDesignDrawerFormTitle || !dirtyFields.title) {
+        handleCloseDrawer()
+        return
+      }
+      titleMutation.mutate(title, {
+        onSuccess: handleCloseDrawer,
+        onError: (error: Error) => {
+          // Mark the just-saved fields clean; keep title's attempted value
+          // and its dirty/error state so the admin can retry just the name.
+          reset(
+            { ...originalStartPageData, title: startPageData?.title },
+            { keepDirtyValues: true },
+          )
+          setError('title', { message: error.message })
+        },
+      })
+    },
+    [
+      dirtyFields.title,
+      handleCloseDrawer,
+      reset,
+      setError,
+      showDesignDrawerFormTitle,
+      startPageData?.title,
+      titleMutation,
+    ],
+  )
+
   const handleUpdateDesign = handleSubmit(
-    async (startPageData: FormStartPageInput) => {
-      const { logo, attachment, estTimeTaken, ...rest } = startPageData
+    async (formValues: FormStartPageInput) => {
+      const { logo, attachment, estTimeTaken, title, ...rest } = formValues
       const estTimeTakenTransformed =
         estTimeTaken === '' ? undefined : estTimeTaken
       if (logo.state !== FormLogoState.Custom) {
@@ -197,7 +234,9 @@ export const DesignInput = (): JSX.Element | null => {
             estTimeTaken: estTimeTakenTransformed,
             ...rest,
           },
-          { onSuccess: handleCloseDrawer },
+          {
+            onSuccess: () => handleSaveTitleThenClose(title, formValues),
+          },
         )
       } else {
         const customLogoMeta = await handleUploadLogo(attachment)
@@ -207,14 +246,12 @@ export const DesignInput = (): JSX.Element | null => {
             estTimeTaken: estTimeTakenTransformed,
             ...rest,
           },
-          { onSuccess: handleCloseDrawer },
+          {
+            onSuccess: () => handleSaveTitleThenClose(title, formValues),
+          },
         )
       }
     },
-  )
-
-  const showDesignDrawerFormTitle = useFeatureIsOn(
-    featureFlags.designDrawerFormTitle,
   )
 
   const handleClick = useCallback(async () => {
@@ -342,7 +379,7 @@ export const DesignInput = (): JSX.Element | null => {
         <FormErrorMessage>{errors.colorTheme?.message}</FormErrorMessage>
       </FormControl>
 
-      {showDesignDrawerFormTitle && <FormDetailsSection />}
+      {showDesignDrawerFormTitle && <DesignFormTitleInput control={control} />}
 
       <FormControl
         isReadOnly={startPageMutation.isLoading}
@@ -398,6 +435,7 @@ export const DesignInput = (): JSX.Element | null => {
 
 export const DesignDrawer = ({
   startPage,
+  title,
 }: DesignDrawerProps): JSX.Element | null => {
   const { t } = useTranslation()
   const { data: { logoBucketUrl } = {} } = useEnv()
@@ -423,6 +461,7 @@ export const DesignDrawer = ({
   useEffect(() => {
     setStartPageData({
       ...startPage,
+      title,
       estTimeTaken: startPage.estTimeTaken || '',
       attachment:
         startPage.logo.state !== FormLogoState.Custom
@@ -444,6 +483,7 @@ export const DesignDrawer = ({
     return resetDesignStore
   }, [
     startPage,
+    title,
     logoBucketUrl,
     resetDesignStore,
     setCustomLogoMeta,

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignDrawerContainer.tsx
@@ -5,5 +5,7 @@ import { DesignDrawer } from './DesignDrawer'
 export const DesignDrawerContainer = (): JSX.Element | null => {
   const { data: form } = useAdminForm()
 
-  return form ? <DesignDrawer startPage={form.startPage} /> : null
+  return form ? (
+    <DesignDrawer startPage={form.startPage} title={form.title} />
+  ) : null
 }

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignFormTitleInput.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignDrawer/DesignDrawer/DesignFormTitleInput.tsx
@@ -1,0 +1,34 @@
+import { Control, Controller } from 'react-hook-form'
+import { useTranslation } from 'react-i18next'
+import { FormControl } from '@chakra-ui/react'
+
+import { useFormTitleValidationRules } from '~utils/formValidation'
+import FormErrorMessage from '~components/FormControl/FormErrorMessage'
+import FormLabel from '~components/FormControl/FormLabel'
+import Input from '~components/Input'
+
+import { FormStartPageInput } from '../../../builder-and-design/useDesignStore'
+
+export const DesignFormTitleInput = ({
+  control,
+}: {
+  control: Control<FormStartPageInput>
+}): JSX.Element => {
+  const { t } = useTranslation()
+  const formTitleValidationRules = useFormTitleValidationRules()
+
+  return (
+    <Controller
+      name="title"
+      control={control}
+      rules={formTitleValidationRules}
+      render={({ field, fieldState }) => (
+        <FormControl isInvalid={!!fieldState.error}>
+          <FormLabel isRequired>{t('features.common.formName')}</FormLabel>
+          <Input {...field} />
+          <FormErrorMessage>{fieldState.error?.message}</FormErrorMessage>
+        </FormControl>
+      )}
+    />
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/useDesignStore.tsx
@@ -29,6 +29,7 @@ export type FormStartPageInput = Omit<
   estTimeTaken: number | ''
   logo: FormLogoBase
   attachment: UploadedImage // Custom logo image
+  title: string
 }
 
 export type DesignStore = {


### PR DESCRIPTION
## Problem

Behind the `design-drawer-form-title` flag, the Form name field in the *Headers & instructions* drawer saves to the server the moment an admin clicks away or presses Enter, before they click Save design. Every other field in that drawer (logo, colour, estimated time, instructions) is held as a draft and only persisted on Save design, so closing the drawer or hitting the discard-confirmation modal reverts them but not the name.

https://github.com/user-attachments/assets/9c979d7a-aa71-4b8e-bad1-4283a18f4e0c

## Solution

- Form name now lives on the drawer's own draft form and store, the same one logo/colour/time/instructions already use, so it shares their dirty-tracking and gets discarded the same way
- Save design persists it alongside the rest: the start page saves first, then the title (only if it changed) since the two live behind separate API endpoints with no single call that covers both. If the title save fails after the start page already succeeded, the drawer stays open with an inline error on the name field instead of closing on a partial success. 
- Settings → General keeps its existing autosave-on-blur behaviour untouched.

**Breaking Changes**

No - backwards compatible. Only frontend changes to mitigate risk surface.

## Screen Recordings

With `design-drawer-form-title` feature flag on:

https://github.com/user-attachments/assets/a7b13a28-b5f2-446e-8e44-ca274b32bfe2

With `design-drawer-form-title` feature flag off:

https://github.com/user-attachments/assets/cb156191-e1d5-4d22-885c-954d89cb784b

## Tests

No automated tests included in this PR, the following should be checked manually with the `design-drawer-form-title` flag forced on (e.g. via GrowthBook DevTools):

**TC1: Editing and discarding**

- [ ] Open the Headers & instructions drawer, edit the form name, close the drawer without clicking Save design
- [ ] Reload the form and confirm the name reverted to its previous value

**TC2: Editing and saving**

- [ ] Edit the form name, click Save design
- [ ] Confirm the drawer closes and the new name persists after reload

**TC3: Live preview**

- [ ] While the drawer is open, type into the form name field and confirm the header preview in the canvas updates as you type, without waiting for a save

**TC4: Discard confirmation**

- [ ] Edit the form name only (no other field), then try to close the drawer or navigate away
- [ ] Confirm the unsaved-changes confirmation modal appears, and confirming discard reverts the name

**TC5: Validation**

- [ ] Clear the form name entirely and click Save design
- [ ] Confirm save is blocked and an inline error appears under the field