### PR TITLE
fix(ci): correct TurboSnap's untraced globs so tracing works at all

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -80,7 +80,9 @@ jobs:
           storybookBaseDir: apps/frontend
           # Skip running Chromatic on dependabot PRs
           skip: dependabot/**
-          # TurboSnap's untraced globs: apps/frontend/chromatic.config.json
+          # TurboSnap's untraced globs. Repo-root-relative on purpose: the CLI
+          # resolves configFile from the action's cwd, not from workingDir.
+          configFile: apps/frontend/chromatic.config.json
 
   chromatic-deployment-emailpreview:
     needs: changes

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -80,8 +80,9 @@ jobs:
           storybookBaseDir: apps/frontend
           # Skip running Chromatic on dependabot PRs
           skip: dependabot/**
-          # Only run when the frontend directory has changes
-          untraced: '!(apps/frontend)/**'
+          # TurboSnap's untraced globs live in apps/frontend/chromatic.config.json,
+          # which the CLI reads from workingDir. They need one glob per excluded
+          # tree, which this input cannot express.
 
   chromatic-deployment-emailpreview:
     needs: changes
@@ -126,5 +127,3 @@ jobs:
           storybookBaseDir: packages/react-email-preview
           # Skip running Chromatic on dependabot PRs
           skip: dependabot/**
-          # Only run when the react-email-preview directory has changes
-          untraced: '!(packages/react-email-preview)/**'

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -80,9 +80,7 @@ jobs:
           storybookBaseDir: apps/frontend
           # Skip running Chromatic on dependabot PRs
           skip: dependabot/**
-          # TurboSnap's untraced globs live in apps/frontend/chromatic.config.json,
-          # which the CLI reads from workingDir. They need one glob per excluded
-          # tree, which this input cannot express.
+          # TurboSnap's untraced globs: apps/frontend/chromatic.config.json
 
   chromatic-deployment-emailpreview:
     needs: changes

--- a/apps/frontend/chromatic.config.json
+++ b/apps/frontend/chromatic.config.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://www.chromatic.com/config-file.schema.json",
+  "untraced": [
+    "!(apps|packages)/**",
+    "apps/!(frontend)/**",
+    "packages/!(shared)/**"
+  ]
+}


### PR DESCRIPTION
## The core issue

- The workflow set `untraced: '!(apps/frontend)/**'`, intending "ignore everything outside `apps/frontend`". But a `/` inside an extglob is invalid: picomatch matches `!(apps/frontend)` against **one path segment**, and the first segment of `apps/frontend/src/...` is `apps`, which is not the string `apps/frontend`. So the negation passes and the file is untraced.

- Because that glob matched every path in the repo, TurboSnap received an empty changed-file list. `chromatic trace` shows it directly: `Traced files... []`.

- Because the changed-file list was empty, TurboSnap resolved 0 affected stories, so Chromatic captured 0 snapshots and posted `892 tests unchanged`. Green, having rendered nothing.

- Because the list was empty, Chromatic's own escape hatch also never fired. A change under `src/i18n` reaches `.storybook/preview.tsx`, which is supposed to disable TurboSnap and force a full build. It would have caught #9852 on the first PR run.

- Net effect: **every** frontend Chromatic check has been a vacuous pass since that glob landed. The only reason develop caught the broken story in #9852 is that the squash-merge orphaned the baseline commit, which made the origin stories count as *new*, and new stories get captured regardless of tracing.

- The fix needs one glob per excluded tree, which the action's single-string `untraced` input cannot express, so it moves to `apps/frontend/chromatic.config.json`. `packages/shared` is now traced rather than excluded, because the frontend builds from its source.

## Evidence

Same changed files, same stats file, only the glob differs:

```
WITHOUT --untraced                    WITH the current CI glob
Traced files...                       Traced files...
[ 'CreateFormOriginScreen.tsx',       []
  'en-sg.ts' ]
```

The escape hatch that the glob was suppressing:

```
⚠ TurboSnap disabled due to file change
Found a Storybook config change in apps/frontend/.storybook/preview.tsx
A full build is required because this file cannot be linked to any specific stories.
```

## What this is not

The stats file and the build flag are both fine. Storybook 8.6 documents `--webpack-stats-json` as a synonym for `--stats-json`, and a local build writes a healthy `preview-stats.json` with 4,988 modules, including 99 from `packages/shared`. Those were early suspects and both were ruled out.

## Changes

- `apps/frontend/chromatic.config.json` (new): `untraced` as an array of three globs, one per excluded tree.
- `.github/workflows/chromatic.yml`: drop the broken `untraced` input from the frontend job, since the config file now carries it.
- `.github/workflows/chromatic.yml`: drop `untraced` from the email-preview job entirely. It carried the identical broken glob, and `untraced` only ever removes snapshots, so no glob is the safe default for a Storybook whose dependency graph reaches into `apps/backend`.

## Verification

Verified with `chromatic trace` against a local `preview-stats.json`. The new globs:

- trace `apps/frontend/**` and `packages/shared/**`
- exclude `apps/backend/**`, `docs/**`, and `CONTEXT.md`
- resolve `CreateFormOriginScreen.tsx` to 7 affected story files

Not verifiable locally: that the CLI picks up `chromatic.config.json` in CI. `chromatic trace` does not read the config file, so the globs are proven but the plumbing is not. The tell is in this PR's own Chromatic log:

```
→ Traversing dependencies for N files that changed since the last build
→ Snapshots will be limited to <non-zero> story files affected by recent changes
```

Any non-zero means it works. Still `0` means the config belongs somewhere else.

Expect a **full** build on the first run: a workflow change traces to nothing, which correctly forces one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)