### PR TITLE
fix(workflow): rest delete-modal focus on the dialog, not a button (5/5)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteStepModal/DeleteStepModal.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteStepModal/DeleteStepModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Modal,
@@ -41,6 +41,20 @@ export const DeleteStepModal = ({
     md: 'md',
   })
 
+  // Chakra's focus lock takes the first tabbable element when it is not told
+  // otherwise, and that is the close button, since it is ModalContent's first
+  // child regardless of sitting in the top right corner.
+  //
+  // Focus goes to the dialog rather than to any of the buttons. Our Button and
+  // CloseButton themes paint `_focus` rather than `_focusVisible`, so a
+  // programmatically focused button shows its ring even though the admin
+  // opened the modal by clicking, and a ring sitting on an action on open reads
+  // as though something has already been chosen. The dialog carries no focus
+  // style, so nothing lights up, focus is still inside the lock, and screen
+  // readers announce the title and the consequences from role and
+  // aria-describedby.
+  const dialogRef = useRef<HTMLDivElement>(null)
+
   const handleDelete = useCallback(() => {
     // Cannot be put in onSuccess since this component will be unmounted by then.
     // No big deal even if we set to inactive here.
@@ -60,9 +74,10 @@ export const DeleteStepModal = ({
       onClose={onClose}
       size={modalSize}
       closeOnOverlayClick={!deleteStepMutation.isLoading}
+      initialFocusRef={dialogRef}
     >
       <ModalOverlay />
-      <ModalContent>
+      <ModalContent ref={dialogRef}>
         <ModalCloseButton isDisabled={deleteStepMutation.isLoading} />
         <ModalHeader color="secondary.700">{title}</ModalHeader>
         <ModalBody whiteSpace="pre-wrap">

--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.test.tsx
@@ -1,0 +1,109 @@
+import { composeStory, Meta, StoryFn } from '@storybook/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+
+import { FormResponseMode, FormStatus } from 'formsg-shared/types'
+
+import { createFormBuilderMocks } from '~/mocks/msw/handlers/admin-form'
+
+import { StoryRouter } from '~utils/storybook'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+
+import { DeleteWorkflowModal } from './DeleteWorkflowModal'
+
+/**
+ * Deliberately not composed from DeleteWorkflowModal.stories: those mock a form
+ * with no `workflow` at all, so `useWorkflowMutations` throws before the modal
+ * renders. An empty array is enough to get past that guard, and focus does not
+ * depend on the steps themselves.
+ */
+const meta = {
+  title: 'Features/AdminForm/Workflow/DeleteWorkflowModalFocus',
+  component: DeleteWorkflowModal,
+  decorators: [StoryRouter({ initialEntries: ['/12345'], path: '/:formId' })],
+} as Meta
+
+const buildParameters = (status: FormStatus) => ({
+  msw: {
+    handlers: {
+      default: createFormBuilderMocks({
+        responseMode: FormResponseMode.Multirespondent,
+        status,
+        workflow: [],
+      }),
+    },
+  },
+})
+
+/**
+ * The modal reads the workflow through useWorkflowMutations, which throws while
+ * the form query is still in flight. WorkflowContent never hits that because it
+ * returns null until the form has loaded; this mirrors that guard so the test
+ * exercises the modal the way the app actually mounts it.
+ */
+const Harness = ({
+  entryPoint,
+}: {
+  entryPoint: 'workflow-card' | 'first-step'
+}) => {
+  const { isLoading } = useAdminForm()
+  if (isLoading) return null
+  return (
+    <DeleteWorkflowModal
+      isOpen
+      onClose={() => undefined}
+      entryPoint={entryPoint}
+    />
+  )
+}
+
+const template =
+  (entryPoint: 'workflow-card' | 'first-step'): StoryFn =>
+  () => <Harness entryPoint={entryPoint} />
+
+const buildStory = (
+  entryPoint: 'workflow-card' | 'first-step',
+  status: FormStatus,
+) => {
+  const story = template(entryPoint)
+  story.parameters = buildParameters(status)
+  return composeStory(story, meta)
+}
+
+/**
+ * Focus belongs on the dialog, not on any button: the Button and CloseButton
+ * themes paint `_focus` rather than `_focusVisible`, so whichever button holds
+ * focus shows its ring the moment the modal opens, which reads as though an
+ * action has already been chosen.
+ *
+ * Scope, so nobody reads more into a green run than is there: jsdom does not
+ * reproduce the browser default this fixes. react-focus-lock picks the first
+ * tabbable element in a real browser, which is the close button, but without
+ * layout it falls back to the dialog, so these pass whether or not
+ * `initialFocusRef` is set. What they do catch is the ref being pointed at a
+ * button, which is the regression worth pinning, since a ring on Cancel or
+ * Delete is just as wrong as one on the X. The browser behaviour itself needs
+ * a manual check.
+ */
+describe('DeleteWorkflowModal initial focus', () => {
+  it.each([
+    ['from the workflow card', 'workflow-card' as const, FormStatus.Private],
+    ['from step 1', 'first-step' as const, FormStatus.Private],
+    ['when the form is open', 'workflow-card' as const, FormStatus.Public],
+  ])(
+    'rests on the dialog rather than any button %s',
+    async (_label, entryPoint, status) => {
+      // Arrange
+      const Story = buildStory(entryPoint, status)
+      await act(async () => {
+        render(<Story />)
+      })
+
+      // Assert
+      await waitFor(() => expect(screen.getByRole('dialog')).toHaveFocus())
+      for (const button of screen.getAllByRole('button')) {
+        expect(button).not.toHaveFocus()
+      }
+    },
+  )
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/DeleteWorkflowModal/DeleteWorkflowModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
@@ -76,6 +76,20 @@ export const DeleteWorkflowModal = ({
     md: 'md',
   })
 
+  // Chakra's focus lock takes the first tabbable element when it is not told
+  // otherwise, and that is the close button, since it is ModalContent's first
+  // child regardless of sitting in the top right corner.
+  //
+  // Focus goes to the dialog rather than to any of the buttons. Our Button and
+  // CloseButton themes paint `_focus` rather than `_focusVisible`, so a
+  // programmatically focused button shows its ring even though the admin
+  // opened the modal by clicking, and a ring sitting on an action on open reads
+  // as though something has already been chosen. The dialog carries no focus
+  // style, so nothing lights up, focus is still inside the lock, and screen
+  // readers announce the title and the consequences from role and
+  // aria-describedby.
+  const dialogRef = useRef<HTMLDivElement>(null)
+
   const isFormOpen = form?.status === FormStatus.Public
 
   // Full literal keys rather than an interpolated path: i18next types its keys
@@ -107,9 +121,10 @@ export const DeleteWorkflowModal = ({
       onClose={onClose}
       size={modalSize}
       closeOnOverlayClick={!isLoading}
+      initialFocusRef={dialogRef}
     >
       <ModalOverlay />
-      <ModalContent>
+      <ModalContent ref={dialogRef}>
         <ModalCloseButton isDisabled={isLoading} />
         <ModalHeader color="secondary.700">{copy.title}</ModalHeader>
         <ModalBody whiteSpace="pre-wrap">


### PR DESCRIPTION
## Problem

- Stacked on #9917. Opening any workflow delete modal puts a focus ring on the close button.
- Chakra's focus lock takes the first tabbable child, and `ModalCloseButton` is `ModalContent`'s first child.
- So the ring lands on dismissal before the consequences underneath have been read. Part of [FRM-2494](https://linear.app/ogp/issue/FRM-2494).

Affects all three: delete workflow from the card, delete step 1, and delete any other step.

## Solution

- `initialFocusRef` now points at `ModalContent` in both `DeleteWorkflowModal` and `DeleteStepModal`.
- Focus rests on the dialog, which carries no focus style, so nothing lights up.
- Our `Button` and `CloseButton` themes paint `_focus` rather than `_focusVisible`, so any button would ring on open.
- A ring sitting on an action reads as though something has already been chosen.
- Focus is still held inside the lock, and `role` plus `aria-describedby` still announce the title and consequences.

**Alternatives considered**

- Focusing Cancel, per WAI-ARIA's alertdialog guidance, rejected. Same ring, different button.
- Moving `ModalCloseButton` last, rejected as implicit. Adding a link to the copy would break it.
- `autoFocus={false}`, rejected. The first Tab still lands on the X.
- Fixing this app-wide, left alone. Around 25 of 34 modals behave this way, and it would bury this diff.

**Breaking changes:** none. Focus target only, behind the same flag as the rest of the stack.

## Screenshots

https://github.com/user-attachments/assets/621b9a17-0aad-4636-bc93-f52384c82534

## Tests

- `DeleteWorkflowModal.test.tsx` asserts, for all three states, that focus rests on the dialog and no button holds it.
- jsdom cannot reproduce the browser default this fixes: without layout, `react-focus-lock` falls back to the dialog anyway.
- What it does catch is the ref pointing at a button, confirmed by pointing it at Cancel and watching all three fail.
- `DeleteWorkflowModal.stories` mock a form with no `workflow`, so all six error out and Chromatic covers nothing. Flagged separately, since they came in with #9917.
- `DeleteStepModal` has no stories, so no coverage here.

**Manual**

- [ ] Open each of the three delete modals; confirm no button shows a focus ring.
- [ ] Press Tab once in each and confirm focus enters the buttons normally.
- [ ] Escape closes each one; close button, Cancel, and the confirm action all still work by click and keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
