### PR TITLE
feat(workflow): add the Spotlight wrapper (1/2)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.stories.tsx
@@ -1,0 +1,130 @@
+import { Box, Divider, Stack, Text } from '@chakra-ui/react'
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+import Button from '~components/Button'
+import Input from '~components/Input'
+
+import { Spotlight, SpotlightProps } from './Spotlight'
+
+const withFlag = (isOn: boolean) =>
+  new GrowthBook({
+    features: {
+      [featureFlags.workflowBuilderRedesign]: { defaultValue: isOn },
+    },
+  })
+
+export default {
+  title: 'Features/AdminForm/create/workflow/components/Spotlight',
+  component: Spotlight,
+} as Meta<SpotlightProps>
+
+/**
+ * Stand-in for one section of a step card: a label, a hint and an input. The
+ * spotlight wraps whatever a section renders, so the contents are incidental.
+ */
+const Section = ({ name }: { name: string }): JSX.Element => (
+  <Stack spacing="0.5rem" px="2rem">
+    <Text textStyle="subhead-1">{name}</Text>
+    <Text textStyle="body-2" color="secondary.400">
+      Hint text explaining what this section is for.
+    </Text>
+    <Input placeholder={`${name} value`} />
+  </Stack>
+)
+
+/**
+ * The whole point is one section lit and the rest dimmed, so the stories show a
+ * card with three sections rather than a single wrapper in isolation.
+ */
+const CardTemplate =
+  (
+    activeSection: number,
+    { isEnabled = true, isFlagOn = true } = {},
+  ): StoryFn =>
+  () => (
+    <GrowthBookProvider growthbook={withFlag(isFlagOn)}>
+      <Box
+        maxW="42rem"
+        bg="white"
+        border="1px solid"
+        borderColor="neutral.300"
+        borderRadius="4px"
+        py="2rem"
+      >
+        <Stack spacing="0">
+          {/* Outside the spotlight and always at full opacity: the buttons are
+              the way forward, and dimming them would look unavailable. */}
+          <Stack spacing="0">
+            <Spotlight isActive={activeSection === 1} isEnabled={isEnabled}>
+              <Section name="Step name" />
+            </Spotlight>
+            <Divider />
+            <Spotlight isActive={activeSection === 2} isEnabled={isEnabled}>
+              <Section name="Who fills this in" />
+            </Spotlight>
+            <Divider />
+            <Spotlight isActive={activeSection === 3} isEnabled={isEnabled}>
+              <Section name="What they can see" />
+            </Spotlight>
+          </Stack>
+          <Divider />
+          <Stack direction="row" justify="flex-end" px="2rem" pt="1.5rem">
+            <Button variant="clear" colorScheme="secondary">
+              Back
+            </Button>
+            <Button>Continue</Button>
+          </Stack>
+        </Stack>
+      </Box>
+    </GrowthBookProvider>
+  )
+
+export const FirstSectionActive = CardTemplate(1)
+FirstSectionActive.storyName = 'Section 1 active'
+FirstSectionActive.parameters = {
+  docs: {
+    description: {
+      story:
+        'One section carries the Active treatment and the rest go inert. Note the active section is inset by 2rem, narrower than the sections around it, which is deliberate.',
+    },
+  },
+}
+
+export const MiddleSectionActive = CardTemplate(2)
+MiddleSectionActive.storyName = 'Section 2 active'
+MiddleSectionActive.parameters = {
+  docs: {
+    description: {
+      story:
+        'With a dimmed section above and below, which is where the reserved transparent border matters: nothing shifts as the spotlight moves.',
+    },
+  },
+}
+
+export const LastSectionActive = CardTemplate(3)
+LastSectionActive.storyName = 'Section 3 active'
+
+export const Disabled = CardTemplate(1, { isEnabled: false })
+Disabled.storyName = 'Spotlight off (step 3+, guidance off)'
+Disabled.parameters = {
+  docs: {
+    description: {
+      story:
+        'Children render untouched: no background, no border, no padding, no dimming. Compare against section 1 active to confirm no wrapper styling leaks through.',
+    },
+  },
+}
+
+export const FlagOff = CardTemplate(1, { isFlagOn: false })
+FlagOff.storyName = 'Redesign flag off'
+FlagOff.parameters = {
+  docs: {
+    description: {
+      story:
+        'Identical to the disabled story. Flag-off has to be untouched children everywhere, which is the same thing isEnabled already means.',
+    },
+  },
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.test.tsx
@@ -1,0 +1,91 @@
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { render, screen } from '@testing-library/react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+import { Spotlight, SPOTLIGHT_TEST_ID, SpotlightProps } from './Spotlight'
+
+const CHILD_LABEL = 'Pick a field'
+
+const renderSpotlight = (
+  props: Omit<SpotlightProps, 'children'>,
+  { isFlagOn = true }: { isFlagOn?: boolean } = {},
+) =>
+  render(
+    <GrowthBookProvider
+      growthbook={
+        new GrowthBook({
+          features: {
+            [featureFlags.workflowBuilderRedesign]: { defaultValue: isFlagOn },
+          },
+        })
+      }
+    >
+      <Spotlight {...props}>
+        <button type="button">{CHILD_LABEL}</button>
+      </Spotlight>
+    </GrowthBookProvider>,
+  )
+
+const child = () => screen.getByRole('button', { name: CHILD_LABEL })
+const wrapper = () => screen.queryByTestId(SPOTLIGHT_TEST_ID)
+
+describe('Spotlight', () => {
+  it('should wrap its children when active and when merely dimmed', () => {
+    const view = renderSpotlight({ isActive: true })
+    expect(wrapper()).toBeInTheDocument()
+    expect(child()).toBeInTheDocument()
+    view.unmount()
+
+    renderSpotlight({ isActive: false })
+    expect(wrapper()).toBeInTheDocument()
+    expect(child()).toBeInTheDocument()
+  })
+
+  // Requirement 4. A dimmed section stays fully interactive, so an admin can
+  // scroll up and fix an earlier answer without leaving the flow.
+  it('should not disable anything when inactive', () => {
+    renderSpotlight({ isActive: false })
+
+    expect(child()).toBeEnabled()
+    expect(child()).not.toHaveAttribute('aria-disabled')
+    expect(wrapper()).not.toHaveAttribute('aria-disabled')
+    expect(wrapper()).not.toHaveAttribute('disabled')
+    expect(wrapper()).not.toHaveStyle({ pointerEvents: 'none' })
+  })
+
+  // The transparent border is load-bearing: it reserves the space the active
+  // border occupies, so sections do not shift when the spotlight moves onto
+  // them. Simplifying the inactive branch to `border: none` reintroduces a 2px
+  // jump on every Continue.
+  it('should reserve the same border width when inactive as when active', () => {
+    const view = renderSpotlight({ isActive: true })
+    const activeBorder = getComputedStyle(wrapper()!).borderWidth
+    view.unmount()
+
+    renderSpotlight({ isActive: false })
+
+    expect(getComputedStyle(wrapper()!).borderWidth).toBe(activeBorder)
+    expect(activeBorder).toBe('2px')
+  })
+
+  // Requirement 1: when off, children render untouched. Asserted as "there is
+  // no wrapper at all", so nothing can leak a border, padding or an opacity,
+  // rather than checking each property in turn.
+  it('should render children with no wrapper at all when disabled', () => {
+    renderSpotlight({ isActive: true, isEnabled: false })
+
+    expect(wrapper()).not.toBeInTheDocument()
+    expect(child()).toBeInTheDocument()
+  })
+
+  // Requirement 7, and the one that matters most: this is live for the whole
+  // Singapore government, so flag-off must leave every section exactly as it
+  // was, including one the flow would otherwise have spotlit.
+  it('should render children with no wrapper at all when the flag is off', () => {
+    renderSpotlight({ isActive: true }, { isFlagOn: false })
+
+    expect(wrapper()).not.toBeInTheDocument()
+    expect(child()).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
@@ -1,0 +1,86 @@
+import { ReactNode } from 'react'
+import { Box, usePrefersReducedMotion } from '@chakra-ui/react'
+
+import { useIsWorkflowBuilderRedesign } from '../hooks/useIsWorkflowBuilderRedesign'
+
+export const SPOTLIGHT_TEST_ID = 'workflow-spotlight'
+
+export interface SpotlightProps {
+  /** This section is the current decision. */
+  isActive: boolean
+  /**
+   * Whether the spotlight applies at all. When false, children render
+   * untouched: no wrapper styling, no reserved border, no padding.
+   *
+   * Named for the spotlight rather than for whatever condition switches it off.
+   * The rule that decides it is requirement 5's, and lives with the caller.
+   */
+  isEnabled?: boolean
+  children: ReactNode
+}
+
+/**
+ * Marks the one section an admin is meant to act on right now, and dims the
+ * rest.
+ *
+ * The inactive state carries a 2px *transparent* border on purpose. It reserves
+ * the space the active border occupies, so sections do not shift when the
+ * spotlight moves onto them. Simplifying it to `border: none` reintroduces a
+ * 2px jump on every Continue.
+ *
+ * The 2rem inline margin insets the active section, making it narrower than the
+ * sections around it. That is deliberate: it reads as a focused panel within
+ * the card, and is not an alignment bug to zero out.
+ *
+ * Dimming is presentation only. A dimmed section stays fully interactive, with
+ * no pointer-events change, no `disabled` and no `aria-disabled`, so an admin
+ * who scrolls up to fix an earlier answer can do it without leaving the flow.
+ * Hover and focus-within restore full opacity, which is what covers a section
+ * an admin deliberately returns to: at 0.5 the darkest label composites to
+ * 3.22:1, below the 4.5:1 AA requirement, and the opacity needed to pass would
+ * make the dimming invisible.
+ *
+ * Opacity is not the only signal, since the active section also gains a
+ * background and a border.
+ *
+ * Shares `primary.100` with the peek card and differs in border weight: 2px
+ * `primary.500` here means "act on this", 1px `primary.200` there reports what
+ * just happened. That is the thinnest distinction in the system, so neither
+ * should move toward the other.
+ */
+export const Spotlight = ({
+  isActive,
+  isEnabled = true,
+  children,
+}: SpotlightProps): JSX.Element => {
+  const prefersReducedMotion = usePrefersReducedMotion()
+  // Gated here rather than at each call site: flag-off has to be untouched
+  // children everywhere, and that is the same thing isEnabled already means.
+  const isRedesign = useIsWorkflowBuilderRedesign()
+
+  if (!isEnabled || !isRedesign) return <>{children}</>
+
+  return (
+    <Box
+      // The wrapper's presence is the whole of "is the spotlight on", so tests
+      // assert on it directly rather than inspecting computed styles.
+      data-testid={SPOTLIGHT_TEST_ID}
+      bg={isActive ? 'primary.100' : 'transparent'}
+      borderRadius={isActive ? '8px' : '0'}
+      border="2px solid"
+      borderColor={isActive ? 'primary.500' : 'transparent'}
+      opacity={isActive ? 1 : 0.5}
+      _hover={{ opacity: 1 }}
+      _focusWithin={{ opacity: 1 }}
+      transition={
+        prefersReducedMotion
+          ? 'none'
+          : 'opacity 0.3s ease, background 0.3s ease, border-color 0.3s ease'
+      }
+      mx={isActive ? '2rem' : '0'}
+      py={isActive ? '2rem' : '0.5rem'}
+    >
+      {children}
+    </Box>
+  )
+}


### PR DESCRIPTION
## Problem

A step card asks for a name, the people who fill it in, what they do there and which fields they see. Every one of those carries the same visual weight, so nothing tells an admin where the current decision is. On `develop`, `EditStepBlock` stacks `StepNameBlock`, `RespondentBlock`, `ApprovalsBlock` and `QuestionsBlock` in one column at full opacity, and nothing inside the card responds to where the admin is.

The spotlight came out of design crit, answering a specific objection: guidance competes with the thing being guided unless it is visually subordinate. It is the cheap version of "blur the out-of-focus fields", in place, without a second column.

Groundwork for FRM-2501. No user-visible change: nothing renders this yet, and it is flag-gated on top of that.

## Solution

One wrapper component used everywhere the treatment appears: `isActive` for "this section is the current decision", `isEnabled` for "the spotlight applies at all". Two states plus an off switch, rather than a component per surface.

Values are requirement 2's: `primary.100` background, 2px solid `primary.500`, 8px radius, 2rem inline margin and 2rem block padding when active; transparent background, transparent 2px border, 0 radius, 0 inline margin, 0.5rem block padding and 0.5 opacity when not.

### Three things that are load-bearing and easy to "simplify" into bugs

**The inactive state keeps a 2px transparent border.** It reserves the space the active border occupies, so sections do not shift when the spotlight moves onto them. `border: none` reintroduces a 2px jump on every Continue. There is a test asserting the two computed widths are equal, so this cannot be quietly undone.

**The 2rem inline margin insets the active section on purpose**, making it narrower than the sections around it so it reads as a focused panel within the card. It is not an alignment bug to zero out.

**Dimming is presentation only.** No `pointer-events` change, no `disabled`, no `aria-disabled`. An admin who scrolls up to fix the step name has to be able to, which is FRM-2498's requirement 3 and depends on this not breaking it.

### The contrast decision, stated rather than buried

At 0.5 opacity the darkest label in a section composites to **3.22:1** against a 4.5:1 AA requirement, and the lightest hint text would need 0.80 opacity to pass, at which point the dimming is invisible. The decision is to keep the dimming, because outside the spotlight there is nothing an admin is meant to read.

What covers it is the hover and `focus-within` restoration to full opacity: WCAG's exemption for inactive components does not apply here, since these sections stay interactive, so a section an admin deliberately returns to is legible while they are in it. That is a requirement, not a nicety.

Transition is `opacity/background/border-color 0.3s ease`, dropped to `none` under `prefers-reduced-motion`.

### Flag gating

Gated on `useIsWorkflowBuilderRedesign` inside the component rather than at each call site, because flag-off has to mean untouched children everywhere, and that is the same thing `isEnabled` already means. Both paths are asserted as "no wrapper element at all", so nothing can leak a border, padding or an opacity.

## Notes for review

**The spec's "Porting warning" is stale.** It says the prototype implements this three times, as a local `SpotlightWrapper`, a local `EditSpotlight` and an inline `Box`, with a misnamed `isFlowComplete` off switch. All three names are now gone from `workflow-exploration-c`; commit `cc18c34d9` collapsed them into one component used at exactly the three call sites requirement 6 lists. The substantive point still stands, and 2/2 acts on it: the prototype's off switch is now called `showSkipGuidedHint`, which is still named for a hint rather than for the spotlight.

**Placed at `components/Spotlight.tsx`, not inside `GuidedCreation/`**, matching the prototype, because `EditStepBlock` is one of its call sites and is not guided-only. That also keeps this stack disjoint from the FRM-2497 peek card stack, so the two need no ordering between them.

**Shares `primary.100` with the peek card** and differs only in border weight: 2px `primary.500` means "act on this", 1px `primary.200` reports what just happened. That is the thinnest distinction in the system, so neither should move toward the other. Worth eyeballing the two side by side.

## Alternatives considered

- **A `variant` prop with three values instead of `isActive` plus `isEnabled`.** Rejected. "Off" is not a third appearance, it is the absence of the wrapper, and collapsing them would make flag-off a style rather than a no-op.
- **Applying opacity to each child instead of the wrapper.** Rejected. Requirement 4 wants one wrapper so the active section can also take a background and a border, and per-child opacity would composite unevenly where children overlap.
- **`filter: blur()`, as the design crit note literally asked for.** Rejected. It costs a compositing layer per section and makes text unreadable rather than subordinate, and the spec settled on opacity.
- **Leaving the flag to the call sites.** Rejected, same reasoning as the peek card: three call sites and forgetting the flag once ships to every agency.

## Screenshots

None in the app; nothing renders this yet. Five Storybook stories are the reviewable surface, each showing a three-section card so the contrast between lit and dimmed is visible rather than implied:

| Story | Shows |
| --- | --- |
| Section 1 active | The treatment, and the deliberate 2rem inset |
| Section 2 active | A dimmed section above and below, where the reserved border matters |
| Section 3 active | The spotlight at the end of the card |
| Spotlight off | Children untouched, for comparison against section 1 active |
| Redesign flag off | Identical to the above, which is the point |

The stories keep the Back and Continue buttons outside the spotlight at full opacity, per requirement 3: they are the way forward, and dimming them would look unavailable.

## Breaking Changes

No - backwards compatible. New files only, no call sites, and flag-gated on top of that.

## Tests

Automated: five tests, on the parts that are contract rather than appearance.

- Children render, and a wrapper exists, in both the active and dimmed states
- Nothing is disabled when inactive: no `disabled`, no `aria-disabled`, no `pointer-events: none`
- **The inactive border width equals the active one**, both 2px, which is the layout-shift guard
- Disabled renders **no wrapper at all**
- **Flag off renders no wrapper at all**

I checked the last two fail if the early return is removed, so they guard the real behaviour rather than passing trivially.

**TC1: the treatment reads correctly**

- [ ] Exactly one section is lit per story, and the rest are legible-but-recessed rather than looking broken or disabled
- [ ] The active section is visibly inset from the card edges compared to its neighbours
- [ ] Stepping through sections 1, 2 and 3 shows no vertical shift in the sections around the active one

**TC2: dimmed sections stay usable**

- [ ] Hovering a dimmed section returns it to full opacity
- [ ] Tabbing into a dimmed section's input returns the whole section to full opacity and keeps it there while focus is inside
- [ ] A dimmed section's input can still be typed into and its dropdown opened

**TC3: off means off**

- [ ] The spotlight-off and flag-off stories are indistinguishable from each other
- [ ] Neither shows a background, border, inset or dimming on any section

**TC4: reduced motion**

- [ ] With `prefers-reduced-motion: reduce` set at OS level, moving the spotlight is instant with no fade

**TC5: nothing changed in the app**

- [ ] The workflow builder tab is unchanged, flag on or off, since nothing renders this yet
