### PR TITLE
feat(submission): flow payment data for pre-migration rows in MRF exports (4/4)

### DIFF
--- a/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
+++ b/apps/backend/src/app/models/__tests__/submission.server.model.spec.ts
@@ -27,6 +27,7 @@ import {
   ISubmissionSchema,
   MultirespondentSubmissionCursorData,
   MultirespondentSubmissionData,
+  StorageModeSubmissionCursorData,
 } from '../../../types'
 import getPaymentModel from '../payment.server.model'
 
@@ -917,6 +918,48 @@ describe('Submission Model', () => {
             nextStepRecipientEmails: ['next@example.com'],
           },
         ])
+      })
+
+      it('should project the payment reference for encrypt submissions and never for multirespondent submissions', async () => {
+        // Arrange
+        // Payment-enabled storage-mode forms are migration-eligible, so a
+        // mode-migrated form can hold encrypt submissions carrying payments.
+        // Payments and workflows never combine on a form, so multirespondent
+        // submissions can never carry one.
+        const mockPaymentId = new ObjectId()
+        const paidEncryptSubmission = await EncryptedSubmission.create({
+          ...MOCK_ENCRYPT_SUBMISSION_PARAMS,
+          paymentId: mockPaymentId,
+        })
+        const unpaidEncryptSubmission = await EncryptedSubmission.create(
+          MOCK_ENCRYPT_SUBMISSION_PARAMS,
+        )
+        const mrfSubmission = await MultirespondentSubmission.create(
+          MOCK_MULTIRESPONDENT_SUBMISSION_PARAMS,
+        )
+
+        // Act
+        const cursor =
+          Submission.getEncryptedOrMultirespondentSubmissionCursorByFormId(
+            MOCK_FORM_ID.toHexString(),
+            {},
+          )
+        const docs = []
+        for await (const doc of cursor) docs.push(doc)
+
+        // Assert
+        expect(docs).toHaveLength(3)
+        const docsById = new Map(docs.map((doc) => [String(doc._id), doc]))
+        const paidDoc = docsById.get(
+          String(paidEncryptSubmission._id),
+        ) as StorageModeSubmissionCursorData
+        expect(String(paidDoc.paymentId)).toEqual(String(mockPaymentId))
+        expect(
+          docsById.get(String(unpaidEncryptSubmission._id)),
+        ).not.toHaveProperty('paymentId')
+        expect(docsById.get(String(mrfSubmission._id))).not.toHaveProperty(
+          'paymentId',
+        )
       })
     })
 

--- a/apps/backend/src/app/models/submission.server.model.ts
+++ b/apps/backend/src/app/models/submission.server.model.ts
@@ -454,6 +454,10 @@ SubmissionSchema.statics.getEncryptedOrMultirespondentSubmissionCursorByFormId =
       encryptedContent: 1,
       verifiedContent: 1,
       attachmentMetadata: 1,
+      // Pre-migration encrypt submissions on a payment form carry a payment
+      // reference; multirespondent submissions never do (payments and
+      // workflows never combine on a form).
+      paymentId: 1,
       created: 1,
       version: 1,
       form_fields: 1,

--- a/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.test.tsx
+++ b/apps/frontend/src/features/admin-form/responses/IndividualResponsePage/IndividualResponsePage.test.tsx
@@ -10,6 +10,10 @@ import {
 
 import { isMaskedInDatadogReplay, render } from '~/test-utils'
 
+import {
+  MRF_PENDING_RESPONSE_AT_LABEL,
+  MRF_WORKFLOW_STATUS_LABEL,
+} from '../constants'
 import { AugmentedDecryptedResponse } from '../ResponsesPage/storage/utils/augmentDecryptedResponses'
 
 import { IndividualResponsePage } from './IndividualResponsePage'
@@ -26,9 +30,11 @@ vi.mock('react-router-dom', () => ({
   }),
 }))
 
+let mockResponseMode: FormResponseMode = FormResponseMode.Encrypt
+
 vi.mock('~features/admin-form/common/queries', () => ({
   useAdminForm: () => ({
-    data: { _id: 'mock-form-id', responseMode: FormResponseMode.Encrypt },
+    data: { _id: 'mock-form-id', responseMode: mockResponseMode },
   }),
 }))
 
