### PR TITLE
fix: inject gb attributes earlier the controller chain

### DIFF
--- a/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/__tests__/multirespondent-submission.middleware.spec.ts
@@ -99,6 +99,13 @@ describe('Multirespondent Submission Middleware', () => {
         respondentEmails: ['test@example.com'],
       },
       formsg: undefined,
+      growthbook: {
+        isOn: jest.fn().mockReturnValue(false),
+        setAttributes: jest.fn().mockResolvedValue(undefined),
+        getAttributes: jest.fn().mockReturnValue({
+          unclobberedAttributeKey: 'unclobberedValue',
+        }),
+      },
       // Add Express request methods and properties
       get: jest.fn((name: string) => {
         if (name === 'cf-connecting-ip') return '127.0.0.1'
@@ -163,6 +170,7 @@ describe('Multirespondent Submission Middleware', () => {
       // Add other required properties to satisfy IPopulatedForm interface
       admin: {
         _id: new ObjectId(),
+        email: 'admin@example.com',
         agency: {
           fullName: 'Government Technology Agency',
         },
@@ -276,6 +284,11 @@ describe('Multirespondent Submission Middleware', () => {
       expect(getMultirespondentSubmission).toHaveBeenCalledWith(
         MOCK_SUBMISSION_ID,
       )
+      expect(mockReq.growthbook?.setAttributes).toHaveBeenCalledWith({
+        ...mockReq.growthbook?.getAttributes(),
+        formId: MOCK_FORM_ID,
+        adminEmail: MOCK_FORM.admin.email,
+      })
     })
 
     it('should return error response when submissionId exists but mrfSubmission is not found', async () => {
@@ -972,12 +985,6 @@ describe('Multirespondent Submission Middleware', () => {
       expect(jest.mocked(adaptV4ToV3)).not.toHaveBeenCalled()
       expect(mockReq.formsg.encryptedPayload.mrfVersion).toBe(2)
       expect(mockNext).toHaveBeenCalled()
-      expect(mockReq.growthbook.setAttributes).toHaveBeenCalledWith(
-        expect.objectContaining({
-          formId: MOCK_FORM_ID,
-          adminEmail: 'admin@example.com',
-        }),
-      )
     })
 
     it('should return 500 and not call next() when decryptFromSubmissionKey returns falsy', async () => {

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -265,6 +265,13 @@ export const createFormsgAndRetrieveForm = (
               // Step 6: Set req.formsg
               req.formsg = formsg
 
+              // Step 7: Inject growthbook attributes to selectively whitelist.
+              void req.growthbook?.setAttributes({
+                ...req.growthbook.getAttributes(),
+                formId,
+                adminEmail: formsg.formDef.admin.email,
+              })
+
               return next()
             })
         })
@@ -786,12 +793,6 @@ export const encryptSubmission = async (
   res: Parameters<ProcessedMultirespondentSubmissionHandlerType>[1],
   next: NextFunction,
 ) => {
-  void req.growthbook?.setAttributes({
-    ...req.growthbook.getAttributes(),
-    formId: req.params.formId,
-    adminEmail: req.formsg.formDef.admin.email,
-  })
-
   const formDef = req.formsg.formDef
   const formPublicKey = formDef.publicKey
   const responses = req.body.responses

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -266,8 +266,9 @@ export const createFormsgAndRetrieveForm = (
               req.formsg = formsg
 
               // Step 7: Inject growthbook attributes to selectively whitelist.
+              const existingAttributes = req.growthbook?.getAttributes() ?? {}
               void req.growthbook?.setAttributes({
-                ...req.growthbook.getAttributes(),
+                ...existingAttributes,
                 formId,
                 adminEmail: formsg.formDef.admin.email,
               })

--- a/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
+++ b/apps/backend/src/app/modules/submission/multirespondent-submission/multirespondent-submission.middleware.ts
@@ -251,7 +251,7 @@ export const createFormsgAndRetrieveForm = (
                 )
               }
             })
-            .map(() => {
+            .map(async () => {
               const formDef = formsg.formDef
               // Step 5: Check that the form def has a public key
               if (!formDef.publicKey) {
@@ -267,7 +267,7 @@ export const createFormsgAndRetrieveForm = (
 
               // Step 7: Inject growthbook attributes to selectively whitelist.
               const existingAttributes = req.growthbook?.getAttributes() ?? {}
-              void req.growthbook?.setAttributes({
+              await req.growthbook?.setAttributes({
                 ...existingAttributes,
                 formId,
                 adminEmail: formsg.formDef.admin.email,


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->

Growthbook attributes are injected at the too late (after the growthbook feature is evaluated, causing whitelisting by the growthbook attribute to fail). It should be injected before the feature is evaluated/read. 

## Solution
<!-- How did you solve the problem? -->
<img width="1215" height="369" alt="image" src="https://github.com/user-attachments/assets/bb01121e-932d-4dd0-96bc-e29b1bcf3b75" />
Move earlier to before the growthbook evaluation occurs. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  