### PR TITLE
feat(workflow): show the welcome card once per admin (5/7)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
@@ -1,6 +1,12 @@
 import { composeStories } from '@storybook/react'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
+
+import { SeenFlags } from 'formsg-shared/types'
+
+import { MOCK_USER } from '~/mocks/msw/handlers/user'
 
 import { useAdminWorkflowStore } from '../adminWorkflowStore'
 import * as pageStories from '../CreatePageWorkflowTab.stories'
@@ -17,17 +23,36 @@ const OLD_HEADER = /create a workflow to collect responses/i
 const GUIDED = { name: /start with guided setup/i }
 const MANUAL = { name: /set up manually/i }
 
+const server = setupServer()
+
+const withGuidedSetupFlag = (value: number | undefined) =>
+  server.use(
+    http.get('/api/v3/user', () =>
+      HttpResponse.json({
+        ...MOCK_USER,
+        flags:
+          value === undefined ? {} : { [SeenFlags.GuidedWorkflowSetup]: value },
+      }),
+    ),
+  )
+
 describe('the workflow tab intro screen', () => {
   beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'bypass' })
     Element.prototype.scrollIntoView = vi.fn()
   })
+
+  afterAll(() => server.close())
 
   afterAll(() => {
     delete (Element.prototype as Partial<Pick<Element, 'scrollIntoView'>>)
       .scrollIntoView
   })
 
