### PR TITLE
fix(myinfo): close FAPI review gaps (session race, cookie cleanup, logging)

### DIFF
--- a/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -34,7 +34,10 @@ import {
 
 import * as AuthService from '../../../auth/auth.service'
 import * as BillingService from '../../../billing/billing.service'
-import { MYINFO_FAPI_SESSION_COOKIE_NAME } from '../../../myinfo/fapi/myinfo.fapi.constants'
+import {
+  MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
+  MYINFO_FAPI_SESSION_COOKIE_NAME,
+} from '../../../myinfo/fapi/myinfo.fapi.constants'
 import {
   MyInfoFapiIncompleteLoginError,
   MyInfoFapiMissingSessionError,
@@ -879,6 +882,39 @@ describe('public-form.controller', () => {
 
         expect(MockMyInfoService.retrieveAccessToken).toHaveBeenCalledWith(
           MOCK_AUTH_CODE,
+        )
+        expect(mockRes.json).toHaveBeenCalledWith({
+          form: MOCK_MYINFO_FORM.getPublicView(),
+          isIntranetUser: false,
+        })
+      })
+
+      it('should clear a FAPI session cookie that cannot be read', async () => {
+        const mockReqWithUnsignedCookie = expressHandler.mockRequest({
+          params: { formId: MOCK_FORM_ID },
+          others: {
+            cookies: {
+              [MYINFO_FAPI_SESSION_COOKIE_NAME]: 's:tampered-or-rotated',
+            },
+            signedCookies: {},
+          },
+        })
+        const mockRes = expressHandler.mockResponse({
+          clearCookie: jest.fn().mockReturnThis(),
+        })
+
+        await PublicFormController.handleGetPublicForm(
+          mockReqWithUnsignedCookie,
+          mockRes,
+          jest.fn(),
+        )
+
+        expect(
+          MockMyInfoFapiService.loadPersonForSession,
+        ).not.toHaveBeenCalled()
+        expect(mockRes.clearCookie).toHaveBeenCalledWith(
+          MYINFO_FAPI_SESSION_COOKIE_NAME,
+          MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
         )
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_MYINFO_FORM.getPublicView(),

--- a/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
+++ b/apps/backend/src/app/modules/form/public-form/__tests__/public-form.controller.spec.ts
@@ -37,6 +37,7 @@ import * as BillingService from '../../../billing/billing.service'
 import {
   MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
   MYINFO_FAPI_SESSION_COOKIE_NAME,
+  MYINFO_FAPI_SESSION_MAX_AGE_MS,
 } from '../../../myinfo/fapi/myinfo.fapi.constants'
 import {
   MyInfoFapiIncompleteLoginError,
@@ -754,7 +755,7 @@ describe('public-form.controller', () => {
         })
       })
 
-      it('should return 200 with no errorCodes and not log an error when login was never completed', async () => {
+      it('should return 200 with no errorCodes and not log an error when the callback is still in flight', async () => {
         MockMyInfoFapiService.loadPersonForSession.mockReturnValueOnce(
           errAsync(new MyInfoFapiIncompleteLoginError()),
         )
@@ -768,7 +769,10 @@ describe('public-form.controller', () => {
           jest.fn(),
         )
 
-        expect(mockRes.clearCookie).toHaveBeenCalled()
+        expect(mockRes.clearCookie).toHaveBeenCalledWith(
+          MYINFO_FAPI_SESSION_COOKIE_NAME,
+          MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
+        )
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_MYINFO_FORM.getPublicView(),
           isIntranetUser: false,
@@ -789,7 +793,10 @@ describe('public-form.controller', () => {
           jest.fn(),
         )
 
-        expect(mockRes.clearCookie).toHaveBeenCalled()
+        expect(mockRes.clearCookie).toHaveBeenCalledWith(
+          MYINFO_FAPI_SESSION_COOKIE_NAME,
+          MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
+        )
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_MYINFO_FORM.getPublicView(),
           isIntranetUser: false,
@@ -889,35 +896,56 @@ describe('public-form.controller', () => {
         })
       })
 
-      it('should clear a FAPI session cookie that cannot be read', async () => {
-        const mockReqWithUnsignedCookie = expressHandler.mockRequest({
+      it('should fall back to legacy MyInfo when the FAPI session belongs to another form', async () => {
+        const mockMyInfoData = new MyInfoData({
+          uinFin: 'mock-uin-fin',
+        } as IPersonResponse)
+        const mockReqWithBothCookies = expressHandler.mockRequest({
           params: { formId: MOCK_FORM_ID },
           others: {
             cookies: {
-              [MYINFO_FAPI_SESSION_COOKIE_NAME]: 's:tampered-or-rotated',
+              [MYINFO_AUTH_CODE_COOKIE_NAME]: {
+                authCode: MOCK_AUTH_CODE,
+                state: MyInfoAuthCodeCookieState.Success,
+              },
             },
-            signedCookies: {},
+            signedCookies: {
+              [MYINFO_FAPI_SESSION_COOKIE_NAME]: MOCK_FAPI_SESSION_ID,
+            },
           },
         })
         const mockRes = expressHandler.mockResponse({
           clearCookie: jest.fn().mockReturnThis(),
+          cookie: jest.fn().mockReturnThis(),
         })
+        MockMyInfoFapiService.loadPersonForSession.mockReturnValueOnce(
+          errAsync(new MyInfoFapiSessionFormMismatchError()),
+        )
+        MockMyInfoService.retrieveAccessToken.mockReturnValueOnce(
+          okAsync(MOCK_ACCESS_TOKEN),
+        )
+        MockMyInfoService.getMyInfoDataForForm.mockReturnValueOnce(
+          okAsync(mockMyInfoData),
+        )
+        MockMyInfoService.prefillAndSaveMyInfoFields.mockReturnValueOnce(
+          okAsync([]),
+        )
 
         await PublicFormController.handleGetPublicForm(
-          mockReqWithUnsignedCookie,
+          mockReqWithBothCookies,
           mockRes,
           jest.fn(),
         )
 
-        expect(
-          MockMyInfoFapiService.loadPersonForSession,
-        ).not.toHaveBeenCalled()
-        expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        // The other form's login session survives, and this form still
+        // authenticates off its own v3 auth code.
+        expect(mockRes.clearCookie).not.toHaveBeenCalledWith(
           MYINFO_FAPI_SESSION_COOKIE_NAME,
           MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
         )
         expect(mockRes.json).toHaveBeenCalledWith({
-          form: MOCK_MYINFO_FORM.getPublicView(),
+          form: { ...MOCK_MYINFO_FORM.getPublicView(), form_fields: [] },
+          spcpSession: { userName: mockMyInfoData.getUinFin() },
           isIntranetUser: false,
         })
       })
@@ -944,7 +972,7 @@ describe('public-form.controller', () => {
         )
         expect(mockRes.clearCookie).not.toHaveBeenCalledWith(
           MYINFO_FAPI_SESSION_COOKIE_NAME,
-          expect.anything(),
+          MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
         )
         expect(mockRes.json).toHaveBeenCalledWith({
           form: MOCK_MYINFO_FORM.getPublicView(),
@@ -1781,6 +1809,54 @@ describe('public-form.controller', () => {
       })
     })
 
+    it('should clear a stale FAPI session cookie when the form has authType MyInfo and myinfoFapi is off', async () => {
+      // Arrange
+      const MOCK_REQ_FLAG_OFF = expressHandler.mockRequest({
+        params: { formId: new ObjectId().toHexString() },
+        query: { isPersistentLogin: true },
+        others: {
+          growthbook: {
+            isOn: jest.fn(() => false),
+            getAttributes: jest.fn(() => ({})),
+            setAttributes: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      })
+      const MOCK_FORM = {
+        admin: MOCK_ADMIN,
+        authType: FormAuthType.MyInfo,
+        esrvcId: 'MOCKED_FORM_ESRVC_ID',
+        getUniqueMyInfoAttrs: jest.fn().mockReturnValue([]),
+      } as unknown as MyInfoForm<IFormDocument>
+
+      const createRedirectURLSpy = jest.spyOn(
+        MockMyInfoService,
+        'createRedirectURL',
+      )
+      const mockRes = expressHandler.mockResponse()
+      MockFormService.retrieveFullFormById.mockReturnValueOnce(
+        okAsync(MOCK_FORM),
+      )
+      createRedirectURLSpy.mockReturnValueOnce(ok(MOCK_REDIRECT_URL))
+
+      // Act
+      await PublicFormController._handleFormAuthRedirect(
+        MOCK_REQ_FLAG_OFF,
+        mockRes,
+        jest.fn(),
+      )
+
+      // Assert
+      expect(MockMyInfoFapiService.startLogin).not.toHaveBeenCalled()
+      expect(mockRes.clearCookie).toHaveBeenCalledWith(
+        MYINFO_FAPI_SESSION_COOKIE_NAME,
+        MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
+      )
+      expect(mockRes.json).toHaveBeenCalledWith({
+        redirectURL: MOCK_REDIRECT_URL,
+      })
+    })
+
     it('should return 200 with the FAPI redirect url, clear the legacy auth code cookie and set the FAPI session cookie when the form has authType MyInfo and myinfoFapi is on', async () => {
       // Arrange
       const MOCK_REQ_WITH_FAPI = expressHandler.mockRequest({
@@ -1832,7 +1908,10 @@ describe('public-form.controller', () => {
       expect(mockRes.cookie).toHaveBeenCalledWith(
         MYINFO_FAPI_SESSION_COOKIE_NAME,
         MOCK_SESSION_ID,
-        expect.anything(),
+        {
+          ...MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
+          maxAge: MYINFO_FAPI_SESSION_MAX_AGE_MS,
+        },
       )
       expect(mockRes.status).toHaveBeenCalledWith(200)
       expect(mockRes.json).toHaveBeenCalledWith({
@@ -2061,7 +2140,7 @@ describe('public-form.controller', () => {
       )
       expect(mockRes.clearCookie).toHaveBeenCalledWith(
         MYINFO_FAPI_SESSION_COOKIE_NAME,
-        expect.anything(),
+        MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
       )
       expect(mockRes.json).toHaveBeenCalledWith({
         message: 'Successfully logged out.',

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -238,6 +238,10 @@ export const handleGetPublicForm: ControllerHandler<
           clearMyInfoFapiSessionCookie(res)
           myInfoFields = fapiFieldsResult.value
         }
+      } else if (req.cookies[MYINFO_FAPI_SESSION_COOKIE_NAME]) {
+        // Present but unreadable (e.g. rotated SESSION_SECRET); drop it
+        // since nothing can consume it.
+        clearMyInfoFapiSessionCookie(res)
       }
 
       if (!myInfoFields) {

--- a/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
+++ b/apps/backend/src/app/modules/form/public-form/public-form.controller.ts
@@ -216,8 +216,8 @@ export const handleGetPublicForm: ControllerHandler<
 
       const authErrors: unknown[] = []
 
-      // Prefer FAPI when its session cookie exists, but fall back to the legacy
-      // auth code when FAPI verification fails.
+      // Prefer FAPI when its cookie exists; fall back to the legacy auth code
+      // on failure.
       const fapiSessionId: unknown =
         req.signedCookies?.[MYINFO_FAPI_SESSION_COOKIE_NAME]
       if (typeof fapiSessionId === 'string' && fapiSessionId) {
@@ -229,8 +229,8 @@ export const handleGetPublicForm: ControllerHandler<
           const { error: fapiError } = fapiFieldsResult
           authErrors.push(fapiError)
 
-          // The tab-scoped frontend guard decides whether a session belonging
-          // to another form should be discarded.
+          // Frontend tab-scoping decides whether to discard a session for
+          // another form.
           if (!(fapiError instanceof MyInfoFapiSessionFormMismatchError)) {
             clearMyInfoFapiSessionCookie(res)
           }
@@ -280,9 +280,8 @@ export const handleGetPublicForm: ControllerHandler<
           })
         }
 
-        // Respondent never reached, or hasn't yet reached, the Singpass
-        // callback (e.g. navigated back before completing login), or the FAPI
-        // session belongs to another tab. Treat either as no login attempt.
+        // Callback not yet reached, or the session belongs to another tab —
+        // treat either as no login attempt.
         if (
           firstAuthError instanceof MyInfoFapiIncompleteLoginError ||
           firstAuthError instanceof MyInfoFapiSessionFormMismatchError

--- a/apps/backend/src/app/modules/myinfo/fapi/__tests__/myinfo.fapi.controller.spec.ts
+++ b/apps/backend/src/app/modules/myinfo/fapi/__tests__/myinfo.fapi.controller.spec.ts
@@ -3,11 +3,27 @@ import { Request } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import { errAsync, okAsync } from 'neverthrow'
 
+import { createLoggerWithLabel } from '../../../../config/logger'
 import { MYINFO_FAPI_SESSION_COOKIE_NAME } from '../myinfo.fapi.constants'
 import { loginToMyInfoFapi } from '../myinfo.fapi.controller'
 import { MyInfoFapiExchangeError } from '../myinfo.fapi.errors'
 import * as MyInfoFapiService from '../myinfo.fapi.service'
 import getMyInfoFapiSessionModel from '../myinfo.fapi.session.model'
+
+jest.mock('../../../../config/logger', () => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }
+  return { createLoggerWithLabel: () => logger }
+})
+
+const mockLogger = createLoggerWithLabel(module) as {
+  info: jest.Mock
+  warn: jest.Mock
+  error: jest.Mock
+}
 
 jest.mock('../myinfo.fapi.service')
 const MockMyInfoFapiService = jest.mocked(MyInfoFapiService)
@@ -58,6 +74,12 @@ describe('loginToMyInfoFapi', () => {
 
     expect(res.sendStatus).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
     expect(MockSession.loadForCallback).not.toHaveBeenCalled()
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({ reason: 'session_missing' }),
+      }),
+    )
+    expect(mockLogger.error).not.toHaveBeenCalled()
   })
 
   it('should reject and clear the cookie when the session is gone', async () => {
@@ -75,6 +97,12 @@ describe('loginToMyInfoFapi', () => {
     expect(res.sendStatus).toHaveBeenCalledWith(StatusCodes.BAD_REQUEST)
     expect(res.clearCookie).toHaveBeenCalled()
     expect(MockMyInfoFapiService.exchangeCallback).not.toHaveBeenCalled()
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({ reason: 'session_missing' }),
+      }),
+    )
+    expect(mockLogger.error).not.toHaveBeenCalled()
   })
 
   it('should exchange the code and redirect to the form on the happy path', async () => {
@@ -174,6 +202,47 @@ describe('loginToMyInfoFapi', () => {
     expect(MockMyInfoFapiService.exchangeCallback).not.toHaveBeenCalled()
     expect(MockSession.markFailed).toHaveBeenCalledWith(MOCK_SESSION_ID)
     expect(res.redirect).toHaveBeenCalledWith(`/${MOCK_FORM_ID}`)
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          reason: 'consent_denied',
+          oauthError: 'access_denied',
+        }),
+      }),
+    )
+    expect(mockLogger.error).not.toHaveBeenCalled()
+  })
+
+  it('should log a Singpass OAuth failure at error so it can be alarmed separately from consent declined', async () => {
+    MockSession.loadForCallback.mockResolvedValueOnce({
+      phase: 'pending',
+      target: MOCK_TARGET,
+      exchange: MOCK_EXCHANGE,
+    })
+    const res = expressHandler.mockResponse()
+
+    await loginToMyInfoFapi(
+      mockCallback(
+        {
+          error: 'server_error',
+          state: 'mock-state',
+        },
+        MOCK_SESSION_ID,
+      ),
+      res,
+      jest.fn(),
+    )
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          reason: 'oauth_error',
+          oauthError: 'server_error',
+        }),
+      }),
+    )
+    expect(MockSession.markFailed).toHaveBeenCalledWith(MOCK_SESSION_ID)
+    expect(res.redirect).toHaveBeenCalledWith(`/${MOCK_FORM_ID}`)
   })
 
   it('should keep the cookie when the exchange fails, so form load raises the MyInfo error', async () => {
@@ -197,6 +266,11 @@ describe('loginToMyInfoFapi', () => {
     expect(MockSession.markFailed).toHaveBeenCalledWith(MOCK_SESSION_ID)
     expect(res.clearCookie).not.toHaveBeenCalled()
     expect(res.redirect).toHaveBeenCalledWith(`/${MOCK_FORM_ID}`)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({ reason: 'exchange_failed' }),
+      }),
+    )
   })
 
   it('should record a failure when the exchange cannot be persisted', async () => {

--- a/apps/backend/src/app/modules/myinfo/fapi/__tests__/myinfo.fapi.session.model.spec.ts
+++ b/apps/backend/src/app/modules/myinfo/fapi/__tests__/myinfo.fapi.session.model.spec.ts
@@ -221,16 +221,25 @@ describe('myinfo.fapi.session.model', () => {
       })
     })
 
-    it('should report failed and delete a failed session', async () => {
+    it('should report failed without deleting, so a later callback can still claim', async () => {
       const sessionId = await MyInfoFapiSession.createPending(pendingSession)
       await MyInfoFapiSession.markFailed(sessionId)
 
       await expect(consume(sessionId)).resolves.toEqual({
         status: 'failed',
       })
+
       await expect(
-        MyInfoFapiSession.loadForCallback(sessionId),
-      ).resolves.toBeNull()
+        MyInfoFapiSession.markExchanged(sessionId, {
+          accessToken: MOCK_ACCESS_TOKEN,
+          sub: MOCK_SUB,
+        }),
+      ).resolves.toBe('claimed')
+
+      await expect(consume(sessionId)).resolves.toMatchObject({
+        status: 'exchanged',
+        session: { accessToken: MOCK_ACCESS_TOKEN, sub: MOCK_SUB },
+      })
     })
 
     it('should leave a pending session untouched', async () => {

--- a/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.constants.ts
+++ b/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.constants.ts
@@ -6,4 +6,10 @@ export const MYINFO_FAPI_JWKS_PATH = '/fapi/.well-known/jwks.json'
 export const MYINFO_FAPI_REDIRECT_URI = `${config.app.appUrl}${MYINFO_ROUTER_PREFIX}${MYINFO_FAPI_REDIRECT_PATH}`
 export const MYINFO_FAPI_SESSION_COOKIE_NAME = 'MyInfoFapiSession'
 export const MYINFO_FAPI_SESSION_MAX_AGE_MS = 15 * 60 * 1000 // 15 minutes
+export const MYINFO_FAPI_SESSION_COOKIE_IDENTITY = {
+  signed: true,
+  httpOnly: true,
+  secure: !config.isDevOrTest,
+  sameSite: 'lax' as const, // cannot use strict for cross-site redirects
+}
 export const SINGPASS_JWKS_CACHE_TTL_SECONDS = 3600 // 1 hour, aligns with Singpass's JWKS cache TTL.

--- a/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.controller.ts
+++ b/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.controller.ts
@@ -68,13 +68,10 @@ const validateMyInfoFapiLogin = celebrate({
 })
 
 /**
- * Exchanges the Singpass authorization code for tokens and redirects to the form.
- * The code is single-use, expires in ~60 seconds, and is bound to a DPoP key
- * that only the session document holds, so the exchange happens here rather
- * than on form load. Failures mark the session `failed` before redirecting,
- * so form load raises ErrorCode.myInfo; a session that never reaches this
- * callback at all is left `pending`, which form load treats as no attempt
- * having been made rather than a failure.
+ * Exchanges the Singpass code for tokens. Happens here, not on form load,
+ * because the code is single-use and bound to a DPoP key only the session
+ * holds. Failure marks the session `failed`; never reaching this callback
+ * leaves it `pending`, which form load treats as no attempt made.
  */
 export const loginToMyInfoFapi: ControllerHandler<
   unknown,
@@ -151,8 +148,8 @@ export const loginToMyInfoFapi: ControllerHandler<
     return res.redirect(destination)
   }
 
-  // Duplicate callback (RBI forwarding race or a double click)
-  // Winner holds valid token, both requests share the cookie, so leave it.
+  // Duplicate callback (RBI race or double click); the winner already holds
+  // a valid token, so leave the cookie for it.
   if (session.phase === 'exchanged') {
     logger.info({
       message:
@@ -204,8 +201,8 @@ export const loginToMyInfoFapi: ControllerHandler<
 }
 
 /**
- * Best-effort marks the session as failed so form load can raise
- * ErrorCode.myInfo. A write failure is logged and leaves the session unchanged.
+ * Best-effort: marks the session failed so form load raises ErrorCode.myInfo.
+ * A write failure is logged and the session is left unchanged.
  */
 const recordFailure = async (
   sessionId: string,
@@ -225,9 +222,8 @@ const recordFailure = async (
 }
 
 /**
- * Form path to send the respondent to after the callback.
- * Uses encodedQuery stored in MongoDB to reconstruct the original query string.
- * Returns the base URL if no encodedQuery is present.
+ * Form path to redirect to after the callback, rebuilt from the stored
+ * encodedQuery (or just the base URL if none).
  */
 const redirectDestination = ({
   formId,

--- a/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.controller.ts
+++ b/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.controller.ts
@@ -9,6 +9,7 @@ import { createLoggerWithLabel } from '../../../config/logger'
 import { ControllerHandler } from '../../core/core.types'
 
 import {
+  MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
   MYINFO_FAPI_SESSION_COOKIE_NAME,
   MYINFO_FAPI_SESSION_MAX_AGE_MS,
 } from './myinfo.fapi.constants'
@@ -20,13 +21,6 @@ import getMyInfoFapiSessionModel, {
 
 const logger = createLoggerWithLabel(module)
 const MyInfoFapiSession = getMyInfoFapiSessionModel(mongoose)
-
-const cookieIdentity = {
-  signed: true,
-  httpOnly: true,
-  secure: !config.isDevOrTest,
-  sameSite: 'lax' as const, // cannot use strict for cross-site redirects
-}
 
 type CallbackQuery = {
   state: string
@@ -41,13 +35,16 @@ export const setMyInfoFapiSessionCookie = (
   sessionId: string,
 ): void => {
   res.cookie(MYINFO_FAPI_SESSION_COOKIE_NAME, sessionId, {
-    ...cookieIdentity,
+    ...MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
     maxAge: MYINFO_FAPI_SESSION_MAX_AGE_MS,
   })
 }
 
 export const clearMyInfoFapiSessionCookie = (res: Response): void => {
-  res.clearCookie(MYINFO_FAPI_SESSION_COOKIE_NAME, cookieIdentity)
+  res.clearCookie(
+    MYINFO_FAPI_SESSION_COOKIE_NAME,
+    MYINFO_FAPI_SESSION_COOKIE_IDENTITY,
+  )
 }
 
 const callbackQuery = {

--- a/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.controller.ts
+++ b/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.controller.ts
@@ -2,6 +2,7 @@ import { celebrate, Joi, Segments } from 'celebrate'
 import { Response } from 'express'
 import { StatusCodes } from 'http-status-codes'
 import mongoose from 'mongoose'
+import { ResultAsync } from 'neverthrow'
 
 import { Environment } from '../../../../types'
 import config from '../../../config/config'
@@ -15,7 +16,6 @@ import {
 } from './myinfo.fapi.constants'
 import { exchangeCallback } from './myinfo.fapi.service'
 import getMyInfoFapiSessionModel, {
-  MyInfoFapiClaimOutcome,
   MyInfoFapiRedirectTarget,
 } from './myinfo.fapi.session.model'
 
@@ -94,17 +94,23 @@ export const loginToMyInfoFapi: ControllerHandler<
     return res.sendStatus(StatusCodes.BAD_REQUEST)
   }
 
-  const session = await MyInfoFapiSession.loadForCallback(sessionId).catch(
+  const loaded = await ResultAsync.fromPromise(
+    MyInfoFapiSession.loadForCallback(sessionId),
     (error) => {
       logger.error({
         message: 'Failed to load MyInfo FAPI session',
         meta: logMeta,
         error,
       })
-      return null
+      return error
     },
   )
+  if (loaded.isErr()) {
+    clearMyInfoFapiSessionCookie(res)
+    return res.sendStatus(StatusCodes.BAD_REQUEST)
+  }
 
+  const session = loaded.value
   if (!session) {
     logger.error({
       message: 'MyInfo FAPI session not found or expired',
@@ -160,18 +166,15 @@ export const loginToMyInfoFapi: ControllerHandler<
     return res.redirect(destination)
   }
 
-  let outcome: MyInfoFapiClaimOutcome
-  try {
-    outcome = await MyInfoFapiSession.markExchanged(
-      sessionId,
-      exchangeResult.value,
-    )
-  } catch (error) {
-    // Best-effort record the failed exchange before redirecting to the form.
+  const claimed = await ResultAsync.fromPromise(
+    MyInfoFapiSession.markExchanged(sessionId, exchangeResult.value),
+    (error) => error,
+  )
+  if (claimed.isErr()) {
     logger.error({
       message: 'Failed to record MyInfo FAPI token exchange',
       meta: formMeta,
-      error,
+      error: claimed.error,
     })
     await recordFailure(sessionId, formMeta)
     return res.redirect(destination)
@@ -179,7 +182,7 @@ export const loginToMyInfoFapi: ControllerHandler<
 
   logger.info({
     message: 'Completed MyInfo FAPI token exchange',
-    meta: { ...formMeta, outcome },
+    meta: { ...formMeta, outcome: claimed.value },
   })
 
   return res.redirect(destination)
@@ -189,17 +192,22 @@ export const loginToMyInfoFapi: ControllerHandler<
  * Best-effort marks the session as failed so form load can raise
  * ErrorCode.myInfo. A write failure is logged and leaves the session unchanged.
  */
-const recordFailure = (
+const recordFailure = async (
   sessionId: string,
   meta: { action: string; formId: string },
-): Promise<void> =>
-  MyInfoFapiSession.markFailed(sessionId).catch((error) => {
+): Promise<void> => {
+  const result = await ResultAsync.fromPromise(
+    MyInfoFapiSession.markFailed(sessionId),
+    (error) => error,
+  )
+  if (result.isErr()) {
     logger.error({
       message: 'Failed to record MyInfo FAPI login failure',
       meta,
-      error,
+      error: result.error,
     })
-  })
+  }
+}
 
 /**
  * Form path to send the respondent to after the callback.

--- a/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.controller.ts
+++ b/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.controller.ts
@@ -87,9 +87,9 @@ export const loginToMyInfoFapi: ControllerHandler<
     req.signedCookies?.[MYINFO_FAPI_SESSION_COOKIE_NAME]
 
   if (typeof sessionId !== 'string' || !sessionId) {
-    logger.error({
+    logger.warn({
       message: 'MyInfo FAPI callback without a session cookie',
-      meta: logMeta,
+      meta: { ...logMeta, reason: 'session_missing' },
     })
     return res.sendStatus(StatusCodes.BAD_REQUEST)
   }
@@ -99,7 +99,7 @@ export const loginToMyInfoFapi: ControllerHandler<
     (error) => {
       logger.error({
         message: 'Failed to load MyInfo FAPI session',
-        meta: logMeta,
+        meta: { ...logMeta, reason: 'session_load_failed' },
         error,
       })
       return error
@@ -112,9 +112,9 @@ export const loginToMyInfoFapi: ControllerHandler<
 
   const session = loaded.value
   if (!session) {
-    logger.error({
+    logger.warn({
       message: 'MyInfo FAPI session not found or expired',
-      meta: logMeta,
+      meta: { ...logMeta, reason: 'session_missing' },
     })
     clearMyInfoFapiSessionCookie(res)
     return res.sendStatus(StatusCodes.BAD_REQUEST)
@@ -124,14 +124,29 @@ export const loginToMyInfoFapi: ControllerHandler<
   const formMeta = { ...logMeta, formId: session.target.formId }
 
   if ('error' in req.query) {
-    logger.error({
-      message: 'Singpass returned an error from the MyInfo FAPI consent flow',
-      meta: {
-        ...formMeta,
-        error: req.query.error,
-        errorDescription: req.query.error_description, // logged but never rendered
-      },
-    })
+    const oauthError = req.query.error
+    const errorDescription = req.query.error_description // logged but never rendered
+    if (oauthError === 'access_denied') {
+      logger.info({
+        message: 'Respondent declined MyInfo FAPI consent',
+        meta: {
+          ...formMeta,
+          reason: 'consent_denied',
+          oauthError,
+          errorDescription,
+        },
+      })
+    } else {
+      logger.error({
+        message: 'Singpass returned an error from the MyInfo FAPI consent flow',
+        meta: {
+          ...formMeta,
+          reason: 'oauth_error',
+          oauthError,
+          errorDescription,
+        },
+      })
+    }
     await recordFailure(sessionId, formMeta)
     return res.redirect(destination)
   }
@@ -159,7 +174,7 @@ export const loginToMyInfoFapi: ControllerHandler<
   if (exchangeResult.isErr()) {
     logger.error({
       message: 'MyInfo FAPI login error',
-      meta: formMeta,
+      meta: { ...formMeta, reason: 'exchange_failed' },
       error: exchangeResult.error,
     })
     await recordFailure(sessionId, formMeta)
@@ -173,7 +188,7 @@ export const loginToMyInfoFapi: ControllerHandler<
   if (claimed.isErr()) {
     logger.error({
       message: 'Failed to record MyInfo FAPI token exchange',
-      meta: formMeta,
+      meta: { ...formMeta, reason: 'persist_failed' },
       error: claimed.error,
     })
     await recordFailure(sessionId, formMeta)
@@ -203,7 +218,7 @@ const recordFailure = async (
   if (result.isErr()) {
     logger.error({
       message: 'Failed to record MyInfo FAPI login failure',
-      meta,
+      meta: { ...meta, reason: 'persist_failed' },
       error: result.error,
     })
   }

--- a/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.session.model.ts
+++ b/apps/backend/src/app/modules/myinfo/fapi/myinfo.fapi.session.model.ts
@@ -12,11 +12,9 @@ import {
 export const MYINFO_FAPI_SESSION_SCHEMA_ID = 'MyInfoFapiSession'
 
 /**
- * A login session moves pending -> exchanged or pending -> failed exactly
- * once, then is deleted. All transitions filter on phase, so Mongo decides
- * which of two concurrent callbacks wins rather than a read-then-write race.
- * A session left `pending` (neither transition ever happened) means the
- * respondent never reached, or hasn't yet reached, the Singpass callback.
+ * pending -> exchanged or pending -> failed, exactly once. Transitions filter
+ * on phase so Mongo, not a read-then-write race, picks the winner between
+ * concurrent callbacks. `pending` means the Singpass callback hasn't landed.
  */
 export type MyInfoFapiSessionPhase = 'pending' | 'exchanged' | 'failed'
 
@@ -52,8 +50,8 @@ export type MyInfoFapiExchangeSession = Pick<
 >
 
 /**
- * The exchange material exists on the pending variant only, so a callback
- * cannot reach for it once someone else has already exchanged.
+ * Exchange material exists on the pending variant only, so a callback can't
+ * reach it once another has already exchanged.
  */
 export type MyInfoFapiCallbackSession =
   | {
@@ -71,15 +69,13 @@ export type MyInfoFapiExchangedSession = {
   dpopPrivateJwk: JsonWebKey
 }
 
-/**
- * `alreadyExchanged` is the legitimate duplicate-callback case and must not
- * be treated as an error.
- */
+/** `alreadyExchanged` is a legitimate duplicate callback, not an error. */
 export type MyInfoFapiClaimOutcome = 'claimed' | 'alreadyExchanged' | 'notFound'
 
 /**
- * `incomplete` is a session still `pending`, or already gone (TTL / unknown
- * id). It is not deleted, so a later callback can still succeed.
+ * `incomplete` covers a `pending` session or one already gone (TTL/unknown
+ * id). `failed` is reported without deleting: a losing duplicate callback may
+ * still be raced by the winner.
  */
 export type MyInfoFapiConsumeOutcome =
   | { status: 'exchanged'; session: MyInfoFapiExchangedSession }
@@ -144,10 +140,9 @@ MyInfoFapiSessionSchema.statics.createPending = async function (
 }
 
 /**
- * Load a session for a callback. For exchanged sessions, omit secrets so
- * duplicate callbacks only redirect. Anything else (pending, or failed by an
- * earlier duplicate callback) still returns the exchange material, so a
- * replay can go on to succeed.
+ * Omits secrets for an exchanged session so a duplicate callback only
+ * redirects; pending/failed still return exchange material so a replay can
+ * succeed.
  */
 MyInfoFapiSessionSchema.statics.loadForCallback = async function (
   sessionId: string,
@@ -179,11 +174,9 @@ MyInfoFapiSessionSchema.statics.loadForCallback = async function (
 }
 
 /**
- * Records a successful token exchange. Filtered on
- * `phase: { $ne: 'exchanged' }`, not on `pending`: a session already marked
- * `failed` by a losing duplicate callback (an RBI forwarding race or a double
- * click) must still be claimable by the request that actually succeeded.
- * An already-exchanged session is left alone and reported as such.
+ * Filters on `phase !== 'exchanged'`, not `pending`, so a session already
+ * marked `failed` by a losing duplicate callback can still be claimed by the
+ * winner.
  */
 MyInfoFapiSessionSchema.statics.markExchanged = async function (
   sessionId: string,
@@ -198,8 +191,7 @@ MyInfoFapiSessionSchema.statics.markExchanged = async function (
         sub: tokens.sub,
       },
     },
-    // Mongoose 7 otherwise resolves to the ModifyResult overload, which types
-    // `claimed` as always truthy even though the runtime returns the document.
+    // Otherwise Mongoose 7 types `claimed` as always truthy (ModifyResult overload).
     { includeResultMetadata: false },
   )
   if (claimed) {
@@ -216,10 +208,8 @@ MyInfoFapiSessionSchema.statics.markExchanged = async function (
 }
 
 /**
- * Records that the callback was reached but the login did not succeed
- * (Singpass returned an error, or the token exchange failed). Filtered on
- * `phase: 'pending'` so a session someone else already exchanged is left
- * alone rather than being overwritten with a failure.
+ * Filtered on `phase: 'pending'` so an already-exchanged session isn't
+ * overwritten with a failure.
  */
 MyInfoFapiSessionSchema.statics.markFailed = async function (
   sessionId: string,
@@ -231,8 +221,9 @@ MyInfoFapiSessionSchema.statics.markFailed = async function (
 }
 
 /**
- * Consumes a resolved session only for the form that started it. A session
- * for another form, or one still pending, is left untouched.
+ * Only for the form that started the session. Deletes on `exchanged`
+ * (single-use tokens); leaves `failed` in place since the winner may still
+ * claim it.
  */
 MyInfoFapiSessionSchema.statics.consume = async function ({
   sessionId,
@@ -241,14 +232,7 @@ MyInfoFapiSessionSchema.statics.consume = async function ({
   sessionId: string
   formId: string
 }): Promise<MyInfoFapiConsumeOutcome> {
-  const session = await this.findOneAndDelete(
-    {
-      _id: sessionId,
-      formId,
-      phase: { $in: ['exchanged', 'failed'] },
-    },
-    { includeResultMetadata: false },
-  )
+  const session = await this.findOne({ _id: sessionId, formId })
   if (!session) {
     const belongsToAnotherForm = await this.exists({
       _id: sessionId,
@@ -259,16 +243,27 @@ MyInfoFapiSessionSchema.statics.consume = async function ({
     }
     return { status: 'incomplete' }
   }
-  if (session.phase === 'failed' || !session.accessTokenEnc || !session.sub) {
+  if (session.phase === 'pending') {
+    return { status: 'incomplete' }
+  }
+  if (session.phase === 'failed') {
     return { status: 'failed' }
+  }
+
+  const exchanged = await this.findOneAndDelete(
+    { _id: sessionId, formId, phase: 'exchanged' },
+    { includeResultMetadata: false },
+  )
+  if (!exchanged || !exchanged.accessTokenEnc || !exchanged.sub) {
+    return { status: exchanged ? 'failed' : 'incomplete' }
   }
   return {
     status: 'exchanged',
     session: {
-      formId: session.formId,
-      accessToken: await decrypt(session.accessTokenEnc),
-      sub: session.sub,
-      dpopPrivateJwk: await decryptJwk(session.dpopPrivateJwkEnc),
+      formId: exchanged.formId,
+      accessToken: await decrypt(exchanged.accessTokenEnc),
+      sub: exchanged.sub,
+      dpopPrivateJwk: await decryptJwk(exchanged.dpopPrivateJwkEnc),
     },
   }
 }


### PR DESCRIPTION
## Problem

Review of the MyInfo FAPI login flow flagged a few gaps: 
* duplicate Singpass callback could lose valid tokens to a race
* cookie signed under a rotated secret was never cleared
* error logs didn't distinguish benign outcomes (declined consent, expired session) from real Singpass outages
* couple of code paths still used try/catch instead of this project's neverthrow convention.

## Solution

* Closes the session-consumption race: a failed FAPI login session is no longer deleted the instant a form loads it, so a still-in-flight winning callback can still claim it instead of finding the document gone. 
* Clears the FAPI session cookie when it's present but unreadable (e.g. after a `SESSION_SECRET` rotation)
* Downgrades benign callback outcomes (consent declined, expired session) from error to info/warn while tagging every remaining failure with a machine-readable `reason` for alerting
* Replaces the callback's remaining try/catch with `ResultAsync` for consistency with the rest of the codebase. 
* Adds the missing test coverage the review called out (FAPI + legacy cookie coexistence, the feature-flag-off cookie clear) and tightens cookie-option assertions from `expect.anything()` to the exact options object.

**Breaking Changes**

No - backwards compatible.

## Tests

Fully covered by the added/updated unit tests (`myinfo.fapi.session.model.spec.ts`, `myinfo.fapi.controller.spec.ts`, `public-form.controller.spec.ts`).

**TC1: MyInfo FAPI login still works end to end**

- [ ] Log into a MyInfo FAPI form via Singpass; confirm the form prefills and no error toast appears.
- [ ] Decline consent at Singpass; confirm the form loads with no error toast (previously this could still log at error).
