### PR TITLE
feat(workflow): add the Spotlight wrapper (1/2)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.stories.tsx
@@ -1,0 +1,130 @@
+import { Box, Divider, Stack, Text } from '@chakra-ui/react'
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { Meta, StoryFn } from '@storybook/react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+import Button from '~components/Button'
+import Input from '~components/Input'
+
+import { Spotlight, SpotlightProps } from './Spotlight'
+
+const withFlag = (isOn: boolean) =>
+  new GrowthBook({
+    features: {
+      [featureFlags.workflowBuilderRedesign]: { defaultValue: isOn },
+    },
+  })
+
+export default {
+  title: 'Features/AdminForm/create/workflow/components/Spotlight',
+  component: Spotlight,
+} as Meta<SpotlightProps>
+
+/**
+ * Stand-in for one section of a step card: a label, a hint and an input. The
+ * spotlight wraps whatever a section renders, so the contents are incidental.
+ */
+const Section = ({ name }: { name: string }): JSX.Element => (
+  <Stack spacing="0.5rem" px="2rem">
+    <Text textStyle="subhead-1">{name}</Text>
+    <Text textStyle="body-2" color="secondary.400">
+      Hint text explaining what this section is for.
+    </Text>
+    <Input placeholder={`${name} value`} />
+  </Stack>
+)
+
+/**
+ * The whole point is one section lit and the rest dimmed, so the stories show a
+ * card with three sections rather than a single wrapper in isolation.
+ */
+const CardTemplate =
+  (
+    activeSection: number,
+    { isEnabled = true, isFlagOn = true } = {},
+  ): StoryFn =>
+  () => (
+    <GrowthBookProvider growthbook={withFlag(isFlagOn)}>
+      <Box
+        maxW="42rem"
+        bg="white"
+        border="1px solid"
+        borderColor="neutral.300"
+        borderRadius="4px"
+        py="2rem"
+      >
+        <Stack spacing="0">
+          {/* Outside the spotlight and always at full opacity: the buttons are
+              the way forward, and dimming them would look unavailable. */}
+          <Stack spacing="0">
+            <Spotlight isActive={activeSection === 1} isEnabled={isEnabled}>
+              <Section name="Step name" />
+            </Spotlight>
+            <Divider />
+            <Spotlight isActive={activeSection === 2} isEnabled={isEnabled}>
+              <Section name="Who fills this in" />
+            </Spotlight>
+            <Divider />
+            <Spotlight isActive={activeSection === 3} isEnabled={isEnabled}>
+              <Section name="What they can see" />
+            </Spotlight>
+          </Stack>
+          <Divider />
+          <Stack direction="row" justify="flex-end" px="2rem" pt="1.5rem">
+            <Button variant="clear" colorScheme="secondary">
+              Back
+            </Button>
+            <Button>Continue</Button>
+          </Stack>
+        </Stack>
+      </Box>
+    </GrowthBookProvider>
+  )
+
+export const FirstSectionActive = CardTemplate(1)
+FirstSectionActive.storyName = 'Section 1 active'
+FirstSectionActive.parameters = {
+  docs: {
+    description: {
+      story:
+        'One section carries the Active treatment and the rest go inert. Note the active section is inset by 2rem, narrower than the sections around it, which is deliberate.',
+    },
+  },
+}
+
+export const MiddleSectionActive = CardTemplate(2)
+MiddleSectionActive.storyName = 'Section 2 active'
+MiddleSectionActive.parameters = {
+  docs: {
+    description: {
+      story:
+        'With a dimmed section above and below, which is where the reserved transparent border matters: nothing shifts as the spotlight moves.',
+    },
+  },
+}
+
+export const LastSectionActive = CardTemplate(3)
+LastSectionActive.storyName = 'Section 3 active'
+
+export const Disabled = CardTemplate(1, { isEnabled: false })
+Disabled.storyName = 'Spotlight off (step 3+, guidance off)'
+Disabled.parameters = {
+  docs: {
+    description: {
+      story:
+        'Children render untouched: no background, no border, no padding, no dimming. Compare against section 1 active to confirm no wrapper styling leaks through.',
+    },
+  },
+}
+
+export const FlagOff = CardTemplate(1, { isFlagOn: false })
+FlagOff.storyName = 'Redesign flag off'
+FlagOff.parameters = {
+  docs: {
+    description: {
+      story:
+        'Identical to the disabled story. Flag-off has to be untouched children everywhere, which is the same thing isEnabled already means.',
+    },
+  },
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.stories.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Stack, Text } from '@chakra-ui/react'
+import { Box, Stack, Text } from '@chakra-ui/react'
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { Meta, StoryFn } from '@storybook/react'
 
@@ -7,7 +7,7 @@ import { featureFlags } from 'formsg-shared/constants'
 import Button from '~components/Button'
 import Input from '~components/Input'
 
