### PR TITLE
feat(workflow): make step 1 deletable (2/2, builder)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
@@ -170,6 +170,14 @@ const workflow_step_1: FormWorkflowStepDto = {
   edit: [form_field_1._id, form_field_2._id],
 }
 
+const workflow_step_1_unset: FormWorkflowStepDto = {
+  _id: '61e6857c9c794b0012f1c6f0',
+  workflow_type: WorkflowType.Static,
+  emails: [],
+  edit: [],
+  isPlaceholder: true,
+}
+
 const workflow_step_2: FormWorkflowStepDto = {
   _id: '61e6857c9c794b0012f1c6f9',
   workflow_type: WorkflowType.Static,
@@ -372,4 +380,36 @@ Step2InvalidConditionalRecipientSelected.parameters = {
 export const Loading = Template.bind({})
 Loading.parameters = {
   msw: { handlers: { default: buildMswRoutes({}, 'infinite') } },
+}
+
+export const UnsetStep1 = Template.bind({})
+UnsetStep1.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [workflow_step_1_unset, workflow_step_2],
+      }),
+    },
+  },
+  documentation: {
+    storyDescription:
+      'Step 1 has been deleted. The slot holds position 1 so step 2 keeps its number and its configuration, and a banner explains that the workflow is not running until step 1 is set up.',
+  },
+}
+
+export const UnsetStep1Only = Template.bind({})
+UnsetStep1Only.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({
+        ...FORM_WITH_WORKFLOW,
+        workflow: [workflow_step_1_unset],
+      }),
+    },
+  },
+  documentation: {
+    storyDescription:
+      'An unset step 1 with nothing behind it. Reachable by deleting a later step after deleting step 1.',
+  },
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteStepModal/DeleteStepModal.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteStepModal/DeleteStepModal.tsx
@@ -19,7 +19,9 @@ import {
   setToInactiveSelector,
   useAdminWorkflowStore,
 } from '../../adminWorkflowStore'
+import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
 import { useWorkflowMutations } from '../../mutations'