@@ -99,6 +105,30 @@ vi.mock('./queries', () => ({
 }))
 
 describe('IndividualResponsePage', () => {
+  afterEach(() => {
+    mockResponseMode = FormResponseMode.Encrypt
+  })
+
+  it('shows the payment section for a pre-migration encrypt submission on a multirespondent form', () => {
+    // A mode-migrated multirespondent form holds pre-migration encrypt
+    // submissions; one with a completed payment decrypts to data with a
+    // payment and no mrf metadata or submission secret key.
+    mockResponseMode = FormResponseMode.Multirespondent
+
+    render(<IndividualResponsePage />)
+
+    // Payment details render presence-based, independent of response mode.
+    expect(screen.getByText(MOCK_PAYER_EMAIL)).toBeInTheDocument()
+    // The MRF chrome still renders (with an empty workflow) alongside the
+    // payment section.
+    expect(
+      screen.getByText(`${MRF_WORKFLOW_STATUS_LABEL}:`),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(`${MRF_PENDING_RESPONSE_AT_LABEL}:`),
+    ).toBeInTheDocument()
+  })
+
   it('masks decrypted answers, attachment names and payment details in session replays', () => {
     render(<IndividualResponsePage />)
 

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.test.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/CsvRecord.class.test.ts
@@ -1,4 +1,8 @@
-import { WorkflowStatus } from 'formsg-shared/types'
+import {
+  PaymentStatus,
+  SubmissionPaymentDto,
+  WorkflowStatus,
+} from 'formsg-shared/types'
 
 import {
   MRF_PENDING_RESPONSE_AT_LABEL,
@@ -43,6 +47,67 @@ describe('CsvRecord', () => {
         ])
         expect(recordResult).not.toContainEqual(
           expect.objectContaining({ question: MRF_REMINDERS_LABEL }),
+        )
+      })
+    })
+
+    describe('when paymentData is defined and mrfData is undefined', () => {
+      it('should output payment columns and no mrf columns for a pre-migration encrypt row', () => {
+        // Arrange
+        // A pre-migration encrypt submission with a completed payment on a
+        // mode-migrated multirespondent form: the worker constructs its
+        // CsvRecord with payment data and no mrf data.
+        const mockPayment: SubmissionPaymentDto = {
+          id: 'mockPaymentId',
+          paymentIntentId: 'pi_MOCK_PAYMENT_INTENT_ID',
+          email: 'payer@example.com',
+          amount: 3141,
+          status: PaymentStatus.Succeeded,
+          paymentDate: 'Thu, 6 Apr 2023, 04:39:22 PM',
+          transactionFee: 600,
+          receiptUrl: 'https://some.random.url.example.com',
+        }
+        const record = new CsvRecord(
+          'mockId',
+          '2025-02-17T00:00:00.000Z',
+          CsvRecordStatus.Ok,
+          'mockFormId',
+          'https://mock.host.origin',
+          mockPayment,
+          undefined,
+        )
+
+        // Act
+        record.materializeSubmissionData()
+
+        // Assert
+        const { record: recordResult } = record.submissionData!
+        expect(recordResult[0]).toEqual(
+          expect.objectContaining({ question: 'Download Status' }),
+        )
+        expect(recordResult).toContainEqual(
+          expect.objectContaining({
+            question: 'Payment status',
+            answer: 'Succeeded',
+          }),
+        )
+        expect(recordResult).toContainEqual(
+          expect.objectContaining({
+            question: 'Payer',
+            answer: mockPayment.email,
+          }),
+        )
+        expect(recordResult).toContainEqual(
+          expect.objectContaining({
+            question: 'Payment amount',
+            answer: 'S$31.41',
+          }),
+        )
+        expect(recordResult).not.toContainEqual(
+          expect.objectContaining({ question: MRF_WORKFLOW_STATUS_LABEL }),
+        )
+        expect(recordResult).not.toContainEqual(
+          expect.objectContaining({ question: MRF_PENDING_RESPONSE_AT_LABEL }),
         )
       })
     })

--- a/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
+++ b/apps/frontend/src/features/admin-form/responses/ResponsesPage/storage/utils/EncryptedResponseCsvGenerator/EncryptedResponseCsvGenerator.test.ts
@@ -479,6 +479,82 @@ describe('EncryptedResponseCsvGenerator', () => {
           expectedMrfRow,
         ])
       })
