### PR TITLE
fix: add factory mocks to prevent unlimited retries against localhost

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -40,8 +40,18 @@ import * as stepToken from '../step-token'
 jest.mock('../../../feature-flags/feature-flags.service')
 jest.mock('../../../form/form.service')
 jest.mock('../multirespondent-submission.service')
-jest.mock('../../../spcp/spcp.oidc.service')
-jest.mock('../../../myinfo/myinfo.service')
+// RATIONALE: The factory mocks are required to prevent Jest from
+// hanging when automock is enabled, due to retries against localhost.
+jest.mock('../../../spcp/spcp.oidc.service', () => ({
+  __esModule: true,
+  getOidcService: jest.fn(),
+}))
+jest.mock('../../../myinfo/myinfo.service', () => ({
+  __esModule: true,
+  MyInfoService: {
+    verifyLoginJwt: jest.fn(),
+  },
+}))
 jest.mock('../../../verified-content/verified-content.service')
 jest.mock('src/app/modules/myinfo/myinfo.util')
 jest.mock('src/app/modules/spcp/spcp.util')


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Jest test cases for `src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts` do not terminate even after successful runs due to failed factory retries. 

This causes unecessary hanging whenever `npm run test` is invoked, slowing down our test suite. 

Running the command `pnpm --filter formsg-backend test src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts`. 

Before: 
<img width="1101" height="504" alt="image" src="https://github.com/user-attachments/assets/03bac656-75d9-4f54-bfce-c4c405aaec1c" />
After: 
<img width="1101" height="668" alt="image" src="https://github.com/user-attachments/assets/35c0ac3b-a1a6-425c-b1dc-aa30e1be00ec" />

## Solution
<!-- How did you solve the problem? -->
Mock the factory method, to prevent the actual method from retrying against localhost which is not set up. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  