### PR TITLE
feat(workflow-builder-redesign): actionable empty states for field pickers

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
@@ -24,7 +24,15 @@ import {
 
 import { StoryRouter, viewports } from '~utils/storybook'
 
+import { CreatePageSidebarProvider } from '~features/admin-form/create/common'
+
 import { CreatePageWorkflowTab } from './CreatePageWorkflowTab'
+
+const withCreatePageSidebar = (Story: StoryFn) => (
+  <CreatePageSidebarProvider>
+    <Story />
+  </CreatePageSidebarProvider>
+)
 
 const buildMswRoutes = (
   overrides?: Partial<AdminFormDto>,
@@ -34,7 +42,10 @@ const buildMswRoutes = (
 export default {
   title: 'Pages/AdminFormPage/Create/WorkflowTab',
   component: CreatePageWorkflowTab,
-  decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
+  decorators: [
+    withCreatePageSidebar,
+    StoryRouter({ initialEntries: ['/12345'], path: '/:formId' }),
+  ],
   parameters: {
     layout: 'fullscreen',
     // Required so skeleton "animation" does not hide content.

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/ApprovalsBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/ApprovalsBlock.tsx
@@ -3,6 +3,8 @@ import { Controller, UseFormReturn } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { FormControl } from '@chakra-ui/react'
 
+import { BasicField } from 'formsg-shared/types'
+
 import { textStyles } from '~theme/textStyles'
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
@@ -13,11 +15,13 @@ import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants
 
 import { useAdminFormWorkflow } from '../../../hooks/useAdminFormWorkflow'
 import { useIsWorkflowBuilderRedesign } from '../../../hooks/useIsWorkflowBuilderRedesign'
+import { useStageFieldAndNavigate } from '../../../hooks/useStageFieldAndNavigate'
 import { EditStepInputs } from '../../../types'
 import { nextEditFieldsForApproval } from '../utils/nextEditFieldsForApproval'
 
 import { APPROVAL_FIELD_NAME, FIELDS_TO_EDIT_NAME } from './EditStepBlock'
 import { EditStepBlockContainer } from './EditStepBlockContainer'
+import { FieldEmptyState } from './EmptyStates'
 
 interface ApprovalsBlockProps {
   formMethods: UseFormReturn<EditStepInputs>
@@ -30,6 +34,7 @@ export const ApprovalsBlock = ({
 }: ApprovalsBlockProps): JSX.Element => {
   const { t } = useTranslation()
   const isRedesign = useIsWorkflowBuilderRedesign()
+  const stageFieldAndNavigate = useStageFieldAndNavigate()
   const {
     control,
     setValue,
@@ -163,6 +168,26 @@ export const ApprovalsBlock = ({
               },
             }}
             render={({ field: { value = '', onChange, ...rest } }) => {
+              // Also runs in the empty-state branch: it clears a stale
+              // approval_field id, and stale ids exist exactly when every
+              // Yes/No field is gone.
+              const displayValue = getValueIfNotDeleted(value)
+              // Swaps what the Controller renders, never the Controller
+              // itself, so the validate rules stay registered.
+              if (isRedesign && yesNoFieldItems.length === 0) {
+                return (
+                  <FieldEmptyState
+                    picker="yesno"
+                    message={t(
+                      'features.adminForm.sidebar.workflow.emptyStates.noYesNoField',
+                    )}
+                    actionLabel={t(
+                      'features.adminForm.sidebar.workflow.emptyStates.noYesNoFieldAction',
+                    )}
+                    onAction={() => stageFieldAndNavigate(BasicField.YesNo)}
+                  />
+                )
+              }
               const handleApprovalFieldChange = (newValue: string) => {
                 // Append to `edit` before handing the value to RHF. Setting
                 // approval_field revalidates it, and validate reads `edit`
@@ -189,7 +214,7 @@ export const ApprovalsBlock = ({
                     'features.adminForm.sidebar.workflow.approvals.toggle.placeholder',
                   )}
                   items={yesNoFieldItems}
-                  value={getValueIfNotDeleted(value)}
+                  value={displayValue}
                   isClearable
                   isDisabled={isLoading}
                   onChange={handleApprovalFieldChange}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/ApprovalsBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/ApprovalsBlock.tsx
@@ -168,12 +168,7 @@ export const ApprovalsBlock = ({
               },
             }}
             render={({ field: { value = '', onChange, ...rest } }) => {
-              // Also runs in the empty-state branch: it clears a stale
-              // approval_field id, and stale ids exist exactly when every
-              // Yes/No field is gone.
               const displayValue = getValueIfNotDeleted(value)
-              // Swaps what the Controller renders, never the Controller
-              // itself, so the validate rules stay registered.
               if (isRedesign && yesNoFieldItems.length === 0) {
                 return (
                   <FieldEmptyState

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
@@ -15,6 +15,8 @@ import { getAdminFormView } from '~/mocks/msw/handlers/admin-form'
 
 import { StoryRouter } from '~utils/storybook'
 
+import { CreatePageSidebarProvider } from '~features/admin-form/create/common'
+
 import { useAdminWorkflowStore } from '../../../adminWorkflowStore'
 
 import { EditStepBlock } from './EditStepBlock'
@@ -148,6 +150,12 @@ const mrfFormViewWithFields = [
   }),
 ]
 
+const withCreatePageSidebar = (Story: StoryFn) => (
+  <CreatePageSidebarProvider>
+    <Story />
+  </CreatePageSidebarProvider>
+)
+
 export default {
   component: EditStepBlock,
   title:
@@ -159,7 +167,10 @@ export default {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onSubmit: () => {},
   },
-  decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
+  decorators: [
+    withCreatePageSidebar,
+    StoryRouter({ initialEntries: ['/12345'], path: '/:formId' }),
+  ],
   parameters: {
     msw: {
       handlers: mrfFormViewWithFields,

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
@@ -8,6 +8,7 @@ import {
   BasicField,
   FormFieldDto,
   FormResponseMode,
+  MyInfoAttribute,
   WorkflowType,
 } from 'formsg-shared/types'
 
@@ -150,6 +151,28 @@ const mrfFormViewWithFields = [
   }),
 ]
 
+const myinfo_field: FormFieldDto = {
+  title: 'Name',
+  description: '',
+  required: true,
+  disabled: false,
+  fieldType: BasicField.ShortText,
+  _id: '6200e1534ad4f00012848d93',
+  ValidationOptions: {
+    customVal: null,
+    selectedValidation: null,
+  },
+  allowPrefill: false,
+  myInfo: { attr: MyInfoAttribute.Name },
+}
+
+const mrfFormViewWith = (form_fields: FormFieldDto[]) => [
+  getAdminFormView({
+    mode: FormResponseMode.Multirespondent,
+    overrides: { form_fields },
+  }),
+]
+
 const withCreatePageSidebar = (Story: StoryFn) => (
   <CreatePageSidebarProvider>
     <Story />
@@ -181,6 +204,12 @@ export default {
 const redesignOn = new GrowthBook({
   features: { [featureFlags.workflowBuilderRedesign]: { defaultValue: true } },
 })
+
+const withRedesignOn = (Story: StoryFn) => (
+  <GrowthBookProvider growthbook={redesignOn}>
+    <Story />
+  </GrowthBookProvider>
+)
 
 const GuidedCreation = ({ children }: { children: ReactNode }): JSX.Element => {
   const [isCreating, setIsCreating] = useState(false)
@@ -646,6 +675,77 @@ export const Step4ApprovalFieldNotInEditErrorMessage = {
         component:
           'When submit is clicked, validation error should occur since approval field is not in edit fields',
       },
+    },
+  },
+}
+
+const selectRespondentOption =
+  (label: string) =>
+  async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement)
+    const option = await canvas.findByRole(
+      'radio',
+      { name: new RegExp(label, 'i') },
+      { timeout: 5000 },
+    )
+    await waitFor(() => expect(option).toBeEnabled(), { timeout: 5000 })
+    await userEvent.click(option)
+    await waitFor(() => expect(option).toBeChecked(), { timeout: 5000 })
+  }
+
+export const EmptyStateFieldsPicker = {
+  args: { stepNumber: 0 },
+  decorators: [withRedesignOn],
+  parameters: { msw: { handlers: mrfFormViewWith([]) } },
+}
+
+export const EmptyStateFieldsPickerMyInfoOnly = {
+  args: { stepNumber: 1 },
+  decorators: [withRedesignOn],
+  parameters: { msw: { handlers: mrfFormViewWith([myinfo_field]) } },
+}
+
+export const EmptyStateEmailRouting = {
+  args: { stepNumber: 1 },
+  decorators: [withRedesignOn],
+  parameters: {
+    msw: {
+      handlers: mrfFormViewWith([
+        form_field_1,
+        form_field_5,
+        dropdown_field_valid_mapping,
+      ]),
+    },
+  },
+  play: selectRespondentOption('An email field from the form'),
+}
+
+export const EmptyStateConditionalRouting = {
+  args: { stepNumber: 1 },
+  decorators: [withRedesignOn],
+  parameters: {
+    msw: {
+      handlers: mrfFormViewWith([form_field_1, form_field_3, form_field_5]),
+    },
+  },
+  play: selectRespondentOption(
+    'Emails assigned to options in a dropdown field',
+  ),
+}
+
+export const EmptyStateApprovalField = {
+  args: {
+    stepNumber: 1,
+    defaultValues: { approval_field: 'deleted_objectId' },
+  },
+  decorators: [withRedesignOn],
+  parameters: {
+    msw: {
+      handlers: mrfFormViewWith([
+        form_field_3,
+        form_field_5,
+        dropdown_field_valid_mapping,
+      ]),
     },
   },
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EmptyStates/FieldEmptyState.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EmptyStates/FieldEmptyState.test.tsx
@@ -1,0 +1,67 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { render } from '~/test-utils'
+
+import { FieldEmptyState } from './FieldEmptyState'
+
+const addAction = vi.fn()
+
+beforeEach(() => {
+  addAction.mockClear()
+  // @ts-expect-error partial DD_RUM mock
+  window.DD_RUM = {
+    addAction,
+    onReady: (cb: () => void) => cb(),
+  }
+})
+
+afterEach(() => {
+  window.DD_RUM = undefined
+})
+
+const renderEmptyState = (onAction = () => undefined) =>
+  render(
+    <FieldEmptyState
+      picker="yesno"
+      message="Your form has no Yes/No field yet."
+      actionLabel="Add a Yes/No field"
+      onAction={onAction}
+    />,
+  )
+
+describe('FieldEmptyState', () => {
+  it('shows the message and the action', () => {
+    renderEmptyState()
+
+    expect(
+      screen.getByText('Your form has no Yes/No field yet.'),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Add a Yes/No field' }),
+    ).toBeInTheDocument()
+  })
+
+  it('calls onAction when the button is clicked', async () => {
+    const onAction = vi.fn()
+    renderEmptyState(onAction)
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add a Yes/No field' }),
+    )
+
+    expect(onAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports which picker was empty, once per mount', async () => {
+    renderEmptyState()
+
+    await waitFor(() =>
+      expect(addAction).toHaveBeenCalledWith(
+        'workflow_builder.empty_state.shown',
+        { picker: 'yesno' },
+      ),
+    )
+    expect(addAction).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EmptyStates/FieldEmptyState.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EmptyStates/FieldEmptyState.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react'
+import { BiLinkExternal } from 'react-icons/bi'
+import { Stack, Text } from '@chakra-ui/react'
+
+import { sendDdAction } from '~utils/datadog'
+import Button from '~components/Button'
+import InlineMessage from '~components/InlineMessage'
+
+export type EmptyStatePicker = 'email' | 'dropdown' | 'yesno' | 'fields'
+
+interface FieldEmptyStateProps {
+  /** Which picker is empty. Sent as the instrumentation dimension. */
+  picker: EmptyStatePicker
+  message: string
+  actionLabel: string
+  onAction: () => void
+}
+
+/**
+ * Shown in place of a picker whose options all come from the form's own
+ * fields, when the form has none of the right type. Props only, so the
+ * guided flow can reuse it without inheriting this tree's context.
+ */
+export const FieldEmptyState = ({
+  picker,
+  message,
+  actionLabel,
+  onAction,
+}: FieldEmptyStateProps): JSX.Element => {
+  useEffect(() => {
+    // sendDdAction, not the datadogRum proxy: the proxy binds window.DD_RUM at
+    // module load and silently drops actions when the datadog chunk lands
+    // after the app bundle. This fires on mount, which is when that happens.
+    void sendDdAction(() => {
+      window.DD_RUM?.addAction('workflow_builder.empty_state.shown', {
+        picker,
+      })
+    })
+  }, [picker])
+
+  return (
+    <InlineMessage variant="info">
+      {/* flex=1: claim the row beside the icon so the button spans the box */}
+      <Stack spacing="0.5rem" flex={1}>
+        <Text>{message}</Text>
+        <Button
+          variant="outline"
+          size="sm"
+          leftIcon={<BiLinkExternal />}
+          onClick={onAction}
+        >
+          {actionLabel}
+        </Button>
+      </Stack>
+    </InlineMessage>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EmptyStates/FieldEmptyState.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EmptyStates/FieldEmptyState.tsx
@@ -9,18 +9,12 @@ import InlineMessage from '~components/InlineMessage'
 export type EmptyStatePicker = 'email' | 'dropdown' | 'yesno' | 'fields'
 
 interface FieldEmptyStateProps {
-  /** Which picker is empty. Sent as the instrumentation dimension. */
   picker: EmptyStatePicker
   message: string
   actionLabel: string
   onAction: () => void
 }
 
-/**
- * Shown in place of a picker whose options all come from the form's own
- * fields, when the form has none of the right type. Props only, so the
- * guided flow can reuse it without inheriting this tree's context.
- */
 export const FieldEmptyState = ({
   picker,
   message,
@@ -28,9 +22,6 @@ export const FieldEmptyState = ({
   onAction,
 }: FieldEmptyStateProps): JSX.Element => {
   useEffect(() => {
-    // sendDdAction, not the datadogRum proxy: the proxy binds window.DD_RUM at
-    // module load and silently drops actions when the datadog chunk lands
-    // after the app bundle. This fires on mount, which is when that happens.
     void sendDdAction(() => {
       window.DD_RUM?.addAction('workflow_builder.empty_state.shown', {
         picker,
@@ -40,7 +31,6 @@ export const FieldEmptyState = ({
 
   return (
     <InlineMessage variant="info">
-      {/* flex=1: claim the row beside the icon so the button spans the box */}
       <Stack spacing="0.5rem" flex={1}>
         <Text>{message}</Text>
         <Button

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EmptyStates/index.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EmptyStates/index.ts
@@ -1,0 +1,1 @@
+export * from './FieldEmptyState'

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
@@ -58,14 +58,8 @@ export const QuestionsBlock = ({
       icon: BASICFIELD_TO_DRAWER_META[f.fieldType].icon,
     }))
 
-  // Every fillable field was removed by the MyInfo restriction, so the
-  // generic "no fields yet" message would be false.
   const hasOnlyMyInfoFields = items.length === 0 && fillableFields.length > 0
 
-  // Rendered inside the Controller so `edit` stays registered, matching the
-  // other pickers. isRequired stays on over the empty state: fields are
-  // still needed for a publishable workflow, and "(optional)" would say
-  // otherwise.
   const showEmptyState = isRedesign && items.length === 0
 
   return (
@@ -108,7 +102,6 @@ export const QuestionsBlock = ({
                   actionLabel={t(
                     'features.adminForm.sidebar.workflow.emptyStates.noFieldsAction',
                   )}
-                  // No field type staged: the admin chooses what to build.
                   onAction={() => stageFieldAndNavigate()}
                 />
               )

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/QuestionsBlock.tsx
@@ -14,9 +14,11 @@ import { NON_RESPONSE_FIELD_SET } from '~features/form/constants'
 
 import { useAdminFormWorkflow } from '../../../hooks/useAdminFormWorkflow'
 import { useIsWorkflowBuilderRedesign } from '../../../hooks/useIsWorkflowBuilderRedesign'
+import { useStageFieldAndNavigate } from '../../../hooks/useStageFieldAndNavigate'
 
 import { APPROVAL_FIELD_NAME, FIELDS_TO_EDIT_NAME } from './EditStepBlock'
 import { EditStepBlockContainer } from './EditStepBlockContainer'
+import { FieldEmptyState } from './EmptyStates'
 
 interface QuestionsBlockProps {
   isLoading: boolean
@@ -31,6 +33,7 @@ export const QuestionsBlock = ({
 }: QuestionsBlockProps): JSX.Element => {
   const { t } = useTranslation()
   const isRedesign = useIsWorkflowBuilderRedesign()
+  const stageFieldAndNavigate = useStageFieldAndNavigate()
   const { formFields = [], idToFieldMap } = useAdminFormWorkflow()
   const {
     formState: { errors },
@@ -40,26 +43,30 @@ export const QuestionsBlock = ({
   } = formMethods
   const selectedApprovalField = watch(APPROVAL_FIELD_NAME)
 
-  const items = formFields
-    .filter((f) => {
-      // Only retain actual inputs (exclude header, statement, image)
-      const isFillableField = !NON_RESPONSE_FIELD_SET.has(f.fieldType)
-      const isMyInfoField = 'myInfo' in f
-      if (!isFillableField) {
-        return false
-      }
-      // TODO(MRF-MYINFO): Remove this restriction once MyInfo fields are
-      // supported in workflow steps >= 2.
-      if (isMyInfoField && !isFirstStep) {
-        return false
-      }
-      return true
-    })
+  // Only retain actual inputs (exclude header, statement, image)
+  const fillableFields = formFields.filter(
+    (f) => !NON_RESPONSE_FIELD_SET.has(f.fieldType),
+  )
+
+  const items = fillableFields
+    // TODO(MRF-MYINFO): Remove this restriction once MyInfo fields are
+    // supported in workflow steps >= 2.
+    .filter((f) => !('myInfo' in f) || isFirstStep)
     .map((f) => ({
       value: f._id,
       label: getLogicFieldLabel(idToFieldMap[f._id]),
       icon: BASICFIELD_TO_DRAWER_META[f.fieldType].icon,
     }))
+
+  // Every fillable field was removed by the MyInfo restriction, so the
+  // generic "no fields yet" message would be false.
+  const hasOnlyMyInfoFields = items.length === 0 && fillableFields.length > 0
+
+  // Rendered inside the Controller so `edit` stays registered, matching the
+  // other pickers. isRequired stays on over the empty state: fields are
+  // still needed for a publishable workflow, and "(optional)" would say
+  // otherwise.
+  const showEmptyState = isRedesign && items.length === 0
 
   return (
     <EditStepBlockContainer>
@@ -89,6 +96,23 @@ export const QuestionsBlock = ({
           control={control}
           name={FIELDS_TO_EDIT_NAME}
           render={({ field: { value = [], onChange, ...field } }) => {
+            if (showEmptyState) {
+              return (
+                <FieldEmptyState
+                  picker="fields"
+                  message={t(
+                    hasOnlyMyInfoFields
+                      ? 'features.adminForm.sidebar.workflow.emptyStates.noFieldsMyInfoOnly'
+                      : 'features.adminForm.sidebar.workflow.emptyStates.noFields',
+                  )}
+                  actionLabel={t(
+                    'features.adminForm.sidebar.workflow.emptyStates.noFieldsAction',
+                  )}
+                  // No field type staged: the admin chooses what to build.
+                  onAction={() => stageFieldAndNavigate()}
+                />
+              )
+            }
             // Re-validate approval_field as soon as `edit` changes, so removing
             // the auto-added chip errors inline rather than at save.
             const handleFieldsChange = (newValue: string[]) => {

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/ConditionalRoutingOption.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/ConditionalRoutingOption.tsx
@@ -14,6 +14,7 @@ import Papa from 'papaparse'
 import isEmail from 'validator/lib/isEmail'
 
 import {
+  BasicField,
   DropdownFieldBase,
   FormFieldDto,
   WorkflowType,
@@ -32,6 +33,8 @@ import { BASICFIELD_TO_DRAWER_META } from '~features/admin-form/create/constants
 import { FormFieldWithQuestionNo } from '~features/form/types'
 
 import { useIsWorkflowBuilderRedesign } from '../../../../../hooks/useIsWorkflowBuilderRedesign'
+import { useStageFieldAndNavigate } from '../../../../../hooks/useStageFieldAndNavigate'
+import { FieldEmptyState } from '../../EmptyStates'
 
 import { ConditionalRoutingMappingDeleteModal } from './ConditionalRoutingMappingDeleteModal'
 import { ConditionalRoutingOptionModal } from './ConditionalRoutingOptionModal'
@@ -357,6 +360,13 @@ export const ConditionalRoutingOption = ({
 
   const workflowTypeValidation = useWorkflowTypeValidation()
   const isRedesign = useIsWorkflowBuilderRedesign()
+  const stageFieldAndNavigate = useStageFieldAndNavigate()
+
+  // The CSV block below is already gated on a selected dropdown field, so it
+  // stays hidden here without extra handling. The empty state swaps what the
+  // Controller renders, never the Controller itself: unmounting would
+  // unregister the `required` rule and Save would fail silently.
+  const showEmptyState = isRedesign && !conditionalFieldItems.length
 
   const handleOpenModal = () => {
     conditionalRoutingConfigSetValue('csvFile', null)
@@ -445,18 +455,33 @@ export const ConditionalRoutingOption = ({
                     )
                   },
                 }}
-                render={({ field: { value = '', ...rest } }) => (
-                  <SingleSelect
-                    isDisabled={isLoading}
-                    isClearable={false}
-                    placeholder={t(
-                      'features.adminForm.sidebar.workflow.dynamicRespondent.select',
-                    )}
-                    items={conditionalFieldItems}
-                    value={value}
-                    {...rest}
-                  />
-                )}
+                render={({ field: { value = '', ...rest } }) =>
+                  showEmptyState ? (
+                    <FieldEmptyState
+                      picker="dropdown"
+                      message={t(
+                        'features.adminForm.sidebar.workflow.emptyStates.noDropdownField',
+                      )}
+                      actionLabel={t(
+                        'features.adminForm.sidebar.workflow.emptyStates.noDropdownFieldAction',
+                      )}
+                      onAction={() =>
+                        stageFieldAndNavigate(BasicField.Dropdown)
+                      }
+                    />
+                  ) : (
+                    <SingleSelect
+                      isDisabled={isLoading}
+                      isClearable={false}
+                      placeholder={t(
+                        'features.adminForm.sidebar.workflow.dynamicRespondent.select',
+                      )}
+                      items={conditionalFieldItems}
+                      value={value}
+                      {...rest}
+                    />
+                  )
+                }
               />
               {isSelectedConditionalFieldFound ? (
                 isOptionsToRecipientsMapAttached ? (

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/ConditionalRoutingOption.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/ConditionalRoutingOption.tsx
@@ -362,10 +362,6 @@ export const ConditionalRoutingOption = ({
   const isRedesign = useIsWorkflowBuilderRedesign()
   const stageFieldAndNavigate = useStageFieldAndNavigate()
 
-  // The CSV block below is already gated on a selected dropdown field, so it
-  // stays hidden here without extra handling. The empty state swaps what the
-  // Controller renders, never the Controller itself: unmounting would
-  // unregister the `required` rule and Save would fail silently.
   const showEmptyState = isRedesign && !conditionalFieldItems.length
 
   const handleOpenModal = () => {

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/DynamicRespondentOption.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/DynamicRespondentOption.tsx
@@ -36,10 +36,6 @@ export const DynamicRespondentOption = ({
   const isRedesign = useIsWorkflowBuilderRedesign()
   const stageFieldAndNavigate = useStageFieldAndNavigate()
 
-  // The radio stays selectable: disabling it would hide the reason.
-  // The empty state swaps what the Controller renders, never the Controller
-  // itself. Unmounting would unregister the `required` rule, and Save would
-  // pass validation, fail to build a step, and return silently.
   const showEmptyState = isRedesign && !emailFieldItems?.length
 
   return (

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/DynamicRespondentOption.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/RespondentBlock/Components/DynamicRespondentOption.tsx
@@ -2,13 +2,15 @@ import { Controller } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { FormControl, Text } from '@chakra-ui/react'
 
-import { WorkflowType } from 'formsg-shared/types'
+import { BasicField, WorkflowType } from 'formsg-shared/types'
 
 import { SingleSelect } from '~components/Dropdown'
 import FormErrorMessage from '~components/FormControl/FormErrorMessage'
 import Radio from '~components/Radio'
 
 import { useIsWorkflowBuilderRedesign } from '../../../../../hooks/useIsWorkflowBuilderRedesign'
+import { useStageFieldAndNavigate } from '../../../../../hooks/useStageFieldAndNavigate'
+import { FieldEmptyState } from '../../EmptyStates'
 
 import { useWorkflowTypeValidation } from './hooks'
 import { FieldItem, RespondentOptionProps } from './types'
@@ -32,6 +34,14 @@ export const DynamicRespondentOption = ({
 
   const workflowTypeValidation = useWorkflowTypeValidation()
   const isRedesign = useIsWorkflowBuilderRedesign()
+  const stageFieldAndNavigate = useStageFieldAndNavigate()
+
+  // The radio stays selectable: disabling it would hide the reason.
+  // The empty state swaps what the Controller renders, never the Controller
+  // itself. Unmounting would unregister the `required` rule, and Save would
+  // pass validation, fail to build a step, and return silently.
+  const showEmptyState = isRedesign && !emailFieldItems?.length
+
   return (
     <>
       <Radio
@@ -80,18 +90,31 @@ export const DynamicRespondentOption = ({
                   )
                 },
               }}
-              render={({ field: { value = '', ...rest } }) => (
-                <SingleSelect
-                  isDisabled={isLoading}
-                  isClearable={false}
-                  placeholder={t(
-                    'features.adminForm.sidebar.workflow.dynamicRespondent.select',
-                  )}
-                  items={emailFieldItems}
-                  value={value}
-                  {...rest}
-                />
-              )}
+              render={({ field: { value = '', ...rest } }) =>
+                showEmptyState ? (
+                  <FieldEmptyState
+                    picker="email"
+                    message={t(
+                      'features.adminForm.sidebar.workflow.emptyStates.noEmailField',
+                    )}
+                    actionLabel={t(
+                      'features.adminForm.sidebar.workflow.emptyStates.noEmailFieldAction',
+                    )}
+                    onAction={() => stageFieldAndNavigate(BasicField.Email)}
+                  />
+                ) : (
+                  <SingleSelect
+                    isDisabled={isLoading}
+                    isClearable={false}
+                    placeholder={t(
+                      'features.adminForm.sidebar.workflow.dynamicRespondent.select',
+                    )}
+                    items={emailFieldItems}
+                    value={value}
+                    {...rest}
+                  />
+                )
+              }
             />
             <FormErrorMessage>{errors.field?.message}</FormErrorMessage>
           </FormControl>

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -138,6 +138,20 @@ export const enSG: Workflow = {
     autoAddHelperTextRedesign:
       'The approval field is added here automatically.',
   },
+  emptyStates: {
+    noEmailField: 'Your form has no email field yet.',
+    noEmailFieldAction: 'Add an email field',
+    noDropdownField: 'Your form has no dropdown field yet.',
+    noDropdownFieldAction: 'Add a dropdown field',
+    noYesNoField: 'Your form has no Yes/No field yet.',
+    noYesNoFieldAction: 'Add a Yes/No field',
+    noFields: 'Your form has no fields yet.',
+    // TODO(MRF-MYINFO): Delete once MyInfo fields are supported in workflow
+    // steps >= 2; the restriction this explains will no longer exist.
+    noFieldsMyInfoOnly:
+      'Your form only has MyInfo fields, which can only be used in the first step.',
+    noFieldsAction: 'Add fields',
+  },
   approvals: {
     title: 'Approvals',
     yesNoDeleted:

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -146,8 +146,6 @@ export const enSG: Workflow = {
     noYesNoField: 'Your form has no Yes/No field yet.',
     noYesNoFieldAction: 'Add a Yes/No field',
     noFields: 'Your form has no fields yet.',
-    // TODO(MRF-MYINFO): Delete once MyInfo fields are supported in workflow
-    // steps >= 2; the restriction this explains will no longer exist.
     noFieldsMyInfoOnly:
       'Your form only has MyInfo fields, which can only be used in the first step.',
     noFieldsAction: 'Add fields',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -123,6 +123,17 @@ export interface Workflow {
     placeholderRedesign: string
     autoAddHelperTextRedesign: string
   }
+  emptyStates: {
+    noEmailField: string
+    noEmailFieldAction: string
+    noDropdownField: string
+    noDropdownFieldAction: string
+    noYesNoField: string
+    noYesNoFieldAction: string
+    noFields: string
+    noFieldsMyInfoOnly: string
+    noFieldsAction: string
+  }
   approvals: {
     title: string
     yesNoDeleted: string


### PR DESCRIPTION
## Problem

Workflow steps do not have empty states when the form is missing fields, resulting in dead-ends for user flows.

Part of FRM-2492.

## Solution

When a picker has nothing to offer, it becomes a short message saying which field type is missing, plus a button that opens the field builder with that field ready to confirm.

One thing worth a reviewer's eye: the empty state swaps what each Controller renders, never the Controller itself. Unmount it and react-hook-form forgets the required rule, so Save would pass validation, build nothing, and fail silently.

Staging comes from the base PR (#9959). This PR sits on that branch and touches nothing outside the workflow feature.

> [!IMPORTANT]
> **Everything is behind `useIsWorkflowBuilderRedesign()`**, and the gate lives in each host file rather than inside the shared component, so with the flag off every picker renders exactly as it does on `develop` today, asterisk included.

### Instrumentation

One event, `workflow_builder.empty_state.shown`, with the picker as a context dimension. It goes through `sendDdAction` rather than the `datadogRum` proxy: the proxy binds `window.DD_RUM` at module load and silently drops actions when the Datadog chunk loads after the app bundle, which is exactly the case for something that fires on mount. `ActiveStepBlock` uses the proxy and can drop events; this deliberately does not copy it.

**Alternatives considered**

- **Preserving the half-built step across the trip to the field builder.** Designed in full, then dropped. Leaving the workflow tab unmounts it and discards the open card, so the obvious move was to stash the in-progress values and restore them. That needs a persisted store, a restore path, dirty-state handling and filtering for fields deleted while away. 
- **Creating the field inline without leaving the tab.** Possible via `createSingleFormField`, but `useCreateFormField` bails unless the builder's create panel is open, so it means a second mutation and cache path. 
- **Suppressing the specific empty state on a form with no fields at all.** On such a form the admin sees two messages at once, the routing one and the fields one, both true and both leading to the same place. Suppressing the specific one was considered and rejected.
- **Four separate Datadog event names.** Matches the sibling `ActiveStepBlock`, which hard-codes its dimension into the name. Rejected in favour of one name with a context object, following `sendDdFormCreationSelectionAction`, so a fifth empty state later needs no new dashboard series.
- **Writing our own auto-assign for the approval field.** The approval field must also appear in the step's `edit` list, enforced on all three backend save paths, so the Yes/No empty state would otherwise send an admin to create a field and then reject it at save. #9850 already solves this with a tested pure helper. Rather than write a second one, that empty state waited for #9850. 

## Known gaps (not addressed here)

- **Picker, copy keys and field type are kept in sync by hand.** Each call site repeats a picker name, two i18n keys named after it, and a `BasicField`, all derivable from the first. 
- **No per-host render tests.** The workflow feature has one test file and it is pure-utils; there is no component-test harness here and `useIsWorkflowBuilderRedesign` is not mocked anywhere in the repo. A render test for any of these blocks needs GrowthBook, react-query, the sidebar context and the field builder store all mocked, for a branch that is `isRedesign && !items.length`. 
## Screenshots

All captured on a multi-respondent form with no fields at all, so every empty state is reachable in one place. Before is the same form with the flag off.

### Step 1, fields picker

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/before-step1-fields-picker.png" width="420"> | <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/after-step1-fields-picker.png" width="420"> |

### Step 2, routing by an email field

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/before-step2-email-routing.png" width="420"> | <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/after-step2-email-routing.png" width="420"> |

### Step 2, routing by dropdown options

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/before-step2-dropdown-routing.png" width="420"> | <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/after-step2-dropdown-routing.png" width="420"> |

### Step 2, MyInfo-only form

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/before-step2-myinfo-only.png" width="420"> | <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/after-step2-myinfo-only.png" width="420"> |

### Step 2, Yes/No approval field

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/before-yesno-approval.png" width="420"> | <img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/after-yesno-approval.png" width="420"> |

### Where the button lands

<img src="https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2492-empty-states/after-email-field-staged.png" width="840">

## Breaking Changes

No, backwards compatible. No schema change, no migration, no backend change. Frontend only, behind a flag, and a revert is a straight revert.

## Tests

Ticked cases were run in a browser against a local MRF form with no fields, flag forced both ways through GrowthBook. Unticked ones are still to do: the two that need a field added or deleted mid-flow, the Save error path, the MyInfo case, and the new Yes/No case.

**TC1: no fields at all (flag ON)**

- [ ] On a form with no fields, open the workflow tab and open step 1
- [ ] The fields picker is replaced by "Your form has no fields yet." and an "Add fields" button
- [ ] The fields picker label does NOT read `(optional)` in this state (kept required: fields are still needed to publish)
- [ ] Click "Add fields" — the Build tab opens with no field type pre-selected
- [ ] Add a field, return to the workflow tab, reopen the step — the normal fields picker is back, asterisk included

**TC2: no email field (flag ON)**

- [ ] On a form with no email field, add step 2 and select the "email field from the form" option
- [ ] The radio is selectable, not disabled
- [ ] The dropdown is replaced by "Your form has no email field yet." and an "Add an email field" button
- [ ] Click it — the Build tab opens with a new Email field already staged for confirmation
- [ ] Cancel in the Build tab instead of confirming, return to the workflow tab — nothing crashes and the form is unchanged

**TC3: no dropdown field (flag ON)**

- [ ] On a form with no dropdown field, add step 2 and select the "emails assigned to dropdown options" option
- [ ] The dropdown is replaced by "Your form has no dropdown field yet." and an "Add a dropdown field" button
- [ ] The CSV upload controls do not appear at all in this state
- [ ] Click the button — the Build tab opens with a new Dropdown field staged

**TC4: both messages at once (intended, not a bug)**

- [ ] On a form with no fields at all, add step 2 and select the "email field from the form" option
- [ ] Two messages show together: the email one in the respondent section, the fields one below
- [ ] Switch to the dropdown routing option — the respondent message changes, the fields message stays

**TC5: Save still explains itself when a field is missing**

- [ ] On a form with no email field, add step 2, select the "email field from the form" option, click Save
- [ ] "Please select a field" appears. Save does not silently do nothing
- [ ] The "Add an email field" button is still there alongside the error
- [ ] Repeat with the dropdown routing option on a form with no dropdown field
- [ ] On a form with no fields at all, saving step 1 is unaffected by this: the fields picker never blocked saving

**TC6: flag OFF is unchanged**

- [ ] With the flag off, on a form with no fields: every picker renders as an enabled, empty dropdown
- [ ] With the flag off: the labels read exactly as on `develop`, with no `(optional)` tag
- [ ] No empty-state message or button appears anywhere

**TC7: MyInfo edge case**

- [ ] On a form whose only fields are MyInfo fields, open step 1 — the normal fields picker shows
- [ ] Open step 2 on the same form — the empty state shows with the MyInfo-specific message ("Your form only has MyInfo fields, which can only be used in the first step."), not the generic "no fields yet" one. CTA is still "Add fields"

**TC8: no Yes/No field (flag ON)**

- [ ] On a form with no Yes/No field, turn on the approval toggle in a step
- [ ] The Yes/No picker is replaced by "Your form has no Yes/No field yet." and an "Add a Yes/No field" button
- [ ] Click it — the Build tab opens with a new Yes/No field staged for confirmation
- [ ] Confirm the field, return, select it — it lands in the step's fields list automatically (via #9850's auto-assign)
- [ ] With the toggle on and no field selected, Save shows "Please select a field", with the button still alongside
- [ ] Delete the form's only Yes/No field while a step has it selected, reopen the step — the empty state shows and the stale selection is cleared


