### PR TITLE
fix(logging): allowlist the headers the access log may record

### DIFF
--- a/apps/backend/src/app/loaders/express/__tests__/logging.spec.ts
+++ b/apps/backend/src/app/loaders/express/__tests__/logging.spec.ts
@@ -1,0 +1,99 @@
+import { ObjectId } from 'bson'
+
+import { pickLoggedHeaders } from 'src/app/loaders/express/logging'
+
+describe('logging', () => {
+  describe('pickLoggedHeaders', () => {
+    it('should drop the authorization header', () => {
+      const picked = pickLoggedHeaders({
+        authorization: 'Bearer formsg_v1_5f7b1b1b1b1b1b1b1b1b1b1b_c2VjcmV0',
+        host: 'form.gov.sg',
+      })
+
+      expect(picked).not.toHaveProperty('authorization')
+      expect(picked).toEqual({ host: 'form.gov.sg' })
+    })
+
+    it('should drop the cookie header', () => {
+      const picked = pickLoggedHeaders({
+        cookie: 'connect.sid=s%3Asome-session-id',
+        host: 'form.gov.sg',
+      })
+
+      expect(picked).not.toHaveProperty('cookie')
+    })
+
+    it('should drop unknown headers rather than pass them through', () => {
+      const picked = pickLoggedHeaders({
+        'x-some-header-nobody-thought-of': 'super-secret-value',
+        'stripe-signature': 't=1,v1=deadbeef',
+        host: 'form.gov.sg',
+      })
+
+      expect(picked).toEqual({ host: 'form.gov.sg' })
+    })
+
+    it('should keep headers that are useful for debugging', () => {
+      const headers = {
+        'cf-connecting-ip': '1.2.3.4',
+        'cf-ray': 'some-ray-id',
+        'content-type': 'application/json',
+        host: 'form.gov.sg',
+        'user-agent': 'Mozilla/5.0',
+        'x-request-id': 'some-request-id',
+      }
+
+      expect(pickLoggedHeaders(headers)).toEqual(headers)
+    })
+
+    it('should strip the mrf key from the referer it keeps', () => {
+      const formId = new ObjectId()
+      const submissionId = new ObjectId()
+      const secret = 'aHf3OiQ64U6Sj%2FkSUlmJRsG0OsJdIayGrv0vjCxHk5Y%3D'
+
+      const picked = pickLoggedHeaders({
+        referer: `https://form.gov.sg/${formId}/edit/${submissionId}?key=${secret}`,
+      })
+
+      expect(picked.referer).toBe(
+        `https://form.gov.sg/${formId}/edit/${submissionId}`,
+      )
+    })
+
+    it('should strip the mrf key even when another param follows it', () => {
+      const formId = new ObjectId()
+      const submissionId = new ObjectId()
+      const secret = 'aHf3OiQ64U6Sj%2FkSUlmJRsG0OsJdIayGrv0vjCxHk5Y%3D'
+
+      const picked = pickLoggedHeaders({
+        referer: `https://form.gov.sg/${formId}/edit/${submissionId}?key=${secret}&step=2`,
+      })
+
+      expect(picked.referer).not.toContain(secret)
+      expect(picked.referer).toBe(
+        `https://form.gov.sg/${formId}/edit/${submissionId}`,
+      )
+    })
+
+    it('should leave a referer without a query string alone', () => {
+      const picked = pickLoggedHeaders({
+        referer: 'https://form.gov.sg/dashboard',
+      })
+
+      expect(picked.referer).toBe('https://form.gov.sg/dashboard')
+    })
+
+    it('should not mutate the headers it is given', () => {
+      const formId = new ObjectId()
+      const submissionId = new ObjectId()
+      const secret = 'aHf3OiQ64U6Sj%2FkSUlmJRsG0OsJdIayGrv0vjCxHk5Y%3D'
+      const referer = `https://form.gov.sg/${formId}/edit/${submissionId}?key=${secret}`
+      const headers = { referer, authorization: 'Bearer token' }
+
+      pickLoggedHeaders(headers)
+
+      expect(headers.referer).toBe(referer)
+      expect(headers.authorization).toBe('Bearer token')
+    })
+  })
+})

