### PR TITLE
feat(submission): stream pre-migration encrypt rows in MRF exports (2/4)

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -25,6 +25,7 @@ import { WorkflowWebhookEventObject } from 'src/app/modules/webhook/webhook.type
 
 import {
   ISubmissionSchema,
+  MultirespondentSubmissionCursorData,
   MultirespondentSubmissionData,
 } from '../../../types'
 import getPaymentModel from '../payment.server.model'
@@ -831,6 +832,91 @@ describe('Submission Model', () => {
 
         // Assert
         expect(actualResult).toBeNull()
+      })
+    })
+
+    describe('getEncryptedOrMultirespondentSubmissionCursorByFormId', () => {
+      it('should stream each encrypt and multirespondent submission exactly once, excluding email submissions', async () => {
+        // Arrange
+        // A mode-migrated form: one encrypt, one MRF v3, one MRF v4 and one
+        // email submission all on the same form.
+        const encryptSubmission = await EncryptedSubmission.create(
+          MOCK_ENCRYPT_SUBMISSION_PARAMS,
+        )
+        const mrfV3Submission = await MultirespondentSubmission.create(
+          MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+        )
+        const mrfV4Submission = await MultirespondentSubmission.create({
+          ...MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+          version: 4,
+          mrfVersion: 2,
+        })
+        await EmailSubmission.create(MOCK_EMAIL_SUBMISSION_PARAMS)
+
+        // Act
+        const cursor =
+          Submission.getEncryptedOrMultirespondentSubmissionCursorByFormId(
+            MOCK_FORM_ID.toHexString(),
+            {},
+          )
+        const docs = []
+        for await (const doc of cursor) docs.push(doc)
+
+        // Assert
+        expect(docs).toHaveLength(3)
+        const docIds = docs.map((doc) => String(doc._id)).sort()
+        expect(docIds).toEqual(
+          [encryptSubmission._id, mrfV3Submission._id, mrfV4Submission._id]
+            .map(String)
+            .sort(),
+        )
+        const typeCounts = docs.reduce<Record<string, number>>((acc, doc) => {
+          acc[doc.submissionType] = (acc[doc.submissionType] ?? 0) + 1
+          return acc
+        }, {})
+        expect(typeCounts).toEqual({
+          [SubmissionType.Encrypt]: 1,
+          [SubmissionType.Multirespondent]: 2,
+        })
+      })
+
+      it('should not load unclassified step sub-fields for multirespondent docs', async () => {
+        // Arrange
+        await MultirespondentSubmission.create({
+          ...MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+          submittedSteps: [
+            {
+              isApproval: true,
+              submittedAt: '2026-07-22T00:00:00.000Z',
+              status: WorkflowStatus.APPROVED,
+              nextStepRecipientEmails: ['next@example.com'],
+              submitterId: 'SUBMITTER_ID_HASH',
+              snapshotTokens: { v4: 'SNAPSHOT_TOKEN_LEAF_VALUE' },
+            },
+          ],
+        })
+
+        // Act
+        const cursor =
+          Submission.getEncryptedOrMultirespondentSubmissionCursorByFormId(
+            MOCK_FORM_ID.toHexString(),
+            {},
+          )
+        const docs = []
+        for await (const doc of cursor) docs.push(doc)
+
+        // Assert
+        expect(docs).toHaveLength(1)
+        expect(
+          (docs[0] as MultirespondentSubmissionCursorData).submittedSteps,
+        ).toEqual([
+          {
+            isApproval: true,
+            submittedAt: '2026-07-22T00:00:00.000Z',
+            status: WorkflowStatus.APPROVED,
+            nextStepRecipientEmails: ['next@example.com'],
+          },
+        ])
       })
     })
 

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -31,6 +31,7 @@ import {
   MultirespondentSubmissionData,
   StorageModeSubmissionCursorData,
   StorageModeSubmissionData,
+  SubmissionCursorData,
   SubmissionData,
   SubmissionWebhookInfo,
   WebhookData,
@@ -275,6 +276,65 @@ SubmissionSchema.statics.findEncryptedOrMultirespondentSubmissionById =
         encryptedStepToken: 1,
       })
       .exec() as Promise<SubmissionData | null>
