### PR TITLE
feat(workflow): give step 1 and the workflow card a delete button (3/5)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../../adminWorkflowStore'
 import { useGuidedStepReveal } from '../../../hooks/useGuidedStepReveal'
 import { useIsWorkflowBuilderRedesign } from '../../../hooks/useIsWorkflowBuilderRedesign'
+import { useIsWorkflowDeletion } from '../../../hooks/useIsWorkflowDeletion'
 import { EditStepInputs } from '../../../types'
 import { getGuidedSecondaryAction } from '../../../utils/guidedStepPolicy'
 import { SpotlightGroup } from '../../Spotlight'
@@ -159,6 +160,7 @@ export const EditStepBlock = ({
   }, [])
 
   const isFirstStep = isFirstStepByStepNumber(stepNumber)
+  const isWorkflowDeletion = useIsWorkflowDeletion()
 
   // RATIONALE: Returned formState is wrapped with a Proxy to improve
   // render performance, we must ead it before a render in order to enable
@@ -309,7 +311,12 @@ export const EditStepBlock = ({
             // opens differs — deleting step 1 means deleting the workflow —
             // but hiding the button left admins hunting for a delete that
             // does not exist, which is the behaviour FRM-2494 is about.
-            handleDelete={handleOpenDeleteModal}
+            // Behind the flag, so with it off step 1 has no delete.
+            handleDelete={
+              !isFirstStep || isWorkflowDeletion
+                ? handleOpenDeleteModal
+                : undefined
+            }
             handleCancel={setToInactive}
             submitButtonLabel={submitButtonLabel}
             ariaLabelName="step"

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -305,7 +305,11 @@ export const EditStepBlock = ({
           <SaveActionGroup
             isLoading={_isLoading}
             handleSubmit={handleSubmit}
-            handleDelete={isFirstStep ? undefined : handleOpenDeleteModal}
+            // Step 1 gets the same affordance as every other step. What it
+            // opens differs — deleting step 1 means deleting the workflow —
+            // but hiding the button left admins hunting for a delete that
+            // does not exist, which is the behaviour FRM-2494 is about.
+            handleDelete={handleOpenDeleteModal}
             handleCancel={setToInactive}
             submitButtonLabel={submitButtonLabel}
             ariaLabelName="step"

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
@@ -10,6 +10,7 @@ import {
   useAdminWorkflowStore,
 } from '../../../adminWorkflowStore'
 import { DeleteStepModal } from '../../DeleteStepModal'
+import { DeleteWorkflowModal } from '../../DeleteWorkflowModal'
 import {
   CompletionPeekCard,
   CompletionPeekCardProps,
@@ -60,14 +61,25 @@ export const WorkflowBlockFactory = ({
         onDeclineAnotherStep: dismissCompletedStep,
         onAddAnotherStep: setToCreating,
       }
+  // A workflow without its first step has no entry point, so deleting step 1 is
+  // deleting the workflow. Same button, same modal as the workflow's own delete
+  // — the outcome is the same, and two different modals would imply otherwise.
+  const isFirstStep = isFirstStepByStepNumber(stepNumber)
 
   return (
     <>
-      <DeleteStepModal
-        isOpen={isDeleteModalOpen}
-        onClose={onDeleteModalClose}
-        stepNumber={stepNumber}
-      />
+      {isFirstStep ? (
+        <DeleteWorkflowModal
+          isOpen={isDeleteModalOpen}
+          onClose={onDeleteModalClose}
+        />
+      ) : (
+        <DeleteStepModal
+          isOpen={isDeleteModalOpen}
+          onClose={onDeleteModalClose}
+          stepNumber={stepNumber}
+        />
+      )}
       {isActiveState ? (
         <ActiveStepBlock
           stepNumber={stepNumber}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -1,11 +1,22 @@
-import { Box, Divider, Stack, Text } from '@chakra-ui/react'
+import { useTranslation } from 'react-i18next'
+import { BiTrash } from 'react-icons/bi'
+import {
+  Box,
+  Divider,
+  Flex,
+  Stack,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
 
 import { BxsChevronDown } from '~assets/icons/BxsChevronDown'
+import IconButton from '~components/IconButton'
 
 import { StatusTrackerToggle } from '~features/admin-form/settings/components/EmailNotificationsSection/StatusTrackerToggle'
 
 import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
 import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
+import { DeleteWorkflowModal } from '../DeleteWorkflowModal'
 import { GuidedSetupToggle, useReportedCompletedStep } from '../GuidedCreation'
 
 import { CompletionEmailBlock } from './CompletionEmailBlock'
@@ -16,13 +27,23 @@ import { WorkflowCompletionMessageBlock } from './WorkflowCompletionMessageBlock
 export const STEP_CONNECTOR_TEST_ID = 'workflow-step-connector'
 
 export const WorkflowContent = (): JSX.Element | null => {
+  const { t } = useTranslation()
   const { formWorkflow, isLoading } = useAdminFormWorkflow()
   const isRedesign = useIsWorkflowBuilderRedesign()
   const isReportingCompletedStep = useReportedCompletedStep() !== null
+  const {
+    isOpen: isDeleteModalOpen,
+    onClose: onDeleteModalClose,
+    onOpen: onDeleteModalOpen,
+  } = useDisclosure()
 
   if (isLoading) return null
   return (
     <Stack color="secondary.500" spacing="2.75rem" mt="1.5rem">
+      <DeleteWorkflowModal
+        isOpen={isDeleteModalOpen}
+        onClose={onDeleteModalClose}
+      />
       {/* <HeaderBlock /> */}
       <Box
         bg="white"
@@ -32,9 +53,25 @@ export const WorkflowContent = (): JSX.Element | null => {
         padding="1.5rem"
       >
         <Stack gap={'1.5rem'}>
-          <Text as="h2" textStyle="h2">
-            Workflow
-          </Text>
+          <Flex align="center" justify="space-between">
+            <Text as="h2" textStyle="h2">
+              Workflow
+            </Text>
+            {/* Grey rather than danger-red. This sits on the card at rest,
+                not inside a confirmation, and a red button in the corner of a
+                page reads as a warning about the page's state rather than as
+                an action. The destructive colour belongs on the button that
+                actually destroys something, in the modal. */}
+            <IconButton
+              variant="clear"
+              colorScheme="secondary"
+              aria-label={t(
+                'features.adminForm.sidebar.workflow.aria.deleteWorkflow',
+              )}
+              icon={<BiTrash />}
+              onClick={onDeleteModalOpen}
+            />
+          </Flex>
           <Divider />
           <StatusTrackerToggle />
           <GuidedSetupToggle />

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -16,6 +16,7 @@ import { StatusTrackerToggle } from '~features/admin-form/settings/components/Em
 
 import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
 import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
+import { useIsWorkflowDeletion } from '../../hooks/useIsWorkflowDeletion'
 import { DeleteWorkflowModal } from '../DeleteWorkflowModal'
 import { GuidedSetupToggle, useReportedCompletedStep } from '../GuidedCreation'
 
@@ -31,6 +32,7 @@ export const WorkflowContent = (): JSX.Element | null => {
   const { formWorkflow, isLoading } = useAdminFormWorkflow()
   const isRedesign = useIsWorkflowBuilderRedesign()
   const isReportingCompletedStep = useReportedCompletedStep() !== null
+  const isWorkflowDeletion = useIsWorkflowDeletion()
   const {
     isOpen: isDeleteModalOpen,
     onClose: onDeleteModalClose,
@@ -62,15 +64,17 @@ export const WorkflowContent = (): JSX.Element | null => {
                 page reads as a warning about the page's state rather than as
                 an action. The destructive colour belongs on the button that
                 actually destroys something, in the modal. */}
-            <IconButton
-              variant="clear"
-              colorScheme="secondary"
-              aria-label={t(
-                'features.adminForm.sidebar.workflow.aria.deleteWorkflow',
-              )}
-              icon={<BiTrash />}
-              onClick={onDeleteModalOpen}
-            />
+            {isWorkflowDeletion ? (
+              <IconButton
+                variant="clear"
+                colorScheme="secondary"
+                aria-label={t(
+                  'features.adminForm.sidebar.workflow.aria.deleteWorkflow',
+                )}
+                icon={<BiTrash />}
+                onClick={onDeleteModalOpen}
+              />
+            ) : null}
           </Flex>
           <Divider />
           <StatusTrackerToggle />

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useIsWorkflowDeletion.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useIsWorkflowDeletion.ts
@@ -1,0 +1,15 @@
+import { useFeatureIsOn } from '@growthbook/growthbook-react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+/**
+ * Whether an admin can delete their workflow, from step 1's card or from the
+ * workflow card itself.
+ *
+ * The backend gates the same flag independently rather than trusting this: with
+ * the flag off, DELETE /workflow does not exist and deleting step 1 keeps its
+ * old behaviour. Hiding the buttons is what stops an admin finding the feature,
+ * not what stops the request.
+ */
+export const useIsWorkflowDeletion = (): boolean =>
+  useFeatureIsOn(featureFlags.workflowDeletion)

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -10,6 +10,9 @@ import { Workflow } from '.'
 
 export const enSG: Workflow = {
   title: 'Add workflow',
+  aria: {
+    deleteWorkflow: 'Delete workflow',
+  },
   respondentBlock: {
     stepRespondent: 'Respondent in this step',
     stepRespondentRedesign: 'Who fills in this step?',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -12,6 +12,9 @@ interface CsvColumnText {
 }
 
 export interface Workflow {
+  aria: {
+    deleteWorkflow: string
+  }
   title: string
   respondentBlock: {
     stepRespondent: string


### PR DESCRIPTION
## Problem

- Stacked on #9908. The modal exists, but nothing opens it yet.
- Step 1 had no trash icon, since `handleDelete` was passed as `undefined` for it.
- So admins deleted step 1 through the API, which promoted step 2 into the entry point. That is [FRM-2494](https://linear.app/ogp/issue/FRM-2494).

## Solution

- Step 1's edit card now shows the same trash icon as every other step.
- It opens the workflow modal, not the step modal, because deleting step 1 is deleting the workflow.
- A trash icon in the workflow card's top-right corner opens the same modal.
- Grey, not danger-red: it sits on a card at rest, not inside a confirmation.
- Both affordances sit behind `useIsWorkflowDeletion`, the same flag the backend checks independently.
- Steps 2 and later keep their own trash icon and still open `DeleteStepModal`.

**Alternatives considered**

- Leaving step 1's icon hidden, rejected. Hiding it never said "you cannot delete this", it just sent admins to the API.

**Breaking changes:** none.

## Screenshots

**BEFORE:** n/a, there was no way to delete a workflow.

**AFTER:**

Form closed, deleting from step 1's delete button:
https://github.com/user-attachments/assets/67e17903-57ff-44ee-ada6-db3b09fffc84

Form closed, deleting from the workflow card's delete button:
https://github.com/user-attachments/assets/da94f93b-6a8f-4add-a2dd-19b71371f6de

Form open, deletion refused, per the PRD spec:
https://github.com/user-attachments/assets/61cdb28a-bdc6-494a-b24f-f5701877a7f3

Workflow deleted mid-flight, so participants are blocked from submitting:
https://github.com/user-attachments/assets/74be03f1-498d-421c-9c71-c932cc627695

## Tests

- 352 frontend tests pass; `tsc` and eslint clean.

**Manual** — the first PR in the stack where the pieces meet.

- [ ] Form open: both trash icons show "Close your form first", and Go to settings lands on settings.
- [ ] Form closed: both delete the workflow, and the card returns to its empty state.
- [ ] Step 2's trash still opens the ordinary step modal and deletes only that step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
