### PR TITLE
feat(myinfo): migrate MyInfo login to FAPI 2.0 flow

### DIFF
--- a/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -38,6 +38,7 @@ import { MYINFO_FAPI_SESSION_COOKIE_NAME } from '../../../myinfo/fapi/myinfo.fap
 import {
   MyInfoFapiIncompleteLoginError,
   MyInfoFapiMissingSessionError,
+  MyInfoFapiSessionFormMismatchError,
 } from '../../../myinfo/fapi/myinfo.fapi.errors'
 import * as MyInfoFapiService from '../../../myinfo/fapi/myinfo.fapi.service'
 import {
@@ -789,6 +790,36 @@ describe('public-form.controller', () => {
           form: MOCK_MYINFO_FORM.getPublicView(),
           isIntranetUser: false,
           errorCodes: [ErrorCode.myInfo],
+        })
+      })
+
+      it('should leave a session belonging to another form untouched', async () => {
+        MockMyInfoFapiService.loadPersonForSession.mockReturnValueOnce(
+          errAsync(new MyInfoFapiSessionFormMismatchError()),
+        )
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
+
+        await PublicFormController.handleGetPublicForm(
+          mockReqWithFapiCookie,
+          mockRes,
+          jest.fn(),
+        )
+
+        expect(MockMyInfoFapiService.loadPersonForSession).toHaveBeenCalledWith(
+          {
+            sessionId: MOCK_FAPI_SESSION_ID,
+            formId: MOCK_FORM_ID,
+          },
+        )
+        expect(mockRes.clearCookie).not.toHaveBeenCalledWith(
+          MYINFO_FAPI_SESSION_COOKIE_NAME,
+          expect.anything(),
+        )
+        expect(mockRes.json).toHaveBeenCalledWith({
+          form: MOCK_MYINFO_FORM.getPublicView(),
+          isIntranetUser: false,
         })
       })
     })

