### PR TITLE
fix(myinfo): redirect stale form tabs after MyInfo auth and clear stale FAPI cookies

### DIFF
--- a/apps/backend/__tests__/integration/helpers/express-setup.ts
+++ b/apps/backend/__tests__/integration/helpers/express-setup.ts
@@ -21,7 +21,7 @@ const testSessionMiddlewares = () => {
   })
 
   return [
-    cookieParser(), // CookieParser should be above session
+    cookieParser('test-session-secret'), // CookieParser should be above session
     expressSession,
   ]
 }

--- a/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -1927,6 +1927,14 @@ describe('public-form.controller', () => {
 
       expect(mockRes.status).toHaveBeenCalledWith(200)
       expect(mockRes.clearCookie).toHaveBeenCalledWith(MYINFO_LOGIN_COOKIE_NAME)
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        MYINFO_AUTH_CODE_COOKIE_NAME,
+        MYINFO_AUTH_CODE_COOKIE_OPTIONS,
+      )
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        MYINFO_FAPI_SESSION_COOKIE_NAME,
+        expect.anything(),
+      )
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Successfully logged out.',
       })

--- a/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -794,6 +794,98 @@ describe('public-form.controller', () => {
         })
       })
 
+      it('should fall back to legacy MyInfo when FAPI verification fails', async () => {
+        const mockMyInfoData = new MyInfoData({
+          uinFin: 'mock-uin-fin',
+        } as IPersonResponse)
+        const mockReqWithBothCookies = expressHandler.mockRequest({
+          params: { formId: MOCK_FORM_ID },
+          others: {
+            cookies: {
+              [MYINFO_AUTH_CODE_COOKIE_NAME]: {
+                authCode: MOCK_AUTH_CODE,
+                state: MyInfoAuthCodeCookieState.Success,
+              },
+            },
+            signedCookies: {
+              [MYINFO_FAPI_SESSION_COOKIE_NAME]: MOCK_FAPI_SESSION_ID,
+            },
+          },
+        })
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+          cookie: jest.fn().mockReturnThis(),
+        })
+        MockMyInfoFapiService.loadPersonForSession.mockReturnValueOnce(
+          errAsync(new MyInfoFapiMissingSessionError()),
+        )
+        MockMyInfoService.retrieveAccessToken.mockReturnValueOnce(
+          okAsync(MOCK_ACCESS_TOKEN),
+        )
+        MockMyInfoService.getMyInfoDataForForm.mockReturnValueOnce(
+          okAsync(mockMyInfoData),
+        )
+        MockMyInfoService.prefillAndSaveMyInfoFields.mockReturnValueOnce(
+          okAsync([]),
+        )
+
+        await PublicFormController.handleGetPublicForm(
+          mockReqWithBothCookies,
+          mockRes,
+          jest.fn(),
+        )
+
+        expect(MockMyInfoFapiService.loadPersonForSession).toHaveBeenCalled()
+        expect(MockMyInfoService.retrieveAccessToken).toHaveBeenCalledWith(
+          MOCK_AUTH_CODE,
+        )
+        expect(mockRes.json).toHaveBeenCalledWith({
+          form: { ...MOCK_MYINFO_FORM.getPublicView(), form_fields: [] },
+          spcpSession: { userName: mockMyInfoData.getUinFin() },
+          isIntranetUser: false,
+        })
+      })
+
+      it('should use the first error when FAPI and legacy MyInfo both fail', async () => {
+        const mockReqWithBothCookies = expressHandler.mockRequest({
+          params: { formId: MOCK_FORM_ID },
+          others: {
+            cookies: {
+              [MYINFO_AUTH_CODE_COOKIE_NAME]: {
+                authCode: MOCK_AUTH_CODE,
+                state: MyInfoAuthCodeCookieState.Success,
+              },
+            },
+            signedCookies: {
+              [MYINFO_FAPI_SESSION_COOKIE_NAME]: MOCK_FAPI_SESSION_ID,
+            },
+          },
+        })
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
+        MockMyInfoFapiService.loadPersonForSession.mockReturnValueOnce(
+          errAsync(new MyInfoFapiIncompleteLoginError()),
+        )
+        MockMyInfoService.retrieveAccessToken.mockReturnValueOnce(
+          errAsync(new MyInfoCircuitBreakerError()),
+        )
+
+        await PublicFormController.handleGetPublicForm(
+          mockReqWithBothCookies,
+          mockRes,
+          jest.fn(),
+        )
+
+        expect(MockMyInfoService.retrieveAccessToken).toHaveBeenCalledWith(
+          MOCK_AUTH_CODE,
+        )
+        expect(mockRes.json).toHaveBeenCalledWith({
+          form: MOCK_MYINFO_FORM.getPublicView(),
+          isIntranetUser: false,
+        })
+      })
+
       it('should leave a session belonging to another form untouched', async () => {
         MockMyInfoFapiService.loadPersonForSession.mockReturnValueOnce(
           errAsync(new MyInfoFapiSessionFormMismatchError()),

--- a/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -43,6 +43,7 @@ import {
 import * as MyInfoFapiService from '../../../myinfo/fapi/myinfo.fapi.service'
 import {
   MYINFO_AUTH_CODE_COOKIE_NAME,
+  MYINFO_AUTH_CODE_COOKIE_OPTIONS,
   MYINFO_LOGIN_COOKIE_NAME,
 } from '../../../myinfo/myinfo.constants'
 import { MyInfoService } from '../../../myinfo/myinfo.service'
@@ -1645,6 +1646,65 @@ describe('public-form.controller', () => {
         expect.objectContaining({
           formEsrvcId: DEFAULT_ESRVC_ID,
         }),
+      )
+      expect(mockRes.status).toHaveBeenCalledWith(200)
+      expect(mockRes.json).toHaveBeenCalledWith({
+        redirectURL: MOCK_REDIRECT_URL,
+      })
+    })
+
+    it('should return 200 with the FAPI redirect url, clear the legacy auth code cookie and set the FAPI session cookie when the form has authType MyInfo and myinfoFapi is on', async () => {
+      // Arrange
+      const MOCK_REQ_WITH_FAPI = expressHandler.mockRequest({
+        params: {
+          formId: new ObjectId().toHexString(),
+        },
+        query: {
+          isPersistentLogin: true,
+        },
+        others: {
+          growthbook: {
+            isOn: jest.fn((flag: string) => flag === featureFlags.myinfoFapi),
+            getAttributes: jest.fn(() => ({})),
+            setAttributes: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      })
+      const MOCK_FORM = {
+        admin: MOCK_ADMIN,
+        authType: FormAuthType.MyInfo,
+        esrvcId: 'MOCKED_FORM_ESRVC_ID',
+        getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+      } as unknown as MyInfoForm<IFormDocument>
+      const MOCK_SESSION_ID = 'mockSessionId'
+
+      const mockRes = expressHandler.mockResponse()
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
+      MockMyInfoFapiService.startLogin.mockReturnValueOnce(
+        okAsync({
+          sessionId: MOCK_SESSION_ID,
+          redirectUrl: MOCK_REDIRECT_URL,
+        }),
+      )
+
+      // Act
+      await PublicFormController._handleFormAuthRedirect(
+        MOCK_REQ_WITH_FAPI,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        MYINFO_AUTH_CODE_COOKIE_NAME,
+        MYINFO_AUTH_CODE_COOKIE_OPTIONS,
+      )
+      expect(mockRes.cookie).toHaveBeenCalledWith(
+        MYINFO_FAPI_SESSION_COOKIE_NAME,
+        MOCK_SESSION_ID,
+        expect.anything(),
       )
       expect(mockRes.status).toHaveBeenCalledWith(200)
       expect(mockRes.json).toHaveBeenCalledWith({

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -214,7 +214,10 @@ export const handleGetPublicForm: ControllerHandler<
       // have the prefilled data
       res.clearCookie(MYINFO_LOGIN_COOKIE_NAME, MYINFO_LOGIN_COOKIE_OPTIONS)
 
-      // If a FAPI session cookie exists, the user started a FAPI login.
+      const authErrors: unknown[] = []
+
+      // Prefer FAPI when its session cookie exists, but fall back to the legacy
+      // auth code when FAPI verification fails.
       const fapiSessionId: unknown =
         req.signedCookies?.[MYINFO_FAPI_SESSION_COOKIE_NAME]
       if (typeof fapiSessionId === 'string' && fapiSessionId) {
@@ -224,75 +227,77 @@ export const handleGetPublicForm: ControllerHandler<
         })
         if (fapiFieldsResult.isErr()) {
           const { error: fapiError } = fapiFieldsResult
+          authErrors.push(fapiError)
+
           // The tab-scoped frontend guard decides whether a session belonging
           // to another form should be discarded.
-          if (fapiError instanceof MyInfoFapiSessionFormMismatchError) {
-            return res.json({ form: publicForm, isIntranetUser })
+          if (!(fapiError instanceof MyInfoFapiSessionFormMismatchError)) {
+            clearMyInfoFapiSessionCookie(res)
           }
-
+        } else {
           clearMyInfoFapiSessionCookie(res)
-          // Respondent never reached, or hasn't yet reached, the Singpass
-          // callback (e.g. navigated back before completing login). Not a
-          // failure, treat as no login attempt.
-          if (fapiError instanceof MyInfoFapiIncompleteLoginError) {
-            return res.json({ form: publicForm, isIntranetUser })
-          }
+          myInfoFields = fapiFieldsResult.value
+        }
+      }
 
-          logger.error({
-            message: 'MyInfo FAPI login error',
-            meta: logMeta,
-            error: fapiError,
-          })
+      if (!myInfoFields) {
+        const authCodeCookie: unknown =
+          req.cookies[MYINFO_AUTH_CODE_COOKIE_NAME]
+        if (authCodeCookie) {
+          // Clear auth code cookie once found, as it can't be reused
+          res.clearCookie(
+            MYINFO_AUTH_CODE_COOKIE_NAME,
+            MYINFO_AUTH_CODE_COOKIE_OPTIONS,
+          )
+          const useEsrvcId = req.growthbook?.isOn(featureFlags.useFormsgEsrvcId)
+          const myInfoFieldsResult = await extractAuthCode(authCodeCookie)
+            .asyncAndThen((authCode) =>
+              MyInfoService.retrieveAccessToken(authCode),
+            )
+            .andThen((accessToken) =>
+              MyInfoService.getMyInfoDataForForm(form, accessToken, useEsrvcId),
+            )
+
+          if (myInfoFieldsResult.isErr()) {
+            authErrors.push(myInfoFieldsResult.error)
+          } else {
+            myInfoFields = myInfoFieldsResult.value
+          }
+        }
+      }
+
+      if (!myInfoFields) {
+        const firstAuthError = authErrors[0]
+        if (!firstAuthError) {
+          // User is accessing the form before logging in.
           return res.json({
             form: publicForm,
-            errorCodes: [ErrorCode.myInfo],
             isIntranetUser,
           })
         }
 
-        clearMyInfoFapiSessionCookie(res)
-        myInfoFields = fapiFieldsResult.value
-        spcpSession = { userName: myInfoFields.getUinFin() }
-        break
-      }
+        // Respondent never reached, or hasn't yet reached, the Singpass
+        // callback (e.g. navigated back before completing login), or the FAPI
+        // session belongs to another tab. Treat either as no login attempt.
+        if (
+          firstAuthError instanceof MyInfoFapiIncompleteLoginError ||
+          firstAuthError instanceof MyInfoFapiSessionFormMismatchError
+        ) {
+          return res.json({ form: publicForm, isIntranetUser })
+        }
 
-      const authCodeCookie: unknown = req.cookies[MYINFO_AUTH_CODE_COOKIE_NAME]
-      // No auth code cookie because user is accessing the form before logging
-      // in
-      if (!authCodeCookie) {
-        return res.json({
-          form: publicForm,
-          isIntranetUser,
-        })
-      }
-      // Clear auth code cookie once found, as it can't be reused
-      res.clearCookie(
-        MYINFO_AUTH_CODE_COOKIE_NAME,
-        MYINFO_AUTH_CODE_COOKIE_OPTIONS,
-      )
-      const useEsrvcId = req.growthbook?.isOn(featureFlags.useFormsgEsrvcId)
-      const myInfoFieldsResult = await extractAuthCode(authCodeCookie)
-        .asyncAndThen((authCode) => MyInfoService.retrieveAccessToken(authCode))
-        .andThen((accessToken) =>
-          MyInfoService.getMyInfoDataForForm(form, accessToken, useEsrvcId),
-        )
-
-      if (myInfoFieldsResult.isErr()) {
-        const error = myInfoFieldsResult.error
         logger.error({
           message: 'MyInfo login error',
           meta: logMeta,
-          error,
+          error: firstAuthError,
         })
-        // No need for cookie if data could not be retrieved
-        // NOTE: If the user does not have any cookie, clearing the cookie still has the same result
         return res.json({
           form: publicForm,
           errorCodes: [ErrorCode.myInfo],
           isIntranetUser,
         })
       }
-      myInfoFields = myInfoFieldsResult.value
+
       spcpSession = { userName: myInfoFields.getUinFin() }
       break
     }
@@ -932,7 +937,7 @@ export const _handlePublicAuthLogout: ControllerHandler<
 
   res.clearCookie(cookieName)
 
-  // Addtional cookies to clear for MyInfo v3/v5
+  // Additional cookies to clear for MyInfo v3/v5
   if (authType === FormAuthType.MyInfo) {
     res.clearCookie(
       MYINFO_AUTH_CODE_COOKIE_NAME,

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -224,8 +224,8 @@ export const handleGetPublicForm: ControllerHandler<
         })
         if (fapiFieldsResult.isErr()) {
           const { error: fapiError } = fapiFieldsResult
-          // Another form can carry this origin-wide cookie. Leave both the
-          // cookie and session untouched for the form that started the login.
+          // The tab-scoped frontend guard decides whether a session belonging
+          // to another form should be discarded.
           if (fapiError instanceof MyInfoFapiSessionFormMismatchError) {
             return res.json({ form: publicForm, isIntranetUser })
           }
@@ -930,10 +930,18 @@ export const _handlePublicAuthLogout: ControllerHandler<
 
   const cookieName = PublicFormService.getCookieNameByAuthType(authType)
 
-  return res
-    .clearCookie(cookieName)
-    .status(200)
-    .json({ message: 'Successfully logged out.' })
+  res.clearCookie(cookieName)
+
+  // Addtional cookies to clear for MyInfo v3/v5
+  if (authType === FormAuthType.MyInfo) {
+    res.clearCookie(
+      MYINFO_AUTH_CODE_COOKIE_NAME,
+      MYINFO_AUTH_CODE_COOKIE_OPTIONS,
+    )
+    clearMyInfoFapiSessionCookie(res)
+  }
+
+  return res.status(200).json({ message: 'Successfully logged out.' })
 }
 
 /**

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -749,6 +749,10 @@ export const _handleFormAuthRedirect: ControllerHandler<
       switch (form.authType) {
         case FormAuthType.MyInfo: {
           if (useMyInfoFapi) {
+            res.clearCookie(
+              MYINFO_AUTH_CODE_COOKIE_NAME,
+              MYINFO_AUTH_CODE_COOKIE_OPTIONS,
+            )
             return MyInfoFapiService.startLogin({
               formId,
               encodedQuery,
@@ -758,6 +762,7 @@ export const _handleFormAuthRedirect: ControllerHandler<
               return redirectUrl
             })
           }
+          clearMyInfoFapiSessionCookie(res)
           return getMyInfoEserviceIdInForm(form, useFormsgEsrvcId).andThen(
             ([form, eserviceId]) =>
               MyInfoService.createRedirectURL({

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
@@ -25,16 +25,31 @@ const MANUAL = { name: /set up manually/i }
 
 const server = setupServer()
 
+let servedUsers = 0
+
 const withGuidedSetupFlag = (value: number | undefined) =>
   server.use(
-    http.get('/api/v3/user', () =>
-      HttpResponse.json({
+    http.get('/api/v3/user', () => {
+      servedUsers += 1
+      return HttpResponse.json({
         ...MOCK_USER,
         flags:
           value === undefined ? {} : { [SeenFlags.GuidedWorkflowSetup]: value },
-      }),
-    ),
+      })
+    }),
   )
+
+/**
+ * The intro screen renders before /api/v3/user resolves, but the fork reads the
+ * admin's seen-flag at click time. Without waiting, a click can beat the query
+ * and an admin who has been taught is treated as one who has not.
+ */
+const settleUser = async () => {
+  await waitFor(() => expect(servedUsers).toBeGreaterThan(0))
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
 
 describe('the workflow tab intro screen', () => {
   beforeAll(() => {
@@ -49,6 +64,13 @@ describe('the workflow tab intro screen', () => {
       .scrollIntoView
   })
 
+  beforeEach(() => {
+    servedUsers = 0
+    // Serve an admin with no flags by default, so every test resolves the user
+    // query rather than relying on it failing.
+    withGuidedSetupFlag(undefined)
+  })
+
   afterEach(() => {
     server.resetHandlers()
     useAdminWorkflowStore.getState().reset()
@@ -60,6 +82,7 @@ describe('the workflow tab intro screen', () => {
         render(<NoWorkflowRedesignOn />)
       })
       await screen.findByText(NEW_HEADER, {}, { timeout: 10000 })
+      await settleUser()
     }
 
     it('says what a workflow does, and offers both ways in', async () => {

--- a/apps/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormPage.tsx
@@ -1,9 +1,6 @@
-import { useEffect } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Navigate, useLocation, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
-import { useToast } from '~hooks/useToast'
 import { fillMinHeightCss } from '~utils/fillHeightCss'
 
 import FloatingToolbar from './components/FloatingToolBar'
@@ -17,41 +14,17 @@ import { PublicFormLogo } from './components/FormLogo'
 import FormStartPage from './components/FormStartPage'
 import LanguageControl from './components/LanguageControl'
 import { PublicFormWrapper } from './components/PublicFormWrapper'
-import {
-  clearExpectedAuthFormId,
-  getExpectedAuthFormId,
-} from './utils/authRedirectStorage'
+import { useAuthFormMismatch } from './hooks/useAuthFormMismatch'
 import { PublicFormProvider } from './PublicFormProvider'
 
 export const PublicFormPage = (): JSX.Element => {
   const { formId, submissionId } = useParams()
-  const { t } = useTranslation()
-  const toast = useToast({ isClosable: true })
-  const location = useLocation()
+  const isResolvingAuthFormMismatch = useAuthFormMismatch(formId)
 
   if (!formId) throw new Error('No formId provided')
 
-  const expectedAuthFormId = getExpectedAuthFormId()
-
-  useEffect(() => {
-    if (!expectedAuthFormId) return
-
-    if (expectedAuthFormId === formId) {
-      clearExpectedAuthFormId()
-      return
-    }
-
-    toast({
-      status: 'danger',
-      description: t('features.publicForm.errors.authFormMismatch'),
-    })
-  }, [expectedAuthFormId, formId, t, toast])
-
-  if (expectedAuthFormId && expectedAuthFormId !== formId) {
-    // Swap the mismatched formId in the current path (preserving any
-    // subroute, e.g. edit/:submissionId) rather than dropping to form root.
-    const redirectPath = location.pathname.replace(formId, expectedAuthFormId)
-    return <Navigate replace to={`${redirectPath}${location.search}`} />
+  if (isResolvingAuthFormMismatch) {
+    return <></>
   }
 
   // Get date time in miliseconds when user first loads the form

--- a/apps/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Navigate, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
+import { useToast } from '~hooks/useToast'
 import { fillMinHeightCss } from '~utils/fillHeightCss'
 
 import FloatingToolbar from './components/FloatingToolBar'
@@ -24,14 +26,26 @@ import { PublicFormProvider } from './PublicFormProvider'
 
 export const PublicFormPage = (): JSX.Element => {
   const { formId, submissionId } = useParams()
+  const { t } = useTranslation()
+  const toast = useToast({ isClosable: true })
 
   if (!formId) throw new Error('No formId provided')
 
   const expectedAuthFormId = getExpectedAuthFormId()
 
   useEffect(() => {
-    if (expectedAuthFormId === formId) clearExpectedAuthFormId()
-  }, [expectedAuthFormId, formId])
+    if (!expectedAuthFormId) return
+
+    if (expectedAuthFormId === formId) {
+      clearExpectedAuthFormId()
+      return
+    }
+
+    toast({
+      status: 'danger',
+      description: t('features.publicForm.errors.authFormMismatch'),
+    })
+  }, [expectedAuthFormId, formId, t, toast])
 
   if (expectedAuthFormId && expectedAuthFormId !== formId) {
     return <Navigate replace to={getPublicFormUrl(expectedAuthFormId)} />

--- a/apps/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormPage.tsx
@@ -1,4 +1,5 @@
-import { useParams } from 'react-router-dom'
+import { useEffect } from 'react'
+import { Navigate, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
 import { fillMinHeightCss } from '~utils/fillHeightCss'
@@ -14,12 +15,27 @@ import { PublicFormLogo } from './components/FormLogo'
 import FormStartPage from './components/FormStartPage'
 import LanguageControl from './components/LanguageControl'
 import { PublicFormWrapper } from './components/PublicFormWrapper'
+import {
+  clearExpectedAuthFormId,
+  getExpectedAuthFormId,
+} from './utils/authRedirectStorage'
+import { getPublicFormUrl } from './utils/urls'
 import { PublicFormProvider } from './PublicFormProvider'
 
 export const PublicFormPage = (): JSX.Element => {
   const { formId, submissionId } = useParams()
 
   if (!formId) throw new Error('No formId provided')
+
+  const expectedAuthFormId = getExpectedAuthFormId()
+
+  useEffect(() => {
+    if (expectedAuthFormId === formId) clearExpectedAuthFormId()
+  }, [expectedAuthFormId, formId])
+
+  if (expectedAuthFormId && expectedAuthFormId !== formId) {
+    return <Navigate replace to={getPublicFormUrl(expectedAuthFormId)} />
+  }
 
   // Get date time in miliseconds when user first loads the form
   const startTime = Date.now()

--- a/apps/frontend/src/features/public-form/PublicFormPage.tsx
+++ b/apps/frontend/src/features/public-form/PublicFormPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Navigate, useParams } from 'react-router-dom'
+import { Navigate, useLocation, useParams } from 'react-router-dom'
 import { Flex } from '@chakra-ui/react'
 
 import { useToast } from '~hooks/useToast'
@@ -21,13 +21,13 @@ import {
   clearExpectedAuthFormId,
   getExpectedAuthFormId,
 } from './utils/authRedirectStorage'
-import { getPublicFormUrl } from './utils/urls'
 import { PublicFormProvider } from './PublicFormProvider'
 
 export const PublicFormPage = (): JSX.Element => {
   const { formId, submissionId } = useParams()
   const { t } = useTranslation()
   const toast = useToast({ isClosable: true })
+  const location = useLocation()
 
   if (!formId) throw new Error('No formId provided')
 
@@ -48,7 +48,10 @@ export const PublicFormPage = (): JSX.Element => {
   }, [expectedAuthFormId, formId, t, toast])
 
   if (expectedAuthFormId && expectedAuthFormId !== formId) {
-    return <Navigate replace to={getPublicFormUrl(expectedAuthFormId)} />
+    // Swap the mismatched formId in the current path (preserving any
+    // subroute, e.g. edit/:submissionId) rather than dropping to form root.
+    const redirectPath = location.pathname.replace(formId, expectedAuthFormId)
+    return <Navigate replace to={`${redirectPath}${location.search}`} />
   }
 
   // Get date time in miliseconds when user first loads the form

--- a/apps/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
+++ b/apps/frontend/src/features/public-form/components/FormAuth/FormAuth.tsx
@@ -60,7 +60,7 @@ export const FormAuth = ({
   }, [form])
 
   const isMobile = useIsMobile()
-  const { handleLoginMutation } = usePublicAuthMutations(formId)
+  const { handleLoginMutation } = usePublicAuthMutations(formId, authType)
   const displayedAuthTypeText = getDispayedAuthTypeText(authType, t)
 
   return (

--- a/apps/frontend/src/features/public-form/hooks/useAuthFormMismatch.ts
+++ b/apps/frontend/src/features/public-form/hooks/useAuthFormMismatch.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useMutation } from 'react-query'
+import { FormAuthType } from 'formsg-shared/types'
+
+import { useToast } from '~hooks/useToast'
+
+import {
+  clearExpectedAuthFormId,
+  getExpectedAuthFormId,
+} from '../utils/authRedirectStorage'
+import { logoutPublicForm } from '../PublicFormService'
+
+export const useAuthFormMismatch = (formId?: string): boolean => {
+  const { t } = useTranslation()
+  const toast = useToast({
+    isClosable: true,
+  })
+  const [expectedAuthFormId] = useState(getExpectedAuthFormId)
+  const hasAuthFormMismatch =
+    !!expectedAuthFormId && expectedAuthFormId !== formId
+  const { isSuccess: hasClearedMyInfoSession, mutate: clearMyInfoSession } =
+    useMutation(() => logoutPublicForm(FormAuthType.MyInfo))
+
+  useEffect(() => {
+    if (!expectedAuthFormId) return
+    if (getExpectedAuthFormId() !== expectedAuthFormId) return
+
+    clearExpectedAuthFormId()
+    if (!hasAuthFormMismatch) return
+
+    clearMyInfoSession()
+    toast({
+      status: 'danger',
+      description: t('features.publicForm.errors.authFormMismatch'),
+    })
+  }, [
+    clearMyInfoSession,
+    expectedAuthFormId,
+    hasAuthFormMismatch,
+    t,
+    toast,
+  ])
+
+  return hasAuthFormMismatch && !hasClearedMyInfoSession
+}

--- a/apps/frontend/src/features/public-form/hooks/useAuthFormMismatch.ts
+++ b/apps/frontend/src/features/public-form/hooks/useAuthFormMismatch.ts
@@ -1,15 +1,16 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useMutation } from 'react-query'
+
 import { FormAuthType } from 'formsg-shared/types'
 
 import { useToast } from '~hooks/useToast'
 
+import { logoutPublicForm } from '../PublicFormService'
 import {
   clearExpectedAuthFormId,
   getExpectedAuthFormId,
 } from '../utils/authRedirectStorage'
-import { logoutPublicForm } from '../PublicFormService'
 
 export const useAuthFormMismatch = (formId?: string): boolean => {
   const { t } = useTranslation()
@@ -19,11 +20,17 @@ export const useAuthFormMismatch = (formId?: string): boolean => {
   const [expectedAuthFormId] = useState(getExpectedAuthFormId)
   const hasAuthFormMismatch =
     !!expectedAuthFormId && expectedAuthFormId !== formId
-  const { isSuccess: hasClearedMyInfoSession, mutate: clearMyInfoSession } =
-    useMutation(() => logoutPublicForm(FormAuthType.MyInfo))
+  const {
+    isSuccess: hasClearedMyInfoSession,
+    isError: hasFailedToClearMyInfoSession,
+    mutate: clearMyInfoSession,
+  } = useMutation(() => logoutPublicForm(FormAuthType.MyInfo))
 
   useEffect(() => {
     if (!expectedAuthFormId) return
+    // StrictMode runs effects twice. The first pass clears the key, so the
+    // second pass reads a different value and bails out instead of firing a
+    // duplicate toast and logout.
     if (getExpectedAuthFormId() !== expectedAuthFormId) return
 
     clearExpectedAuthFormId()
@@ -34,13 +41,14 @@ export const useAuthFormMismatch = (formId?: string): boolean => {
       status: 'danger',
       description: t('features.publicForm.errors.authFormMismatch'),
     })
-  }, [
-    clearMyInfoSession,
-    expectedAuthFormId,
-    hasAuthFormMismatch,
-    t,
-    toast,
-  ])
+  }, [clearMyInfoSession, expectedAuthFormId, hasAuthFormMismatch, t, toast])
 
-  return hasAuthFormMismatch && !hasClearedMyInfoSession
+  // Render the form once the logout call settles, successfully or not. A stale
+  // cookie on a form the respondent is not filling beats a page that never
+  // renders because the request failed.
+  return (
+    hasAuthFormMismatch &&
+    !hasClearedMyInfoSession &&
+    !hasFailedToClearMyInfoSession
+  )
 }

--- a/apps/frontend/src/features/public-form/mutations.ts
+++ b/apps/frontend/src/features/public-form/mutations.ts
@@ -10,6 +10,7 @@ import {
 import { useToast } from '~hooks/useToast'
 
 import { useStorePrefillQuery } from './hooks/useStorePrefillQuery'
+import { setExpectedAuthFormId } from './utils/authRedirectStorage'
 import {
   FieldIdToQuarantineKeyType,
   getAttachmentPresignedPostData,
@@ -41,6 +42,7 @@ export const usePublicAuthMutations = (formId: string) => {
     },
     {
       onSuccess: (redirectUrl) => {
+        setExpectedAuthFormId(formId)
         window.location.assign(redirectUrl)
       },
       onError: (error: Error) => {

--- a/apps/frontend/src/features/public-form/mutations.ts
+++ b/apps/frontend/src/features/public-form/mutations.ts
@@ -30,7 +30,10 @@ import {
   uploadAttachmentToQuarantine,
 } from './PublicFormService'
 
-export const usePublicAuthMutations = (formId: string) => {
+export const usePublicAuthMutations = (
+  formId: string,
+  authType?: Exclude<FormAuthType, FormAuthType.NIL>,
+) => {
   const { storePrefillQuery } = useStorePrefillQuery()
 
   const toast = useToast({ status: 'success', isClosable: true })
@@ -42,7 +45,11 @@ export const usePublicAuthMutations = (formId: string) => {
     },
     {
       onSuccess: (redirectUrl) => {
-        setExpectedAuthFormId(formId)
+        // Only MyInfo carries the origin-wide FAPI session cookie that can be
+        // claimed by another form, so only MyInfo needs the tab-scoped guard.
+        if (authType === FormAuthType.MyInfo) {
+          setExpectedAuthFormId(formId)
+        }
         window.location.assign(redirectUrl)
       },
       onError: (error: Error) => {

--- a/apps/frontend/src/features/public-form/utils/authRedirectStorage.ts
+++ b/apps/frontend/src/features/public-form/utils/authRedirectStorage.ts
@@ -1,0 +1,32 @@
+import { MONGODB_ID_REGEX } from '~constants/routes'
+
+const EXPECTED_AUTH_FORM_ID_KEY = 'formsg.expectedAuthFormId'
+
+export const getExpectedAuthFormId = (): string | null => {
+  try {
+    const formId = window.sessionStorage.getItem(EXPECTED_AUTH_FORM_ID_KEY)
+
+    if (formId && MONGODB_ID_REGEX.test(formId)) return formId
+
+    window.sessionStorage.removeItem(EXPECTED_AUTH_FORM_ID_KEY)
+    return null
+  } catch {
+    return null
+  }
+}
+
+export const setExpectedAuthFormId = (formId: string): void => {
+  try {
+    window.sessionStorage.setItem(EXPECTED_AUTH_FORM_ID_KEY, formId)
+  } catch {
+    // Continue without the tab-scoped guard when storage is unavailable.
+  }
+}
+
+export const clearExpectedAuthFormId = (): void => {
+  try {
+    window.sessionStorage.removeItem(EXPECTED_AUTH_FORM_ID_KEY)
+  } catch {
+    // Nothing to clear when storage is unavailable.
+  }
+}

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -94,7 +94,7 @@ export const enSG: PublicForm = {
     notFound: 'Form not found',
     deleted: 'This form is no longer active',
     authFormMismatch:
-      'This form does not match the form you authenticated for. Redirecting you to the correct form.',
+      'This form does not match the form you authenticated for. Please log in again.',
     private:
       'If you require further assistance, please contact the agency that gave you the form link.',
     takenDown:

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -93,6 +93,8 @@ export const enSG: PublicForm = {
     notAvailable: 'This form is not available.',
     notFound: 'Form not found',
     deleted: 'This form is no longer active',
+    authFormMismatch:
+      'This form does not match the form you authenticated for. Please refresh and try again.',
     private:
       'If you require further assistance, please contact the agency that gave you the form link.',
     takenDown:

--- a/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/en-sg.ts
@@ -94,7 +94,7 @@ export const enSG: PublicForm = {
     notFound: 'Form not found',
     deleted: 'This form is no longer active',
     authFormMismatch:
-      'This form does not match the form you authenticated for. Please refresh and try again.',
+      'This form does not match the form you authenticated for. Redirecting you to the correct form.',
     private:
       'If you require further assistance, please contact the agency that gave you the form link.',
     takenDown:

--- a/apps/frontend/src/i18n/locales/features/public-form/index.ts
+++ b/apps/frontend/src/i18n/locales/features/public-form/index.ts
@@ -67,6 +67,7 @@ export interface PublicForm {
     notAvailable: string
     notFound: string
     deleted: string
+    authFormMismatch: string
     private: string
     takenDown: string
 


### PR DESCRIPTION
## Problem

A respondent can end up on the wrong form after MyInfo login.
- Form A login -> redirect to MyInfo
- Form B login -> redirect to MyInfo
- Form A refresh and continues MyInfo login
- Form A ends up in Form B


## Solution

1.  On the frontend, starting a MyInfo login records the form id we expect to return to in `sessionStorage`
2. `PublicFormPage` checks this on load and redirects to the expected form if the current form doesn't match

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: Normal MyInfo login**

- [ ] Start MyInfo login on a form, complete auth, confirm the form loads normally with no redirect loop.

**TC2: Stale tab after login elsewhere**

- [ ] Start MyInfo login on form A, then in a second tab open form B and let form A's tab reload/regain focus. Confirm form A's tab redirects to form B (the expected form) instead of showing stale state.

**TC3: Fresh login after a previous stale cookie**

- [ ] Start and complete MyInfo login on form A, then start a new MyInfo login on form B. Confirm form B's login proceeds cleanly without any leftover cookie from form A affecting it.
