### PR TITLE
fix(responses): put response metadata back on the type scale

### DIFF
--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -216,7 +216,7 @@ export const IndividualResponsePage = (): JSX.Element => {
         spacing={{ base: '1.5rem', md: '2.5rem' }}
         data-dd-privacy="mask"
       >
-        <Stack bg="primary.100" p="1.5rem" textStyle="monospace">
+        <Stack bg="primary.100" p="1.5rem" textStyle="body-1">
           <StackRow
             label="Response ID"
             value={submissionId}


### PR DESCRIPTION
https://app.notion.com/p/opengov/Metadata-section-0s-inconsistent-vs-response-section-9af608dccbf44d5b9849f8662757999a?source=copy_link

## Problem

The metadata block at the top of the individual response page (Response ID, Timestamp, and the MRF rows) was rendering in a different type to the rest of the admin UI, and each row was internally inconsistent: the label and its value did not match.

The cause is that the block's container carried `textStyle="monospace"`. Despite the name, that text style sets only `font-feature-settings` (`tnum`, `lnum`, `zero`, `cv05`) — no `font-size`, `font-weight`, `line-height` or `letter-spacing`, and no `font-family` either. The labels set `textStyle="subhead-1"` explicitly, so they were on the scale; the values inherited the container and fell back to browser defaults. The `zero` feature also drew slashed zeros, which made timestamps read like code.

## Solution

Switch the container to `textStyle="body-1"`, the scale entry these values should have had. It pairs with `subhead-1` on size and line-height, keeps the tabular/lining figures so the values stay column-aligned, and drops the slashed zero.

`PaymentSection` keeps `monospace` on the payment intent and payout IDs. Those are opaque identifiers where character disambiguation is worth the visual break, so that usage is deliberate and is left alone.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Response metadata on the individual response page now uses the `body-1` text style, so values match their labels and the rest of the admin UI.

## Before & After Screenshots

**BEFORE**:
<img width="1004" height="426" alt="Screenshot 2026-08-28 at 1 32 23 PM" src="https://github.com/user-attachments/assets/66d08394-7dea-4c23-a733-27046a81807a" />

**AFTER**:
<img width="1019" height="450" alt="Screenshot 2026-08-28 at 1 41 18 PM" src="https://github.com/user-attachments/assets/3697a2bf-559d-4ba9-bb23-d5fe73e01dac" />

## Tests

- `pnpm vitest run src/features/admin-form/responses/IndividualResponsePage/` in `apps/frontend` — 2 files, 2 tests passing.
- Manual: open any submission under Responses > individual response and confirm the metadata block's labels and values share the same type, and that timestamps no longer show slashed zeros.

## Deploy Notes

None. Presentation-only change to a single component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)