### PR TITLE
feat(myinfo): add MyInfo FAPI 2.0 config and key plumbing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,11 @@ FORMSG_SDK_MODE=
 # CP_OIDC_RP_JWKS_PUBLIC_PATH=
 # CP_OIDC_RP_JWKS_SECRET_PATH=
 
+# MYINFO_FAPI_ISSUER=http://localhost:5156/singpass/v3/fapi
+# MYINFO_FAPI_CLIENT_ID=mockFapiClientId
+# MYINFO_FAPI_RP_JWKS_PUBLIC_PATH=./__tests__/setup/certs/test_myinfo_fapi_rp_public_jwks.json
+# MYINFO_FAPI_RP_JWKS_SECRET_PATH=./__tests__/setup/certs/test_myinfo_fapi_rp_secret_jwks.json
+
 # IS_SP_MAINTENANCE=
 # IS_CP_MAINTENANCE=
 # MYINFO_BANNER_CONTENT=

--- a/apps/backend/__tests__/setup/.test-env
+++ b/apps/backend/__tests__/setup/.test-env
@@ -21,6 +21,11 @@ MYINFO_CLIENT_SECRET=mockClientSecret
 MYINFO_JWT_SECRET=mockJwtSecret
 SINGPASS_ESRVC_ID=Test-eServiceId-Sp # Needed for MyInfo
 
+MYINFO_FAPI_ISSUER=http://localhost:5156/singpass/v3/fapi
+MYINFO_FAPI_CLIENT_ID=mockFapiClientId
+MYINFO_FAPI_RP_JWKS_PUBLIC_PATH=./__tests__/setup/certs/test_myinfo_fapi_rp_public_jwks.json
+MYINFO_FAPI_RP_JWKS_SECRET_PATH=./__tests__/setup/certs/test_myinfo_fapi_rp_secret_jwks.json
+
 SGID_HOSTNAME=http://localhost:5156
 SGID_CLIENT_ID=sgidclientid
 SGID_CLIENT_SECRET=sgidclientsecret

--- a/apps/backend/__tests__/setup/certs/test_myinfo_fapi_rp_public_jwks.json
+++ b/apps/backend/__tests__/setup/certs/test_myinfo_fapi_rp_public_jwks.json
@@ -1,0 +1,22 @@
+{
+  "keys": [
+    {
+      "kty": "EC",
+      "alg": "ES256",
+      "use": "sig",
+      "kid": "XBF06sG1r0OE-j07gvUTfH4Q888jNDM0A18rK9HSLGM",
+      "crv": "P-256",
+      "x": "_GoOHZCtu2jnlvhAzS-YN73u3v35aWKVEC5_RBldvaQ",
+      "y": "DU9bmIEjkXcF7YNLuWFbOnyopt0Hm7bdy9qbUYAS6hE"
+    },
+    {
+      "kty": "EC",
+      "alg": "ECDH-ES+A256KW",
+      "use": "enc",
+      "kid": "FX1lobmocyRokEqmkgEl4-jK5Lc04u6l5vPHdYj50Mc",
+      "crv": "P-256",
+      "x": "cpOUkD2CFv9ORJfQdFLKJ8AURnssi9PO44W-UANcLx4",
+      "y": "zVgwkhly1ycBFrybLUsZXi2K3xdOqzT-pl6KP9f1yhk"
+    }
+  ]
+}

--- a/apps/backend/__tests__/setup/certs/test_myinfo_fapi_rp_secret_jwks.json
+++ b/apps/backend/__tests__/setup/certs/test_myinfo_fapi_rp_secret_jwks.json
@@ -1,0 +1,24 @@
+{
+  "keys": [
+    {
+      "kty": "EC",
+      "alg": "ES256",
+      "use": "sig",
+      "kid": "XBF06sG1r0OE-j07gvUTfH4Q888jNDM0A18rK9HSLGM",
+      "crv": "P-256",
+      "x": "_GoOHZCtu2jnlvhAzS-YN73u3v35aWKVEC5_RBldvaQ",
+      "y": "DU9bmIEjkXcF7YNLuWFbOnyopt0Hm7bdy9qbUYAS6hE",
+      "d": "RM8lOFvnCS2Wt38vgDmANNY_Sed77RW-LAuNKbAYw1k"
+    },
+    {
+      "kty": "EC",
+      "alg": "ECDH-ES+A256KW",
+      "use": "enc",
+      "kid": "FX1lobmocyRokEqmkgEl4-jK5Lc04u6l5vPHdYj50Mc",
+      "crv": "P-256",
+      "x": "cpOUkD2CFv9ORJfQdFLKJ8AURnssi9PO44W-UANcLx4",
+      "y": "zVgwkhly1ycBFrybLUsZXi2K3xdOqzT-pl6KP9f1yhk",
+      "d": "OTpVxnUjK720jWu4PnnpHaYh7z9RCNE2Mnydp5pzbd0"
+    }
+  ]
+}

--- a/apps/backend/src/app/config/features/spcp-myinfo.config.ts
+++ b/apps/backend/src/app/config/features/spcp-myinfo.config.ts
@@ -47,6 +47,12 @@ type IMyInfoConfig = {
   myInfoClientId: string
   myInfoClientSecret: string
   myInfoJwtSecret: string
+  myInfoFapiIssuer: string
+  myInfoFapiClientId: string
+  myInfoFapiRpJwksPublic: string
+  myInfoFapiRpJwksSecret: string
+  myInfoFapiRpJwksPublicPath: string
+  myInfoFapiRpJwksSecretPath: string
 }
 
 // Config of MyInfo is coupled to that of Singpass