-  afterEach(() => useAdminWorkflowStore.getState().reset())
+  afterEach(() => {
+    server.resetHandlers()
+    useAdminWorkflowStore.getState().reset()
+  })
 
   describe('with the redesign flag on', () => {
     const renderIntro = async () => {
@@ -67,6 +92,35 @@ describe('the workflow tab intro screen', () => {
     })
 
     describe('the fork', () => {
+      it('skips the card for an admin who has been taught', async () => {
+        const user = userEvent.setup()
+        withGuidedSetupFlag(1)
+        await renderIntro()
+
+        await act(async () => {
+          await user.click(screen.getByRole('button', GUIDED))
+        })
+
+        expect(
+          screen.queryByText(/let's start with step 1/i),
+        ).not.toBeInTheDocument()
+        await waitFor(() =>
+          expect(screen.getAllByTestId(SPOTLIGHT_TEST_ID)).toHaveLength(1),
+        )
+      })
+
+      it('still shows the card to an admin seeded as pre-existing', async () => {
+        const user = userEvent.setup()
+        withGuidedSetupFlag(0)
+        await renderIntro()
+
+        await act(async () => {
+          await user.click(screen.getByRole('button', GUIDED))
+        })
+
+        expect(screen.getByText(/let's start with step 1/i)).toBeInTheDocument()
+      })
+
       it('orients on the welcome card before asking for anything', async () => {
         const user = userEvent.setup()
         await renderIntro()

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
@@ -14,6 +14,7 @@ import {
   useAdminWorkflowStore,
 } from '../adminWorkflowStore'
 import { useAdminFormWorkflow } from '../hooks/useAdminFormWorkflow'
+import { useGuidedSetupTaught } from '../hooks/useGuidedSetupTaught'
 import { useIsWorkflowBuilderRedesign } from '../hooks/useIsWorkflowBuilderRedesign'
 
 import { FormToWorkflowIllustration } from './FormToWorkflowIllustration'
@@ -30,13 +31,14 @@ export const EmptyWorkflow = (): JSX.Element => {
 
   const startSetup = (isGuidedSetup: boolean) => () => {
     setGuidedSetup(isGuidedSetup)
-    if (isGuidedSetup) {
+    if (isGuidedSetup && !hasBeenTaught) {
       showWelcomeCard()
       return
     }
     setToCreating()
   }
   const { isPaymentEnabled } = useAdminFormWorkflow()
+  const { hasBeenTaught } = useGuidedSetupTaught()
 
   const paymentBlockedLabel = isPaymentEnabled
     ? t('features.adminForm.sidebar.workflow.paymentEnabledNoSteps')

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/WelcomeCard.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/WelcomeCard.test.tsx
@@ -1,12 +1,16 @@
+import { QueryClient, QueryClientProvider } from 'react-query'
 import { ChakraProvider } from '@chakra-ui/react'
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { setupServer } from 'msw/node'
 
 import { featureFlags } from 'formsg-shared/constants'
-import { Language } from 'formsg-shared/types'
+import { Language, SeenFlags } from 'formsg-shared/types'
 
 import i18n from '~/i18n/i18n'
+import { MOCK_USER } from '~/mocks/msw/handlers/user'
 
 import { theme } from '~theme/index'
 
@@ -15,27 +19,49 @@ import { AdminEditWorkflowState } from '../../types'
 
 import { WelcomeCard } from './WelcomeCard'
 
+let flagWrites: unknown[] = []
+
+const server = setupServer(
+  http.get('/api/v3/user', () => HttpResponse.json(MOCK_USER)),
+  http.post('/api/v3/user/flag/last-seen', async ({ request }) => {
+    flagWrites.push(await request.json())
+    return HttpResponse.json(MOCK_USER)
+  }),
+)
+
 const renderCard = () =>
   render(
-    <ChakraProvider theme={theme}>
-      <GrowthBookProvider
-        growthbook={
-          new GrowthBook({
-            features: {
-              [featureFlags.workflowBuilderRedesign]: { defaultValue: true },
-            },
-          })
-        }
-      >
-        <WelcomeCard />
-      </GrowthBookProvider>
-    </ChakraProvider>,
+    // @ts-expect-error missing FC type in old version
+    <QueryClientProvider client={new QueryClient()}>
+      <ChakraProvider theme={theme}>
+        <GrowthBookProvider
+          growthbook={
+            new GrowthBook({
+              features: {
+                [featureFlags.workflowBuilderRedesign]: { defaultValue: true },
+              },
+            })
+          }
+        >
+          <WelcomeCard />
+        </GrowthBookProvider>
+      </ChakraProvider>
+    </QueryClientProvider>,
   )
 
 describe('WelcomeCard', () => {
-  beforeAll(() => i18n.changeLanguage(Language.ENGLISH))
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'bypass' })
+    return i18n.changeLanguage(Language.ENGLISH)
+  })
 
-  afterEach(() => useAdminWorkflowStore.getState().reset())
+  afterAll(() => server.close())
+
+  afterEach(() => {
+    server.resetHandlers()
+    flagWrites = []
+    useAdminWorkflowStore.getState().reset()
+  })
 
   it('names step 1 as what the first person to open the link fills in', () => {
     renderCard()
@@ -71,6 +97,30 @@ describe('WelcomeCard', () => {
       }),
     )
     expect(useAdminWorkflowStore.getState().isOnWelcomeCard).toBe(false)
+  })
+
+  it('records the admin as taught when they click through', async () => {
+    const user = userEvent.setup()
+    renderCard()
+
+    expect(flagWrites).toEqual([])
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /let's go/i }))
+    })
+
+    await waitFor(() =>
+      expect(flagWrites).toEqual([
+        { flag: SeenFlags.GuidedWorkflowSetup, version: 1 },
+      ]),
+    )
+  })
+
+  it('records nothing from merely being shown', async () => {
+    renderCard()
+    await screen.findByText('Step 1')
+
+    expect(flagWrites).toEqual([])
   })
 
   it('shows the form before turning it into a workflow', async () => {

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/WelcomeCard.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/WelcomeCard.tsx
@@ -14,6 +14,7 @@ import {
   startBuildingFromWelcomeSelector,
   useAdminWorkflowStore,
 } from '../../adminWorkflowStore'
+import { useGuidedSetupTaught } from '../../hooks/useGuidedSetupTaught'
 import { FormToWorkflowIllustration } from '../FormToWorkflowIllustration'
 
 const WELCOME_I18N_PREFIX = 'features.adminForm.sidebar.workflow.welcome'
@@ -25,6 +26,7 @@ const LEAVE_DURATION_MS = 150
 export const WelcomeCard = (): JSX.Element => {
   const { t } = useTranslation()
   const startBuilding = useAdminWorkflowStore(startBuildingFromWelcomeSelector)
+  const { markTaught } = useGuidedSetupTaught()
   const prefersReducedMotion = usePrefersReducedMotion()
 
   const [showWorkflow, setShowWorkflow] = useState(false)
@@ -40,6 +42,7 @@ export const WelcomeCard = (): JSX.Element => {
   }, [prefersReducedMotion])
 
   const handleStartBuilding = () => {
+    markTaught()
     if (prefersReducedMotion) {
       startBuilding()
       return

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupTaught.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupTaught.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react'
+
+import { SeenFlags } from 'formsg-shared/types'
+
+import { GUIDED_WORKFLOW_SETUP_TAUGHT } from '~features/user/constants'
+import { useUserMutations } from '~features/user/mutations'
+import { useUser } from '~features/user/queries'
+
+export interface GuidedSetupTaught {
+  hasBeenTaught: boolean
+  markTaught: () => void
+}
+
+export const useGuidedSetupTaught = (): GuidedSetupTaught => {
+  const { user } = useUser()
+  const { updateLastSeenFlagMutation } = useUserMutations()
+
+  const flagValue = user?.flags?.[SeenFlags.GuidedWorkflowSetup]
+
+  const markTaught = useCallback(() => {
+    updateLastSeenFlagMutation.mutate({
+      flag: SeenFlags.GuidedWorkflowSetup,
+      version: GUIDED_WORKFLOW_SETUP_TAUGHT,
+    })
+  }, [updateLastSeenFlagMutation])
+
+  return {
+    hasBeenTaught:
+      flagValue !== undefined && flagValue >= GUIDED_WORKFLOW_SETUP_TAUGHT,
+    markTaught,
+  }
+}

--- a/apps/frontend/src/features/user/constants.ts
+++ b/apps/frontend/src/features/user/constants.ts
@@ -2,6 +2,8 @@ import { SeenFlags } from 'formsg-shared/types'
 
 import { FEATURE_UPDATE_LIST } from '~features/whats-new/FeatureUpdateList'
 
+export const GUIDED_WORKFLOW_SETUP_TAUGHT = 1
+
 const LegacySeenFlags = {
   [SeenFlags.LastSeenFeatureUpdateVersion]: FEATURE_UPDATE_LIST.version,
 }
@@ -10,4 +12,5 @@ export const SeenFlagsMapVersion: { [key in SeenFlags]: number } = {
   ...LegacySeenFlags,
   [SeenFlags.SettingsNotification]: 0,
   [SeenFlags.CreateBuilderMrfWorkflow]: 0,
+  [SeenFlags.GuidedWorkflowSetup]: GUIDED_WORKFLOW_SETUP_TAUGHT,
 }

--- a/packages/shared/types/user.ts
+++ b/packages/shared/types/user.ts
@@ -9,6 +9,7 @@ export enum SeenFlags {
   LastSeenFeatureUpdateVersion = 'lastSeenFeatureUpdateVersion',
   SettingsNotification = 'settingsNotification',
   CreateBuilderMrfWorkflow = 'createBuilderMrfWorkflow',
+  GuidedWorkflowSetup = 'guidedWorkflowSetup',
 }
 
 // Base used for being referenced by schema/model in the backend.


### PR DESCRIPTION
Stacked on #9967. Review that first.

## Problem

- The welcome card shows on every form, so an admin who has read it gets it again.
- Nothing records that an admin has been through guided setup.
- Part of FRM-2499.

## Solution

- `SeenFlags.GuidedWorkflowSetup` records that an admin has been taught.
- `useGuidedSetupTaught` reads it and writes it; `EmptyWorkflow` skips the card when set.
- `WelcomeCard` writes it on "Let's go", not on render.
- Read from `user.flags` directly, since the helper cannot tell unset from `0`.
- `SeenFlagsMapVersion` gains the entry its type requires.
- No backend or schema change: `flags` is already a `Schema.Types.Map` of Number.

**Alternatives considered**

- localStorage — skipped, per-browser, so a new laptop teaches them again.
- Writing on render — skipped, a page load that teaches nobody would retire the card.
- Writing on completion or skip, per the PRD — skipped, the skip action is unbuilt.

**Breaking changes:** none. Unset means never taught, so existing admins see the card once.

## Screenshots

Backend-only change to the flag; the card itself is unchanged from #9967.

**Verified that first-time users see the welcome card:**
<img width="1512" height="763" alt="Screenshot 2026-09-08 at 2 16 04 PM" src="https://github.com/user-attachments/assets/d6e018d8-35b9-4cb2-86fb-121b756a6bbd" />
<img width="1512" height="764" alt="Screenshot 2026-09-08 at 2 15 50 PM" src="https://github.com/user-attachments/assets/0935330e-b0f1-4107-94d6-8efbab176549" />
<img width="1512" height="766" alt="Screenshot 2026-09-08 at 2 16 19 PM" src="https://github.com/user-attachments/assets/f85e8621-2e1b-42f6-8aaf-2aa7d8588b78" />

**Verified that if the user already clicked through the welcome card, they never see it again:**
<img width="1512" height="763" alt="Screenshot 2026-09-08 at 2 16 04 PM" src="https://github.com/user-attachments/assets/1df7af1e-55f7-48e1-9341-9cd6461e8acc" />
<img width="1512" height="766" alt="Screenshot 2026-09-08 at 2 16 19 PM" src="https://github.com/user-attachments/assets/610012a2-ff93-4c31-9e88-98ba10bcee28" />

## Tests

**Automated**

- `WelcomeCard.test.tsx` — "Let's go" posts the flag with the taught value.
- `WelcomeCard.test.tsx` — rendering the card alone posts nothing.
- `EmptyWorkflow.test.tsx` — a taught admin goes straight to a paced step.
- `EmptyWorkflow.test.tsx` — an admin seeded `0` still sees the card.

**Manual**

- [ ] Rebuild shared and restart the backend, since the enum lives there.
- [ ] Start guided setup, click "Let's go", then delete the step.
- [ ] Start guided setup again; expect no welcome card.
