### PR TITLE
feat(workflow-builder-redesign): stage a field creation across tabs

### DIFF
--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.test.tsx
@@ -10,8 +10,6 @@ import { getFieldCreationMeta } from '../utils/fieldCreation'
 
 import { BuilderAndDesignContent } from './BuilderAndDesignContent'
 
-// The form builder itself is beside the point here; this file is only about
-// what the two mount effects do to the field builder store.
 vi.mock('./FormBuilder', () => ({ FormBuilder: () => null }))
 
 vi.mock('~features/admin-form/settings/queries', () => ({
@@ -30,9 +28,6 @@ beforeEach(() =>
 
 describe('BuilderAndDesignContent', () => {
   it('opens on a field staged before it mounted', () => {
-    // The mount reset and the consume are separate effects, and only their
-    // declaration order stops the reset from wiping the staged field on the
-    // way in. Swap the two effects and this is the check that notices.
     useFieldBuilderStore.getState().stageFieldCreation(emailField, 3)
 
     render(<BuilderAndDesignContent placeholderProps={{}} />)

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.test.tsx
@@ -1,0 +1,46 @@
+import { BasicField } from 'formsg-shared/types'
+
+import { render } from '~/test-utils'
+
+import {
+  FieldBuilderState,
+  useFieldBuilderStore,
+} from '../useFieldBuilderStore'
+import { getFieldCreationMeta } from '../utils/fieldCreation'
+
+import { BuilderAndDesignContent } from './BuilderAndDesignContent'
+
+// The form builder itself is beside the point here; this file is only about
+// what the two mount effects do to the field builder store.
+vi.mock('./FormBuilder', () => ({ FormBuilder: () => null }))
+
+vi.mock('~features/admin-form/settings/queries', () => ({
+  useAdminFormSettings: () => ({ data: undefined }),
+}))
+
+const emailField = getFieldCreationMeta(BasicField.Email)
+
+beforeEach(() =>
+  useFieldBuilderStore.setState({
+    stateData: { state: FieldBuilderState.Inactive },
+    holdingStateData: null,
+    pendingFieldCreation: null,
+  }),
+)
+
+describe('BuilderAndDesignContent', () => {
+  it('opens on a field staged before it mounted', () => {
+    // The mount reset and the consume are separate effects, and only their
+    // declaration order stops the reset from wiping the staged field on the
+    // way in. Swap the two effects and this is the check that notices.
+    useFieldBuilderStore.getState().stageFieldCreation(emailField, 3)
+
+    render(<BuilderAndDesignContent placeholderProps={{}} />)
+
+    expect(useFieldBuilderStore.getState().stateData).toEqual({
+      state: FieldBuilderState.CreatingField,
+      field: emailField,
+      insertionIndex: 3,
+    })
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -8,6 +8,8 @@ import { useAdminFormSettings } from '~features/admin-form/settings/queries'
 
 import { DndPlaceholderProps } from '../types'
 import {
+  consumePendingFieldCreationSelector,
+  pendingFieldCreationSelector,
   setToInactiveSelector,
   useFieldBuilderStore,
 } from '../useFieldBuilderStore'
@@ -27,11 +29,24 @@ export const BuilderAndDesignContent = ({
   const { data: settings } = useAdminFormSettings()
 
   const setFieldsToInactive = useFieldBuilderStore(setToInactiveSelector)
+  const pendingFieldCreation = useFieldBuilderStore(
+    pendingFieldCreationSelector,
+  )
+  const consumePendingFieldCreation = useFieldBuilderStore(
+    consumePendingFieldCreationSelector,
+  )
 
   useEffect(() => {
     setFieldsToInactive()
     return () => setFieldsToInactive()
   }, [setFieldsToInactive])
+
+  // Runs after the reset above, which is why the field another tab staged
+  // has to live outside stateData. Declaration order is the ordering
+  // guarantee: on mount React runs these two in the order they appear.
+  useEffect(() => {
+    if (pendingFieldCreation) consumePendingFieldCreation()
+  }, [pendingFieldCreation, consumePendingFieldCreation])
 
   return (
     <Flex flex={1} overflow="auto">

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/BuilderAndDesignContent/BuilderAndDesignContent.tsx
@@ -41,9 +41,6 @@ export const BuilderAndDesignContent = ({
     return () => setFieldsToInactive()
   }, [setFieldsToInactive])
 
-  // Runs after the reset above, which is why the field another tab staged
-  // has to live outside stateData. Declaration order is the ordering
-  // guarantee: on mount React runs these two in the order they appear.
   useEffect(() => {
     if (pendingFieldCreation) consumePendingFieldCreation()
   }, [pendingFieldCreation, consumePendingFieldCreation])

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.test.ts
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.test.ts
@@ -1,0 +1,71 @@
+import { BasicField } from 'formsg-shared/types'
+
+import { getFieldCreationMeta } from './utils/fieldCreation'
+import { FieldBuilderState, useFieldBuilderStore } from './useFieldBuilderStore'
+
+const emailField = getFieldCreationMeta(BasicField.Email)
+
+const reset = () =>
+  useFieldBuilderStore.setState({
+    stateData: { state: FieldBuilderState.Inactive },
+    holdingStateData: null,
+    pendingFieldCreation: null,
+  })
+
+beforeEach(reset)
+
+describe('pendingFieldCreation', () => {
+  it('survives setToInactive', () => {
+    // The reason this slot exists. Opening the builder from another tab mounts
+    // BuilderAndDesignContent, which calls setToInactive as it mounts. A field
+    // written to stateData before the trip would be gone on arrival.
+    const { stageFieldCreation, setToInactive } =
+      useFieldBuilderStore.getState()
+
+    stageFieldCreation(emailField, 3)
+    setToInactive()
+
+    expect(useFieldBuilderStore.getState().pendingFieldCreation).toEqual({
+      field: emailField,
+      insertionIndex: 3,
+    })
+  })
+
+  it('opens the builder on the staged field once consumed', () => {
+    const { stageFieldCreation, consumePendingFieldCreation } =
+      useFieldBuilderStore.getState()
+
+    stageFieldCreation(emailField, 3)
+    consumePendingFieldCreation()
+
+    expect(useFieldBuilderStore.getState().stateData).toEqual({
+      state: FieldBuilderState.CreatingField,
+      field: emailField,
+      insertionIndex: 3,
+    })
+  })
+
+  it('clears itself on consumption, so a later mount does not reopen it', () => {
+    const { stageFieldCreation, consumePendingFieldCreation, setToInactive } =
+      useFieldBuilderStore.getState()
+
+    stageFieldCreation(emailField, 3)
+    consumePendingFieldCreation()
+    setToInactive()
+    consumePendingFieldCreation()
+
+    expect(useFieldBuilderStore.getState().stateData).toEqual({
+      state: FieldBuilderState.Inactive,
+    })
+  })
+
+  it('leaves state alone when nothing was staged', () => {
+    const { consumePendingFieldCreation } = useFieldBuilderStore.getState()
+
+    consumePendingFieldCreation()
+
+    expect(useFieldBuilderStore.getState().stateData).toEqual({
+      state: FieldBuilderState.Inactive,
+    })
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.test.ts
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.test.ts
@@ -16,9 +16,6 @@ beforeEach(reset)
 
 describe('pendingFieldCreation', () => {
   it('survives setToInactive', () => {
-    // The reason this slot exists. Opening the builder from another tab mounts
-    // BuilderAndDesignContent, which calls setToInactive as it mounts. A field
-    // written to stateData before the trip would be gone on arrival.
     const { stageFieldCreation, setToInactive } =
       useFieldBuilderStore.getState()
 
@@ -46,8 +43,6 @@ describe('pendingFieldCreation', () => {
   })
 
   it('can be cleared without touching stateData, for trips that stage nothing', () => {
-    // The generic "Add fields" path promises the builder opens with nothing
-    // staged, even if an earlier staging was never consumed.
     const { stageFieldCreation, clearPendingFieldCreation } =
       useFieldBuilderStore.getState()
 

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.test.ts
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.test.ts
@@ -45,6 +45,21 @@ describe('pendingFieldCreation', () => {
     })
   })
 
+  it('can be cleared without touching stateData, for trips that stage nothing', () => {
+    // The generic "Add fields" path promises the builder opens with nothing
+    // staged, even if an earlier staging was never consumed.
+    const { stageFieldCreation, clearPendingFieldCreation } =
+      useFieldBuilderStore.getState()
+
+    stageFieldCreation(emailField, 3)
+    clearPendingFieldCreation()
+
+    expect(useFieldBuilderStore.getState().pendingFieldCreation).toBeNull()
+    expect(useFieldBuilderStore.getState().stateData).toEqual({
+      state: FieldBuilderState.Inactive,
+    })
+  })
+
   it('clears itself on consumption, so a later mount does not reopen it', () => {
     const { stageFieldCreation, consumePendingFieldCreation, setToInactive } =
       useFieldBuilderStore.getState()

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
@@ -40,6 +40,15 @@ export type FieldBuilderStore = {
     | null
   clearHoldingStateData: () => void
   moveFromHolding: () => void
+  // A field another tab asked the builder to open on. Survives setToInactive
+  // on purpose: the builder clears its own state as it mounts, so anything
+  // written to stateData before the trip is gone by the time it arrives.
+  pendingFieldCreation: {
+    field: FieldCreateDto
+    insertionIndex: number
+  } | null
+  stageFieldCreation: (field: FieldCreateDto, insertionIndex: number) => void
+  consumePendingFieldCreation: () => void
 }
 
 export const useFieldBuilderStore = create<FieldBuilderStore>()(
@@ -95,6 +104,21 @@ export const useFieldBuilderStore = create<FieldBuilderStore>()(
         set({ stateData })
       }
     },
+    pendingFieldCreation: null,
+    stageFieldCreation: (field, insertionIndex) =>
+      set({ pendingFieldCreation: { field, insertionIndex } }),
+    consumePendingFieldCreation: () => {
+      const pending = get().pendingFieldCreation
+      if (!pending) return
+      set({
+        stateData: {
+          state: FieldBuilderState.CreatingField,
+          field: pending.field,
+          insertionIndex: pending.insertionIndex,
+        },
+        pendingFieldCreation: null,
+      })
+    },
     setToInactive: (holding?: boolean) => {
       const nextState: FieldBuilderStore['holdingStateData'] = {
         state: FieldBuilderState.Inactive,
@@ -123,6 +147,19 @@ export const updateCreateStateSelector = (
 export const updateEditStateSelector = (
   state: FieldBuilderStore,
 ): FieldBuilderStore['updateEditState'] => state.updateEditState
+
+export const pendingFieldCreationSelector = (
+  state: FieldBuilderStore,
+): FieldBuilderStore['pendingFieldCreation'] => state.pendingFieldCreation
+
+export const stageFieldCreationSelector = (
+  state: FieldBuilderStore,
+): FieldBuilderStore['stageFieldCreation'] => state.stageFieldCreation
+
+export const consumePendingFieldCreationSelector = (
+  state: FieldBuilderStore,
+): FieldBuilderStore['consumePendingFieldCreation'] =>
+  state.consumePendingFieldCreation
 
 export const setToInactiveSelector = (
   state: FieldBuilderStore,

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
@@ -40,9 +40,6 @@ export type FieldBuilderStore = {
     | null
   clearHoldingStateData: () => void
   moveFromHolding: () => void
-  // A field another tab asked the builder to open on. Survives setToInactive
-  // on purpose: the builder clears its own state as it mounts, so anything
-  // written to stateData before the trip is gone by the time it arrives.
   pendingFieldCreation: {
     field: FieldCreateDto
     insertionIndex: number

--- a/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
+++ b/apps/frontend/src/features/admin-form/create/builder-and-design/useFieldBuilderStore.tsx
@@ -48,6 +48,7 @@ export type FieldBuilderStore = {
     insertionIndex: number
   } | null
   stageFieldCreation: (field: FieldCreateDto, insertionIndex: number) => void
+  clearPendingFieldCreation: () => void
   consumePendingFieldCreation: () => void
 }
 
@@ -107,6 +108,7 @@ export const useFieldBuilderStore = create<FieldBuilderStore>()(
     pendingFieldCreation: null,
     stageFieldCreation: (field, insertionIndex) =>
       set({ pendingFieldCreation: { field, insertionIndex } }),
+    clearPendingFieldCreation: () => set({ pendingFieldCreation: null }),
     consumePendingFieldCreation: () => {
       const pending = get().pendingFieldCreation
       if (!pending) return
@@ -155,6 +157,11 @@ export const pendingFieldCreationSelector = (
 export const stageFieldCreationSelector = (
   state: FieldBuilderStore,
 ): FieldBuilderStore['stageFieldCreation'] => state.stageFieldCreation
+
+export const clearPendingFieldCreationSelector = (
+  state: FieldBuilderStore,
+): FieldBuilderStore['clearPendingFieldCreation'] =>
+  state.clearPendingFieldCreation
 
 export const consumePendingFieldCreationSelector = (
   state: FieldBuilderStore,

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useStageFieldAndNavigate.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useStageFieldAndNavigate.ts
@@ -1,0 +1,39 @@
+import { useCallback } from 'react'
+
+import { BasicField } from 'formsg-shared/types'
+
+import { useAdminForm } from '~features/admin-form/common/queries'
+import {
+  stageFieldCreationSelector,
+  useFieldBuilderStore,
+} from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
+import { getFieldCreationMeta } from '~features/admin-form/create/builder-and-design/utils/fieldCreation'
+import { useCreatePageSidebar } from '~features/admin-form/create/common'
+
+/**
+ * Opens the field builder, optionally with a new field of `fieldType` staged
+ * for creation. The admin still confirms; nothing is written to the form here.
+ *
+ * `handleBuilderClick(false)` is deliberate. Passing true routes through the
+ * pending-tab machinery, which prompts on unsaved changes. That prompt is
+ * noise on a trip the admin just asked for.
+ *
+ * The field is staged rather than written straight to the builder's state.
+ * Opening the builder mounts BuilderAndDesignContent, which clears that state
+ * as it mounts, so anything written here first would be gone on arrival.
+ */
+export const useStageFieldAndNavigate = () => {
+  const { handleBuilderClick } = useCreatePageSidebar()
+  const stageFieldCreation = useFieldBuilderStore(stageFieldCreationSelector)
+  const { data: form } = useAdminForm()
+  const fieldCount = form?.form_fields?.length ?? 0
+
+  return useCallback(
+    (fieldType?: BasicField) => {
+      handleBuilderClick(false)
+      if (!fieldType) return
+      stageFieldCreation(getFieldCreationMeta(fieldType), fieldCount)
+    },
+    [handleBuilderClick, stageFieldCreation, fieldCount],
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useStageFieldAndNavigate.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useStageFieldAndNavigate.ts
@@ -11,18 +11,6 @@ import {
 import { getFieldCreationMeta } from '~features/admin-form/create/builder-and-design/utils/fieldCreation'
 import { useCreatePageSidebar } from '~features/admin-form/create/common'
 
-/**
- * Opens the field builder, optionally with a new field of `fieldType` staged
- * for creation. The admin still confirms; nothing is written to the form here.
- *
- * `handleBuilderClick(false)` is deliberate. Passing true routes through the
- * pending-tab machinery, which prompts on unsaved changes. That prompt is
- * noise on a trip the admin just asked for.
- *
- * The field is staged rather than written straight to the builder's state.
- * Opening the builder mounts BuilderAndDesignContent, which clears that state
- * as it mounts, so anything written here first would be gone on arrival.
- */
 export const useStageFieldAndNavigate = () => {
   const { handleBuilderClick } = useCreatePageSidebar()
   const stageFieldCreation = useFieldBuilderStore(stageFieldCreationSelector)
@@ -36,8 +24,6 @@ export const useStageFieldAndNavigate = () => {
     (fieldType?: BasicField) => {
       handleBuilderClick(false)
       if (!fieldType) {
-        // "Opens the builder with nothing staged" has to hold even if an
-        // earlier staging was never consumed.
         clearPendingFieldCreation()
         return
       }

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useStageFieldAndNavigate.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useStageFieldAndNavigate.ts
@@ -4,6 +4,7 @@ import { BasicField } from 'formsg-shared/types'
 
 import { useAdminForm } from '~features/admin-form/common/queries'
 import {
+  clearPendingFieldCreationSelector,
   stageFieldCreationSelector,
   useFieldBuilderStore,
 } from '~features/admin-form/create/builder-and-design/useFieldBuilderStore'
@@ -25,15 +26,28 @@ import { useCreatePageSidebar } from '~features/admin-form/create/common'
 export const useStageFieldAndNavigate = () => {
   const { handleBuilderClick } = useCreatePageSidebar()
   const stageFieldCreation = useFieldBuilderStore(stageFieldCreationSelector)
+  const clearPendingFieldCreation = useFieldBuilderStore(
+    clearPendingFieldCreationSelector,
+  )
   const { data: form } = useAdminForm()
   const fieldCount = form?.form_fields?.length ?? 0
 
   return useCallback(
     (fieldType?: BasicField) => {
       handleBuilderClick(false)
-      if (!fieldType) return
+      if (!fieldType) {
+        // "Opens the builder with nothing staged" has to hold even if an
+        // earlier staging was never consumed.
+        clearPendingFieldCreation()
+        return
+      }
       stageFieldCreation(getFieldCreationMeta(fieldType), fieldCount)
     },
-    [handleBuilderClick, stageFieldCreation, fieldCount],
+    [
+      handleBuilderClick,
+      stageFieldCreation,
+      clearPendingFieldCreation,
+      fieldCount,
+    ],
   )
 }


### PR DESCRIPTION
## Problem

The empty-state buttons in #9911 should open the form builder with a new field already set up. But the builder wipes its own state as it opens, so this PR parks the staged field somewhere the wipe doesn't touch, and the builder picks it up right after.

Part of FRM-2492.

## Solution

The field is staged in a pendingFieldCreation slot the builder's mount reset deliberately skips, and the builder consumes it in a second effect. React runs mount effects in declaration order, so reset always beats consume without a timer.

Callers get one hook, useStageFieldAndNavigate: it opens the builder and stages an optional BasicField. 

**Alternatives considered**

- We considered writing straight to `updateCreateState` before navigating, but the mount reset wipes it. 
- We considered deferring the write with a timer. It works, because the reset lands before a 0ms timeout, but it would be timing-dependent in a place nobody would think to look. 
- We considered reusing the store's existing `holdingStateData`, but that slot is coupled to the DirtyModal confirm flow
- `handleBuilderClick(true)` routes through the pending-tab machinery, which prompts on unsaved changes. That prompt is noise on a trip the admin just asked for, so the hook passes `false`.

**Breaking Changes**

No - backwards compatible. Frontend only, no schema change, and no caller until the stacked PR.

## Tests

The slot's behaviour is covered by unit tests in `useFieldBuilderStore.test.ts` (staging survives `setToInactive`, consume writes `CreatingField` and clears the slot, consume is a no-op when nothing is staged), each check watched failing under a targeted mutation. 