--- a/apps/backend/src/app/loaders/express/logging.ts
+++ b/apps/backend/src/app/loaders/express/logging.ts
@@ -1,4 +1,5 @@
 import expressWinston from 'express-winston'
+import { IncomingHttpHeaders } from 'http'
 import get from 'lodash/get'
 import winston from 'winston'
 
@@ -7,6 +8,79 @@ import { customFormat } from '../../config/logger'
 import { getRequestIp, getTrace, maskOAuthCode } from '../../utils/request'
 
 const LOGGER_LABEL = 'network'
+
+/**
+ * Request headers that may be written to the access log verbatim.
+ *
+ * This is an allowlist, not a blacklist. express-winston's default
+ * `requestWhitelist` includes `headers`, so every inbound header is logged
+ * unless something removes it, and `headerBlacklist` only removes the names
+ * we thought of in advance. That fails open: a header carrying a new
+ * credential leaks from the moment it is introduced until someone notices.
+ * Both `authorization` (public API keys) and the MRF key in `referer` reached
+ * production that way.
+ *
+ * Anything not listed here is dropped. Add to this list deliberately, and only
+ * for headers that cannot carry a secret.
+ */
+const LOGGED_HEADERS = [
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'cf-connecting-ip',
+  'cf-ipcountry',
+  'cf-ray',
+  'connection',
+  'content-length',
+  'content-type',
+  'host',
+  'origin',
+  // Query string stripped below: carries the MRF submission edit key.
+  'referer',
+  'sec-fetch-dest',
+  'sec-fetch-mode',
+  'sec-fetch-site',
+  'user-agent',
+  'x-amz-sns-message-type',
+  'x-forwarded-for',
+  'x-forwarded-port',
+  'x-forwarded-proto',
+  'x-request-id',
+] as const
+
+/**
+ * Drops the query string from a referer.
+ *
+ * `utils/request` masks the MRF key in the referer with a regex anchored to
+ * the end of the string, which quietly masks the wrong 24 characters if any
+ * param ever follows `key=`. Nothing needs the query string here: the path is
+ * what makes an access log line useful, and the query string is the only part
+ * that carries secrets. Dropping it is exact where a pattern match is a guess.
+ */
+const stripQueryString = (referer: string): string => {
+  const queryStart = referer.indexOf('?')
+  return queryStart === -1 ? referer : referer.slice(0, queryStart)
+}
+
+// Exported for testing: this is the gate that keeps credentials out of the
+// access log, so it is worth asserting on directly.
+export const pickLoggedHeaders = (
+  headers: IncomingHttpHeaders,
+): IncomingHttpHeaders => {
+  // Built as a plain record rather than an IncomingHttpHeaders: the latter
+  // narrows well-known names (`host` is `string`, not `string | string[]`),
+  // which a copy loop over a literal union of keys cannot satisfy.
+  const picked: Record<string, string | string[] | undefined> = {}
+  for (const name of LOGGED_HEADERS) {
+    if (name in headers) {
+      picked[name] = headers[name]
+    }
+  }
+  if (typeof picked.referer === 'string') {
+    picked.referer = stripQueryString(picked.referer)
+  }
+  return picked as IncomingHttpHeaders
+}
 
 type LogMeta = {
   clientIp: string
@@ -80,6 +154,9 @@ const loggingMiddleware = () => {
     // Singpass/Corppass/sgID login callbacks must be masked here.
     requestFilter: (req, propName) => {
       const value = get(req, propName)
+      if (propName === 'headers' && value && typeof value === 'object') {
+        return pickLoggedHeaders(value as IncomingHttpHeaders)
+      }
       if (propName === 'query' && value && typeof value === 'object') {
         const query = value as Record<string, unknown>
         if ('code' in query) {
@@ -88,6 +165,8 @@ const loggingMiddleware = () => {
       }
       return value
     },
+    // Redundant now that headers are allowlisted above, but kept as a second
+    // line of defence if the allowlist is ever widened carelessly.
     headerBlacklist: ['cookie', 'authorization'],
     ignoredRoutes: ['/'],
     skip: (req, res) => {

--- a/apps/backend/src/app/utils/request.ts
+++ b/apps/backend/src/app/utils/request.ts
@@ -49,6 +49,13 @@ const HEADERS_RULES = {
   },
 }
 
+/**
+ * Masks the MRF submission edit key that respondents carry in the `referer`
+ * when their browser makes same-origin calls from `/<formId>/edit/<submissionId>?key=...`.
+ *
+ * Returns a copy: the caller passes `req.headers` straight in, and masking in
+ * place rewrites the live request object that downstream handlers still read.
+ */
 const maskRefererHeaders = (
   headers: ReqMeta['headers'],
 ): ReqMeta['headers'] => {
@@ -58,15 +65,16 @@ const maskRefererHeaders = (
   if (!headers?.referer) {
     return headers
   }
+  const masked = { ...headers }
   for (const [headerKey, { regex, replacement }] of Object.entries(
     HEADERS_RULES,
   )) {
-    const value = headers[headerKey]
+    const value = masked[headerKey]
     if (typeof value === 'string') {
-      headers[headerKey] = value.replace(regex, replacement)
+      masked[headerKey] = value.replace(regex, replacement)
     }
   }
-  return headers
+  return masked
 }
 
 /**


### PR DESCRIPTION
## Problem

#9964 added `authorization` to the access logger's `headerBlacklist` after public API keys were found in cleartext in prod logs. It closes the one header we know about and leaves the shape of the bug intact.

express-winston's default `requestWhitelist` includes `headers` (`express-winston/index.js:33`), so **every inbound header is logged unless something removes it**, and `headerBlacklist` only removes the names we thought of in advance. It fails open.

Two credentials have already reached production through it:

1. **The public API key** in `authorization`. Fixed by #9964.
2. **The MRF submission edit key** in `referer`, which #9964 does **not** address and which is still leaking today. Helmet is set to `strict-origin-when-cross-origin` (`helmet.ts:33`), so same-origin XHR from `/<formId>/edit/<submissionId>?key=<secret>` sends the full URL. `createReqMeta` has masked exactly this since #8301, but that masking was never wired into the access logger.

`stripe-signature` is logged today for the same reason.

## Solution

Invert the filter. `requestFilter` now picks a fixed `LOGGED_HEADERS` set and drops everything else, so a header carrying a new credential is absent from the log until someone deliberately adds it. `headerBlacklist` stays as a second line of defence.

`referer` is kept, because the path is worth having when reading access logs, but its **query string is dropped rather than masked**. `utils/request` masks the MRF key with a regex anchored to the end of the string (`/(?<=\/edit\/[a-zA-Z0-9]{24}\?key=.+).{24}$/i`), which masks the wrong 24 characters if a param ever follows `key=`. The query string is the only part of a referer that carries secrets and nothing here needs it, so removing it outright is exact where a pattern match is a guess.

Commit 1 is a standalone fix: `maskRefererHeaders` is handed `req.headers` and masks in place, rewriting the live request object rather than the copy being logged.

### Scope

Request headers only. Response headers and bodies were never at risk: express-winston defaults `responseWhitelist` to `['statusCode']` and `bodyWhitelist` to `[]`, and neither is overridden here.

This stops new leakage. It does nothing about what is already in CloudWatch (`formsg-prod/ecs/formsg-app`) and downstream in Datadog. Purge and API key rotation are being tracked separately as part of the incident.

**Breaking Changes**

No. Access log lines lose headers that were not deliberately allowlisted, and referer query strings.

## Tests

Unit tests added in `apps/backend/src/app/loaders/express/__tests__/logging.spec.ts` covering: `authorization` dropped, `cookie` dropped, unknown headers dropped, useful headers kept, MRF key stripped from referer (including when a param follows `key=`), referers without a query string left alone, and no mutation of the input.

**TC1: Authorization is absent from the access log**
- [ ] Send a request with `Authorization: Bearer <api key>` to any route
- [ ] Confirm the access log line contains no `authorization` key at all

**TC2: MRF key is absent from the referer**
- [ ] Open an MRF submission edit link (`/<formId>/edit/<submissionId>?key=...`) and let the page make its API calls
- [ ] Confirm access log lines show `referer` truncated at the path, with no `?key=`

**TC3: Access logs are still useful**
- [ ] Confirm log lines still carry `host`, `user-agent`, `content-type`, `cf-connecting-ip`, `cf-ray` and `x-request-id`
