### PR TITLE
feat(workflow): reveal a step one decision at a time (1/7)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.stories.tsx
@@ -250,6 +250,12 @@ const redesignOn = new GrowthBook({
   features: { [featureFlags.workflowBuilderRedesign]: { defaultValue: true } },
 })
 
+const withRedesignOn = (Story: StoryFn) => (
+  <GrowthBookProvider growthbook={redesignOn}>
+    <Story />
+  </GrowthBookProvider>
+)
+
 const Template: StoryFn = () => <CreatePageWorkflowTab />
 export const NoWorkflow = Template.bind({})
 
@@ -385,13 +391,7 @@ Step2InvalidConditionalRecipientSelected.parameters = {
 // states: off keeps the inline message pointing at Settings, on replaces it
 // with the editable card.
 export const WithWorkflowRedesignOn = Template.bind({})
-WithWorkflowRedesignOn.decorators = [
-  (Story: StoryFn) => (
-    <GrowthBookProvider growthbook={redesignOn}>
-      <Story />
-    </GrowthBookProvider>
-  ),
-]
+WithWorkflowRedesignOn.decorators = [withRedesignOn]
 WithWorkflowRedesignOn.parameters = {
   msw: {
     handlers: [
@@ -409,6 +409,16 @@ WithWorkflowRedesignOn.parameters = {
       }),
       patchAdminFormSettings({ mode: FormResponseMode.Multirespondent }),
     ],
+  },
+}
+
+export const NoWorkflowRedesignOn = Template.bind({})
+NoWorkflowRedesignOn.decorators = [withRedesignOn]
+NoWorkflowRedesignOn.parameters = {
+  msw: {
+    handlers: {
+      default: buildMswRoutes({ ...FORM_WITH_WORKFLOW, workflow: [] }),
+    },
   },
 }
 

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.stories.tsx
@@ -1,5 +1,9 @@
+import { ReactNode, useLayoutEffect, useState } from 'react'
+import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
+import { StoryFn } from '@storybook/react'
 import { expect, userEvent, waitFor, within } from '@storybook/test'
 
