### PR TITLE
feat(workflow): report a finished step under its card (2/7)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
@@ -16,11 +16,15 @@ type AdminWorkflowStore = {
   requestSwitchToCreating: () => void
   cancelPendingSwitch: () => void
   completeSave: () => void
+  completedStepNumber: number | null
+  setCompletedStep: (stepNumber: number) => void
+  dismissCompletedStep: () => void
 }
 
 const INITIAL_STATE = {
   createOrEditData: null,
   pendingSwitchTo: null,
+  completedStepNumber: null,
 }
 
 export const isCreatingStateSelector = (state: AdminWorkflowStore) =>
@@ -69,15 +73,26 @@ export const cancelPendingSwitchSelector = (state: AdminWorkflowStore) =>
 export const completeSaveSelector = (state: AdminWorkflowStore) =>
   state.completeSave
 
+export const completedStepNumberSelector = (state: AdminWorkflowStore) =>
+  state.completedStepNumber
+
+export const setCompletedStepSelector = (state: AdminWorkflowStore) =>
+  state.setCompletedStep
+
+export const dismissCompletedStepSelector = (state: AdminWorkflowStore) =>
+  state.dismissCompletedStep
+
 export const useAdminWorkflowStore = create<AdminWorkflowStore>()(
   devtools((set, get) => ({
     createOrEditData: null,
     pendingSwitchTo: null,
+    completedStepNumber: null,
     setToCreating: () =>
       set({
         createOrEditData: {
           state: AdminEditWorkflowState.CreatingStep,
         },
+        completedStepNumber: null,
       }),
     setToEditing: (stepNumber) =>
       set({
@@ -85,13 +100,17 @@ export const useAdminWorkflowStore = create<AdminWorkflowStore>()(
           state: AdminEditWorkflowState.EditingStep,
           stepNumber,
         },
+        completedStepNumber: null,
       }),
     setToEditingEmailCard: () =>
       set({
         createOrEditData: {
           state: AdminEditWorkflowState.EditingEmailCard,
         },
+        completedStepNumber: null,
       }),
+    setCompletedStep: (stepNumber) => set({ completedStepNumber: stepNumber }),
+    dismissCompletedStep: () => set({ completedStepNumber: null }),
     setToInactive: () => set({ createOrEditData: null }),
     reset: () => set(INITIAL_STATE),
     requestSwitchTo: (stepNumber) =>
@@ -112,7 +131,13 @@ export const useAdminWorkflowStore = create<AdminWorkflowStore>()(
     cancelPendingSwitch: () => set({ pendingSwitchTo: null }),
     // Hand over to a pending switch, or collapse when there is none: a null
     // pending target is exactly the collapsed state.
-    completeSave: () =>
-      set({ createOrEditData: get().pendingSwitchTo, pendingSwitchTo: null }),
+    completeSave: () => {
+      const pendingSwitchTo = get().pendingSwitchTo
+      set({
+        createOrEditData: pendingSwitchTo,
+        pendingSwitchTo: null,
+        ...(pendingSwitchTo ? { completedStepNumber: null } : {}),
+      })
+    },
   })),
 )

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/index.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/index.ts
@@ -1,2 +1,3 @@
 export * from './CompletionPeekCard'
 export * from './PeekCard'
+export * from './useReportedCompletedStep'

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/useReportedCompletedStep.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/useReportedCompletedStep.ts
@@ -1,0 +1,15 @@
+import {
+  completedStepNumberSelector,
+  createOrEditDataSelector,
+  useAdminWorkflowStore,
+} from '../../adminWorkflowStore'
+import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
+
+export const useReportedCompletedStep = (): number | null => {
+  const isRedesign = useIsWorkflowBuilderRedesign()
+  const createOrEditData = useAdminWorkflowStore(createOrEditDataSelector)
+  const completedStepNumber = useAdminWorkflowStore(completedStepNumberSelector)
+
+  if (!isRedesign || createOrEditData !== null) return null
+  return completedStepNumber
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/NewStepBlock/NewStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/NewStepBlock/NewStepBlock.tsx
@@ -13,6 +13,7 @@ import {
   createOrEditDataSelector,
   isCreatingStateSelector,
   requestSwitchToCreatingSelector,
+  setCompletedStepSelector,
   setToCreatingSelector,
   useAdminWorkflowStore,
 } from '../../../adminWorkflowStore'
@@ -31,6 +32,7 @@ export const NewStepBlock = () => {
     requestSwitchToCreating,
     completeSave,
     cancelPendingSwitch,
+    setCompletedStep,
   } = useAdminWorkflowStore((state) => ({
     isCreatingState: isCreatingStateSelector(state),
     stateData: createOrEditDataSelector(state),
@@ -38,7 +40,10 @@ export const NewStepBlock = () => {
     requestSwitchToCreating: requestSwitchToCreatingSelector(state),
     completeSave: completeSaveSelector(state),
     cancelPendingSwitch: cancelPendingSwitchSelector(state),
+    setCompletedStep: setCompletedStepSelector(state),
   }))
+
+  const newStepNumber = formWorkflow?.length ?? 0
 
   // Another card is open: hand it a pending switch so it saves first, the same
   // way clicking a step card or the email card does. Calling setToCreating
@@ -55,11 +60,20 @@ export const NewStepBlock = () => {
   const handleSubmit = useCallback(
     (step: FormWorkflowStep) =>
       createStepMutation.mutate(step, {
-        onSuccess: completeSave,
+        onSuccess: () => {
+          setCompletedStep(newStepNumber)
+          completeSave()
+        },
         // Drop any pending switch so a failed save can't redirect a later one.
         onError: cancelPendingSwitch,
       }),
-    [createStepMutation, completeSave, cancelPendingSwitch],
+    [
+      createStepMutation,
+      completeSave,
+      cancelPendingSwitch,
+      setCompletedStep,
+      newStepNumber,
+    ],
   )
 
   if (!formWorkflow) return null

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.test.tsx
@@ -8,6 +8,7 @@ import i18n from '~/i18n/i18n'
 
 import { useAdminWorkflowStore } from '../../../adminWorkflowStore'
 import * as pageStories from '../../../CreatePageWorkflowTab.stories'
+import { STEP_CONNECTOR_TEST_ID } from '../WorkflowContent'
 
 const { WithWorkflowRedesignOn, WithWorkflow } = composeStories(pageStories)
 
@@ -100,6 +101,55 @@ describe('completion peek card after a step is built', () => {
     })
 
     expect(screen.queryByText(STEP_ONE_DONE)).not.toBeInTheDocument()
+  })
+
+  describe('while a step is reporting', () => {
+    it('withholds the Add step button, leaving the report the only way on', async () => {
+      await renderWorkflow(WithWorkflowRedesignOn)
+      expect(
+        screen.getByRole('button', { name: /add step/i }),
+      ).toBeInTheDocument()
+
+      await finishCreating(0)
+
+      expect(
+        screen.queryByRole('button', { name: /add step/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('takes the connector with it, so nothing dangles under the report', async () => {
+      await renderWorkflow(WithWorkflowRedesignOn)
+      const before = screen.queryAllByTestId(STEP_CONNECTOR_TEST_ID).length
+
+      await finishCreating(0)
+
+      expect(screen.queryAllByTestId(STEP_CONNECTOR_TEST_ID)).toHaveLength(
+        before - 1,
+      )
+    })
+
+    it('gives the Add step button back once the admin says they are done', async () => {
+      const user = userEvent.setup()
+      await renderWorkflow(WithWorkflowRedesignOn)
+      await finishCreating(0)
+
+      await act(async () => {
+        await user.click(screen.getByRole('button', DECLINE))
+      })
+
+      expect(
+        await screen.findByRole('button', { name: /add step/i }),
+      ).toBeInTheDocument()
+    })
+
+    it('keeps the Add step button when the flag is off, since no report shows', async () => {
+      await renderWorkflow(WithWorkflow)
+      await finishCreating(0)
+
+      expect(
+        screen.getByRole('button', { name: /add step/i }),
+      ).toBeInTheDocument()
+    })
   })
 
   it('does not appear with the redesign flag off', async () => {

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.test.tsx
@@ -1,0 +1,132 @@
+import { composeStories } from '@storybook/react'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { Language } from 'formsg-shared/types'
+
+import i18n from '~/i18n/i18n'
+
+import { useAdminWorkflowStore } from '../../../adminWorkflowStore'
+import * as pageStories from '../../../CreatePageWorkflowTab.stories'
+
+const { WithWorkflowRedesignOn, WithWorkflow } = composeStories(pageStories)
+
+const STEP_ONE_DONE = /step 1 is the public-facing step/i
+const STEP_TWO_DONE = /nice, step 2 is all set/i
+const ADD_ANOTHER = { name: /yes, add a step/i }
+const DECLINE = { name: /no, i'm done/i }
+
+const renderWorkflow = async (Story: typeof WithWorkflowRedesignOn) => {
+  await act(async () => {
+    render(<Story />)
+  })
+  await screen.findByRole('button', { name: /add step/i }, { timeout: 4000 })
+}
+
+const finishCreating = async (stepNumber: number) => {
+  await act(async () => {
+    useAdminWorkflowStore.getState().setCompletedStep(stepNumber)
+  })
+}
+
+describe('completion peek card after a step is built', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    return i18n.changeLanguage(Language.ENGLISH)
+  })
+
+  afterAll(() => {
+    delete (Element.prototype as Partial<Pick<Element, 'scrollIntoView'>>)
+      .scrollIntoView
+  })
+
+  afterEach(() => useAdminWorkflowStore.getState().reset())
+
+  it('reports step 1 in its own words, since its respondents are not chosen', async () => {
+    await renderWorkflow(WithWorkflowRedesignOn)
+    await finishCreating(0)
+
+    expect(screen.getByText(STEP_ONE_DONE)).toBeInTheDocument()
+    expect(screen.getByRole('button', ADD_ANOTHER)).toBeInTheDocument()
+  })
+
+  it('names a later step, counting from one', async () => {
+    await renderWorkflow(WithWorkflowRedesignOn)
+    await finishCreating(1)
+
+    expect(screen.getByText(STEP_TWO_DONE)).toBeInTheDocument()
+  })
+
+  it('reports on the step that was built and no other', async () => {
+    await renderWorkflow(WithWorkflowRedesignOn)
+    await finishCreating(1)
+
+    expect(screen.queryByText(STEP_ONE_DONE)).not.toBeInTheDocument()
+  })
+
+  it('opens a new step card and stops reporting when another step is asked for', async () => {
+    const user = userEvent.setup()
+    await renderWorkflow(WithWorkflowRedesignOn)
+    await finishCreating(0)
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', ADD_ANOTHER))
+    })
+
+    expect(screen.queryByText(STEP_ONE_DONE)).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: /^continue$/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('goes away for good when the admin says they are done', async () => {
+    const user = userEvent.setup()
+    await renderWorkflow(WithWorkflowRedesignOn)
+    await finishCreating(0)
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', DECLINE))
+    })
+
+    expect(screen.queryByText(STEP_ONE_DONE)).not.toBeInTheDocument()
+    expect(useAdminWorkflowStore.getState().completedStepNumber).toBeNull()
+  })
+
+  it('stays out of the way while the step it reports on is open for editing', async () => {
+    await renderWorkflow(WithWorkflowRedesignOn)
+    await finishCreating(0)
+    await act(async () => {
+      useAdminWorkflowStore.getState().setToEditing(0)
+    })
+
+    expect(screen.queryByText(STEP_ONE_DONE)).not.toBeInTheDocument()
+  })
+
+  it('does not appear with the redesign flag off', async () => {
+    await renderWorkflow(WithWorkflow)
+    await finishCreating(0)
+
+    expect(screen.queryByText(STEP_ONE_DONE)).not.toBeInTheDocument()
+  })
+})
+
+describe('what retires a completion report', () => {
+  afterEach(() => useAdminWorkflowStore.getState().reset())
+
+  it('drops it when a save was only clearing the way for another card', () => {
+    const store = useAdminWorkflowStore.getState()
+    store.requestSwitchTo(1)
+    store.setCompletedStep(0)
+    store.completeSave()
+
+    expect(useAdminWorkflowStore.getState().completedStepNumber).toBeNull()
+  })
+
+  it('keeps it when a save finished a step and opened nothing', () => {
+    const store = useAdminWorkflowStore.getState()
+    store.setCompletedStep(0)
+    store.completeSave()
+
+    expect(useAdminWorkflowStore.getState().completedStepNumber).toBe(0)
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
@@ -4,12 +4,21 @@ import { useDisclosure } from '@chakra-ui/react'
 import { FormWorkflowStepDto } from 'formsg-shared/types'
 
 import {
+  completedStepNumberSelector,
+  dismissCompletedStepSelector,
   editDataSelector,
+  setToCreatingSelector,
   useAdminWorkflowStore,
 } from '../../../adminWorkflowStore'
 import { DeleteStepModal } from '../../DeleteStepModal'
+import {
+  CompletionPeekCard,
+  CompletionPeekCardProps,
+} from '../../GuidedCreation'
+import { CompletionPeekMomentType } from '../../GuidedCreation/utils/completionPeekContent'
 import { ActiveStepBlock } from '../ActiveStepBlock'
 import { InactiveStepBlock } from '../InactiveStepBlock'
+import { isFirstStepByStepNumber } from '../utils/isFirstStepByStepNumber'
 
 export interface WorkflowBlockFactoryProps {
   stepNumber: number
@@ -21,6 +30,11 @@ export const WorkflowBlockFactory = ({
   step,
 }: WorkflowBlockFactoryProps): JSX.Element => {
   const editState = useAdminWorkflowStore(editDataSelector)
+  const completedStepNumber = useAdminWorkflowStore(completedStepNumberSelector)
+  const dismissCompletedStep = useAdminWorkflowStore(
+    dismissCompletedStepSelector,
+  )
+  const setToCreating = useAdminWorkflowStore(setToCreatingSelector)
   const {
     isOpen: isDeleteModalOpen,
     onClose: onDeleteModalClose,
@@ -31,6 +45,21 @@ export const WorkflowBlockFactory = ({
     () => editState?.stepNumber === stepNumber,
     [editState?.stepNumber, stepNumber],
   )
+
+  const peekCardProps: CompletionPeekCardProps = isFirstStepByStepNumber(
+    stepNumber,
+  )
+    ? {
+        type: CompletionPeekMomentType.StepOneDone,
+        onDeclineAnotherStep: dismissCompletedStep,
+        onAddAnotherStep: setToCreating,
+      }
+    : {
+        type: CompletionPeekMomentType.LaterStepDone,
+        stepNumber,
+        onDeclineAnotherStep: dismissCompletedStep,
+        onAddAnotherStep: setToCreating,
+      }
 
   return (
     <>
@@ -48,6 +77,9 @@ export const WorkflowBlockFactory = ({
       ) : (
         <InactiveStepBlock stepNumber={stepNumber} step={step} />
       )}
+      {completedStepNumber === stepNumber ? (
+        <CompletionPeekCard {...peekCardProps} />
+      ) : null}
     </>
   )
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowBlockFactory/WorkflowBlockFactory.tsx
@@ -4,7 +4,6 @@ import { useDisclosure } from '@chakra-ui/react'
 import { FormWorkflowStepDto } from 'formsg-shared/types'
 
 import {
-  completedStepNumberSelector,
   dismissCompletedStepSelector,
   editDataSelector,
   setToCreatingSelector,
@@ -14,6 +13,7 @@ import { DeleteStepModal } from '../../DeleteStepModal'
 import {
   CompletionPeekCard,
   CompletionPeekCardProps,
+  useReportedCompletedStep,
 } from '../../GuidedCreation'
 import { CompletionPeekMomentType } from '../../GuidedCreation/utils/completionPeekContent'
 import { ActiveStepBlock } from '../ActiveStepBlock'
@@ -30,7 +30,7 @@ export const WorkflowBlockFactory = ({
   step,
 }: WorkflowBlockFactoryProps): JSX.Element => {
   const editState = useAdminWorkflowStore(editDataSelector)
-  const completedStepNumber = useAdminWorkflowStore(completedStepNumberSelector)
+  const reportedStepNumber = useReportedCompletedStep()
   const dismissCompletedStep = useAdminWorkflowStore(
     dismissCompletedStepSelector,
   )
@@ -77,7 +77,7 @@ export const WorkflowBlockFactory = ({
       ) : (
         <InactiveStepBlock stepNumber={stepNumber} step={step} />
       )}
-      {completedStepNumber === stepNumber ? (
+      {reportedStepNumber === stepNumber ? (
         <CompletionPeekCard {...peekCardProps} />
       ) : null}
     </>

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -6,15 +6,19 @@ import { StatusTrackerToggle } from '~features/admin-form/settings/components/Em
 
 import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
 import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
+import { useReportedCompletedStep } from '../GuidedCreation'
 
 import { CompletionEmailBlock } from './CompletionEmailBlock'
 import { NewStepBlock } from './NewStepBlock'
 import { WorkflowBlockFactory } from './WorkflowBlockFactory'
 import { WorkflowCompletionMessageBlock } from './WorkflowCompletionMessageBlock'
 
+export const STEP_CONNECTOR_TEST_ID = 'workflow-step-connector'
+
 export const WorkflowContent = (): JSX.Element | null => {
   const { formWorkflow, isLoading } = useAdminFormWorkflow()
   const isRedesign = useIsWorkflowBuilderRedesign()
+  const isReportingCompletedStep = useReportedCompletedStep() !== null
 
   if (isLoading) return null
   return (
@@ -39,7 +43,7 @@ export const WorkflowContent = (): JSX.Element | null => {
         {formWorkflow?.map((step, i) => (
           <WorkflowBlockFactory key={i} stepNumber={i} step={step} />
         ))}
-        <NewStepBlock />
+        {isReportingCompletedStep ? null : <NewStepBlock />}
       </Stack>
       {formWorkflow?.length ? (
         isRedesign ? (
@@ -53,7 +57,12 @@ export const WorkflowContent = (): JSX.Element | null => {
 }
 
 const WorkflowStepBlockDivider = () => (
-  <Box alignSelf="center" justifyContent="center" border="none">
+  <Box
+    data-testid={STEP_CONNECTOR_TEST_ID}
+    alignSelf="center"
+    justifyContent="center"
+    border="none"
+  >
     <Divider
       orientation="vertical"
       h="1rem"


### PR DESCRIPTION
## Problem

- Finishing a step ends in silence: the card collapses and nothing says what comes next.
- `PeekCard` and `CompletionPeekCard` have had no call sites since #9942.

## Solution

- `WorkflowBlockFactory` renders `CompletionPeekCard` under the step it reports on.
- `completedStepNumber` in `adminWorkflowStore` holds the step whose creation just finished.
- `NewStepBlock` calls `setCompletedStep` on create success, before `completeSave`.
- `WorkflowContent` withholds `NewStepBlock` while a report shows, so Add step never repeats it.
- `useReportedCompletedStep` answers "is a report showing" for both the list and the card.
- Step 1 reports as `StepOneDone`, later steps as `LaterStepDone` with a number.

**Alternatives considered**

- Deriving the step from the workflow list — skipped, cannot tell a new step from an old one.
- Hiding the button inside `NewStepBlock` — skipped, leaves the Stack's connector dangling.
- Rendering the card from `WorkflowContent` — skipped, the tuck needs an immediate sibling.

**Breaking changes:** none.

## Screenshots

| Scenario | Screenshot |
|---|---|
|Step 1 is done|<img width="534" height="343" alt="Screenshot 2026-09-08 at 1 42 31 AM" src="https://github.com/user-attachments/assets/3d05eb0b-77dd-4e97-ab96-7362218d6ed3" />|
|Step 2 is done|<img width="530" height="339" alt="Screenshot 2026-09-08 at 1 42 51 AM" src="https://github.com/user-attachments/assets/60388cab-1235-4916-a887-78631fdbb0f1" />|
|Step 3 is done|<img width="525" height="336" alt="Screenshot 2026-09-08 at 1 43 08 AM" src="https://github.com/user-attachments/assets/dab5174a-df64-40e7-9dc2-a3fb150796a6" />|
|When you click No|<img width="540" height="296" alt="Screenshot 2026-09-08 at 1 43 18 AM" src="https://github.com/user-attachments/assets/f6e90b15-5c1b-40a7-a97d-c315f7ff634f" />|

## Tests

**Automated**

- `WorkflowBlockFactory.test.tsx` — step 1 gets its own wording, later steps get a number.
- `WorkflowBlockFactory.test.tsx` — reports on the step that was built and no other.
- `WorkflowBlockFactory.test.tsx` — Add step and its connector go while a report shows.
- `WorkflowBlockFactory.test.tsx` — Add step returns once the admin says they are done.
- `WorkflowBlockFactory.test.tsx` — hidden while that step is open, and with the flag off.

**Manual**

- [ ] Create a step, click Done; expect a card tucked under it, no Add step button.
- [ ] Click "Yes, add a step"; expect a new step card with a connector above it.
- [ ] Create another step, click "No, I'm done"; expect Add step back.
