### PR TITLE
feat(workflow): add the PeekCard component (1/3)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/PeekCard.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/PeekCard.stories.tsx
@@ -1,0 +1,100 @@
+import { Box, Stack } from '@chakra-ui/react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { PeekCard, PeekCardProps } from './PeekCard'
+
+export default {
+  title:
+    'Features/AdminForm/create/workflow/components/GuidedCreation/PeekCard',
+  component: PeekCard,
+} as Meta<PeekCardProps>
+
+/**
+ * The tucked variant only reads correctly beneath a card of matching width, so
+ * the stories that use it supply a stand-in for the card above rather than
+ * floating the peek card on its own.
+ */
+const CardAbove = (): JSX.Element => (
+  <Box
+    bg="white"
+    border="1px solid"
+    borderColor="neutral.300"
+    borderRadius="4px"
+    p="2rem"
+  >
+    Stand-in for the card that was just finished
+  </Box>
+)
+
+const TuckedTemplate: StoryFn<PeekCardProps> = (args) => (
+  <Stack spacing="0" maxW="42rem">
+    <CardAbove />
+    <PeekCard {...args} />
+  </Stack>
+)
+
+const FreeStandingTemplate: StoryFn<PeekCardProps> = (args) => (
+  <Box maxW="42rem">
+    <PeekCard {...args} />
+  </Box>
+)
+
+export const TwoActions = TuckedTemplate.bind({})
+TwoActions.storyName = 'Tucked, two actions'
+TwoActions.args = {
+  title: 'Nice, Step 2 is all set',
+  subtitle: 'Would you like to add another step?',
+  actions: [
+    { label: "No, I'm done", onClick: () => undefined },
+    { label: 'Yes, add a step', onClick: () => undefined },
+  ],
+}
+TwoActions.parameters = {
+  docs: {
+    description: {
+      story:
+        'The case that shapes the API. The secondary is a clear variant and the primary is solid, with the primary last.',
+    },
+  },
+}
+
+export const OneAction = TuckedTemplate.bind({})
+OneAction.storyName = 'Tucked, one action'
+OneAction.args = {
+  title: 'Your workflow is ready',
+  subtitle:
+    'Before you finish, you can let people check the status of their response.',
+  actions: [{ label: 'Done', onClick: () => undefined }],
+}
+
+export const FreeStanding = FreeStandingTemplate.bind({})
+FreeStanding.storyName = 'Free-standing'
+FreeStanding.args = {
+  title: "You've set up the completion email.",
+  subtitle: 'Next, set up an extra workflow setting.',
+  actions: [{ label: 'Continue', onClick: () => undefined }],
+  isTucked: false,
+}
+FreeStanding.parameters = {
+  docs: {
+    description: {
+      story:
+        'Full radius and no negative margin, for a card that follows a block rather than sitting under another card.',
+    },
+  },
+}
+
+export const NoSubtitle = TuckedTemplate.bind({})
+NoSubtitle.storyName = 'Tucked, no subtitle'
+NoSubtitle.args = {
+  title: "You've finished guided setup",
+  actions: [{ label: 'Done', onClick: () => undefined }],
+}
+NoSubtitle.parameters = {
+  docs: {
+    description: {
+      story:
+        'The subtitle is optional, so the title and actions close up without leaving a gap where it would have been.',
+    },
+  },
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/PeekCard.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/PeekCard.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { PeekCard } from './PeekCard'
+
+describe('PeekCard', () => {
+  it('should render the title, and the subtitle only when given one', () => {
+    const { rerender } = render(
+      <PeekCard
+        title="Nice, Step 2 is all set"
+        subtitle="Would you like to add another step?"
+        actions={[{ label: 'Done', onClick: () => undefined }]}
+      />,
+    )
+
+    expect(screen.getByText('Nice, Step 2 is all set')).toBeInTheDocument()
+    expect(
+      screen.getByText('Would you like to add another step?'),
+    ).toBeInTheDocument()
+
+    rerender(
+      <PeekCard
+        title="Nice, Step 2 is all set"
+        actions={[{ label: 'Done', onClick: () => undefined }]}
+      />,
+    )
+
+    expect(screen.getByText('Nice, Step 2 is all set')).toBeInTheDocument()
+    expect(
+      screen.queryByText('Would you like to add another step?'),
+    ).not.toBeInTheDocument()
+  })
+
+  // The reason actions is an array rather than one onDone callback: each action
+  // carries its own handler, so two of them cannot be collapsed into one.
+  it('should give each action its own handler', () => {
+    const onDecline = vi.fn()
+    const onAccept = vi.fn()
+
+    render(
+      <PeekCard
+        title="Nice, Step 2 is all set"
+        actions={[
+          { label: "No, I'm done", onClick: onDecline },
+          { label: 'Yes, add a step', onClick: onAccept },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: "No, I'm done" }))
+    expect(onDecline).toHaveBeenCalledTimes(1)
+    expect(onAccept).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, add a step' }))
+    expect(onAccept).toHaveBeenCalledTimes(1)
+    expect(onDecline).toHaveBeenCalledTimes(1)
+  })
+
+  // Primary last is positional, so the order actions arrive in is the order
+  // they render in. Getting this backwards would put the solid button first.
+  it('should render actions in the order given, primary last', () => {
+    render(
+      <PeekCard
+        title="Nice, Step 2 is all set"
+        actions={[
+          { label: "No, I'm done", onClick: () => undefined },
+          { label: 'Yes, add a step', onClick: () => undefined },
+        ]}
+      />,
+    )
+
+    expect(
+      screen.getAllByRole('button').map((button) => button.textContent),
+    ).toEqual(["No, I'm done", 'Yes, add a step'])
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/PeekCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/PeekCard.tsx
@@ -1,0 +1,96 @@
+import { Box, Flex, Stack, Text } from '@chakra-ui/react'
+
+import Button from '~components/Button'
+
+export interface PeekCardAction {
+  label: string
+  onClick: () => void
+}
+
+export interface PeekCardProps {
+  /** What just happened. Required: a peek card always names a completion. */
+  title: string
+  /** What comes next. */
+  subtitle?: string
+  /**
+   * One or two actions, right-aligned with the primary last. Where there are
+   * two, the earlier is a clear-variant secondary.
+   *
+   * An array rather than a single `onDone` callback because the two-action case
+   * is the one that shapes this API: "No, I'm done" beside "Yes, add a step"
+   * cannot be expressed by one callback.
+   */
+  actions: PeekCardAction[]
+  /**
+   * Tucked beneath the card it reports on, so its top edge is hidden behind
+   * that card and it reads as sliding out from underneath.
+   *
+   * Only looks right directly beneath a card of matching width; anywhere else
+   * it reads as a floating tab. Set false for a free-standing card, which is
+   * the moment that follows the end-of-workflow block rather than a card.
+   */
+  isTucked?: boolean
+}
+
+/**
+ * Acknowledges a card the admin has just finished and points at what comes
+ * next, without taking them out of the workflow.
+ *
+ * Presentational only: it takes resolved copy and callbacks, and holds no
+ * feature flag, store or translation of its own. Which moment is being reported
+ * and whether one should render at all belong to the caller.
+ *
+ * Shares `primary.100` with the spotlight and differs only in border weight.
+ * The spotlight means "act here"; this reports what happened. That is the
+ * thinnest distinction in the system, so neither should move toward the other.
+ */
+export const PeekCard = ({
+  title,
+  subtitle,
+  actions,
+  isTucked = true,
+}: PeekCardProps): JSX.Element => {
+  return (
+    <Box
+      bg="primary.100"
+      // Flat top plus a negative margin is what hides the top edge behind the
+      // card above. The bottom radius is constant, so only the top varies.
+      borderTopRadius={isTucked ? '0' : '8px'}
+      borderBottomRadius="8px"
+      border="1px solid"
+      borderColor="primary.200"
+      mt={isTucked ? '-0.5rem' : undefined}
+      py="1.5rem"
+      px={{ base: '1.5rem', md: '2rem' }}
+    >
+      <Stack spacing="1rem">
+        <Stack spacing="0.25rem">
+          <Text textStyle="subhead-1" color="secondary.500">
+            {title}
+          </Text>
+          {subtitle ? (
+            <Text textStyle="body-2" color="secondary.400">
+              {subtitle}
+            </Text>
+          ) : null}
+        </Stack>
+        <Flex justify="flex-end" gap="0.75rem">
+          {actions.map((action, index) => (
+            // Primary is last, so index position decides the treatment rather
+            // than a per-action flag the caller could set inconsistently.
+            <Button
+              key={action.label}
+              variant={index === actions.length - 1 ? undefined : 'clear'}
+              colorScheme={
+                index === actions.length - 1 ? undefined : 'secondary'
+              }
+              onClick={action.onClick}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </Flex>
+      </Stack>
+    </Box>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/index.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/index.ts
@@ -1,0 +1,1 @@
+export * from './PeekCard'


### PR DESCRIPTION
## Problem

The guided workflow flow has five completion moments (Step 1 done, Step 2+ done, email set up, status tracking, guided setup finished). Each one needs to say what just finished, what comes next, and offer the action that gets there. Right now saving a step fires a toast and the page returns to rest, so every completion is silent.

Groundwork for FRM-2497. No user-visible change: nothing renders this yet.

## Solution

Adds the one `PeekCard` component all five moments will use. Presentational only: it takes resolved copy and callbacks and holds no feature flag, store or translation, so which moment is being reported and whether one should render at all stay with the caller.

Two decisions are worth calling out.

**`actions` is an array, not a single `onDone`.** The two-action case is what shapes the API: "No, I'm done" beside "Yes, add a step" cannot be expressed by one callback. The primary is positional, last in the array, so a caller cannot mark two actions primary or none.

**`isTucked` defaults to true.** The flat top and `-0.5rem` top margin are what hide the card's top edge behind the card above, which is where "peek" comes from. Four of the five moments are tucked, so it is opt-out.

Every value comes from the spec's requirement 3: `primary.100` background, `1px solid primary.200`, 8px radius, `subhead-1`/`secondary.500` title, `body-2`/`secondary.400` subtitle, `1.5rem` block padding and `1.5rem`/`2rem` inline, `0.75rem` between actions.

## Notes for review

The prototype on `workflow-exploration-c` already has an equivalent component, and this is close to it deliberately. Worth knowing that **the spec's "Porting warning" is stale**: it describes three competing implementations and says the prototype's own component "went unused at three of five sites". That was true when the spec was drafted on 2026-08-27; commit `cb95ce9fb` consolidated them on 2026-08-28. The prototype now uses one component at all five sites. Likewise the dead `WorkflowSuccessModal` the spec warns against porting was already deleted in `e7b5c7f78`.

Placed in a new `components/GuidedCreation/` directory, matching where the prototype keeps it, so the rest of the guided flow lands beside it rather than having to move this later.

No feature flag here. A component with no call sites cannot leak, and gating belongs where it can be asserted once. The flag arrives in 3/3, which is also where flag-off is tested.

## Alternatives considered

- **A single `onDone` callback with an optional secondary label.** Rejected. It makes the two-action case the awkward one when it is actually three of the five moments, and it is what left the prototype's first attempt unused.
- **A `variant` prop instead of `isTucked`.** Rejected. There are exactly two treatments and the difference is mechanical, so a boolean says more than a name would.
- **Passing `isPrimary` per action.** Rejected. It permits two primaries and none, neither of which is a real state.
- **Putting it in `WorkflowContent/` beside the existing cards.** Rejected. Peek cards only ever appear in the guided flow, and the spec's non-goals put them explicitly outside normal editing.

## Screenshots

None yet. Nothing renders this component in the app. The four Storybook stories are the reviewable surface: tucked with two actions, tucked with one, free-standing, and tucked with no subtitle. The tucked stories include a stand-in for the card above, since the treatment only reads correctly beneath a card of matching width.

## Breaking Changes

No - backwards compatible. New files only, no call sites, no API, schema or copy changes.

## Tests

Automated: three unit tests, covering the parts that are contract rather than styling.

- Title always renders; the subtitle renders only when given
- Each action gets its own handler, which is the reason `actions` is an array
- Actions render in the order given, so primary-last stays positional

**TC1: the four stories look right**

- [ ] Tucked stories: the peek card's top edge sits behind the card above with no seam, and the top corners are square
- [ ] Free-standing story: all four corners are rounded and there is no overlap
- [ ] Two-action story: secondary on the left in a clear treatment, solid primary on the right
- [ ] No-subtitle story: title and actions close up with no leftover gap

**TC2: nothing changed in the app**

- [ ] The workflow builder tab is unchanged, flag on or off, since nothing renders this yet
