### PR TITLE
feat(workflow): wire the peek card to its five moments (3/3)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/CompletionPeekCard.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/CompletionPeekCard.stories.tsx
@@ -1,0 +1,128 @@
+import { Box, Stack } from '@chakra-ui/react'
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+import { CompletionPeekMomentType } from './utils/completionPeekContent'
+import {
+  CompletionPeekCard,
+  CompletionPeekCardProps,
+} from './CompletionPeekCard'
+
+const redesignOn = new GrowthBook({
+  features: { [featureFlags.workflowBuilderRedesign]: { defaultValue: true } },
+})
+
+/**
+ * Stand-in for the card the peek card reports on. The tucked treatment only
+ * reads correctly beneath a card of matching width, so the tucked stories show
+ * one rather than floating the peek card alone.
+ */
+const CardAbove = (): JSX.Element => (
+  <Box
+    bg="white"
+    border="1px solid"
+    borderColor="neutral.300"
+    borderRadius="4px"
+    p="2rem"
+  >
+    The card that was just finished
+  </Box>
+)
+
+export default {
+  title:
+    'Features/AdminForm/create/workflow/components/GuidedCreation/CompletionPeekCard',
+  component: CompletionPeekCard,
+  decorators: [
+    (Story: StoryFn) => (
+      <GrowthBookProvider growthbook={redesignOn}>
+        <Story />
+      </GrowthBookProvider>
+    ),
+  ],
+} as Meta<CompletionPeekCardProps>
+
+const TuckedTemplate: StoryFn<CompletionPeekCardProps> = (args) => (
+  <Stack spacing="0" maxW="42rem">
+    <CardAbove />
+    <CompletionPeekCard {...args} />
+  </Stack>
+)
+
+const FreeStandingTemplate: StoryFn<CompletionPeekCardProps> = (args) => (
+  <Box maxW="42rem">
+    <CompletionPeekCard {...args} />
+  </Box>
+)
+
+export const StepOneDone = TuckedTemplate.bind({})
+StepOneDone.storyName = 'Step 1 done'
+StepOneDone.args = {
+  type: CompletionPeekMomentType.StepOneDone,
+  onDeclineAnotherStep: () => undefined,
+  onAddAnotherStep: () => undefined,
+}
+StepOneDone.parameters = {
+  docs: {
+    description: {
+      story:
+        'Step 1 gets its own wording because it is the only step whose respondents the admin does not choose.',
+    },
+  },
+}
+
+export const LaterStepDone = TuckedTemplate.bind({})
+LaterStepDone.storyName = 'Step 2+ done'
+LaterStepDone.args = {
+  type: CompletionPeekMomentType.LaterStepDone,
+  stepNumber: 1,
+  onDeclineAnotherStep: () => undefined,
+  onAddAnotherStep: () => undefined,
+}
+LaterStepDone.parameters = {
+  docs: {
+    description: {
+      story:
+        'stepNumber is zero-based, as everywhere else in the workflow, so index 1 reads "Step 2".',
+    },
+  },
+}
+
+export const EmailSetUp = FreeStandingTemplate.bind({})
+EmailSetUp.storyName = 'Email set up'
+EmailSetUp.args = {
+  type: CompletionPeekMomentType.EmailSetUp,
+  onContinue: () => undefined,
+}
+EmailSetUp.parameters = {
+  docs: {
+    description: {
+      story:
+        'The one free-standing moment. It follows the end-of-workflow block rather than a card, so it takes a full radius and no negative margin.',
+    },
+  },
+}
+
+export const StatusTracking = TuckedTemplate.bind({})
+StatusTracking.storyName = 'Status tracking'
+StatusTracking.args = {
+  type: CompletionPeekMomentType.StatusTracking,
+  onFinish: () => undefined,
+}
+StatusTracking.parameters = {
+  docs: {
+    description: {
+      story:
+        'The one moment that does not report a completion. The title gives the admin the completion they earned and the subtitle offers the setting as optional.',
+    },
+  },
+}
+
+export const GuidedSetupFinished = TuckedTemplate.bind({})
+GuidedSetupFinished.storyName = 'Guided setup finished'
+GuidedSetupFinished.args = {
+  type: CompletionPeekMomentType.GuidedSetupFinished,
+  onFinish: () => undefined,
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/CompletionPeekCard.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/CompletionPeekCard.test.tsx
@@ -1,0 +1,122 @@
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+import { useAdminWorkflowStore } from '../../adminWorkflowStore'
+
+import { CompletionPeekMomentType } from './utils/completionPeekContent'
+import { CompletionPeekCard } from './CompletionPeekCard'
+
+const withFlag = (isOn: boolean) =>
+  new GrowthBook({
+    features: {
+      [featureFlags.workflowBuilderRedesign]: { defaultValue: isOn },
+    },
+  })
+
+const renderCard = (
+  props: Parameters<typeof CompletionPeekCard>[0],
+  { isFlagOn = true }: { isFlagOn?: boolean } = {},
+) =>
+  render(
+    <GrowthBookProvider growthbook={withFlag(isFlagOn)}>
+      <CompletionPeekCard {...props} />
+    </GrowthBookProvider>,
+  )
+
+describe('CompletionPeekCard', () => {
+  afterEach(() => useAdminWorkflowStore.getState().reset())
+
+  it('should render the copy and both actions for a finished step', () => {
+    renderCard({
+      type: CompletionPeekMomentType.LaterStepDone,
+      stepNumber: 1,
+      onDeclineAnotherStep: () => undefined,
+      onAddAnotherStep: () => undefined,
+    })
+
+    expect(screen.getByText('Nice, Step 2 is all set')).toBeInTheDocument()
+    expect(
+      screen.getByText('Would you like to add another step?'),
+    ).toBeInTheDocument()
+    expect(screen.getAllByRole('button').map((b) => b.textContent)).toEqual([
+      "No, I'm done",
+      'Yes, add a step',
+    ])
+  })
+
+  it('should wire each of the two step actions to its own callback', () => {
+    const onDeclineAnotherStep = vi.fn()
+    const onAddAnotherStep = vi.fn()
+
+    renderCard({
+      type: CompletionPeekMomentType.StepOneDone,
+      onDeclineAnotherStep,
+      onAddAnotherStep,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: "No, I'm done" }))
+    expect(onDeclineAnotherStep).toHaveBeenCalledTimes(1)
+    expect(onAddAnotherStep).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, add a step' }))
+    expect(onAddAnotherStep).toHaveBeenCalledTimes(1)
+  })
+
+  it('should render one action for the single-action moments', () => {
+    const onContinue = vi.fn()
+    const { unmount } = renderCard({
+      type: CompletionPeekMomentType.EmailSetUp,
+      onContinue,
+    })
+
+    expect(screen.getAllByRole('button').map((b) => b.textContent)).toEqual([
+      'Continue',
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }))
+    expect(onContinue).toHaveBeenCalledTimes(1)
+    unmount()
+
+    const onFinish = vi.fn()
+    renderCard({
+      type: CompletionPeekMomentType.StatusTracking,
+      onFinish,
+    })
+
+    expect(screen.getAllByRole('button').map((b) => b.textContent)).toEqual([
+      'Done',
+    ])
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(onFinish).toHaveBeenCalledTimes(1)
+  })
+
+  // Requirement 6, and the one that matters most: this is live for the whole
+  // Singapore government, so flag-off must render nothing at all.
+  it('should render nothing when the redesign flag is off', () => {
+    const { container } = renderCard(
+      {
+        type: CompletionPeekMomentType.GuidedSetupFinished,
+        onFinish: () => undefined,
+      },
+      { isFlagOn: false },
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // A peek card reports on a finished card, so while one is open for editing
+  // nothing is finished. Owned here so no call site can forget it.
+  it('should render nothing while a card is open for editing', () => {
+    useAdminWorkflowStore.getState().setToEditing(0)
+
+    const { container } = renderCard({
+      type: CompletionPeekMomentType.LaterStepDone,
+      stepNumber: 1,
+      onDeclineAnotherStep: () => undefined,
+      onAddAnotherStep: () => undefined,
+    })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/CompletionPeekCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/CompletionPeekCard.tsx
@@ -1,0 +1,108 @@
+import { useTranslation } from 'react-i18next'
+
+import { useAdminWorkflowStore } from '../../adminWorkflowStore'
+import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
+
+import {
+  CompletionPeekMomentType,
+  getCompletionPeekActionLabels,
+  getCompletionPeekContent,
+  isCompletionPeekTucked,
+} from './utils/completionPeekContent'
+import { PeekCard, PeekCardAction } from './PeekCard'
+
+/**
+ * A moment plus the callbacks its actions need.
+ *
+ * One union member per moment, each carrying exactly the callbacks that moment
+ * offers, so a caller cannot supply the wrong ones or omit one. The two-step
+ * moments need two callbacks, which is why an action cannot be a single
+ * `onDone`.
+ */
+export type CompletionPeekCardProps =
+  | {
+      type: CompletionPeekMomentType.StepOneDone
+      onDeclineAnotherStep: () => void
+      onAddAnotherStep: () => void
+    }
+  | {
+      type: CompletionPeekMomentType.LaterStepDone
+      /** Zero-based, as everywhere else in the workflow. Reads as +1. */
+      stepNumber: number
+      onDeclineAnotherStep: () => void
+      onAddAnotherStep: () => void
+    }
+  | {
+      type: CompletionPeekMomentType.EmailSetUp
+      onContinue: () => void
+    }
+  | {
+      type: CompletionPeekMomentType.StatusTracking
+      onFinish: () => void
+    }
+  | {
+      type: CompletionPeekMomentType.GuidedSetupFinished
+      onFinish: () => void
+    }
+
+/**
+ * A peek card for one of the guided flow's completion moments, wired to its
+ * copy and its actions.
+ *
+ * Owns the two conditions under which no peek card should appear at all, rather
+ * than leaving them to five call sites that could each forget one:
+ *
+ * - Behind `workflow-builder-redesign`. No exceptions; this is live for the
+ *   whole Singapore government.
+ * - Hidden while any step or email card is open for editing. A peek card
+ *   reports on a finished card, and while the admin is editing, nothing is
+ *   finished.
+ */
+export const CompletionPeekCard = (
+  props: CompletionPeekCardProps,
+): JSX.Element | null => {
+  const { t } = useTranslation()
+  const isRedesign = useIsWorkflowBuilderRedesign()
+  // One check rather than one per card type: an open card is an open card. The
+  // completion email card of FRM-2495 becomes a third variant of
+  // createOrEditData rather than separate state, so it is covered here the day
+  // it lands, with nothing to add.
+  const isAnyCardOpen = useAdminWorkflowStore(
+    (state) => state.createOrEditData !== null,
+  )
+
+  if (!isRedesign || isAnyCardOpen) return null
+
+  const { title, subtitle } = getCompletionPeekContent(t, props)
+  const labels = getCompletionPeekActionLabels(t)
+
+  // Exhaustive over the union with no default, so adding a moment without
+  // giving it actions is a compile error rather than an empty button row.
+  const actions = ((): PeekCardAction[] => {
+    switch (props.type) {
+      case CompletionPeekMomentType.StepOneDone:
+      case CompletionPeekMomentType.LaterStepDone:
+        return [
+          {
+            label: labels.declineAnotherStep,
+            onClick: props.onDeclineAnotherStep,
+          },
+          { label: labels.addAnotherStep, onClick: props.onAddAnotherStep },
+        ]
+      case CompletionPeekMomentType.EmailSetUp:
+        return [{ label: labels.continue, onClick: props.onContinue }]
+      case CompletionPeekMomentType.StatusTracking:
+      case CompletionPeekMomentType.GuidedSetupFinished:
+        return [{ label: labels.finish, onClick: props.onFinish }]
+    }
+  })()
+
+  return (
+    <PeekCard
+      title={title}
+      subtitle={subtitle}
+      actions={actions}
+      isTucked={isCompletionPeekTucked(props)}
+    />
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/index.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/index.ts
@@ -1,1 +1,2 @@
+export * from './CompletionPeekCard'
 export * from './PeekCard'


### PR DESCRIPTION
## Problem

1/3 gives a `PeekCard` that takes strings and callbacks. 2/3 gives the copy. Nothing yet turns "step 2 was just saved" into a rendered card, and nothing enforces the two rules that decide whether a peek card should appear at all.

Stacked on #9935 — please review/merge that first. Base retargets to `develop` once it lands.

Part of FRM-2497.

## Solution

`CompletionPeekCard` binds a moment to its copy and its actions, so the guided flow's five call sites pass a moment and its callbacks and nothing else.

### The props union is the point

One union member per moment, each carrying exactly the callbacks that moment offers:

```ts
| { type: StepOneDone;    onDeclineAnotherStep; onAddAnotherStep }
| { type: LaterStepDone;  stepNumber; onDeclineAnotherStep; onAddAnotherStep }
| { type: EmailSetUp;     onContinue }
| { type: StatusTracking; onFinish }
| { type: GuidedSetupFinished; onFinish }
```

A caller cannot pass `onFinish` to a step moment, cannot omit one of the two step callbacks, and cannot pass a `stepNumber` to a moment that has no step. The switch that builds the actions array is exhaustive with no `default`, so a sixth moment added without actions is a compile error rather than an empty button row.

That last property is deliberate, and it is the thing #9874 could not have: its `AdminEditWorkflowState` is only ever compared for equality, so a new member compiles cleanly while every consumer ignores it. Here the compiler catches it.

### Both "don't render" rules live in one place

The component owns them rather than leaving them to five call sites that could each forget one.

**Feature flag (requirement 6).** Gated on `useIsWorkflowBuilderRedesign`. Flag-off renders nothing, and that is asserted rather than assumed. No exceptions: this is live for the entire Singapore government.

**Hidden while editing (requirement 5).** A peek card reports on a finished card, so while a card is open for editing nothing is finished. This is a single check on `createOrEditData !== null` rather than one per card type, which means the completion email card of FRM-2495 is covered the day it lands, with nothing to add. That falls out of #9874 having made the email card a third variant of the existing union instead of separate state; had it been tracked separately this would need a second condition and would silently miss it.

## What is deliberately not here

**The five call sites.** The spec makes the flow's state machine a non-goal and assigns it to FRM-2498, and four of the five moments live inside guided-mode machinery (`startEmailSetup`, `addAnotherStep`, the status-toggle and success modes) that does not exist on `develop` at all. I checked: `GuidedCreation`, `guidedWorkflowStore`, `Spotlight`, `WorkflowCard`, `EndOfWorkflowBlock` and `SortableStepList` are all zero files on `develop`.

So this stack delivers the complete feature surface, ready to mount, and FRM-2498 mounts it. Nothing renders in the app yet, which is why flag-off being tested matters more than usual: it is the only assertion standing between this and a surface that is live for every agency.

## Alternatives considered

- **Taking the moment and the callbacks as separate props.** Rejected. It permits a moment paired with the wrong callbacks, which is exactly what the union rules out.
- **Leaving the flag and the editing check to the call sites.** Rejected. Five call sites, two rules each, and forgetting the flag one means shipping to every agency. Owning both here makes forgetting impossible.
- **A `moment` object prop rather than spreading the union onto props.** Considered. Spreading reads better at the call site (`<CompletionPeekCard type={...} onFinish={...} />`) and the union still holds. Worth revisiting if the call sites in FRM-2498 end up passing a moment they already hold as an object.
- **Rendering a placeholder when a card is open.** Rejected. The spec says no peek card renders while editing, and a gap that reserves space would show the tucked card's seam under nothing.

## Screenshots

None in the app; nothing mounts this yet. Five Storybook stories are the reviewable surface, one per moment, and they are what Chromatic pins:

| Story | Treatment |
| --- | --- |
| Step 1 done | Tucked, two actions |
| Step 2+ done | Tucked, two actions, "Step 2" from index 1 |
| Email set up | **Free-standing**, one action |
| Status tracking | Tucked, one action |
| Guided setup finished | Tucked, one action |

The tucked stories include a stand-in for the card above, since the treatment only reads correctly beneath a card of matching width.

## Breaking Changes

No - backwards compatible. New files only, no call sites, and gated behind `workflow-builder-redesign` on top of that.

## Tests

Automated: six tests on the binding layer, plus the eight inherited from 1/3 and 2/3. 23 tests pass across the workflow feature.

- The copy and both actions render for a finished step, in order
- Each of the two step actions calls its own callback and not the other
- The single-action moments render exactly one button, wired correctly
- **Flag off renders nothing at all** (`toBeEmptyDOMElement`)
- **A card open for editing renders nothing at all**

**TC1: flag off is inert**

- [ ] With the flag off, no peek card renders in any story or anywhere in the app

**TC2: the five moments match the spec**

- [ ] Each story's title and subtitle read exactly as the spec's requirement 4 table
- [ ] Step 2+ shows "Nice, Step 2 is all set" for `stepNumber={1}`
- [ ] Only the email story is free-standing; the other four are tucked

**TC3: the two treatments stay distinguishable**

- [ ] The peek card and the spotlight share `primary.100` but differ in border weight, and are still telling apart side by side

**TC4: nothing changed in the app**

- [ ] The workflow builder tab is unchanged, flag on or off
