### PR TITLE
feat(submission): list pre-migration encrypt rows in MRF dashboard metadata (3/4)

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -920,6 +920,115 @@ describe('Submission Model', () => {
       })
     })
 
+    describe('findAllEncryptedOrMultirespondentMetadataByFormId', () => {
+      it('should return agreeing rows and count across both submission types, excluding email submissions', async () => {
+        // Arrange
+        const encryptSubmission = await EncryptedSubmission.create(
+          MOCK_ENCRYPT_SUBMISSION_PARAMS,
+        )
+        const mrfSubmission = await MultirespondentSubmission.create(
+          MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+        )
+        await EmailSubmission.create(MOCK_EMAIL_SUBMISSION_PARAMS)
+
+        // Act
+        const actualResult =
+          await Submission.findAllEncryptedOrMultirespondentMetadataByFormId(
+            MOCK_FORM_ID.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult.count).toEqual(2)
+        expect(actualResult.metadata).toHaveLength(2)
+        expect(actualResult.metadata.map((entry) => entry.number)).toEqual([
+          2, 1,
+        ])
+        const metadataByRefNo = new Map(
+          actualResult.metadata.map((entry) => [String(entry.refNo), entry]),
+        )
+        // The encrypt row carries no mrf metadata, so the dashboard renders
+        // it like a multirespondent submission with no workflow.
+        expect(
+          metadataByRefNo.get(String(encryptSubmission._id))?.mrf,
+        ).toBeUndefined()
+        const mrfEntry = metadataByRefNo.get(String(mrfSubmission._id))
+        expect(mrfEntry?.mrf).toBeDefined()
+        expect(mrfEntry?.mrf?.workflowNumTotalSteps).toEqual(2)
+        expect(mrfEntry?.mrf?.workflowCurrentStepNumber).toEqual(1)
+      })
+
+      it('should return empty page and zero count when the form only has email submissions', async () => {
+        // Arrange
+        await EmailSubmission.create(MOCK_EMAIL_SUBMISSION_PARAMS)
+
+        // Act
+        const actualResult =
+          await Submission.findAllEncryptedOrMultirespondentMetadataByFormId(
+            MOCK_FORM_ID.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult).toEqual({ metadata: [], count: 0 })
+      })
+    })
+
+    describe('findEncryptedOrMultirespondentSingleMetadata', () => {
+      it('should return metadata without mrf for an encrypt submission', async () => {
+        // Arrange
+        const submission = await EncryptedSubmission.create(
+          MOCK_ENCRYPT_SUBMISSION_PARAMS,
+        )
+
+        // Act
+        const actualResult =
+          await Submission.findEncryptedOrMultirespondentSingleMetadata(
+            MOCK_FORM_ID.toHexString(),
+            submission._id.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult).not.toBeNull()
+        expect(String(actualResult?.refNo)).toEqual(String(submission._id))
+        expect(actualResult?.mrf).toBeUndefined()
+      })
+
+      it('should return metadata with mrf for a multirespondent submission', async () => {
+        // Arrange
+        const submission = await MultirespondentSubmission.create(
+          MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+        )
+
+        // Act
+        const actualResult =
+          await Submission.findEncryptedOrMultirespondentSingleMetadata(
+            MOCK_FORM_ID.toHexString(),
+            submission._id.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult).not.toBeNull()
+        expect(actualResult?.mrf).toBeDefined()
+        expect(actualResult?.mrf?.workflowNumTotalSteps).toEqual(2)
+      })
+
+      it('should return null for an email submission', async () => {
+        // Arrange
+        const submission = await EmailSubmission.create(
+          MOCK_EMAIL_SUBMISSION_PARAMS,
+        )
+
+        // Act
+        const actualResult =
+          await Submission.findEncryptedOrMultirespondentSingleMetadata(
+            MOCK_FORM_ID.toHexString(),
+            submission._id.toHexString(),
+          )
+
+        // Assert
+        expect(actualResult).toBeNull()
+      })
+    })
+
     describe('findSingleMetadata', () => {
       it('should not return mrf metadata for storage mode form', async () => {
         // Arrange

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -278,6 +278,155 @@ SubmissionSchema.statics.findEncryptedOrMultirespondentSubmissionById =
       .exec() as Promise<SubmissionData | null>
   }
 
+/**
+ * Builds a metadata entry for a document of either admin-viewable submission
+ * type. Multirespondent docs carry workflow-derived mrf metadata; encrypt
+ * docs carry payment metadata and no mrf metadata, so the dashboard renders
+ * them like a multirespondent submission with no workflow (empty cells).
+ */
+const buildMixedSubmissionMetadata = (
+  result: MixedMetadataAggregateResult,
+  currentNumber: number,
+): SubmissionMetadata => {
+  if (result.submissionType === SubmissionType.Multirespondent) {
+    return buildSubmissionMetadata({
+      result,
+      currentNumber,
+      mrfMeta: {
+        workflowStep: result.workflowStep ?? 0,
+        workflow: result.workflow ?? [],
+        submittedSteps: result.submittedSteps,
+      },
+    })
+  }
+  return buildSubmissionMetadata({
+    result,
+    currentNumber,
+    paymentMeta: result.payments?.[0],
+  })
+}
+
+const MIXED_METADATA_MATCH_SUBMISSION_TYPES = {
+  $in: [SubmissionType.Encrypt, SubmissionType.Multirespondent],
+}
+
+const MIXED_METADATA_AGGREGATE_PROJECTION = {
+  _id: 1,
+  created: 1,
+  submissionType: 1,
+  workflowStep: 1,
+  workflow: 1,
+  submittedSteps: 1,
+  'payments.payout': 1,
+  'payments.completedPayment': 1,
+  'payments.amount': 1,
+  'payments.email': 1,
+}
+
+SubmissionSchema.statics.findEncryptedOrMultirespondentSingleMetadata =
+  function (
+    this: ISubmissionModel,
+    formId: string,
+    submissionId: string,
+  ): Promise<SubmissionMetadata | null> {
+    const pageResults: Promise<MixedMetadataAggregateResult[]> = this.aggregate(
+      [
+        {
+          $match: {
+            submissionType: MIXED_METADATA_MATCH_SUBMISSION_TYPES,
+            form: new mongoose.Types.ObjectId(formId),
+            _id: new mongoose.Types.ObjectId(submissionId),
+          },
+        },
+        { $limit: 1 },
+        {
+          $lookup: {
+            from: 'payments',
+            localField: 'paymentId',
+            foreignField: '_id',
+            as: 'payments',
+          },
+        },
+        { $project: MIXED_METADATA_AGGREGATE_PROJECTION },
+      ],
+    ).exec()
+
+    return Promise.resolve(pageResults).then((results) => {
+      if (!results || results.length <= 0) {
+        return null
+      }
+      return buildMixedSubmissionMetadata(results[0], 1)
+    })
+  }
+
+SubmissionSchema.statics.findAllEncryptedOrMultirespondentMetadataByFormId =
+  function (
+    this: ISubmissionModel,
+    formId: string,
+    {
+      page = 1,
+      pageSize = 10,
+    }: {
+      page?: number
+      pageSize?: number
+    } = {},
+  ): Promise<{
+    metadata: SubmissionMetadata[]
+    count: number
+  }> {
+    const numToSkip = (page - 1) * pageSize
+    // Multirespondent forms mode-migrated from storage mode retain their
+    // pre-migration encrypt submissions; the page and the count must both
+    // span the same two submission types so rows and totals agree. Email
+    // submissions stay excluded from both.
+    const pageResults: Promise<MixedMetadataAggregateResult[]> = this.aggregate(
+      [
+        {
+          $match: {
+            submissionType: MIXED_METADATA_MATCH_SUBMISSION_TYPES,
+            form: new mongoose.Types.ObjectId(formId),
+          },
+        },
+        { $sort: { created: -1 } },
+        { $skip: numToSkip },
+        { $limit: pageSize },
+        {
+          $lookup: {
+            from: 'payments',
+            localField: 'paymentId',
+            foreignField: '_id',
+            as: 'payments',
+          },
+        },
+        { $project: MIXED_METADATA_AGGREGATE_PROJECTION },
+      ],
+    ).exec()
+
+    const count =
+      this.countDocuments({
+        form: new mongoose.Types.ObjectId(formId),
+        submissionType: MIXED_METADATA_MATCH_SUBMISSION_TYPES,
+      }).exec() ?? 0
+
+    return Promise.all([pageResults, count]).then(([results, count]) => {
+      let currentNumber = count - numToSkip
+
+      const metadata = results.map((result) => {
+        const metadataEntry = buildMixedSubmissionMetadata(
+          result,
+          currentNumber,
+        )
+        currentNumber--
+        return metadataEntry
+      })
+
+      return {
+        metadata,
+        count,
+      }
+    })
+  }
+
 SubmissionSchema.statics.getEncryptedOrMultirespondentSubmissionCursorByFormId =
   function (
     this: ISubmissionModel,
@@ -727,6 +876,15 @@ type MultiRespondentAggregates = Pick<
 >
 type MultiRespondentAggregateResult = MetadataAggregateResult &
   MultiRespondentAggregates
+
+/**
+ * Aggregate row spanning both admin-viewable submission types: the
+ * multirespondent fields are absent on encrypt documents.
+ */
+type MixedMetadataAggregateResult = MetadataAggregateResult &
+  Partial<MultiRespondentAggregates> & {
+    submissionType: SubmissionType
+  }
 
 /**
  * Returns an object which represents the encrypted submission

--- a/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/admin-form/__tests__/admin-form.controller.spec.ts
@@ -1864,7 +1864,12 @@ describe('admin-form.controller', () => {
         MockSubmissionService.getFormSubmissionsCount,
       ).toHaveBeenNthCalledWith(3, {
         formId: String(MOCK_FORM._id),
-        submissionType: SubmissionType.Multirespondent,
+        // Multirespondent forms mode-migrated from storage mode retain their
+        // pre-migration encrypt submissions, so both types are counted.
+        submissionType: [
+          SubmissionType.Encrypt,
+          SubmissionType.Multirespondent,
+        ],
         dateRange: {},
       })
     })

--- a/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
+++ b/apps/backend/src/app/modules/form/admin-form/admin-form.controller.ts
@@ -45,6 +45,7 @@ import {
   SmsCountsDto,
   StartPageUpdateDto,
   SubmissionCountQueryDto,
+  SubmissionType,
   WebhookSettingsUpdateDto,
 } from 'formsg-shared/types'
 import {
@@ -625,12 +626,20 @@ export const countFormSubmissions: ControllerHandler<
 
   // Step 3: Has permissions, continue to retrieve submission counts.
   return formResult
-    .map(({ responseMode }) => getSubmissionType(responseMode))
+    .map(({ responseMode }) =>
+      // RATIONALE: For storage mode forms converted from email mode, only
+      // count encrypt mode submissions. Multirespondent forms mode-migrated
+      // from storage mode retain their pre-migration encrypt submissions, so
+      // both admin-viewable types are counted to match the metadata list.
+      responseMode === FormResponseMode.Multirespondent
+        ? [SubmissionType.Encrypt, SubmissionType.Multirespondent]
+        : getSubmissionType(responseMode),
+    )
     .asyncAndThen((submissionType) =>
       SubmissionService.getFormSubmissionsCount({
         formId,
         dateRange,
-        submissionType, // RATIONALE: For storage mode forms converted from email mode, only count encrypt mode submissions
+        submissionType,
       }),
     )
     .map((count) => res.json(count))

--- a/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -288,6 +288,64 @@ describe('submission.service', () => {
       expect(actualResult._unsafeUnwrap()).toEqual(expectedSubmissionCount)
     })
 
+    it('should count across submission types when an array of types is provided', async () => {
+      // Arrange
+      // A mode-migrated multirespondent form holds encrypt submissions
+      // alongside multirespondent ones; the count must span both while
+      // still excluding email submissions.
+      const encryptSubmissionCount = 4
+      const multirespondentSubmissionCount = 3
+      const subEncryptPromise = times(encryptSubmissionCount, () =>
+        Submission.create({
+          submissionType: SubmissionType.Encrypt,
+          form: MOCK_FORM_ID,
+          version: 1,
+          encryptedContent: 'some random encrypted content',
+        }),
+      )
+      const subEmailPromise = Submission.create({
+        submissionType: SubmissionType.Email,
+        form: MOCK_FORM_ID,
+        responseHash: 'hash',
+        responseSalt: 'salt',
+        recipientEmails: [],
+      })
+      const subMultirespondentPromise = times(
+        multirespondentSubmissionCount,
+        () =>
+          Submission.create({
+            submissionType: SubmissionType.Multirespondent,
+            form: MOCK_FORM_ID,
+            workflowStep: 0,
+            version: 3,
+            encryptedContent: 'some random encrypted content',
+            encryptedSubmissionSecretKey:
+              'some random encrypted submission secret key',
+            submissionPublicKey: 'some random submission public key',
+          }),
+      )
+      await Promise.all([
+        ...subEncryptPromise,
+        subEmailPromise,
+        ...subMultirespondentPromise,
+      ])
+
+      // Act
+      const actualResult = await SubmissionService.getFormSubmissionsCount({
+        formId: MOCK_FORM_ID.toHexString(),
+        submissionType: [
+          SubmissionType.Encrypt,
+          SubmissionType.Multirespondent,
+        ],
+      })
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(
+        encryptSubmissionCount + multirespondentSubmissionCount,
+      )
+    })
+
     it('should return correct form counts in range when date range is provided', async () => {
       // Arrange
       const expectedSubmissionCount = 4

--- a/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
+++ b/apps/backend/src/app/modules/submission/__tests__/submission.service.spec.ts
@@ -1085,6 +1085,37 @@ describe('submission.service', () => {
       expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, mockSubmissionId)
     })
 
+    it('should look up multirespondent form metadata across both submission types via the base model', async () => {
+      // Arrange
+      const mockSubmissionId = new ObjectId().toHexString()
+      const expectedMetadata: SubmissionMetadata = {
+        number: 1,
+        refNo: mockSubmissionId as SubmissionId,
+        submissionTime: 'some submission time',
+        payments: null,
+      }
+      const mixedMetaSpy = jest
+        .spyOn(Submission, 'findEncryptedOrMultirespondentSingleMetadata')
+        .mockResolvedValueOnce(expectedMetadata)
+      const mrfMetaSpy = jest.spyOn(
+        MultirespondentSubmission,
+        'findSingleMetadata',
+      )
+
+      // Act
+      const actualResult = await SubmissionService.getSubmissionMetadata(
+        FormResponseMode.Multirespondent,
+        MOCK_FORM_ID,
+        mockSubmissionId,
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedMetadata)
+      expect(mixedMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, mockSubmissionId)
+      expect(mrfMetaSpy).not.toHaveBeenCalled()
+    })
+
     it('should return null when given submissionId is not valid', async () => {
       // Arrange
       const invalidSubmissionId = 'not an id at all'
@@ -1176,6 +1207,41 @@ describe('submission.service', () => {
       expect(getMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, {
         page: undefined,
       })
+    })
+
+    it('should list multirespondent form metadata across both submission types via the base model', async () => {
+      // Arrange
+      const expectedResult = {
+        metadata: [
+          {
+            number: 2,
+            refNo: new ObjectId().toHexString(),
+            submissionTime: 'some submission time',
+          },
+        ] as SubmissionMetadata[],
+        count: 2,
+      }
+      const mixedMetaSpy = jest
+        .spyOn(Submission, 'findAllEncryptedOrMultirespondentMetadataByFormId')
+        .mockResolvedValueOnce(expectedResult)
+      const mrfMetaSpy = jest.spyOn(
+        MultirespondentSubmission,
+        'findAllMetadataByFormId',
+      )
+
+      // Act
+      const actualResult = await SubmissionService.getSubmissionMetadataList(
+        FormResponseMode.Multirespondent,
+        MOCK_FORM_ID,
+      )
+
+      // Assert
+      expect(actualResult.isOk()).toEqual(true)
+      expect(actualResult._unsafeUnwrap()).toEqual(expectedResult)
+      expect(mixedMetaSpy).toHaveBeenCalledWith(MOCK_FORM_ID, {
+        page: undefined,
+      })
+      expect(mrfMetaSpy).not.toHaveBeenCalled()
     })
 
     it('should return metadata list successfully with page param', async () => {

--- a/apps/backend/src/app/modules/submission/submission.service.ts
+++ b/apps/backend/src/app/modules/submission/submission.service.ts
@@ -133,7 +133,7 @@ export const getFormSubmissionsCount = ({
     startDate?: string
     endDate?: string
   }
-  submissionType?: SubmissionType
+  submissionType?: SubmissionType | SubmissionType[]
 }): ResultAsync<number, MalformedParametersError | DatabaseError> => {
   if (
     isMalformedDate(dateRange.startDate) ||
@@ -145,7 +145,13 @@ export const getFormSubmissionsCount = ({
   const countQuery = {
     form: formId,
     ...createQueryWithDateParam(dateRange?.startDate, dateRange?.endDate),
-    ...(submissionType ? { submissionType } : {}),
+    ...(submissionType
+      ? {
+          submissionType: Array.isArray(submissionType)
+            ? { $in: submissionType }
+            : submissionType,
+        }
+      : {}),
   }
 
   return ResultAsync.fromPromise(

--- a/apps/backend/src/app/modules/submission/submission.service.ts
+++ b/apps/backend/src/app/modules/submission/submission.service.ts
@@ -558,7 +558,15 @@ export const getSubmissionMetadata = (
   return getEncryptedSubmissionModelByResponseMode(responseMode).asyncAndThen(
     (modelToUse) =>
       ResultAsync.fromPromise(
-        modelToUse.findSingleMetadata(formId, submissionId),
+        // Multirespondent forms mode-migrated from storage mode retain their
+        // pre-migration encrypt submissions, so metadata lookups must span
+        // both submission types via the base model.
+        responseMode === FormResponseMode.Multirespondent
+          ? SubmissionModel.findEncryptedOrMultirespondentSingleMetadata(
+              formId,
+              submissionId,
+            )
+          : modelToUse.findSingleMetadata(formId, submissionId),
         (error) => {
           logger.error({
             message: 'Failure retrieving metadata from database',
@@ -584,7 +592,14 @@ export const getSubmissionMetadataList = (
   getEncryptedSubmissionModelByResponseMode(responseMode).asyncAndThen(
     (modelToUse) =>
       ResultAsync.fromPromise(
-        modelToUse.findAllMetadataByFormId(formId, { page }),
+        // See getSubmissionMetadata: mode-migrated multirespondent forms mix
+        // submission types, and the page and count must agree across both.
+        responseMode === FormResponseMode.Multirespondent
+          ? SubmissionModel.findAllEncryptedOrMultirespondentMetadataByFormId(
+              formId,
+              { page },
+            )
+          : modelToUse.findAllMetadataByFormId(formId, { page }),
         (error) => {
           logger.error({
             message: 'Failure retrieving metadata page from database',

--- a/apps/backend/src/types/submission.ts
+++ b/apps/backend/src/types/submission.ts
@@ -170,6 +170,34 @@ export interface ISubmissionModel extends Model<ISubmissionSchema> {
     isSortByLatest?: boolean,
     limit?: number,
   ): QueryCursor<SubmissionCursorData, QueryOptions<ISubmissionSchema>>
+
+  /**
+   * Returns metadata for a single admin-viewable submission of a form,
+   * across both Encrypt and Multirespondent submission types. Encrypt
+   * documents produce entries without mrf metadata, so they render like a
+   * multirespondent submission with no workflow.
+   * @param formId the id of the form the submission belongs to
+   * @param submissionId the id of the submission
+   */
+  findEncryptedOrMultirespondentSingleMetadata(
+    formId: string,
+    submissionId: string,
+  ): Promise<SubmissionMetadata | null>
+
+  /**
+   * Returns a page of metadata and the total count of a form's
+   * admin-viewable submissions, spanning both Encrypt and Multirespondent
+   * submission types so page rows and totals agree on mode-migrated forms.
+   * Email submissions are deliberately excluded from both.
+   * @param formId the id of the form to list metadata for
+   */
+  findAllEncryptedOrMultirespondentMetadataByFormId(
+    formId: string,
+    params?: { page?: number; pageSize?: number },
+  ): Promise<{
+    metadata: SubmissionMetadata[]
+    count: number
+  }>
 }
 
 export interface IEmailSubmissionSchema


### PR DESCRIPTION
## Problem

On a mode-migrated multirespondent form (see #9929 for the migration context), the MRF metadata aggregation had no `submissionType` filter while its sibling count did, so page rows and the total disagreed — and an encrypt document reaching the MRF metadata builder crashed when it touched the missing workflow. Closes #9921.

## Solution

For multirespondent forms, metadata reads (single and list) now go through base-`Submission`-model statics with an explicit `submissionType: { $in: [Encrypt, Multirespondent] }` filter, and the list's page query and count share that filter — so rows and totals agree in one sorted, stably paginated sequence spanning both types. The metadata builder branches per document on `submissionType`: an encrypt document produces a row with no mrf metadata, which the dashboard already renders exactly like a workflow-less MRF submission (empty status cell, no reminder button) — no frontend change needed. The `/count` endpoint for MRF forms now counts both admin-viewable types, by widening `getFormSubmissionsCount` to accept an array of types. Email submissions stay excluded from every query.

PR 3 of a 4-PR stack — stacked on #9930, tracking #9919–#9922.

**Alternatives considered**

- For the count endpoint, we considered adding another base-model static mirroring the new metadata pair, but the existing `getFormSubmissionsCount` service function already runs a plain `countDocuments` on the base model with an optional type filter — only the filter shape was missing, so we widened its parameter to `SubmissionType | SubmissionType[]` (mapped to `$in`) instead of duplicating the query for one extra operator.
- The dashboard needed no frontend code — its MRF status/pending-at accessors already return empty cells when a row has no `mrf` metadata, so this PR ships the backend row shape and relies on that existing behavior.

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: Responses dashboard on a mode-migrated MRF form (staging, post-dry-run)**

- [ ] Open the Responses tab; verify one row per submission of both types, sorted by submission time, paginating cleanly across the type boundary
- [ ] Verify encrypt rows show an empty workflow-status cell and no reminder button, like a workflow-less MRF row
- [ ] Verify the response count equals the total number of rows; email-mode documents appear in neither

🤖 Generated with [Claude Code](https://claude.com/claude-code)
