### PR TITLE
feat(submission): serve pre-migration encrypt submissions on the MRF individual response view (1/4)

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -23,7 +23,10 @@ import getSubmissionModel, {
 import { buildMrfMetadata } from 'src/app/modules/submission/submission.utils'
 import { WorkflowWebhookEventObject } from 'src/app/modules/webhook/webhook.types'
 
-import { ISubmissionSchema } from '../../../types'
+import {
+  ISubmissionSchema,
+  MultirespondentSubmissionData,
+} from '../../../types'
 import getPaymentModel from '../payment.server.model'
 
 jest.mock('dns', () => ({
@@ -688,6 +691,146 @@ describe('Submission Model', () => {
 
         // Assert
         expect(actualResult).toEqual([])
+      })
+    })
+
+    describe('findEncryptedOrMultirespondentSubmissionById', () => {
+      it('should find an encrypt submission on the form', async () => {
+        // Arrange
+        const submission = await EncryptedSubmission.create(
+          MOCK_ENCRYPT_SUBMISSION_PARAMS,
+        )
+
+        // Act
+        const actualResult =
+          await Submission.findEncryptedOrMultirespondentSubmissionById(
+            MOCK_FORM_ID.toHexString(),
+            submission._id.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult).not.toBeNull()
+        expect(actualResult?.submissionType).toEqual(SubmissionType.Encrypt)
+        expect(actualResult?.encryptedContent).toEqual(MOCK_ENCRYPTED_CONTENT)
+        expect(actualResult?.version).toEqual(1)
+      })
+
+      it('should find an encrypt submission with version 2.1', async () => {
+        // Arrange
+        const submission = await EncryptedSubmission.create({
+          ...MOCK_ENCRYPT_SUBMISSION_PARAMS,
+          version: 2.1,
+        })
+
+        // Act
+        const actualResult =
+          await Submission.findEncryptedOrMultirespondentSubmissionById(
+            MOCK_FORM_ID.toHexString(),
+            submission._id.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult?.submissionType).toEqual(SubmissionType.Encrypt)
+        expect(actualResult?.version).toEqual(2.1)
+      })
+
+      it('should find a multirespondent submission on the form', async () => {
+        // Arrange
+        const submission = await MultirespondentSubmission.create(
+          MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+        )
+
+        // Act
+        const actualResult =
+          await Submission.findEncryptedOrMultirespondentSubmissionById(
+            MOCK_FORM_ID.toHexString(),
+            submission._id.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult).not.toBeNull()
+        expect(actualResult?.submissionType).toEqual(
+          SubmissionType.Multirespondent,
+        )
+        const mrfResult = actualResult as MultirespondentSubmissionData
+        expect(mrfResult.encryptedSubmissionSecretKey).toEqual(
+          'This is an encrypted secret key',
+        )
+        expect(mrfResult.workflow).toBeDefined()
+      })
+
+      it('should find every submission type on a mode-migrated form holding encrypt, v3 and v4 submissions', async () => {
+        // Arrange
+        const encryptSubmission = await EncryptedSubmission.create(
+          MOCK_ENCRYPT_SUBMISSION_PARAMS,
+        )
+        const mrfV3Submission = await MultirespondentSubmission.create(
+          MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+        )
+        const mrfV4Submission = await MultirespondentSubmission.create({
+          ...MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+          version: 4,
+          mrfVersion: 2,
+        })
+
+        // Act
+        const results = await Promise.all(
+          [encryptSubmission, mrfV3Submission, mrfV4Submission].map(
+            (submission) =>
+              Submission.findEncryptedOrMultirespondentSubmissionById(
+                MOCK_FORM_ID.toHexString(),
+                submission._id.toHexString(),
+              ),
+          ),
+        )
+
+        // Assert
+        expect(results[0]?.submissionType).toEqual(SubmissionType.Encrypt)
+        expect(results[1]?.submissionType).toEqual(
+          SubmissionType.Multirespondent,
+        )
+        expect(results[1]?.version).toEqual(3)
+        expect(results[2]?.submissionType).toEqual(
+          SubmissionType.Multirespondent,
+        )
+        expect(results[2]?.version).toEqual(4)
+        expect(
+          (results[2] as MultirespondentSubmissionData).mrfVersion,
+        ).toEqual(2)
+      })
+
+      it('should return null for an email submission on the same form', async () => {
+        // Arrange
+        const submission = await EmailSubmission.create(
+          MOCK_EMAIL_SUBMISSION_PARAMS,
+        )
+
+        // Act
+        const actualResult =
+          await Submission.findEncryptedOrMultirespondentSubmissionById(
+            MOCK_FORM_ID.toHexString(),
+            submission._id.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult).toBeNull()
+      })
+
+      it('should return null when the submission belongs to another form', async () => {
+        // Arrange
+        const submission = await EncryptedSubmission.create(
+          MOCK_ENCRYPT_SUBMISSION_PARAMS,
+        )
+
+        // Act
+        const actualResult =
+          await Submission.findEncryptedOrMultirespondentSubmissionById(
+            new ObjectId().toHexString(),
+            submission._id.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult).toBeNull()
       })
     })
 

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -31,6 +31,7 @@ import {
   MultirespondentSubmissionData,
   StorageModeSubmissionCursorData,
   StorageModeSubmissionData,
+  SubmissionData,
   SubmissionWebhookInfo,
   WebhookData,
   WebhookView,
@@ -238,6 +239,43 @@ SubmissionSchema.statics.saveIfSubmitterIdIsUnique = async function (
   await session.endSession()
   return afterCreateRes[0]
 }
+
+SubmissionSchema.statics.findEncryptedOrMultirespondentSubmissionById =
+  function (
+    this: ISubmissionModel,
+    formId: string,
+    submissionId: string,
+  ): Promise<SubmissionData | null> {
+    // Multirespondent forms mode-migrated from storage mode retain their
+    // pre-migration encrypt submissions, so this lookup spans both types.
+    // Email submissions have no encrypted content and stay excluded.
+    return this.findOne({
+      _id: submissionId,
+      form: formId,
+      submissionType: {
+        $in: [SubmissionType.Encrypt, SubmissionType.Multirespondent],
+      },
+    })
+      .select({
+        submissionType: 1,
+        encryptedContent: 1,
+        verifiedContent: 1,
+        attachmentMetadata: 1,
+        paymentId: 1,
+        created: 1,
+        version: 1,
+        form_fields: 1,
+        form_logics: 1,
+        workflow: 1,
+        submissionPublicKey: 1,
+        encryptedSubmissionSecretKey: 1,
+        workflowStep: 1,
+        mrfVersion: 1,
+        ...buildAdminSubmittedStepsMongoProjection(),
+        encryptedStepToken: 1,
+      })
+      .exec() as Promise<SubmissionData | null>
+  }
 
 // Exported for use in pending submissions model
 export const EmailSubmissionSchema = new Schema<IEmailSubmissionSchema>({

--- a/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -1329,6 +1329,67 @@ describe('submission.service', () => {
         mockSubmissionId,
       )
     })
+
+    it('should look up multirespondent forms across both submission types via the base model', async () => {
+      // Arrange
+      // A mode-migrated multirespondent form can hold a pre-migration encrypt
+      // submission; the multirespondent read path must still find it.
+      const expected = {
+        submissionType: SubmissionType.Encrypt,
+        encryptedContent: 'mock encrypted content',
+        verifiedContent: 'mock verified content',
+        attachmentMetadata: new Map(),
+        created: new Date(),
+        version: 1,
+      } as unknown as StorageModeSubmissionData
+
+      const mixedLookupSpy = jest
+        .spyOn(Submission, 'findEncryptedOrMultirespondentSubmissionById')
+        .mockResolvedValueOnce(expected)
+      const mrfLookupSpy = jest.spyOn(
+        MultirespondentSubmission,
+        'findEncryptedSubmissionById',
+      )
+      const mockFormId = new ObjectId().toHexString()
+      const mockSubmissionId = new ObjectId().toHexString()
+
+      // Act
+      const actualResult = await SubmissionService.getEncryptedSubmissionData(
+        FormResponseMode.Multirespondent,
+        mockFormId,
+        mockSubmissionId,
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expected)
+      expect(mixedLookupSpy).toHaveBeenCalledWith(mockFormId, mockSubmissionId)
+      expect(mrfLookupSpy).not.toHaveBeenCalled()
+    })
+
+    it('should return SubmissionNotFoundError when the mixed-type lookup finds nothing', async () => {
+      // Arrange
+      jest
+        .spyOn(Submission, 'findEncryptedOrMultirespondentSubmissionById')
+        .mockResolvedValueOnce(null)
+      const mockFormId = new ObjectId().toHexString()
+      const mockSubmissionId = new ObjectId().toHexString()
+
+      // Act
+      const actualResult = await SubmissionService.getEncryptedSubmissionData(
+        FormResponseMode.Multirespondent,
+        mockFormId,
+        mockSubmissionId,
+      )
+
+      // Assert
+      expect(actualResult.isErr()).toEqual(true)
+      expect(actualResult._unsafeUnwrapErr()).toEqual(
+        new SubmissionNotFoundError(
+          'Unable to find encrypted submission from database',
+        ),
+      )
+    })
   })
 
   describe('getSubmissionCursor', () => {

--- a/apps/backend/src/app/modules/submission/submission.service.ts
+++ b/apps/backend/src/app/modules/submission/submission.service.ts
@@ -619,10 +619,18 @@ export const getEncryptedSubmissionData = (
   getEncryptedSubmissionModelByResponseMode(responseMode).asyncAndThen(
     (modelToUse) =>
       ResultAsync.fromPromise(
-        modelToUse.findEncryptedSubmissionById(
-          formId,
-          submissionId,
-        ) as Promise<SubmissionData | null>,
+        // Multirespondent forms mode-migrated from storage mode retain their
+        // pre-migration encrypt submissions, so the lookup must span both
+        // submission types via the base model.
+        responseMode === FormResponseMode.Multirespondent
+          ? SubmissionModel.findEncryptedOrMultirespondentSubmissionById(
+              formId,
+              submissionId,
+            )
+          : (modelToUse.findEncryptedSubmissionById(
+              formId,
+              submissionId,
+            ) as Promise<SubmissionData | null>),
         (error) => {
           logger.error({
             message: 'Failure retrieving encrypted submission from database',

--- a/apps/backend/src/types/submission.ts
+++ b/apps/backend/src/types/submission.ts
@@ -137,6 +137,20 @@ export interface ISubmissionModel extends Model<ISubmissionSchema> {
     submissionId: string,
     webhookResponse: WebhookResponse,
   ): Promise<ISubmissionSchema | null>
+
+  /**
+   * Finds a single admin-viewable submission of a form by id, across both
+   * Encrypt and Multirespondent submission types. Multirespondent forms
+   * mode-migrated from storage mode retain their pre-migration encrypt
+   * submissions, so the lookup must not be pinned to one discriminator.
+   * Email submissions are deliberately excluded.
+   * @param formId the id of the form the submission belongs to
+   * @param submissionId the id of the submission to retrieve
+   */
+  findEncryptedOrMultirespondentSubmissionById(
+    formId: string,
+    submissionId: string,
+  ): Promise<SubmissionData | null>
 }
 
 export interface IEmailSubmissionSchema

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.tsx
@@ -299,6 +299,9 @@ export const IndividualResponsePage = (): JSX.Element => {
             </Stack>
           )}
           {form?.responseMode === FormResponseMode.Multirespondent &&
+            // Pre-mode-migration encrypt submissions have no submission secret
+            // key, so no valid response link can be built for them.
+            data?.submissionSecretKey &&
             user?.betaFlags?.mrfAdminSubmissionKey && (
               <StackRow
                 label={t(


### PR DESCRIPTION
## Problem

Storage-mode forms will be mode-migrated to multirespondent (MRF) forms via an in-place `responseMode` flip that keeps the form's keypair, field ids, and all existing submission documents. A migrated form therefore permanently holds encrypt-mode submissions (versions 1 and 2.1) alongside multirespondent ones (versions 3 and 4). The admin individual-response fetch resolved a single Mongoose discriminator model from `form.responseMode`, whose injected `submissionType` filter made pre-migration encrypt submissions invisible — opening one 404s. Closes #9919.

## Solution

For multirespondent forms, the single-submission lookup now goes through a new base-`Submission`-model static with an explicit `submissionType: { $in: [Encrypt, Multirespondent] }` filter, branching per document afterwards. The controller already switches on the submission's own `submissionType` when building the DTO, and the frontend already branches per submission when decrypting — so an encrypt submission on an MRF form renders as an MRF submission with no workflow (empty status, "-" pending-response-at), decrypts content and attachments with the form secret key, and keeps PDF export. Applies to all MRF forms uniformly (no migrated-form flag): non-migrated forms simply have zero encrypt docs. Email submissions stay excluded — they carry no encrypted content.

This is PR 1 of a 4-PR stack (individual fetch → download stream/CSV → metadata/dashboard → payments), tracking issues #9919–#9922.

**Alternatives considered**

- We considered querying both discriminator models and merging in the service, but skipped it: it's a pointless double round-trip for a point lookup, and it doesn't generalise to the stream and metadata slices later in this stack, where merge-sort pagination across two sorted queries gets genuinely painful.
- We considered a fallback lookup (retry the other model on a miss), but that only works for point lookups — it composes with neither streams nor aggregations.
- We deliberately do **not** branch on `submission.version` to pick a decryption path: `version` and payload shape are decoupled in both directions in this codebase (the receiver shim keeps `version: 3` on V4-shaped payloads; the MRF middleware stores V3-shaped payloads under `version: 4` when `mrfVersion !== 2`). Dispatch is on `submissionType` only; payload-shape sniffing and `mrfVersion` handle the rest, unchanged.

**Screenshots**

Omitted — the changed rendering is only observable on a mode-migrated form, which cannot exist until the migration tool lands. Covered by the pre-migration staging dry-run gate instead.

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: encrypt submission on a mode-migrated MRF form (staging, post-dry-run)**

- [ ] Open a pre-migration encrypt submission from the responses list of a migrated form
- [ ] Verify it renders with empty workflow status and "-" for pending response at
- [ ] Verify content and attachments decrypt with the form secret key, and PDF export works

**TC2: existing MRF submissions unaffected**

- [ ] Open a v3 and a v4 MRF submission on any MRF form; verify rendering is unchanged (workflow status, pending-at, attachments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
