### PR TITLE
fix(workflow): remember whether an admin builds in guided mode

### DIFF
--- a/apps/frontend/src/constants/localStorage.ts
+++ b/apps/frontend/src/constants/localStorage.ts
@@ -33,3 +33,9 @@ export const EMERGENCY_CONTACT_KEY_PREFIX = 'has-seen-emergency-contact'
  * Key to store when was the last time user has seen the admin feedback modal
  */
 export const ADMIN_FEEDBACK_HISTORY_PREFIX = 'last-seen-admin-feedback-'
+
+/**
+ * Key to store whether an admin builds MRF workflows in guided mode. Their
+ * choice, so it outlives the workflow store's per-visit state.
+ */
+export const GUIDED_WORKFLOW_MODE_KEY_PREFIX = 'prefers-guided-workflow-'

--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.test.ts
@@ -1,0 +1,32 @@
+import { useAdminWorkflowStore } from './adminWorkflowStore'
+
+describe('reset', () => {
+  afterEach(() => {
+    useAdminWorkflowStore.getState().reset()
+    useAdminWorkflowStore.getState().setGuidedSetup(true)
+  })
+
+  // reset() runs every time the workflow tab unmounts. It used to put guided
+  // mode back on however the admin had left the switch.
+  it('leaves the guided mode choice alone', () => {
+    const { setGuidedSetup, reset } = useAdminWorkflowStore.getState()
+
+    setGuidedSetup(false)
+    reset()
+
+    expect(useAdminWorkflowStore.getState().isGuidedSetup).toBe(false)
+  })
+
+  it('still clears the per-visit step state', () => {
+    const { setToEditing, setCompletedStep, reset } =
+      useAdminWorkflowStore.getState()
+
+    setToEditing(1)
+    setCompletedStep(1)
+    reset()
+
+    const state = useAdminWorkflowStore.getState()
+    expect(state.createOrEditData).toBeNull()
+    expect(state.completedStepNumber).toBeNull()
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.test.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.test.ts
@@ -6,8 +6,6 @@ describe('reset', () => {
     useAdminWorkflowStore.getState().setGuidedSetup(true)
   })
 
-  // reset() runs every time the workflow tab unmounts. It used to put guided
-  // mode back on however the admin had left the switch.
   it('leaves the guided mode choice alone', () => {
     const { setGuidedSetup, reset } = useAdminWorkflowStore.getState()
 

--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
@@ -26,6 +26,8 @@ type AdminWorkflowStore = {
   startBuildingFromWelcome: () => void
 }
 
+export const DEFAULT_IS_GUIDED_SETUP = true
+
 const INITIAL_STATE = {
   createOrEditData: null,
   pendingSwitchTo: null,
@@ -108,7 +110,7 @@ export const useAdminWorkflowStore = create<AdminWorkflowStore>()(
     createOrEditData: null,
     pendingSwitchTo: null,
     completedStepNumber: null,
-    isGuidedSetup: true,
+    isGuidedSetup: DEFAULT_IS_GUIDED_SETUP,
     isOnWelcomeCard: false,
     setToCreating: () =>
       set({

--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
@@ -26,11 +26,12 @@ type AdminWorkflowStore = {
   startBuildingFromWelcome: () => void
 }
 
+// isGuidedSetup is deliberately absent: it is the admin's standing choice,
+// not per-visit state, and reset() runs every time the workflow tab unmounts.
 const INITIAL_STATE = {
   createOrEditData: null,
   pendingSwitchTo: null,
   completedStepNumber: null,
-  isGuidedSetup: true,
   isOnWelcomeCard: false,
 }
 

--- a/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/adminWorkflowStore.ts
@@ -26,8 +26,6 @@ type AdminWorkflowStore = {
   startBuildingFromWelcome: () => void
 }
 
-// isGuidedSetup is deliberately absent: it is the admin's standing choice,
-// not per-visit state, and reset() runs every time the workflow tab unmounts.
 const INITIAL_STATE = {
   createOrEditData: null,
   pendingSwitchTo: null,

--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.tsx
@@ -8,12 +8,12 @@ import Link from '~components/Link'
 import Tooltip from '~components/Tooltip'
 
 import {
-  setGuidedSetupSelector,
   setToCreatingSelector,
   showWelcomeCardSelector,
   useAdminWorkflowStore,
 } from '../adminWorkflowStore'
 import { useAdminFormWorkflow } from '../hooks/useAdminFormWorkflow'
+import { useGuidedSetupPreference } from '../hooks/useGuidedSetupPreference'
 import { useGuidedSetupTaught } from '../hooks/useGuidedSetupTaught'
 import { useIsWorkflowBuilderRedesign } from '../hooks/useIsWorkflowBuilderRedesign'
 
@@ -25,7 +25,7 @@ const INTRO_I18N_PREFIX = 'features.adminForm.sidebar.workflow.intro'
 export const EmptyWorkflow = (): JSX.Element => {
   const { t } = useTranslation()
   const setToCreating = useAdminWorkflowStore(setToCreatingSelector)
-  const setGuidedSetup = useAdminWorkflowStore(setGuidedSetupSelector)
+  const { setGuidedSetup } = useGuidedSetupPreference()
   const showWelcomeCard = useAdminWorkflowStore(showWelcomeCardSelector)
   const isRedesign = useIsWorkflowBuilderRedesign()
 

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.test.tsx
@@ -41,8 +41,6 @@ describe('the Guided mode switch', () => {
       .scrollIntoView
   })
 
-  // reset() deliberately leaves the guided mode choice alone, so each test has
-  // to put it back itself.
   afterEach(() => {
     useAdminWorkflowStore.getState().reset()
     useAdminWorkflowStore.getState().setGuidedSetup(true)

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.test.tsx
@@ -41,7 +41,12 @@ describe('the Guided mode switch', () => {
       .scrollIntoView
   })
 
-  afterEach(() => useAdminWorkflowStore.getState().reset())
+  // reset() deliberately leaves the guided mode choice alone, so each test has
+  // to put it back itself.
+  afterEach(() => {
+    useAdminWorkflowStore.getState().reset()
+    useAdminWorkflowStore.getState().setGuidedSetup(true)
+  })
 
   it('sits in the workflow card, on by default', async () => {
     await openTab(WithWorkflowRedesignOn)

--- a/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/GuidedCreation/GuidedSetupToggle.tsx
@@ -16,12 +16,8 @@ import Button from '~components/Button'
 import { ModalCloseButton } from '~components/Modal'
 import Toggle from '~components/Toggle'
 
-import {
-  isGuidedSetupSelector,
-  setGuidedSetupSelector,
-  useAdminWorkflowStore,
-} from '../../adminWorkflowStore'
 import { useAdminFormWorkflow } from '../../hooks/useAdminFormWorkflow'
+import { useGuidedSetupPreference } from '../../hooks/useGuidedSetupPreference'
 import { useIsWorkflowBuilderRedesign } from '../../hooks/useIsWorkflowBuilderRedesign'
 
 const WORKFLOW_I18N_PREFIX = 'features.adminForm.sidebar.workflow'
@@ -31,8 +27,7 @@ export const GuidedSetupToggle = (): JSX.Element | null => {
   const { t } = useTranslation()
   const { isOpen, onOpen, onClose } = useDisclosure()
   const isRedesign = useIsWorkflowBuilderRedesign()
-  const isGuidedSetup = useAdminWorkflowStore(isGuidedSetupSelector)
-  const setGuidedSetup = useAdminWorkflowStore(setGuidedSetupSelector)
+  const { isGuidedSetup, setGuidedSetup } = useGuidedSetupPreference()
   const { formWorkflow } = useAdminFormWorkflow()
 
   const modalSize = useBreakpointValue({ base: 'mobile', md: 'md' })

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.test.tsx
@@ -10,8 +10,6 @@ import {
 } from '../adminWorkflowStore'
 import * as pageStories from '../CreatePageWorkflowTab.stories'
 
-// The story's msw handlers stop at the form, so useUser resolves to nothing
-// and the per-admin key would never be built.
 const MOCK_USER_ID = 'mock-admin-id'
 vi.mock('~features/user/queries', () => ({
   useUser: () => ({ user: { _id: MOCK_USER_ID, flags: {} }, isLoading: false }),
@@ -22,8 +20,6 @@ const { WithWorkflowRedesignOn } = composeStories(pageStories)
 const SWITCH = { name: /guided mode/i }
 const CONFIRM = { name: /^skip guidance$/i }
 
-// jsdom here ships without localStorage, so useLocalStorage would silently
-// swallow every read and write and these tests would pass on nothing.
 let store: Record<string, string> = {}
 
 const isGuided = () => isGuidedSetupSelector(useAdminWorkflowStore.getState())
@@ -91,7 +87,6 @@ describe('remembering the guided mode choice', () => {
     await turnGuidedOff(ui)
     await waitFor(() => expect(guidedModeKeys()).toHaveLength(1))
 
-    // What a fresh page load looks like: default store, storage intact.
     act(() => {
       useAdminWorkflowStore.getState().reset()
       useAdminWorkflowStore.getState().setGuidedSetup(true)

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.test.tsx
@@ -11,8 +11,12 @@ import {
 import * as pageStories from '../CreatePageWorkflowTab.stories'
 
 const MOCK_USER_ID = 'mock-admin-id'
+const currentUserId = { value: MOCK_USER_ID }
 vi.mock('~features/user/queries', () => ({
-  useUser: () => ({ user: { _id: MOCK_USER_ID, flags: {} }, isLoading: false }),
+  useUser: () => ({
+    user: { _id: currentUserId.value, flags: {} },
+    isLoading: false,
+  }),
 }))
 
 const { WithWorkflowRedesignOn } = composeStories(pageStories)
@@ -67,6 +71,7 @@ describe('remembering the guided mode choice', () => {
 
   beforeEach(() => {
     store = {}
+    currentUserId.value = MOCK_USER_ID
     useAdminWorkflowStore.getState().reset()
     useAdminWorkflowStore.getState().setGuidedSetup(true)
   })
@@ -94,5 +99,16 @@ describe('remembering the guided mode choice', () => {
     await openTab()
 
     await waitFor(() => expect(isGuided()).toBe(false))
+  })
+
+  it('gives the guided default to a second admin in the same tab', async () => {
+    const ui = await openTab()
+    await turnGuidedOff(ui)
+    await waitFor(() => expect(isGuided()).toBe(false))
+
+    currentUserId.value = 'another-admin-id'
+    await openTab()
+
+    await waitFor(() => expect(isGuided()).toBe(true))
   })
 })

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.test.tsx
@@ -1,0 +1,103 @@
+import { composeStories } from '@storybook/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { GUIDED_WORKFLOW_MODE_KEY_PREFIX } from '~constants/localStorage'
+
+import {
+  isGuidedSetupSelector,
+  useAdminWorkflowStore,
+} from '../adminWorkflowStore'
+import * as pageStories from '../CreatePageWorkflowTab.stories'
+
+// The story's msw handlers stop at the form, so useUser resolves to nothing
+// and the per-admin key would never be built.
+const MOCK_USER_ID = 'mock-admin-id'
+vi.mock('~features/user/queries', () => ({
+  useUser: () => ({ user: { _id: MOCK_USER_ID, flags: {} }, isLoading: false }),
+}))
+
+const { WithWorkflowRedesignOn } = composeStories(pageStories)
+
+const SWITCH = { name: /guided mode/i }
+const CONFIRM = { name: /^skip guidance$/i }
+
+// jsdom here ships without localStorage, so useLocalStorage would silently
+// swallow every read and write and these tests would pass on nothing.
+let store: Record<string, string> = {}
+
+const isGuided = () => isGuidedSetupSelector(useAdminWorkflowStore.getState())
+
+const guidedModeKeys = () =>
+  Object.keys(store).filter((key) =>
+    key.startsWith(GUIDED_WORKFLOW_MODE_KEY_PREFIX),
+  )
+
+const openTab = async () => {
+  await act(async () => {
+    render(<WithWorkflowRedesignOn />)
+  })
+  await screen.findByRole('heading', { name: /^workflow$/i }, { timeout: 8000 })
+  return userEvent.setup()
+}
+
+const turnGuidedOff = async (ui: Awaited<ReturnType<typeof openTab>>) => {
+  await ui.click(screen.getByRole('checkbox', SWITCH))
+  await ui.click(await screen.findByRole('button', CONFIRM))
+}
+
+describe('remembering the guided mode choice', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value
+      },
+      removeItem: (key: string) => {
+        delete store[key]
+      },
+      clear: () => {
+        store = {}
+      },
+    })
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+    delete (Element.prototype as Partial<Pick<Element, 'scrollIntoView'>>)
+      .scrollIntoView
+  })
+
+  beforeEach(() => {
+    store = {}
+    useAdminWorkflowStore.getState().reset()
+    useAdminWorkflowStore.getState().setGuidedSetup(true)
+  })
+
+  it('writes the choice to local storage, keyed for this admin', async () => {
+    const ui = await openTab()
+    await turnGuidedOff(ui)
+
+    await waitFor(() =>
+      expect(store[`${GUIDED_WORKFLOW_MODE_KEY_PREFIX}${MOCK_USER_ID}`]).toBe(
+        'false',
+      ),
+    )
+  })
+
+  it('reopens on the stored choice once the store is back to its default', async () => {
+    const ui = await openTab()
+    await turnGuidedOff(ui)
+    await waitFor(() => expect(guidedModeKeys()).toHaveLength(1))
+
+    // What a fresh page load looks like: default store, storage intact.
+    act(() => {
+      useAdminWorkflowStore.getState().reset()
+      useAdminWorkflowStore.getState().setGuidedSetup(true)
+    })
+    await openTab()
+
+    await waitFor(() => expect(isGuided()).toBe(false))
+  })
+})

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect } from 'react'
+
+import { GUIDED_WORKFLOW_MODE_KEY_PREFIX } from '~constants/localStorage'
+import { useLocalStorage } from '~hooks/useLocalStorage'
+
+import { useUser } from '~features/user/queries'
+
+import {
+  isGuidedSetupSelector,
+  setGuidedSetupSelector,
+  useAdminWorkflowStore,
+} from '../adminWorkflowStore'
+
+export interface GuidedSetupPreference {
+  isGuidedSetup: boolean
+  setGuidedSetup: (isGuidedSetup: boolean) => void
+}
+
+/**
+ * The admin's guided-mode choice, remembered per browser and shared across
+ * their forms. The store stays the read surface every consumer already uses;
+ * this keeps it in step with the stored choice and writes both on a change.
+ */
+export const useGuidedSetupPreference = (): GuidedSetupPreference => {
+  const { user } = useUser()
+  const isGuidedSetup = useAdminWorkflowStore(isGuidedSetupSelector)
+  const setGuidedSetupInStore = useAdminWorkflowStore(setGuidedSetupSelector)
+
+  const storageKey = user?._id
+    ? `${GUIDED_WORKFLOW_MODE_KEY_PREFIX}${user._id}`
+    : null
+  const [storedPreference, setStoredPreference] =
+    useLocalStorage<boolean>(storageKey)
+
+  // An admin who has never chosen keeps the guided default.
+  useEffect(() => {
+    if (storedPreference === undefined) return
+    if (storedPreference === isGuidedSetup) return
+    setGuidedSetupInStore(storedPreference)
+  }, [storedPreference, isGuidedSetup, setGuidedSetupInStore])
+
+  const setGuidedSetup = useCallback(
+    (next: boolean) => {
+      setStoredPreference(next)
+      setGuidedSetupInStore(next)
+    },
+    // setStoredPreference is redefined every render by useLocalStorage.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setGuidedSetupInStore, storageKey],
+  )
+
+  return { isGuidedSetup, setGuidedSetup }
+}

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.ts
@@ -6,6 +6,7 @@ import { useLocalStorage } from '~hooks/useLocalStorage'
 import { useUser } from '~features/user/queries'
 
 import {
+  DEFAULT_IS_GUIDED_SETUP,
   isGuidedSetupSelector,
   setGuidedSetupSelector,
   useAdminWorkflowStore,
@@ -24,8 +25,10 @@ export const useGuidedSetupPreference = (): GuidedSetupPreference => {
   const storageKey = user?._id
     ? `${GUIDED_WORKFLOW_MODE_KEY_PREFIX}${user._id}`
     : null
-  const [storedPreference, setStoredPreference] =
-    useLocalStorage<boolean>(storageKey)
+  const [storedPreference, setStoredPreference] = useLocalStorage<boolean>(
+    storageKey,
+    DEFAULT_IS_GUIDED_SETUP,
+  )
 
   useEffect(() => {
     if (storedPreference === undefined) return

--- a/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.ts
+++ b/apps/frontend/src/features/admin-form/create/workflow/hooks/useGuidedSetupPreference.ts
@@ -16,11 +16,6 @@ export interface GuidedSetupPreference {
   setGuidedSetup: (isGuidedSetup: boolean) => void
 }
 
-/**
- * The admin's guided-mode choice, remembered per browser and shared across
- * their forms. The store stays the read surface every consumer already uses;
- * this keeps it in step with the stored choice and writes both on a change.
- */
 export const useGuidedSetupPreference = (): GuidedSetupPreference => {
   const { user } = useUser()
   const isGuidedSetup = useAdminWorkflowStore(isGuidedSetupSelector)
@@ -32,7 +27,6 @@ export const useGuidedSetupPreference = (): GuidedSetupPreference => {
   const [storedPreference, setStoredPreference] =
     useLocalStorage<boolean>(storageKey)
 
-  // An admin who has never chosen keeps the guided default.
   useEffect(() => {
     if (storedPreference === undefined) return
     if (storedPreference === isGuidedSetup) return
@@ -44,7 +38,6 @@ export const useGuidedSetupPreference = (): GuidedSetupPreference => {
       setStoredPreference(next)
       setGuidedSetupInStore(next)
     },
-    // setStoredPreference is redefined every render by useLocalStorage.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [setGuidedSetupInStore, storageKey],
   )


### PR DESCRIPTION
## Problem

- `reset()` runs whenever the workflow tab unmounts, and restored `isGuidedSetup: true` from `INITIAL_STATE`.
- Turning guidance off, leaving the tab, then returning put it back.
- Nothing outside the store held it, so reloads lost it too.

## Solution

- `isGuidedSetup` leaves `INITIAL_STATE`, so `reset()` spares the choice.
- New `useGuidedSetupPreference` hook keeps the choice in `localStorage`, keyed by admin id.
- An unset key reads as the guided default, so logout leaks nothing to the next admin.
- The store stays the read surface, so consumers are unchanged.
- `EmptyWorkflow`'s guided and manual buttons persist too.

**Alternatives considered**

- Dropping it from `reset()` alone — reloads would still restore guidance.
- A per-user server field — `SeenFlags` is a version map, not preferences.
- Keying per form — an admin who opted out should not be re-asked.

**Breaking changes:** none. An admin with nothing stored keeps the guided default.

## Screenshots

- None. The switch is unchanged; only its persistence differs.

## Tests

**Automated**

- `reset()` spares the choice; the key is written, re-read, not inherited.
- `localStorage` is stubbed, being absent from this jsdom.

**Manual**

- [ ] Off, switch to Build, return to Workflow — still off.
- [ ] Off, reload the page — still off.
- [ ] Off, open a different MRF form — still off.
- [ ] Back on — pacing returns, no confirmation modal.
- [ ] A second admin in the same tab gets the guided default.