+  }
+
+SubmissionSchema.statics.getEncryptedOrMultirespondentSubmissionCursorByFormId =
+  function (
+    this: ISubmissionModel,
+    formId: string,
+    dateRange: {
+      startDate?: string
+      endDate?: string
+    } = {},
+    isSortByLatest = false,
+    limit?: number,
+  ): QueryCursor<SubmissionCursorData, QueryOptions<ISubmissionSchema>> {
+    // Multirespondent forms mode-migrated from storage mode retain their
+    // pre-migration encrypt submissions, so the stream must span both types
+    // in one cursor to keep sort order and completeness. Email submissions
+    // have no encrypted content and stay excluded.
+    const streamQuery = {
+      form: formId,
+      submissionType: {
+        $in: [SubmissionType.Encrypt, SubmissionType.Multirespondent],
+      },
+      ...createQueryWithDateParam(dateRange?.startDate, dateRange?.endDate),
+    }
+    let query = this.find(streamQuery).select({
+      submissionType: 1,
+      encryptedContent: 1,
+      verifiedContent: 1,
+      attachmentMetadata: 1,
+      created: 1,
+      version: 1,
+      form_fields: 1,
+      form_logics: 1,
+      workflow: 1,
+      workflowStep: 1,
+      ...buildAdminSubmittedStepsMongoProjection(),
+      encryptedSubmissionSecretKey: 1,
+      mrfVersion: 1,
+      id: 1,
+    })
+    if (isSortByLatest) {
+      query = query.sort({ created: -1 })
+    }
+    if (limit && limit > 0 && Number.isSafeInteger(limit)) {
+      query = query.limit(limit)
+    }
+    return (
+      query
+        .batchSize(2000)
+        .read('secondary')
+        .lean()
+        // Override typing: Map is converted to Object once passed through
+        // `lean()`, and the base model's document type does not carry the
+        // per-discriminator fields the union projection selects.
+        .cursor() as unknown as QueryCursor<
+        SubmissionCursorData,
+        QueryOptions<ISubmissionSchema>
+      >
+    )
   }
 
 // Exported for use in pending submissions model

--- a/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -1421,6 +1421,45 @@ describe('submission.service', () => {
       expect(actualResult._unsafeUnwrap()).toEqual(mockCursor)
     })
 
