### PR TITLE
feat(workflow): make step 1 deletable (1/2, backend)

### DIFF
--- a/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/form.server.model.spec.ts
@@ -2818,6 +2818,65 @@ describe('Form Model', () => {
         expect(actual).toEqual(expected)
       })
 
+      it('should return an empty workflow when step 1 is an unset placeholder', async () => {
+        // Arrange: a workflow whose first step was deleted. It has no one to
+        // start it, so respondents should see an ordinary form with every field
+        // fillable rather than one greyed out by a step nobody owns.
+        const multirespondentForm = await Form.create({
+          admin: populatedAdmin._id,
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mock multirespondent form with unset step 1',
+          publicKey: 'mock public key',
+          workflow: [
+            {
+              workflow_type: WorkflowType.Static,
+              emails: [],
+              edit: [],
+              isPlaceholder: true,
+            },
+            {
+              workflow_type: WorkflowType.Static,
+              emails: ['supervisor@example.com'],
+              edit: [],
+            },
+          ],
+        })
+
+        // Act
+        const actual = multirespondentForm.getPublicView()
+
+        // Assert
+        expect(actual.workflow).toEqual([])
+      })
+
+      it('should return the workflow when step 1 is set up', async () => {
+        // Arrange
+        const multirespondentForm = await Form.create({
+          admin: populatedAdmin._id,
+          responseMode: FormResponseMode.Multirespondent,
+          title: 'mock multirespondent form with a set up step 1',
+          publicKey: 'mock public key',
+          workflow: [
+            {
+              workflow_type: WorkflowType.Static,
+              emails: [],
+              edit: [],
+            },
+            {
+              workflow_type: WorkflowType.Static,
+              emails: ['supervisor@example.com'],
+              edit: [],
+            },
+          ],
+        })
+
+        // Act
+        const actual = multirespondentForm.getPublicView()
+
+        // Assert
+        expect(actual.workflow).toHaveLength(2)
+      })
+
       it('should correctly return public view of unpopulated multirespondent mode form', async () => {
         // Arrange
         const multirespondentForm = await Form.create({

--- a/apps/backend/src/app/models/form.server.model.ts
+++ b/apps/backend/src/app/models/form.server.model.ts
@@ -43,6 +43,7 @@ import {
 } from 'formsg-shared/types'
 import { reorder } from 'formsg-shared/utils/immutable-array-fns'
 import { getApplicableIfStates } from 'formsg-shared/utils/logic'
+import { getRunnableWorkflow } from 'formsg-shared/utils/runnable-workflow'
 import { stripDropdownFieldOptionsToRecipientsMap } from 'formsg-shared/utils/strip-dropdown-field-optionsToRecipientsMap'
 import { stripWorkflowEmails } from 'formsg-shared/utils/strip-workflow-emails'
 import { compact, omit, pick, uniq } from 'lodash'
@@ -1093,7 +1094,12 @@ const compileFormModel = (db: Mongoose): IFormModel => {
       const strippedFormFields = stripDropdownFieldOptionsToRecipientsMap(
         mrfPublicViewFields.form_fields,
       )
-      const strippedWorkflow = stripWorkflowEmails(mrfPublicViewFields.workflow)
+      // Respondents and the admin preview see the workflow that will actually
+      // run. A workflow whose step 1 is unset does not run, so every field
+      // stays fillable instead of being greyed out by a step nobody owns.
+      const strippedWorkflow = stripWorkflowEmails(
+        getRunnableWorkflow(mrfPublicViewFields.workflow),
+      )
       const mrfPublicView = {
         ...mrfPublicViewFields,
         workflow: strippedWorkflow,

--- a/apps/backend/src/app/models/form_workflow_step.server.schema.ts
+++ b/apps/backend/src/app/models/form_workflow_step.server.schema.ts
@@ -29,6 +29,12 @@ const WorkflowStepSchema = new Schema<IWorkflowStepSchema>(
       type: String,
       required: false,
     },
+    // Written only by deleteFormWorkflowStep when step 1 is removed. Absent on
+    // every step an admin has actually set up.
+    isPlaceholder: {
+      type: Boolean,
+      required: false,
+    },
   },
   {
     discriminatorKey: 'workflow_type',

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -4238,6 +4238,50 @@ describe('admin-form.service', () => {
       expect(workflow).toEqual([stepOne, stepTwo, stepThree])
     })
 
+    it('should clear the workflow when the last set up step is deleted', async () => {
+      // Arrange: step 1 was already deleted, and now the only real step goes
+      // too. Keeping the slot would leave a workflow that can never run and a
+      // warning the admin cannot clear.
+      const spy = spyOnPersistedWorkflow()
+      const placeholder = {
+        _id: 'placeholder',
+        workflow_type: WorkflowType.Static,
+        emails: [],
+        edit: [],
+        isPlaceholder: true,
+      }
+      const mockForm = mockFormWithWorkflow([placeholder, stepTwo])
+
+      // Act
+      const result = await AdminFormService.deleteFormWorkflowStep(mockForm, 1)
+
+      // Assert
+      expect(result.isOk()).toBe(true)
+      expect((spy.mock.calls[0][1] as any).workflow).toEqual([])
+    })
+
+    it('should keep the slot while a set up step remains behind it', async () => {
+      // Arrange
+      const spy = spyOnPersistedWorkflow()
+      const placeholder = {
+        _id: 'placeholder',
+        workflow_type: WorkflowType.Static,
+        emails: [],
+        edit: [],
+        isPlaceholder: true,
+      }
+      const mockForm = mockFormWithWorkflow([placeholder, stepTwo, stepThree])
+
+      // Act
+      await AdminFormService.deleteFormWorkflowStep(mockForm, 1)
+
+      // Assert
+      expect((spy.mock.calls[0][1] as any).workflow).toEqual([
+        placeholder,
+        stepThree,
+      ])
+    })
+
     it('should reject an out of range step number', async () => {
       // Arrange
       const mockForm = mockFormWithWorkflow([stepOne])

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.service.spec.ts
@@ -4087,4 +4087,166 @@ describe('admin-form.service', () => {
       })
     })
   })
+
+  describe('deleteFormWorkflowStep', () => {
+    const FIELD_A = new ObjectId().toHexString()
+    const FIELD_B = new ObjectId().toHexString()
+    const APPROVAL_FIELD = new ObjectId().toHexString()
+
+    const stepOne = {
+      _id: 'step0',
+      workflow_type: WorkflowType.Static,
+      emails: [],
+      edit: [FIELD_A],
+    }
+    const stepTwo = {
+      _id: 'step1',
+      workflow_type: WorkflowType.Dynamic,
+      field: new ObjectId().toHexString(),
+      edit: [FIELD_B],
+      approval_field: APPROVAL_FIELD,
+      step_name: 'Supervisor',
+    }
+    const stepThree = {
+      _id: 'step2',
+      workflow_type: WorkflowType.Static,
+      emails: ['finance@example.com'],
+      edit: [FIELD_B],
+    }
+
+    const mockFormWithWorkflow = (workflow: unknown[]) =>
+      ({
+        _id: new ObjectId().toHexString(),
+        responseMode: FormResponseMode.Multirespondent,
+        form_fields: [],
+        workflow,
+      }) as unknown as IPopulatedForm
+
+    /** Returns the workflow that was actually persisted. */
+    const spyOnPersistedWorkflow = () => {
+      const findByIdAndUpdateSpy = jest
+        .spyOn(MultirespondentFormModel, 'findByIdAndUpdate')
+        // @ts-ignore
+        .mockImplementation((_id, update) => ({
+          exec: jest
+            .fn()
+            .mockResolvedValue({ _id, workflow: (update as any).workflow }),
+        }))
+      return findByIdAndUpdateSpy
+    }
+
+    beforeEach(() => jest.restoreAllMocks())
+
+    it('should leave an unset placeholder in position 1 when step 1 is deleted', async () => {
+      // Arrange
+      const spy = spyOnPersistedWorkflow()
+      const mockForm = mockFormWithWorkflow([stepOne, stepTwo, stepThree])
+
+      // Act
+      const result = await AdminFormService.deleteFormWorkflowStep(mockForm, 0)
+
+      // Assert
+      expect(result.isOk()).toBe(true)
+      const persisted = (spy.mock.calls[0][1] as any).workflow
+      expect(persisted).toHaveLength(3)
+      expect(persisted[0]).toEqual({
+        workflow_type: WorkflowType.Static,
+        emails: [],
+        edit: [],
+        isPlaceholder: true,
+      })
+    })
+
+    it('should preserve the remaining steps untouched when step 1 is deleted', async () => {
+      // Arrange
+      const spy = spyOnPersistedWorkflow()
+      const mockForm = mockFormWithWorkflow([stepOne, stepTwo, stepThree])
+
+      // Act
+      await AdminFormService.deleteFormWorkflowStep(mockForm, 0)
+
+      // Assert: positions, ids, routing, approvals and names all survive, since
+      // nothing is promoted into step 1's role.
+      const persisted = (spy.mock.calls[0][1] as any).workflow
+      expect(persisted[1]).toBe(stepTwo)
+      expect(persisted[2]).toBe(stepThree)
+    })
+
+    it('should empty the workflow when the only step is deleted', async () => {
+      // Arrange: an empty workflow already means "run as an ordinary form", so
+      // no placeholder is needed.
+      const spy = spyOnPersistedWorkflow()
+      const mockForm = mockFormWithWorkflow([stepOne])
+
+      // Act
+      const result = await AdminFormService.deleteFormWorkflowStep(mockForm, 0)
+
+      // Assert
+      expect(result.isOk()).toBe(true)
+      expect((spy.mock.calls[0][1] as any).workflow).toEqual([])
+    })
+
+    it('should splice without a placeholder when a later step is deleted', async () => {
+      // Arrange
+      const spy = spyOnPersistedWorkflow()
+      const mockForm = mockFormWithWorkflow([stepOne, stepTwo, stepThree])
+
+      // Act
+      const result = await AdminFormService.deleteFormWorkflowStep(mockForm, 1)
+
+      // Assert
+      expect(result.isOk()).toBe(true)
+      expect((spy.mock.calls[0][1] as any).workflow).toEqual([
+        stepOne,
+        stepThree,
+      ])
+    })
+
+    it('should not stack placeholders when step 1 is deleted twice', async () => {
+      // Arrange
+      const spy = spyOnPersistedWorkflow()
+      const placeholder = {
+        _id: 'placeholder',
+        workflow_type: WorkflowType.Static,
+        emails: [],
+        edit: [],
+        isPlaceholder: true,
+      }
+      const mockForm = mockFormWithWorkflow([placeholder, stepTwo, stepThree])
+
+      // Act
+      await AdminFormService.deleteFormWorkflowStep(mockForm, 0)
+
+      // Assert
+      const persisted = (spy.mock.calls[0][1] as any).workflow
+      expect(persisted).toHaveLength(3)
+      expect(persisted.filter((step: any) => step.isPlaceholder)).toHaveLength(
+        1,
+      )
+    })
+
+    it('should not mutate the original workflow', async () => {
+      // Arrange
+      spyOnPersistedWorkflow()
+      const workflow = [stepOne, stepTwo, stepThree]
+      const mockForm = mockFormWithWorkflow(workflow)
+
+      // Act
+      await AdminFormService.deleteFormWorkflowStep(mockForm, 0)
+
+      // Assert
+      expect(workflow).toEqual([stepOne, stepTwo, stepThree])
+    })
+
+    it('should reject an out of range step number', async () => {
+      // Arrange
+      const mockForm = mockFormWithWorkflow([stepOne])
+
+      // Act
+      const result = await AdminFormService.deleteFormWorkflowStep(mockForm, 5)
+
+      // Assert
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(MalformedParametersError)
+    })
+  })
 })

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1879,8 +1879,10 @@ const FIRST_STEP_PLACEHOLDER = {
  * while the slot is unset, so nothing routes to a step that was never meant to
  * start the form.
  *
- * Deleting the only step needs no placeholder. An empty workflow already means
- * the form runs as an ordinary single-respondent form.
+ * Deleting the last step that was actually set up clears the workflow entirely,
+ * placeholder included. An empty workflow already means the form runs as an
+ * ordinary single-respondent form, and keeping a slot nobody can fill in would
+ * leave the admin with a warning they cannot clear.
  */
 const buildWorkflowWithoutStep = (
   workflow: FormWorkflowDto,
@@ -1888,7 +1890,10 @@ const buildWorkflowWithoutStep = (
 ): FormWorkflowDto => {
   const remainingSteps = workflow.filter((_, index) => index !== stepNumber)
 
-  if (stepNumber !== 0 || remainingSteps.length === 0) return remainingSteps
+  const hasStepsLeftToRun = remainingSteps.some((step) => !step.isPlaceholder)
+  if (!hasStepsLeftToRun) return []
+
+  if (stepNumber !== 0) return remainingSteps
 
   return [FIRST_STEP_PLACEHOLDER, ...remainingSteps]
 }

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.service.ts
@@ -1857,6 +1857,42 @@ export const updateFormWorkflowStep = (
   })
 }
 
+/**
+ * The unset slot left in position 1 when step 1 is deleted. Mongoose assigns the
+ * `_id` on write, so it is absent here.
+ */
+const FIRST_STEP_PLACEHOLDER = {
+  workflow_type: WorkflowType.Static,
+  emails: [],
+  edit: [],
+  isPlaceholder: true,
+} as unknown as FormWorkflowStepDto
+
+/**
+ * The workflow after removing one step.
+ *
+ * Deleting step 1 leaves an unset slot in its position instead of shifting the
+ * remaining steps up. Steps 2 onwards therefore keep their positions, their
+ * respondent routing and their approvals, none of which would survive being
+ * promoted into step 1's role: step 1's respondent is always "anyone with the
+ * form link", and step 1 cannot be an approval step. The workflow does not run
+ * while the slot is unset, so nothing routes to a step that was never meant to
+ * start the form.
+ *
+ * Deleting the only step needs no placeholder. An empty workflow already means
+ * the form runs as an ordinary single-respondent form.
+ */
+const buildWorkflowWithoutStep = (
+  workflow: FormWorkflowDto,
+  stepNumber: number,
+): FormWorkflowDto => {
+  const remainingSteps = workflow.filter((_, index) => index !== stepNumber)
+
+  if (stepNumber !== 0 || remainingSteps.length === 0) return remainingSteps
+
+  return [FIRST_STEP_PLACEHOLDER, ...remainingSteps]
+}
+
 export const deleteFormWorkflowStep = (
   originalForm: IPopulatedForm,
   stepNumber: number,
@@ -1878,9 +1914,7 @@ export const deleteFormWorkflowStep = (
     return errAsync(new MalformedParametersError('Invalid step number'))
   }
 
-  // Remove step with stepNumber from workflow
-  const updatedWorkflow = originalWorkflow
-  updatedWorkflow.splice(stepNumber, 1)
+  const updatedWorkflow = buildWorkflowWithoutStep(originalWorkflow, stepNumber)
 
   const MultirespondentFormModel = getFormModelByResponseMode(
     originalForm.responseMode,

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -5,7 +5,12 @@ import {
 } from '@opengovsg/formsg-sdk/adapters'
 import { ObjectId } from 'bson'
 import { featureFlags } from 'formsg-shared/constants'
-import { BasicField, FormAuthType, FormResponseMode } from 'formsg-shared/types'
+import {
+  BasicField,
+  FormAuthType,
+  FormResponseMode,
+  WorkflowType,
+} from 'formsg-shared/types'
 import { StatusCodes } from 'http-status-codes'
 import { errAsync, ok, okAsync } from 'neverthrow'
 import nacl from 'tweetnacl'
@@ -1414,6 +1419,92 @@ describe('Multirespondent Submission Middleware', () => {
       )
       expect(mockNext).not.toHaveBeenCalled()
       expect(mockRes.status).toHaveBeenCalledWith(400)
+    })
+
+    describe('unset step 1', () => {
+      // form_fields reach the new-submission branch as mongoose subdocuments.
+      const LIVE_FORM_FIELDS = SNAPSHOT_FORM_FIELDS.map((field) => ({
+        ...field,
+        toObject: () => field,
+      }))
+
+      const FIRST_SUBMISSION_RESPONSES = {
+        [EDITABLE_FIELD_ID]: {
+          fieldType: BasicField.ShortText,
+          answer: { value: 'first' },
+          question: 'Editable Field',
+          provenance: {},
+        },
+        [NON_EDITABLE_FIELD_ID]: {
+          fieldType: BasicField.ShortText,
+          answer: { value: 'second' },
+          question: 'Non-editable Field',
+          provenance: {},
+        },
+      }
+
+      const submitFirstStepAgainstWorkflow = async (workflow: unknown[]) => {
+        const mockReq = createMockReq({ formId: MOCK_FORM_ID })
+        mockReq.body.responses = FIRST_SUBMISSION_RESPONSES
+        mockReq.formsg = {
+          formDef: {
+            _id: MOCK_FORM_ID,
+            form_fields: LIVE_FORM_FIELDS,
+            form_logics: [],
+            workflow,
+          },
+          // No previous submission: this is the first step.
+          mrfSubmission: undefined,
+        }
+
+        const mockNext = jest.fn()
+        const mockRes = createMockRes()
+        await validateMultirespondentSubmission(
+          mockReq,
+          mockRes as any,
+          mockNext,
+        )
+        return { mockNext, mockRes }
+      }
+
+      it('should accept fields no step owns when step 1 is an unset placeholder', async () => {
+        // Arrange: step 1 was deleted, so the workflow does not run and the
+        // form is an ordinary one again. This is the escape hatch for an admin
+        // who added step 1 by accident.
+        const { mockNext, mockRes } = await submitFirstStepAgainstWorkflow([
+          {
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [],
+            isPlaceholder: true,
+          },
+          {
+            workflow_type: WorkflowType.Static,
+            emails: ['supervisor@example.com'],
+            edit: [EDITABLE_FIELD_ID],
+          },
+        ])
+
+        // Assert
+        expect(mockRes.status).not.toHaveBeenCalledWith(400)
+        expect(mockNext).toHaveBeenCalled()
+      })
+
+      it('should reject fields outside step 1 when step 1 is set up', async () => {
+        // Arrange: the control. The same responses against a workflow whose
+        // step 1 only owns one of the two fields.
+        const { mockNext, mockRes } = await submitFirstStepAgainstWorkflow([
+          {
+            workflow_type: WorkflowType.Static,
+            emails: [],
+            edit: [EDITABLE_FIELD_ID],
+          },
+        ])
+
+        // Assert
+        expect(mockNext).not.toHaveBeenCalled()
+        expect(mockRes.status).toHaveBeenCalledWith(400)
+      })
     })
 
     describe('step-token write-guard', () => {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -17,6 +17,7 @@ import {
   FormResponseMode,
   SubmissionType,
 } from 'formsg-shared/types'
+import { getRunnableWorkflow } from 'formsg-shared/utils/runnable-workflow'
 import { StatusCodes } from 'http-status-codes'
 import { err, errAsync, ok, okAsync, Result, ResultAsync } from 'neverthrow'
 
@@ -511,7 +512,7 @@ export const validateMultirespondentSubmission = async (
           : ok({
               previousSubmission: undefined,
               workflowStep: 0,
-              workflow: req.formsg.formDef.workflow,
+              workflow: getRunnableWorkflow(req.formsg.formDef.workflow),
               form_fields: req.formsg.formDef.form_fields.map(
                 (ff_schema) => ff_schema.toObject() as FormFieldDto,
               ),

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.service.ts
@@ -12,6 +12,7 @@ import {
   SubmittedStep,
   WorkflowStatus,
 } from 'formsg-shared/types'
+import { getRunnableWorkflow } from 'formsg-shared/utils/runnable-workflow'
 import { getMultirespondentSubmissionEditPath } from 'formsg-shared/utils/urls'
 import moment from 'moment'
 import mongoose from 'mongoose'
@@ -203,7 +204,7 @@ const sendNextStepEmail = ({
     nextWorkflowStep: nextStepNumber,
   }
 
-  const nextStep = form.workflow[nextStepNumber]
+  const nextStep = getRunnableWorkflow(form.workflow)[nextStepNumber]
   if (!nextStep) {
     return okAsync(true)
   }
@@ -401,7 +402,7 @@ const getEmailsToNotifyAboutMrfOutcome = ({
     : []
 
   // Emails to notify under the 'People who are filling up a workflow step' setting
-  const stepsToNotifyUpToCurrentStep = form.workflow.slice(
+  const stepsToNotifyUpToCurrentStep = getRunnableWorkflow(form.workflow).slice(
     1, // exclude first step since notification is indicated by `stepOneEmailNotificationFieldId`
     currentStepNumber + 1,
   )
@@ -449,10 +450,11 @@ const checkIsWorkflowCompleted = ({
   form: Pick<IPopulatedMultirespondentForm, 'workflow'>
   isRejected: boolean
 }) => {
-  const lastStepNumber = form.workflow.length - 1
+  const workflow = getRunnableWorkflow(form.workflow)
+  const lastStepNumber = workflow.length - 1
   const isLastStepSubmitted = currentStepNumber === lastStepNumber
 
-  return !form.workflow.length || isRejected || isLastStepSubmitted
+  return !workflow.length || isRejected || isLastStepSubmitted
 }
 
 const sendMrfOutcomeEmails = ({
@@ -769,8 +771,9 @@ export const createMultiRespondentFormSubmission = ({
       } = encryptedPayload
 
       const nextStepNumber = 1 // since current step is 0
+      const runnableWorkflow = getRunnableWorkflow(form.workflow)
       const nextStep =
-        form.workflow.length >= 1 ? form.workflow[nextStepNumber] : null
+        runnableWorkflow.length >= 1 ? runnableWorkflow[nextStepNumber] : null
 
       const nextStepRecipientEmailsResult = nextStep
         ? retrieveWorkflowStepEmailAddresses(
@@ -816,7 +819,10 @@ export const createMultiRespondentFormSubmission = ({
         myInfoFields: form.getUniqueMyInfoAttrs(),
         form_fields: form.form_fields,
         form_logics: form.form_logics,
-        workflow: form.workflow,
+        // Snapshot what will actually run, so a submission started while step 1
+        // is unset stays an ordinary form for its whole life even if step 1 is
+        // set up again midway.
+        workflow: runnableWorkflow,
         submissionPublicKey,
         encryptedSubmissionSecretKey,
         encryptedContent,
@@ -1232,8 +1238,9 @@ export const performMultiRespondentPostSubmissionCreateActions = ({
   const currentStepNumber = 0
 
   // if there is no workflow, every field is an active field
-  const currentStepActiveFields: string[] = form.workflow.length
-    ? (form.workflow[currentStepNumber]?.edit ?? [])
+  const runnableWorkflow = getRunnableWorkflow(form.workflow)
+  const currentStepActiveFields: string[] = runnableWorkflow.length
+    ? (runnableWorkflow[currentStepNumber]?.edit ?? [])
     : form.form_fields.map((field) => field._id)
 
   logMeta = {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -175,6 +175,10 @@
       "require": "./dist/utils/strip-dropdown-field-optionsToRecipientsMap.js",
       "default": "./utils/strip-dropdown-field-optionsToRecipientsMap.ts"
     },
+    "./utils/runnable-workflow": {
+      "require": "./dist/utils/runnable-workflow.js",
+      "default": "./utils/runnable-workflow.ts"
+    },
     "./utils/strip-workflow-emails": {
       "require": "./dist/utils/strip-workflow-emails.js",
       "default": "./utils/strip-workflow-emails.ts"

--- a/packages/shared/types/form/workflow.ts
+++ b/packages/shared/types/form/workflow.ts
@@ -11,6 +11,16 @@ export interface FormWorkflowStepBase {
   edit: FormFieldDto['_id'][]
   approval_field?: FormFieldDto['_id']
   step_name?: string
+  /**
+   * Marks a step slot that exists but has not been set up. Only step 1 can be a
+   * placeholder, and only the delete-step endpoint writes one: deleting step 1
+   * leaves this behind instead of shifting the remaining steps up, so steps 2
+   * onwards keep their positions and their configuration.
+   *
+   * A workflow whose first step is a placeholder does not run. See
+   * `getRunnableWorkflow`.
+   */
+  isPlaceholder?: boolean
 }
 
 export interface FormWorkflowStepStatic extends FormWorkflowStepBase {

--- a/packages/shared/utils/__tests__/runnable-workflow.spec.ts
+++ b/packages/shared/utils/__tests__/runnable-workflow.spec.ts
@@ -1,0 +1,67 @@
+import { FormWorkflowStep, WorkflowType } from '../../types'
+import {
+  getRunnableWorkflow,
+  isFirstStepPlaceholder,
+} from '../runnable-workflow'
+
+const step = (overrides: Partial<FormWorkflowStep> = {}): FormWorkflowStep =>
+  ({
+    workflow_type: WorkflowType.Static,
+    emails: [],
+    edit: [],
+    ...overrides,
+  }) as FormWorkflowStep
+
+const placeholder = () => step({ isPlaceholder: true })
+
+describe('isFirstStepPlaceholder', () => {
+  it('should return true when the first step is a placeholder', () => {
+    expect(isFirstStepPlaceholder([placeholder(), step()])).toBe(true)
+  })
+
+  it('should return false when the first step is set up', () => {
+    expect(isFirstStepPlaceholder([step(), step()])).toBe(false)
+  })
+
+  it('should return false for an empty workflow', () => {
+    expect(isFirstStepPlaceholder([])).toBe(false)
+  })
+
+  it('should return false for an undefined workflow', () => {
+    expect(isFirstStepPlaceholder(undefined)).toBe(false)
+  })
+
+  it('should return false when a later step is a placeholder', () => {
+    expect(isFirstStepPlaceholder([step(), placeholder()])).toBe(false)
+  })
+})
+
+describe('getRunnableWorkflow', () => {
+  it('should return an empty workflow when the first step is a placeholder', () => {
+    expect(getRunnableWorkflow([placeholder(), step(), step()])).toEqual([])
+  })
+
+  it('should return an empty workflow when the placeholder is the only step', () => {
+    expect(getRunnableWorkflow([placeholder()])).toEqual([])
+  })
+
+  it('should return the workflow unchanged when the first step is set up', () => {
+    const workflow = [step({ step_name: 'Requestor' }), step()]
+    expect(getRunnableWorkflow(workflow)).toBe(workflow)
+  })
+
+  it('should return the workflow unchanged when only a later step is a placeholder', () => {
+    // Unreachable through the delete endpoint. Stopping the workflow here would
+    // disable it for a reason the admin could not see, so we leave it alone.
+    const workflow = [step(), placeholder()]
+    expect(getRunnableWorkflow(workflow)).toBe(workflow)
+  })
+
+  it('should return an empty workflow for an empty workflow', () => {
+    expect(getRunnableWorkflow([])).toEqual([])
+  })
+
+  it('should return an empty workflow for an undefined workflow', () => {
+    expect(getRunnableWorkflow(undefined)).toEqual([])
+  })
+})

--- a/packages/shared/utils/runnable-workflow.ts
+++ b/packages/shared/utils/runnable-workflow.ts
@@ -1,0 +1,35 @@
+import { FormWorkflowStepBase } from '../types'
+
+type MaybePlaceholderStep = Pick<FormWorkflowStepBase, 'isPlaceholder'>
+
+/**
+ * Whether the workflow exists but its first step has not been set up.
+ *
+ * Used by the admin builder, which is the one consumer that must still see the
+ * empty slot so it can render it and let the admin fill it back in.
+ */
+export const isFirstStepPlaceholder = (
+  workflow: MaybePlaceholderStep[] | undefined,
+): boolean => !!workflow?.[0]?.isPlaceholder
+
+/**
+ * The workflow that will actually run, as opposed to the workflow as stored.
+ *
+ * A workflow whose first step is unset has no one to start it, so it does not
+ * run at all: this returns an empty workflow, which everything downstream
+ * already understands as "behave like an ordinary single-respondent form".
+ * Steps 2 onwards are still stored, and start running again the moment step 1
+ * is set up.
+ *
+ * Only position 1 is considered. A placeholder anywhere else cannot be produced
+ * by the delete endpoint, and treating it as a stop signal would silently
+ * disable a workflow for a reason no admin could see.
+ *
+ * Call this wherever the *live* form drives behaviour. In-flight submissions
+ * read their own snapshot instead, and the snapshot is taken from the result of
+ * this function, so a run started while step 1 was missing stays an ordinary
+ * form for its whole life.
+ */
+export const getRunnableWorkflow = <T extends MaybePlaceholderStep>(
+  workflow: T[] | undefined,
+): T[] => (isFirstStepPlaceholder(workflow) ? [] : (workflow ?? []))


### PR DESCRIPTION
Part 1 of 2 for [FRM-2494](https://linear.app/ogp/issue/FRM-2494). This is the backend half. The builder affordance is in #9898.

## Problem

Every new form is created as a multi-respondent form, so every form has a Workflow tab. Adding step 1 immediately locks the form down: only the fields step 1 names stay fillable, everything else is greyed out and rejected server side. Step 1 cannot be deleted and `responseMode` cannot be changed, so an admin who added step 1 out of curiosity has no way back short of rebuilding the form.

## Solution

Deleting step 1 leaves an **unset slot** in position 1 rather than shifting the remaining steps up, and a workflow whose first step is unset does not run.

Shifting up is the obvious answer and the wrong one. Step 1's respondent is always "anyone with the form link" and step 1 cannot approve, so a promoted step 2 would silently lose its routing and its approval. Worse, an `approval_field` that survived onto step 1 is *ignored* at submission time rather than rejected (`isApproval: false` is hardcoded on the first-step path), so a rejected approval would let the workflow proceed with no rejection email and no rejected status.

Leaving the slot unset avoids all of that. Steps 2 onwards keep their positions, ids, routing and approvals, and start running again the moment step 1 is set up.

The leverage here is that **"workflow does not run" already exists**: an empty workflow already means "every field fillable, one submission, no routing, no step notifications". So `getRunnableWorkflow` resolves a workflow with an unset step 1 to an empty one, and no new downstream behaviour is needed.

## Notes for review

- **In-flight submissions are unaffected.** Each submission snapshots the workflow at creation and every later step reads that snapshot. The resolver is applied *at the snapshot boundary*, so a submission started while step 1 was unset stays an ordinary form for its whole life even if step 1 is set up midway, and every in-flight code path is untouched.
- **This ships unflagged, deliberately.** `DELETE /:formId/workflow/0` already works today via the API; only the UI hides it. Gating the correctness fix behind `workflow-builder-redesign` would leave that gap open for flag-off traffic. The affordance is flagged, in the frontend PR.
- **`isPlaceholder` is not in the create or update validators.** The delete endpoint is the only thing that can set one, and saving the slot clears it.
- **`stepsToNotify` is deliberately left alone.** Those references point at step ids rather than positions, and nothing is renumbered, so they stay valid. They are also read live rather than from the snapshot, so pruning them would change runs already in progress.
- `deleteFormWorkflowStep` had no test coverage at all, so those tests are greenfield.

## Alternatives considered

**Promote step 2 into step 1 and normalise it** (force static routing, clear the approval). Rejected: it silently discards admin configuration, and it does not solve the actual problem. An admin escaping an accidental workflow does not want step 2 promoted, they want the workflow to stop applying.

**Represent the slot as "step 1 with no fields selected".** Rejected: an empty field list on step 1 already means *the respondent can fill nothing*, which is the opposite of inactive and strictly worse than the bug being fixed. The slot has to be distinguishable from a genuinely empty step, hence the marker.

## Open product decision (not in this PR)

A **published** form that loses step 1 silently stops routing and becomes an ordinary form. For a live approval form that is a serious silent failure. Options are: allow with a strong warning (what the frontend PR implements), block deletion while the form is public, or force the form back to private. The latter two need a server-side activation gate, which does not exist today. Flagged with the PM.

## Tests

- `pnpm test:shared` green
- Backend `src/app/modules/submission`, `src/app/models`, `src/app/modules/form`: 1461 passed
- New: resolver unit tests, `deleteFormWorkflowStep` tests, `getPublicView` tests, and a middleware test that a first submission with an unset step 1 accepts fields no step owns (with a control asserting the same responses are rejected when step 1 *is* set up)
