### PR TITLE
feat(workflow): rewrite the workflow tab intro screen (3/7)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
@@ -19,12 +19,15 @@ type AdminWorkflowStore = {
   completedStepNumber: number | null
   setCompletedStep: (stepNumber: number) => void
   dismissCompletedStep: () => void
+  isGuidedSetup: boolean
+  setGuidedSetup: (isGuidedSetup: boolean) => void
 }
 
 const INITIAL_STATE = {
   createOrEditData: null,
   pendingSwitchTo: null,
   completedStepNumber: null,
+  isGuidedSetup: true,
 }
 
 export const isCreatingStateSelector = (state: AdminWorkflowStore) =>
@@ -82,11 +85,18 @@ export const setCompletedStepSelector = (state: AdminWorkflowStore) =>
 export const dismissCompletedStepSelector = (state: AdminWorkflowStore) =>
   state.dismissCompletedStep
 
+export const isGuidedSetupSelector = (state: AdminWorkflowStore) =>
+  state.isGuidedSetup
+
+export const setGuidedSetupSelector = (state: AdminWorkflowStore) =>
+  state.setGuidedSetup
+
 export const useAdminWorkflowStore = create<AdminWorkflowStore>()(
   devtools((set, get) => ({
     createOrEditData: null,
     pendingSwitchTo: null,
     completedStepNumber: null,
+    isGuidedSetup: true,
     setToCreating: () =>
       set({
         createOrEditData: {
@@ -111,6 +121,7 @@ export const useAdminWorkflowStore = create<AdminWorkflowStore>()(
       }),
     setCompletedStep: (stepNumber) => set({ completedStepNumber: stepNumber }),
     dismissCompletedStep: () => set({ completedStepNumber: null }),
+    setGuidedSetup: (isGuidedSetup) => set({ isGuidedSetup }),
     setToInactive: () => set({ createOrEditData: null }),
     reset: () => set(INITIAL_STATE),
     requestSwitchTo: (stepNumber) =>

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
@@ -1,0 +1,96 @@
+import { composeStories } from '@storybook/react'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useAdminWorkflowStore } from '../adminWorkflowStore'
+import * as pageStories from '../CreatePageWorkflowTab.stories'
+import { AdminEditWorkflowState } from '../types'
+
+const { NoWorkflow, NoWorkflowRedesignOn } = composeStories(pageStories)
+
+const NEW_HEADER = /workflows split your form into steps/i
+const NEW_SUBHEADER = /send each step to a different person/i
+const OLD_HEADER = /create a workflow to collect responses/i
+
+const GUIDED = { name: /start with guided setup/i }
+const MANUAL = { name: /set up manually/i }
+
+describe('the workflow tab intro screen', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterAll(() => {
+    delete (Element.prototype as Partial<Pick<Element, 'scrollIntoView'>>)
+      .scrollIntoView
+  })
+
+  afterEach(() => useAdminWorkflowStore.getState().reset())
+
+  describe('with the redesign flag on', () => {
+    const renderIntro = async () => {
+      await act(async () => {
+        render(<NoWorkflowRedesignOn />)
+      })
+      await screen.findByText(NEW_HEADER, {}, { timeout: 10000 })
+    }
+
+    it('says what a workflow does, and offers both ways in', async () => {
+      await renderIntro()
+
+      expect(screen.getByText(NEW_SUBHEADER)).toBeInTheDocument()
+      expect(screen.getByRole('button', GUIDED)).toBeInTheDocument()
+      expect(screen.getByRole('button', MANUAL)).toBeInTheDocument()
+    })
+
+    it('drops the heading that named the feature and the guide link', async () => {
+      await renderIntro()
+
+      expect(screen.queryByText(OLD_HEADER)).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole('link', { name: /learn how to create a workflow/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it('illustrates a form rather than borrowing the real title', async () => {
+      await renderIntro()
+
+      expect(screen.getByText('My form')).toBeInTheDocument()
+    })
+
+    it.each([
+      ['guided', GUIDED],
+      ['manual', MANUAL],
+    ])('starts a step from the %s action', async (_label, action) => {
+      const user = userEvent.setup()
+      await renderIntro()
+
+      await act(async () => {
+        await user.click(screen.getByRole('button', action))
+      })
+
+      expect(useAdminWorkflowStore.getState().createOrEditData).toEqual({
+        state: AdminEditWorkflowState.CreatingStep,
+      })
+    })
+  })
+
+  describe('with the redesign flag off', () => {
+    it('keeps the pre-redesign screen whole', async () => {
+      await act(async () => {
+        render(<NoWorkflow />)
+      })
+
+      expect(
+        await screen.findByText(OLD_HEADER, {}, { timeout: 10000 }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('link', { name: /learn how to create a workflow/i }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /create workflow/i }),
+      ).toBeInTheDocument()
+      expect(screen.queryByText(NEW_HEADER)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
@@ -6,6 +6,8 @@ import { useAdminWorkflowStore } from '../adminWorkflowStore'
 import * as pageStories from '../CreatePageWorkflowTab.stories'
 import { AdminEditWorkflowState } from '../types'
 
+import { SPOTLIGHT_TEST_ID } from './Spotlight'
+
 const { NoWorkflow, NoWorkflowRedesignOn } = composeStories(pageStories)
 
 const NEW_HEADER = /workflows split your form into steps/i
@@ -62,6 +64,55 @@ describe('the workflow tab intro screen', () => {
       await renderIntro()
 
       expect(screen.getByAltText('FormSG')).toBeInTheDocument()
+    })
+
+    describe('the fork', () => {
+      it('paces the step one decision at a time from guided setup', async () => {
+        const user = userEvent.setup()
+        await renderIntro()
+
+        await act(async () => {
+          await user.click(screen.getByRole('button', GUIDED))
+        })
+
+        expect(useAdminWorkflowStore.getState().isGuidedSetup).toBe(true)
+        expect(screen.getAllByTestId(SPOTLIGHT_TEST_ID)).toHaveLength(1)
+        expect(
+          screen.getByRole('button', { name: /^continue$/i }),
+        ).toBeInTheDocument()
+      })
+
+      it('opens every section at once from manual setup', async () => {
+        const user = userEvent.setup()
+        await renderIntro()
+
+        await act(async () => {
+          await user.click(screen.getByRole('button', MANUAL))
+        })
+
+        expect(useAdminWorkflowStore.getState().isGuidedSetup).toBe(false)
+        expect(screen.queryAllByTestId(SPOTLIGHT_TEST_ID)).toHaveLength(0)
+        expect(
+          screen.queryByRole('button', { name: /^continue$/i }),
+        ).not.toBeInTheDocument()
+      })
+
+      it('leaves manual setup without completion reports', async () => {
+        const user = userEvent.setup()
+        await renderIntro()
+
+        await act(async () => {
+          await user.click(screen.getByRole('button', MANUAL))
+        })
+        await act(async () => {
+          useAdminWorkflowStore.getState().setCompletedStep(0)
+          useAdminWorkflowStore.getState().setToInactive()
+        })
+
+        expect(
+          screen.queryByText(/step 1 is the public-facing step/i),
+        ).not.toBeInTheDocument()
+      })
     })
 
     it.each([

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
@@ -58,6 +58,12 @@ describe('the workflow tab intro screen', () => {
       expect(screen.getByText('My form')).toBeInTheDocument()
     })
 
+    it('shows the logo a real form falls back to', async () => {
+      await renderIntro()
+
+      expect(screen.getByAltText('FormSG')).toBeInTheDocument()
+    })
+
     it.each([
       ['guided', GUIDED],
       ['manual', MANUAL],

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
@@ -8,6 +8,7 @@ import Link from '~components/Link'
 import Tooltip from '~components/Tooltip'
 
 import {
+  setGuidedSetupSelector,
   setToCreatingSelector,
   useAdminWorkflowStore,
 } from '../adminWorkflowStore'
@@ -22,7 +23,13 @@ const INTRO_I18N_PREFIX = 'features.adminForm.sidebar.workflow.intro'
 export const EmptyWorkflow = (): JSX.Element => {
   const { t } = useTranslation()
   const setToCreating = useAdminWorkflowStore(setToCreatingSelector)
+  const setGuidedSetup = useAdminWorkflowStore(setGuidedSetupSelector)
   const isRedesign = useIsWorkflowBuilderRedesign()
+
+  const startSetup = (isGuidedSetup: boolean) => () => {
+    setGuidedSetup(isGuidedSetup)
+    setToCreating()
+  }
   const { isPaymentEnabled } = useAdminFormWorkflow()
 
   const paymentBlockedLabel = isPaymentEnabled
@@ -46,8 +53,6 @@ export const EmptyWorkflow = (): JSX.Element => {
         </Text>
         <Tooltip
           label={paymentBlockedLabel}
-          // Disabled buttons swallow hover events; the wrapper span keeps the
-          // tooltip reachable exactly when it has something to say.
           shouldWrapChildren={isPaymentEnabled}
         >
           <Stack
@@ -56,12 +61,12 @@ export const EmptyWorkflow = (): JSX.Element => {
             my="2.5rem"
             justify="center"
           >
-            <Button onClick={setToCreating} isDisabled={isPaymentEnabled}>
+            <Button onClick={startSetup(true)} isDisabled={isPaymentEnabled}>
               {t(`${INTRO_I18N_PREFIX}.guided`)}
             </Button>
             <Button
               variant="outline"
-              onClick={setToCreating}
+              onClick={startSetup(false)}
               isDisabled={isPaymentEnabled}
             >
               {t(`${INTRO_I18N_PREFIX}.manual`)}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import { BiPlus } from 'react-icons/bi'
-import { Flex, Text } from '@chakra-ui/react'
+import { Flex, Stack, Text } from '@chakra-ui/react'
 
 import { GUIDE_FORM_MRF } from '~constants/links'
 import Button from '~components/Button'
@@ -14,13 +14,64 @@ import {
 import { useAdminFormWorkflow } from '../hooks/useAdminFormWorkflow'
 import { useIsWorkflowBuilderRedesign } from '../hooks/useIsWorkflowBuilderRedesign'
 
+import { FormIllustration } from './FormIllustration'
 import { WorkflowSvgr } from './WorkflowSvgr'
+
+const INTRO_I18N_PREFIX = 'features.adminForm.sidebar.workflow.intro'
 
 export const EmptyWorkflow = (): JSX.Element => {
   const { t } = useTranslation()
   const setToCreating = useAdminWorkflowStore(setToCreatingSelector)
   const isRedesign = useIsWorkflowBuilderRedesign()
   const { isPaymentEnabled } = useAdminFormWorkflow()
+
+  const paymentBlockedLabel = isPaymentEnabled
+    ? t('features.adminForm.sidebar.workflow.paymentEnabledNoSteps')
+    : undefined
+
+  if (isRedesign) {
+    return (
+      <Flex
+        textAlign="center"
+        flexDir="column"
+        align="center"
+        color="secondary.500"
+        pt={{ base: '0.5rem', md: '2.75rem' }}
+      >
+        <Text textStyle="h2" as="h2">
+          {t(`${INTRO_I18N_PREFIX}.header`)}
+        </Text>
+        <Text textStyle="body-1" mt="1rem">
+          {t(`${INTRO_I18N_PREFIX}.subheader`)}
+        </Text>
+        <Tooltip
+          label={paymentBlockedLabel}
+          // Disabled buttons swallow hover events; the wrapper span keeps the
+          // tooltip reachable exactly when it has something to say.
+          shouldWrapChildren={isPaymentEnabled}
+        >
+          <Stack
+            direction={{ base: 'column', md: 'row' }}
+            spacing="0.75rem"
+            my="2.5rem"
+            justify="center"
+          >
+            <Button onClick={setToCreating} isDisabled={isPaymentEnabled}>
+              {t(`${INTRO_I18N_PREFIX}.guided`)}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={setToCreating}
+              isDisabled={isPaymentEnabled}
+            >
+              {t(`${INTRO_I18N_PREFIX}.manual`)}
+            </Button>
+          </Stack>
+        </Tooltip>
+        <FormIllustration />
+      </Flex>
+    )
+  }
 
   return (
     <Flex
@@ -31,26 +82,18 @@ export const EmptyWorkflow = (): JSX.Element => {
       pt={{ base: '0.5rem', md: '2.75rem' }}
     >
       <Text textStyle="h2" as="h2">
-        {isRedesign
-          ? 'Create a workflow to collect responses from multiple people in the same form submission'
-          : 'Create a workflow to collect responses from multiple respondents in the same form submission'}
+        Create a workflow to collect responses from multiple respondents in the
+        same form submission
       </Text>
       <Text textStyle="body-1" mt="1rem">
-        {isRedesign
-          ? 'Assign people to specific steps, and control which fields they can fill in.'
-          : 'Assign respondents to specific steps, and control which fields they can fill.'}{' '}
+        Assign respondents to specific steps, and control which fields they can
+        fill.{' '}
         <Link isExternal href={GUIDE_FORM_MRF}>
           Learn how to create a workflow
         </Link>
       </Text>
       <Tooltip
-        label={
-          isPaymentEnabled
-            ? t('features.adminForm.sidebar.workflow.paymentEnabledNoSteps')
-            : undefined
-        }
-        // Disabled buttons swallow hover events; the wrapper span keeps the
-        // tooltip reachable exactly when it has something to say.
+        label={paymentBlockedLabel}
         shouldWrapChildren={isPaymentEnabled}
       >
         <Button

--- a/apps/frontend/src/features/admin-form/create/workflow/components/FormIllustration.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/FormIllustration.tsx
@@ -1,4 +1,6 @@
-import { Box, Flex, Stack, Text } from '@chakra-ui/react'
+import { Box, Flex, Image, Stack, Text } from '@chakra-ui/react'
+
+import formSgLogo from '~/assets/svgs/brand/brand-hort-colour.svg'
 
 const ILLUSTRATED_FORM_TITLE = 'My form'
 
@@ -32,7 +34,7 @@ export const FormIllustration = (): JSX.Element => (
         borderTop="1px solid"
         borderColor="neutral.300"
       >
-        <Box bg="secondary.200" borderRadius="4px" w="2.5rem" h="2.5rem" />
+        <Image src={formSgLogo} alt="FormSG" h="1.75rem" />
       </Flex>
 
       <Flex

--- a/apps/frontend/src/features/admin-form/create/workflow/components/FormIllustration.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/FormIllustration.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Image, Stack, Text } from '@chakra-ui/react'
 
-import formSgLogo from '~/assets/svgs/brand/brand-hort-colour.svg'
+import formSgLogo from '~/assets/svgs/brand/brand-mark-colour.svg'
 
 const ILLUSTRATED_FORM_TITLE = 'My form'
 
@@ -34,7 +34,7 @@ export const FormIllustration = (): JSX.Element => (
         borderTop="1px solid"
         borderColor="neutral.300"
       >
-        <Image src={formSgLogo} alt="FormSG" h="1.75rem" />
+        <Image src={formSgLogo} alt="FormSG" w="2.5rem" h="2.5rem" />
       </Flex>
 
       <Flex

--- a/apps/frontend/src/features/admin-form/create/workflow/components/FormIllustration.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/FormIllustration.tsx
@@ -1,0 +1,82 @@
+import { Box, Flex, Stack, Text } from '@chakra-ui/react'
+
+const ILLUSTRATED_FORM_TITLE = 'My form'
+
+const SkeletonLine = ({ w }: { w: string }) => (
+  <Box bg="secondary.200" borderRadius="3px" w={w} h="0.5rem" flexShrink={0} />
+)
+
+const SkeletonField = ({ labelWidth }: { labelWidth: string }) => (
+  <Stack spacing="0.5rem">
+    <SkeletonLine w={labelWidth} />
+    <Box
+      bg="white"
+      border="1px solid"
+      borderColor="neutral.300"
+      borderRadius="4px"
+      h="2.25rem"
+    />
+  </Stack>
+)
+
+export const FormIllustration = (): JSX.Element => (
+  <Box w="100%" maxW="25rem">
+    <Stack spacing={0} w="100%">
+      <Flex
+        justify="center"
+        align="center"
+        py="1rem"
+        bg="white"
+        borderTopRadius="8px"
+        borderX="1px solid"
+        borderTop="1px solid"
+        borderColor="neutral.300"
+      >
+        <Box bg="secondary.200" borderRadius="4px" w="2.5rem" h="2.5rem" />
+      </Flex>
+
+      <Flex
+        bg="primary.500"
+        justify="center"
+        align="center"
+        py="1.5rem"
+        px="1.5rem"
+        borderX="1px solid"
+        borderColor="primary.500"
+      >
+        <Text textStyle="subhead-1" color="white" noOfLines={1}>
+          {ILLUSTRATED_FORM_TITLE}
+        </Text>
+      </Flex>
+
+      <Box
+        bg="primary.100"
+        px="1.25rem"
+        py="1.25rem"
+        borderX="1px solid"
+        borderBottom="1px solid"
+        borderColor="neutral.300"
+        borderBottomRadius="8px"
+        position="relative"
+      >
+        <Box bg="white" borderRadius="4px" px="1.25rem" py="1.25rem">
+          <Stack spacing="1.25rem">
+            <SkeletonField labelWidth="25%" />
+            <SkeletonField labelWidth="40%" />
+            <SkeletonField labelWidth="20%" />
+          </Stack>
+        </Box>
+
+        <Box
+          position="absolute"
+          bottom={0}
+          left={0}
+          right={0}
+          h="3rem"
+          bgGradient="linear(to-b, transparent, primary.100)"
+          borderBottomRadius="8px"
+        />
+      </Box>
+    </Stack>
+  </Box>
+)

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/useReportedCompletedStep.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/useReportedCompletedStep.ts
@@ -1,15 +1,17 @@
 import {
   completedStepNumberSelector,
   createOrEditDataSelector,
+  isGuidedSetupSelector,
   useAdminWorkflowStore,
 } from '../../adminWorkflowStore'
 import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
 
 export const useReportedCompletedStep = (): number | null => {
   const isRedesign = useIsWorkflowBuilderRedesign()
+  const isGuidedSetup = useAdminWorkflowStore(isGuidedSetupSelector)
   const createOrEditData = useAdminWorkflowStore(createOrEditDataSelector)
   const completedStepNumber = useAdminWorkflowStore(completedStepNumberSelector)
 
-  if (!isRedesign || createOrEditData !== null) return null
+  if (!isRedesign || !isGuidedSetup || createOrEditData !== null) return null
   return completedStepNumber
 }

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/EditStepBlock/EditStepBlock.tsx
@@ -15,6 +15,7 @@ import {
   cancelPendingSwitchSelector,
   completeSaveSelector,
   isCreatingStateSelector,
+  isGuidedSetupSelector,
   pendingSwitchToSelector,
   setToInactiveSelector,
   useAdminWorkflowStore,
@@ -134,6 +135,7 @@ export const EditStepBlock = ({
   const completeSave = useAdminWorkflowStore(completeSaveSelector)
   const cancelPendingSwitch = useAdminWorkflowStore(cancelPendingSwitchSelector)
   const isCreatingState = useAdminWorkflowStore(isCreatingStateSelector)
+  const isGuidedSetup = useAdminWorkflowStore(isGuidedSetupSelector)
   const isRedesign = useIsWorkflowBuilderRedesign()
 
   const formMethods = useForm<EditStepInputs>({
@@ -212,7 +214,7 @@ export const EditStepBlock = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingSwitchTo])
 
-  const isGuided = isRedesign && isCreatingState
+  const isGuided = isRedesign && isCreatingState && isGuidedSetup
 
   // Only the order differs between flag states, so build each section once and
   // swap the sequence rather than duplicating the subtree per branch.

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -179,6 +179,13 @@ export const enSG: Workflow = {
   stepName: {
     label: 'Step name',
   },
+  intro: {
+    header: 'Workflows split your form into steps',
+    subheader:
+      'Send each step to a different person. Each person only fills in their own part.',
+    guided: 'Start with guided setup',
+    manual: 'Set up manually',
+  },
   guided: {
     continue: 'Continue',
     back: 'Back',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -154,6 +154,12 @@ export interface Workflow {
   stepName: {
     label: string
   }
+  intro: {
+    header: string
+    subheader: string
+    guided: string
+    manual: string
+  }
   guided: {
     continue: string
     back: string


### PR DESCRIPTION
Stacked on #9957. Review that first.

## Problem

- The empty state is where most admins first meet the workflow concept, often the only place.
- All four Round 1 UT participants hit orientation confusion before reaching any task.
- Closes FRM-2499.

## Solution

- `EmptyWorkflow` leads with "Workflows split your form into steps" and a one-line subheader.
- The guide link goes; the explanation is on the screen instead.
- "Start with guided setup" paces the step and reports each finished one.
- "Set up manually" opens the same card with every section at once and no reporting.
- `isGuidedSetup` on `adminWorkflowStore` carries that choice; it defaults on.
- `FormIllustration` draws a form with a fixed `My form` title and the square brand mark.

**Alternatives considered**

- Swapping copy in place — skipped, the old screen's guide link is structural, not wording.
- The real form title, per the prototype — skipped, reads as a broken preview.
- Carrying the mode on the open-card state — skipped, it doubles as the pending-switch shape.
- The animated form-to-workflow illustration — skipped, FRM-2500 owns that component.

**Breaking changes:** none. `isGuidedSetup` defaults on, so pacing behaves as before.

## Screenshots

| Before | After |
|---|---|
|<img width="1512" height="755" alt="Screenshot 2026-09-08 at 1 37 33 AM" src="https://github.com/user-attachments/assets/95e69e02-7bec-4ab4-a62f-de2b7835b61e" />|<img width="1512" height="767" alt="Screenshot 2026-09-08 at 11 44 36 AM" src="https://github.com/user-attachments/assets/cf604fec-d95c-4831-937a-616bfb3d8543" />|

| Scenario | Screenshot |
|---|---|
|Click on guided mode|<img width="1511" height="760" alt="Screenshot 2026-09-08 at 11 44 51 AM" src="https://github.com/user-attachments/assets/c8604feb-3536-4a3a-8020-8e67b2707eda" />|
|Click on manual|<img width="1512" height="759" alt="Screenshot 2026-09-08 at 11 45 02 AM" src="https://github.com/user-attachments/assets/44713405-bc56-41a4-ad2d-1497783a4973" />|

## Tests

**Automated**

- `EmptyWorkflow.test.tsx` — guided setup shows one spotlight band and a Continue button.
- `EmptyWorkflow.test.tsx` — manual setup shows no band and no Continue button.
- `EmptyWorkflow.test.tsx` — manual setup renders no completion report.
- `EmptyWorkflow.test.tsx` — flag off keeps the pre-redesign screen and its link.

**Manual**

- [ ] Click "Start with guided setup"; expect the step name alone and Continue.
- [ ] Go back, click "Set up manually"; expect every section and the Save row.
