### PR TITLE
feat(myinfo): expose FAPI 2.0 login route

### DIFF
--- a/apps/backend/src/app/modules/myinfo/myinfo.routes.ts
+++ b/apps/backend/src/app/modules/myinfo/myinfo.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express'
 
 import { authCallbackForwardingMiddleware } from '../auth/auth.middlewares'
 
+import { MyInfoFapiRouter } from './fapi/myinfo.fapi.routes'
 import { MYINFO_REDIRECT_PATH } from './myinfo.constants'
 import {
   handleMyInfoLogin,
@@ -26,3 +27,8 @@ MyInfoRouter.get(
   authCallbackForwardingMiddleware,
   handleMyInfoLogin,
 )
+
+/**
+ * MyInfo FAPI 2.0 routes, which run in parallel with MyInfo v3 during migration.
+ */
+MyInfoRouter.use(MyInfoFapiRouter)

--- a/apps/frontend/src/features/compatibility/RbiProxyForwardingPage.tsx
+++ b/apps/frontend/src/features/compatibility/RbiProxyForwardingPage.tsx
@@ -11,6 +11,7 @@ import { useIsRbiIpCheck } from '~features/login/queries'
 const ALLOWED_FORWARDING_ROUTES = [
   '/sgid/login',
   '/mi/login',
+  '/mi/fapi/login',
   '/api/v3/singpass/login',
   '/api/v3/corppass/login',
   '/api/v3/auth/sgid/login/callback',


### PR DESCRIPTION
## Problem

The FAPI 2.0 module (previous PR) has no route mounted, and its login endpoint isn't reachable through the RBI compatibility proxy that some respondents are forwarded through.

## Solution

Mounts the FAPI router under `/mi`, and allows `/mi/fapi/login` through the RBI proxy forwarding allowlist alongside the existing MyInfo v3 route. No caller links to this route yet, so it's reachable only by a client that already knows the exact path.

**Breaking Changes**

No - backwards compatible. New, unlinked route.

## Tests

**TC1: FAPI login route is reachable**

- [ ] `GET /mi/fapi/login` on a running backend returns a redirect (not a 404), confirming the router is mounted