+
+      it('should fill payment columns for a payment-bearing encrypt row and leave them empty for mrf rows', () => {
+        // Arrange
+        // Payment-enabled storage-mode forms are migration-eligible, so a
+        // pre-migration encrypt row can carry the payment pseudo-fields that
+        // CsvRecord.materializeSubmissionData injects (reserved ids). MRF
+        // rows never carry payments (payments and workflows never combine on
+        // a form), so their payment cells must stay empty.
+        const mrfGenerator = new EncryptedResponseCsvGenerator(2, 0, true)
+        const sharedField = generateRecord(1)
+        const paymentStatusColumn: CsvRecordData = {
+          _id: '000000000000000000000004',
+          fieldType: 'textfield',
+          question: 'Payment status',
+          answer: 'Succeeded',
+        }
+        const paymentAmountColumn: CsvRecordData = {
+          _id: '000000000000000000000002',
+          fieldType: 'textfield',
+          question: 'Payment amount',
+          answer: 'S$31.41',
+        }
+        const workflowStatusColumn: CsvRecordData = {
+          _id: '000000000000000000010001',
+          fieldType: 'textfield',
+          question: 'Workflow status',
+          answer: 'Completed',
+        }
+        const encryptRecord = {
+          record: [sharedField, paymentStatusColumn, paymentAmountColumn],
+          created: mockCreatedEarly,
+          submissionId: 'mockEncryptSubmissionId',
+        }
+        const mrfRecord = {
+          record: [workflowStatusColumn, sharedField],
+          created: mockCreatedLater,
+          submissionId: 'mockMrfSubmissionId',
+        }
+        mrfGenerator.addRecord(encryptRecord)
+        mrfGenerator.addRecord(mrfRecord)
+
+        // Act
+        mrfGenerator.process()
+
+        // Assert
+        const expectedHeaderRow = stringify([
+          'Response ID',
+          MRF_RESPONSE_TIMESTAMP_LABEL,
+          sharedField.question,
+          paymentStatusColumn.question,
+          paymentAmountColumn.question,
+          workflowStatusColumn.question,
+        ])
+        const expectedEncryptRow = stringify([
+          encryptRecord.submissionId,
+          getFormattedDate(encryptRecord.created),
+          sharedField.answer,
+          paymentStatusColumn.answer,
+          paymentAmountColumn.answer,
+          '',
+        ])
+        const expectedMrfRow = stringify([
+          mrfRecord.submissionId,
+          getFormattedDate(mrfRecord.created),
+          sharedField.answer,
+          '',
+          '',
+          workflowStatusColumn.answer,
+        ])
+        expect(mrfGenerator.records).toEqual([
+          UTF8_BYTE_ORDER_MARK,
+          expectedHeaderRow,
+          expectedEncryptRow,
+          expectedMrfRow,
+        ])
+      })
     })
 
     describe('submissions with only answer key', () => {


### PR DESCRIPTION
## Problem

Payment-enabled storage-mode forms are migration-eligible, so a mode-migrated multirespondent form can hold pre-migration encrypt submissions carrying payment data. Payment handling was already presence-based per row on every layer (individual-fetch per-type switch, the shared payment-expansion stream transform, per-row CSV payment column injection in the worker) — but the mixed-type cursor introduced in #9930 never projected the payment reference, so payment data was silently dropped from the download stream and CSV. Closes #9922.

## Solution

The mixed-type cursor now projects `paymentId`, so encrypt rows on a migrated payment form flow their payment data through the existing `addPaymentDataStream` expansion into the CSV payment columns, and the individual response page shows its payment section for a pre-migration encrypt submission with a completed payment. MRF rows are unaffected: payments and workflows never combine on a form, so a multirespondent document can never carry a payment reference. That one projection line is the whole production change — the rest of the PR pins the presence-based behavior with tests at each layer: the model cursor (payment reference on encrypt rows, never on MRF rows), the worker's `CsvRecord` (payment pseudo-columns without mrf columns), the CSV generator (empty payment cells for MRF rows), and the individual response view (payment section under the empty-workflow MRF chrome).

PR 4 of a 4-PR stack — stacked on the #9921 branch, tracking #9919–#9922.

**Alternatives considered**

- We considered gating payment rendering by response mode on the frontend (only show payments on storage-mode forms), but payments on a mode-migrated MRF form are legitimate pre-migration data and presence-based rendering is exactly what already ships for storage mode — a gate would have been new code whose only effect is removing capability.

**Breaking Changes**

No - backwards compatible.

## Tests

**TC1: CSV export on a mode-migrated payment form (staging, post-dry-run)**

- [ ] Download responses as CSV; verify the payment-bearing encrypt row exports payment columns with correct values
- [ ] Verify rows without payments — including every MRF row — have empty payment cells

**TC2: Individual response view**

- [ ] Open the payment-bearing encrypt submission; verify the payment section renders below the responses, with the MRF chrome empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)
