### PR TITLE
chore(logging): redact client assertion and OAuth exchange codes from logs

### DIFF
--- a/apps/backend/src/app/config/logger.ts
+++ b/apps/backend/src/app/config/logger.ts
@@ -117,6 +117,17 @@ export const customFormat = format.printf((info) => {
 })
 
 /**
+ * Keys whose values must never be serialised into our logs, at any depth.
+ * Axios attaches the entire outgoing request to the errors it throws, and we
+ * copy every own property off an error below. Non-2xx response
+ * from the SP/CP token endpoint logs `config.data` verbatim (form-encoded token
+ * request,`client_assertion` JWT. `headers` and `request` are redacted also
+ * to redact cookies, authorization headers and the raw request body.
+ */
+const REDACTED_KEYS = new Set(['config', 'headers', 'request'])
+const REDACTED_VALUE = '[REDACTED]'
+
+/**
  * This is required as JSON.stringify(new Error()) returns an empty object. This
  * function converts the error in `info.error` into a readable JSON stack trace.
  *
@@ -124,6 +135,13 @@ export const customFormat = format.printf((info) => {
  * https://github.com/winstonjs/winston/issues/1243#issuecomment-463548194.
  */
 function jsonErrorReplacer(this: any, key: string, value: any) {
+  // Checked before the Error branch below: the object that branch returns is
+  // itself traversed by JSON.stringify, so redacting by key name here covers
+  // properties nested at any depth of the flattened error.
+  if (REDACTED_KEYS.has(key)) {
+    return REDACTED_VALUE
+  }
+
   if (value instanceof Error) {
     return Object.getOwnPropertyNames(value).reduce((all, valKey) => {
       if (valKey === 'stack') {

--- a/apps/backend/src/app/config/logger.ts
+++ b/apps/backend/src/app/config/logger.ts
@@ -121,7 +121,7 @@ export const customFormat = format.printf((info) => {
  * Axios attaches the entire outgoing request to the errors it throws, and we
  * copy every own property off an error below. Non-2xx response
  * from the SP/CP token endpoint logs `config.data` verbatim (form-encoded token
- * request,`client_assertion` JWT. `headers` and `request` are redacted also
+ * request, `client_assertion` JWT). `headers` and `request` are also redacted
  * to redact cookies, authorization headers and the raw request body.
  */
 const REDACTED_KEYS = new Set(['config', 'headers', 'request'])

--- a/apps/backend/src/app/loaders/express/logging.ts
+++ b/apps/backend/src/app/loaders/express/logging.ts
@@ -4,7 +4,7 @@ import winston from 'winston'
 
 import config from '../../config/config'
 import { customFormat } from '../../config/logger'
-import { getRequestIp, getTrace } from '../../utils/request'
+import { getRequestIp, getTrace, maskOAuthCode } from '../../utils/request'
 
 const LOGGER_LABEL = 'network'
 
@@ -73,6 +73,20 @@ const loggingMiddleware = () => {
       }
 
       return meta
+    },
+    // The parsed query object is logged alongside the url. The Datadog
+    // sensitive data scanner redacts `code=` inside the url strings but not
+    // the parsed `req.query.code` attribute, so the OAuth exchange code on
+    // Singpass/Corppass/sgID login callbacks must be masked here.
+    requestFilter: (req, propName) => {
+      const value = get(req, propName)
+      if (propName === 'query' && value && typeof value === 'object') {
+        const query = value as Record<string, unknown>
+        if ('code' in query) {
+          return { ...query, code: maskOAuthCode(query.code) }
+        }
+      }
+      return value
     },
     headerBlacklist: ['cookie'],
     ignoredRoutes: ['/'],

--- a/apps/backend/src/app/modules/spcp/spcp.controller.ts
+++ b/apps/backend/src/app/modules/spcp/spcp.controller.ts
@@ -3,7 +3,6 @@ import { StatusCodes } from 'http-status-codes'
 
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
-import { maskOAuthCode } from '../../utils/request'
 import * as BillingService from '../billing/billing.service'
 import { ControllerHandler } from '../core/core.types'
 import * as FormService from '../form/form.service'
@@ -29,7 +28,7 @@ export const handleSpcpOidcLogin: (
   const logMeta = {
     action: 'handleSpcpOidcLogin',
     state,
-    code: maskOAuthCode(code),
+    hasCode: !!code,
     authType,
   }
 

--- a/apps/backend/src/app/modules/spcp/spcp.controller.ts
+++ b/apps/backend/src/app/modules/spcp/spcp.controller.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from 'http-status-codes'
 
 import config from '../../config/config'
 import { createLoggerWithLabel } from '../../config/logger'
+import { maskOAuthCode } from '../../utils/request'
 import * as BillingService from '../billing/billing.service'
 import { ControllerHandler } from '../core/core.types'
 import * as FormService from '../form/form.service'
@@ -28,7 +29,7 @@ export const handleSpcpOidcLogin: (
   const logMeta = {
     action: 'handleSpcpOidcLogin',
     state,
-    code,
+    code: maskOAuthCode(code),
     authType,
   }
 

--- a/apps/backend/src/app/utils/request.ts
+++ b/apps/backend/src/app/utils/request.ts
@@ -35,13 +35,17 @@ export const getTrace = <R extends LooseRequest>(
   return req.get('cf-ray') ?? req.id // trace using cloudflare cf-ray header, with x-request-id header as backup
 }
 
+// Masks the last 24 characters of a secret with asterisks, keeping a prefix
+// so log lines carrying the same secret can still be correlated.
+const MASK_REPLACEMENT = '************************'
+
 const HEADERS_RULES = {
   referer: {
     // Match the referer URL and replace the last 24 characters of the key with asterisks
     // e.g.                  /edit/<form_id>/?key=12345678901234567890123456789012345678901234567890
     // will be replaced with /edit/<form_id>/?key=12345678901234567890123456************************
     regex: /(?<=\/edit\/[a-zA-Z0-9]{24}\?key=.+).{24}$/i,
-    replacement: '************************',
+    replacement: MASK_REPLACEMENT,
   },
 }
 
@@ -63,6 +67,26 @@ const maskRefererHeaders = (
     }
   }
   return headers
+}
+
+/**
+ * Masks the OAuth exchange code that Singpass and Corppass append when
+ * redirecting a respondent back to our login callbacks, in the same way as the
+ * referer key masking above. The code is a single-use credential and must not
+ * be logged in full.
+ *
+ * Note that the Datadog sensitive data scanner only redacts `code=` inside
+ * url-shaped strings, so parsed values (`req.query.code`, `meta.code`) must be
+ * masked here before they are logged.
+ */
+export const maskOAuthCode = (code: unknown): unknown => {
+  if (typeof code !== 'string') {
+    return code
+  }
+  return (
+    code.slice(0, Math.max(code.length - MASK_REPLACEMENT.length, 0)) +
+    MASK_REPLACEMENT
+  )
 }
 
 export const createReqMeta = <R extends LooseRequest>(req: R): ReqMeta => {

--- a/apps/backend/src/app/utils/request.ts
+++ b/apps/backend/src/app/utils/request.ts
@@ -83,9 +83,12 @@ export const maskOAuthCode = (code: unknown): unknown => {
   if (typeof code !== 'string') {
     return code
   }
+
+  const maskLength = Math.min(code.length, MASK_REPLACEMENT.length)
+
   return (
-    code.slice(0, Math.max(code.length - MASK_REPLACEMENT.length, 0)) +
-    MASK_REPLACEMENT
+    code.slice(0, code.length - maskLength) +
+    MASK_REPLACEMENT.slice(0, maskLength)
   )
 }
 


### PR DESCRIPTION
## Problem

Failed Corppass token exchanges log the entire outgoing axios request (`error.config.data`) — including the `client_assertion` JWT we authenticate to NDI with. Login callbacks also log the raw OAuth exchange code (`req.query.code`, `meta.code`); the Datadog scanner only redacts `code=` inside url-shaped strings, not parsed attributes.

## Solution

- `jsonErrorReplacer` now redacts `config`, `headers` and `request` keys at any depth of a serialised error. `response.data` (upstream error body) is kept.
- New `maskOAuthCode` (reuses the existing referer-key asterisk masking) applied to the spcp `logMeta` and to `req.query.code` via an express-winston `requestFilter`.
- sgid `logMeta` left untouched — SGID auth type is deprecated; its callbacks still get `query.code` masked by the network logger.

**Breaking Changes**
- No — logging output only.