### PR TITLE
test(workspace): assert Q1's own required message in the origin story

### DIFF
--- a/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.stories.tsx
+++ b/apps/frontend/src/features/workspace/components/CreateFormModal/CreateFormModalContent/CreateFormOriginScreen.stories.tsx
@@ -93,7 +93,7 @@ Q1ValidationError.play = async () => {
     ),
   )
   await expect(
-    await screen.findByText('Please select at least 1 option.', undefined, {
+    await screen.findByText('Please select an option.', undefined, {
       timeout: 3000,
     }),
   ).toBeInTheDocument()


### PR DESCRIPTION
## Problem

`UI Tests: formsg-app` has been failing on `develop` since #9852 merged (`fcf0df93f`), and is still red on `020af3939`. The status reads **"Failed test"**, which in Chromatic means an errored snapshot, not a visual diff — so `autoAcceptChanges: develop` cannot clear it and there is no baseline to accept.

## Cause

#9852 split Q1's validation into its own message (`errors.q1Required` = "Please select an option.") but left `Q1ValidationError`'s play function waiting on the Q2 copy, `errors.atLeastOne` = "Please select at least 1 option."

That text only renders once Q1 is `"existing"` — the Q2 block is not mounted otherwise — so `findByText` never resolved and Chromatic reported the story as errored.

Unit coverage stayed green throughout because `CreateFormOriginScreen.test.tsx` already asserts the split message.

## Fix

One line in the story's play function, so it asserts the message the component actually renders in that state.

## Verification

`pnpm exec vitest run CreateFormOriginScreen.test.tsx` passes 13/13, including the case that clicks Next with nothing selected and asserts "Please select an option." appears. That is the same state the story exercises.

Once this lands, the `develop` build re-runs the play function and the accompanying visual baselines auto-accept as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)