### PR TITLE
fix(logging): redact Authorization header from access logs

### DIFF
--- a/apps/backend/src/app/loaders/express/logging.ts
+++ b/apps/backend/src/app/loaders/express/logging.ts
@@ -88,7 +88,7 @@ const loggingMiddleware = () => {
       }
       return value
     },
-    headerBlacklist: ['cookie'],
+    headerBlacklist: ['cookie', 'authorization'],
     ignoredRoutes: ['/'],
     skip: (req, res) => {
       // Skip if it's ELB-HealthChecker to avoid polluting logs


### PR DESCRIPTION
## Problem

The access log middleware ships every request's headers to Datadog, but only blacklists the `cookie` header. Bearer tokens sent in the `Authorization` header — including long-lived Public API keys used by form admins — are logged in cleartext on every request, including calls to routes like `/api/public/v1/admin/forms/:formId/settings`.

## Solution

Add `authorization` to the access logger's `headerBlacklist` alongside `cookie`, so bearer credentials are stripped before the request/response log line is emitted.

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: Authorization header is not logged**
- [ ] Make an authenticated request to any API route with an `Authorization: Bearer <token>` header (e.g. `POST /api/public/v1/admin/forms/:formId/settings` with a valid API key)
- [ ] Confirm the access log line for that request does not contain the `authorization` value (check local console output or a non-prod Datadog log stream)

**TC2: Cookie redaction still works**
- [ ] Make an authenticated request via session cookie (e.g. any dashboard API call)
- [ ] Confirm the access log line still omits the `cookie` header value (unchanged behaviour, regression check)
