### PR TITLE
test(workflow): give the intro screen tests a localStorage to write to

### DIFF
--- a/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
+++ b/apps/frontend/src/features/admin-form/create/workflow/components/EmptyWorkflow.test.tsx
@@ -51,20 +51,36 @@ const settleUser = async () => {
   })
 }
 
+let localStore: Record<string, string> = {}
+
 describe('the workflow tab intro screen', () => {
   beforeAll(() => {
     server.listen({ onUnhandledRequest: 'bypass' })
     Element.prototype.scrollIntoView = vi.fn()
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => localStore[key] ?? null,
+      setItem: (key: string, value: string) => {
+        localStore[key] = value
+      },
+      removeItem: (key: string) => {
+        delete localStore[key]
+      },
+      clear: () => {
+        localStore = {}
+      },
+    })
   })
 
   afterAll(() => server.close())
 
   afterAll(() => {
+    vi.unstubAllGlobals()
     delete (Element.prototype as Partial<Pick<Element, 'scrollIntoView'>>)
       .scrollIntoView
   })
 
   beforeEach(() => {
+    localStore = {}
     servedUsers = 0
     // Serve an admin with no flags by default, so every test resolves the user
     // query rather than relying on it failing.


### PR DESCRIPTION
## Problem

`EmptyWorkflow.test.tsx > the fork > opens every section at once from manual setup` fails on `develop` as of bf0079504. It is reproducible locally on a clean checkout of `develop`, and it is not flaky.

#9986 fixed a real flake in this file: the intro screen renders before `/api/v3/user` resolves, but the fork between the welcome card and the step editor reads the admin's seen flag at click time, so a fast click read a taught admin as untaught. The fix serves the user in every test and waits for the response before clicking.

Serving that user also gave `useGuidedSetupPreference` an admin `_id` to key its writes on, which switched on a code path the file never exercised before. jsdom in this suite has no `localStorage` at all (node reports `localStorage is not available because --localstorage-file was not provided`), so `useLocalStorage` throws inside `setValue`, the `catch` swallows it, and `setStoredValue` never runs. Choosing manual setup therefore wrote nothing and left the hook still reading `true`, whose effect pushed `isGuidedSetup` back to guided and failed the assertion.

## Solution

Stub an in-memory `localStorage`, cleared between tests, so the preference can keep a choice. This mirrors what `useGuidedSetupPreference.test.tsx` already does for the same reason.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Bug Fixes**:

- The workflow intro screen tests pass again, with #9986's flake fix left intact.

## Tests

- `EmptyWorkflow.test.tsx`: 12 passed, previously 11 passed and 1 failed.
- Whole workflow feature: 22 files, 139 tests passing.
- Frontend suite on the branch that carries this: 85 files, 510 tests passing.
- Typecheck, lint and prettier clean.

## Deploy Notes

None. Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
