### PR TITLE
feat(workflow): decide when the spotlight applies (2/2)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/utils/spotlightPolicy.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/utils/spotlightPolicy.test.ts
@@ -1,0 +1,71 @@
+import { isSpotlightEnabled } from './spotlightPolicy'
+
+describe('isSpotlightEnabled', () => {
+  // The only situation the spotlight is off in. All three conditions have to
+  // hold, which is the part the prototype's naming obscured.
+  it('should be off only on step 3+ with every section visible and guidance off', () => {
+    expect(
+      isSpotlightEnabled({
+        stepNumber: 2,
+        areAllSectionsVisible: true,
+        isGuidanceOn: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('should stay on for steps 1 and 2 regardless of the other two facts', () => {
+    ;[0, 1].forEach((stepNumber) => {
+      ;[true, false].forEach((areAllSectionsVisible) => {
+        ;[true, false].forEach((isGuidanceOn) => {
+          expect(
+            isSpotlightEnabled({
+              stepNumber,
+              areAllSectionsVisible,
+              isGuidanceOn,
+            }),
+          ).toBe(true)
+        })
+      })
+    })
+  })
+
+  // Turning the toggle on re-enables it, which is what lets an admin who
+  // skipped guidance ask for it back.
+  it('should be on when guidance is on, even on a later step with all sections visible', () => {
+    expect(
+      isSpotlightEnabled({
+        stepNumber: 4,
+        areAllSectionsVisible: true,
+        isGuidanceOn: true,
+      }),
+    ).toBe(true)
+  })
+
+  // Mid-step on a later step with guidance off: sections are still being
+  // revealed, so the spotlight is still doing the revealing.
+  it('should be on while a later step still has sections to reveal', () => {
+    expect(
+      isSpotlightEnabled({
+        stepNumber: 2,
+        areAllSectionsVisible: false,
+        isGuidanceOn: false,
+      }),
+    ).toBe(true)
+  })
+
+  // Step 3 is index 2. Off by one in either direction changes which step first
+  // gets to skip the spotlight.
+  it('should treat step index 2 as the first later step', () => {
+    const allVisibleGuidanceOff = {
+      areAllSectionsVisible: true,
+      isGuidanceOn: false,
+    }
+
+    expect(
+      isSpotlightEnabled({ stepNumber: 1, ...allVisibleGuidanceOff }),
+    ).toBe(true)
+    expect(
+      isSpotlightEnabled({ stepNumber: 2, ...allVisibleGuidanceOff }),
+    ).toBe(false)
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/utils/spotlightPolicy.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/utils/spotlightPolicy.ts
@@ -1,0 +1,41 @@
+/**
+ * When the section spotlight applies at all.
+ *
+ * Its own module, taking three plain facts rather than reading the guided
+ * flow's state, so the rule is testable on its own and the flow does not have
+ * to re-derive it at each call site.
+ */
+
+export interface SpotlightPolicyInput {
+  /**
+   * Zero-based, matching `WorkflowContent`'s `stepNumber={i}` and the workflow
+   * store. "Step 3 and onwards" is therefore index 2 and above.
+   */
+  stepNumber: number
+  /** Every section of this step has been revealed. */
+  areAllSectionsVisible: boolean
+  /** The per-step guided toggle is on. */
+  isGuidanceOn: boolean
+}
+
+/**
+ * The spotlight is on except in one situation: step 3 or later, with every
+ * section already visible, and guidance switched off. There the admin has done
+ * this twice already and asked not to be guided, so every section renders at
+ * full weight and the card carries the treatment instead.
+ *
+ * Named for what it decides. The prototype's equivalents were named for a hint
+ * (`showSkipGuidedHint`) and, earlier, for flow completion (`isFlowComplete`),
+ * neither of which is what the value means: it is false on steps 1 and 2 no
+ * matter how far through them the admin is.
+ *
+ * Steps 1 and 2 never return to full opacity in place. They reach it by
+ * unmounting when the step saves, which is why there is no early-step case
+ * here.
+ */
+export const isSpotlightEnabled = ({
+  stepNumber,
+  areAllSectionsVisible,
+  isGuidanceOn,
+}: SpotlightPolicyInput): boolean =>
+  !(stepNumber >= 2 && areAllSectionsVisible && !isGuidanceOn)


### PR DESCRIPTION
## Problem

1/2 gives a wrapper with an `isEnabled` switch but says nothing about when it should be off. Requirement 5 has a specific rule, and it is the part of this feature the prototype makes hardest to read: its off switch is called `showSkipGuidedHint`, and an earlier version was called `isFlowComplete`, neither of which describes what the value means.

Stacked on #9945. Please review and merge that one first; the base retargets to `develop` once it lands.

**1/2 was restyled after design crit and force-pushed.** Nothing in this PR changed: the rule below is about *when* the spotlight applies, and the restyle was about what it looks like. Worth knowing only because 1/2's diff is no longer the one you may have already read, and it now ships a second component, `SpotlightGroup`, which is what `isSpotlightEnabled` will feed.

Part of FRM-2501.

## Solution

Requirement 5's rule as its own tested function:

```ts
isSpotlightEnabled({ stepNumber, areAllSectionsVisible, isGuidanceOn })
```

The spotlight is on **except** on step 3 or later, with every section already visible, and guidance switched off. There the admin has done this twice and asked not to be guided, so every section renders at full weight and the card carries the treatment instead.

Three conditions, all of which have to hold. That is the part worth pinning, and the part the prototype's naming obscures.

### Why this is separate from 1/2

Different review question. 1/2 is "is this the right treatment"; this is "is this the right rule". They fail independently, and the rule is the one a reader can check against the spec without looking at any CSS.

### Naming

Named for what it decides, per the spec's porting warning. `isFlowComplete` was actively misleading: it is false on steps 1 and 2 however far through them the admin is, so nothing about it tracks flow completion. `showSkipGuidedHint`, the current prototype name, describes a hint that happens to appear in the same situation.

### Takes facts, not the store

Three plain booleans and a number rather than reading the guided store, so the rule is testable on its own and FRM-2498 passes what it already knows instead of re-deriving this at each of the three call sites. That also means this module needs no mocking to test and does not have to change when the guided store's shape settles.

`stepNumber` is zero-based, matching `WorkflowContent`'s `stepNumber={i}` and the workflow store, so "step 3 and onwards" is index 2 and above.

## The case that is deliberately absent

There is no early-step branch. Steps 1 and 2 never return to full opacity in place; they reach it by unmounting when the step saves. If a future change makes an early step want the spotlight off in place, that is a spec change rather than a missing condition here.

## Alternatives considered

- **Folding the rule into `Spotlight` as a `stepNumber` prop.** Rejected. It would make the wrapper know about steps, sections and toggles, when its whole job is one section's appearance, and it would put the rule behind a render to test.
- **A hook reading the guided store.** Rejected. The store is FRM-2498's and does not exist yet, so a hook would either be speculative about its shape or need mocking to test. A function taking facts is neither.
- **Keeping the prototype's inverted `showSkipGuidedHint`.** Rejected. A negated value named after a different piece of UI is how the prototype ended up with three implementations that disagreed.
- **Two conditions instead of three, dropping `areAllSectionsVisible`.** Rejected. It reads like a simplification but changes behaviour: a later step mid-reveal with guidance off would lose the spotlight while sections are still appearing, which is exactly when it is doing the revealing.

## Screenshots

Testing in Storybook:

|Scenario|Screenshot|
|---|---|
|Spotlight on first section|<img width="656" height="567" alt="Screenshot 2026-09-03 at 3 39 33 PM" src="https://github.com/user-attachments/assets/ee0a545a-bc41-42f7-aad1-ce204c60290a" />|
|Spotlight on middle section|<img width="655" height="579" alt="Screenshot 2026-09-03 at 3 39 37 PM" src="https://github.com/user-attachments/assets/afb3f5bb-3bca-4c00-b870-e5c6a8cd3e44" />|
|Spotlight on last section|<img width="652" height="584" alt="Screenshot 2026-09-03 at 3 39 41 PM" src="https://github.com/user-attachments/assets/188ac96d-9ac5-417e-bde6-72ab233ce2c1" />|
|No spotlight|<img width="648" height="572" alt="Screenshot 2026-09-03 at 3 39 45 PM" src="https://github.com/user-attachments/assets/e2fa7fae-68db-4211-8de7-49451df07e38" />|

## Breaking Changes

No - backwards compatible. One new module and its test, no call sites.

## Tests

Automated: five tests, chosen so each one fails for a different mistake.

- The single off case: step 3+, all sections visible, guidance off
- Every combination of the other two facts on steps 1 and 2, all on
- Guidance turned back on re-enables it, even on a later step with everything visible
- A later step mid-reveal with guidance off stays on, which is the case dropping `areAllSectionsVisible` would break
- **Step index 2 is the first later step**, asserted against index 1, so the off-by-one cannot drift in either direction

**TC1: the rule matches the spec**

- [ ] Requirement 5 reads "step 3 and beyond, every section visible, toggle off", and the function is false in exactly that case
- [ ] Turning the toggle on returns the spotlight, per requirement 5's second paragraph

**TC2: no behaviour change**

- [ ] Nothing calls this yet, so the workflow builder tab is unchanged, flag on or off