+import { featureFlags } from 'formsg-shared/constants'
 import {
   BasicField,
   FormFieldDto,
@@ -10,6 +14,8 @@ import {
 import { getAdminFormView } from '~/mocks/msw/handlers/admin-form'
 
 import { StoryRouter } from '~utils/storybook'
+
+import { useAdminWorkflowStore } from '../../../adminWorkflowStore'
 
 import { EditStepBlock } from './EditStepBlock'
 
@@ -159,6 +165,70 @@ export default {
       handlers: mrfFormViewWithFields,
     },
   },
+}
+
+const redesignOn = new GrowthBook({
+  features: { [featureFlags.workflowBuilderRedesign]: { defaultValue: true } },
+})
+
+const GuidedCreation = ({ children }: { children: ReactNode }): JSX.Element => {
+  const [isCreating, setIsCreating] = useState(false)
+
+  useLayoutEffect(() => {
+    useAdminWorkflowStore.getState().setToCreating()
+    setIsCreating(true)
+    return () => useAdminWorkflowStore.getState().reset()
+  }, [])
+
+  return (
+    <GrowthBookProvider growthbook={redesignOn}>
+      {isCreating ? children : null}
+    </GrowthBookProvider>
+  )
+}
+
+const withGuidedCreation = (Story: StoryFn) => (
+  <GuidedCreation>
+    <Story />
+  </GuidedCreation>
+)
+
+const revealSections =
+  (count: number) =>
+  async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement)
+    for (let i = 0; i < count; i++) {
+      await userEvent.click(
+        await canvas.findByRole('button', { name: 'Continue' }),
+      )
+    }
+  }
+
+export const GuidedStep1Name = {
+  args: { stepNumber: 0, submitButtonLabel: 'Add step' },
+  decorators: [withGuidedCreation],
+}
+
+export const GuidedStep1People = {
+  ...GuidedStep1Name,
+  play: revealSections(1),
+}
+
+export const GuidedStep1Fields = {
+  ...GuidedStep1Name,
+  play: revealSections(2),
+}
+
+export const GuidedStep2WhatTheyDo = {
+  args: { stepNumber: 1, submitButtonLabel: 'Add step' },
+  decorators: [withGuidedCreation],
+  play: revealSections(2),
+}
+
+export const GuidedStep2Fields = {
+  args: { stepNumber: 1, submitButtonLabel: 'Add step' },
+  decorators: [withGuidedCreation],
+  play: revealSections(3),
 }
 
 export const Step1Empty = {

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.test.tsx
@@ -1,0 +1,162 @@
+import { composeStories } from '@storybook/react'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useAdminWorkflowStore } from '../../../adminWorkflowStore'
+import * as pageStories from '../../../CreatePageWorkflowTab.stories'
+import { SPOTLIGHT_TEST_ID } from '../../Spotlight'
+
+const { NoWorkflowRedesignOn, WithWorkflowRedesignOn, WithWorkflow } =
+  composeStories(pageStories)
+
+const STEP_NAME_LABEL = /step name/i
+const PEOPLE_LABEL = /who fills in this step/i
+const WHAT_THEY_DO_LABEL = /make this person approve/i
+const FIELDS_LABEL = /choose the fields this person fills in/i
+
+const CONTINUE = { name: /^continue$/i }
+const BACK = { name: /^back$/i }
+const CANCEL = { name: /^cancel$/i }
+const DONE = { name: /^done$/i }
+
+const bandCount = () => screen.queryAllByTestId(SPOTLIGHT_TEST_ID).length
+
+const findOpenCard = () =>
+  screen.findByText(STEP_NAME_LABEL, {}, { timeout: 10000 })
+
+const openNewStepCard = async (Story: typeof NoWorkflowRedesignOn) => {
+  await act(async () => {
+    render(<Story />)
+  })
+  await act(async () => {
+    useAdminWorkflowStore.getState().setToCreating()
+  })
+  await findOpenCard()
+  return userEvent.setup()
+}
+
+describe('one decision at a time', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterAll(() => {
+    delete (Element.prototype as Partial<Pick<Element, 'scrollIntoView'>>)
+      .scrollIntoView
+  })
+
+  afterEach(() => useAdminWorkflowStore.getState().reset())
+
+  describe('building step 1', () => {
+    it('asks only for the step name, with nothing to go back to', async () => {
+      await openNewStepCard(NoWorkflowRedesignOn)
+
+      expect(screen.getByText(STEP_NAME_LABEL)).toBeInTheDocument()
+      expect(screen.queryByText(PEOPLE_LABEL)).not.toBeInTheDocument()
+      expect(bandCount()).toBe(1)
+
+      expect(screen.getByRole('button', CONTINUE)).toBeInTheDocument()
+      expect(screen.queryByRole('button', BACK)).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', CANCEL)).not.toBeInTheDocument()
+    })
+
+    it('reveals the next decision on Continue, and offers Back once there is one', async () => {
+      const user = await openNewStepCard(NoWorkflowRedesignOn)
+
+      await act(async () => {
+        await user.click(screen.getByRole('button', CONTINUE))
+      })
+
+      expect(screen.getByText(PEOPLE_LABEL)).toBeInTheDocument()
+      expect(bandCount()).toBe(2)
+      expect(screen.getByRole('button', BACK)).toBeInTheDocument()
+    })
+
+    it('offers Done rather than Continue once the last decision is on screen', async () => {
+      const user = await openNewStepCard(NoWorkflowRedesignOn)
+
+      await act(async () => {
+        await user.click(screen.getByRole('button', CONTINUE))
+      })
+      await act(async () => {
+        await user.click(screen.getByRole('button', CONTINUE))
+      })
+
+      expect(screen.getByText(FIELDS_LABEL)).toBeInTheDocument()
+      expect(screen.queryByText(WHAT_THEY_DO_LABEL)).not.toBeInTheDocument()
+      expect(bandCount()).toBe(3)
+      expect(screen.getByRole('button', DONE)).toBeInTheDocument()
+      expect(screen.queryByRole('button', CONTINUE)).not.toBeInTheDocument()
+    })
+
+    it('takes the revealed decision back off screen on Back', async () => {
+      const user = await openNewStepCard(NoWorkflowRedesignOn)
+
+      await act(async () => {
+        await user.click(screen.getByRole('button', CONTINUE))
+      })
+      await act(async () => {
+        await user.click(screen.getByRole('button', BACK))
+      })
+
+      expect(screen.queryByText(PEOPLE_LABEL)).not.toBeInTheDocument()
+      expect(bandCount()).toBe(1)
+    })
+  })
+
+  describe('building a later step', () => {
+    it('is paced the same way, and offers Cancel where step 1 offers nothing', async () => {
+      await openNewStepCard(WithWorkflowRedesignOn)
+
+      expect(bandCount()).toBe(1)
+      expect(screen.getByRole('button', CONTINUE)).toBeInTheDocument()
+      expect(screen.getByRole('button', CANCEL)).toBeInTheDocument()
+    })
+
+    it('asks what they do, which step 1 has no section for', async () => {
+      const user = await openNewStepCard(WithWorkflowRedesignOn)
+
+      await act(async () => {
+        await user.click(screen.getByRole('button', CONTINUE))
+      })
+      await act(async () => {
+        await user.click(screen.getByRole('button', CONTINUE))
+      })
+
+      expect(screen.getByText(WHAT_THEY_DO_LABEL)).toBeInTheDocument()
+      expect(bandCount()).toBe(3)
+      expect(screen.getByRole('button', CONTINUE)).toBeInTheDocument()
+    })
+  })
+
+  describe('re-opening a saved step', () => {
+    it('is not paced, since the admin came back for one part of it', async () => {
+      await act(async () => {
+        render(<WithWorkflowRedesignOn />)
+      })
+      await act(async () => {
+        useAdminWorkflowStore.getState().setToEditing(0)
+      })
+      await findOpenCard()
+
+      expect(screen.getByText(FIELDS_LABEL)).toBeInTheDocument()
+      expect(bandCount()).toBe(0)
+      expect(
+        screen.getByRole('button', { name: /save step/i }),
+      ).toBeInTheDocument()
+      expect(screen.queryByRole('button', CONTINUE)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('with the redesign flag off', () => {
+    it('opens a new step with every section at once and the usual Save row', async () => {
+      await openNewStepCard(WithWorkflow)
+
+      expect(bandCount()).toBe(0)
+      expect(
+        screen.getByRole('button', { name: /add step/i }),
+      ).toBeInTheDocument()
+      expect(screen.queryByRole('button', CONTINUE)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
-import { Divider, Stack } from '@chakra-ui/react'
+import { Box, Stack } from '@chakra-ui/react'
 
 import {
   FormWorkflowStep,
@@ -19,11 +19,15 @@ import {
   setToInactiveSelector,
   useAdminWorkflowStore,
 } from '../../../adminWorkflowStore'
+import { useGuidedStepReveal } from '../../../hooks/useGuidedStepReveal'
 import { useIsWorkflowBuilderRedesign } from '../../../hooks/useIsWorkflowBuilderRedesign'
 import { EditStepInputs } from '../../../types'
+import { getGuidedSecondaryAction } from '../../../utils/guidedStepPolicy'
+import { SpotlightGroup } from '../../Spotlight'
 import { isFirstStepByStepNumber } from '../utils/isFirstStepByStepNumber'
 
 import { ApprovalsBlock } from './ApprovalsBlock'
+import { GuidedActionGroup } from './GuidedActionGroup'
 import { QuestionsBlock } from './QuestionsBlock'
 import { RespondentBlock } from './RespondentBlock'
 import { StepNameBlock } from './StepNameBlock'
@@ -41,6 +45,8 @@ export interface EditLogicBlockProps {
 
 export const FIELDS_TO_EDIT_NAME = 'edit'
 export const APPROVAL_FIELD_NAME = 'approval_field'
+
+const SECTION_REVEAL_SCROLL_DELAY_MS = 100
 
 /**
  * Builds a workflow step from form inputs, or undefined if they cannot form a
@@ -206,66 +212,104 @@ export const EditStepBlock = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingSwitchTo])
 
+  const isGuided = isRedesign && isCreatingState
+
   // Only the order differs between flag states, so build each section once and
   // swap the sequence rather than duplicating the subtree per branch.
   const questionsSection = (
-    <>
-      <Divider />
-      <QuestionsBlock
-        formMethods={formMethods}
-        isLoading={_isLoading}
-        isFirstStep={isFirstStep}
-      />
-    </>
+    <QuestionsBlock
+      key="fields"
+      formMethods={formMethods}
+      isLoading={_isLoading}
+      isFirstStep={isFirstStep}
+    />
   )
   const approvalsSection = isFirstStep ? null : (
-    <>
-      <Divider />
-      <ApprovalsBlock formMethods={formMethods} stepNumber={stepNumber} />
-    </>
+    <ApprovalsBlock
+      key="what-they-do"
+      formMethods={formMethods}
+      stepNumber={stepNumber}
+    />
   )
+
+  const sections: JSX.Element[] = [
+    <StepNameBlock
+      key="name"
+      formMethods={formMethods}
+      stepNumber={stepNumber}
+    />,
+    <RespondentBlock
+      key="people"
+      user={user}
+      stepNumber={stepNumber}
+      formMethods={formMethods}
+      isLoading={_isLoading}
+    />,
+    ...(isRedesign
+      ? [approvalsSection, questionsSection]
+      : [questionsSection, approvalsSection]
+    ).filter((section): section is JSX.Element => section !== null),
+  ]
+
+  const reveal = useGuidedStepReveal({
+    sectionCount: sections.length,
+    isEnabled: isGuided,
+  })
+
+  const { visibleCount } = reveal
+
+  useEffect(() => {
+    if (!isGuided || visibleCount <= 1) return
+    const timeout = setTimeout(() => {
+      wrapperRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+    }, SECTION_REVEAL_SCROLL_DELAY_MS)
+    return () => clearTimeout(timeout)
+  }, [isGuided, visibleCount])
 
   return (
     <Stack
       ref={wrapperRef}
-      py="2rem"
-      spacing="1.5rem"
+      spacing="0"
+      pt="0.5rem"
+      pb="2rem"
       borderRadius="4px"
       bg="white"
       border="1px solid"
-      borderColor="primary.500"
-      boxShadow="0 0 0 1px var(--chakra-colors-primary-500)"
+      borderColor={isGuided ? 'neutral.300' : 'primary.500'}
+      boxShadow={
+        isGuided ? 'none' : '0 0 0 1px var(--chakra-colors-primary-500)'
+      }
       transitionProperty="common"
       transitionDuration="normal"
     >
-      <StepNameBlock formMethods={formMethods} stepNumber={stepNumber} />
-      <Divider />
-      <RespondentBlock
-        user={user}
-        stepNumber={stepNumber}
-        formMethods={formMethods}
-        isLoading={_isLoading}
-      />
-      {isRedesign ? (
-        <>
-          {approvalsSection}
-          {questionsSection}
-        </>
-      ) : (
-        <>
-          {questionsSection}
-          {approvalsSection}
-        </>
-      )}
-      <Divider />
-      <SaveActionGroup
-        isLoading={_isLoading}
-        handleSubmit={handleSubmit}
-        handleDelete={isFirstStep ? undefined : handleOpenDeleteModal}
-        handleCancel={setToInactive}
-        submitButtonLabel={submitButtonLabel}
-        ariaLabelName="step"
-      />
+      <SpotlightGroup activeIndex={reveal.activeIndex} isEnabled={isGuided}>
+        {sections.slice(0, visibleCount)}
+      </SpotlightGroup>
+      <Box pt="1.5rem">
+        {isGuided ? (
+          <GuidedActionGroup
+            secondaryAction={getGuidedSecondaryAction({
+              sectionIndex: visibleCount - 1,
+              isFirstStep,
+            })}
+            isOnLastSection={reveal.isOnLastSection}
+            isLoading={isLoading}
+            onBack={reveal.goBack}
+            onCancel={setToInactive}
+            onContinue={reveal.advance}
+            onDone={handleSubmit}
+          />
+        ) : (
+          <SaveActionGroup
+            isLoading={_isLoading}
+            handleSubmit={handleSubmit}
+            handleDelete={isFirstStep ? undefined : handleOpenDeleteModal}
+            handleCancel={setToInactive}
+            submitButtonLabel={submitButtonLabel}
+            ariaLabelName="step"
+          />
+        )}
+      </Box>
     </Stack>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/GuidedActionGroup.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/GuidedActionGroup.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from 'react-i18next'
+import { Flex } from '@chakra-ui/react'
+
+import Button from '~components/Button'
+
+import { GuidedSecondaryAction } from '../../../utils/guidedStepPolicy'
+
+export interface GuidedActionGroupProps {
+  secondaryAction: GuidedSecondaryAction
+  isOnLastSection: boolean
+  isLoading: boolean
+  onBack: () => void
+  onCancel: () => void
+  onContinue: () => void
+  onDone: () => void
+}
+
+export const GuidedActionGroup = ({
+  secondaryAction,
+  isOnLastSection,
+  isLoading,
+  onBack,
+  onCancel,
+  onContinue,
+  onDone,
+}: GuidedActionGroupProps): JSX.Element => {
+  const { t } = useTranslation()
+
+  return (
+    <Flex
+      justify="flex-end"
+      gap="0.75rem"
+      px={{ base: '1.5rem', md: '2rem' }}
+      align="center"
+    >
+      {secondaryAction === GuidedSecondaryAction.None ? null : (
+        <Button
+          variant="clear"
+          colorScheme="secondary"
+          isDisabled={isLoading}
+          onClick={
+            secondaryAction === GuidedSecondaryAction.Back ? onBack : onCancel
+          }
+        >
+          {t(
+            secondaryAction === GuidedSecondaryAction.Back
+              ? 'features.adminForm.sidebar.workflow.guided.back'
+              : 'features.adminForm.sidebar.workflow.guided.cancel',
+          )}
+        </Button>
+      )}
+      <Button
+        isLoading={isOnLastSection && isLoading}
+        onClick={isOnLastSection ? onDone : onContinue}
+      >
+        {t(
+          isOnLastSection
+            ? 'features.adminForm.sidebar.workflow.guided.done'
+            : 'features.adminForm.sidebar.workflow.guided.continue',
+        )}
+      </Button>
+    </Flex>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedStepReveal.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedStepReveal.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useGuidedStepReveal } from './useGuidedStepReveal'
+
+const SECTION_COUNT = 3
+
+const renderReveal = ({
+  sectionCount = SECTION_COUNT,
+  isEnabled = true,
+} = {}) => renderHook(() => useGuidedStepReveal({ sectionCount, isEnabled }))
+
+describe('useGuidedStepReveal', () => {
+  describe('while a step is being paced', () => {
+    it('opens on the first section alone, with it lit', () => {
+      const { result } = renderReveal()
+
+      expect(result.current.visibleCount).toBe(1)
+      expect(result.current.activeIndex).toBe(0)
+      expect(result.current.isOnLastSection).toBe(false)
+    })
+
+    it('reveals one more section per advance and lights the new one', () => {
+      const { result } = renderReveal()
+
+      act(() => result.current.advance())
+
+      expect(result.current.visibleCount).toBe(2)
+      expect(result.current.activeIndex).toBe(1)
+    })
+
+    it('stops advancing at the last section', () => {
+      const { result } = renderReveal()
+
+      act(() => result.current.advance())
+      act(() => result.current.advance())
+      act(() => result.current.advance())
+
+      expect(result.current.visibleCount).toBe(SECTION_COUNT)
+      expect(result.current.isOnLastSection).toBe(true)
+      expect(result.current.activeIndex).toBe(SECTION_COUNT - 1)
+    })
+
+    it('un-reveals the section left behind when going back', () => {
+      const { result } = renderReveal()
+
+      act(() => result.current.advance())
+      act(() => result.current.goBack())
+
+      expect(result.current.visibleCount).toBe(1)
+      expect(result.current.activeIndex).toBe(0)
+    })
+
+    it('keeps the step name on screen when going back from the first section', () => {
+      const { result } = renderReveal()
+
+      act(() => result.current.goBack())
+
+      expect(result.current.visibleCount).toBe(1)
+    })
+  })
+
+  describe('when the step is not being paced', () => {
+    it('shows every section with none lit', () => {
+      const { result } = renderReveal({ isEnabled: false })
+
+      expect(result.current.visibleCount).toBe(SECTION_COUNT)
+      expect(result.current.activeIndex).toBeNull()
+      expect(result.current.isOnLastSection).toBe(true)
+    })
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedStepReveal.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedStepReveal.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react'
+
+export interface UseGuidedStepRevealInput {
+  sectionCount: number
+  isEnabled: boolean
+}
+
+export interface GuidedStepReveal {
+  visibleCount: number
+  activeIndex: number | null
+  isOnLastSection: boolean
+  advance: () => void
+  goBack: () => void
+}
+
+export const useGuidedStepReveal = ({
+  sectionCount,
+  isEnabled,
+}: UseGuidedStepRevealInput): GuidedStepReveal => {
+  const [revealedCount, setRevealedCount] = useState(1)
+
+  const advance = useCallback(
+    () => setRevealedCount((count) => Math.min(count + 1, sectionCount)),
+    [sectionCount],
+  )
+
+  const goBack = useCallback(
+    () => setRevealedCount((count) => Math.max(count - 1, 1)),
+    [],
+  )
+
+  const visibleCount = isEnabled
+    ? Math.min(revealedCount, sectionCount)
+    : sectionCount
+
+  return {
+    visibleCount,
+    activeIndex: isEnabled ? visibleCount - 1 : null,
+    isOnLastSection: visibleCount >= sectionCount,
+    advance,
+    goBack,
+  }
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/utils/guidedStepPolicy.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/utils/guidedStepPolicy.test.ts
@@ -1,0 +1,27 @@
+import {
+  getGuidedSecondaryAction,
+  GuidedSecondaryAction,
+} from './guidedStepPolicy'
+
+describe('getGuidedSecondaryAction', () => {
+  it('offers nothing on the first section of step 1', () => {
+    expect(
+      getGuidedSecondaryAction({ sectionIndex: 0, isFirstStep: true }),
+    ).toBe(GuidedSecondaryAction.None)
+  })
+
+  it('offers Cancel on the first section of a later step', () => {
+    expect(
+      getGuidedSecondaryAction({ sectionIndex: 0, isFirstStep: false }),
+    ).toBe(GuidedSecondaryAction.Cancel)
+  })
+
+  it.each([1, 2, 3])(
+    'offers Back on section %i, which has one behind it',
+    (sectionIndex) => {
+      expect(
+        getGuidedSecondaryAction({ sectionIndex, isFirstStep: true }),
+      ).toBe(GuidedSecondaryAction.Back)
+    },
+  )
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/utils/guidedStepPolicy.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/utils/guidedStepPolicy.ts
@@ -1,4 +1,3 @@
-
 export enum GuidedSecondaryAction {
   None = 'none',
   Back = 'back',

--- a/apps/frontend/src/features/admin-form/create/workflow/utils/guidedStepPolicy.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/utils/guidedStepPolicy.ts
@@ -1,0 +1,19 @@
+
+export enum GuidedSecondaryAction {
+  None = 'none',
+  Back = 'back',
+  Cancel = 'cancel',
+}
+
+export interface GuidedSecondaryActionInput {
+  sectionIndex: number
+  isFirstStep: boolean
+}
+
+export const getGuidedSecondaryAction = ({
+  sectionIndex,
+  isFirstStep,
+}: GuidedSecondaryActionInput): GuidedSecondaryAction => {
+  if (sectionIndex > 0) return GuidedSecondaryAction.Back
+  return isFirstStep ? GuidedSecondaryAction.None : GuidedSecondaryAction.Cancel
+}

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -179,6 +179,12 @@ export const enSG: Workflow = {
   stepName: {
     label: 'Step name',
   },
+  guided: {
+    continue: 'Continue',
+    back: 'Back',
+    cancel: 'Cancel',
+    done: 'Done',
+  },
   paymentEnabledNoSteps:
     'Remove the payment field to add workflow steps. A form cannot have both a payment field and a workflow.',
   completionEmail: {

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -154,6 +154,12 @@ export interface Workflow {
   stepName: {
     label: string
   }
+  guided: {
+    continue: string
+    back: string
+    cancel: string
+    done: string
+  }
   paymentEnabledNoSteps: string
   completionEmail: {
     title: string


### PR DESCRIPTION
## Problem

- Building one step means four decisions at once: name, people, what they do, fields.
- UT completion on unaided step creation was 0/4 until pacing changed.
- Closes FRM-2498.

## Solution

- `EditStepBlock` renders its four sections through `SpotlightGroup`, revealing one per Continue.
- `useGuidedStepReveal` tracks how many sections show and which one is lit.
- `guidedStepPolicy` picks the secondary action: Back, Cancel, or none on step 1.
- `GuidedActionGroup` replaces `SaveActionGroup` while a step is being created.
- Pacing applies when `isCreatingState` is true; re-opening a saved step is unchanged.
- The card rests at `neutral.300` while a band is lit, so one thing reads active.

**Alternatives considered**

- Separate `GuidedWorkflowCreation` tree — skipped, duplicates `buildWorkflowStep` and the child blocks.
- Pacing every open card — skipped, takes the card's delete action away.
- Step 3 lighter-touch toggle — skipped, a second mode before the first is tested.

**Breaking changes:** none.

## Screenshots

| Scenario | Screenshot |
|---|---|
|Step 1: Step name|<img width="690" height="344" alt="Screenshot 2026-09-07 at 10 53 44 PM" src="https://github.com/user-attachments/assets/4566caf9-54ae-4fd5-a31b-80ff66358bff" />|
|Step 1: Who fills it in|<img width="670" height="447" alt="Screenshot 2026-09-07 at 10 53 49 PM" src="https://github.com/user-attachments/assets/14041b3f-ddab-4698-81c3-6764c3cc4d63" />|
|Step 1: Choose the fields|<img width="674" height="540" alt="Screenshot 2026-09-07 at 10 54 26 PM" src="https://github.com/user-attachments/assets/40c633ac-2923-4224-88ac-d034df875461" />|
|Step X: Step name|<img width="675" height="316" alt="Screenshot 2026-09-07 at 10 54 38 PM" src="https://github.com/user-attachments/assets/1df12722-1878-4572-9f8f-60201a7ce18e" />|
|Step X: Who fills it in|<img width="683" height="582" alt="Screenshot 2026-09-07 at 10 55 06 PM" src="https://github.com/user-attachments/assets/37f36c89-58bc-40bb-b86f-a3c71cac7d21" />|
|Step X: Approval|<img width="683" height="668" alt="Screenshot 2026-09-07 at 10 55 12 PM" src="https://github.com/user-attachments/assets/c7321421-cbb4-46bb-ba43-5bcf5a435e04" />|
|Step X: Choose the fields|<img width="602" height="692" alt="Screenshot 2026-09-07 at 10 55 29 PM" src="https://github.com/user-attachments/assets/6953f868-aa83-4bd5-bbe1-ecb127402480" />|
|Step 1: Already filled in|<img width="596" height="487" alt="Screenshot 2026-09-07 at 10 55 52 PM" src="https://github.com/user-attachments/assets/a224c82b-60f8-438e-a369-7ee3ec54f14b" />|
|Step X: Already filled in|<img width="557" height="677" alt="Screenshot 2026-09-07 at 10 56 02 PM" src="https://github.com/user-attachments/assets/fa0cee2e-5fba-4290-a616-619bd8891f3a" />|

## Tests

**Automated**

- `EditStepBlock.test.tsx` — a new step opens on the step name alone, no Next button.
- `EditStepBlock.test.tsx` — Continue reveals the next section, Back takes it off screen.
- `EditStepBlock.test.tsx` — a re-opened step and a flag-off card show every section.
- `useGuidedStepReveal.test.ts` — advancing stops at the last section.
- `guidedStepPolicy.test.ts` — step 1's first section offers no secondary action.

**Manual**

- [ ] Turn on `workflow-builder-redesign`, click Add step.
- [ ] Continue through to Done, then Back one section.
- [ ] Click a saved step card; expect every section and the Save row.
