### PR TITLE
fix(workflow): centre the workflow view against the viewport (7/7)

### DIFF
--- a/apps/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.test.tsx
@@ -60,6 +60,7 @@ vi.mock(
       handleLogicClick: vi.fn(),
       handleEndpageClick: vi.fn(),
       handleWorkflowClick: vi.fn(),
+      reportSidebarWidth: vi.fn(),
     }),
   }),
 )

--- a/apps/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
+++ b/apps/frontend/src/features/admin-form/create/common/CreatePageSidebar/CreatePageSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { BiGitMerge, BiQuestionMark } from 'react-icons/bi'
 import { Divider, Stack } from '@chakra-ui/react'
@@ -60,7 +60,22 @@ export const CreatePageSidebar = (): JSX.Element | null => {
     handleLogicClick,
     handleEndpageClick,
     handleWorkflowClick,
+    reportSidebarWidth,
   } = useCreatePageSidebar()
+
+  const sidebarRef = useRef<HTMLDivElement | null>(null)
+  useEffect(() => {
+    const sidebar = sidebarRef.current
+    if (!sidebar) return
+
+    const report = () =>
+      reportSidebarWidth(sidebar.getBoundingClientRect().width)
+
+    report()
+    const observer = new ResizeObserver(report)
+    observer.observe(sidebar)
+    return () => observer.disconnect()
+  }, [reportSidebarWidth])
 
   const handleDrawerBuilderClick = useCallback(() => {
     // Always show create field drawer when sidebar icon is tapped on mobile.
@@ -120,6 +135,7 @@ export const CreatePageSidebar = (): JSX.Element | null => {
 
   return (
     <Stack
+      ref={sidebarRef}
       bg="white"
       pos="sticky"
       top={0}

--- a/apps/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
+++ b/apps/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/CreatePageSidebarContext.tsx
@@ -46,10 +46,15 @@ export type CreatePageSidebarContextProps = {
   isDrawerOpen: boolean
   fieldListTabIndex: FieldListTabIndex
   setFieldListTabIndex: (tabIndex: FieldListTabIndex) => void
+  sidebarWidth: number
+  reportSidebarWidth: (width: number) => void
 }
 const CreatePageSidebarContext = createContext<
   CreatePageSidebarContextProps | undefined
 >(undefined)
+
+export const useSidebarWidth = (): number =>
+  useContext(CreatePageSidebarContext)?.sidebarWidth ?? 0
 
 export const useCreatePageSidebar = (): CreatePageSidebarContextProps => {
   const context = useContext(CreatePageSidebarContext)
@@ -63,6 +68,13 @@ export const useCreatePageSidebar = (): CreatePageSidebarContextProps => {
 export const useCreatePageSidebarContext =
   (): CreatePageSidebarContextProps => {
     const isMobile = useIsMobile()
+    const [sidebarWidth, setSidebarWidth] = useState(0)
+    const reportSidebarWidth = useCallback(
+      (width: number) =>
+        setSidebarWidth((current) => (current === width ? current : width)),
+      [],
+    )
+
     const [activeTab, setActiveTab] = useState<DrawerTabs | null>(null)
     // Any pending tab due to unsaved changes.
     // Pending tab can be `null` if the next tab state is to be closed.
@@ -161,6 +173,8 @@ export const useCreatePageSidebarContext =
     }, [isMobile, pendingTab, setFieldsToInactive])
 
     return {
+      sidebarWidth,
+      reportSidebarWidth,
       activeTab,
       pendingTab,
       clearPendingTab,

--- a/apps/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/useSidebarWidth.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/common/CreatePageSidebarContext/useSidebarWidth.test.tsx
@@ -1,0 +1,51 @@
+import { act, render, screen } from '@testing-library/react'
+
+import {
+  CreatePageSidebarProvider,
+  useCreatePageSidebar,
+  useSidebarWidth,
+} from './CreatePageSidebarContext'
+
+const Readout = () => <span data-testid="width">{useSidebarWidth()}</span>
+
+const Reporter = ({ width }: { width: number }) => {
+  const { reportSidebarWidth } = useCreatePageSidebar()
+  return (
+    <button type="button" onClick={() => reportSidebarWidth(width)}>
+      report
+    </button>
+  )
+}
+
+const widthReadout = () => screen.getByTestId('width').textContent
+
+describe('useSidebarWidth', () => {
+  it('reads zero with no provider above it', () => {
+    render(<Readout />)
+
+    expect(widthReadout()).toBe('0')
+  })
+
+  it('reads zero under a provider until the sidebar reports', () => {
+    render(
+      <CreatePageSidebarProvider>
+        <Readout />
+      </CreatePageSidebarProvider>,
+    )
+
+    expect(widthReadout()).toBe('0')
+  })
+
+  it('reads what the sidebar reported', () => {
+    render(
+      <CreatePageSidebarProvider>
+        <Readout />
+        <Reporter width={68} />
+      </CreatePageSidebarProvider>,
+    )
+
+    act(() => screen.getByRole('button', { name: 'report' }).click())
+
+    expect(widthReadout()).toBe('68')
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/CreatePageWorkflowTab.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import { Box, Container } from '@chakra-ui/react'
 
+import { useSidebarWidth } from '../common/CreatePageSidebarContext'
+
 import { EmptyWorkflow } from './components/EmptyWorkflow'
 import { WelcomeCard } from './components/GuidedCreation'
 import { WorkflowContent } from './components/WorkflowContent'
@@ -20,6 +22,7 @@ export const CreatePageWorkflowTab = (): JSX.Element => {
     }, []),
   )
   const { isLoading, formWorkflow } = useAdminFormWorkflow()
+  const sidebarWidth = useSidebarWidth()
 
   const isEmptyWorkflow = useMemo(
     () => formWorkflow?.length === 0 && !createOrEditData,
@@ -46,6 +49,7 @@ export const CreatePageWorkflowTab = (): JSX.Element => {
       bg="neutral.100"
       py={{ base: '2rem', md: '1rem' }}
       px={{ base: '1.5rem', md: '3.75rem' }}
+      pr={{ base: '1.5rem', md: `calc(3.75rem + ${sidebarWidth}px)` }}
     >
       <Container p={0} maxW="42.5rem">
         {isOnWelcomeCard ? (


### PR DESCRIPTION
Stacked on #9969. Review that first.

## Problem

- The workflow view reads off-centre, pushed right by the sidebar beside it.
- A container centred in the space left over sits at `(V + S) / 2`, not `V / 2`.

## Solution

- `CreatePageWorkflowTab` pads its far side by the sidebar's width from `md` up.
- `CreatePageSidebar` measures its own border box and reports it up on resize.
- `sidebarWidth` on `CreatePageSidebarContext` carries it, since no constant fits.
- `useSidebarWidth` reads it without throwing, so the tab still renders alone.
- Below `md` nothing changes: the sidebar is a bottom bar, not a column.

**Alternatives considered**

- A hardcoded width — skipped, the `sidebarNavLabels` flag makes one of two states wrong.
- Shifting by the full width — skipped, over-corrects; the offset is half of it.
- `contentRect` in the observer — skipped, excludes the padding and 1px border.

**Breaking changes:** none. Other tabs still centre in the space beside the sidebar.

## Screenshots

It's centred now.

| Before | After |
|---|---|
|<img width="1511" height="761" alt="Screenshot 2026-09-08 at 3 10 15 PM" src="https://github.com/user-attachments/assets/73ff1ae4-bf2a-4f97-b67e-eadb6224f187" />|<img width="1511" height="758" alt="Screenshot 2026-09-08 at 3 13 33 PM" src="https://github.com/user-attachments/assets/bb076870-cbf1-4ca5-8bde-4d8e431b5b2c" />|

## Tests

**Automated**

- `useSidebarWidth.test.tsx` — reads 0 with no provider, which keeps stories working.
- `useSidebarWidth.test.tsx` — reads 0 under a provider until the sidebar reports.
- `useSidebarWidth.test.tsx` — reads the reported width.
- `CreatePageSidebar.test.tsx` — its context mock now supplies the reporter.

**Manual**

- [ ] Open the Workflow tab and check the card is centred in the window.
- [ ] Toggle the `sidebarNavLabels` flag; expect it centred in both states.
- [ ] Narrow to mobile; expect no change, and no horizontal scroll.