-import { Spotlight, SpotlightProps } from './Spotlight'
+import { SpotlightGroup, SpotlightGroupProps } from './Spotlight'
 
 const withFlag = (isOn: boolean) =>
   new GrowthBook({
@@ -18,8 +18,8 @@ const withFlag = (isOn: boolean) =>
 
 export default {
   title: 'Features/AdminForm/create/workflow/components/Spotlight',
-  component: Spotlight,
-} as Meta<SpotlightProps>
+  component: SpotlightGroup,
+} as Meta<SpotlightGroupProps>
 
 /**
  * Stand-in for one section of a step card: a label, a hint and an input. The
@@ -37,94 +37,109 @@ const Section = ({ name }: { name: string }): JSX.Element => (
 
 /**
  * The whole point is one section lit and the rest dimmed, so the stories show a
- * card with three sections rather than a single wrapper in isolation.
+ * card with three sections rather than a single band in isolation.
+ *
+ * The card is deliberately not `overflow: hidden`. The lit band is 2% wider
+ * than the card and is meant to cross its border, which is only visible with a
+ * real card edge to cross.
+ *
+ * `pt` is `0.5rem` rather than the card's usual `2rem` because the group
+ * contributes the other `1.5rem` itself. `EditStepBlock` makes the same swap
+ * when it adopts the group.
  */
 const CardTemplate =
   (
-    activeSection: number,
+    activeIndex: number | null,
     { isEnabled = true, isFlagOn = true } = {},
   ): StoryFn =>
   () => (
     <GrowthBookProvider growthbook={withFlag(isFlagOn)}>
-      <Box
-        maxW="42rem"
-        bg="white"
-        border="1px solid"
-        borderColor="neutral.300"
-        borderRadius="4px"
-        py="2rem"
-      >
-        <Stack spacing="0">
-          {/* Outside the spotlight and always at full opacity: the buttons are
-              the way forward, and dimming them would look unavailable. */}
+      {/* Story-only gutter. The lit band is wider than the card, so without
+          room either side the left overhang is clipped by the canvas edge and
+          the treatment looks asymmetric. */}
+      <Box p="1.5rem">
+        <Box
+          maxW="42rem"
+          bg="white"
+          border="1px solid"
+          borderColor="neutral.300"
+          borderRadius="4px"
+          pt="0.5rem"
+          pb="2rem"
+        >
           <Stack spacing="0">
-            <Spotlight isActive={activeSection === 1} isEnabled={isEnabled}>
+            <SpotlightGroup activeIndex={activeIndex} isEnabled={isEnabled}>
               <Section name="Step name" />
-            </Spotlight>
-            <Divider />
-            <Spotlight isActive={activeSection === 2} isEnabled={isEnabled}>
               <Section name="Who fills this in" />
-            </Spotlight>
-            <Divider />
-            <Spotlight isActive={activeSection === 3} isEnabled={isEnabled}>
               <Section name="What they can see" />
-            </Spotlight>
+            </SpotlightGroup>
+            {/* Outside the group and always at full opacity: the buttons are
+                the way forward, and dimming them would look unavailable. The
+                divider above them is the group's trailing boundary, so it is
+                rendered there and not here. */}
+            <Stack direction="row" justify="flex-end" px="2rem" pt="1.5rem">
+              <Button variant="clear" colorScheme="secondary">
+                Back
+              </Button>
+              <Button>Continue</Button>
+            </Stack>
           </Stack>
-          <Divider />
-          <Stack direction="row" justify="flex-end" px="2rem" pt="1.5rem">
-            <Button variant="clear" colorScheme="secondary">
-              Back
-            </Button>
-            <Button>Continue</Button>
-          </Stack>
-        </Stack>
+        </Box>
       </Box>
     </GrowthBookProvider>
   )
 
-export const FirstSectionActive = CardTemplate(1)
+export const FirstSectionActive = CardTemplate(0)
 FirstSectionActive.storyName = 'Section 1 active'
 FirstSectionActive.parameters = {
   docs: {
     description: {
       story:
-        'One section carries the Active treatment and the rest go inert. Note the active section is inset by 2rem, narrower than the sections around it, which is deliberate.',
+        'One band carries the Active treatment and the rest go inert. The lit band is enlarged 2% at full card width, so it crosses the card border on both sides rather than being inset. Its contents are the same size as every other section, only scaled with the band.',
     },
   },
 }
 
-export const MiddleSectionActive = CardTemplate(2)
+export const MiddleSectionActive = CardTemplate(1)
 MiddleSectionActive.storyName = 'Section 2 active'
 MiddleSectionActive.parameters = {
   docs: {
     description: {
       story:
-        'With a dimmed section above and below, which is where the reserved transparent border matters: nothing shifts as the spotlight moves.',
+        'With a dimmed section above and below, which is where the boundary lines matter: the outline is drawn on the two lines that bound the section, and both grey lines are suppressed so no hairline shows inside the blue.',
     },
   },
 }
 
-export const LastSectionActive = CardTemplate(3)
+export const LastSectionActive = CardTemplate(2)
 LastSectionActive.storyName = 'Section 3 active'
+LastSectionActive.parameters = {
+  docs: {
+    description: {
+      story:
+        "The last section's lower boundary is the divider above the buttons, which stays put: it belongs to the button row, not to the group.",
+    },
+  },
+}
 
-export const Disabled = CardTemplate(1, { isEnabled: false })
+export const Disabled = CardTemplate(0, { isEnabled: false })
 Disabled.storyName = 'Spotlight off (step 3+, guidance off)'
 Disabled.parameters = {
   docs: {
     description: {
       story:
-        'Children render untouched: no background, no border, no padding, no dimming. Compare against section 1 active to confirm no wrapper styling leaks through.',
+        'Sections render untouched, in the pre-redesign structure: sibling dividers, the same 1.5rem rhythm, no band, no outline, no enlargement, no dimming. Compare against section 1 active to confirm no band styling leaks through.',
     },
   },
 }
 
-export const FlagOff = CardTemplate(1, { isFlagOn: false })
+export const FlagOff = CardTemplate(0, { isFlagOn: false })
 FlagOff.storyName = 'Redesign flag off'
 FlagOff.parameters = {
   docs: {
     description: {
       story:
-        'Identical to the disabled story. Flag-off has to be untouched children everywhere, which is the same thing isEnabled already means.',
+        'Identical to the disabled story. Flag-off has to be untouched sections everywhere, which is the same thing isEnabled already means.',
     },
   },
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.test.tsx
@@ -1,34 +1,66 @@
+import { ReactNode } from 'react'
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { render, screen } from '@testing-library/react'
 
 import { featureFlags } from 'formsg-shared/constants'
 
-import { Spotlight, SPOTLIGHT_TEST_ID, SpotlightProps } from './Spotlight'
+import {
+  Spotlight,
+  SPOTLIGHT_TEST_ID,
+  SpotlightGroup,
+  SpotlightProps,
+} from './Spotlight'
 
 const CHILD_LABEL = 'Pick a field'
+
+const withFlag = (isFlagOn: boolean, children: ReactNode) => (
+  <GrowthBookProvider
+    growthbook={
+      new GrowthBook({
+        features: {
+          [featureFlags.workflowBuilderRedesign]: { defaultValue: isFlagOn },
+        },
+      })
+    }
+  >
+    {children}
+  </GrowthBookProvider>
+)
 
 const renderSpotlight = (
   props: Omit<SpotlightProps, 'children'>,
   { isFlagOn = true }: { isFlagOn?: boolean } = {},
 ) =>
   render(
-    <GrowthBookProvider
-      growthbook={
-        new GrowthBook({
-          features: {
-            [featureFlags.workflowBuilderRedesign]: { defaultValue: isFlagOn },
-          },
-        })
-      }
-    >
+    withFlag(
+      isFlagOn,
       <Spotlight {...props}>
         <button type="button">{CHILD_LABEL}</button>
-      </Spotlight>
-    </GrowthBookProvider>,
+      </Spotlight>,
+    ),
+  )
+
+const renderGroup = (
+  {
+    activeIndex,
+    isEnabled,
+  }: { activeIndex: number | null; isEnabled?: boolean },
+  { isFlagOn = true }: { isFlagOn?: boolean } = {},
+) =>
+  render(
+    withFlag(
+      isFlagOn,
+      <SpotlightGroup activeIndex={activeIndex} isEnabled={isEnabled}>
+        <button type="button">Step name</button>
+        <button type="button">Who fills this in</button>
+        <button type="button">What they can see</button>
+      </SpotlightGroup>,
+    ),
   )
 
 const child = () => screen.getByRole('button', { name: CHILD_LABEL })
 const wrapper = () => screen.queryByTestId(SPOTLIGHT_TEST_ID)
+const bands = () => screen.queryAllByTestId(SPOTLIGHT_TEST_ID)
 
 describe('Spotlight', () => {
   it('should wrap its children when active and when merely dimmed', () => {
@@ -54,23 +86,63 @@ describe('Spotlight', () => {
     expect(wrapper()).not.toHaveStyle({ pointerEvents: 'none' })
   })
 
-  // The transparent border is load-bearing: it reserves the space the active
-  // border occupies, so sections do not shift when the spotlight moves onto
-  // them. Simplifying the inactive branch to `border: none` reintroduces a 2px
-  // jump on every Continue.
-  it('should reserve the same border width when inactive as when active', () => {
+  // The spotlight moves on every Continue, so activation must cost no layout.
+  // Design's enlargement is a transform and the ring is an outline, neither of
+  // which reflows; padding and border width are what would, so they are pinned
+  // identical across the two states. Re-implementing the ring as a `border`
+  // reintroduces the 2px jump this replaced.
+  it('should occupy the same space active as inactive', () => {
+    const view = renderSpotlight({ isActive: false, hasTopBorder: true })
+    const inactive = getComputedStyle(wrapper()!)
+    const inactiveBox = {
+      paddingTop: inactive.paddingTop,
+      paddingBottom: inactive.paddingBottom,
+      borderTopWidth: inactive.borderTopWidth,
+      marginLeft: inactive.marginLeft,
+    }
+    view.unmount()
+
+    renderSpotlight({ isActive: true, hasTopBorder: true })
+    const active = getComputedStyle(wrapper()!)
+
+    expect(active.paddingTop).toBe(inactiveBox.paddingTop)
+    expect(active.paddingBottom).toBe(inactiveBox.paddingBottom)
+    expect(active.borderTopWidth).toBe(inactiveBox.borderTopWidth)
+    // Design rejected the inset: the lit band stays full card width.
+    expect(active.marginLeft).toBe(inactiveBox.marginLeft)
+    expect(active.marginLeft).toBe('')
+  })
+
+  // The enlargement is what design asked for in place of the inset, and it is
+  // also what makes the band cover the boundary line of the section below it.
+  it('should enlarge and raise the active band, and neither when inactive', () => {
     const view = renderSpotlight({ isActive: true })
-    const activeBorder = getComputedStyle(wrapper()!).borderWidth
+    expect(getComputedStyle(wrapper()!).transform).toBe('scale(1.02)')
+    expect(getComputedStyle(wrapper()!).zIndex).toBe('1')
     view.unmount()
 
     renderSpotlight({ isActive: false })
+    expect(getComputedStyle(wrapper()!).transform).toBe('none')
+    expect(getComputedStyle(wrapper()!).zIndex).toBe('0')
+  })
 
-    expect(getComputedStyle(wrapper()!).borderWidth).toBe(activeBorder)
-    expect(activeBorder).toBe('2px')
+  // The ring is colour-switched rather than switched off. `outline: none` loses
+  // to the `outlineColor` longhand beside it, which painted the ring on every
+  // band and showed as a rectangle around the whole group at 0.5 opacity.
+  it('should show the ring only when active', () => {
+    const view = renderSpotlight({ isActive: true })
+    const activeRing = getComputedStyle(wrapper()!).outlineColor
+    view.unmount()
+
+    renderSpotlight({ isActive: false })
+    const inactiveRing = getComputedStyle(wrapper()!).outlineColor
+
+    expect(inactiveRing).not.toBe(activeRing)
+    expect(inactiveRing).toMatch(/transparent|rgba\(0, 0, 0, 0\)/)
   })
 
   // Requirement 1: when off, children render untouched. Asserted as "there is
-  // no wrapper at all", so nothing can leak a border, padding or an opacity,
+  // no wrapper at all", so nothing can leak an outline, a band or an opacity,
   // rather than checking each property in turn.
   it('should render children with no wrapper at all when disabled', () => {
     renderSpotlight({ isActive: true, isEnabled: false })
@@ -88,4 +160,113 @@ describe('Spotlight', () => {
     expect(wrapper()).not.toBeInTheDocument()
     expect(child()).toBeInTheDocument()
   })
+})
+
+describe('SpotlightGroup', () => {
+  it('should light exactly one band', () => {
+    renderGroup({ activeIndex: 1 })
+
+    expect(bands()).toHaveLength(3)
+    const transforms = bands().map((b) => getComputedStyle(b).transform)
+    expect(transforms).toEqual(['none', 'scale(1.02)', 'none'])
+  })
+
+  it('should ring exactly one band', () => {
+    renderGroup({ activeIndex: 1 })
+    const rings = bands().map((b) => getComputedStyle(b).outlineColor)
+
+    expect(rings[1]).not.toMatch(/transparent|rgba\(0, 0, 0, 0\)/)
+    expect(rings[0]).toMatch(/transparent|rgba\(0, 0, 0, 0\)/)
+    expect(rings[2]).toMatch(/transparent|rgba\(0, 0, 0, 0\)/)
+  })
+
+  // The two lines the outline is drawn on have to go, or a grey hairline shows
+  // a pixel inside the blue. The line below section N belongs to section N+1,
+  // which is the whole reason the lines live in the group rather than the band.
+  it('should suppress the boundary lines the active outline is drawn on', () => {
+    renderGroup({ activeIndex: 1 })
+    const [first, active, belowActive] = bands()
+
+    // The first section's boundary is the card edge, so it never has a line.
+    const suppressed = getComputedStyle(first).borderTopColor
+    expect(getComputedStyle(active).borderTopColor).toBe(suppressed)
+    expect(getComputedStyle(belowActive).borderTopColor).toBe(suppressed)
+  })
+
+  it('should draw the boundary line on a section the outline does not touch', () => {
+    renderGroup({ activeIndex: 0 })
+    const [first, , unaffected] = bands()
+
+    // Section 3 is neither active nor below the active one, so its line stays.
+    expect(getComputedStyle(unaffected).borderTopColor).not.toBe(
+      getComputedStyle(first).borderTopColor,
+    )
+  })
+
+  // The last section's lower boundary belongs to the group, not the container.
+  // If the container owned that gap the last band could not reach its own line
+  // and the outline would float above it while every other section's sat on it.
+  it('should give the last band a lower boundary of its own', () => {
+    renderGroup({ activeIndex: 0 })
+    const [first, , last] = bands()
+
+    expect(getComputedStyle(last).borderBottomColor).not.toBe(
+      getComputedStyle(first).borderBottomColor,
+    )
+    expect(getComputedStyle(first).borderBottomColor).toMatch(
+      /transparent|rgba\(0, 0, 0, 0\)/,
+    )
+  })
+
+  it('should suppress the trailing boundary when the last band is lit', () => {
+    renderGroup({ activeIndex: 2 })
+    const [first, , last] = bands()
+
+    expect(getComputedStyle(last).borderBottomColor).toBe(
+      getComputedStyle(first).borderBottomColor,
+    )
+  })
+
+  // Every boundary line gets the same clearance, which is what EditStepBlock's
+  // Stack spacing already gives its sibling dividers. Halving it on the theory
+  // that two bands share one gap makes the whole card tighter than it is today.
+  it('should clear every boundary line by the same amount', () => {
+    renderGroup({ activeIndex: 1 })
+
+    bands().forEach((band) => {
+      const style = getComputedStyle(band)
+      expect(style.paddingTop).toBe('1.5rem')
+      expect(style.paddingBottom).toBe('1.5rem')
+    })
+  })
+
+  it('should light nothing when there is no active section', () => {
+    renderGroup({ activeIndex: null })
+
+    expect(bands().map((b) => getComputedStyle(b).transform)).toEqual([
+      'none',
+      'none',
+      'none',
+    ])
+  })
+
+  // Flag-off and spotlight-off keep the pre-redesign structure: sibling
+  // dividers, no bands. Asserted as structure rather than styling, because
+  // "looks the same" is exactly what a band with neutral styling would pass.
+  it.each([
+    ['disabled', { activeIndex: 0, isEnabled: false }, { isFlagOn: true }],
+    ['the flag is off', { activeIndex: 0 }, { isFlagOn: false }],
+  ])(
+    'should render sibling dividers and no bands when %s',
+    (_, props, opts) => {
+      renderGroup(props, opts)
+
+      expect(bands()).toHaveLength(0)
+      // Two between the three sections, plus the group's trailing boundary.
+      expect(screen.getAllByRole('separator')).toHaveLength(3)
+      expect(
+        screen.getByRole('button', { name: 'Who fills this in' }),
+      ).toBeInTheDocument()
+    },
+  )
 })

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.test.tsx
@@ -1,0 +1,91 @@
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { render, screen } from '@testing-library/react'
+
+import { featureFlags } from 'formsg-shared/constants'
+
+import { Spotlight, SPOTLIGHT_TEST_ID, SpotlightProps } from './Spotlight'
+
+const CHILD_LABEL = 'Pick a field'
+
+const renderSpotlight = (
+  props: Omit<SpotlightProps, 'children'>,
+  { isFlagOn = true }: { isFlagOn?: boolean } = {},
+) =>
+  render(
+    <GrowthBookProvider
+      growthbook={
+        new GrowthBook({
+          features: {
+            [featureFlags.workflowBuilderRedesign]: { defaultValue: isFlagOn },
+          },
+        })
+      }
+    >
+      <Spotlight {...props}>
+        <button type="button">{CHILD_LABEL}</button>
+      </Spotlight>
+    </GrowthBookProvider>,
+  )
+
+const child = () => screen.getByRole('button', { name: CHILD_LABEL })
+const wrapper = () => screen.queryByTestId(SPOTLIGHT_TEST_ID)
+
+describe('Spotlight', () => {
+  it('should wrap its children when active and when merely dimmed', () => {
+    const view = renderSpotlight({ isActive: true })
+    expect(wrapper()).toBeInTheDocument()
+    expect(child()).toBeInTheDocument()
+    view.unmount()
+
+    renderSpotlight({ isActive: false })
+    expect(wrapper()).toBeInTheDocument()
+    expect(child()).toBeInTheDocument()
+  })
+
+  // Requirement 4. A dimmed section stays fully interactive, so an admin can
+  // scroll up and fix an earlier answer without leaving the flow.
+  it('should not disable anything when inactive', () => {
+    renderSpotlight({ isActive: false })
+
+    expect(child()).toBeEnabled()
+    expect(child()).not.toHaveAttribute('aria-disabled')
+    expect(wrapper()).not.toHaveAttribute('aria-disabled')
+    expect(wrapper()).not.toHaveAttribute('disabled')
+    expect(wrapper()).not.toHaveStyle({ pointerEvents: 'none' })
+  })
+
+  // The transparent border is load-bearing: it reserves the space the active
+  // border occupies, so sections do not shift when the spotlight moves onto
+  // them. Simplifying the inactive branch to `border: none` reintroduces a 2px
+  // jump on every Continue.
+  it('should reserve the same border width when inactive as when active', () => {
+    const view = renderSpotlight({ isActive: true })
+    const activeBorder = getComputedStyle(wrapper()!).borderWidth
+    view.unmount()
+
+    renderSpotlight({ isActive: false })
+
+    expect(getComputedStyle(wrapper()!).borderWidth).toBe(activeBorder)
+    expect(activeBorder).toBe('2px')
+  })
+
+  // Requirement 1: when off, children render untouched. Asserted as "there is
+  // no wrapper at all", so nothing can leak a border, padding or an opacity,
+  // rather than checking each property in turn.
+  it('should render children with no wrapper at all when disabled', () => {
+    renderSpotlight({ isActive: true, isEnabled: false })
+
+    expect(wrapper()).not.toBeInTheDocument()
+    expect(child()).toBeInTheDocument()
+  })
+
+  // Requirement 7, and the one that matters most: this is live for the whole
+  // Singapore government, so flag-off must leave every section exactly as it
+  // was, including one the flow would otherwise have spotlit.
+  it('should render children with no wrapper at all when the flag is off', () => {
+    renderSpotlight({ isActive: true }, { isFlagOn: false })
+
+    expect(wrapper()).not.toBeInTheDocument()
+    expect(child()).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.test.tsx
@@ -126,6 +126,22 @@ describe('Spotlight', () => {
     expect(getComputedStyle(wrapper()!).zIndex).toBe('0')
   })
 
+  // Elevation comes from a theme token, not a literal. Every literal boxShadow
+  // in features/ is a focus ring, so a literal here would read as one.
+  it('should elevate only the active band', () => {
+    const view = renderSpotlight({ isActive: true })
+    const activeShadow = getComputedStyle(wrapper()!).boxShadow
+    view.unmount()
+
+    renderSpotlight({ isActive: false })
+
+    // The token name, not its value: these tests render without a
+    // ChakraProvider, so theme tokens stay unresolved. Asserting the name is
+    // the point anyway, since a literal is what we are guarding against.
+    expect(activeShadow).toBe('md')
+    expect(getComputedStyle(wrapper()!).boxShadow).toBe('none')
+  })
+
   // The ring is colour-switched rather than switched off. `outline: none` loses
   // to the `outlineColor` longhand beside it, which painted the ring on every
   // band and showed as a rectangle around the whole group at 0.5 opacity.

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
@@ -142,6 +142,15 @@ export const Spotlight = ({
       // DOM as attributes and which never become CSS at all.
       outline="2px solid"
       outlineColor={isActive ? 'primary.500' : 'transparent'}
+      // A token rather than a literal on purpose: every literal boxShadow in
+      // features/ is a focus ring (`0 0 0 Npx`, no blur), so a literal here
+      // would read as one. Note the token has no Y offset, like all three of
+      // them: elevation in this codebase is a soft halo, not a downward cast.
+      //
+      // `md` and not `sm`. `sm` composites to about 4% darker than white at its
+      // densest, spread over a 10px blur, with its inner ring hidden under the
+      // 2px outline, so it was invisible on the card.
+      boxShadow={isActive ? 'md' : 'none'}
       opacity={isActive ? 1 : 0.5}
       _hover={{ opacity: 1 }}
       _focusWithin={{ opacity: 1 }}
@@ -157,7 +166,7 @@ export const Spotlight = ({
       transition={
         prefersReducedMotion
           ? 'none'
-          : 'opacity 0.3s ease, background 0.3s ease, outline-color 0.3s ease, transform 0.3s ease'
+          : 'opacity 0.3s ease, background 0.3s ease, outline-color 0.3s ease, transform 0.3s ease, box-shadow 0.3s ease'
       }
     >
       {children}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
@@ -1,36 +1,83 @@
-import { ReactNode } from 'react'
-import { Box, usePrefersReducedMotion } from '@chakra-ui/react'
+import { Children, ReactNode } from 'react'
+import { Box, Divider, Stack, usePrefersReducedMotion } from '@chakra-ui/react'
 
 import { useIsWorkflowBuilderRedesign } from '../hooks/useIsWorkflowBuilderRedesign'
 
 export const SPOTLIGHT_TEST_ID = 'workflow-spotlight'
+
+/**
+ * Clearance between a section's content and each of its boundary lines.
+ *
+ * `1.5rem` because that is what `EditStepBlock`'s `Stack spacing="1.5rem"`
+ * already puts on both sides of every sibling `<Divider />`. The rhythm is
+ * content-to-line, not content-to-content, so halving this to `0.75rem` on the
+ * theory that two bands share a gap makes the whole card tighter than it is
+ * today.
+ *
+ * This is not padding that insets the section. Content keeps the size and
+ * position it had; the band simply owns whitespace the parent Stack used to.
+ * A container that had `2rem` of its own padding above the first section should
+ * drop that to `0.5rem`, since the band now contributes the other `1.5rem`.
+ */
+const BAND_GAP = '1.5rem'
+
+/** How much the active band grows. Design's "hovers upwards", as a 2% enlargement. */
+const ACTIVE_SCALE = 'scale(1.02)'
 
 export interface SpotlightProps {
   /** This section is the current decision. */
   isActive: boolean
   /**
    * Whether the spotlight applies at all. When false, children render
-   * untouched: no wrapper styling, no reserved border, no padding.
+   * untouched: no wrapper, no band, no boundary line.
    *
    * Named for the spotlight rather than for whatever condition switches it off.
    * The rule that decides it is requirement 5's, and lives with the caller.
    */
   isEnabled?: boolean
+  /**
+   * Draws this band's top boundary: the line that used to be a sibling
+   * `<Divider />`. Owned by the band rather than the parent so the active
+   * outline can be drawn on the line rather than inside it.
+   *
+   * `SpotlightGroup` decides this. Callers rendering a lone band leave it off.
+   */
+  hasTopBorder?: boolean
+  /**
+   * Draws this band's bottom boundary. Only the last band in a run needs one,
+   * since every other band's lower boundary is the next band's top border.
+   */
+  hasBottomBorder?: boolean
   children: ReactNode
 }
 
 /**
- * Marks the one section an admin is meant to act on right now, and dims the
- * rest.
+ * One section of a step card as a band that runs boundary to boundary, lit when
+ * it is the current decision and dimmed when it is not.
  *
- * The inactive state carries a 2px *transparent* border on purpose. It reserves
- * the space the active border occupies, so sections do not shift when the
- * spotlight moves onto them. Simplifying it to `border: none` reintroduces a
- * 2px jump on every Continue.
+ * The active band is enlarged by 2% rather than inset and padded. An earlier
+ * version added `2rem` of inline margin and vertical padding on activation,
+ * which made the lit section narrower than its neighbours and squeezed its
+ * contents. Design rejected that: the section is meant to read as lifting off
+ * the card at full size, not as a smaller panel within it.
  *
- * The 2rem inline margin insets the active section, making it narrower than the
- * sections around it. That is deliberate: it reads as a focused panel within
- * the card, and is not an alignment bug to zero out.
+ * The 2% scale is uniform, so the band ends up wider than the card and crosses
+ * the card's own border on both sides. That is the intended "hover", and no
+ * ancestor clips it. Do not clamp it back to the card width.
+ *
+ * Two properties make the enlargement free of layout cost, which matters
+ * because the spotlight moves on every Continue and any reflow reads as a jump:
+ *
+ * - `transform` does not participate in layout, so neighbours never move.
+ * - the ring is an `outline`, not a `border`, so it occupies no space and needs
+ *   no transparent placeholder reserving room for it.
+ *
+ * The top boundary line is the one thing that could still shift, so it is
+ * always a 1px border and only its colour changes.
+ *
+ * The band is positioned with a raised `zIndex` when active. That is
+ * load-bearing rather than cosmetic: the enlarged band has to paint over the
+ * boundary line of the section below it, which belongs to that sibling.
  *
  * Dimming is presentation only. A dimmed section stays fully interactive, with
  * no pointer-events change, no `disabled` and no `aria-disabled`, so an admin
@@ -40,8 +87,8 @@ export interface SpotlightProps {
  * 3.22:1, below the 4.5:1 AA requirement, and the opacity needed to pass would
  * make the dimming invisible.
  *
- * Opacity is not the only signal, since the active section also gains a
- * background and a border.
+ * Opacity is not the only signal, since the active band also gains a background
+ * and an outline.
  *
  * Shares `primary.100` with the peek card and differs in border weight: 2px
  * `primary.500` here means "act on this", 1px `primary.200` there reports what
@@ -51,6 +98,8 @@ export interface SpotlightProps {
 export const Spotlight = ({
   isActive,
   isEnabled = true,
+  hasTopBorder = false,
+  hasBottomBorder = false,
   children,
 }: SpotlightProps): JSX.Element => {
   const prefersReducedMotion = usePrefersReducedMotion()
@@ -65,22 +114,137 @@ export const Spotlight = ({
       // The wrapper's presence is the whole of "is the spotlight on", so tests
       // assert on it directly rather than inspecting computed styles.
       data-testid={SPOTLIGHT_TEST_ID}
+      py={BAND_GAP}
       bg={isActive ? 'primary.100' : 'transparent'}
       borderRadius={isActive ? '8px' : '0'}
-      border="2px solid"
-      borderColor={isActive ? 'primary.500' : 'transparent'}
+      // Always 1px on both edges, colour-switched. Toggling a border itself
+      // would move the section by a pixel every time the spotlight arrived or
+      // left, and every band carries both so their heights stay identical.
+      borderTop="1px solid"
+      borderTopColor={hasTopBorder ? 'neutral.300' : 'transparent'}
+      borderBottom="1px solid"
+      borderBottomColor={hasBottomBorder ? 'neutral.300' : 'transparent'}
+      // An outline, not a border: drawn outside the box at zero layout cost, so
+      // it can sit on the boundary lines instead of inside them.
+      //
+      // Colour-switched, and deliberately not `outline="none"` when inactive:
+      // the shorthand loses to the `outlineColor` longhand beside it, which
+      // painted a blue ring on every band and left a lavender rectangle around
+      // the whole group at 0.5 opacity. Costs nothing to leave the outline in
+      // place, since it never occupies layout.
+      //
+      // Has to be this pair of props. Chakra maps `outline` and `outlineColor`
+      // but not `outlineWidth` or `outlineStyle`, which React forwards to the
+      // DOM as attributes and which never become CSS at all.
+      outline="2px solid"
+      outlineColor={isActive ? 'primary.500' : 'transparent'}
       opacity={isActive ? 1 : 0.5}
       _hover={{ opacity: 1 }}
       _focusWithin={{ opacity: 1 }}
+      transform={
+        // A static enlargement rather than an animation, so reduced motion
+        // drops the transition and keeps the state. Without the scale the band
+        // would stop covering the line below it.
+        isActive ? ACTIVE_SCALE : 'none'
+      }
+      transformOrigin="center"
+      position="relative"
+      zIndex={isActive ? 1 : 0}
       transition={
         prefersReducedMotion
           ? 'none'
-          : 'opacity 0.3s ease, background 0.3s ease, border-color 0.3s ease'
+          : 'opacity 0.3s ease, background 0.3s ease, outline-color 0.3s ease, transform 0.3s ease'
       }
-      mx={isActive ? '2rem' : '0'}
-      py={isActive ? '2rem' : '0.5rem'}
     >
       {children}
     </Box>
+  )
+}
+
+export interface SpotlightGroupProps {
+  /**
+   * Which section is the current decision, zero-based, or `null` for none.
+   * Zero-based to match `WorkflowContent`'s `stepNumber={i}` and the workflow
+   * store.
+   */
+  activeIndex: number | null
+  /** Passed through to every band. See `SpotlightProps.isEnabled`. */
+  isEnabled?: boolean
+  /** One child per section. */
+  children: ReactNode
+}
+
+/**
+ * The run of sections a spotlight moves through, and the owner of every
+ * boundary line in that run.
+ *
+ * A band cannot own both its lines: the line below section N is the line above
+ * section N+1. So the lines live here, where the active index is known, and the
+ * two lines the active outline is drawn on are suppressed. Without that
+ * suppression a grey hairline shows a pixel inside the blue outline.
+ *
+ * That includes the line *below the last section*, which is why this renders a
+ * trailing boundary and the caller must not. The last section's lower boundary
+ * is the divider above the Save/Continue row, and if the container owned that
+ * gap the last band could not reach its own line: the outline would float
+ * `1.5rem` above it while every other section's sat on it.
+ *
+ * Only the spotlit sections belong inside. The Save/Continue row stays outside
+ * and below the trailing boundary: the buttons are the way forward and dimming
+ * them would look unavailable.
+ *
+ * When the spotlight is off, this renders the pre-redesign structure, sibling
+ * dividers at the same `1.5rem` clearance and the same trailing divider,
+ * because flag-off has to leave the card as it was.
+ *
+ * Both states put `1.5rem` inside the group's own top edge and above its
+ * trailing line, so a card is laid out identically whichever way the flag
+ * falls. A container that had `2rem` above its first section drops that to
+ * `0.5rem`, since the group now contributes the rest.
+ */
+export const SpotlightGroup = ({
+  activeIndex,
+  isEnabled = true,
+  children,
+}: SpotlightGroupProps): JSX.Element => {
+  const isRedesign = useIsWorkflowBuilderRedesign()
+
+  const sections = Children.toArray(children)
+
+  if (!isEnabled || !isRedesign) {
+    return (
+      // `pt` matches the clearance a band contributes above the first section,
+      // so a card is laid out identically whichever way the flag falls and the
+      // container needs only one set of padding values.
+      <Stack spacing={BAND_GAP} pt={BAND_GAP}>
+        {sections.flatMap((section, i) =>
+          i === 0 ? [section] : [<Divider key={`line-${i}`} />, section],
+        )}
+        <Divider />
+      </Stack>
+    )
+  }
+
+  return (
+    <Stack spacing="0">
+      {sections.map((section, i) => {
+        const isActive = i === activeIndex
+        const isBelowActive = activeIndex !== null && i === activeIndex + 1
+
+        return (
+          <Spotlight
+            key={i}
+            isActive={isActive}
+            // The first section's upper boundary is the card edge, not a line.
+            hasTopBorder={i > 0 && !isActive && !isBelowActive}
+            // Only the last band draws its own lower boundary, and not when it
+            // is the lit one: there the outline is already on that line.
+            hasBottomBorder={i === sections.length - 1 && !isActive}
+          >
+            {section}
+          </Spotlight>
+        )
+      })}
+    </Stack>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
@@ -116,7 +116,11 @@ export const Spotlight = ({
       data-testid={SPOTLIGHT_TEST_ID}
       py={BAND_GAP}
       bg={isActive ? 'primary.100' : 'transparent'}
-      borderRadius={isActive ? '8px' : '0'}
+      // `4px` is the workflow builder's radius: the step card, EditStepBlock,
+      // InactiveStepBlock and StepLabel all use it. The band is a surface
+      // inside that card, so a rounder corner reads as a different kind of
+      // object rather than a lit section of the same one.
+      borderRadius={isActive ? '4px' : '0'}
       // Always 1px on both edges, colour-switched. Toggling a border itself
       // would move the section by a pixel every time the spotlight arrived or
       // left, and every band carries both so their heights stay identical.

--- a/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/Spotlight.tsx
@@ -1,0 +1,86 @@
+import { ReactNode } from 'react'
+import { Box, usePrefersReducedMotion } from '@chakra-ui/react'
+
+import { useIsWorkflowBuilderRedesign } from '../hooks/useIsWorkflowBuilderRedesign'
+
+export const SPOTLIGHT_TEST_ID = 'workflow-spotlight'
+
+export interface SpotlightProps {
+  /** This section is the current decision. */
+  isActive: boolean
+  /**
+   * Whether the spotlight applies at all. When false, children render
+   * untouched: no wrapper styling, no reserved border, no padding.
+   *
+   * Named for the spotlight rather than for whatever condition switches it off.
+   * The rule that decides it is requirement 5's, and lives with the caller.
+   */
+  isEnabled?: boolean
+  children: ReactNode
+}
+
+/**
+ * Marks the one section an admin is meant to act on right now, and dims the
+ * rest.
+ *
+ * The inactive state carries a 2px *transparent* border on purpose. It reserves
+ * the space the active border occupies, so sections do not shift when the
+ * spotlight moves onto them. Simplifying it to `border: none` reintroduces a
+ * 2px jump on every Continue.
+ *
+ * The 2rem inline margin insets the active section, making it narrower than the
+ * sections around it. That is deliberate: it reads as a focused panel within
+ * the card, and is not an alignment bug to zero out.
+ *
+ * Dimming is presentation only. A dimmed section stays fully interactive, with
+ * no pointer-events change, no `disabled` and no `aria-disabled`, so an admin
+ * who scrolls up to fix an earlier answer can do it without leaving the flow.
+ * Hover and focus-within restore full opacity, which is what covers a section
+ * an admin deliberately returns to: at 0.5 the darkest label composites to
+ * 3.22:1, below the 4.5:1 AA requirement, and the opacity needed to pass would
+ * make the dimming invisible.
+ *
+ * Opacity is not the only signal, since the active section also gains a
+ * background and a border.
+ *
+ * Shares `primary.100` with the peek card and differs in border weight: 2px
+ * `primary.500` here means "act on this", 1px `primary.200` there reports what
+ * just happened. That is the thinnest distinction in the system, so neither
+ * should move toward the other.
+ */
+export const Spotlight = ({
+  isActive,
+  isEnabled = true,
+  children,
+}: SpotlightProps): JSX.Element => {
+  const prefersReducedMotion = usePrefersReducedMotion()
+  // Gated here rather than at each call site: flag-off has to be untouched
+  // children everywhere, and that is the same thing isEnabled already means.
+  const isRedesign = useIsWorkflowBuilderRedesign()
+
+  if (!isEnabled || !isRedesign) return <>{children}</>
+
+  return (
+    <Box
+      // The wrapper's presence is the whole of "is the spotlight on", so tests
+      // assert on it directly rather than inspecting computed styles.
+      data-testid={SPOTLIGHT_TEST_ID}
+      bg={isActive ? 'primary.100' : 'transparent'}
+      borderRadius={isActive ? '8px' : '0'}
+      border="2px solid"
+      borderColor={isActive ? 'primary.500' : 'transparent'}
+      opacity={isActive ? 1 : 0.5}
+      _hover={{ opacity: 1 }}
+      _focusWithin={{ opacity: 1 }}
+      transition={
+        prefersReducedMotion
+          ? 'none'
+          : 'opacity 0.3s ease, background 0.3s ease, border-color 0.3s ease'
+      }
+      mx={isActive ? '2rem' : '0'}
+      py={isActive ? '2rem' : '0.5rem'}
+    >
+      {children}
+    </Box>
+  )
+}


### PR DESCRIPTION
## Problem

A step card asks for a name, the people who fill it in, what they do there and which fields they see. Every one of those carries the same visual weight, so nothing tells an admin where the current decision is. On `develop`, `EditStepBlock` stacks `StepNameBlock`, `RespondentBlock`, `ApprovalsBlock` and `QuestionsBlock` in one column at full opacity, and nothing inside the card responds to where the admin is.

The spotlight came out of design crit, answering a specific objection: guidance competes with the thing being guided unless it is visually subordinate. It is the cheap version of "blur the out-of-focus fields", in place, without a second column.

Groundwork for FRM-2501. No user-visible change: nothing renders this yet, and it is flag-gated on top of that.

## Solution

Two components.

`Spotlight` is one section as a band running boundary to boundary: `isActive` for "this section is the current decision", `isEnabled` for "the spotlight applies at all". Two states plus an off switch, rather than a component per surface.

`SpotlightGroup` is the run of sections a spotlight moves through, and the owner of every boundary line in that run. It takes `activeIndex` and passes `isEnabled` down.

Values, after the design crit described below: `primary.100` background, a 2px solid `primary.500` **outline**, 4px radius, the `md` shadow token and a 2% enlargement when active. Transparent background, transparent outline, 0 radius, no shadow and no enlargement when not, at 0.5 opacity. Band padding is 1.5rem in both states, and the band is full card width in both.

### Read the commits in order

The first commit is a design reversal, not a first draft. The original treatment inset the active section by 2rem and added 2rem of block padding, which made the lit section narrower than its neighbours and squeezed its contents. Design rejected it on sight in Storybook: the section is meant to read as lifting off the card at full size. The radius and the shadow are the two follow-ups from the same review.

### Why there is a group at all

Design's rule is that the outline sits **on** the two divider lines bounding the section, not inside them. A band cannot own both: the line below section N is the line above section N+1. Both have to be suppressed where the outline is drawn, or a grey hairline shows a pixel inside the blue.

So the lines live in the group, which knows the active index. That includes the trailing line above Save/Continue: it is the last section's lower boundary, and if the container owned that gap the last band could not reach its own line, so its outline would float 1.5rem above it while every other section's sat on it.

### Three things that are load-bearing and easy to "simplify" into bugs

**The ring is an `outline`, not a `border`.** An outline is drawn outside the box at zero layout cost, which is what lets it sit on the boundary lines and what removed the transparent-border placeholder the first version needed. Re-implementing it as a border reintroduces a 2px jump on every Continue. A test pins padding and border width identical across both states.

**It must be `outline` plus `outlineColor`, colour-switched.** Chakra maps those two and does *not* map `outlineWidth` or `outlineStyle`, which React forwards to the DOM as attributes where they never become CSS. And `outline="none"` loses to the `outlineColor` longhand beside it, which painted the ring on every band and showed as a lavender rectangle around the whole group at 0.5 opacity. Both mistakes are in the history of this branch; two tests guard against them.

**Dimming is presentation only.** No `pointer-events` change, no `disabled`, no `aria-disabled`. An admin who scrolls up to fix the step name has to be able to, which is FRM-2498's requirement 3 and depends on this not breaking it.

### Clearance, which is the easiest thing to get wrong

Every boundary line gets 1.5rem of clearance, because that is what `EditStepBlock`'s `Stack spacing="1.5rem"` already gives each sibling `<Divider />`. The rhythm is content-to-line, not content-to-content. The first cut used 0.75rem on the theory that two adjacent bands share one gap, which made the whole card tighter than it is today at every boundary. Measured in Storybook and pinned by a test.

Both flag states also pad their own top edge by 1.5rem, so a card lays out identically whichever way the flag falls.

### The contrast decision, stated rather than buried

At 0.5 opacity the darkest label in a section composites to **3.22:1** against a 4.5:1 AA requirement, and the lightest hint text would need 0.80 opacity to pass, at which point the dimming is invisible. The decision is to keep the dimming, because outside the spotlight there is nothing an admin is meant to read.

What covers it is the hover and `focus-within` restoration to full opacity: WCAG's exemption for inactive components does not apply here, since these sections stay interactive, so a section an admin deliberately returns to is legible while they are in it. That is a requirement, not a nicety.

Transition is `opacity`, `background`, `outline-color`, `transform` and `box-shadow` at 0.3s ease, dropped to `none` under `prefers-reduced-motion`. The enlargement itself is kept under reduced motion, since it is a state rather than an animation.

### Flag gating

Gated on `useIsWorkflowBuilderRedesign` inside both components rather than at each call site, because flag-off has to mean untouched children everywhere, and that is the same thing `isEnabled` already means.

`Spotlight`'s off path is asserted as "no wrapper element at all", so nothing can leak an outline, padding or an opacity. `SpotlightGroup`'s off path renders the pre-redesign structure instead: sibling dividers at the same 1.5rem clearance, plus the same trailing divider. It has to render *something*, because with the group owning the lines the naive off path would drop the dividers entirely.

## Notes for review

**What FRM-2498 has to do at the call sites**, since the group changes the shape of `EditStepBlock`:

- Pass one `activeIndex` to a group, not three `isActive` booleans. `isSpotlightEnabled` from 2/2 still feeds `isEnabled`, unchanged.
- **Delete** `EditStepBlock`'s trailing `<Divider />`. The group renders it. Leaving it in produces two lines.
- Change that Stack's `py="2rem"` to `pt="0.5rem"` / `pb="2rem"`. The group contributes 1.5rem above its first section in both flag states, so leaving the container at 2rem puts 3.5rem above section 1.
- **`activeIndex` is positional, and this is the trap.** `ApprovalsBlock` only renders for non-first steps, so a given section's index is not fixed across steps. Derive it from the list actually being rendered, not from a constant.

**The lit band is wider than the card on purpose.** A uniform 2% scale on a full-width band puts it about 6px past the card's border on each side. That is the intended lift, and nothing in the tree clips it. It is not an overflow bug to clamp.

**The shadow is a halo, not a drop.** None of the three theme tokens has a Y offset, so `md` reads as the band being backlit rather than raised. If design wants a real lift, the missing ingredient is an offset shadow, which would be the first one in the codebase. Flagging it rather than doing it.

**The spec's "Porting warning" is stale.** It says the prototype implements this three times, as a local `SpotlightWrapper`, a local `EditSpotlight` and an inline `Box`, with a misnamed `isFlowComplete` off switch. All three names are now gone from `workflow-exploration-c`; commit `cc18c34d9` collapsed them into one component used at exactly the three call sites requirement 6 lists. The substantive point still stands, and 2/2 acts on it: the prototype's off switch is now called `showSkipGuidedHint`, which is still named for a hint rather than for the spotlight.

**Placed at `components/Spotlight.tsx`, not inside `GuidedCreation/`**, matching the prototype, because `EditStepBlock` is one of its call sites and is not guided-only. That also keeps this stack disjoint from the FRM-2497 peek card stack, so the two need no ordering between them.

**Shares `primary.100` with the peek card** and differs in weight: a 2px `primary.500` outline means "act on this", a 1px `primary.200` border reports what just happened. That is the thinnest distinction in the system, so neither should move toward the other. Worth eyeballing the two side by side.

## Alternatives considered

- **Keeping the inset panel treatment.** Rejected by design. It made the lit section narrower than its neighbours and squeezed its contents, which reads as a smaller panel rather than a lifted one.
- **Letting each band own its own two boundary lines.** Rejected. The line below section N is the line above section N+1, so ownership is genuinely shared and one of the two bands would always draw a grey line inside the other's outline.
- **Leaving the trailing line to the container.** Rejected. The last band could not then reach its own lower boundary, so its outline would float above the line while every other section's sat on it.
- **The `sm` shadow token.** Tried and rejected as invisible: it composites to roughly 4% darker than white at its densest, spread over a 10px blur, with its inner ring hidden under the 2px outline.
- **A `variant` prop with three values instead of `isActive` plus `isEnabled`.** Rejected. "Off" is not a third appearance, it is the absence of the wrapper, and collapsing them would make flag-off a style rather than a no-op.
- **Applying opacity to each child instead of the wrapper.** Rejected. Requirement 4 wants one wrapper so the active section can also take a background and an outline, and per-child opacity would composite unevenly where children overlap.
- **`filter: blur()`, as the design crit note literally asked for.** Rejected. It costs a compositing layer per section and makes text unreadable rather than subordinate, and the spec settled on opacity.
- **Leaving the flag to the call sites.** Rejected, same reasoning as the peek card: three call sites and forgetting the flag once ships to every agency.

## Screenshots

None in the app; nothing renders this yet. Five Storybook stories are the reviewable surface, each showing a three-section card so the contrast between lit and dimmed is visible rather than implied:

| Story | Shows |
| --- | --- |
| Section 1 active | The treatment, and the band crossing the card border on both sides |
| Section 2 active | A dimmed section above and below, where the suppressed boundary lines matter |
| Section 3 active | The outline landing on the trailing line above the buttons |
| Spotlight off | The pre-redesign structure, for comparison against section 1 active |
| Redesign flag off | Identical to the above, which is the point |

The stories keep the Back and Continue buttons outside the group at full opacity, per requirement 3: they are the way forward, and dimming them would look unavailable.

## Breaking Changes

No - backwards compatible. New files only, no call sites, and flag-gated on top of that.

## Tests

Automated: 18, on the parts that are contract rather than appearance. Six of them exist because the mistake they describe was actually made on this branch.

`Spotlight`:

- Children render, and a wrapper exists, in both the active and dimmed states
- Nothing is disabled when inactive: no `disabled`, no `aria-disabled`, no `pointer-events: none`
- **Padding and border width are identical active and inactive**, and margin is unset, which is the layout-shift guard and the "no inset" guard together
- The active band is enlarged and raised; the inactive one is neither
- **The ring shows only when active**, the guard against the `outline: none` shorthand being overridden
- Elevation is the `md` token, not a literal
- Disabled renders **no wrapper at all**
- **Flag off renders no wrapper at all**

`SpotlightGroup`:

- Exactly one band is lit, and exactly one is ringed
- **The two boundary lines the outline is drawn on are suppressed**
- A line the outline does not touch is still drawn
- **The last band has a lower boundary of its own**, and it is suppressed when that band is the lit one
- **Every band clears its boundary lines by the same 1.5rem**, the guard against halving the card's rhythm
- Nothing is lit when `activeIndex` is null
- Disabled and flag-off both render sibling dividers and no bands

The shadow test asserts the token name rather than its computed value, because these tests render without a `ChakraProvider` so theme tokens stay unresolved. The resolved values were checked in Storybook instead, along with every boundary measurement quoted above.

**TC1: the treatment reads correctly**

- [ ] Exactly one section is lit per story, and the rest are legible-but-recessed rather than looking broken or disabled
- [ ] The lit section is full card width and visibly crosses the card border on both sides, rather than being inset
- [ ] Its contents are the same size as the other sections', only scaled with the band
- [ ] Stepping through sections 1, 2 and 3 shows no vertical shift in the sections around the active one

**TC2: the outline sits on the lines**

- [ ] No grey hairline is visible inside the blue outline, top or bottom
- [ ] With section 3 lit, the outline lands on the divider above the buttons
- [ ] Every divider has the same clearance above and below it, lit or not

**TC3: dimmed sections stay usable**

- [ ] Hovering a dimmed section returns it to full opacity
- [ ] Tabbing into a dimmed section's input returns the whole section to full opacity and keeps it there while focus is inside
- [ ] A dimmed section's input can still be typed into and its dropdown opened

**TC4: off means off**

- [ ] The spotlight-off and flag-off stories are indistinguishable from each other
- [ ] Neither shows a background, outline, enlargement, shadow or dimming on any section
- [ ] Both still show the dividers between sections and above the buttons

**TC5: reduced motion**

- [ ] With `prefers-reduced-motion: reduce` set at OS level, moving the spotlight is instant with no fade, and the lit section is still enlarged

**TC6: nothing changed in the app**

- [ ] The workflow builder tab is unchanged, flag on or off, since nothing renders this yet
