### PR TITLE
feat(workflow): delete workflow design polish (4/5)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.stories.tsx
@@ -9,10 +9,15 @@ import { StoryRouter, viewports } from '~utils/storybook'
 import { DeleteWorkflowModal } from './DeleteWorkflowModal'
 
 /**
- * The modal has two states and they are not variants of each other: one asks
- * the admin to confirm something destructive, the other tells them they cannot
- * do it yet and points at the fix. Which one shows is decided by the form's
- * status, so the stories differ only in that.
+ * The modal has three states. Two of them are not variants of each other: one
+ * asks the admin to confirm something destructive, the other tells them they
+ * cannot do it yet and points at the fix. Which of those shows is decided by
+ * the form's status.
+ *
+ * The third is the destructive state entered from step 1, which adds a line
+ * explaining why deleting a step deleted the whole workflow. The form-open
+ * state is deliberately shared across both entry points, so there is no
+ * first-step variant of it to shoot.
  */
 const buildMocks = (status: FormStatus) =>
   createFormBuilderMocks({
@@ -31,7 +36,19 @@ export default {
 } as Meta
 
 const Template: StoryFn = () => (
-  <DeleteWorkflowModal isOpen onClose={() => undefined} />
+  <DeleteWorkflowModal
+    isOpen
+    onClose={() => undefined}
+    entryPoint="workflow-card"
+  />
+)
+
+const FirstStepTemplate: StoryFn = () => (
+  <DeleteWorkflowModal
+    isOpen
+    onClose={() => undefined}
+    entryPoint="first-step"
+  />
 )
 
 /** Form closed: deleting is allowed, and the confirm button is destructive. */
@@ -62,6 +79,25 @@ MobileFormClosed.parameters = {
 export const MobileFormOpen = Template.bind({})
 MobileFormOpen.parameters = {
   ...FormOpen.parameters,
+  viewport: {
+    defaultViewport: 'mobile1',
+  },
+  chromatic: { viewports: [viewports.xs] },
+}
+
+/**
+ * Entered from step 1's delete button. Same outcome and same actions as
+ * FormClosed, with a leading line explaining why a step delete removes the
+ * workflow.
+ */
+export const FirstStepFormClosed = FirstStepTemplate.bind({})
+FirstStepFormClosed.parameters = {
+  msw: { handlers: { default: buildMocks(FormStatus.Private) } },
+}
+
+export const MobileFirstStepFormClosed = FirstStepTemplate.bind({})
+MobileFirstStepFormClosed.parameters = {
+  ...FirstStepFormClosed.parameters,
   viewport: {
     defaultViewport: 'mobile1',
   },

--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
+  ListItem,
   Modal,
   ModalBody,
   ModalContent,
@@ -10,6 +11,7 @@ import {
   ModalOverlay,
   Stack,
   Text,
+  UnorderedList,
   useBreakpointValue,
 } from '@chakra-ui/react'
 
@@ -30,6 +32,11 @@ import { useWorkflowMutations } from '../../mutations'
 interface DeleteWorkflowModalProps {
   isOpen: boolean
   onClose: () => void
+  /**
+   * Which delete button opened this. Named rather than a boolean so the reason
+   * the copy differs is readable here, without opening the call site.
+   */
+  entryPoint: 'workflow-card' | 'first-step'
 }
 
 /**
@@ -37,17 +44,24 @@ interface DeleteWorkflowModalProps {
  *
  * Shown from two places that mean the same thing: the workflow card's own
  * delete button, and the delete button on step 1. A workflow without its first
- * step has no entry point, so deleting step 1 is deleting the workflow — and
+ * step has no entry point, so deleting step 1 is deleting the workflow, and
  * offering two different modals for one outcome would suggest otherwise.
  *
- * Which of the two states it shows depends on whether the form is still open.
- * Deleting the workflow while respondents may be part-way through it is refused
- * by the API, so the modal's job when the form is open is not to warn but to
- * send the admin to the one place they can do something about it.
+ * One modal, but it speaks two ways. Entering from step 1 says so in the title,
+ * since the surprise to head off is that a step delete removed everything;
+ * entering from the card needs no such explanation, because the button already
+ * said workflow. The consequences below the title are identical either way.
+ *
+ * Both of those assume the form is closed. Deleting the workflow while
+ * respondents may be part-way through it is refused by the API, so when the
+ * form is open the modal's job is not to warn but to send the admin to the one
+ * place they can do something about it. That state reads the same from either
+ * entry point: it is about the form's status, not about what was clicked.
  */
 export const DeleteWorkflowModal = ({
   isOpen,
   onClose,
+  entryPoint,
 }: DeleteWorkflowModalProps): JSX.Element => {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -64,12 +78,15 @@ export const DeleteWorkflowModal = ({
 
   const isFormOpen = form?.status === FormStatus.Public
 
-  const copy = t(
-    isFormOpen
-      ? 'features.adminForm.sidebar.workflow.conditionalRouting.modals.closeFormFirst'
-      : 'features.adminForm.sidebar.workflow.conditionalRouting.modals.deleteWorkflow',
-    { returnObjects: true },
-  )
+  // Full literal keys rather than an interpolated path: i18next types its keys
+  // off string literals, and building the path up would drop that checking.
+  const copyKey = isFormOpen
+    ? 'features.adminForm.sidebar.workflow.conditionalRouting.modals.closeFormFirst'
+    : entryPoint === 'first-step'
+      ? 'features.adminForm.sidebar.workflow.conditionalRouting.modals.deleteFirstStep'
+      : 'features.adminForm.sidebar.workflow.conditionalRouting.modals.deleteWorkflow'
+
+  const copy = t(copyKey, { returnObjects: true })
 
   const handleGoToSettings = useCallback(() => {
     navigate(`${ADMINFORM_ROUTE}/${formId}/${ADMINFORM_SETTINGS_SUBROUTE}`)
@@ -96,9 +113,25 @@ export const DeleteWorkflowModal = ({
         <ModalCloseButton isDisabled={isLoading} />
         <ModalHeader color="secondary.700">{copy.title}</ModalHeader>
         <ModalBody whiteSpace="pre-wrap">
-          <Text textStyle="body-2" color="secondary.500">
-            {copy.description}
-          </Text>
+          {/* The two delete states list their consequences; closeFormFirst has
+              a single sentence, and one sentence set as a lone bullet reads as
+              a list that lost its other items. Discriminating on the shape of
+              the copy keeps that decision with the copy itself. */}
+          {Array.isArray(copy.description) ? (
+            <UnorderedList styleType="disc" spacing={2}>
+              {copy.description.map((consequence) => (
+                <ListItem key={consequence}>
+                  <Text textStyle="body-2" color="secondary.500">
+                    {consequence}
+                  </Text>
+                </ListItem>
+              ))}
+            </UnorderedList>
+          ) : (
+            <Text textStyle="body-2" color="secondary.500">
+              {copy.description}
+            </Text>
+          )}
         </ModalBody>
         <ModalFooter>
           <Stack

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
@@ -62,8 +62,10 @@ export const WorkflowBlockFactory = ({
         onAddAnotherStep: setToCreating,
       }
   // A workflow without its first step has no entry point, so deleting step 1 is
-  // deleting the workflow. Same button, same modal as the workflow's own delete
-  // — the outcome is the same, and two different modals would imply otherwise.
+  // deleting the workflow. Same button, same modal as the workflow's own
+  // delete: the outcome is the same, and two different modals would imply
+  // otherwise. The modal is told where it was opened from so it can explain
+  // the jump from step to workflow, which the card's own button need not.
   const isFirstStep = isFirstStepByStepNumber(stepNumber)
 
   return (
@@ -72,6 +74,7 @@ export const WorkflowBlockFactory = ({
         <DeleteWorkflowModal
           isOpen={isDeleteModalOpen}
           onClose={onDeleteModalClose}
+          entryPoint="first-step"
         />
       ) : (
         <DeleteStepModal

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -45,6 +45,7 @@ export const WorkflowContent = (): JSX.Element | null => {
       <DeleteWorkflowModal
         isOpen={isDeleteModalOpen}
         onClose={onDeleteModalClose}
+        entryPoint="workflow-card"
       />
       {/* <HeaderBlock /> */}
       <Box

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -60,15 +60,26 @@ export const WorkflowContent = (): JSX.Element | null => {
             <Text as="h2" textStyle="h2">
               Workflow
             </Text>
-            {/* Grey rather than danger-red. This sits on the card at rest,
-                not inside a confirmation, and a red button in the corner of a
-                page reads as a warning about the page's state rather than as
-                an action. The destructive colour belongs on the button that
-                actually destroys something, in the modal. */}
+            {/* Grey at rest, red on intent. A red button sitting in the
+                corner of a page reads as a warning about the page's state
+                rather than as an action, so the destructive colour waits until
+                the pointer is on it. The resting grey matches the pencil on
+                the step cards, so the two affordances read as one family.
+
+                The states are set inline rather than through a variant: the
+                clear variant derives every state from a single colorScheme and
+                so cannot span two, and one call site does not warrant a
+                theme-wide variant that would invite use where plain danger is
+                correct. */}
             {isWorkflowDeletion ? (
               <IconButton
                 variant="clear"
-                colorScheme="secondary"
+                colorScheme="danger"
+                color="neutral.500"
+                transitionProperty="common"
+                transitionDuration="normal"
+                _hover={{ color: 'danger.500', bg: 'danger.100' }}
+                _active={{ color: 'danger.500', bg: 'danger.200' }}
                 aria-label={t(
                   'features.adminForm.sidebar.workflow.aria.deleteWorkflow',
                 )}

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -51,7 +51,7 @@ export const enSG: Workflow = {
         title: 'Delete your workflow',
         description: [
           'Responses already in progress will continue on the current workflow.',
-          'When you reopen your form, anyone with the link can fill in every field.',
+          'When you reopen your form, anyone with the link will be able to fill in every field.',
         ],
         confirm: 'Delete workflow',
         cancel: 'Cancel',
@@ -63,7 +63,7 @@ export const enSG: Workflow = {
         title: 'Deleting the first step removes your workflow',
         description: [
           'Responses already in progress will continue on the current workflow.',
-          'When you reopen your form, anyone with the link can fill in every field.',
+          'When you reopen your form, anyone with the link will be able to fill in every field.',
         ],
         confirm: 'Delete workflow',
         cancel: 'Cancel',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -49,8 +49,22 @@ export const enSG: Workflow = {
       },
       deleteWorkflow: {
         title: 'Delete your workflow',
-        description:
-          'Responses already in progress will carry on as they are. When you reopen your form, anyone with the link will be able to fill in every field.',
+        description: [
+          'Responses already in progress will continue on the current workflow.',
+          'When you reopen your form, anyone with the link can fill in every field.',
+        ],
+        confirm: 'Delete workflow',
+        cancel: 'Cancel',
+      },
+      // Same consequences as deleteWorkflow, repeated rather than shared: the
+      // two differ only in the title, and translators need whole sentences,
+      // since clause order differs by language and stitched fragments break.
+      deleteFirstStep: {
+        title: 'Deleting the first step removes your workflow',
+        description: [
+          'Responses already in progress will continue on the current workflow.',
+          'When you reopen your form, anyone with the link can fill in every field.',
+        ],
         confirm: 'Delete workflow',
         cancel: 'Cancel',
       },

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -51,7 +51,15 @@ export interface Workflow {
       }
       deleteWorkflow: {
         title: string
-        description: string
+        // Rendered as bullets. closeFormFirst stays a single string: one
+        // sentence as a lone bullet reads as a broken list.
+        description: string[]
+        confirm: string
+        cancel: string
+      }
+      deleteFirstStep: {
+        title: string
+        description: string[]
         confirm: string
         cancel: string
       }


### PR DESCRIPTION
<!-- ccr-slack-attribution -->
_Requested by **Sufyan Selamet** · [Slack thread](https://opengovproducts.slack.com/archives/CKHLS3W3X/p1783500267319609?thread_ts=1783500267.319609&cid=CKHLS3W3X)_

## Problem

- Stacked on #9909. Both delete buttons open the same modal, and the modal only ever spoke for the card.
- An admin deleting step 1 sees "Delete your workflow" with no explanation of why a step delete became that.
- The card's delete control is navy at rest, giving a destructive action the same weight as everything else. Part of [FRM-2494](https://linear.app/ogp/issue/FRM-2494).

## Solution

- The modal now takes an `entryPoint`, so from step 1 the title says deleting the first step removes the workflow.
- From the card the title is unchanged, because the button already said workflow.
- The consequences are identical either way, and now read as bullets rather than one paragraph.
- "Close your form first" stays a single paragraph; one sentence as a lone bullet reads as a list that lost its items.
- The reopen consequence now reads "anyone with the link will be able to fill in every field".
- The delete control sits at the step cards' grey and takes the danger colour on hover and press, once the pointer shows intent.

**Alternatives considered**

- A `clearDanger` theme variant for the grey-to-red hover, skipped. One call site does not justify a theme-wide variant.
- A full stop in the modal title, dropped. 13 of 15 FormSG modal titles carry none.
- Composing step 1's copy from a shared prefix, dropped. Translators need whole sentences, and fragments break on clause order.
- A boolean `isFirstStep` prop, replaced by a named `entryPoint` union so the reason the copy differs reads at the modal.
- A step 1 version of "close your form first", left shared. That screen routes to settings, and workflow detail would dilute one instruction.

**Breaking changes:** none. Copy and styling only, behind the same flag as #9909.

## Screenshots

Captured on an MRF form with a two-step workflow, closed to responses. Before is #9909.

Deleting step 1. The title now carries the reason.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/before-modal-step1.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/after-modal-step1.png) |

Deleting from the card. Same consequences, now as bullets.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/before-modal-card.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/after-modal-card.png) |

The delete control at rest.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/before-card-rest.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/after-card-rest.png) |

And on hover.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/before-card-hover.png) | ![after](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/after-card-hover.png) |

The form-open state is shared by both entry points and is unchanged.

![form open](https://raw.githubusercontent.com/opengovsg/FormSG/screenshots/.github/screenshots/frm-2494-workflow-deletion/after-modal-formopen.png)

## Tests

**Manual**

- [ ] Open an MRF form with a two-step workflow, closed to responses.
- [ ] Delete from step 1: title reads "Deleting the first step removes your workflow", with two bullets below it.
- [ ] Delete from the card: title reads "Delete your workflow", with the same two bullets.
- [ ] The card's delete control is grey at rest, red on a pale red background on hover, darker on press.
- [ ] Set the form open: both entry points show "Close your form first" as a paragraph, offering "Go to settings".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rnq9JJSWKJH8XmEzviGey
