### PR TITLE
feat(workflow): add the five completion moments' copy (2/3)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/utils/completionPeekContent.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/utils/completionPeekContent.test.ts
@@ -1,0 +1,95 @@
+import i18next from 'i18next'
+
+import {
+  CompletionPeekMomentType,
+  getCompletionPeekActionLabels,
+  getCompletionPeekContent,
+  isCompletionPeekTucked,
+} from './completionPeekContent'
+
+const t = i18next.t.bind(i18next)
+
+describe('getCompletionPeekContent', () => {
+  it('should give step 1 its own wording, not the later-step wording', () => {
+    const stepOne = getCompletionPeekContent(t, {
+      type: CompletionPeekMomentType.StepOneDone,
+    })
+    const laterStep = getCompletionPeekContent(t, {
+      type: CompletionPeekMomentType.LaterStepDone,
+      stepNumber: 1,
+    })
+
+    expect(stepOne.title).not.toEqual(laterStep.title)
+    expect(stepOne.subtitle).not.toEqual(laterStep.subtitle)
+    expect(stepOne.title).toContain('public-facing')
+  })
+
+  // The store and WorkflowContent are zero-based, the admin counts from one.
+  it('should render a zero-based step number as its one-based label', () => {
+    expect(
+      getCompletionPeekContent(t, {
+        type: CompletionPeekMomentType.LaterStepDone,
+        stepNumber: 1,
+      }).title,
+    ).toEqual('Nice, Step 2 is all set')
+
+    expect(
+      getCompletionPeekContent(t, {
+        type: CompletionPeekMomentType.LaterStepDone,
+        stepNumber: 4,
+      }).title,
+    ).toEqual('Nice, Step 5 is all set')
+  })
+
+  it('should resolve a title and subtitle for every moment', () => {
+    const moments = [
+      { type: CompletionPeekMomentType.StepOneDone },
+      { type: CompletionPeekMomentType.LaterStepDone, stepNumber: 1 },
+      { type: CompletionPeekMomentType.EmailSetUp },
+      { type: CompletionPeekMomentType.StatusTracking },
+      { type: CompletionPeekMomentType.GuidedSetupFinished },
+    ] as const
+
+    moments.forEach((moment) => {
+      const { title, subtitle } = getCompletionPeekContent(t, moment)
+      // A missing key resolves to the key itself, so this catches a typo or an
+      // enum member added without copy.
+      expect(title).not.toContain('completionPeek')
+      expect(subtitle).not.toContain('completionPeek')
+      expect(title.length).toBeGreaterThan(0)
+      expect(subtitle.length).toBeGreaterThan(0)
+    })
+  })
+})
+
+describe('isCompletionPeekTucked', () => {
+  it('should tuck every moment except the email one', () => {
+    expect(
+      isCompletionPeekTucked({ type: CompletionPeekMomentType.EmailSetUp }),
+    ).toBe(false)
+
+    const tucked = [
+      { type: CompletionPeekMomentType.StepOneDone },
+      { type: CompletionPeekMomentType.LaterStepDone, stepNumber: 1 },
+      { type: CompletionPeekMomentType.StatusTracking },
+      { type: CompletionPeekMomentType.GuidedSetupFinished },
+    ] as const
+
+    tucked.forEach((moment) => {
+      expect(isCompletionPeekTucked(moment)).toBe(true)
+    })
+  })
+})
+
+describe('getCompletionPeekActionLabels', () => {
+  it('should resolve every action label', () => {
+    const labels = getCompletionPeekActionLabels(t)
+
+    expect(labels).toEqual({
+      declineAnotherStep: "No, I'm done",
+      addAnotherStep: 'Yes, add a step',
+      continue: 'Continue',
+      finish: 'Done',
+    })
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/utils/completionPeekContent.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/utils/completionPeekContent.ts
@@ -1,0 +1,102 @@
+import { TFunction } from 'i18next'
+
+/**
+ * The copy for each of the guided flow's five completion moments.
+ *
+ * Separate from the components so the one rule worth testing, step 1 reading
+ * differently from every later step, is testable without rendering. Kept in one
+ * place because the pattern has to read the same at every moment.
+ */
+
+const PREFIX = 'features.adminForm.sidebar.workflow.completionPeek'
+
+export enum CompletionPeekMomentType {
+  /**
+   * Step 1 gets its own wording because it is the only step whose respondents
+   * the admin does not choose.
+   */
+  StepOneDone = 'stepOneDone',
+  LaterStepDone = 'laterStepDone',
+  EmailSetUp = 'emailSetUp',
+  /**
+   * The one moment that does not report a completion. It introduces a setting
+   * the admin has not met, so the title gives them the completion they earned
+   * and the subtitle offers the setting as something optional.
+   */
+  StatusTracking = 'statusTracking',
+  GuidedSetupFinished = 'guidedSetupFinished',
+}
+
+/**
+ * Which moment is being reported. A union rather than a bare enum because only
+ * the later-step moment needs a step number, and the others must not be given
+ * one.
+ */
+export type CompletionPeekMoment =
+  | { type: CompletionPeekMomentType.StepOneDone }
+  | {
+      type: CompletionPeekMomentType.LaterStepDone
+      /**
+       * Zero-based, matching `WorkflowContent`'s `stepNumber={i}` and the rest
+       * of the workflow store. Rendered as `stepNumber + 1`, so step index 1
+       * reads "Step 2".
+       */
+      stepNumber: number
+    }
+  | { type: CompletionPeekMomentType.EmailSetUp }
+  | { type: CompletionPeekMomentType.StatusTracking }
+  | { type: CompletionPeekMomentType.GuidedSetupFinished }
+
+export interface CompletionPeekContent {
+  title: string
+  subtitle: string
+}
+
+/**
+ * The title and subtitle for a moment. Every moment has both; the card's
+ * subtitle is optional but no moment currently omits it.
+ */
+export const getCompletionPeekContent = (
+  t: TFunction,
+  moment: CompletionPeekMoment,
+): CompletionPeekContent => ({
+  title: t(
+    `${PREFIX}.${moment.type}.title`,
+    moment.type === CompletionPeekMomentType.LaterStepDone
+      ? { stepNumber: moment.stepNumber + 1 }
+      : undefined,
+  ),
+  subtitle: t(`${PREFIX}.${moment.type}.subtitle`),
+})
+
+export interface CompletionPeekActionLabels {
+  declineAnotherStep: string
+  addAnotherStep: string
+  continue: string
+  finish: string
+}
+
+/**
+ * The four action labels, resolved together so that all of this pattern's copy
+ * lives in one module. Labels are separate from the moments because an action
+ * is a label paired with a callback, and the callbacks belong to whoever is
+ * driving the flow.
+ */
+export const getCompletionPeekActionLabels = (
+  t: TFunction,
+): CompletionPeekActionLabels => ({
+  declineAnotherStep: t(`${PREFIX}.actions.declineAnotherStep`),
+  addAnotherStep: t(`${PREFIX}.actions.addAnotherStep`),
+  continue: t(`${PREFIX}.actions.continue`),
+  finish: t(`${PREFIX}.actions.finish`),
+})
+
+/**
+ * Tucked under the card it reports on, except for the email moment, which
+ * follows the end-of-workflow block rather than a card and so is free-standing.
+ *
+ * Derived rather than passed in, so no call site can tuck a card under
+ * something that is not a card.
+ */
+export const isCompletionPeekTucked = (moment: CompletionPeekMoment): boolean =>
+  moment.type !== CompletionPeekMomentType.EmailSetUp

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -175,4 +175,35 @@ export const enSG: Workflow = {
   stepName: {
     label: 'Step name',
   },
+  completionPeek: {
+    stepOneDone: {
+      title:
+        'Step 1 is the public-facing step. Anyone with your link starts here.',
+      subtitle: 'Now add the steps that route to specific people.',
+    },
+    laterStepDone: {
+      title: 'Nice, Step {stepNumber} is all set',
+      subtitle: 'Would you like to add another step?',
+    },
+    emailSetUp: {
+      title: "You've set up the completion email.",
+      subtitle: 'Next, set up an extra workflow setting.',
+    },
+    statusTracking: {
+      title: 'Your workflow is ready',
+      subtitle:
+        'Before you finish, you can let people check the status of their response.',
+    },
+    guidedSetupFinished: {
+      title: "You've finished guided setup",
+      subtitle:
+        'Use the Preview button on the top right to check what each step looks like.',
+    },
+    actions: {
+      declineAnotherStep: "No, I'm done",
+      addAnotherStep: 'Yes, add a step',
+      continue: 'Continue',
+      finish: 'Done',
+    },
+  },
 }

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -1,5 +1,10 @@
 export * from './en-sg'
 
+interface CompletionPeekText {
+  title: string
+  subtitle: string
+}
+
 interface CsvColumnText {
   title: string
   explanation: string
@@ -146,5 +151,18 @@ export interface Workflow {
   }
   stepName: {
     label: string
+  }
+  completionPeek: {
+    stepOneDone: CompletionPeekText
+    laterStepDone: CompletionPeekText
+    emailSetUp: CompletionPeekText
+    statusTracking: CompletionPeekText
+    guidedSetupFinished: CompletionPeekText
+    actions: {
+      declineAnotherStep: string
+      addAnotherStep: string
+      continue: string
+      finish: string
+    }
   }
 }


### PR DESCRIPTION
## Problem

The five completion moments need ten strings (a title and a subtitle each) plus four action labels. The prototype hardcodes all of them in English inside the components. Production keys everything through i18n, and the copy is the part of this feature most likely to be revised, so it should not be spread across five call sites.

Stacked on #9934 — please review/merge that first. Base retargets to `develop` once it lands.

Part of FRM-2497.

## Solution

Adds the copy under `sidebar.workflow.completionPeek`, with matching entries on the `Workflow` interface, and one module that resolves a moment to its copy.

`getCompletionPeekContent(t, moment)` takes `t` as a parameter rather than calling `useTranslation` itself, following `completionEmailLabels` from FRM-2495. That keeps the one rule worth testing testable without rendering: **step 1 reads differently from every later step**, because it is the only step whose respondents the admin does not choose.

`CompletionPeekMoment` is a discriminated union rather than a bare enum, so only the later-step moment carries a `stepNumber` and the other four cannot be given one.

`isCompletionPeekTucked` derives the treatment from the moment instead of taking it as a prop. The email moment is the sole exception, since it follows the end-of-workflow block rather than a card, and deriving it means no call site can tuck a card under something that is not a card.

`getCompletionPeekActionLabels` resolves the four labels together, so every string in this feature lives in this one module. Labels are separate from moments because an action is a label paired with a callback, and the callbacks belong to whoever drives the flow. That pairing happens in 3/3.

## The off-by-one, made explicit

`stepNumber` is **zero-based**, matching `WorkflowContent`'s `stepNumber={i}` and the rest of the workflow store, and renders as `stepNumber + 1`. So step index 1 reads "Step 2".

This is the single most likely thing to be got wrong here, in either direction, so it is pinned by a test asserting the exact rendered string at two different indices rather than just that some number appears.

## Interpolation

Strings use ICU single-brace `{stepNumber}`, not `{{stepNumber}}`. The app initialises i18next with `i18next-icu`, and the existing `People in Step {stepNumber}` in the email notification strings uses the same form. Double braces would render literally.

## Alternatives considered

- **A hook, `useCompletionPeekContent`.** Rejected. It would force a render to test the step 1 rule, and the module has no other reason to be a hook.
- **Copy inline at the five call sites, as the prototype has it.** Rejected. The spec's own second-order note is that all five moments share one pattern, and copy is what drifts first.
- **One flat key per moment rather than nested title/subtitle.** Rejected. The nested shape lets `CompletionPeekText` be one interface reused five times on the `Workflow` interface.
- **Returning the subtitle as optional.** Rejected. `PeekCard` allows an absent subtitle, but no moment currently omits one, so a required field here means a missing subtitle is a type error rather than a silently sparse card.

## Screenshots

None. This PR adds no rendering. The copy is visible in the stories added by 3/3.

## Breaking Changes

No - backwards compatible. Additive locale entries and one new module. No existing string changes.

## Tests

Automated: five unit tests.

- Step 1's title and subtitle both differ from the later-step wording
- A zero-based step number renders as its one-based label, checked at two indices
- Every moment resolves a non-empty title and subtitle, which catches a moment added without copy since a missing key resolves to the key itself
- Every moment is tucked except the email one
- All four action labels resolve to their exact strings

**TC1: copy matches the spec**

- [ ] The five titles and five subtitles read exactly as the spec's requirement 4 table
- [ ] Neither the word "tour" nor "modal" appears anywhere in the new copy; the flow is called guided setup everywhere

**TC2: no existing copy moved**

- [ ] Settings → Email notifications and the workflow tab read exactly as before