+    it('should stream multirespondent forms across both submission types via the base model', async () => {
+      // Arrange
+      // A mode-migrated multirespondent form can hold pre-migration encrypt
+      // submissions; a single-discriminator cursor would silently omit them
+      // from the download stream.
+      const mockCursor = jest.fn() as unknown as ReturnType<
+        typeof Submission.getEncryptedOrMultirespondentSubmissionCursorByFormId
+      >
+      const mixedCursorSpy = jest
+        .spyOn(
+          Submission,
+          'getEncryptedOrMultirespondentSubmissionCursorByFormId',
+        )
+        .mockReturnValueOnce(mockCursor)
+      const mrfCursorSpy = jest.spyOn(
+        MultirespondentSubmission,
+        'getSubmissionCursorByFormId',
+      )
+      const mockFormId = new ObjectId().toHexString()
+
+      // Act
+      const actualResult = SubmissionService.getSubmissionCursor(
+        FormResponseMode.Multirespondent,
+        mockFormId,
+      )
+
+      // Assert
+      expect(mixedCursorSpy).toHaveBeenCalledTimes(1)
+      expect(mixedCursorSpy).toHaveBeenCalledWith(
+        mockFormId,
+        {},
+        undefined,
+        undefined,
+      )
+      expect(mrfCursorSpy).not.toHaveBeenCalled()
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(mockCursor)
+    })
+
     it('should return cursor successfully when date range is provided', async () => {
       // Arrange
       const mockCursor = jest.fn() as unknown as ReturnType<
@@ -1512,11 +1551,15 @@ describe('submission.service', () => {
 
     it('should return cursor successfully when isSortByLatest and limit are provided', () => {
       // Arrange
+      // Multirespondent forms stream via the base-model mixed-type cursor.
       const mockCursor = jest.fn() as unknown as ReturnType<
-        typeof MultirespondentSubmission.getSubmissionCursorByFormId
+        typeof Submission.getEncryptedOrMultirespondentSubmissionCursorByFormId
       >
       const getSubmissionSpy = jest
-        .spyOn(MultirespondentSubmission, 'getSubmissionCursorByFormId')
+        .spyOn(
+          Submission,
+          'getEncryptedOrMultirespondentSubmissionCursorByFormId',
+        )
         .mockReturnValueOnce(mockCursor)
       const mockFormId = new ObjectId().toHexString()
       const mockDateRange = {

--- a/apps/backend/src/app/modules/submission/submission.service.ts
+++ b/apps/backend/src/app/modules/submission/submission.service.ts
@@ -29,6 +29,7 @@ import {
   IEncryptSubmissionModel,
   IMultirespondentSubmissionModel,
   IPopulatedForm,
+  ISubmissionModel,
   ISubmissionSchema,
   MultirespondentSubmissionCursorData,
   StorageModeSubmissionCursorData,
@@ -686,6 +687,7 @@ export const getSubmissionCursor = (
   ReturnType<
     | IEncryptSubmissionModel['getSubmissionCursorByFormId']
     | IMultirespondentSubmissionModel['getSubmissionCursorByFormId']
+    | ISubmissionModel['getEncryptedOrMultirespondentSubmissionCursorByFormId']
   >,
   MalformedParametersError
 > => {
@@ -703,12 +705,22 @@ export const getSubmissionCursor = (
   return getEncryptedSubmissionModelByResponseMode(responseMode).andThen(
     (modelToUse) =>
       ok(
-        modelToUse.getSubmissionCursorByFormId(
-          formId,
-          dateRange,
-          isSortByLatest,
-          limit,
-        ),
+        // Multirespondent forms mode-migrated from storage mode retain their
+        // pre-migration encrypt submissions, so their stream must span both
+        // submission types via the base model.
+        responseMode === FormResponseMode.Multirespondent
+          ? SubmissionModel.getEncryptedOrMultirespondentSubmissionCursorByFormId(
+              formId,
+              dateRange,
+              isSortByLatest,
+              limit,
+            )
+          : modelToUse.getSubmissionCursorByFormId(
+              formId,
+              dateRange,
+              isSortByLatest,
+              limit,
+            ),
       ),
   )
 }

--- a/apps/backend/src/types/submission.ts
+++ b/apps/backend/src/types/submission.ts
@@ -151,6 +151,25 @@ export interface ISubmissionModel extends Model<ISubmissionSchema> {
     formId: string,
     submissionId: string,
   ): Promise<SubmissionData | null>
+
+  /**
+   * Returns a cursor over a form's admin-viewable submissions, spanning both
+   * Encrypt and Multirespondent submission types in one sorted stream.
+   * Multirespondent forms mode-migrated from storage mode retain their
+   * pre-migration encrypt submissions, which a single discriminator cursor
+   * cannot see. Email submissions are deliberately excluded.
+   * @param formId the id of the form to stream submissions for
+   * @param dateRange optional date range to limit submissions to
+   */
+  getEncryptedOrMultirespondentSubmissionCursorByFormId(
+    formId: string,
+    dateRange: {
+      startDate?: string
+      endDate?: string
+    },
+    isSortByLatest?: boolean,
+    limit?: number,
+  ): QueryCursor<SubmissionCursorData, QueryOptions<ISubmissionSchema>>
 }
 
 export interface IEmailSubmissionSchema

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -409,6 +409,78 @@ describe('EncryptedResponseCsvGenerator', () => {
       })
     })
 
+    describe('mode-migrated form submissions', () => {
+      it('should share one column per field id between encrypt and mrf rows, leaving mrf metadata cells empty for encrypt rows', () => {
+        // Arrange
+        // On a mode-migrated form, a pre-migration encrypt row and an MRF row
+        // answer the same field (same field id). The MRF row additionally
+        // carries the workflow-status/pending-at pseudo-fields that
+        // CsvRecord.materializeSubmissionData injects (reserved ids).
+        const mrfGenerator = new EncryptedResponseCsvGenerator(2, 0, true)
+        const sharedField = generateRecord(1)
+        const workflowStatusColumn: CsvRecordData = {
+          _id: '000000000000000000010001',
+          fieldType: 'textfield',
+          question: 'Workflow status',
+          answer: 'Rejected',
+        }
+        const pendingAtColumn: CsvRecordData = {
+          _id: '000000000000000000010002',
+          fieldType: 'textfield',
+          question: 'Pending response at',
+          answer: '',
+        }
+        const mrfRecord = {
+          record: [workflowStatusColumn, pendingAtColumn, sharedField],
+          created: mockCreatedLater,
+          submissionId: 'mockMrfSubmissionId',
+        }
+        const encryptRecord = {
+          record: [
+            { ...sharedField, answer: 'preMigrationAnswer' } as CsvRecordData,
+          ],
+          created: mockCreatedEarly,
+          submissionId: 'mockEncryptSubmissionId',
+        }
+        mrfGenerator.addRecord(encryptRecord)
+        mrfGenerator.addRecord(mrfRecord)
+
+        // Act
+        mrfGenerator.process()
+
+        // Assert
+        // One shared column for the field; empty mrf metadata cells for the
+        // encrypt row.
+        const expectedHeaderRow = stringify([
+          'Response ID',
+          MRF_RESPONSE_TIMESTAMP_LABEL,
+          sharedField.question,
+          workflowStatusColumn.question,
+          pendingAtColumn.question,
+        ])
+        const expectedEncryptRow = stringify([
+          encryptRecord.submissionId,
+          getFormattedDate(encryptRecord.created),
+          'preMigrationAnswer',
+          '',
+          '',
+        ])
+        const expectedMrfRow = stringify([
+          mrfRecord.submissionId,
+          getFormattedDate(mrfRecord.created),
+          sharedField.answer,
+          workflowStatusColumn.answer,
+          pendingAtColumn.answer,
+        ])
+        expect(mrfGenerator.records).toEqual([
+          UTF8_BYTE_ORDER_MARK,
+          expectedHeaderRow,
+          expectedEncryptRow,
+          expectedMrfRow,
+        ])
+      })
+    })
+
     describe('submissions with only answer key', () => {
       it('should handle a single submission', () => {
         // Arrange


### PR DESCRIPTION
## Problem

On a mode-migrated multirespondent form (see #9929 for the migration context), the admin download stream resolved the multirespondent discriminator cursor, whose injected `submissionType` filter silently drops every pre-migration encrypt submission — a CSV export would be missing rows with no error shown. Closes #9920.

## Solution

For multirespondent forms, the download stream now uses a base-`Submission`-model cursor with an explicit `submissionType: { $in: [Encrypt, Multirespondent] }` filter, delivering both types exactly once in one sorted stream (email submissions stay excluded). Everything downstream was already per-row: `addMrfMetadata` passes encrypt rows through untouched, the stream DTO is a discriminated union on `submissionType`, the decryption worker branches per row (form-key decrypt for encrypt rows, shape-sniffing `decryptToV4` for MRF rows), the attachment key rule falls back to the form secret key when no submission key exists, and the CSV generator keys columns by field id. Charts consumes this same stream, so pre-migration responses appear there too.

PR 2 of a 4-PR stack — stacked on #9929, tracking #9919–#9922.

**Alternatives considered**

- We considered merging two discriminator cursors in the service, but a single base-model cursor keeps sort order and completeness for free; merging two sorted streams adds bookkeeping for no benefit.
- The frontend needed no code for the mixed stream — the worker, attachment-key rule, and CSV generator already behave per-row. This PR pins that behavior with tests instead of adding code.
- `paymentId` is deliberately not yet projected in the mixed cursor: it lands in the payments slice (#9922) together with its fixtures and end-to-end verification, per the issue breakdown.

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: CSV export on a mode-migrated MRF form (staging, post-dry-run)**

- [ ] Download responses as CSV; verify pre-migration encrypt rows and MRF rows all appear, sharing one column per untouched field
- [ ] Verify encrypt rows have empty workflow-status and pending-response-at cells
- [ ] Download with attachments; verify attachments from both eras decrypt

**TC2: Charts on the mixed form**

- [ ] Open the Charts tab; verify it renders without error and includes pre-migration responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