--- a/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -34,6 +34,12 @@ import {
 
 import * as AuthService from '../../../auth/auth.service'
 import * as BillingService from '../../../billing/billing.service'
+import { MYINFO_FAPI_SESSION_COOKIE_NAME } from '../../../myinfo/fapi/myinfo.fapi.constants'
+import {
+  MyInfoFapiIncompleteLoginError,
+  MyInfoFapiMissingSessionError,
+} from '../../../myinfo/fapi/myinfo.fapi.errors'
+import * as MyInfoFapiService from '../../../myinfo/fapi/myinfo.fapi.service'
 import {
   MYINFO_AUTH_CODE_COOKIE_NAME,
   MYINFO_LOGIN_COOKIE_NAME,
@@ -65,6 +71,7 @@ jest.mock('../../../auth/auth.service')
 jest.mock('../../../spcp/spcp.oidc.service/spcp.oidc.service.sp')
 jest.mock('../../../spcp/spcp.oidc.service/spcp.oidc.service.cp')
 jest.mock('../../../myinfo/myinfo.service')
+jest.mock('../../../myinfo/fapi/myinfo.fapi.service')
 jest.mock('../../../billing/billing.service')
 jest.mock('src/app/config/features/spcp-myinfo.config')
 
@@ -78,6 +85,7 @@ const MockPublicFormService = jest.mocked(PublicFormService)
 const MockAuthService = jest.mocked(AuthService)
 
 const MockMyInfoService = jest.mocked(MyInfoService)
+const MockMyInfoFapiService = jest.mocked(MyInfoFapiService)
 const MockBillingService = jest.mocked(BillingService)
 
 describe('public-form.controller', () => {
@@ -695,6 +703,87 @@ describe('public-form.controller', () => {
         )
 
         // Assert
+        expect(mockRes.clearCookie).toHaveBeenCalled()
+        expect(mockRes.json).toHaveBeenCalledWith({
+          form: MOCK_MYINFO_FORM.getPublicView(),
+          isIntranetUser: false,
+          errorCodes: [ErrorCode.myInfo],
+        })
+      })
+    })
+
+    describe('myInfo FAPI login', () => {
+      const MOCK_MYINFO_FORM = {
+        ...BASE_FORM,
+        toJSON: jest.fn().mockReturnThis(),
+        authType: FormAuthType.MyInfo,
+      } as unknown as IPopulatedForm
+
+      const MOCK_FAPI_SESSION_ID = 'mock-fapi-session-id'
+
+      let mockReqWithFapiCookie: Request<{ formId: string }>
+
+      beforeEach(() => {
+        MockAuthService.getFormIfPublic.mockReturnValue(
+          okAsync(MOCK_MYINFO_FORM),
+        )
+        MockFormService.checkIsIntranetFormAccess.mockReturnValue(false)
+        MockFormService.checkFormSubmissionLimitAndDeactivateForm.mockReturnValue(
+          okAsync(MOCK_MYINFO_FORM),
+        )
+        MockFormService.checkFormSmsLimitAndDeactivateForm.mockReturnValue(
+          okAsync(MOCK_MYINFO_FORM),
+        )
+        MockBillingService.recordLoginByForm.mockReturnValue(
+          okAsync(MOCK_LOGIN_DOC),
+        )
+
+        mockReqWithFapiCookie = expressHandler.mockRequest({
+          params: { formId: MOCK_FORM_ID },
+          others: {
+            cookies: {},
+            signedCookies: {
+              [MYINFO_FAPI_SESSION_COOKIE_NAME]: MOCK_FAPI_SESSION_ID,
+            },
+          },
+        })
+      })
+
+      it('should return 200 with no errorCodes and not log an error when login was never completed', async () => {
+        MockMyInfoFapiService.loadPersonForSession.mockReturnValueOnce(
+          errAsync(new MyInfoFapiIncompleteLoginError()),
+        )
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
+
+        await PublicFormController.handleGetPublicForm(
+          mockReqWithFapiCookie,
+          mockRes,
+          jest.fn(),
+        )
+
+        expect(mockRes.clearCookie).toHaveBeenCalled()
+        expect(mockRes.json).toHaveBeenCalledWith({
+          form: MOCK_MYINFO_FORM.getPublicView(),
+          isIntranetUser: false,
+        })
+      })
+
+      it('should return 200 with myInfoError when the login genuinely failed', async () => {
+        MockMyInfoFapiService.loadPersonForSession.mockReturnValueOnce(
+          errAsync(new MyInfoFapiMissingSessionError()),
+        )
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
+
+        await PublicFormController.handleGetPublicForm(
+          mockReqWithFapiCookie,
+          mockRes,
+          jest.fn(),
+        )
+
         expect(mockRes.clearCookie).toHaveBeenCalled()
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_MYINFO_FORM.getPublicView(),

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -27,6 +27,12 @@ import { createReqMeta, getRequestIp } from '../../../utils/request'
 import { getFormIfPublic } from '../../auth/auth.service'
 import * as BillingService from '../../billing/billing.service'
 import { ControllerHandler } from '../../core/core.types'
+import { MYINFO_FAPI_SESSION_COOKIE_NAME } from '../../myinfo/fapi/myinfo.fapi.constants'
+import {
+  clearMyInfoFapiSessionCookie,
+  setMyInfoFapiSessionCookie,
+} from '../../myinfo/fapi/myinfo.fapi.controller'
+import * as MyInfoFapiService from '../../myinfo/fapi/myinfo.fapi.service'
 import { MyInfoData } from '../../myinfo/myinfo.adapter'
 import {
   MYINFO_AUTH_CODE_COOKIE_NAME,
@@ -203,6 +209,32 @@ export const handleGetPublicForm: ControllerHandler<
       // We always want to clear existing login cookies because we no longer
       // have the prefilled data
       res.clearCookie(MYINFO_LOGIN_COOKIE_NAME, MYINFO_LOGIN_COOKIE_OPTIONS)
+
+      // If FAPI session cookie exists, means user started with FAPI login
+      // Cookie is cleared here to avoid double login.
+      const fapiSessionId: unknown =
+        req.signedCookies?.[MYINFO_FAPI_SESSION_COOKIE_NAME]
+      if (typeof fapiSessionId === 'string' && fapiSessionId) {
+        clearMyInfoFapiSessionCookie(res)
+        const fapiFieldsResult =
+          await MyInfoFapiService.loadPersonForSession(fapiSessionId)
+        if (fapiFieldsResult.isErr()) {
+          logger.error({
+            message: 'MyInfo FAPI login error',
+            meta: logMeta,
+            error: fapiFieldsResult.error,
+          })
+          return res.json({
+            form: publicForm,
+            errorCodes: [ErrorCode.myInfo],
+            isIntranetUser,
+          })
+        }
+        myInfoFields = fapiFieldsResult.value
+        spcpSession = { userName: myInfoFields.getUinFin() }
+        break
+      }
+
       const authCodeCookie: unknown = req.cookies[MYINFO_AUTH_CODE_COOKIE_NAME]
       // No auth code cookie because user is accessing the form before logging
       // in
@@ -691,8 +723,20 @@ export const _handleFormAuthRedirect: ControllerHandler<
       const useStateNonce =
         req.growthbook?.isOn(featureFlags.spcpOidcStateNonce) ?? false
       const nonce = useStateNonce ? randomBytes(16).toString('hex') : undefined
+      const useMyInfoFapi =
+        req.growthbook?.isOn(featureFlags.myinfoFapi) ?? false
       switch (form.authType) {
-        case FormAuthType.MyInfo:
+        case FormAuthType.MyInfo: {
+          if (useMyInfoFapi) {
+            return MyInfoFapiService.startLogin({
+              formId,
+              encodedQuery,
+              requestedAttributes: form.getUniqueMyInfoAttrs(),
+            }).map(({ sessionId, redirectUrl }) => {
+              setMyInfoFapiSessionCookie(res, sessionId)
+              return redirectUrl
+            })
+          }
           return getMyInfoEserviceIdInForm(form, useFormsgEsrvcId).andThen(
             ([form, eserviceId]) =>
               MyInfoService.createRedirectURL({
@@ -702,6 +746,7 @@ export const _handleFormAuthRedirect: ControllerHandler<
                 encodedQuery,
               }),
           )
+        }
         case FormAuthType.SP: {
           return validateSpcpForm(form).asyncAndThen((form) => {
             const target = getRedirectTargetSpcpOidc(

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -32,6 +32,7 @@ import {
   clearMyInfoFapiSessionCookie,
   setMyInfoFapiSessionCookie,
 } from '../../myinfo/fapi/myinfo.fapi.controller'
+import { MyInfoFapiIncompleteLoginError } from '../../myinfo/fapi/myinfo.fapi.errors'
 import * as MyInfoFapiService from '../../myinfo/fapi/myinfo.fapi.service'
 import { MyInfoData } from '../../myinfo/myinfo.adapter'
 import {
@@ -219,10 +220,18 @@ export const handleGetPublicForm: ControllerHandler<
         const fapiFieldsResult =
           await MyInfoFapiService.loadPersonForSession(fapiSessionId)
         if (fapiFieldsResult.isErr()) {
+          const { error: fapiError } = fapiFieldsResult
+          // Respondent never reached, or hasn't yet reached, the Singpass
+          // callback (e.g. navigated back before completing login). Not a
+          // failure, treat as no login attempt.
+          if (fapiError instanceof MyInfoFapiIncompleteLoginError) {
+            return res.json({ form: publicForm, isIntranetUser })
+          }
+
           logger.error({
             message: 'MyInfo FAPI login error',
             meta: logMeta,
-            error: fapiFieldsResult.error,
+            error: fapiError,
           })
           return res.json({
             form: publicForm,
@@ -230,6 +239,7 @@ export const handleGetPublicForm: ControllerHandler<
             isIntranetUser,
           })
         }
+
         myInfoFields = fapiFieldsResult.value
         spcpSession = { userName: myInfoFields.getUinFin() }
         break

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -32,7 +32,10 @@ import {
   clearMyInfoFapiSessionCookie,
   setMyInfoFapiSessionCookie,
 } from '../../myinfo/fapi/myinfo.fapi.controller'
-import { MyInfoFapiIncompleteLoginError } from '../../myinfo/fapi/myinfo.fapi.errors'
+import {
+  MyInfoFapiIncompleteLoginError,
+  MyInfoFapiSessionFormMismatchError,
+} from '../../myinfo/fapi/myinfo.fapi.errors'
 import * as MyInfoFapiService from '../../myinfo/fapi/myinfo.fapi.service'
 import { MyInfoData } from '../../myinfo/myinfo.adapter'
 import {
@@ -211,16 +214,23 @@ export const handleGetPublicForm: ControllerHandler<
       // have the prefilled data
       res.clearCookie(MYINFO_LOGIN_COOKIE_NAME, MYINFO_LOGIN_COOKIE_OPTIONS)
 
-      // If FAPI session cookie exists, means user started with FAPI login
-      // Cookie is cleared here to avoid double login.
+      // If a FAPI session cookie exists, the user started a FAPI login.
       const fapiSessionId: unknown =
         req.signedCookies?.[MYINFO_FAPI_SESSION_COOKIE_NAME]
       if (typeof fapiSessionId === 'string' && fapiSessionId) {
-        clearMyInfoFapiSessionCookie(res)
-        const fapiFieldsResult =
-          await MyInfoFapiService.loadPersonForSession(fapiSessionId)
+        const fapiFieldsResult = await MyInfoFapiService.loadPersonForSession({
+          sessionId: fapiSessionId,
+          formId,
+        })
         if (fapiFieldsResult.isErr()) {
           const { error: fapiError } = fapiFieldsResult
+          // Another form can carry this origin-wide cookie. Leave both the
+          // cookie and session untouched for the form that started the login.
+          if (fapiError instanceof MyInfoFapiSessionFormMismatchError) {
+            return res.json({ form: publicForm, isIntranetUser })
+          }
+
+          clearMyInfoFapiSessionCookie(res)
           // Respondent never reached, or hasn't yet reached, the Singpass
           // callback (e.g. navigated back before completing login). Not a
           // failure, treat as no login attempt.
@@ -240,6 +250,7 @@ export const handleGetPublicForm: ControllerHandler<
           })
         }
 
+        clearMyInfoFapiSessionCookie(res)
         myInfoFields = fapiFieldsResult.value
         spcpSession = { userName: myInfoFields.getUinFin() }
         break

--- a/packages/shared/constants/feature-flags.ts
+++ b/packages/shared/constants/feature-flags.ts
@@ -36,6 +36,7 @@ export const featureFlags = {
   workflowBuilderRedesign: 'workflow-builder-redesign' as const,
   formIdJson: 'formid-json' as const,
   mrfPayments: 'mrf-payments' as const,
+  myinfoFapi: 'myinfo-fapi' as const,
 }
 
 export enum AdminEmailPdfFeatureValue {


### PR DESCRIPTION
## Problem

MyInfo forms still redirect through the v3 login flow. To migrate to FAPI 2.0, form auth redirect and the public-form loader need to actually use the new flow.

## Solution

Redirects MyInfo-authed forms through the FAPI 2.0 flow behind the new `myinfo-fapi` GrowthBook flag (default off). On form load, if a FAPI session cookie is present, it's read to load the respondent's person data instead of the v3 auth-code cookie, and cleared to avoid a double login. The lookup is scoped to the form being loaded, so a session started from another form is refused and surfaces `ErrorCode.myInfo` rather than prefilling from a scope that form never requested. Turning the flag on in GrowthBook is the actual rollout step, independent of this deploy.

**Breaking Changes**

No - backwards compatible. Flag defaults off; v3 MyInfo login is unaffected until the flag is turned on.

## Screenshots

`redirectUrl` returned should be `/fapi/auth`.

<img width="984" height="565" alt="Screenshot 2026-09-07 at 09-31-18" src="https://github.com/user-attachments/assets/cf4949ce-7ffc-478b-b985-c894b284353a" />

MyInfo forms should prefill as expected.

<img width="811" height="595" alt="Screenshot 2026-09-07 at 09-34-12" src="https://github.com/user-attachments/assets/24ca9ba6-3638-40b1-b98f-be0f3cf7c271" />


## Tests

**TC1: Flag off - v3 flow unaffected**

- [ ] With `myinfo-fapi` off, load and log in to a MyInfo form; confirm the existing v3 flow still runs end to end

**TC2: Flag on - FAPI 2.0 flow**

- [ ] With `myinfo-fapi` on, load a MyInfo form; confirm auth redirect goes through `/mi/fapi/login` and the form loads with the respondent's MyInfo fields prefilled after login
- [ ] Reload the form page after a successful FAPI login; confirm the FAPI session cookie is cleared and a second load doesn't re-trigger the flow

**TC3: Flag on - a session can't be redeemed on a different form**

- [ ] With `myinfo-fapi` on, start a login on one MyInfo form, then load a *different* MyInfo form in the same browser before completing it
- [ ] Confirm the second form does not prefill and shows the MyInfo error, and that the original form can still complete its login

