### PR TITLE
fix: use _id which is defined for generating hashedSubmitterId

### DIFF
--- a/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/__tests__/encrypt-submission.controller.spec.ts
@@ -291,7 +291,6 @@ describe('encrypt-submission.controller', () => {
       const mockFormId = new ObjectId()
       const mockSpAuthTypeAndIsSingleSubmissionEnabledForm = {
         _id: mockFormId,
-        id: mockFormId.toHexString(),
         title: 'some form',
         authType: FormAuthType.SP,
         isSingleSubmission: true,
@@ -301,7 +300,7 @@ describe('encrypt-submission.controller', () => {
 
       const mockReq = merge(
         expressHandler.mockRequest({
-          params: { formId: 'some id' },
+          params: { formId: String(mockFormId) },
           body: {
             responses: [],
           },
@@ -329,13 +328,13 @@ describe('encrypt-submission.controller', () => {
       expect(saveIfSubmitterIdIsUniqueSpy.mock.calls[0][1]).toEqual(
         generateHashedSubmitterId(
           MOCK_JWT_PAYLOAD.userName.toUpperCase(),
-          mockSpAuthTypeAndIsSingleSubmissionEnabledForm.id,
+          String(mockFormId),
         ),
       )
       expect(saveIfSubmitterIdIsUniqueSpy.mock.calls[0][2].submitterId).toEqual(
         generateHashedSubmitterId(
           MOCK_JWT_PAYLOAD.userName.toUpperCase(),
-          mockSpAuthTypeAndIsSingleSubmissionEnabledForm.id,
+          String(mockFormId),
         ),
       )
     })
@@ -363,7 +362,6 @@ describe('encrypt-submission.controller', () => {
       const mockFormId = new ObjectId()
       const mockCpAuthTypeAndIsSingleSubmissionEnabledForm = {
         _id: mockFormId,
-        id: mockFormId.toHexString(),
         title: 'some form',
         authType: FormAuthType.CP,
         isSingleSubmission: true,
@@ -373,7 +371,7 @@ describe('encrypt-submission.controller', () => {
 
       const mockReq = merge(
         expressHandler.mockRequest({
-          params: { formId: 'some id' },
+          params: { formId: String(mockFormId) },
           body: {
             responses: [],
           },
@@ -401,13 +399,13 @@ describe('encrypt-submission.controller', () => {
       expect(saveIfSubmitterIdIsUniqueSpy.mock.calls[0][1]).toEqual(
         generateHashedSubmitterId(
           MOCK_JWT_PAYLOAD.userName.toUpperCase(),
-          mockCpAuthTypeAndIsSingleSubmissionEnabledForm.id,
+          String(mockFormId),
         ),
       )
       expect(saveIfSubmitterIdIsUniqueSpy.mock.calls[0][2].submitterId).toEqual(
         generateHashedSubmitterId(
           MOCK_JWT_PAYLOAD.userName.toUpperCase(),
-          mockCpAuthTypeAndIsSingleSubmissionEnabledForm.id,
+          String(mockFormId),
         ),
       )
     })

--- a/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
+++ b/apps/backend/src/app/modules/submission/encrypt-submission/encrypt-submission.controller.ts
@@ -280,7 +280,7 @@ const submitEncryptModeForm = async (
   let hashedSubmitterId
   // Generate submitterId for Singpass auth modes
   if (submitterId && form.authType !== FormAuthType.NIL) {
-    hashedSubmitterId = generateHashedSubmitterId(submitterId, form.id)
+    hashedSubmitterId = generateHashedSubmitterId(submitterId, String(form._id))
   }
 
   // Encrypt Verified SPCP Fields


### PR DESCRIPTION
## Problem
<!-- What problem are you trying to solve? What issue does this close? -->
| | Before | After |
|---|---|---|
| Respondents on storage mode bypass the login card with error message card. They should see the login card with error message instead of being able to fill the form when they have already previously submitted. | <img width="2950" height="1508" alt="image" src="https://github.com/user-attachments/assets/261860a6-28a6-4922-abef-aca7bb5e9430" /> | <img width="1940" height="1060" alt="image" src="https://github.com/user-attachments/assets/0018ef34-eaa5-4686-9e82-c6e5ebd45078" /> |

Note: this issue only affects storage mode forms. 

Verified on stg-alt: 


https://github.com/user-attachments/assets/3893a866-ee2a-4b55-a578-b6561a53e08f


## Solution
<!-- How did you solve the problem? -->
The formId, used as a salt, is reading an undefined value for storage mode, causing the generated hash to not match the records. Thus, the login card check evaluates as no previous submission hit and the respondent can bypass the check. 

Switching to use a defined formId value fixes this issue. 

**Breaking Changes** 
<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->
No - this PR is backwards compatible  