### PR TITLE
fix(admin-form): review fixes for per-step MRF preview (FRM-2493)

### DIFF
--- a/apps/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/apps/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -144,8 +144,9 @@ export const PreviewFormBanner = ({
                     isClearable={false}
                     value={String(previewWorkflowStepNumber ?? 0)}
                     onChange={(val) => {
-                      setSearchParams((prev) =>
-                        withPreviewStepParam(prev, Number(val)),
+                      setSearchParams(
+                        (prev) => withPreviewStepParam(prev, Number(val)),
+                        { replace: true },
                       )
                     }}
                     items={previewWorkflowSteps.map((step, idx) => ({

--- a/apps/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
+++ b/apps/frontend/src/features/admin-form/common/components/PreviewFormBanner/PreviewFormBanner.tsx
@@ -31,7 +31,7 @@ import FormLabel from '~components/FormControl/FormLabel'
 import Link from '~components/Link'
 
 import { getPreviewStepLabel } from '~features/admin-form/preview/utils/getPreviewStepLabel'
-import { PREVIEW_STEP_PARAM } from '~features/admin-form/preview/utils/previewStepParam'
+import { withPreviewStepParam } from '~features/admin-form/preview/utils/previewStepParam'
 import { UseTemplateModal } from '~features/admin-form/template/UseTemplateModal'
 // Explicit deep import to avoid circular dependency warnings by rollup.
 import {
@@ -144,16 +144,9 @@ export const PreviewFormBanner = ({
                     isClearable={false}
                     value={String(previewWorkflowStepNumber ?? 0)}
                     onChange={(val) => {
-                      const newStep = Number(val)
-                      setSearchParams((prev) => {
-                        const next = new URLSearchParams(prev)
-                        if (newStep === 0) {
-                          next.delete(PREVIEW_STEP_PARAM)
-                        } else {
-                          next.set(PREVIEW_STEP_PARAM, String(newStep))
-                        }
-                        return next
-                      })
+                      setSearchParams((prev) =>
+                        withPreviewStepParam(prev, Number(val)),
+                      )
                     }}
                     items={previewWorkflowSteps.map((step, idx) => ({
                       value: String(idx),

--- a/apps/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/apps/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -36,7 +36,10 @@ import { usePreviewFormMutations } from '../common/mutations'
 import { carryOverPreviousStepValues } from './utils/carryOverPreviousStepValues'
 import { clampWorkflowStep } from './utils/clampWorkflowStep'
 import { getPreviewStepLabel } from './utils/getPreviewStepLabel'
-import { PREVIEW_STEP_PARAM } from './utils/previewStepParam'
+import {
+  PREVIEW_STEP_PARAM,
+  withPreviewStepParam,
+} from './utils/previewStepParam'
 
 interface PreviewFormProviderProps {
   formId: string
@@ -339,7 +342,7 @@ export const PreviewFormProvider = ({
     })
   }
 
-  const [searchParams] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
 
   const form = data?.form
   const formFields = form?.form_fields
@@ -361,6 +364,18 @@ export const PreviewFormProvider = ({
     formWorkflow && formWorkflow.length > currentWorkflowStepNumber
       ? formWorkflow[currentWorkflowStepNumber]
       : undefined
+
+  useEffect(() => {
+    if (!formWorkflow) return
+    const rawStepParam = searchParams.get(PREVIEW_STEP_PARAM)
+    const canonicalStepParam =
+      currentWorkflowStepNumber === 0 ? null : String(currentWorkflowStepNumber)
+    if (rawStepParam === canonicalStepParam) return
+    setSearchParams(
+      (prev) => withPreviewStepParam(prev, currentWorkflowStepNumber),
+      { replace: true },
+    )
+  }, [formWorkflow, searchParams, currentWorkflowStepNumber, setSearchParams])
 
   const fieldPrefillMap = useMemo(
     () => (formFields ? getFieldPrefillMap(formFields, searchParams) : {}),

--- a/apps/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/apps/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -403,6 +403,8 @@ export const PreviewFormProvider = ({
   const hasSeenInitialStepRef = useRef(false)
   const stepToastIdRef = useRef<string | number>()
 
+  const hasLoadedWorkflow = !!formWorkflow
+
   useEffect(() => {
     formMethods.reset(
       carryOverPreviousStepValues({
@@ -415,6 +417,7 @@ export const PreviewFormProvider = ({
       { keepDirty: true },
     )
 
+    if (!hasLoadedWorkflow) return
     if (!hasSeenInitialStepRef.current) {
       hasSeenInitialStepRef.current = true
       return
@@ -432,7 +435,7 @@ export const PreviewFormProvider = ({
       )}.`,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentWorkflowStepNumber])
+  }, [currentWorkflowStepNumber, hasLoadedWorkflow])
 
   if (isNotFormId) {
     return <NotFoundErrorPage />

--- a/apps/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
+++ b/apps/frontend/src/features/admin-form/preview/PreviewFormProvider.tsx
@@ -403,13 +403,6 @@ export const PreviewFormProvider = ({
   const hasSeenInitialStepRef = useRef(false)
   const stepToastIdRef = useRef<string | number>()
 
-  // On a step switch, carry the answers already entered into the fields the
-  // preceding steps fill in. They stand in for those respondents' submitted
-  // answers, which a real respondent at this step would see filled in. Every
-  // other field falls back to its default.
-  //
-  // The switch also raises a toast naming the step. The first run is skipped so
-  // that arriving on the preview does not announce a step the admin never chose.
   useEffect(() => {
     formMethods.reset(
       carryOverPreviousStepValues({
@@ -419,6 +412,7 @@ export const PreviewFormProvider = ({
         enteredValues: formMethods.getValues(),
         defaultFormValues,
       }),
+      { keepDirty: true },
     )
 
     if (!hasSeenInitialStepRef.current) {
@@ -427,7 +421,6 @@ export const PreviewFormProvider = ({
     }
     if (!currentStepNumberWorkflowStep) return
 
-    // Replace rather than stack, so flicking through steps leaves one toast.
     if (stepToastIdRef.current) {
       toast.close(stepToastIdRef.current)
     }

--- a/apps/frontend/src/features/admin-form/preview/utils/previewStepParam.test.ts
+++ b/apps/frontend/src/features/admin-form/preview/utils/previewStepParam.test.ts
@@ -1,0 +1,33 @@
+import { withPreviewStepParam } from './previewStepParam'
+
+describe('withPreviewStepParam', () => {
+  it('sets the step param for a non-zero step', () => {
+    expect(withPreviewStepParam(new URLSearchParams(), 2).toString()).toBe(
+      'step=2',
+    )
+  })
+
+  it('removes the step param for step 0', () => {
+    expect(
+      withPreviewStepParam(new URLSearchParams('step=3'), 0).toString(),
+    ).toBe('')
+  })
+
+  it('overwrites an existing step param', () => {
+    expect(
+      withPreviewStepParam(new URLSearchParams('step=999'), 2).toString(),
+    ).toBe('step=2')
+  })
+
+  it('preserves unrelated params', () => {
+    expect(
+      withPreviewStepParam(new URLSearchParams('foo=bar&step=1'), 0).toString(),
+    ).toBe('foo=bar')
+  })
+
+  it('does not mutate the input params', () => {
+    const prev = new URLSearchParams('step=1')
+    withPreviewStepParam(prev, 2)
+    expect(prev.toString()).toBe('step=1')
+  })
+})

--- a/apps/frontend/src/features/admin-form/preview/utils/previewStepParam.ts
+++ b/apps/frontend/src/features/admin-form/preview/utils/previewStepParam.ts
@@ -1,2 +1,19 @@
 /** URL query-param key used to persist the current MRF workflow step in preview mode. */
 export const PREVIEW_STEP_PARAM = 'step'
+
+/**
+ * Returns a copy of `prev` with the step param set to `step`, or removed when
+ * `step` is `0` so the first step has a single canonical URL (no param).
+ */
+export const withPreviewStepParam = (
+  prev: URLSearchParams,
+  step: number,
+): URLSearchParams => {
+  const next = new URLSearchParams(prev)
+  if (step === 0) {
+    next.delete(PREVIEW_STEP_PARAM)
+  } else {
+    next.set(PREVIEW_STEP_PARAM, String(step))
+  }
+  return next
+}

--- a/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.test.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.test.tsx
@@ -17,6 +17,12 @@ vi.mock('~features/public-form/PublicFormContext', () => ({
   }),
 }))
 
+// Stub out the real field component so assertions can inspect exactly what
+// FieldFactory forwards to it, without needing a react-hook-form tree.
+// The stub is a `vi.fn` (rather than a plain arrow function) so tests can
+// assert on render *call count* directly — DOM node identity alone doesn't
+// prove whether React re-invoked the component, since React can re-render
+// without replacing the underlying DOM node.
 vi.mock('~templates/Field', async (importOriginal) => {
   const actual = await importOriginal<typeof import('~templates/Field')>()
   return {
@@ -75,32 +81,14 @@ describe('FieldFactory', () => {
       />,
     )
 
+    // Asserting call count (rather than only the rendered output) proves
+    // the memoized component was actually re-invoked, not just that its
+    // DOM node happens to have new attributes.
     expect(mockShortTextField).toHaveBeenCalledTimes(2)
     const el = screen.getByTestId('mock-short-text-field')
     expect(el).toHaveAttribute('data-disabled', 'true')
     expect(el).toHaveAttribute('data-high-contrast', 'true')
     expect(el).toHaveAttribute('data-disable-required-validation', 'true')
-  })
-
-  it('re-renders when any other schema property changes, e.g. title', () => {
-    const { rerender } = render(
-      <FieldFactory
-        field={baseField}
-        isHighContrast={false}
-        disableRequiredValidation={false}
-      />,
-    )
-    expect(mockShortTextField).toHaveBeenCalledTimes(1)
-
-    rerender(
-      <FieldFactory
-        field={{ ...baseField, title: 'Renamed field' }}
-        isHighContrast={false}
-        disableRequiredValidation={false}
-      />,
-    )
-
-    expect(mockShortTextField).toHaveBeenCalledTimes(2)
   })
 
   it('does not re-render when field, isHighContrast, and disableRequiredValidation are unchanged', () => {
@@ -121,6 +109,8 @@ describe('FieldFactory', () => {
       />,
     )
 
+    // Call count staying at 1 proves React bailed out of re-rendering the
+    // memoized component entirely, which DOM node identity alone cannot show.
     expect(mockShortTextField).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.test.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.test.tsx
@@ -17,12 +17,6 @@ vi.mock('~features/public-form/PublicFormContext', () => ({
   }),
 }))
 
-// Stub out the real field component so assertions can inspect exactly what
-// FieldFactory forwards to it, without needing a react-hook-form tree.
-// The stub is a `vi.fn` (rather than a plain arrow function) so tests can
-// assert on render *call count* directly — DOM node identity alone doesn't
-// prove whether React re-invoked the component, since React can re-render
-// without replacing the underlying DOM node.
 vi.mock('~templates/Field', async (importOriginal) => {
   const actual = await importOriginal<typeof import('~templates/Field')>()
   return {
@@ -81,14 +75,32 @@ describe('FieldFactory', () => {
       />,
     )
 
-    // Asserting call count (rather than only the rendered output) proves
-    // the memoized component was actually re-invoked, not just that its
-    // DOM node happens to have new attributes.
     expect(mockShortTextField).toHaveBeenCalledTimes(2)
     const el = screen.getByTestId('mock-short-text-field')
     expect(el).toHaveAttribute('data-disabled', 'true')
     expect(el).toHaveAttribute('data-high-contrast', 'true')
     expect(el).toHaveAttribute('data-disable-required-validation', 'true')
+  })
+
+  it('re-renders when any other schema property changes, e.g. title', () => {
+    const { rerender } = render(
+      <FieldFactory
+        field={baseField}
+        isHighContrast={false}
+        disableRequiredValidation={false}
+      />,
+    )
+    expect(mockShortTextField).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <FieldFactory
+        field={{ ...baseField, title: 'Renamed field' }}
+        isHighContrast={false}
+        disableRequiredValidation={false}
+      />,
+    )
+
+    expect(mockShortTextField).toHaveBeenCalledTimes(2)
   })
 
   it('does not re-render when field, isHighContrast, and disableRequiredValidation are unchanged', () => {
@@ -109,8 +121,6 @@ describe('FieldFactory', () => {
       />,
     )
 
-    // Call count staying at 1 proves React bailed out of re-rendering the
-    // memoized component entirely, which DOM node identity alone cannot show.
     expect(mockShortTextField).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react'
+import { isEqual } from 'lodash'
 
 import { BasicField } from 'formsg-shared/types/field'
 import { FormColorTheme, FormResponseMode } from 'formsg-shared/types/form'
@@ -136,13 +137,5 @@ export const FieldFactory = memo(
         )
     }
   },
-  // NOTE: if a new `field` property or prop starts affecting what's rendered
-  // below, add it to this comparator too, or this memo will silently skip
-  // re-renders that should have happened.
-  (prevProps, nextProps) =>
-    prevProps.field._id === nextProps.field._id &&
-    prevProps.field.questionNumber === nextProps.field.questionNumber &&
-    prevProps.field.disabled === nextProps.field.disabled &&
-    prevProps.isHighContrast === nextProps.isHighContrast &&
-    prevProps.disableRequiredValidation === nextProps.disableRequiredValidation,
+  (prevProps, nextProps) => isEqual(prevProps, nextProps),
 )

--- a/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -1,5 +1,4 @@
 import { memo } from 'react'
-import { isEqual } from 'lodash'
 
 import { BasicField } from 'formsg-shared/types/field'
 import { FormColorTheme, FormResponseMode } from 'formsg-shared/types/form'
@@ -137,5 +136,13 @@ export const FieldFactory = memo(
         )
     }
   },
-  (prevProps, nextProps) => isEqual(prevProps, nextProps),
+  // NOTE: if a new `field` property or prop starts affecting what's rendered
+  // below, add it to this comparator too, or this memo will silently skip
+  // re-renders that should have happened.
+  (prevProps, nextProps) =>
+    prevProps.field._id === nextProps.field._id &&
+    prevProps.field.questionNumber === nextProps.field.questionNumber &&
+    prevProps.field.disabled === nextProps.field.disabled &&
+    prevProps.isHighContrast === nextProps.isHighContrast &&
+    prevProps.disableRequiredValidation === nextProps.disableRequiredValidation,
 )

--- a/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FieldFactory.tsx
@@ -51,6 +51,17 @@ interface FieldFactoryProps {
   isHighContrast?: boolean
 }
 
+const FIELD_KEYS_AFFECTING_RENDER = [
+  '_id',
+  'questionNumber',
+  'disabled',
+] as const
+
+const PROP_KEYS_AFFECTING_RENDER = [
+  'isHighContrast',
+  'disableRequiredValidation',
+] as const
+
 export const FieldFactory = memo(
   ({ field, ...rest }: FieldFactoryProps) => {
     const { myInfoChildrenBirthRecords, form } = usePublicFormContext()
@@ -136,13 +147,11 @@ export const FieldFactory = memo(
         )
     }
   },
-  // NOTE: if a new `field` property or prop starts affecting what's rendered
-  // below, add it to this comparator too, or this memo will silently skip
-  // re-renders that should have happened.
   (prevProps, nextProps) =>
-    prevProps.field._id === nextProps.field._id &&
-    prevProps.field.questionNumber === nextProps.field.questionNumber &&
-    prevProps.field.disabled === nextProps.field.disabled &&
-    prevProps.isHighContrast === nextProps.isHighContrast &&
-    prevProps.disableRequiredValidation === nextProps.disableRequiredValidation,
+    FIELD_KEYS_AFFECTING_RENDER.every(
+      (key) => prevProps.field[key] === nextProps.field[key],
+    ) &&
+    PROP_KEYS_AFFECTING_RENDER.every(
+      (key) => prevProps[key] === nextProps[key],
+    ),
 )

--- a/apps/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
+++ b/apps/frontend/src/features/public-form/components/FormFields/FormFieldsContainer.tsx
@@ -25,6 +25,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     encryptedPreviousSubmission,
     previousSubmission,
     previousAttachments,
+    previewWorkflowStepNumber,
   } = usePublicFormContext()
 
   const { workflowStep } = encryptedPreviousSubmission ?? {}
@@ -71,7 +72,8 @@ export const FormFieldsContainer = (): JSX.Element | null => {
             ? form.workflow[
                 // If no submission, then the workflowStep will be undefined.
                 // Require explicit undefined check here since both 0 and undefined are falsy but mean different things here.
-                workflowStep === undefined ? 0 : workflowStep + 1
+                previewWorkflowStepNumber ??
+                  (workflowStep === undefined ? 0 : workflowStep + 1)
               ]
             : undefined
         }
@@ -85,6 +87,7 @@ export const FormFieldsContainer = (): JSX.Element | null => {
     isAuthRequired,
     previousAttachments,
     workflowStep,
+    previewWorkflowStepNumber,
     handleSubmitForm,
     hasSingleSubmissionValidationError,
     hasRespondentNotWhitelistedError,


### PR DESCRIPTION
_Review follow-up to #9860, targeting its branch so the fixes land as part of the same feature._

## Problem

Review of #9860 found that the per-step preview compiles, passes CI, and demos in Storybook, but two of its core behaviours don't survive contact with the real form tree, and two smaller behaviours contradict the PR's own test plan:

1. **Validation and styling ignore the selected step.** `FormFieldsContainer` derives `workflowStep` from `encryptedPreviousSubmission`, which a preview never has, so it always falls back to `workflow[0]`. Each field's `disabled` state tracks `?step=` correctly (it flows through `augmentedFormFields`), but `disableRequiredValidation` and `isHighContrast` are computed against step 1's edit set no matter which step is being previewed: at step 2, the fields that step's respondent should fill render with read-only styling and skipped required validation, while step 1's read-only fields still enforce `required`.
2. **Carried-over answers are wiped the moment they matter.** `FormFields` has an existing effect that resets the form to `defaultFormValues` whenever `isDirty` is false (it populates values when the form data loads). The carry-over reset on a step switch clears the dirty flag, which re-fires that effect and immediately replaces the carried answers with the new step's plain defaults. Once the admin has typed anything, the headline carry-over behaviour never survives a step switch.
3. **The step toast fires on a cold load of `?step=N`.** Until the form data arrives, the clamp sees zero workflow steps and pins the step to 0; the first-run latch is consumed on mount, so the data arrival re-fires the effect at step N and toasts as if the admin had switched. Whether this happens depends on react-query cache warmth, which is why it can pass manual testing and still fail on a hard refresh — TC1's "no toast when opening `?step=1` directly" is not currently true.
4. **The URL and history handling are non-canonical.** `?step=999` renders the last step but the URL (and any copied link) keeps saying 999; `?step=0` and no param alias the same state; and every dropdown selection pushes a history entry, so Back walks through every step visited, re-firing the toast at each stop.

## Solution

One commit per fix, in review order:

- **`fix(public-form): drive preview validation and styling from the previewed step`** — `FormFieldsContainer` prefers `previewWorkflowStepNumber` from context when present. It is the current step (not the previous respondent's), so it indexes the workflow directly rather than being incremented; the real-respondent path is untouched.
- **`fix(admin-form): stop the defaults reset from wiping carried-over answers`** — the carry-over reset passes `keepDirty: true`, so the `FormFields` effect keeps treating the form as user-touched and leaves the carried values alone. The data-load population path is unaffected: before any typing the flag is false and that effect still runs.
- **`fix(admin-form): suppress the step toast until the form has loaded`** — the first-run latch is only consumed once the workflow exists, so the data arrival counts as the initial step however it re-fires the effect, and the toast is reserved for switches the admin actually makes. Behaviour no longer depends on cache warmth.
- **`refactor(admin-form): extract withPreviewStepParam`** — the delete-at-zero-else-set rule moves next to `PREVIEW_STEP_PARAM` with unit tests, ahead of gaining a second caller.
- **`fix(admin-form): canonicalise the ?step param once the workflow loads`** — the clamped step is written back with replace navigation, making the URL the single source of truth. This closes the "URL still reads 999" caveat #9860's TC4 documents as known.
- **`fix(admin-form): replace instead of push when switching preview steps`** — the dropdown is a view switch within one page, not a navigation; Back now leaves the preview instead of replaying every step visited.

- **`refactor(public-form): define FieldFactory's render-affecting keys once`** — the comparator's hand-written equality clauses become two const key lists (`FIELD_KEYS_AFFECTING_RENDER`, `PROP_KEYS_AFFECTING_RENDER`) that the comparator iterates. Same compared keys, no behaviour change; extending the memo is now a one-line list entry. (The branch history also contains a tried-and-reverted `isEqual` comparator — see Alternatives.)

**Alternatives considered**

- **Content-equality memo comparator (`isEqual(prevProps, nextProps)`) for `FieldFactory`: tried in-branch, then reverted.** It removes the maintenance burden of the explicit prop list, but it makes every prop render-affecting by default — any content change to any schema property triggers a re-render — and deep-compares every visible field on every keystroke whenever upstream references churn. The explicit comparator keeps the re-render conditions an intentional, bounded list: a render-affecting prop is added deliberately, with the cost weighed. Kept in history as a revert pair rather than rebased away, per force-push policy. The follow-up refactor keeps the explicit allowlist but defines it once as key lists, so extending it no longer means editing comparison logic.
- For the carry-over wipe, gating the `FormFields` reset effect on `isPreview` was rejected because it couples a respondent-facing component to preview concerns and changes shared behaviour; `keepDirty` confines the fix to the preview provider.
- For the toast latch, depending on the `formWorkflow` object was rejected in favour of a boolean, so a background refetch returning a new array identity can never re-fire the effect (which would reset typed values and toast on window refocus). react-query's structural sharing makes this unlikely, but the boolean makes it impossible.
- For history handling, keeping push navigation so Back steps backwards through steps was rejected: the dropdown already provides step navigation, and push meant Back re-fired a toast per entry. The spec asks for a way to jump between steps, not a browsing history of them.

**Screenshots**

None — every change is behavioural (validation state, form values, toast timing, URL/history), with no new UI. #9860's screenshots remain accurate.

**Breaking Changes**

No - backwards compatible.

## Tests

Unit: `previewStepParam.test.ts` (new, 5 cases). All 23 tests across the touched/adjacent suites pass locally.

**TC1: Validation and styling follow the selected step** _(this is #9860's TC1, which currently fails)_

- [ ] On a 3-step MRF form, open Preview and switch to Step 2.
- [ ] Fields Step 2 edits render enabled, full-contrast, and enforce required validation.
- [ ] Fields Step 1 edits render disabled and greyed, and do NOT block submission via required validation.

**TC2: Carry-over survives a step switch** _(this is #9860's TC2, which currently fails once anything is typed)_

- [ ] On Step 1, type a recognisable value into a Step 1 field.
- [ ] Switch to Step 2: the value is still shown, read-only. Switch to Step 3: still shown.
- [ ] Switch back to Step 1: Step 3's fields are empty again.

**TC3: Toast only on genuine switches**

- [ ] Hard-refresh the preview at `?step=1`: no toast after the form loads.
- [ ] Open preview with no param, wait for load, then pick Step 2: toast appears exactly then.

**TC4: URL is canonical**

- [ ] Open `?step=999` on a 3-step form: after load the URL reads `?step=2`.
- [ ] Open `?step=abc` or `?step=0`: after load the param is removed.
- [ ] Copying the URL at any point reproduces the same view.

**TC5: History**

- [ ] Flick through Steps 1→2→3→1, then press Back once: you leave the preview (no step-by-step replay, no toast storm).

**TC6: No regression to respondent-facing forms**

- [ ] Submit a real (non-preview) MRF form across two steps: validation, disabled states, and styling behave as on develop.

