### PR TITLE
feat(workflow): let an admin turn guided mode off (6/7)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.test.tsx
@@ -1,0 +1,123 @@
+import { composeStories } from '@storybook/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { useAdminWorkflowStore } from '../../adminWorkflowStore'
+import * as pageStories from '../../CreatePageWorkflowTab.stories'
+import { SPOTLIGHT_TEST_ID } from '../Spotlight'
+
+const { WithWorkflowRedesignOn, WithWorkflow } = composeStories(pageStories)
+
+const SWITCH = { name: /guided mode/i }
+const CONFIRM = { name: /^skip guidance$/i }
+const CONFIRM_TITLE = /skip guided setup\?/i
+
+const bandCount = () => screen.queryAllByTestId(SPOTLIGHT_TEST_ID).length
+
+const openTab = async (Story: typeof WithWorkflowRedesignOn) => {
+  await act(async () => {
+    render(<Story />)
+  })
+  await screen.findByRole('heading', { name: /^workflow$/i }, { timeout: 8000 })
+  return userEvent.setup()
+}
+
+const openPacedStep = async () => {
+  const ui = await openTab(WithWorkflowRedesignOn)
+  await act(async () => {
+    useAdminWorkflowStore.getState().setToCreating()
+  })
+  await waitFor(() => expect(bandCount()).toBe(1))
+  return ui
+}
+
+describe('the Guided mode switch', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterAll(() => {
+    delete (Element.prototype as Partial<Pick<Element, 'scrollIntoView'>>)
+      .scrollIntoView
+  })
+
+  afterEach(() => useAdminWorkflowStore.getState().reset())
+
+  it('sits in the workflow card, on by default', async () => {
+    await openTab(WithWorkflowRedesignOn)
+
+    expect(screen.getByRole('checkbox', SWITCH)).toBeChecked()
+  })
+
+  it('is absent with the redesign flag off', async () => {
+    await openTab(WithWorkflow)
+
+    expect(screen.queryByRole('checkbox', SWITCH)).not.toBeInTheDocument()
+  })
+
+  it('asks before switching off', async () => {
+    const ui = await openTab(WithWorkflowRedesignOn)
+
+    await act(async () => {
+      await ui.click(screen.getByRole('checkbox', SWITCH))
+    })
+
+    expect(screen.getByText(CONFIRM_TITLE)).toBeInTheDocument()
+    expect(useAdminWorkflowStore.getState().isGuidedSetup).toBe(true)
+  })
+
+  it.each([
+    ['cancel', /^cancel$/i],
+    ['the close icon', /close/i],
+  ])('changes nothing on %s', async (_label, name) => {
+    const ui = await openTab(WithWorkflowRedesignOn)
+
+    await act(async () => {
+      await ui.click(screen.getByRole('checkbox', SWITCH))
+    })
+    await act(async () => {
+      await ui.click(screen.getByRole('button', { name }))
+    })
+
+    expect(useAdminWorkflowStore.getState().isGuidedSetup).toBe(true)
+    expect(screen.getByRole('checkbox', SWITCH)).toBeChecked()
+  })
+
+  it('drops the pacing on confirm, keeping the step open', async () => {
+    const ui = await openPacedStep()
+
+    await act(async () => {
+      await ui.click(screen.getByRole('checkbox', SWITCH))
+    })
+    await act(async () => {
+      await ui.click(screen.getByRole('button', CONFIRM))
+    })
+
+    expect(bandCount()).toBe(0)
+    expect(
+      screen.queryByRole('button', { name: /^continue$/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(/step name/i)).toBeInTheDocument()
+  })
+
+  it('puts the pacing back when switched on again, without asking', async () => {
+    const ui = await openPacedStep()
+
+    await act(async () => {
+      await ui.click(screen.getByRole('checkbox', SWITCH))
+    })
+    await act(async () => {
+      await ui.click(screen.getByRole('button', CONFIRM))
+    })
+    await waitFor(() =>
+      expect(screen.queryByText(CONFIRM_TITLE)).not.toBeInTheDocument(),
+    )
+
+    await act(async () => {
+      await ui.click(screen.getByRole('checkbox', SWITCH))
+    })
+
+    expect(screen.queryByText(CONFIRM_TITLE)).not.toBeInTheDocument()
+    await waitFor(() => expect(bandCount()).toBe(1))
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.tsx
@@ -1,0 +1,97 @@
+import { useTranslation } from 'react-i18next'
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+  useBreakpointValue,
+  useDisclosure,
+} from '@chakra-ui/react'
+
+import Button from '~components/Button'
+import { ModalCloseButton } from '~components/Modal'
+import Toggle from '~components/Toggle'
+
+import {
+  isGuidedSetupSelector,
+  setGuidedSetupSelector,
+  useAdminWorkflowStore,
+} from '../../adminWorkflowStore'
+import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
+import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
+
+const WORKFLOW_I18N_PREFIX = 'features.adminForm.sidebar.workflow'
+const SKIP_I18N_PREFIX = `${WORKFLOW_I18N_PREFIX}.skipGuidance`
+
+export const GuidedSetupToggle = (): JSX.Element | null => {
+  const { t } = useTranslation()
+  const { isOpen, onOpen, onClose } = useDisclosure()
+  const isRedesign = useIsWorkflowBuilderRedesign()
+  const isGuidedSetup = useAdminWorkflowStore(isGuidedSetupSelector)
+  const setGuidedSetup = useAdminWorkflowStore(setGuidedSetupSelector)
+  const { formWorkflow } = useAdminFormWorkflow()
+
+  const modalSize = useBreakpointValue({ base: 'mobile', md: 'md' })
+
+  const hasSteps = (formWorkflow?.length ?? 0) > 0
+
+  const handleChange = () => {
+    if (isGuidedSetup) {
+      onOpen()
+      return
+    }
+    setGuidedSetup(true)
+  }
+
+  const handleConfirm = () => {
+    setGuidedSetup(false)
+    onClose()
+  }
+
+  if (!isRedesign) return null
+
+  const label = t(`${WORKFLOW_I18N_PREFIX}.guidedMode.label`)
+
+  return (
+    <>
+      <Toggle isChecked={isGuidedSetup} onChange={handleChange} label={label} />
+
+      <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalHeader color="secondary.700">
+            {t(`${SKIP_I18N_PREFIX}.modal.title`)}
+          </ModalHeader>
+          <ModalBody>
+            <Text textStyle="body-2" color="secondary.500">
+              {t(
+                hasSteps
+                  ? `${SKIP_I18N_PREFIX}.modal.bodyWithSteps`
+                  : `${SKIP_I18N_PREFIX}.modal.bodyWithoutSteps`,
+              )}
+            </Text>
+          </ModalBody>
+          <ModalFooter>
+            <Stack
+              direction={{ base: 'column-reverse', md: 'row' }}
+              w="100%"
+              justify="flex-end"
+            >
+              <Button variant="clear" colorScheme="secondary" onClick={onClose}>
+                {t(`${SKIP_I18N_PREFIX}.modal.cancel`)}
+              </Button>
+              <Button onClick={handleConfirm}>
+                {t(`${SKIP_I18N_PREFIX}.modal.confirm`)}
+              </Button>
+            </Stack>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  )
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/index.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/index.ts
@@ -1,4 +1,5 @@
 export * from './CompletionPeekCard'
+export * from './GuidedSetupToggle'
 export * from './PeekCard'
 export * from './useReportedCompletedStep'
 export * from './WelcomeCard'

--- a/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/WorkflowContent/WorkflowContent.tsx
@@ -6,7 +6,7 @@ import { StatusTrackerToggle } from '~features/admin-form/settings/components/Em
 
 import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
 import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
-import { useReportedCompletedStep } from '../GuidedCreation'
+import { GuidedSetupToggle, useReportedCompletedStep } from '../GuidedCreation'
 
 import { CompletionEmailBlock } from './CompletionEmailBlock'
 import { NewStepBlock } from './NewStepBlock'
@@ -37,6 +37,7 @@ export const WorkflowContent = (): JSX.Element | null => {
           </Text>
           <Divider />
           <StatusTrackerToggle />
+          <GuidedSetupToggle />
         </Stack>
       </Box>
       <Stack spacing="0" divider={<WorkflowStepBlockDivider />}>

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/en-sg.ts
@@ -179,6 +179,20 @@ export const enSG: Workflow = {
   stepName: {
     label: 'Step name',
   },
+  guidedMode: {
+    label: 'Guided mode',
+  },
+  skipGuidance: {
+    modal: {
+      title: 'Skip guided setup?',
+      bodyWithSteps:
+        "You'll set up your workflow yourself. Any steps you've already created will be kept.",
+      bodyWithoutSteps:
+        "You'll set up your workflow yourself. We won't show this guide again.",
+      confirm: 'Skip guidance',
+      cancel: 'Cancel',
+    },
+  },
   welcome: {
     header: "Let's start with Step 1",
     stepOne: 'Step 1 is what everyone who opens your form link fills in first.',

--- a/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
+++ b/apps/frontend/src/i18n/locales/features/admin-form/sidebar/workflow/index.ts
@@ -154,6 +154,18 @@ export interface Workflow {
   stepName: {
     label: string
   }
+  guidedMode: {
+    label: string
+  }
+  skipGuidance: {
+    modal: {
+      title: string
+      bodyWithSteps: string
+      bodyWithoutSteps: string
+      confirm: string
+      cancel: string
+    }
+  }
   welcome: {
     header: string
     stepOne: string


### PR DESCRIPTION
Stacked on #9968. Review that first.

## Problem

- Guidance is on by default, so nobody opts in and there is no way out of it.
- UT Round 3's P2 rejected the approach at the concept rather than getting stuck in it.
- Closes FRM-2502.

## Solution

- `SkipGuidance` puts the exit beside the "Workflow" title in `WorkflowContent`'s header.
- One placement covers every paced screen; the intro and welcome screens exclude themselves.
- Confirming calls `markTaught` and sets `isGuidedSetup` false.
- The body copy varies on the workflow's step count, not on which screen opened it.
- Cancel, the close icon and Escape all route to `onClose`, so only confirm commits.
- Button and confirmation are one component, so there is one modal by construction.

**Alternatives considered**

- A header on each step card — skipped, would offer the exit on re-opened saved steps.
- Telling the confirmation which screen opened it — skipped, step count is the real input.
- Describing the destination as a mode — skipped, there is no manual mode in the product.

**Breaking changes:** none.

## Screenshots

| Before | After |
|---|---|
|Toggle in workflow card|<img width="677" height="558" alt="Screenshot 2026-09-08 at 3 06 54 PM" src="https://github.com/user-attachments/assets/15971485-34ca-4511-b121-e8c3a066bb50" />|
|Skip guidance modal|<img width="715" height="584" alt="Screenshot 2026-09-08 at 3 06 58 PM" src="https://github.com/user-attachments/assets/959a0bbf-eeb3-4820-a978-e73bb32f981d" />|
|Guided mode is skipped now|<img width="659" height="678" alt="Screenshot 2026-09-08 at 3 07 15 PM" src="https://github.com/user-attachments/assets/7bbb334d-5363-48d0-9a16-e0f5f061142b" />|

## Tests

**Automated**

- `SkipGuidance.test.tsx` — the exit shows while paced, and not after manual setup.
- `SkipGuidance.test.tsx` — hidden with the redesign flag off.
- `SkipGuidance.test.tsx` — cancel writes no flag and leaves guidance on.
- `SkipGuidance.test.tsx` — confirm writes the flag and keeps the saved steps.
- `SkipGuidance.test.tsx` — confirm drops the pacing from the open step card.

**Manual**

- [ ] Start guided setup, click Skip guidance, cancel; expect nothing to change.
- [ ] Skip again and confirm; expect all sections and the Save row, steps intact.
- [ ] Reload; expect no guidance, since the flag is now set.