@@ -154,6 +160,42 @@ const spcpMyInfoSchema: Schema<ISpcpMyInfo> = {
     format: String,
     default: null,
     env: 'MYINFO_JWT_SECRET',
+  },
+  myInfoFapiIssuer: {
+    doc: "Issuer identifier of Singpass' MyInfo FAPI 2.0 authorization server. Discovery is performed against <issuer>/.well-known/openid-configuration.",
+    format: String,
+    default: null,
+    env: 'MYINFO_FAPI_ISSUER',
+  },
+  myInfoFapiClientId: {
+    doc: "The Relying Party's client ID as registered in the Singpass Developer Portal for MyInfo FAPI 2.0.",
+    format: String,
+    default: null,
+    env: 'MYINFO_FAPI_CLIENT_ID',
+  },
+  myInfoFapiRpJwksPublic: {
+    doc: "The Relying Party's public JSON Web Key Set for MyInfo FAPI 2.0. Hosted at /mi/fapi/.well-known/jwks.json.",
+    format: validateIacStringParam,
+    default: null,
+    env: 'MYINFO_FAPI_RP_JWKS_PUBLIC',
+  },
+  myInfoFapiRpJwksSecret: {
+    doc: "The Relying Party's secret JSON Web Key Set for MyInfo FAPI 2.0. Signs client assertions and decrypts ID tokens and userinfo.",
+    format: validateIacStringParam,
+    default: null,
+    env: 'MYINFO_FAPI_RP_JWKS_SECRET',
+  },
+  myInfoFapiRpJwksPublicPath: {
+    doc: "Path to the Relying Party's public JSON Web Key Set for MyInfo FAPI 2.0.",
+    format: validateNonIacStringParam,
+    default: null,
+    env: 'MYINFO_FAPI_RP_JWKS_PUBLIC_PATH',
+  },
+  myInfoFapiRpJwksSecretPath: {
+    doc: "Path to the Relying Party's secret JSON Web Key Set for MyInfo FAPI 2.0.",
+    format: validateNonIacStringParam,
+    default: null,
+    env: 'MYINFO_FAPI_RP_JWKS_SECRET_PATH',
   },
   spOidcNdiDiscoveryEndpoint: {
     doc: "NDI's Singpass OIDC Discovery Endpoint",

--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -262,6 +262,22 @@
           "valueFrom": "/<ENVIRONMENT_SITE_NAME>/SP_OIDC_RP_JWKS_SECRET"
         },
         {
+          "name": "MYINFO_FAPI_ISSUER",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_FAPI_ISSUER"
+        },
+        {
+          "name": "MYINFO_FAPI_CLIENT_ID",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_FAPI_CLIENT_ID"
+        },
+        {
+          "name": "MYINFO_FAPI_RP_JWKS_PUBLIC",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_FAPI_RP_JWKS_PUBLIC"
+        },
+        {
+          "name": "MYINFO_FAPI_RP_JWKS_SECRET",
+          "valueFrom": "/<ENVIRONMENT_SITE_NAME>/MYINFO_FAPI_RP_JWKS_SECRET"
+        },
+        {
           "name": "CP_OIDC_NDI_DISCOVERY_ENDPOINT",
           "valueFrom": "/<ENVIRONMENT_SITE_NAME>/CP_OIDC_NDI_DISCOVERY_ENDPOINT"
         },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,11 @@ services:
       - MYINFO_CLIENT_ID=mockClientId
       - MYINFO_CLIENT_SECRET=mockClientSecret
       - MYINFO_JWT_SECRET=mockJwtSecret
+      # MyInfo FAPI 2.0
+      - MYINFO_FAPI_ISSUER=http://localhost:5156/singpass/v3/fapi
+      - MYINFO_FAPI_CLIENT_ID=mockFapiClientId
+      - MYINFO_FAPI_RP_JWKS_PUBLIC_PATH=__tests__/setup/certs/test_myinfo_fapi_rp_public_jwks.json
+      - MYINFO_FAPI_RP_JWKS_SECRET_PATH=__tests__/setup/certs/test_myinfo_fapi_rp_secret_jwks.json
       - SGID_HOSTNAME=http://localhost:5156
       - SGID_CLIENT_ID=sgidclientid
       - SGID_CLIENT_SECRET=sgidclientsecret
@@ -155,6 +160,7 @@ services:
       - SHOW_LOGIN_PAGE=true
       - SP_RP_JWKS_ENDPOINT=http://localhost:5000/sp/.well-known/jwks.json
       - CP_RP_JWKS_ENDPOINT=http://localhost:5000/api/v3/corppass/.well-known/jwks.json
+      - FAPI_CLIENT_JWKS_ENDPOINT=http://localhost:5000/mi/fapi/.well-known/jwks.json
     network_mode: 'service:backend' # reuse backend service's network stack so that it can resolve localhost:5156 to mockpass:5156
 
   database:


### PR DESCRIPTION
## Problem

The upcoming MyInfo FAPI 2.0 client needs its own config: the Singpass FAPI issuer, our client ID, and the Relying Party's JWKS key pair for signing client assertions and decrypting responses.

## Solution

Adds the new config schema fields (issuer, client ID, RP JWKS public/secret), their env vars, and test JWKS certs/mockpass wiring so the flow can be exercised locally and in tests. Every new field defaults to `null` and nothing reads them yet.

**Breaking Changes**

No - backwards compatible. Additive config only.