+import { isFirstStepByStepNumber } from '../WorkflowContent/utils/isFirstStepByStepNumber'
 
 interface DeleteStepModalProps {
   onClose: () => void
@@ -35,6 +37,7 @@ export const DeleteStepModal = ({
   const { t } = useTranslation()
   const setToInactive = useAdminWorkflowStore(setToInactiveSelector)
   const { deleteStepMutation } = useWorkflowMutations()
+  const { formWorkflow } = useAdminFormWorkflow()
   const modalSize = useBreakpointValue({
     base: 'mobile',
     xs: 'mobile',
@@ -50,10 +53,28 @@ export const DeleteStepModal = ({
     })
   }, [setToInactive, deleteStepMutation, stepNumber, onClose])
 
-  const { title, description, confirm, cancel } = t(
+  // Deleting step 1 stops the whole workflow running, rather than just
+  // shortening it, so it gets its own copy. Silently turning a live routing
+  // form back into an ordinary one is not something to confirm with "this
+  // action cannot be undone".
+  const isFirstStep = isFirstStepByStepNumber(stepNumber)
+  const hasLaterSteps = (formWorkflow?.length ?? 0) > 1
+
+  const genericCopy = t(
     'features.adminForm.sidebar.workflow.conditionalRouting.modals.deleteStep',
     { returnObjects: true },
   )
+  const firstStepCopy = t(
+    'features.adminForm.sidebar.workflow.conditionalRouting.modals.deleteFirstStep',
+    { returnObjects: true },
+  )
+
+  const { title, confirm, cancel } = isFirstStep ? firstStepCopy : genericCopy
+  const description = !isFirstStep
+    ? genericCopy.description
+    : hasLaterSteps
+      ? firstStepCopy.descriptionWithLaterSteps
+      : firstStepCopy.description
   return (
     <Modal
       isOpen={isOpen}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/ActiveStepBlock/ActiveStepBlock.tsx
@@ -15,7 +15,7 @@ import { EditStepBlock } from '../EditStepBlock'
 export interface ActiveStepBlockProps {
   stepNumber: number
   step: FormWorkflowStepDto
-  handleOpenDeleteModal: () => void
+  handleOpenDeleteModal?: () => void
 }
 
 const handleTracking = (step: FormWorkflowStep, stepNumber: number) => {

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -19,6 +19,7 @@ import {
   setToInactiveSelector,
   useAdminWorkflowStore,
 } from '../../../adminWorkflowStore'
+import { useIsWorkflowBuilderRedesign } from '../../../hooks/useIsWorkflowBuilderRedesign'
 import { EditStepInputs } from '../../../types'
 import { isFirstStepByStepNumber } from '../utils/isFirstStepByStepNumber'
 
@@ -152,6 +153,10 @@ export const EditStepBlock = ({
   }, [])
 
   const isFirstStep = isFirstStepByStepNumber(stepNumber)
+  const isRedesign = useIsWorkflowBuilderRedesign()
+  // Deleting step 1 leaves the slot unset and stops the workflow running, so
+  // the steps behind it keep their positions and their configuration.
+  const canDelete = isRedesign || !isFirstStep
 
   // RATIONALE: Returned formState is wrapped with a Proxy to improve
   // render performance, we must ead it before a render in order to enable
@@ -244,7 +249,7 @@ export const EditStepBlock = ({
       <SaveActionGroup
         isLoading={_isLoading}
         handleSubmit={handleSubmit}
-        handleDelete={isFirstStep ? undefined : handleOpenDeleteModal}
+        handleDelete={canDelete ? handleOpenDeleteModal : undefined}
         handleCancel={setToInactive}
         submitButtonLabel={submitButtonLabel}
         ariaLabelName="step"

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -57,6 +57,10 @@ const buildWorkflowStep = (
   if (inputs.step_name === '') {
     inputs.step_name = undefined
   }
+  // Saving an unset step 1 is what fills the slot, so it stops being one.
+  // Leaving the marker on would also fail the update validator, which does not
+  // accept it: only the delete endpoint may ever set it.
+  delete inputs.isPlaceholder
 
   if (isFirstStep) {
     return inputs.field

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/UnsetStepBlock/UnsetStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/UnsetStepBlock/UnsetStepBlock.tsx
@@ -1,0 +1,75 @@
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { BiPlus } from 'react-icons/bi'
+import { Box, chakra, Icon, Stack, Text } from '@chakra-ui/react'
+
+import {
+  createOrEditDataSelector,
+  requestSwitchToSelector,
+  setToEditingSelector,
+  useAdminWorkflowStore,
+} from '../../../adminWorkflowStore'
+import { StepLabel } from '../StepLabel'
+
+interface UnsetStepBlockProps {
+  stepNumber: number
+}
+
+/**
+ * The slot left behind when step 1 is deleted.
+ *
+ * It holds position 1 so the steps behind it keep their numbers, and clicking
+ * it opens the same editor as any other step, which saves over the slot rather
+ * than adding a step at the end.
+ */
+export const UnsetStepBlock = ({
+  stepNumber,
+}: UnsetStepBlockProps): JSX.Element => {
+  const { t } = useTranslation()
+  const setToEditing = useAdminWorkflowStore(setToEditingSelector)
+  const stateData = useAdminWorkflowStore(createOrEditDataSelector)
+  const requestSwitchTo = useAdminWorkflowStore(requestSwitchToSelector)
+
+  const handleClick = useCallback(() => {
+    if (stateData) {
+      // Another step is open: auto-save it and switch here.
+      requestSwitchTo(stepNumber)
+      return
+    }
+    setToEditing(stepNumber)
+  }, [stateData, stepNumber, setToEditing, requestSwitchTo])
+
+  return (
+    <Box pos="relative" role="group">
+      <chakra.button
+        type="button"
+        w="100%"
+        textAlign="start"
+        borderRadius="4px"
+        bg="white"
+        border="1px dashed"
+        borderColor="neutral.400"
+        transitionProperty="common"
+        transitionDuration="normal"
+        cursor="pointer"
+        _groupHover={{ borderColor: 'primary.500', bg: 'primary.100' }}
+        onClick={handleClick}
+      >
+        <Stack spacing="1rem" p={{ base: '1.5rem', md: '2rem' }}>
+          <StepLabel stepNumber={stepNumber} />
+          <Stack direction="row" spacing="0.5rem" align="center">
+            <Icon as={BiPlus} fontSize="1.25rem" color="secondary.500" />
+            <Text textStyle="subhead-3">
+              {t('features.adminForm.sidebar.workflow.unsetFirstStep.title')}
+            </Text>
+          </Stack>
+          <Text textStyle="body-2" color="secondary.400">
+            {t(
+              'features.adminForm.sidebar.workflow.unsetFirstStep.description',
+            )}
+          </Text>
+        </Stack>
+      </chakra.button>
+    </Box>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/UnsetStepBlock/index.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/UnsetStepBlock/index.ts
@@ -1,0 +1,1 @@
+export * from './UnsetStepBlock'

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
@@ -44,7 +44,11 @@ export const WorkflowBlockFactory = ({
         <ActiveStepBlock
           stepNumber={stepNumber}
           step={step}
-          handleOpenDeleteModal={onDeleteModalOpen}
+          // An unset slot has nothing to delete. Deleting it would only write
+          // the same slot back.
+          handleOpenDeleteModal={
+            step.isPlaceholder ? undefined : onDeleteModalOpen
+          }
         />
       ) : step.isPlaceholder ? (
         // The slot left by deleting step 1. Rendering it as a normal step would

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
@@ -10,6 +10,7 @@ import {
 import { DeleteStepModal } from '../../DeleteStepModal'
 import { ActiveStepBlock } from '../ActiveStepBlock'
 import { InactiveStepBlock } from '../InactiveStepBlock'
+import { UnsetStepBlock } from '../UnsetStepBlock'
 
 export interface WorkflowBlockFactoryProps {
   stepNumber: number
@@ -45,6 +46,11 @@ export const WorkflowBlockFactory = ({
           step={step}
           handleOpenDeleteModal={onDeleteModalOpen}
         />
+      ) : step.isPlaceholder ? (
+        // The slot left by deleting step 1. Rendering it as a normal step would
+        // claim it routes to anyone with the form link, which it does not: the
+        // workflow is not running at all until it is set up.
+        <UnsetStepBlock stepNumber={stepNumber} />
       ) : (
         <InactiveStepBlock stepNumber={stepNumber} step={step} />
       )}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -1,6 +1,10 @@
+import { useTranslation } from 'react-i18next'
 import { Box, Divider, Stack, Text } from '@chakra-ui/react'
 
+import { isFirstStepPlaceholder } from 'formsg-shared/utils/runnable-workflow'
+
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
+import InlineMessage from '~components/InlineMessage'
 
 import { StatusTrackerToggle } from '~features/admin-form/settings/components/EmailNotificationsSection/StatusTrackerToggle'
 
@@ -11,6 +15,7 @@ import { WorkflowBlockFactory } from './WorkflowBlockFactory'
 import { WorkflowCompletionMessageBlock } from './WorkflowCompletionMessageBlock'
 
 export const WorkflowContent = (): JSX.Element | null => {
+  const { t } = useTranslation()
   const { formWorkflow, isLoading } = useAdminFormWorkflow()
 
   if (isLoading) return null
@@ -32,6 +37,11 @@ export const WorkflowContent = (): JSX.Element | null => {
           <StatusTrackerToggle />
         </Stack>
       </Box>
+      {isFirstStepPlaceholder(formWorkflow) ? (
+        <InlineMessage variant="warning">
+          {t('features.adminForm.sidebar.workflow.unsetFirstStep.banner')}
+        </InlineMessage>
+      ) : null}
       <Stack spacing="0" divider={<WorkflowStepBlockDivider />}>
         {formWorkflow?.map((step, i) => (
           <WorkflowBlockFactory key={i} stepNumber={i} step={step} />

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -44,6 +44,15 @@ export const enSG: Workflow = {
       notDropdownRedesign: 'Choose a dropdown field.',
     },
     modals: {
+      deleteFirstStep: {
+        title: 'Delete step 1',
+        description:
+          'Your workflow will stop running. Anyone with your form link will be able to fill in every field, and the form will not be sent on to anyone.\n\nYou can set step 1 up again at any time.',
+        descriptionWithLaterSteps:
+          'Your workflow will stop running until you set step 1 up again. Your other steps are kept, along with who fills them in and any approvals.\n\nIn the meantime, anyone with your form link will be able to fill in every field, and the form will not be sent on to anyone.',
+        confirm: 'Yes, delete step 1',
+        cancel: "No, don't delete",
+      },
       deleteStep: {
         title: 'Delete step',
         description:

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -20,6 +20,13 @@ export const enSG: Workflow = {
     fieldsToFill: 'Fields to fill',
     clickToEdit: 'Click to edit',
   },
+  unsetFirstStep: {
+    title: 'Set up step 1',
+    description:
+      'Choose who fills in this step and which fields they fill in. Your other steps are saved and will run again once step 1 is set up.',
+    banner:
+      'This workflow is not running because step 1 has not been set up. Until then, anyone with your form link can fill in every field, and the form will not be sent on to your other steps.',
+  },
   dynamicRespondent: {
     title: 'An email field from the form',
     required: 'Please select a field.',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -18,6 +18,11 @@ export interface Workflow {
     fieldsToFill: string
     clickToEdit: string
   }
+  unsetFirstStep: {
+    title: string
+    description: string
+    banner: string
+  }
   dynamicRespondent: {
     title: string
     required: string

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -40,6 +40,13 @@ export interface Workflow {
       notDropdownRedesign: string
     }
     modals: {
+      deleteFirstStep: {
+        title: string
+        description: string
+        descriptionWithLaterSteps: string
+        confirm: string
+        cancel: string
+      }
       deleteStep: {
         title: string
         description: string


### PR DESCRIPTION
Part 2 of 2 for [FRM-2494](https://linear.app/ogp/issue/FRM-2494). Stacked on #9897, which has the full problem statement and the design rationale. **Merge #9897 first**, then this retargets to `develop`.

This half is the builder UI, behind `workflow-builder-redesign`.

## What changes

- **Step 1 gets a delete button.** One guard removed. Everything it depends on is in #9897.
- **The unset slot gets its own card.** Rendering it as an ordinary step would claim it routes to anyone with the form link, which is exactly what it no longer does. Clicking it opens the normal editor, which saves over the slot via `PUT /workflow/0` rather than adding a step at the end.
- **A banner on the workflow tab** while step 1 is unset.
- **Step-1-specific delete modal copy**, in two variants depending on whether later steps exist.

## Notes for review

- **The copy is deliberately blunt.** The generic modal says "this action cannot be undone", which is both wrong here (it is undoable) and unhelpful. What matters is the consequence: respondents can now fill in every field and nothing is sent on. An admin deleting step 1 on a live form needs to know that before they confirm, not after.
- **Saving the slot clears `isPlaceholder`.** It also has to, because the update validator does not accept the key. That keeps the delete endpoint as the only thing that can ever set one.
- **An unset slot offers no delete**, since deleting it would only write the same slot back.
- Storybook covers both new states: an unset step 1 with a step behind it, and an unset step 1 on its own.

## Open product decision

This implements **allow-with-warning** for a published form losing step 1. The alternatives (block deletion while public, or force the form back to private) need a server-side activation gate that does not exist today, and would change this modal copy. Flagged with the PM. If they pick one of those, the copy here is the thing to revisit.

## Tests

- Frontend typecheck clean, 347 tests passed
- Two new Storybook stories
