### PR TITLE
feat(workflow): add the delete-workflow modal (2/5)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/FormWorkflowService.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/FormWorkflowService.ts
@@ -20,6 +20,18 @@ export const deleteWorkflowStep = (formId: string, stepNumber: number) => {
   ).then(({ data }) => data)
 }
 
+/**
+ * Deletes the form's entire workflow.
+ *
+ * Also what deleting step 1 means — the API refuses to delete step 1 on its own
+ * precisely so that this is the only way to express it.
+ */
+export const deleteWorkflow = (formId: string) => {
+  return ApiService.delete<FormWorkflowDto>(
+    `${ADMIN_FORM_ENDPOINT}/${formId}/workflow`,
+  ).then(({ data }) => data)
+}
+
 export const updateWorkflowStep = (
   formId: string,
   stepNumber: number,

--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.stories.tsx
@@ -1,0 +1,69 @@
+import { Meta, StoryFn } from '@storybook/react'
+
+import { FormResponseMode, FormStatus } from 'formsg-shared/types'
+
+import { createFormBuilderMocks } from '~/mocks/msw/handlers/admin-form'
+
+import { StoryRouter, viewports } from '~utils/storybook'
+
+import { DeleteWorkflowModal } from './DeleteWorkflowModal'
+
+/**
+ * The modal has two states and they are not variants of each other: one asks
+ * the admin to confirm something destructive, the other tells them they cannot
+ * do it yet and points at the fix. Which one shows is decided by the form's
+ * status, so the stories differ only in that.
+ */
+const buildMocks = (status: FormStatus) =>
+  createFormBuilderMocks({
+    responseMode: FormResponseMode.Multirespondent,
+    status,
+  })
+
+export default {
+  title: 'Features/AdminForm/Workflow/DeleteWorkflowModal',
+  component: DeleteWorkflowModal,
+  decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
+  parameters: {
+    layout: 'fullscreen',
+    chromatic: { pauseAnimationAtEnd: true, delay: 300 },
+  },
+} as Meta
+
+const Template: StoryFn = () => (
+  <DeleteWorkflowModal isOpen onClose={() => undefined} />
+)
+
+/** Form closed: deleting is allowed, and the confirm button is destructive. */
+export const FormClosed = Template.bind({})
+FormClosed.parameters = {
+  msw: { handlers: { default: buildMocks(FormStatus.Private) } },
+}
+
+/**
+ * Form open: the API refuses this, so the modal does not offer it. The primary
+ * action goes to settings, which is the only place the admin can unblock
+ * themselves.
+ */
+export const FormOpen = Template.bind({})
+FormOpen.parameters = {
+  msw: { handlers: { default: buildMocks(FormStatus.Public) } },
+}
+
+export const MobileFormClosed = Template.bind({})
+MobileFormClosed.parameters = {
+  ...FormClosed.parameters,
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
+}
+
+export const MobileFormOpen = Template.bind({})
+MobileFormOpen.parameters = {
+  ...FormOpen.parameters,
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.tsx
@@ -1,0 +1,133 @@
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+  useBreakpointValue,
+} from '@chakra-ui/react'
+
+import { FormStatus } from 'formsg-shared/types'
+
+import { ADMINFORM_ROUTE, ADMINFORM_SETTINGS_SUBROUTE } from '~constants/routes'
+import Button from '~components/Button'
+import { ModalCloseButton } from '~components/Modal'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+
+import {
+  setToInactiveSelector,
+  useAdminWorkflowStore,
+} from '../../adminWorkflowStore'
+import { useWorkflowMutations } from '../../mutations'
+
+interface DeleteWorkflowModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * Confirms deleting a form's entire workflow.
+ *
+ * Shown from two places that mean the same thing: the workflow card's own
+ * delete button, and the delete button on step 1. A workflow without its first
+ * step has no entry point, so deleting step 1 is deleting the workflow — and
+ * offering two different modals for one outcome would suggest otherwise.
+ *
+ * Which of the two states it shows depends on whether the form is still open.
+ * Deleting the workflow while respondents may be part-way through it is refused
+ * by the API, so the modal's job when the form is open is not to warn but to
+ * send the admin to the one place they can do something about it.
+ */
+export const DeleteWorkflowModal = ({
+  isOpen,
+  onClose,
+}: DeleteWorkflowModalProps): JSX.Element => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { formId } = useParams()
+  const { data: form } = useAdminForm()
+  const setToInactive = useAdminWorkflowStore(setToInactiveSelector)
+  const { deleteWorkflowMutation } = useWorkflowMutations()
+
+  const modalSize = useBreakpointValue({
+    base: 'mobile',
+    xs: 'mobile',
+    md: 'md',
+  })
+
+  const isFormOpen = form?.status === FormStatus.Public
+
+  const copy = t(
+    isFormOpen
+      ? 'features.adminForm.sidebar.workflow.conditionalRouting.modals.closeFormFirst'
+      : 'features.adminForm.sidebar.workflow.conditionalRouting.modals.deleteWorkflow',
+    { returnObjects: true },
+  )
+
+  const handleGoToSettings = useCallback(() => {
+    navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_SETTINGS_SUBROUTE}`)
+  }, [navigate, formId])
+
+  const handleDelete = useCallback(() => {
+    // Set here rather than in onSuccess: this component is unmounted by the
+    // time that fires, since the card it belongs to is gone with the workflow.
+    setToInactive()
+    return deleteWorkflowMutation.mutate(undefined, { onSuccess: onClose })
+  }, [setToInactive, deleteWorkflowMutation, onClose])
+
+  const isLoading = deleteWorkflowMutation.isLoading
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size={modalSize}
+      closeOnOverlayClick={!isLoading}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalCloseButton isDisabled={isLoading} />
+        <ModalHeader color="secondary.700">{copy.title}</ModalHeader>
+        <ModalBody whiteSpace="pre-wrap">
+          <Text textStyle="body-2" color="secondary.500">
+            {copy.description}
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <Stack
+            direction={{ base: 'column-reverse', md: 'row' }}
+            w="100%"
+            justify="flex-end"
+          >
+            <Button
+              variant="clear"
+              colorScheme="secondary"
+              isDisabled={isLoading}
+              onClick={onClose}
+            >
+              {copy.cancel}
+            </Button>
+            {isFormOpen ? (
+              <Button onClick={handleGoToSettings}>{copy.confirm}</Button>
+            ) : (
+              <Button
+                colorScheme="danger"
+                onClick={handleDelete}
+                isLoading={isLoading}
+              >
+                {copy.confirm}
+              </Button>
+            )}
+          </Stack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/index.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/index.ts
@@ -1,0 +1,1 @@
+export * from './DeleteWorkflowModal'

--- a/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/mutations.ts
@@ -16,6 +16,7 @@ import { useAdminFeedbackStore } from '~features/workspace/components/AdminFeedb
 import { useAdminFormWorkflow } from './hooks/useAdminFormWorkflow'
 import {
   createWorkflowStep,
+  deleteWorkflow,
   deleteWorkflowStep,
   updateWorkflowStep,
 } from './FormWorkflowService'
@@ -92,6 +93,23 @@ export const useWorkflowMutations = () => {
     },
   )
 
+  const deleteWorkflowMutation = useMutation(() => deleteWorkflow(formId), {
+    onSuccess: (updatedWorkflow) => {
+      toast.closeAll()
+      queryClient.setQueryData<AdminFormDto>(adminFormKey, (prev) => {
+        if (!prev) throw new Error('Query should have been set')
+        if (prev.responseMode !== FormResponseMode.Multirespondent) {
+          throw new Error('Invalid response mode')
+        }
+        return { ...prev, workflow: updatedWorkflow }
+      })
+      toast({
+        description: 'Your workflow was deleted.',
+      })
+    },
+    onError: handleError,
+  })
+
   const updateStepMutation = useMutation(
     ({
       stepNumber,
@@ -127,6 +145,7 @@ export const useWorkflowMutations = () => {
   return {
     createStepMutation,
     deleteStepMutation,
+    deleteWorkflowMutation,
     updateStepMutation,
   }
 }

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -44,6 +44,20 @@ export const enSG: Workflow = {
         confirm: 'Yes, delete step',
         cancel: "No, don't delete",
       },
+      deleteWorkflow: {
+        title: 'Delete your workflow',
+        description:
+          'Responses already in progress will carry on as they are. When you reopen your form, anyone with the link will be able to fill in every field.',
+        confirm: 'Delete workflow',
+        cancel: 'Cancel',
+      },
+      closeFormFirst: {
+        title: 'Close your form first',
+        description:
+          'You can only delete your workflow when your form is closed to new responses.',
+        confirm: 'Go to settings',
+        cancel: 'Cancel',
+      },
       deleteMapping: {
         title: 'Delete CSV file',
         description:

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -46,6 +46,18 @@ export interface Workflow {
         confirm: string
         cancel: string
       }
+      deleteWorkflow: {
+        title: string
+        description: string
+        confirm: string
+        cancel: string
+      }
+      closeFormFirst: {
+        title: string
+        description: string
+        confirm: string
+        cancel: string
+      }
       deleteMapping: {
         title: string
         description: string


### PR DESCRIPTION
## Problem

- Stacked on #9907. The API can delete a workflow, but nothing asks the admin first.
- "This action cannot be undone" tells an admin nothing they had not already assumed.
- The consequence they do miss is what reopening the form exposes. Part of [FRM-2494](https://linear.app/ogp/issue/FRM-2494).

## Solution

- New `DeleteWorkflowModal` with two states, picked by whether the form is open.
- Form closed: names the consequence, that reopening lets anyone with the link fill in every field.
- Form open: "Close your form first", with a primary "Go to settings" rather than a dead end.
- One modal for both entry points, because deleting step 1 is deleting the workflow.
- Adds the `deleteWorkflow` service call and `deleteWorkflowMutation`, which updates the form cache and toasts.
- Nothing opens it yet. #9909 wires up the two triggers.

**Alternatives considered**

- A disabled delete button plus an explanation, skipped. It leaves the admin reading a modal that cannot act.
- Separate modals for step 1 and the card, skipped. Two modals for one outcome would imply the outcomes differ.

**Breaking changes:** none. New component, no call sites.

## Screenshots

Storybook: `Features/AdminForm/Workflow/DeleteWorkflowModal` — `FormClosed`, `FormOpen`, and a mobile variant of each. The two states differ only by the form's status in the mocked response.

**BEFORE:** n/a, new component.

## Tests

- Typecheck and lint clean; 352 frontend tests pass.
- Behaviour is covered in #9909, where the triggers land. On its own this component has no callers.

**Manual**

- [ ] Run Storybook and open the four stories; check the copy, button order, and mobile layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
